### PR TITLE
[WIP] Add libnss build and 15 fuzzers from crrev.com/1677803002.

### DIFF
--- a/nss/Dockerfile
+++ b/nss/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM ossfuzz/base-libfuzzer
+MAINTAINER mmoroz@chromium.org
+RUN apt-get install -y make autoconf automake libtool mercurial zlib1g-dev
+
+COPY build.sh /src/
+
+ENV LD_LIBRARY_PATH "$LD_LIBRARY_PATH:/out"

--- a/nss/Jenkinsfile
+++ b/nss/Jenkinsfile
@@ -1,0 +1,25 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+def libfuzzerBuild = fileLoader.fromGit('infra/libfuzzer-pipeline.groovy',
+                                        'https://github.com/google/oss-fuzz.git',
+                                        'master', null, '')
+
+libfuzzerBuild {
+  // We can't use git. We need to use mercurial (hg) and checkout 2 repos.
+  // build.sh does the checkout with hg. The below is just a dummy.
+  git = "https://github.com/google/oss-fuzz"
+}

--- a/nss/build.sh
+++ b/nss/build.sh
@@ -28,23 +28,30 @@ mkdir -p /work/nss
 cp -u -r /src/nss/* /work/nss/
 cd /work/nss/nss
 make BUILD_OPT=1 USE_64=1 NSS_DISABLE_GTESTS=1 CC="$CC $CFLAGS" \
-  CXX="$CXX $CXXFLAGS" LD="$CC $CFLAGS" ZDEFS_FLAG= clean nss_build_all install
+  CXX="$CXX $CXXFLAGS" LD="$CC $CFLAGS" ZDEFS_FLAG= clean nss_build_all
 
-
+cd ..
 # Copy libraries to /usr/lib.
-cd ../dist
-cp Linux*/lib/*.so /usr/lib
-cp Linux*/lib/{*.chk,libcrmf.a} /usr/lib
+#cp Linux*/lib/*.so /usr/lib
+#cp Linux*/lib/{*.chk,libcrmf.a} /usr/lib
 
 # Copy libraries to /out since fuzzers don't work without them.
-cp Linux*/lib/*.so /out
-cp Linux*/lib/*.a /out
+mkdir -p /work/nss/lib
+#cp Linux*/lib/*.so /out
+cp dist/Linux*/lib/*.a /work/nss/lib
+#cp Linux*/*.o /out
+#cp nss/lib/ssl/Linux*/*.o /work/nss/obj
+#cp nspr/Linux*/lib/ds/*.o /work/nss/obj
+#/lib/libc/src/
+#config/
+#/pr/src/md/
+#/pr/src/md/unix/
 
 # Copy includes to /work/nss/include.
 mkdir -p /work/nss/include
-cp -rL Linux*/include/* /work/nss/include
-cp -rL {public,private}/nss/* /work/nss/include
-cd ..
+cp -rL dist/Linux*/include/* /work/nss/include
+cp -rL dist/{public,private}/nss/* /work/nss/include
+
 
 # Build the fuzzers.
 FUZZERS="asn1_algorithmid_fuzzer \
@@ -77,10 +84,12 @@ for fuzzer in $FUZZERS; do
   $CXX $CXXFLAGS -std=c++11 /src/oss-fuzz/nss/fuzzers/$fuzzer.cc \
      -I/work/nss/include \
      /work/libfuzzer/*.o \
-     /out/*.a \
+     /work/nss/lib/libnss.a /work/nss/lib/libnssutil.a \
+     /work/nss/lib/libnspr4.a /work/nss/lib/libplc4.a /work/nss/lib/libplds4.a \
      -o /out/$fuzzer $LDFLAGS
 done
 
+#     /work/nss/lib/*.a \
 # To avoid "unbound variable" error.
 #if [[ ! -v LD_LIBRARY_PATH ]]; then
 #  export LD_LIBRARY_PATH=/work/nss/lib

--- a/nss/build.sh
+++ b/nss/build.sh
@@ -31,7 +31,7 @@ make BUILD_OPT=1 USE_64=1 NSS_DISABLE_GTESTS=1 CC="$CC $CFLAGS" \
     CXX="$CXX $CXXFLAGS" LD="$CC $CFLAGS" ZDEFS_FLAG= clean nss_build_all
 cd ..
 
-# Copy libraries to /out since fuzzers don't work without them.
+# Copy libraries and some objects to /work/nss/lib.
 mkdir -p /work/nss/lib
 cp dist/Linux*/lib/*.a /work/nss/lib
 cp nspr/Linux*/pr/src/misc/prlog2.o /work/nss/lib
