### PR TITLE
Add fuzzer for rapidjson.

### DIFF
--- a/targets/rapidjson/Dockerfile
+++ b/targets/rapidjson/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM ossfuzz/base-libfuzzer
+MAINTAINER aarongreen@google.com
+RUN git clone https://github.com/miloyip/rapidjson.git
+RUN git clone https://github.com/json-schema-org/JSON-Schema-Test-Suite.git
+COPY build.sh /src/
+COPY parse_fuzzer.cc /src/rapidjson

--- a/targets/rapidjson/Jenkinsfile
+++ b/targets/rapidjson/Jenkinsfile
@@ -1,0 +1,22 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+def libfuzzerBuild = fileLoader.fromGit('infra/libfuzzer-pipeline.groovy',
+                                        'https://github.com/google/oss-fuzz.git')
+
+libfuzzerBuild {
+  git = "https://github.com/miloyip/rapidjson.git"
+}

--- a/targets/rapidjson/build.sh
+++ b/targets/rapidjson/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+NAME=parse_fuzzer
+
+zip -j /out/${NAME}_seed_corpus.zip $(find /src/JSON-Schema-Test-Suite/tests/draft4 -name '*.json')
+
+cd /src/rapidjson
+$CXX $CXXFLAGS -std=c++11 -Iinclude ${NAME}.cc -o /out/${NAME} -lfuzzer $FUZZER_LDFLAGS

--- a/targets/rapidjson/parse_fuzzer.cc
+++ b/targets/rapidjson/parse_fuzzer.cc
@@ -1,0 +1,27 @@
+// Based on rapidjson/example/simpledom/simpledom.cpp`
+#include <iostream>
+#include "rapidjson/document.h"
+#include "rapidjson/memorystream.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
+
+using namespace rapidjson;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
+  const char* s = reinterpret_cast<const char*>(Data);
+  MemoryStream ms(s, Size);
+
+  //  Parse a JSON string into DOM.
+  Document d;
+  d.ParseStream(ms);
+  if (d.HasParseError()) {
+    return 0;
+  }
+
+  //  Stringify the DOM
+  StringBuffer buffer;
+  Writer<StringBuffer> writer(buffer);
+  d.Accept(writer);
+  buffer.GetString();
+  return 0;
+}


### PR DESCRIPTION
The fuzzer is based on the rapidjson example described here:
  https://github.com/miloyip/rapidjson#usage-at-a-glance

It is seeded with an open source JSON corpus from here:
  https://github.com/json-schema-org/JSON-Schema-Test-Suite.git