### PR TITLE
Port sqlite3 fuzzer

### DIFF
--- a/sqlite3/Dockerfile
+++ b/sqlite3/Dockerfile
@@ -1,0 +1,22 @@
+
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM ossfuzz/base-libfuzzer
+MAINTAINER tanin@google.com
+RUN apt-get install -y make autoconf automake libtool fossil tcl
+
+CMD /src/oss-fuzz/sqlite3/build.sh

--- a/sqlite3/Jenkinsfile
+++ b/sqlite3/Jenkinsfile
@@ -1,0 +1,28 @@
+
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+def libfuzzerBuild = fileLoader.fromGit('infra/libfuzzer-pipeline.groovy',
+                                        'https://github.com/google/oss-fuzz.git',
+                                        'master', null, '')
+
+libfuzzerBuild {
+  # We can't use git. We need to use fossil.
+  # build.sh switches to fossil.
+  # The below is just a dummy.
+  # See: crbug.com/643224#c4
+  git = "https://github.com/google/oss-fuzz"
+}

--- a/sqlite3/build.sh
+++ b/sqlite3/build.sh
@@ -1,0 +1,38 @@
+
+#!/bin/bash -eu
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd /src/sqlite3
+
+rm -rf fossil
+mkdir fossil
+cd fossil
+
+fossil clone https://www.sqlite.org/src sqlite --user `whoami`
+fossil open sqlite
+
+mkdir bld
+cd bld
+
+export ASAN_OPTIONS=detect_leaks=0
+../configure
+make
+make sqlite3.c
+
+$CXX $CXXFLAGS -std=c++11 -I. \
+    /src/oss-fuzz/sqlite3/sqlite3_fuzzer.cc -o /out/sqlite3_fuzzer \
+    /work/libfuzzer/*.o ./sqlite3.o $LDFLAGS

--- a/sqlite3/sqlite3_fuzzer.cc
+++ b/sqlite3/sqlite3_fuzzer.cc
@@ -1,0 +1,81 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <algorithm>
+#include <array>
+#include <string>
+#include <vector>
+
+#include "sqlite3.h"
+
+
+static const std::array<uint8_t, 6> kBadKeyword{{'R', 'E', 'G', 'E', 'X', 'P'}};
+
+
+bool checkForBadKeyword(const uint8_t* data, size_t size) {
+  auto it = std::search(
+      data, data + size, kBadKeyword.begin(), kBadKeyword.end(),
+      [](char c1, char c2) { return std::toupper(c1) == std::toupper(c2); });
+
+  if (it != data + size)
+    return true;
+
+  return false;
+}
+
+
+static int Progress(void *not_used_ptr) {
+  return 1;
+}
+
+
+// Entry point for LibFuzzer.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  if (size < 2)
+    return 0;
+
+  if (checkForBadKeyword(data, size))
+    return 0;
+
+  sqlite3* db;
+  int return_code = sqlite3_open_v2(
+      "db.db",
+      &db,
+      SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MEMORY, 0);
+
+
+  if (SQLITE_OK != return_code)
+    return 0;
+
+  // Use first byte as random selector for other parameters.
+  int selector = data[0];
+
+  // To cover both cases when progress_handler is used and isn't used.
+  if (selector & 1)
+    sqlite3_progress_handler(db, 4, &Progress, NULL);
+  else
+    sqlite3_progress_handler(db, 0, NULL, NULL);
+
+  // Remove least significant bit to make further usage of selector independent.
+  selector >>= 1;
+
+  sqlite3_stmt* statement = NULL;
+  int result = sqlite3_prepare_v2(db, reinterpret_cast<const char*>(data + 1),
+                                  static_cast<int>(size - 1), &statement, NULL);
+  if (result == SQLITE_OK) {
+    // Use selector value to randomize number of iterations.
+    for (int i = 0; i < selector; i++) {
+      if (sqlite3_step(statement) != SQLITE_ROW)
+        break;
+    }
+
+    sqlite3_finalize(statement);
+  }
+
+  sqlite3_close(db);
+  return 0;
+}


### PR DESCRIPTION
- It needs fossil. Therefore, the build.sh looks weird.
- I can't make sqlite3.a. So, I use sqlite3.o. I have no idea how they are different. (Not a C++ person here.)