### PR TITLE
Add fuzzers for lcms. Fixes #43

### DIFF
--- a/targets/README.md
+++ b/targets/README.md
@@ -14,6 +14,7 @@ Targets integrated with oss-fuzz.
 | [libarchive](https://github.com/libarchive/libarchive) | [/targets/libarchive](libarchive) |
 | [libass](https://github.com/libass/libass) | [/targets/libass](libass) |
 | [libchewing](http://chewing.im/) | [/targets/libchewing](libchewing) |
+| [lcms](https://github.com/mm2/Little-CMS) | [/targets/lcms](lcms) |
 | [libpng](http://www.libpng.org/pub/png/libpng.html) | [/targets/libpng](libpng) |
 | [libteken](http://80386.nl/projects/libteken/) | [/targets/libteken](libteken) |
 | [libtsm](https://www.freedesktop.org/wiki/Software/kmscon/libtsm/) | [/targets/libtsm](libtsm) |

--- a/targets/lcms/Dockerfile
+++ b/targets/lcms/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM ossfuzz/base-libfuzzer
+MAINTAINER kcwu@google.com
+RUN apt-get install -y make autoconf automake libtool
+RUN git clone https://github.com/mm2/Little-CMS.git lcms
+COPY build.sh cmsIT8_load_fuzzer.c cms_transform_fuzzer.c /src/

--- a/targets/lcms/Jenkinsfile
+++ b/targets/lcms/Jenkinsfile
@@ -1,0 +1,22 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+def libfuzzerBuild = fileLoader.fromGit('infra/libfuzzer-pipeline.groovy',
+                                        'https://github.com/google/oss-fuzz.git')
+
+libfuzzerBuild {
+  git = "https://github.com/mm2/Little-CMS.git"
+}

--- a/targets/lcms/build.sh
+++ b/targets/lcms/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -eu
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd /src/lcms
+
+# build the target.
+./configure
+make -j$(nproc) all
+
+# build your fuzzer(s)
+FUZZERS="cmsIT8_load_fuzzer cms_transform_fuzzer"
+for F in $FUZZERS; do
+    $CC $CFLAGS -Iinclude \
+        /src/$F.c -o /out/$F \
+        -lfuzzer src/.libs/liblcms2.a $FUZZER_LDFLAGS
+done

--- a/targets/lcms/cmsIT8_load_fuzzer.c
+++ b/targets/lcms/cmsIT8_load_fuzzer.c
@@ -1,0 +1,31 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include <stdint.h>
+
+#include "lcms2.h"
+
+// The main sink
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  if (size == 0)
+    return 0;
+
+  cmsHANDLE handle = cmsIT8LoadFromMem(0, (void *)data, size);
+  if (handle)
+    cmsIT8Free(handle);
+
+  return 0;
+}

--- a/targets/lcms/cms_transform_fuzzer.c
+++ b/targets/lcms/cms_transform_fuzzer.c
@@ -1,0 +1,50 @@
+// Copyright 2016 The PDFium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+#include <stdint.h>
+
+#include "lcms2.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  cmsHPROFILE srcProfile = cmsOpenProfileFromMem(data, size);
+  if (!srcProfile) return 0;
+
+  cmsHPROFILE dstProfile = cmsCreate_sRGBProfile();
+  if (!dstProfile) {
+    cmsCloseProfile(srcProfile);
+    return 0;
+  }
+
+  cmsColorSpaceSignature srcCS = cmsGetColorSpace(srcProfile);
+  cmsUInt32Number nSrcComponents = cmsChannelsOf(srcCS);
+  cmsUInt32Number srcFormat;
+  if (srcCS == cmsSigLabData) {
+    srcFormat =
+        COLORSPACE_SH(PT_Lab) | CHANNELS_SH(nSrcComponents) | BYTES_SH(0);
+  } else {
+    srcFormat =
+        COLORSPACE_SH(PT_ANY) | CHANNELS_SH(nSrcComponents) | BYTES_SH(1);
+  }
+
+  cmsUInt32Number intent = 0;
+  cmsUInt32Number flags = 0;
+  cmsHTRANSFORM hTransform = cmsCreateTransform(
+      srcProfile, srcFormat, dstProfile, TYPE_BGR_8, intent, flags);
+  cmsCloseProfile(srcProfile);
+  cmsCloseProfile(dstProfile);
+  if (!hTransform) return 0;
+
+  uint8_t output[4];
+  if (T_BYTES(srcFormat) == 0) {  // 0 means double
+    double input[nSrcComponents];
+    for (uint32_t i = 0; i < nSrcComponents; i++) input[i] = 0.5f;
+    cmsDoTransform(hTransform, input, output, 1);
+  } else {
+    uint8_t input[nSrcComponents];
+    for (uint32_t i = 0; i < nSrcComponents; i++) input[i] = 128;
+    cmsDoTransform(hTransform, input, output, 1);
+  }
+  cmsDeleteTransform(hTransform);
+
+  return 0;
+}


### PR DESCRIPTION
cmsIT8_load_fuzzer and cms_open_profile_fuzzer are ported from
https://github.com/google/libfuzzer-bot/tree/master/dockerfiles/lcms2

cms_transform_fuzzer is simplified from pdfium's usage
https://pdfium.googlesource.com/pdfium/+/master/testing/libfuzzer/pdf_codec_icc_fuzzer.cc