@@ -57,7 +57,7 @@ FUZZERS="asn1_algorithmid_fuzzer \
   asn1_utctime_fuzzer \
   asn1_utf8string_fuzzer"
 
-# The following fuzzers are currently disabled due to linking issues.
+# The following fuzzers are currently disabled due to linking issues:
 #  cert_certificate_fuzzer, seckey_privatekeyinfo_fuzzer
 
 

--- a/nss/build.sh
+++ b/nss/build.sh
@@ -39,6 +39,7 @@ cd ..
 mkdir -p /work/nss/lib
 #cp Linux*/lib/*.so /out
 cp dist/Linux*/lib/*.a /work/nss/lib
+cp nspr/Linux*/pr/src/misc/prlog2.o /work/nss/lib
 #cp Linux*/*.o /out
 #cp nss/lib/ssl/Linux*/*.o /work/nss/obj
 #cp nspr/Linux*/lib/ds/*.o /work/nss/obj
@@ -86,7 +87,7 @@ for fuzzer in $FUZZERS; do
      /work/libfuzzer/*.o \
      /work/nss/lib/libnss.a /work/nss/lib/libnssutil.a \
      /work/nss/lib/libnspr4.a /work/nss/lib/libplc4.a /work/nss/lib/libplds4.a \
-     -o /out/$fuzzer $LDFLAGS
+     /work/nss/lib/prlog2.o -o /out/$fuzzer $LDFLAGS
 done
 
 #     /work/nss/lib/*.a \

--- a/nss/build.sh
+++ b/nss/build.sh
@@ -28,25 +28,13 @@ mkdir -p /work/nss
 cp -u -r /src/nss/* /work/nss/
 cd /work/nss/nss
 make BUILD_OPT=1 USE_64=1 NSS_DISABLE_GTESTS=1 CC="$CC $CFLAGS" \
-  CXX="$CXX $CXXFLAGS" LD="$CC $CFLAGS" ZDEFS_FLAG= clean nss_build_all
-
+    CXX="$CXX $CXXFLAGS" LD="$CC $CFLAGS" ZDEFS_FLAG= clean nss_build_all
 cd ..
-# Copy libraries to /usr/lib.
-#cp Linux*/lib/*.so /usr/lib
-#cp Linux*/lib/{*.chk,libcrmf.a} /usr/lib
 
 # Copy libraries to /out since fuzzers don't work without them.
 mkdir -p /work/nss/lib
-#cp Linux*/lib/*.so /out
 cp dist/Linux*/lib/*.a /work/nss/lib
 cp nspr/Linux*/pr/src/misc/prlog2.o /work/nss/lib
-#cp Linux*/*.o /out
-#cp nss/lib/ssl/Linux*/*.o /work/nss/obj
-#cp nspr/Linux*/lib/ds/*.o /work/nss/obj
-#/lib/libc/src/
-#config/
-#/pr/src/md/
-#/pr/src/md/unix/
 
 # Copy includes to /work/nss/include.
 mkdir -p /work/nss/include
@@ -67,19 +55,11 @@ FUZZERS="asn1_algorithmid_fuzzer \
   asn1_objectid_fuzzer \
   asn1_octetstring_fuzzer \
   asn1_utctime_fuzzer \
-  asn1_utf8string_fuzzer \
-  cert_certificate_fuzzer \
-  seckey_privatekeyinfo_fuzzer"
+  asn1_utf8string_fuzzer"
 
+# The following fuzzers are currently disabled due to linking issues.
+#  cert_certificate_fuzzer, seckey_privatekeyinfo_fuzzer
 
-# Instead of:
-#     -lnss3 -lnssutil3 -lnspr4 -lplc4 -lplds4 \
-# I tried to use /out/*.a
-# log: https://gist.github.com/Dor1s/d9873b241480ccbb530d2ee2af8d7072
-#
-# and another version with exact names:
-#      /out/libnss.a /out/libnssutil.a /out/libnspr4.a /out/libplc4.a /out/libplds4.a
-# log: https://gist.github.com/Dor1s/fdd88b7092a85bcdd1a03bcd2382fe6b
 
 for fuzzer in $FUZZERS; do
   $CXX $CXXFLAGS -std=c++11 /src/oss-fuzz/nss/fuzzers/$fuzzer.cc \
