### PR TITLE
[infra] .options support for run command

### DIFF
--- a/infra/base-images/base-libfuzzer/Dockerfile
+++ b/infra/base-images/base-libfuzzer/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM ossfuzz/base-clang
 MAINTAINER mike.aizatsky@gmail.com
-RUN apt-get install -y libc6-dev libtool git subversion jq zip
+RUN apt-get install -y libc6-dev libtool git subversion jq zip python3
 
 ENV SANITIZER_FLAGS="-fsanitize=address"
 ENV COV_FLAGS="-fsanitize-coverage=edge,indirect-calls,8bit-counters"
@@ -27,7 +27,7 @@ ENV FUZZER_LDFLAGS "-Wl,-whole-archive /usr/local/lib/libc++.a /usr/local/lib/li
 RUN mkdir /out && chmod a+w /out
 
 RUN mkdir /src/bin
-COPY compile srcmap reproduce run test /src/bin/
+COPY compile srcmap reproduce run just_run test /src/bin/
 ENV PATH=/src/bin:$PATH
 WORKDIR /src
 CMD ["compile"]

--- a/infra/base-images/base-libfuzzer/Dockerfile
+++ b/infra/base-images/base-libfuzzer/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM ossfuzz/base-clang
 MAINTAINER mike.aizatsky@gmail.com
-RUN apt-get install -y libc6-dev libtool git subversion jq zip python3
+RUN apt-get install -y libc6-dev libtool git subversion jq zip
 
 ENV SANITIZER_FLAGS="-fsanitize=address"
 ENV COV_FLAGS="-fsanitize-coverage=edge,indirect-calls,8bit-counters"

--- a/infra/base-images/base-libfuzzer/just_run
+++ b/infra/base-images/base-libfuzzer/just_run
@@ -1,4 +1,4 @@
-#!/bin/bash -eux
+#!/usr/bin/env python3
 # Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,26 @@
 #
 ################################################################################
 
-compile
-cd /out
-export PATH="/out:$PATH"
-just_run $@
+# Fuzzer runner.
+
+import configparser
+import os
+import subprocess
+import sys
+
+run_args = sys.argv[1:]
+
+# Use .options file if any.
+fuzzer_name = run_args[0]
+options_file = fuzzer_name + ".options"
+if os.path.isfile(options_file):
+  config = configparser.ConfigParser()
+  config.read(options_file)
+  for (key, value) in config["libfuzzer"].items():
+    run_args.append("-{0}={1}".format(key, value))
+
+# Run
+print("$", " ".join(run_args))
+run_process = subprocess.Popen(run_args)
+run_process.wait()
+assert run_process.returncode == 0

--- a/infra/base-images/base-libfuzzer/just_run
+++ b/infra/base-images/base-libfuzzer/just_run
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/bin/bash -eu
 # Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,24 +17,15 @@
 
 # Fuzzer runner.
 
-import configparser
-import os
-import subprocess
-import sys
+FUZZER=$1
+shift
+CMD_LINE="$FUZZER $@"
 
-run_args = sys.argv[1:]
+OPTIONS_FILE="${FUZZER}.options"
+if [ -f $OPTIONS_FILE ]; then
+  OPTIONS_ARGS=$(grep "=" $OPTIONS_FILE | sed 's/\(\w*\)\W*=\W*\(.*\)/-\1=\2 /g' | tr '\n' ' ')
+  CMD_LINE="$CMD_LINE $OPTIONS_ARGS"
+fi
 
-# Use .options file if any.
-fuzzer_name = run_args[0]
-options_file = fuzzer_name + ".options"
-if os.path.isfile(options_file):
-  config = configparser.ConfigParser()
-  config.read(options_file)
-  for (key, value) in config["libfuzzer"].items():
-    run_args.append("-{0}={1}".format(key, value))
-
-# Run
-print("$", " ".join(run_args))
-run_process = subprocess.Popen(run_args)
-run_process.wait()
-assert run_process.returncode == 0
+echo $CMD_LINE
+bash -c "$CMD_LINE"

--- a/targets/expat/parse_fuzzer.options
+++ b/targets/expat/parse_fuzzer.options
@@ -1,2 +1,3 @@
 [libfuzzer]
 dict = xml.dict
+max_len = 1024


### PR DESCRIPTION
Initial work for #19.

I'm not happy that I pull `python3` package in. I'd like to add this functionality to libfuzzer-runner, but I am not sure I'd like to add python dependency to that image as well. Ideas are appreciated.