### PR TITLE
 Add fuzzer for linenoise.

### DIFF
--- a/targets/linenoise/Dockerfile
+++ b/targets/linenoise/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM ossfuzz/base-libfuzzer
+MAINTAINER aarongreen@google.com
+RUN apt-get install -y make
+RUN git clone https://github.com/antirez/linenoise.git
+COPY build.sh input.cc /src/
+COPY Makefile wrapper.c /src/linenoise/

--- a/targets/linenoise/Jenkinsfile
+++ b/targets/linenoise/Jenkinsfile
@@ -1,0 +1,22 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+def libfuzzerBuild = fileLoader.fromGit('infra/libfuzzer-pipeline.groovy',
+                                        'https://github.com/google/oss-fuzz.git')
+
+libfuzzerBuild {
+  git = "https://github.com/antirez/linenoise.git"
+}

--- a/targets/linenoise/Makefile
+++ b/targets/linenoise/Makefile
@@ -1,0 +1,16 @@
+PROJ=$(notdir $(shell pwd))
+
+CFLAGS:=-Wall -Werror -ggdb
+
+.PHONY: all
+all: lib$(PROJ).a
+
+.PHONY: clean
+clean:
+	rm -f *.a *.o
+
+lib$(PROJ).a : wrapper.o
+	ar rcs $@ $^
+
+%.o : %.c %.h
+	$(CC) $(CFLAGS) -c -o $@ $<

--- a/targets/linenoise/build.sh
+++ b/targets/linenoise/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# build the target.
+CFLAGS="${CFLAGS} -Wall -Werror -Os -std=c11"
+make -C /src/linenoise clean all
+
+# build the fuzzer.
+$CXX $CXXFLAGS -I/src/linenoise input.cc -o /out/input -lfuzzer /src/linenoise/liblinenoise.a $FUZZER_LDFLAGS

--- a/targets/linenoise/input.cc
+++ b/targets/linenoise/input.cc
@@ -1,0 +1,40 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <assert.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+
+// We need to get directly at linenoiseEdit to bypass the TTY check
+#include <linenoise.h>
+
+#define LINENOISE_MAX_LINE 4096
+
+extern "C" void linenoiseWrapper(char* buf, size_t buflen);
+
+// Entry point for LibFuzzer.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  int p[2];
+  close(STDOUT_FILENO);
+  int dev_null = open("/dev/null", O_WRONLY);
+  close(STDIN_FILENO);
+  pipe2(p, O_NONBLOCK);
+  linenoiseSetMultiLine(1);
+  linenoiseHistorySetMaxLen(256);
+  char buf[LINENOISE_MAX_LINE];
+  ssize_t written = 0;
+  while (size > 0) {
+    do {
+      written = write(p[1], data, 1);
+      if (written > 0) {
+        data += written;
+        size -= written;
+      }
+    } while (size > 0 && written >= 0);
+    linenoiseWrapper(buf, LINENOISE_MAX_LINE);
+  }
+  return 0;
+}

--- a/targets/linenoise/wrapper.c
+++ b/targets/linenoise/wrapper.c
@@ -1,0 +1,5 @@
+#include "linenoise.c"
+
+void linenoiseWrapper(char* buf, size_t buflen) {
+  linenoiseEdit(STDIN_FILENO, STDOUT_FILENO, buf, buflen, "");
+}


### PR DESCRIPTION
 The fuzzer adds a wrapper that exposes an internal API for testing.
 This is needed to invoke the TTY code without going through an actual
 TTY.