@@ -89,11 +69,3 @@ for fuzzer in $FUZZERS; do
      /work/nss/lib/libnspr4.a /work/nss/lib/libplc4.a /work/nss/lib/libplds4.a \
      /work/nss/lib/prlog2.o -o /out/$fuzzer $LDFLAGS
 done
-
-#     /work/nss/lib/*.a \
-# To avoid "unbound variable" error.
-#if [[ ! -v LD_LIBRARY_PATH ]]; then
-#  export LD_LIBRARY_PATH=/work/nss/lib
-#else
-#  export LD_LIBRARY_PATH=/work/nss/lib:$LD_LIBRARY_PATH
-#fi

--- a/nss/build.sh
+++ b/nss/build.sh
@@ -1,0 +1,89 @@
+#!/bin/bash -eu
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd /src/nss
+
+# Check out the code using mercurial.
+rm -rf nspr
+rm -rf nss
+hg clone https://hg.mozilla.org/projects/nspr
+hg clone https://hg.mozilla.org/projects/nss
+
+# Build the library.
+mkdir -p /work/nss
+cp -u -r /src/nss/* /work/nss/
+cd /work/nss/nss
+make BUILD_OPT=1 USE_64=1 NSS_DISABLE_GTESTS=1 CC="$CC $CFLAGS" \
+  CXX="$CXX $CXXFLAGS" LD="$CC $CFLAGS" ZDEFS_FLAG= clean nss_build_all install
+
+
+# Copy libraries to /usr/lib.
+cd ../dist
+cp Linux*/lib/*.so /usr/lib
+cp Linux*/lib/{*.chk,libcrmf.a} /usr/lib
+
+# Copy libraries to /out since fuzzers don't work without them.
+cp Linux*/lib/*.so /out
+cp Linux*/lib/*.a /out
+
+# Copy includes to /work/nss/include.
+mkdir -p /work/nss/include
+cp -rL Linux*/include/* /work/nss/include
+cp -rL {public,private}/nss/* /work/nss/include
+cd ..
+
+# Build the fuzzers.
+FUZZERS="asn1_algorithmid_fuzzer \
+  asn1_any_fuzzer \
+  asn1_bitstring_fuzzer \
+  asn1_bmpstring_fuzzer \
+  asn1_boolean_fuzzer \
+  asn1_generalizedtime_fuzzer \
+  asn1_ia5string_fuzzer \
+  asn1_integer_fuzzer \
+  asn1_null_fuzzer \
+  asn1_objectid_fuzzer \
+  asn1_octetstring_fuzzer \
+  asn1_utctime_fuzzer \
+  asn1_utf8string_fuzzer \
+  cert_certificate_fuzzer \
+  seckey_privatekeyinfo_fuzzer"
+
+
+# Instead of:
+#     -lnss3 -lnssutil3 -lnspr4 -lplc4 -lplds4 \
+# I tried to use /out/*.a
+# log: https://gist.github.com/Dor1s/d9873b241480ccbb530d2ee2af8d7072
+#
+# and another version with exact names:
+#      /out/libnss.a /out/libnssutil.a /out/libnspr4.a /out/libplc4.a /out/libplds4.a
+# log: https://gist.github.com/Dor1s/fdd88b7092a85bcdd1a03bcd2382fe6b
+
+for fuzzer in $FUZZERS; do
+  $CXX $CXXFLAGS -std=c++11 /src/oss-fuzz/nss/fuzzers/$fuzzer.cc \
+     -I/work/nss/include \
+     /work/libfuzzer/*.o \
+     /out/libnss.a /out/libnssutil.a /out/libnspr4.a /out/libplc4.a /out/libplds4.a \
+     -o /out/$fuzzer
+done
+
+# To avoid "unbound variable" error.
+#if [[ ! -v LD_LIBRARY_PATH ]]; then
+#  export LD_LIBRARY_PATH=/work/nss/lib
+#else
+#  export LD_LIBRARY_PATH=/work/nss/lib:$LD_LIBRARY_PATH
+#fi

--- a/nss/build.sh
+++ b/nss/build.sh
@@ -77,8 +77,8 @@ for fuzzer in $FUZZERS; do
   $CXX $CXXFLAGS -std=c++11 /src/oss-fuzz/nss/fuzzers/$fuzzer.cc \
      -I/work/nss/include \
      /work/libfuzzer/*.o \
-     /out/libnss.a /out/libnssutil.a /out/libnspr4.a /out/libplc4.a /out/libplds4.a \
-     -o /out/$fuzzer
+     /out/*.a \
+     -o /out/$fuzzer $LDFLAGS
 done
 
 # To avoid "unbound variable" error.

--- a/nss/fuzzers/asn1_algorithmid_fuzzer.cc
+++ b/nss/fuzzers/asn1_algorithmid_fuzzer.cc
@@ -1,0 +1,19 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <secoid.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "asn1_fuzzer_template.h"
+
+// Entry point for LibFuzzer.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  NSSFuzzOneInput<SECAlgorithmID, SEC_QuickDERDecodeItem>(
+      SEC_ASN1_GET(SECOID_AlgorithmIDTemplate), data, size);
+  NSSFuzzOneInput<SECAlgorithmID, SEC_ASN1DecodeItem>(
+      SEC_ASN1_GET(SECOID_AlgorithmIDTemplate), data, size);
+
+  return 0;
+}

--- a/nss/fuzzers/asn1_any_fuzzer.cc
+++ b/nss/fuzzers/asn1_any_fuzzer.cc
@@ -1,0 +1,18 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "asn1_fuzzer_template.h"
+
+// Entry point for LibFuzzer.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  NSSFuzzOneInput<SECItem, SEC_QuickDERDecodeItem>(
+      SEC_ASN1_GET(SEC_AnyTemplate), data, size);
+  NSSFuzzOneInput<SECItem, SEC_ASN1DecodeItem>(
+      SEC_ASN1_GET(SEC_AnyTemplate), data, size);
+
+  return 0;
+}

--- a/nss/fuzzers/asn1_bitstring_fuzzer.cc
+++ b/nss/fuzzers/asn1_bitstring_fuzzer.cc
@@ -1,0 +1,18 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "asn1_fuzzer_template.h"
+
+// Entry point for LibFuzzer.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  NSSFuzzOneInput<SECItem, SEC_QuickDERDecodeItem>(
+      SEC_ASN1_GET(SEC_BitStringTemplate), data, size);
+  NSSFuzzOneInput<SECItem, SEC_ASN1DecodeItem>(
+      SEC_ASN1_GET(SEC_BitStringTemplate), data, size);
+
+  return 0;
+}

--- a/nss/fuzzers/asn1_bmpstring_fuzzer.cc
+++ b/nss/fuzzers/asn1_bmpstring_fuzzer.cc
@@ -1,0 +1,18 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "asn1_fuzzer_template.h"
+
+// Entry point for LibFuzzer.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  NSSFuzzOneInput<SECItem, SEC_QuickDERDecodeItem>(
+      SEC_ASN1_GET(SEC_BMPStringTemplate), data, size);
+  NSSFuzzOneInput<SECItem, SEC_ASN1DecodeItem>(
+      SEC_ASN1_GET(SEC_BMPStringTemplate), data, size);
+
+  return 0;
+}

--- a/nss/fuzzers/asn1_boolean_fuzzer.cc
+++ b/nss/fuzzers/asn1_boolean_fuzzer.cc
@@ -1,0 +1,18 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "asn1_fuzzer_template.h"
+
+// Entry point for LibFuzzer.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  NSSFuzzOneInput<SECItem, SEC_QuickDERDecodeItem>(
+      SEC_ASN1_GET(SEC_BooleanTemplate), data, size);
+  NSSFuzzOneInput<SECItem, SEC_ASN1DecodeItem>(
+      SEC_ASN1_GET(SEC_BooleanTemplate), data, size);
+
+  return 0;
+}

--- a/nss/fuzzers/asn1_fuzzer_template.h
+++ b/nss/fuzzers/asn1_fuzzer_template.h
@@ -1,0 +1,45 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ASN1_FUZZER_TEMPLATE_H_
+#define ASN1_FUZZER_TEMPLATE_H_
+
+#include <nspr.h>
+#include <nss.h>
+#include <secasn1.h>
+#include <secder.h>
+#include <secitem.h>
+#include <secport.h>
+#include <stddef.h>
+#include <stdint.h>
+
+template <typename DestinationType,
+          SECStatus (*DecodeFunction)(PLArenaPool*,
+                                      void*,
+                                      const SEC_ASN1Template*,
+                                      const SECItem*)>
+void NSSFuzzOneInput(const SEC_ASN1Template* the_template,
+                     const uint8_t* data,
+                     size_t size) {
+  DestinationType* destination = new DestinationType();
+  memset(destination, 0, sizeof(DestinationType));
+
+  PLArenaPool* arena = PORT_NewArena(DER_DEFAULT_CHUNKSIZE);
+  if (!arena) {
+    delete destination;
+    return;
+  }
+
+  SECItem source;
+  source.type = siBuffer;
+  source.data = static_cast<unsigned char*>(const_cast<uint8_t*>(data));
+  source.len = static_cast<unsigned int>(size);
+
+  DecodeFunction(arena, destination, the_template, &source);
+
+  PORT_FreeArena(arena, PR_FALSE);
+  delete destination;
+}
+
+#endif  // ASN1_FUZZER_TEMPLATE_H_

--- a/nss/fuzzers/asn1_generalizedtime_fuzzer.cc
+++ b/nss/fuzzers/asn1_generalizedtime_fuzzer.cc
@@ -1,0 +1,18 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "asn1_fuzzer_template.h"
+
+// Entry point for LibFuzzer.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  NSSFuzzOneInput<SECItem, SEC_QuickDERDecodeItem>(
+      SEC_ASN1_GET(SEC_GeneralizedTimeTemplate), data, size);
+  NSSFuzzOneInput<SECItem, SEC_ASN1DecodeItem>(
+      SEC_ASN1_GET(SEC_GeneralizedTimeTemplate), data, size);
+
+  return 0;
+}

--- a/nss/fuzzers/asn1_ia5string_fuzzer.cc
+++ b/nss/fuzzers/asn1_ia5string_fuzzer.cc
@@ -1,0 +1,18 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "asn1_fuzzer_template.h"
+
+// Entry point for LibFuzzer.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  NSSFuzzOneInput<SECItem, SEC_QuickDERDecodeItem>(
+      SEC_ASN1_GET(SEC_IA5StringTemplate), data, size);
+  NSSFuzzOneInput<SECItem, SEC_ASN1DecodeItem>(
+      SEC_ASN1_GET(SEC_IA5StringTemplate), data, size);
+
+  return 0;
+}

--- a/nss/fuzzers/asn1_integer_fuzzer.cc
+++ b/nss/fuzzers/asn1_integer_fuzzer.cc
@@ -1,0 +1,18 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "asn1_fuzzer_template.h"
+
+// Entry point for LibFuzzer.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  NSSFuzzOneInput<SECItem, SEC_QuickDERDecodeItem>(
+      SEC_ASN1_GET(SEC_IntegerTemplate), data, size);
+  NSSFuzzOneInput<SECItem, SEC_ASN1DecodeItem>(
+      SEC_ASN1_GET(SEC_IntegerTemplate), data, size);
+
+  return 0;
+}

--- a/nss/fuzzers/asn1_null_fuzzer.cc
+++ b/nss/fuzzers/asn1_null_fuzzer.cc
@@ -1,0 +1,18 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "asn1_fuzzer_template.h"
+
+// Entry point for LibFuzzer.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  NSSFuzzOneInput<SECItem, SEC_QuickDERDecodeItem>(
+      SEC_ASN1_GET(SEC_NullTemplate), data, size);
+  NSSFuzzOneInput<SECItem, SEC_ASN1DecodeItem>(
+      SEC_ASN1_GET(SEC_NullTemplate), data, size);
+
+  return 0;
+}

--- a/nss/fuzzers/asn1_objectid_fuzzer.cc
+++ b/nss/fuzzers/asn1_objectid_fuzzer.cc
@@ -1,0 +1,18 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "asn1_fuzzer_template.h"
+
+// Entry point for LibFuzzer.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  NSSFuzzOneInput<SECItem, SEC_QuickDERDecodeItem>(
+      SEC_ASN1_GET(SEC_ObjectIDTemplate), data, size);
+  NSSFuzzOneInput<SECItem, SEC_ASN1DecodeItem>(
+      SEC_ASN1_GET(SEC_ObjectIDTemplate), data, size);
+
+  return 0;
+}

--- a/nss/fuzzers/asn1_octetstring_fuzzer.cc
+++ b/nss/fuzzers/asn1_octetstring_fuzzer.cc
@@ -1,0 +1,18 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "asn1_fuzzer_template.h"
+
+// Entry point for LibFuzzer.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  NSSFuzzOneInput<SECItem, SEC_QuickDERDecodeItem>(
+      SEC_ASN1_GET(SEC_OctetStringTemplate), data, size);
+  NSSFuzzOneInput<SECItem, SEC_ASN1DecodeItem>(
+      SEC_ASN1_GET(SEC_OctetStringTemplate), data, size);
+
+  return 0;
+}

--- a/nss/fuzzers/asn1_utctime_fuzzer.cc
+++ b/nss/fuzzers/asn1_utctime_fuzzer.cc
@@ -1,0 +1,18 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "asn1_fuzzer_template.h"
+
+// Entry point for LibFuzzer.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  NSSFuzzOneInput<SECItem, SEC_QuickDERDecodeItem>(
+      SEC_ASN1_GET(SEC_UTCTimeTemplate), data, size);
+  NSSFuzzOneInput<SECItem, SEC_ASN1DecodeItem>(
+      SEC_ASN1_GET(SEC_UTCTimeTemplate), data, size);
+
+  return 0;
+}

--- a/nss/fuzzers/asn1_utf8string_fuzzer.cc
+++ b/nss/fuzzers/asn1_utf8string_fuzzer.cc
@@ -1,0 +1,18 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "asn1_fuzzer_template.h"
+
+// Entry point for LibFuzzer.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  NSSFuzzOneInput<SECItem, SEC_QuickDERDecodeItem>(
+      SEC_ASN1_GET(SEC_UTF8StringTemplate), data, size);
+  NSSFuzzOneInput<SECItem, SEC_ASN1DecodeItem>(
+      SEC_ASN1_GET(SEC_UTF8StringTemplate), data, size);
+
+  return 0;
+}

--- a/nss/fuzzers/cert_certificate_fuzzer.cc
+++ b/nss/fuzzers/cert_certificate_fuzzer.cc
@@ -1,0 +1,19 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <cert.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "asn1_fuzzer_template.h"
+
+// Entry point for LibFuzzer.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  NSSFuzzOneInput<CERTCertificate, SEC_QuickDERDecodeItem>(
+      SEC_ASN1_GET(CERT_CertificateTemplate), data, size);
+  NSSFuzzOneInput<CERTCertificate, SEC_ASN1DecodeItem>(
+      SEC_ASN1_GET(CERT_CertificateTemplate), data, size);
+
+  return 0;
+}

--- a/nss/fuzzers/seckey_privatekeyinfo_fuzzer.cc
+++ b/nss/fuzzers/seckey_privatekeyinfo_fuzzer.cc
@@ -1,0 +1,19 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <secmod.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "asn1_fuzzer_template.h"
+
+// Entry point for LibFuzzer.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  NSSFuzzOneInput<SECKEYPrivateKeyInfo, SEC_QuickDERDecodeItem>(
+      SEC_ASN1_GET(SECKEY_PrivateKeyInfoTemplate), data, size);
+  NSSFuzzOneInput<SECKEYPrivateKeyInfo, SEC_ASN1DecodeItem>(
+      SEC_ASN1_GET(SECKEY_PrivateKeyInfoTemplate), data, size);
+
+  return 0;
+}


### PR DESCRIPTION
My attempts to statically link nss libraries into fuzzers. Link to logs:

Instead of:
    -lnss3 -lnssutil3 -lnspr4 -lplc4 -lplds4 \
I tried to use /out/*.a
log: https://gist.github.com/Dor1s/d9873b241480ccbb530d2ee2af8d7072


and another version with exact names:
     /out/libnss.a /out/libnssutil.a /out/libnspr4.a /out/libplc4.a /out/libplds4.a
log: https://gist.github.com/Dor1s/fdd88b7092a85bcdd1a03bcd2382fe6b