### PR TITLE
[infra] reproduce command

### DIFF
--- a/infra/base-images/base-libfuzzer/README.md
+++ b/infra/base-images/base-libfuzzer/README.md
@@ -1,15 +1,17 @@
 # base-libfuzzer
 > Abstract base image for libfuzzer builders.
 
+`docker run -ti <image_name> <command> <arguments>`
+
 Supported commands:
 
-* `docker run -ti <image_name> [compile]` - builds fuzzers.
-* `docker run -ti <image_name> run <fuzzer_name> <fuzzer_options...>` - build fuzzers and start
-  specified one with given options.
-* `docker run -ti <image_name> test` - builds fuzzers and runs each
-  for a little while to verify it is working correctly.
-* `docker run -ti <image_name> /bin/bash` - drop into shell. Run `compile` script
-  to start build.
+| Command | Description |
+|---------|-------------|
+| `compile` (default) | build all fuzzers
+| `reproduce <fuzzer_name> <base64_testcase>` | build all fuzzers and run specified one with a given base64-encoded input
+| `run <fuzzer_name> <fuzzer_options...>` | build all fuzzers and run specified one with given options.
+| `test` | build all fuzzers and run each one for a little while to verify it is working correctly.
+| `/bin/bash` | drop into shell, execute `compile` script to start build.
 
 # Image Files Layout
 

--- a/infra/base-images/base-libfuzzer/README.md
+++ b/infra/base-images/base-libfuzzer/README.md
@@ -8,7 +8,7 @@ Supported commands:
 | Command | Description |
 |---------|-------------|
 | `compile` (default) | build all fuzzers
-| `reproduce <fuzzer_name> <base64_testcase>` | build all fuzzers and run specified one with a given base64-encoded input
+| `reproduce <fuzzer_name> <fuzzer_options>` | build all fuzzers and run specified one with `/testcase` content.
 | `run <fuzzer_name> <fuzzer_options...>` | build all fuzzers and run specified one with given options.
 | `test` | build all fuzzers and run each one for a little while to verify it is working correctly.
 | `/bin/bash` | drop into shell, execute `compile` script to start build.

--- a/infra/base-images/base-libfuzzer/reproduce
+++ b/infra/base-images/base-libfuzzer/reproduce
@@ -29,9 +29,5 @@ compile
 export PATH=/out:$PATH
 cd /out
 
-TEST_CORPUS=$(tempfile)
-rm -rf $TEST_CORPUS
-mkdir $TEST_CORPUS
-cp $TESTCASE $TEST_CORPUS/
-$FUZZER $@ -runs=0 $TEST_CORPUS
+$FUZZER $@ -runs=0 $TESTCASE
 

--- a/infra/base-images/base-libfuzzer/reproduce
+++ b/infra/base-images/base-libfuzzer/reproduce
@@ -19,12 +19,12 @@ compile
 export PATH=/out:$PATH
 cd /out
 FUZZER=$1
-TEST_INPUT=$2
-shift 2
+shift
+TEST_INPUT=$(cat -)
 
 TEST_CORPUS=$(tempfile)
-rm -rf TEST_CORPUS
-mkdir TEST_CORPUS
-echo $TEST_INPUT | base64 -w 0 > $TEST_CORPUS/input
-$FUZZER $@ $TEST_CORPUS
+rm -rf $TEST_CORPUS
+mkdir $TEST_CORPUS
+echo $TEST_INPUT | $TEST_CORPUS/input
+$FUZZER $@ -runs=0 $TEST_CORPUS
 

--- a/infra/base-images/base-libfuzzer/reproduce
+++ b/infra/base-images/base-libfuzzer/reproduce
@@ -1,3 +1,4 @@
+#!/bin/bash -eux
 # Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,21 +15,16 @@
 #
 ################################################################################
 
-FROM ossfuzz/base-clang
-MAINTAINER mike.aizatsky@gmail.com
-RUN apt-get install -y libc6-dev libtool git subversion jq
+compile
+export PATH=/out:$PATH
+cd /out
+FUZZER=$1
+TEST_INPUT=$2
+shift 2
 
-ENV SANITIZER_FLAGS="-fsanitize=address"
-ENV COV_FLAGS="-fsanitize-coverage=edge,indirect-calls,8bit-counters"
-
-ENV ASAN_OPTIONS="symbolize=1:detect_leaks=0"
-ENV FUZZER_LDFLAGS "-Wl,-whole-archive /usr/local/lib/libc++.a /usr/local/lib/libc++abi.a -Wl,-no-whole-archive"
-
-RUN mkdir /out && chmod a+w /out
-
-RUN mkdir /src/bin
-COPY compile srcmap reproduce run test /src/bin/
-ENV PATH=/src/bin:$PATH
-WORKDIR /src
-CMD ["compile"]
+TEST_CORPUS=$(tempfile)
+rm -rf TEST_CORPUS
+mkdir TEST_CORPUS
+echo $TEST_INPUT | base64 -w 0 > $TEST_CORPUS/input
+$FUZZER $@ $TEST_CORPUS
 

--- a/infra/base-images/base-libfuzzer/reproduce
+++ b/infra/base-images/base-libfuzzer/reproduce
@@ -20,7 +20,7 @@ shift
 TESTCASE="/testcase"
 
 if [ ! -f $TESTCASE ]; then
-  eho "Error: $TESTCASE not found, use: docker run -v <path>:$TESTCASE ..."
+  echo "Error: $TESTCASE not found, use: docker run -v <path>:$TESTCASE ..."
   exit 1
 fi
 

--- a/infra/base-images/base-libfuzzer/reproduce
+++ b/infra/base-images/base-libfuzzer/reproduce
@@ -15,16 +15,23 @@
 #
 ################################################################################
 
+FUZZER=$1
+shift
+TESTCASE="/testcase"
+
+if [ ! -f $TESTCASE ]; then
+  eho "Error: $TESTCASE not found, use: docker run -v <path>:$TESTCASE ..."
+  exit 1
+fi
+
+
 compile
 export PATH=/out:$PATH
 cd /out
-FUZZER=$1
-shift
-TEST_INPUT=$(cat -)
 
 TEST_CORPUS=$(tempfile)
 rm -rf $TEST_CORPUS
 mkdir $TEST_CORPUS
-echo $TEST_INPUT | $TEST_CORPUS/input
+cp $TESTCASE $TEST_CORPUS/
 $FUZZER $@ -runs=0 $TEST_CORPUS
 

--- a/infra/base-images/base-libfuzzer/reproduce
+++ b/infra/base-images/base-libfuzzer/reproduce
@@ -29,5 +29,5 @@ compile
 export PATH=/out:$PATH
 cd /out
 
-$FUZZER $@ -runs=0 $TESTCASE
+$FUZZER $@ $TESTCASE
 


### PR DESCRIPTION
This is an experimental version of reproduce command. I was thinking that CF could show display it on testcase page. Do you like it? Maybe we should use something else rather then base64? Maybe gzip it first?

(real) command line example:

```bash
docker run -ti ossfuzz/libxml2 reproduce libxml2_xml_read_memory_fuzzer PHhtbC8+Cg==
```