### PR TITLE
[infra] use $src and $out in build scripts instead of /src and /out

### DIFF
--- a/docs/new_target.md
+++ b/docs/new_target.md
@@ -45,7 +45,7 @@ MAINTAINER YOUR_EMAIL                     # each file should have a maintainer
 RUN apt-get install -y ...                # install required packages to build a project
 RUN git checkout <git_url> <checkout_dir> # checkout all sources needed to build your target
 WORKDIR <checkout_dir>                    # current directory for build script
-COPY build.sh fuzzer.cc /src/             # install build script and other source files.
+COPY build.sh fuzzer.cc $SRC/             # install build script and other source files.
 ```
 Expat example: [expat/Dockerfile](../targets/expat/Dockerfile)
 
@@ -66,7 +66,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
 Make sure you add the file to your Docker image:
 ```docker
-COPY build.sh my_fuzzer.cc /src/         # install build script & fuzzer.
+COPY build.sh my_fuzzer.cc $SRC/         # install build script & fuzzer.
 ```
 
 There are [lots](../targets/libxml2/libxml2_xml_read_memory_fuzzer.cc)
@@ -104,7 +104,7 @@ make -j$(nproc) clean all
 
 # build the fuzzer, linking with libFuzzer and libexpat.a
 $CXX $CXXFLAGS -std=c++11 -Ilib/ \
-    /src/parse_fuzzer.cc -o /out/expat_parse_fuzzer \
+    $SRC/parse_fuzzer.cc -o /out/expat_parse_fuzzer \
     -lfuzzer .libs/libexpat.a \
     $FUZZER_LDFLAGS
 ```
@@ -115,7 +115,7 @@ When build.sh script is executed, the following locations are available within t
 
 | Path                   | Description
 | ------                 | -----
-| `/src/<some_dir>`      | Source code needed to build your target.
+| `$SRC/<some_dir>`      | Source code needed to build your target.
 | `/usr/lib/libfuzzer.a` | Prebuilt libFuzzer library that need to be linked into all fuzzers (`-lfuzzer`).
 
 You *must* use special compiler flags to build your target and fuzzers.

--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -20,7 +20,6 @@ FROM ossfuzz/base
 MAINTAINER mike.aizatsky@gmail.com
 
 RUN apt-get install -y libc6-dev binutils libgcc-5-dev
-RUN mkdir /src /work && chmod a+w /src /work
 
 COPY checkout_build_install_llvm.sh /root/
 # Keep all steps in the same script to decrease the number of intermediate

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -19,11 +19,11 @@ LLVM_DEP_PACKAGES="build-essential make cmake ninja-build git python2.7"
 apt-get install -y $LLVM_DEP_PACKAGES
 
 # Checkout
-cd /src && git clone --depth 1 http://llvm.org/git/llvm.git
-cd /src/llvm/tools && git clone --depth 1 http://llvm.org/git/clang.git
-cd /src/llvm/projects && git clone --depth 1 http://llvm.org/git/compiler-rt.git
-cd /src/llvm/projects && git clone --depth 1 http://llvm.org/git/libcxx.git
-cd /src/llvm/projects && git clone --depth 1 http://llvm.org/git/libcxxabi.git
+cd $SRC && git clone --depth 1 http://llvm.org/git/llvm.git
+cd $SRC/llvm/tools && git clone --depth 1 http://llvm.org/git/clang.git
+cd $SRC/llvm/projects && git clone --depth 1 http://llvm.org/git/compiler-rt.git
+cd $SRC/llvm/projects && git clone --depth 1 http://llvm.org/git/libcxx.git
+cd $SRC/llvm/projects && git clone --depth 1 http://llvm.org/git/libcxxabi.git
 
 # Build & Install
 mkdir -p /work/llvm
@@ -31,18 +31,18 @@ cd /work/llvm
 cmake -G "Ninja" \
       -DLIBCXX_ENABLE_SHARED=OFF -DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON \
       -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD="X86" \
-      /src/llvm
+      $SRC/llvm
 ninja
 ninja install
 rm -rf /work/llvm
 
 # Copy libfuzzer sources
-mkdir /src/libfuzzer
-cp -r /src/llvm/lib/Fuzzer/* /src/libfuzzer/
+mkdir $SRC/libfuzzer
+cp -r $SRC/llvm/lib/Fuzzer/* $SRC/libfuzzer/
 
-cp /src/llvm/tools/sancov/coverage-report-server.py /usr/local/bin/
+cp $SRC/llvm/tools/sancov/coverage-report-server.py /usr/local/bin/
 
 # Cleanup
-rm -rf /src/llvm
+rm -rf $SRC/llvm
 apt-get remove --purge -y $LLVM_DEP_PACKAGES
 apt-get autoremove -y

--- a/infra/base-images/base-libfuzzer/Dockerfile
+++ b/infra/base-images/base-libfuzzer/Dockerfile
@@ -29,9 +29,9 @@ RUN mkdir /src/bin
 COPY coverage_report compile srcmap reproduce run just_run test /src/bin/
 
 ENV PATH=/src/bin:$PATH
-ENV src=/src
-ENV out=/out
+ENV SRC=/src
+ENV OUT=/out
 
-WORKDIR $src
+WORKDIR $SRC
 CMD ["compile"]
 

--- a/infra/base-images/base-libfuzzer/Dockerfile
+++ b/infra/base-images/base-libfuzzer/Dockerfile
@@ -30,6 +30,7 @@ COPY coverage_report compile srcmap reproduce run just_run test /usr/local/bin/
 # ENV PATH=/src/bin:$PATH
 ENV SRC=/src
 ENV OUT=/out
+ENV WORK=/work
 
 WORKDIR $SRC
 CMD ["compile"]

--- a/infra/base-images/base-libfuzzer/Dockerfile
+++ b/infra/base-images/base-libfuzzer/Dockerfile
@@ -23,14 +23,8 @@ ENV COV_FLAGS="-fsanitize-coverage=edge,indirect-calls,8bit-counters"
 ENV ASAN_OPTIONS="symbolize=1:detect_leaks=0"
 ENV FUZZER_LDFLAGS "-Wl,-whole-archive /usr/local/lib/libc++.a /usr/local/lib/libc++abi.a -Wl,-no-whole-archive"
 
-RUN mkdir /out && chmod a+w /out
-
-COPY coverage_report compile srcmap reproduce run just_run test /usr/local/bin/
-
-# ENV PATH=/src/bin:$PATH
-ENV SRC=/src
-ENV OUT=/out
-ENV WORK=/work
+COPY coverage_report compile srcmap reproduce run just_run test \
+     /usr/local/bin/
 
 WORKDIR $SRC
 CMD ["compile"]

--- a/infra/base-images/base-libfuzzer/Dockerfile
+++ b/infra/base-images/base-libfuzzer/Dockerfile
@@ -20,7 +20,6 @@ RUN apt-get install -y git subversion jq zip python3
 
 ENV SANITIZER_FLAGS="-fsanitize=address"
 ENV COV_FLAGS="-fsanitize-coverage=edge,indirect-calls,8bit-counters"
-
 ENV ASAN_OPTIONS="symbolize=1:detect_leaks=0"
 ENV FUZZER_LDFLAGS "-Wl,-whole-archive /usr/local/lib/libc++.a /usr/local/lib/libc++abi.a -Wl,-no-whole-archive"
 
@@ -28,7 +27,11 @@ RUN mkdir /out && chmod a+w /out
 
 RUN mkdir /src/bin
 COPY coverage_report compile srcmap reproduce run just_run test /src/bin/
+
 ENV PATH=/src/bin:$PATH
-WORKDIR /src
+ENV src=/src
+ENV out=/out
+
+WORKDIR $src
 CMD ["compile"]
 

--- a/infra/base-images/base-libfuzzer/Dockerfile
+++ b/infra/base-images/base-libfuzzer/Dockerfile
@@ -25,10 +25,9 @@ ENV FUZZER_LDFLAGS "-Wl,-whole-archive /usr/local/lib/libc++.a /usr/local/lib/li
 
 RUN mkdir /out && chmod a+w /out
 
-RUN mkdir /src/bin
-COPY coverage_report compile srcmap reproduce run just_run test /src/bin/
+COPY coverage_report compile srcmap reproduce run just_run test /usr/local/bin/
 
-ENV PATH=/src/bin:$PATH
+# ENV PATH=/src/bin:$PATH
 ENV SRC=/src
 ENV OUT=/out
 

--- a/infra/base-images/base-libfuzzer/README.md
+++ b/infra/base-images/base-libfuzzer/README.md
@@ -15,14 +15,19 @@
 
 # Image Files Layout
 
+
 | Location | Description |
 | -------- | ----------  |
-| `/out/`                | build artifacts should be copied here  |
-| `/src/`                | place to checkout source files |
-| `/work/`               | used to store intermediate files |
+| `/out/` (`$OUT`)       | build artifacts should be copied here  |
+| `/src/` (`$SRC`)       | place to checkout source files |
+| `/work/`(`$WORK`)      | used to store intermediate files |
 | `/usr/lib/libfuzzer.a` | libfuzzer static library |
 
-# Provided Environment Variables
+While files layout is fixed within a container, `$SRC`, `$OUT`, `$WORK` are
+provided to be able to write retargetable scripts.
+
+
+## Compiler Flags
 
 You *must* use special compiler flags to build your target and fuzzers.
 These flags are provided in following environment variables:
@@ -37,6 +42,7 @@ These flags are provided in following environment variables:
 
 Many well-crafted build scripts will automatically use these variables. If not,
 passing them manually to a build tool might be required.
+
 
 # Child Image Interface
 

--- a/infra/base-images/base-libfuzzer/README.md
+++ b/infra/base-images/base-libfuzzer/README.md
@@ -49,7 +49,7 @@ passing them manually to a build tool might be required.
 ## Sources
 
 Child image has to checkout all sources it needs to compile fuzzers into
-`/src/` directory. When the image is executed, a directory could be mounted
+`$SRC` directory. When the image is executed, a directory could be mounted
 on top of these with local checkouts using
 `docker run -v $HOME/my_target:/src/my_target ...`.
 
@@ -59,4 +59,4 @@ Following files have to be added by child images:
 
 | File Location   | Description |
 | -------------   | ----------- |
-| `/src/build.sh` | build script to build the target and its fuzzers |
+| `$SRC/build.sh` | build script to build the target and its fuzzers |

--- a/infra/base-images/base-libfuzzer/compile
+++ b/infra/base-images/base-libfuzzer/compile
@@ -20,10 +20,10 @@ echo "---------------------------------------------------------------"
 pushd .
 
 echo -n "Compiling libFuzzer into /usr/lib/libfuzzer.a ..."
-mkdir -p /work/libfuzzer
-cd /work/libfuzzer
+mkdir -p $WORK/libfuzzer
+cd $WORK/libfuzzer
 $CXX $CXXFLAGS -std=c++11 $SANITIZER_FLAGS -c $SRC/libfuzzer/*.cpp -I$SRC/libfuzzer
-ar ruv /usr/lib/libfuzzer.a /work/libfuzzer/*.o
+ar ruv /usr/lib/libfuzzer.a $WORK/libfuzzer/*.o
 echo "Done."
 
 export CFLAGS="$CFLAGS $SANITIZER_FLAGS $COV_FLAGS"

--- a/infra/base-images/base-libfuzzer/compile
+++ b/infra/base-images/base-libfuzzer/compile
@@ -22,7 +22,7 @@ pushd .
 echo -n "Compiling libFuzzer into /usr/lib/libfuzzer.a ..."
 mkdir -p /work/libfuzzer
 cd /work/libfuzzer
-$CXX $CXXFLAGS -std=c++11 $SANITIZER_FLAGS -c /src/libfuzzer/*.cpp -I/src/libfuzzer
+$CXX $CXXFLAGS -std=c++11 $SANITIZER_FLAGS -c $SRC/libfuzzer/*.cpp -I$SRC/libfuzzer
 ar ruv /usr/lib/libfuzzer.a /work/libfuzzer/*.o
 echo "Done."
 
@@ -38,4 +38,4 @@ echo "FUZZER_LDFLAGS=$FUZZER_LDFLAGS"
 echo "---------------------------------------------------------------"
 
 popd >/dev/null 2>&1
-bash -x /src/build.sh
+bash -x $SRC/build.sh

--- a/infra/base-images/base-libfuzzer/just_run
+++ b/infra/base-images/base-libfuzzer/just_run
@@ -18,8 +18,8 @@
 # Fuzzer runner. Appends .options arguments and seed corpus to users args.
 # Usage: $0 <fuzzer_name> <fuzzer_args>
 
-cd /out
-export PATH="/out:$PATH"
+cd $OUT
+export PATH="$OUT:$PATH"
 
 FUZZER=$1
 shift

--- a/infra/base-images/base-libfuzzer/srcmap
+++ b/infra/base-images/base-libfuzzer/srcmap
@@ -26,7 +26,7 @@ function jq_inplace() {
 }
 
 # Git
-for DOT_GIT_DIR in $(find /src -name ".git" -type d); do
+for DOT_GIT_DIR in $(find $SRC -name ".git" -type d); do
   GIT_DIR=$(dirname $DOT_GIT_DIR)
   cd $GIT_DIR
   GIT_URL=$(git config --get remote.origin.url)
@@ -35,7 +35,7 @@ for DOT_GIT_DIR in $(find /src -name ".git" -type d); do
 done
 
 # Subversion
-for DOT_SVN_DIR in $(find /src -name ".svn" -type d); do
+for DOT_SVN_DIR in $(find $SRC -name ".svn" -type d); do
   SVN_DIR=$(dirname $DOT_SVN_DIR)
   cd $SVN_DIR
   SVN_URL=$(svn info | grep "^URL:" | sed  's/URL: //g')
@@ -44,7 +44,7 @@ for DOT_SVN_DIR in $(find /src -name ".svn" -type d); do
 done
 
 # Mercurial
-for DOT_HG_DIR in $(find /src -name ".hg" -type d); do
+for DOT_HG_DIR in $(find $SRC -name ".hg" -type d); do
   HG_DIR=$(dirname $DOT_HG_DIR)
   cd $HG_DIR
   HG_URL=$(hg paths default)

--- a/infra/base-images/base-libfuzzer/test
+++ b/infra/base-images/base-libfuzzer/test
@@ -24,7 +24,7 @@ mkdir -p $REPORT_DIR
 
 set -o pipefail
 
-DIR="/out"
+DIR="$OUT"
 N=0
 for FUZZER_BINARY in $(find $DIR -executable -type f); do
   FUZZER=$(basename $FUZZER_BINARY)
@@ -48,7 +48,7 @@ done
 
 if [ "$N" -eq "0" ]; then
   echo "ERROR: no fuzzers found in $DIR"
-  ls -al /out
+  ls -al $OUT
   exit 1
 fi
 

--- a/infra/base-images/base/Dockerfile
+++ b/infra/base-images/base/Dockerfile
@@ -22,3 +22,11 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update
 RUN apt-get upgrade -y
 RUN apt-get autoremove -y
+
+ENV OUT=/out
+ENV SRC=/src
+ENV WORK=/work
+
+RUN mkdir -p $OUT $SRC $WORK && chmod a+rwx $OUT $SRC $WORK
+ENV PATH="$PATH:/out"
+

--- a/infra/base-images/libfuzzer-runner/Dockerfile
+++ b/infra/base-images/libfuzzer-runner/Dockerfile
@@ -20,8 +20,3 @@ RUN apt-get install -y gdb zip
 COPY llvm-symbolizer run_fuzzer /usr/local/bin/
 ENV ASAN_OPTIONS="symbolize=1:detect_leaks=0"
 
-# set up /out dir
-RUN mkdir /out
-VOLUME /out
-ENV PATH "$PATH:/out"
-WORKDIR /out

--- a/infra/base-images/libfuzzer-runner/run_fuzzer
+++ b/infra/base-images/libfuzzer-runner/run_fuzzer
@@ -18,8 +18,7 @@
 # Fuzzer runner. Appends .options arguments and seed corpus to users args.
 # Usage: $0 <fuzzer_name> <fuzzer_args>
 
-cd /out
-export PATH="/out:$PATH"
+cd $OUT
 
 FUZZER=$1
 shift

--- a/infra/templates.py
+++ b/infra/templates.py
@@ -61,7 +61,7 @@ MAINTAINER your@email.com
 RUN apt-get install -y make autoconf automake libtool
 RUN git clone <git_url> %(target_name)s     # or use other version control
 WORKDIR %(target_name)s
-COPY build.sh /src/
+COPY build.sh $src/
 """
 
 BUILD_TEMPLATE = """\

--- a/targets/all.sh
+++ b/targets/all.sh
@@ -19,8 +19,6 @@
 # Development script to build all images.
 IGNORE="build:docs:infra:tpm2:scripts"
 
-# Build
-./infra/base-images/all.sh
 for target in targets/*; do
   if [[ -f $target || ":${IGNORE}:" == *":$target:"* ]]; then continue; fi
   echo "@ Building $target"

--- a/targets/boringssl/Dockerfile
+++ b/targets/boringssl/Dockerfile
@@ -19,4 +19,4 @@ MAINTAINER mike.aizatsky@gmail.com
 RUN apt-get install -y cmake ninja-build golang
 
 RUN git clone https://boringssl.googlesource.com/boringssl
-COPY build.sh /src/
+COPY build.sh $SRC/

--- a/targets/boringssl/build.sh
+++ b/targets/boringssl/build.sh
@@ -25,10 +25,10 @@ export LDFLAGS=$FUZZER_LDFLAGS
 cmake -GNinja -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX \
     -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
     -DCMAKE_EXE_LINKER_FLAGS="$FUZZER_LDFLAGS" \
-    /src/boringssl/
+    $src/boringssl/
 ninja
 
-fuzzerFiles=$(find /src/boringssl/fuzz/ -name "*.cc")
+fuzzerFiles=$(find $src/boringssl/fuzz/ -name "*.cc")
 
 find . -name "*.a"
 
@@ -36,10 +36,10 @@ for F in $fuzzerFiles; do
   fuzzerName=$(basename $F .cc)
   echo "Building fuzzer $fuzzerName"
   $CXX $CXXFLAGS $FUZZER_LDFLAGS -std=c++11 \
-      -o /out/${fuzzerName} -lfuzzer $F \
-      -I /src/boringssl/include ./ssl/libssl.a  ./crypto/libcrypto.a
+      -o $out/${fuzzerName} -lfuzzer $F \
+      -I $src/boringssl/include ./ssl/libssl.a  ./crypto/libcrypto.a
 
-  if [ -d "/src/boringssl/fuzz/${fuzzerName}_corpus" ]; then
-    zip -j /out/${fuzzerName}_seed_corpus.zip /src/boringssl/fuzz/${fuzzerName}_corpus/*
+  if [ -d "$src/boringssl/fuzz/${fuzzerName}_corpus" ]; then
+    zip -j $out/${fuzzerName}_seed_corpus.zip $src/boringssl/fuzz/${fuzzerName}_corpus/*
   fi
 done

--- a/targets/boringssl/build.sh
+++ b/targets/boringssl/build.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 #
 ################################################################################
-mkdir -p /work/boringssl
-cd /work/boringssl
+mkdir -p $WORK/boringssl
+cd $WORK/boringssl
 
 CFLAGS="$CFLAGS -DBORINGSSL_UNSAFE_FUZZER_MODE"
 CXXFLAGS="$CXXFLAGS -DBORINGSSL_UNSAFE_FUZZER_MODE"

--- a/targets/boringssl/build.sh
+++ b/targets/boringssl/build.sh
@@ -25,10 +25,10 @@ export LDFLAGS=$FUZZER_LDFLAGS
 cmake -GNinja -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX \
     -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
     -DCMAKE_EXE_LINKER_FLAGS="$FUZZER_LDFLAGS" \
-    $src/boringssl/
+    $SRC/boringssl/
 ninja
 
-fuzzerFiles=$(find $src/boringssl/fuzz/ -name "*.cc")
+fuzzerFiles=$(find $SRC/boringssl/fuzz/ -name "*.cc")
 
 find . -name "*.a"
 
@@ -36,10 +36,10 @@ for F in $fuzzerFiles; do
   fuzzerName=$(basename $F .cc)
   echo "Building fuzzer $fuzzerName"
   $CXX $CXXFLAGS $FUZZER_LDFLAGS -std=c++11 \
-      -o $out/${fuzzerName} -lfuzzer $F \
-      -I $src/boringssl/include ./ssl/libssl.a  ./crypto/libcrypto.a
+      -o $OUT/${fuzzerName} -lfuzzer $F \
+      -I $SRC/boringssl/include ./ssl/libssl.a  ./crypto/libcrypto.a
 
-  if [ -d "$src/boringssl/fuzz/${fuzzerName}_corpus" ]; then
-    zip -j $out/${fuzzerName}_seed_corpus.zip $src/boringssl/fuzz/${fuzzerName}_corpus/*
+  if [ -d "$SRC/boringssl/fuzz/${fuzzerName}_corpus" ]; then
+    zip -j $OUT/${fuzzerName}_seed_corpus.zip $SRC/boringssl/fuzz/${fuzzerName}_corpus/*
   fi
 done

--- a/targets/c-ares/Dockerfile
+++ b/targets/c-ares/Dockerfile
@@ -19,4 +19,4 @@ MAINTAINER mmoroz@chromium.org
 RUN apt-get install -y make autoconf automake libtool
 RUN git clone https://github.com/c-ares/c-ares.git
 WORKDIR c-ares
-COPY build.sh *_fuzzer.cc /src/
+COPY build.sh *_fuzzer.cc $SRC/

--- a/targets/c-ares/build.sh
+++ b/targets/c-ares/build.sh
@@ -25,6 +25,6 @@ make CFLAGS= -j$(nproc) all
 
 # Build the fuzzer.
 $CXX $CXXFLAGS -std=c++11 -I. \
-    $src/c_ares_ares_create_query_fuzzer.cc \
-    -o $out/c_ares_ares_create_query_fuzzer \
-    -lfuzzer $src/c-ares/.libs/libcares.a $FUZZER_LDFLAGS
+    $SRC/c_ares_ares_create_query_fuzzer.cc \
+    -o $OUT/c_ares_ares_create_query_fuzzer \
+    -lfuzzer $SRC/c-ares/.libs/libcares.a $FUZZER_LDFLAGS

--- a/targets/c-ares/build.sh
+++ b/targets/c-ares/build.sh
@@ -25,6 +25,6 @@ make CFLAGS= -j$(nproc) all
 
 # Build the fuzzer.
 $CXX $CXXFLAGS -std=c++11 -I. \
-    /src/c_ares_ares_create_query_fuzzer.cc \
-    -o /out/c_ares_ares_create_query_fuzzer \
-    -lfuzzer /src/c-ares/.libs/libcares.a $FUZZER_LDFLAGS
+    $src/c_ares_ares_create_query_fuzzer.cc \
+    -o $out/c_ares_ares_create_query_fuzzer \
+    -lfuzzer $src/c-ares/.libs/libcares.a $FUZZER_LDFLAGS

--- a/targets/curl/Dockerfile
+++ b/targets/curl/Dockerfile
@@ -20,5 +20,5 @@ RUN apt-get install -y make autoconf automake libtool libssl-dev zlib1g-dev
 
 RUN git clone https://github.com/curl/curl.git
 WORKDIR curl
-COPY build.sh curl_fuzzer.cc *.options *.dict /src/
+COPY build.sh curl_fuzzer.cc *.options *.dict $SRC/
 

--- a/targets/curl/build.sh
+++ b/targets/curl/build.sh
@@ -18,5 +18,5 @@
 ./buildconf
 ./configure --disable-shared --enable-debug --enable-maintainer-mode --disable-symbol-hiding --disable-threaded-resolver --enable-ipv6 --with-random=/dev/null
 make -j$(nproc)
-$CXX $CXXFLAGS $src/curl_fuzzer.cc -Iinclude lib/.libs/libcurl.a -lssl -lcrypto -lz -lfuzzer -o $out/curl_fuzzer $FUZZER_LDFLAGS
-cp $src/*.dict $src/*.options /out
+$CXX $CXXFLAGS $SRC/curl_fuzzer.cc -Iinclude lib/.libs/libcurl.a -lssl -lcrypto -lz -lfuzzer -o $OUT/curl_fuzzer $FUZZER_LDFLAGS
+cp $SRC/*.dict $SRC/*.options /out

--- a/targets/curl/build.sh
+++ b/targets/curl/build.sh
@@ -18,5 +18,5 @@
 ./buildconf
 ./configure --disable-shared --enable-debug --enable-maintainer-mode --disable-symbol-hiding --disable-threaded-resolver --enable-ipv6 --with-random=/dev/null
 make -j$(nproc)
-$CXX $CXXFLAGS /src/curl_fuzzer.cc -Iinclude lib/.libs/libcurl.a -lssl -lcrypto -lz -lfuzzer -o /out/curl_fuzzer $FUZZER_LDFLAGS
-cp /src/*.dict /src/*.options /out
+$CXX $CXXFLAGS $src/curl_fuzzer.cc -Iinclude lib/.libs/libcurl.a -lssl -lcrypto -lz -lfuzzer -o $out/curl_fuzzer $FUZZER_LDFLAGS
+cp $src/*.dict $src/*.options /out

--- a/targets/curl/build.sh
+++ b/targets/curl/build.sh
@@ -19,4 +19,4 @@
 ./configure --disable-shared --enable-debug --enable-maintainer-mode --disable-symbol-hiding --disable-threaded-resolver --enable-ipv6 --with-random=/dev/null
 make -j$(nproc)
 $CXX $CXXFLAGS $SRC/curl_fuzzer.cc -Iinclude lib/.libs/libcurl.a -lssl -lcrypto -lz -lfuzzer -o $OUT/curl_fuzzer $FUZZER_LDFLAGS
-cp $SRC/*.dict $SRC/*.options /out
+cp $SRC/*.dict $SRC/*.options $OUT/

--- a/targets/expat/Dockerfile
+++ b/targets/expat/Dockerfile
@@ -20,4 +20,4 @@ RUN apt-get install -y make autoconf automake libtool docbook2x
 
 RUN git clone git://git.code.sf.net/p/expat/code_git expat 
 WORKDIR expat/expat
-COPY build.sh parse_fuzzer.*  xml.dict /src/
+COPY build.sh parse_fuzzer.*  xml.dict $SRC/

--- a/targets/expat/build.sh
+++ b/targets/expat/build.sh
@@ -21,7 +21,7 @@ make clean
 make -j$(nproc) all
 
 $CXX $CXXFLAGS -std=c++11 -Ilib/ \
-    $src/parse_fuzzer.cc -o $out/parse_fuzzer \
+    $SRC/parse_fuzzer.cc -o $OUT/parse_fuzzer \
     -lfuzzer .libs/libexpat.a $FUZZER_LDFLAGS
 
-cp $src/*.dict $src/*.options $out/
+cp $SRC/*.dict $SRC/*.options $OUT/

--- a/targets/expat/build.sh
+++ b/targets/expat/build.sh
@@ -21,7 +21,7 @@ make clean
 make -j$(nproc) all
 
 $CXX $CXXFLAGS -std=c++11 -Ilib/ \
-    /src/parse_fuzzer.cc -o /out/parse_fuzzer \
+    $src/parse_fuzzer.cc -o $out/parse_fuzzer \
     -lfuzzer .libs/libexpat.a $FUZZER_LDFLAGS
 
-cp /src/*.dict /src/*.options /out/
+cp $src/*.dict $src/*.options $out/

--- a/targets/ffmpeg/Dockerfile
+++ b/targets/ffmpeg/Dockerfile
@@ -40,4 +40,4 @@ RUN git clone git://git.xiph.org/vorbis.git
 RUN git clone git://git.videolan.org/git/x264.git
 RUN hg clone https://bitbucket.org/multicoreware/x265
 
-COPY build.sh group_seed_corpus.py /src/
+COPY build.sh group_seed_corpus.py $SRC/

--- a/targets/ffmpeg/build.sh
+++ b/targets/ffmpeg/build.sh
@@ -18,10 +18,10 @@
 export LDFLAGS="$FUZZER_LDFLAGS"
 
 # Build dependencies.
-export FFMPEG_DEPS_PATH=/src/ffmpeg_deps
+export FFMPEG_DEPS_PATH=$src/ffmpeg_deps
 mkdir -p $FFMPEG_DEPS_PATH
 
-cd /src
+cd $src
 bzip2 -f -d alsa-lib-*
 tar xf alsa-lib-*
 cd alsa-lib-*
@@ -30,7 +30,7 @@ make clean
 make -j$(nproc) all
 make install
 
-cd /src/drm
+cd $src/drm
 # Requires xutils-dev libpciaccess-dev
 ./autogen.sh
 ./configure --prefix="$FFMPEG_DEPS_PATH" --enable-static
@@ -38,14 +38,14 @@ make clean
 make -j$(nproc)
 make install
 
-cd /src/fdk-aac
+cd $src/fdk-aac
 autoreconf -fiv
 ./configure --prefix="$FFMPEG_DEPS_PATH" --disable-shared
 make clean
 make -j$(nproc) all
 make install
 
-cd /src
+cd $src
 tar xzf lame.tar.gz
 cd lame-*
 ./configure --prefix="$FFMPEG_DEPS_PATH" --enable-static
@@ -53,56 +53,56 @@ make clean
 make -j$(nproc)
 make install
 
-cd /src/libXext
+cd $src/libXext
 ./autogen.sh
 ./configure --prefix="$FFMPEG_DEPS_PATH" --enable-static
 make clean
 make -j$(nproc)
 make install
 
-cd /src/libXfixes
+cd $src/libXfixes
 ./autogen.sh
 ./configure --prefix="$FFMPEG_DEPS_PATH" --enable-static
 make clean
 make -j$(nproc)
 make install
 
-cd /src/libva
+cd $src/libva
 ./autogen.sh
 ./configure --prefix="$FFMPEG_DEPS_PATH" --enable-static --disable-shared
 make clean
 make -j$(nproc) all
 make install
 
-cd /src/libvdpau
+cd $src/libvdpau
 ./autogen.sh
 ./configure --prefix="$FFMPEG_DEPS_PATH" --enable-static --disable-shared
 make clean
 make -j$(nproc) all
 make install
 
-cd /src/libvpx
+cd $src/libvpx
 LDFLAGS="$CXXFLAGS $LDFLAGS" ./configure --prefix="$FFMPEG_DEPS_PATH" \
     --disable-examples --disable-unit-tests
 make clean
 make -j$(nproc) all
 make install
 
-cd /src/ogg
+cd $src/ogg
 ./autogen.sh
 ./configure --prefix="$FFMPEG_DEPS_PATH" --enable-static
 make clean
 make -j$(nproc)
 make install
 
-cd /src/opus
+cd $src/opus
 ./autogen.sh
 ./configure --prefix="$FFMPEG_DEPS_PATH" --enable-static
 make clean
 make -j$(nproc) all
 make install
 
-cd /src/theora
+cd $src/theora
 # theora requires ogg, need to pass its location to the "configure" script.
 CFLAGS="$CFLAGS -fPIC" LDFLAGS="$LDFLAGS -L$FFMPEG_DEPS_PATH/lib/" \
     CPPFLAGS="$CXXFLAGS -I$FFMPEG_DEPS_PATH/include/" \
@@ -112,21 +112,21 @@ make clean
 make -j$(nproc)
 make install
 
-cd /src/vorbis
+cd $src/vorbis
 ./autogen.sh
 ./configure --prefix="$FFMPEG_DEPS_PATH" --enable-static
 make clean
 make -j$(nproc)
 make install
 
-cd /src/x264
+cd $src/x264
 LDFLAGS="$CXXFLAGS $LDFLAGS" ./configure --prefix="$FFMPEG_DEPS_PATH" \
     --enable-static
 make clean
 make -j$(nproc)
 make install
 
-cd /src/x265/build/linux
+cd $src/x265/build/linux
 cmake -G "Unix Makefiles" \
     -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX \
     -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
@@ -142,7 +142,7 @@ rm $FFMPEG_DEPS_PATH/lib/*.so
 rm $FFMPEG_DEPS_PATH/lib/*.so.*
 
 # Build the target.
-cd /src/ffmpeg
+cd $src/ffmpeg
 PKG_CONFIG_PATH="$FFMPEG_DEPS_PATH/lib/pkgconfig" ./configure \
     --cc=$CC --cxx=$CXX --ld="$CXX $CXXFLAGS -std=c++11" \
     --extra-cflags="-I$FFMPEG_DEPS_PATH/include" \
@@ -166,11 +166,11 @@ make clean
 make -j$(nproc) install
 
 # Download test sampes, will be used as seed corpus.
-export TEST_SAMPLES_PATH=/src/ffmpeg/fate-suite/
+export TEST_SAMPLES_PATH=$src/ffmpeg/fate-suite/
 make fate-rsync SAMPLES=$TEST_SAMPLES_PATH
 
 # Build the fuzzers.
-cd /src/ffmpeg
+cd $src/ffmpeg
 
 export TEMP_VAR_CODEC="AV_CODEC_ID_H264"
 export TEMP_VAR_CODEC_TYPE="VIDEO"
@@ -208,12 +208,12 @@ for codec in $CODEC_NAMES; do
   fuzzer_name=ffmpeg_${CODEC_TYPE}_${codec}_fuzzer
 
   $CC $CFLAGS -I${FFMPEG_DEPS_PATH}/include \
-      /src/ffmpeg/doc/examples/decoder_targeted.c \
-      -o /out/${fuzzer_name} \
+      $src/ffmpeg/doc/examples/decoder_targeted.c \
+      -o $out/${fuzzer_name} \
       -DFFMPEG_CODEC=${codec} -DFUZZ_FFMPEG_${CODEC_TYPE}= \
       ${FFMPEG_FUZZERS_COMMON_FLAGS}
 
-  echo -en "[libfuzzer]\nmax_len = 1000000\n" > /out/${fuzzer_name}.options
+  echo -en "[libfuzzer]\nmax_len = 1000000\n" > $out/${fuzzer_name}.options
 done
 
 # Build fuzzers for subtitles formats.
@@ -226,8 +226,8 @@ for codec in $CODEC_NAMES; do
   fuzzer_name=ffmpeg_${CODEC_TYPE}_${codec}_fuzzer
 
   $CC $CFLAGS -I${FFMPEG_DEPS_PATH}/include \
-      /src/ffmpeg/doc/examples/decoder_targeted.c \
-      -o /out/${fuzzer_name} \
+      $src/ffmpeg/doc/examples/decoder_targeted.c \
+      -o $out/${fuzzer_name} \
       -DFFMPEG_CODEC=${codec} -DFUZZ_FFMPEG_${CODEC_TYPE}= \
       ${FFMPEG_FUZZERS_COMMON_FLAGS}
 done
@@ -281,14 +281,14 @@ for codec in $CODEC_NAMES; do
   fuzzer_name=ffmpeg_${CODEC_TYPE}_${codec}_fuzzer
 
   $CC $CFLAGS -I${FFMPEG_DEPS_PATH}/include \
-      /src/ffmpeg/doc/examples/decoder_targeted.c \
-      -o /out/${fuzzer_name} \
+      $src/ffmpeg/doc/examples/decoder_targeted.c \
+      -o $out/${fuzzer_name} \
       -DFFMPEG_CODEC=${codec} -DFUZZ_FFMPEG_${CODEC_TYPE}= \
       ${FFMPEG_FUZZERS_COMMON_FLAGS}
 
-  echo -en "[libfuzzer]\nmax_len = 1000000\n" > /out/${fuzzer_name}.options
+  echo -en "[libfuzzer]\nmax_len = 1000000\n" > $out/${fuzzer_name}.options
 done
 
 # Find relevant corpus in test samples and archive them for every fuzzer.
-cd /src
-python group_seed_corpus.py $TEST_SAMPLES_PATH /out
+cd $src
+python group_seed_corpus.py $TEST_SAMPLES_PATH $out/

--- a/targets/ffmpeg/build.sh
+++ b/targets/ffmpeg/build.sh
@@ -18,10 +18,10 @@
 export LDFLAGS="$FUZZER_LDFLAGS"
 
 # Build dependencies.
-export FFMPEG_DEPS_PATH=$src/ffmpeg_deps
+export FFMPEG_DEPS_PATH=$SRC/ffmpeg_deps
 mkdir -p $FFMPEG_DEPS_PATH
 
-cd $src
+cd $SRC
 bzip2 -f -d alsa-lib-*
 tar xf alsa-lib-*
 cd alsa-lib-*
@@ -30,7 +30,7 @@ make clean
 make -j$(nproc) all
 make install
 
-cd $src/drm
+cd $SRC/drm
 # Requires xutils-dev libpciaccess-dev
 ./autogen.sh
 ./configure --prefix="$FFMPEG_DEPS_PATH" --enable-static
@@ -38,14 +38,14 @@ make clean
 make -j$(nproc)
 make install
 
-cd $src/fdk-aac
+cd $SRC/fdk-aac
 autoreconf -fiv
 ./configure --prefix="$FFMPEG_DEPS_PATH" --disable-shared
 make clean
 make -j$(nproc) all
 make install
 
-cd $src
+cd $SRC
 tar xzf lame.tar.gz
 cd lame-*
 ./configure --prefix="$FFMPEG_DEPS_PATH" --enable-static
@@ -53,56 +53,56 @@ make clean
 make -j$(nproc)
 make install
 
-cd $src/libXext
+cd $SRC/libXext
 ./autogen.sh
 ./configure --prefix="$FFMPEG_DEPS_PATH" --enable-static
 make clean
 make -j$(nproc)
 make install
 
-cd $src/libXfixes
+cd $SRC/libXfixes
 ./autogen.sh
 ./configure --prefix="$FFMPEG_DEPS_PATH" --enable-static
 make clean
 make -j$(nproc)
 make install
 
-cd $src/libva
+cd $SRC/libva
 ./autogen.sh
 ./configure --prefix="$FFMPEG_DEPS_PATH" --enable-static --disable-shared
 make clean
 make -j$(nproc) all
 make install
 
-cd $src/libvdpau
+cd $SRC/libvdpau
 ./autogen.sh
 ./configure --prefix="$FFMPEG_DEPS_PATH" --enable-static --disable-shared
 make clean
 make -j$(nproc) all
 make install
 
-cd $src/libvpx
+cd $SRC/libvpx
 LDFLAGS="$CXXFLAGS $LDFLAGS" ./configure --prefix="$FFMPEG_DEPS_PATH" \
     --disable-examples --disable-unit-tests
 make clean
 make -j$(nproc) all
 make install
 
-cd $src/ogg
+cd $SRC/ogg
 ./autogen.sh
 ./configure --prefix="$FFMPEG_DEPS_PATH" --enable-static
 make clean
 make -j$(nproc)
 make install
 
-cd $src/opus
+cd $SRC/opus
 ./autogen.sh
 ./configure --prefix="$FFMPEG_DEPS_PATH" --enable-static
 make clean
 make -j$(nproc) all
 make install
 
-cd $src/theora
+cd $SRC/theora
 # theora requires ogg, need to pass its location to the "configure" script.
 CFLAGS="$CFLAGS -fPIC" LDFLAGS="$LDFLAGS -L$FFMPEG_DEPS_PATH/lib/" \
     CPPFLAGS="$CXXFLAGS -I$FFMPEG_DEPS_PATH/include/" \
@@ -112,21 +112,21 @@ make clean
 make -j$(nproc)
 make install
 
-cd $src/vorbis
+cd $SRC/vorbis
 ./autogen.sh
 ./configure --prefix="$FFMPEG_DEPS_PATH" --enable-static
 make clean
 make -j$(nproc)
 make install
 
-cd $src/x264
+cd $SRC/x264
 LDFLAGS="$CXXFLAGS $LDFLAGS" ./configure --prefix="$FFMPEG_DEPS_PATH" \
     --enable-static
 make clean
 make -j$(nproc)
 make install
 
-cd $src/x265/build/linux
+cd $SRC/x265/build/linux
 cmake -G "Unix Makefiles" \
     -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX \
     -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
@@ -142,7 +142,7 @@ rm $FFMPEG_DEPS_PATH/lib/*.so
 rm $FFMPEG_DEPS_PATH/lib/*.so.*
 
 # Build the target.
-cd $src/ffmpeg
+cd $SRC/ffmpeg
 PKG_CONFIG_PATH="$FFMPEG_DEPS_PATH/lib/pkgconfig" ./configure \
     --cc=$CC --cxx=$CXX --ld="$CXX $CXXFLAGS -std=c++11" \
     --extra-cflags="-I$FFMPEG_DEPS_PATH/include" \
@@ -166,11 +166,11 @@ make clean
 make -j$(nproc) install
 
 # Download test sampes, will be used as seed corpus.
-export TEST_SAMPLES_PATH=$src/ffmpeg/fate-suite/
+export TEST_SAMPLES_PATH=$SRC/ffmpeg/fate-suite/
 make fate-rsync SAMPLES=$TEST_SAMPLES_PATH
 
 # Build the fuzzers.
-cd $src/ffmpeg
+cd $SRC/ffmpeg
 
 export TEMP_VAR_CODEC="AV_CODEC_ID_H264"
 export TEMP_VAR_CODEC_TYPE="VIDEO"
@@ -208,12 +208,12 @@ for codec in $CODEC_NAMES; do
   fuzzer_name=ffmpeg_${CODEC_TYPE}_${codec}_fuzzer
 
   $CC $CFLAGS -I${FFMPEG_DEPS_PATH}/include \
-      $src/ffmpeg/doc/examples/decoder_targeted.c \
-      -o $out/${fuzzer_name} \
+      $SRC/ffmpeg/doc/examples/decoder_targeted.c \
+      -o $OUT/${fuzzer_name} \
       -DFFMPEG_CODEC=${codec} -DFUZZ_FFMPEG_${CODEC_TYPE}= \
       ${FFMPEG_FUZZERS_COMMON_FLAGS}
 
-  echo -en "[libfuzzer]\nmax_len = 1000000\n" > $out/${fuzzer_name}.options
+  echo -en "[libfuzzer]\nmax_len = 1000000\n" > $OUT/${fuzzer_name}.options
 done
 
 # Build fuzzers for subtitles formats.
@@ -226,8 +226,8 @@ for codec in $CODEC_NAMES; do
   fuzzer_name=ffmpeg_${CODEC_TYPE}_${codec}_fuzzer
 
   $CC $CFLAGS -I${FFMPEG_DEPS_PATH}/include \
-      $src/ffmpeg/doc/examples/decoder_targeted.c \
-      -o $out/${fuzzer_name} \
+      $SRC/ffmpeg/doc/examples/decoder_targeted.c \
+      -o $OUT/${fuzzer_name} \
       -DFFMPEG_CODEC=${codec} -DFUZZ_FFMPEG_${CODEC_TYPE}= \
       ${FFMPEG_FUZZERS_COMMON_FLAGS}
 done
@@ -281,14 +281,14 @@ for codec in $CODEC_NAMES; do
   fuzzer_name=ffmpeg_${CODEC_TYPE}_${codec}_fuzzer
 
   $CC $CFLAGS -I${FFMPEG_DEPS_PATH}/include \
-      $src/ffmpeg/doc/examples/decoder_targeted.c \
-      -o $out/${fuzzer_name} \
+      $SRC/ffmpeg/doc/examples/decoder_targeted.c \
+      -o $OUT/${fuzzer_name} \
       -DFFMPEG_CODEC=${codec} -DFUZZ_FFMPEG_${CODEC_TYPE}= \
       ${FFMPEG_FUZZERS_COMMON_FLAGS}
 
-  echo -en "[libfuzzer]\nmax_len = 1000000\n" > $out/${fuzzer_name}.options
+  echo -en "[libfuzzer]\nmax_len = 1000000\n" > $OUT/${fuzzer_name}.options
 done
 
 # Find relevant corpus in test samples and archive them for every fuzzer.
-cd $src
-python group_seed_corpus.py $TEST_SAMPLES_PATH $out/
+cd $SRC
+python group_seed_corpus.py $TEST_SAMPLES_PATH $OUT/

--- a/targets/file/Dockerfile
+++ b/targets/file/Dockerfile
@@ -19,4 +19,4 @@ MAINTAINER mike.aizatsky@gmail.com
 RUN apt-get install -y make autoconf automake libtool shtool 
 RUN git clone https://github.com/file/file.git
 WORKDIR file
-COPY build.sh magic_fuzzer.cc /src/
+COPY build.sh magic_fuzzer.cc $SRC/

--- a/targets/file/build.sh
+++ b/targets/file/build.sh
@@ -20,8 +20,8 @@ autoreconf -i
 make V=1 all
 
 $CXX $CXXFLAGS -std=c++11 -Isrc/ \
-     $src/magic_fuzzer.cc -o $out/magic_fuzzer \
-     -lfuzzer .$src/.libs/libmagic.a $FUZZER_LDFLAGS
+     $SRC/magic_fuzzer.cc -o $OUT/magic_fuzzer \
+     -lfuzzer ./src/.libs/libmagic.a $FUZZER_LDFLAGS
 
-cp ./magic/magic.mgc $out/
+cp ./magic/magic.mgc $OUT/
 

--- a/targets/file/build.sh
+++ b/targets/file/build.sh
@@ -20,8 +20,8 @@ autoreconf -i
 make V=1 all
 
 $CXX $CXXFLAGS -std=c++11 -Isrc/ \
-     /src/magic_fuzzer.cc -o /out/magic_fuzzer \
-     -lfuzzer ./src/.libs/libmagic.a $FUZZER_LDFLAGS
+     $src/magic_fuzzer.cc -o $out/magic_fuzzer \
+     -lfuzzer .$src/.libs/libmagic.a $FUZZER_LDFLAGS
 
-cp ./magic/magic.mgc /out/
+cp ./magic/magic.mgc $out/
 

--- a/targets/freetype2/Dockerfile
+++ b/targets/freetype2/Dockerfile
@@ -20,4 +20,4 @@ RUN apt-get install -y make autoconf libtool libarchive-dev
 
 RUN git clone git://git.sv.nongnu.org/freetype/freetype2.git
 WORKDIR freetype2
-COPY build.sh /src/
+COPY build.sh $SRC/

--- a/targets/freetype2/build.sh
+++ b/targets/freetype2/build.sh
@@ -22,7 +22,7 @@ make -j$(nproc) clean all
 
 $CXX $CXXFLAGS $FUZZER_LDFLAGS -std=c++11 \
   -I./include -I. \
-  ./src/tools/ftfuzzer/ftfuzzer.cc -o /out/ftfuzzer \
+  .$src/tools/ftfuzzer/ftfuzzer.cc -o $out/ftfuzzer \
   ./objs/*.o -lfuzzer \
   /usr/lib/x86_64-linux-gnu/libarchive.a \
   ./objs/.libs/libfreetype.a

--- a/targets/freetype2/build.sh
+++ b/targets/freetype2/build.sh
@@ -22,7 +22,7 @@ make -j$(nproc) clean all
 
 $CXX $CXXFLAGS $FUZZER_LDFLAGS -std=c++11 \
   -I./include -I. \
-  .$src/tools/ftfuzzer/ftfuzzer.cc -o $out/ftfuzzer \
+  ./src/tools/ftfuzzer/ftfuzzer.cc -o $OUT/ftfuzzer \
   ./objs/*.o -lfuzzer \
   /usr/lib/x86_64-linux-gnu/libarchive.a \
   ./objs/.libs/libfreetype.a

--- a/targets/harfbuzz/Dockerfile
+++ b/targets/harfbuzz/Dockerfile
@@ -20,4 +20,4 @@ RUN apt-get install -y make autoconf automake libtool ragel pkg-config
 
 RUN git clone https://anongit.freedesktop.org/git/harfbuzz.git
 WORKDIR harfbuzz
-COPY build.sh harfbuzz_fuzzer.cc /src/
+COPY build.sh harfbuzz_fuzzer.cc $SRC/

--- a/targets/harfbuzz/build.sh
+++ b/targets/harfbuzz/build.sh
@@ -22,5 +22,5 @@ export LDFLAGS=$FUZZER_LDFLAGS
 make -j$(nproc) clean all
 
 $CXX $CXXFLAGS -std=c++11 -Isrc \
-    $src/harfbuzz_fuzzer.cc -o $out/harfbuzz_fuzzer \
+    $SRC/harfbuzz_fuzzer.cc -o $OUT/harfbuzz_fuzzer \
     -lfuzzer src/.libs/*.o src/hb-ucdn/.libs/*.o $FUZZER_LDFLAGS

--- a/targets/harfbuzz/build.sh
+++ b/targets/harfbuzz/build.sh
@@ -22,5 +22,5 @@ export LDFLAGS=$FUZZER_LDFLAGS
 make -j$(nproc) clean all
 
 $CXX $CXXFLAGS -std=c++11 -Isrc \
-    /src/harfbuzz_fuzzer.cc -o /out/harfbuzz_fuzzer \
+    $src/harfbuzz_fuzzer.cc -o $out/harfbuzz_fuzzer \
     -lfuzzer src/.libs/*.o src/hb-ucdn/.libs/*.o $FUZZER_LDFLAGS

--- a/targets/icu/Dockerfile
+++ b/targets/icu/Dockerfile
@@ -19,4 +19,4 @@ MAINTAINER mike.aizatsky@gmail.com
 RUN apt-get install -y make
 
 RUN svn co http://source.icu-project.org/repos/icu/trunk/icu4c/ icu
-COPY build.sh *.cc *.h *.dict *.options /src/
+COPY build.sh *.cc *.h *.dict *.options $SRC/

--- a/targets/icu/build.sh
+++ b/targets/icu/build.sh
@@ -25,7 +25,7 @@ CFLAGS="$CFLAGS $DEFINES"
 CXXFLAGS="$CXXFLAGS $DEFINES"
 
 CFLAGS=$CFLAGS CXXFLAGS=$CXXFLAGS CC=$CC CXX=$CXX LDFLAGS=$FUZZER_LDFLAGS \
-  /bin/bash $src/icu/source/runConfigureICU Linux \
+  /bin/bash $SRC/icu/source/runConfigureICU Linux \
    --with-library-bits=64 --with-data-packaging=static --enable-static --disable-shared
 
 make -j$(nproc)
@@ -40,9 +40,9 @@ FUZZERS="break_iterator_fuzzer \
   "
 for fuzzer in $FUZZERS; do
   $CXX $CXXFLAGS -std=c++11 \
-    $src/$fuzzer.cc -o $out/$fuzzer \
-    -I$src/icu/source/common -I$src/icu/source/i18n -L/work/icu/lib \
+    $SRC/$fuzzer.cc -o $OUT/$fuzzer \
+    -I$SRC/icu/source/common -I$SRC/icu/source/i18n -L/work/icu/lib \
     -lfuzzer -licui18n -licuuc -licutu -licudata $FUZZER_LDFLAGS
 done
 
-cp $src/*.dict $src/*.options  $out/
+cp $SRC/*.dict $SRC/*.options  $OUT/

--- a/targets/icu/build.sh
+++ b/targets/icu/build.sh
@@ -25,7 +25,7 @@ CFLAGS="$CFLAGS $DEFINES"
 CXXFLAGS="$CXXFLAGS $DEFINES"
 
 CFLAGS=$CFLAGS CXXFLAGS=$CXXFLAGS CC=$CC CXX=$CXX LDFLAGS=$FUZZER_LDFLAGS \
-  /bin/bash /src/icu/source/runConfigureICU Linux \
+  /bin/bash $src/icu/source/runConfigureICU Linux \
    --with-library-bits=64 --with-data-packaging=static --enable-static --disable-shared
 
 make -j$(nproc)
@@ -40,9 +40,9 @@ FUZZERS="break_iterator_fuzzer \
   "
 for fuzzer in $FUZZERS; do
   $CXX $CXXFLAGS -std=c++11 \
-    /src/$fuzzer.cc -o /out/$fuzzer \
-    -I/src/icu/source/common -I/src/icu/source/i18n -L/work/icu/lib \
+    $src/$fuzzer.cc -o $out/$fuzzer \
+    -I$src/icu/source/common -I$src/icu/source/i18n -L/work/icu/lib \
     -lfuzzer -licui18n -licuuc -licutu -licudata $FUZZER_LDFLAGS
 done
 
-cp /src/*.dict /src/*.options  /out
+cp $src/*.dict $src/*.options  $out/

--- a/targets/icu/build.sh
+++ b/targets/icu/build.sh
@@ -16,8 +16,8 @@
 #
 ################################################################################
 
-mkdir /work/icu
-cd /work/icu
+mkdir $WORK/icu
+cd $WORK/icu
 
 # TODO: icu build failes without -DU_USE_STRTOD_L=0
 DEFINES="-DU_CHARSET_IS_UTF8=1 -DU_USING_ICU_NAMESPACE=0 -DU_ENABLE_DYLOAD=0 -DU_USE_STRTOD_L=0"
@@ -41,7 +41,7 @@ FUZZERS="break_iterator_fuzzer \
 for fuzzer in $FUZZERS; do
   $CXX $CXXFLAGS -std=c++11 \
     $SRC/$fuzzer.cc -o $OUT/$fuzzer \
-    -I$SRC/icu/source/common -I$SRC/icu/source/i18n -L/work/icu/lib \
+    -I$SRC/icu/source/common -I$SRC/icu/source/i18n -L$WORK/icu/lib \
     -lfuzzer -licui18n -licuuc -licutu -licudata $FUZZER_LDFLAGS
 done
 

--- a/targets/json/Dockerfile
+++ b/targets/json/Dockerfile
@@ -19,5 +19,5 @@ MAINTAINER vitalybuka@gmail.com
 RUN apt-get install -y binutils gcc
 
 RUN git clone https://github.com/nlohmann/json.git
-WORKDIR /src/json/
-COPY build.sh parse_fuzzer.* /src/
+WORKDIR json/
+COPY build.sh parse_fuzzer.* $SRC/

--- a/targets/json/build.sh
+++ b/targets/json/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 $CXX $CXXFLAGS -std=c++11 -Isrc/ \
-    /src/parse_fuzzer.cc -o /out/parse_fuzzer \
+    $src/parse_fuzzer.cc -o $out/parse_fuzzer \
     -lfuzzer $FUZZER_LDFLAGS
 
-cp /src/*.options /out/
+cp $src/*.options $out/

--- a/targets/json/build.sh
+++ b/targets/json/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 $CXX $CXXFLAGS -std=c++11 -Isrc/ \
-    $src/parse_fuzzer.cc -o $out/parse_fuzzer \
+    $SRC/parse_fuzzer.cc -o $OUT/parse_fuzzer \
     -lfuzzer $FUZZER_LDFLAGS
 
-cp $src/*.options $out/
+cp $SRC/*.options $OUT/

--- a/targets/lcms/Dockerfile
+++ b/targets/lcms/Dockerfile
@@ -19,4 +19,4 @@ MAINTAINER kcwu@google.com
 RUN apt-get install -y make autoconf automake libtool
 RUN git clone https://github.com/mm2/Little-CMS.git lcms
 WORKDIR lcms
-COPY build.sh cmsIT8_load_fuzzer.* cms_transform_fuzzer.* icc.dict /src/
+COPY build.sh cmsIT8_load_fuzzer.* cms_transform_fuzzer.* icc.dict $SRC/

--- a/targets/lcms/build.sh
+++ b/targets/lcms/build.sh
@@ -23,8 +23,8 @@ make -j$(nproc) all
 FUZZERS="cmsIT8_load_fuzzer cms_transform_fuzzer"
 for F in $FUZZERS; do
     $CC $CFLAGS -Iinclude \
-        $src/$F.c -o $out/$F \
+        $SRC/$F.c -o $OUT/$F \
         -lfuzzer src/.libs/liblcms2.a $FUZZER_LDFLAGS
 done
 
-cp $src/icc.dict $src/*.options $out/
+cp $SRC/icc.dict $SRC/*.options $OUT/

--- a/targets/lcms/build.sh
+++ b/targets/lcms/build.sh
@@ -23,8 +23,8 @@ make -j$(nproc) all
 FUZZERS="cmsIT8_load_fuzzer cms_transform_fuzzer"
 for F in $FUZZERS; do
     $CC $CFLAGS -Iinclude \
-        /src/$F.c -o /out/$F \
+        $src/$F.c -o $out/$F \
         -lfuzzer src/.libs/liblcms2.a $FUZZER_LDFLAGS
 done
 
-cp /src/icc.dict /src/*.options /out
+cp $src/icc.dict $src/*.options $out/

--- a/targets/libarchive/Dockerfile
+++ b/targets/libarchive/Dockerfile
@@ -24,4 +24,4 @@ RUN apt-get install -y make autoconf automake libtool pkg-config \
         libxml2-dev libssl-dev
 RUN git clone https://github.com/libarchive/libarchive.git
 WORKDIR libarchive
-COPY build.sh libarchive_fuzzer.cc /src/
+COPY build.sh libarchive_fuzzer.cc $SRC/

--- a/targets/libarchive/build.sh
+++ b/targets/libarchive/build.sh
@@ -22,6 +22,6 @@ make -j$(nproc) all
 
 # build your fuzzer(s)
 $CXX $CXXFLAGS -Ilibarchive \
-    /src/libarchive_fuzzer.cc -o /out/libarchive_fuzzer \
+    $src/libarchive_fuzzer.cc -o $out/libarchive_fuzzer \
     -lfuzzer .libs/libarchive.a $FUZZER_LDFLAGS \
     -lbz2 -llzo2 -llzma -lxml2 -lz -lcrypto -llz4

--- a/targets/libarchive/build.sh
+++ b/targets/libarchive/build.sh
@@ -22,6 +22,6 @@ make -j$(nproc) all
 
 # build your fuzzer(s)
 $CXX $CXXFLAGS -Ilibarchive \
-    $src/libarchive_fuzzer.cc -o $out/libarchive_fuzzer \
+    $SRC/libarchive_fuzzer.cc -o $OUT/libarchive_fuzzer \
     -lfuzzer .libs/libarchive.a $FUZZER_LDFLAGS \
     -lbz2 -llzo2 -llzma -lxml2 -lz -lcrypto -llz4

--- a/targets/libass/Dockerfile
+++ b/targets/libass/Dockerfile
@@ -21,4 +21,4 @@ RUN apt-get install -y make autoconf automake libtool pkg-config libfreetype6-de
 RUN git clone https://github.com/libass/libass.git
 RUN git clone https://github.com/behdad/fribidi.git
 
-COPY build.sh libass_fuzzer.cc *.dict *.options /src/
+COPY build.sh libass_fuzzer.cc *.dict *.options $SRC/

--- a/targets/libass/build.sh
+++ b/targets/libass/build.sh
@@ -15,22 +15,22 @@
 #
 ################################################################################
 
-cd $src/fribidi
+cd $SRC/fribidi
 ./bootstrap
 ./configure --enable-static=yes --enable-shared=no --with-pic=yes
 # Don't run "make": it's broken. Run "make install".
 make install
 
-cd $src/libass
+cd $SRC/libass
 
 ./autogen.sh
 ./configure --disable-asm
 make -j$(nproc)
 
-$CXX $CXXFLAGS -std=c++11 -I$src/libass \
-    $src/libass_fuzzer.cc -o $out/libass_fuzzer \
+$CXX $CXXFLAGS -std=c++11 -I$SRC/libass \
+    $SRC/libass_fuzzer.cc -o $OUT/libass_fuzzer \
     -lfuzzer libass/.libs/libass.a \
     -Wl,-Bstatic -lfontconfig  -lfribidi -lfreetype -lz -lpng12 -lexpat -Wl,-Bdynamic \
     $FUZZER_LDFLAGS
 
-cp $src/*.dict $src/*.options $out/
+cp $SRC/*.dict $SRC/*.options $OUT/

--- a/targets/libass/build.sh
+++ b/targets/libass/build.sh
@@ -15,22 +15,22 @@
 #
 ################################################################################
 
-cd /src/fribidi
+cd $src/fribidi
 ./bootstrap
 ./configure --enable-static=yes --enable-shared=no --with-pic=yes
 # Don't run "make": it's broken. Run "make install".
 make install
 
-cd /src/libass
+cd $src/libass
 
 ./autogen.sh
 ./configure --disable-asm
 make -j$(nproc)
 
-$CXX $CXXFLAGS -std=c++11 -I/src/libass \
-    /src/libass_fuzzer.cc -o /out/libass_fuzzer \
+$CXX $CXXFLAGS -std=c++11 -I$src/libass \
+    $src/libass_fuzzer.cc -o $out/libass_fuzzer \
     -lfuzzer libass/.libs/libass.a \
     -Wl,-Bstatic -lfontconfig  -lfribidi -lfreetype -lz -lpng12 -lexpat -Wl,-Bdynamic \
     $FUZZER_LDFLAGS
 
-cp /src/*.dict /src/*.options /out/
+cp $src/*.dict $src/*.options $out/

--- a/targets/libchewing/Dockerfile
+++ b/targets/libchewing/Dockerfile
@@ -20,4 +20,4 @@ RUN apt-get install -y make autoconf automake libtool texinfo
 
 RUN git clone https://github.com/chewing/libchewing.git
 WORKDIR libchewing
-COPY build.sh chewing_fuzzer_common.[ch] chewing_*_fuzzer.c /src/
+COPY build.sh chewing_fuzzer_common.[ch] chewing_*_fuzzer.c $SRC/

--- a/targets/libchewing/build.sh
+++ b/targets/libchewing/build.sh
@@ -26,11 +26,11 @@ make -C test CFLAGS="$CFLAGS -Dmain=stress_main -Drand=get_fuzz_input" stress.o
 
 for variant in default random_init dynamic_config; do
     $CC $CFLAGS \
-	-o /out/chewing_${variant}_fuzzer \
-	/src/chewing_${variant}_fuzzer.c /src/chewing_fuzzer_common.c \
+	-o $out/chewing_${variant}_fuzzer \
+	$src/chewing_${variant}_fuzzer.c $src/chewing_fuzzer_common.c \
 	test/stress.o test/.libs/libtesthelper.a src/.libs/libchewing.a \
 	-lfuzzer $FUZZER_LDFLAGS
 done
 
 # install data files
-make -j$(nproc) -C data pkgdatadir=/out install
+make -j$(nproc) -C data pkgdatadir=$out install

--- a/targets/libchewing/build.sh
+++ b/targets/libchewing/build.sh
@@ -26,11 +26,11 @@ make -C test CFLAGS="$CFLAGS -Dmain=stress_main -Drand=get_fuzz_input" stress.o
 
 for variant in default random_init dynamic_config; do
     $CC $CFLAGS \
-	-o $out/chewing_${variant}_fuzzer \
-	$src/chewing_${variant}_fuzzer.c $src/chewing_fuzzer_common.c \
+	-o $OUT/chewing_${variant}_fuzzer \
+	$SRC/chewing_${variant}_fuzzer.c $SRC/chewing_fuzzer_common.c \
 	test/stress.o test/.libs/libtesthelper.a src/.libs/libchewing.a \
 	-lfuzzer $FUZZER_LDFLAGS
 done
 
 # install data files
-make -j$(nproc) -C data pkgdatadir=$out install
+make -j$(nproc) -C data pkgdatadir=$OUT install

--- a/targets/libjpeg-turbo/Dockerfile
+++ b/targets/libjpeg-turbo/Dockerfile
@@ -25,4 +25,4 @@ RUN cd afl-testcases/ && tar -xf afl_testcases.tgz
 RUN zip libjpeg_turbo_fuzzer_seed_corpus.zip afl-testcases/jpeg/full/images/*
 
 WORKDIR libjpeg-turbo
-COPY build.sh libjpeg_turbo_fuzzer.cc /src/
+COPY build.sh libjpeg_turbo_fuzzer.cc $SRC/

--- a/targets/libjpeg-turbo/build.sh
+++ b/targets/libjpeg-turbo/build.sh
@@ -20,7 +20,7 @@ autoreconf -fiv
 make "-j$(nproc)"
 
 $CXX $CXXFLAGS -std=c++11 -I. \
-    /src/libjpeg_turbo_fuzzer.cc -o /out/libjpeg_turbo_fuzzer \
+    $src/libjpeg_turbo_fuzzer.cc -o $out/libjpeg_turbo_fuzzer \
     -lfuzzer ./.libs/libturbojpeg.a $FUZZER_LDFLAGS
 
-cp /src/libjpeg_turbo_fuzzer_seed_corpus.zip /out/
+cp $src/libjpeg_turbo_fuzzer_seed_corpus.zip $out/

--- a/targets/libjpeg-turbo/build.sh
+++ b/targets/libjpeg-turbo/build.sh
@@ -20,7 +20,7 @@ autoreconf -fiv
 make "-j$(nproc)"
 
 $CXX $CXXFLAGS -std=c++11 -I. \
-    $src/libjpeg_turbo_fuzzer.cc -o $out/libjpeg_turbo_fuzzer \
+    $SRC/libjpeg_turbo_fuzzer.cc -o $OUT/libjpeg_turbo_fuzzer \
     -lfuzzer ./.libs/libturbojpeg.a $FUZZER_LDFLAGS
 
-cp $src/libjpeg_turbo_fuzzer_seed_corpus.zip $out/
+cp $SRC/libjpeg_turbo_fuzzer_seed_corpus.zip $OUT/

--- a/targets/libpng/Dockerfile
+++ b/targets/libpng/Dockerfile
@@ -20,4 +20,4 @@ RUN apt-get install -y make autoconf automake libtool zlib1g-dev
 
 RUN git clone git://git.code.sf.net/p/libpng/code libpng
 WORKDIR libpng
-COPY build.sh libpng_read_fuzzer.* png.dict /src/
+COPY build.sh libpng_read_fuzzer.* png.dict $SRC/

--- a/targets/libpng/build.sh
+++ b/targets/libpng/build.sh
@@ -27,7 +27,7 @@ make -j$(nproc) clean all
 
 # build libpng_read_fuzzer
 $CXX $CXXFLAGS -std=c++11 -I. -lz \
-     $src/libpng_read_fuzzer.cc -o $out/libpng_read_fuzzer \
+     $SRC/libpng_read_fuzzer.cc -o $OUT/libpng_read_fuzzer \
      -lfuzzer .libs/libpng16.a $FUZZER_LDFLAGS
 
-cp $src/*.dict $src/*.options $out/
+cp $SRC/*.dict $SRC/*.options $OUT/

--- a/targets/libpng/build.sh
+++ b/targets/libpng/build.sh
@@ -27,7 +27,7 @@ make -j$(nproc) clean all
 
 # build libpng_read_fuzzer
 $CXX $CXXFLAGS -std=c++11 -I. -lz \
-     /src/libpng_read_fuzzer.cc -o /out/libpng_read_fuzzer \
+     $src/libpng_read_fuzzer.cc -o $out/libpng_read_fuzzer \
      -lfuzzer .libs/libpng16.a $FUZZER_LDFLAGS
 
-cp /src/*.dict /src/*.options /out/
+cp $src/*.dict $src/*.options $out/

--- a/targets/libteken/Dockerfile
+++ b/targets/libteken/Dockerfile
@@ -18,4 +18,5 @@ FROM ossfuzz/base-libfuzzer
 MAINTAINER kcwu@csie.org
 RUN apt-get install -y pmake
 RUN svn co https://svn.freebsd.org/base/head/sys/teken
+WORKDIR teken
 COPY build.sh libteken_fuzzer.c /src/

--- a/targets/libteken/Dockerfile
+++ b/targets/libteken/Dockerfile
@@ -19,4 +19,4 @@ MAINTAINER kcwu@csie.org
 RUN apt-get install -y pmake
 RUN svn co https://svn.freebsd.org/base/head/sys/teken
 WORKDIR teken
-COPY build.sh libteken_fuzzer.c /src/
+COPY build.sh libteken_fuzzer.c $SRC/

--- a/targets/libteken/build.sh
+++ b/targets/libteken/build.sh
@@ -15,14 +15,12 @@
 #
 ################################################################################
 
-cd $src
-
 # build the library.
 pmake -C teken/libteken teken_state.h
 CFLAGS="$CFLAGS -D__unused=" pmake -C teken/libteken libteken.a
 
 # build your fuzzer(s)
 $CC $CFLAGS -Iteken \
-    -o $out/libteken_fuzzer \
+    -o $OUT/libteken_fuzzer \
     libteken_fuzzer.c \
     -lfuzzer teken/libteken/libteken.a $FUZZER_LDFLAGS

--- a/targets/libteken/build.sh
+++ b/targets/libteken/build.sh
@@ -15,7 +15,7 @@
 #
 ################################################################################
 
-cd /src
+cd $src
 
 # build the library.
 pmake -C teken/libteken teken_state.h
@@ -23,6 +23,6 @@ CFLAGS="$CFLAGS -D__unused=" pmake -C teken/libteken libteken.a
 
 # build your fuzzer(s)
 $CC $CFLAGS -Iteken \
-    -o /out/libteken_fuzzer \
+    -o $out/libteken_fuzzer \
     libteken_fuzzer.c \
     -lfuzzer teken/libteken/libteken.a $FUZZER_LDFLAGS

--- a/targets/libtsm/Dockerfile
+++ b/targets/libtsm/Dockerfile
@@ -20,4 +20,4 @@ RUN apt-get install -y make autoconf automake libtool pkg-config
 
 RUN git clone git://people.freedesktop.org/~dvdhrm/libtsm
 WORKDIR libtsm
-COPY build.sh libtsm_fuzzer.c /src/
+COPY build.sh libtsm_fuzzer.c $SRC/

--- a/targets/libtsm/build.sh
+++ b/targets/libtsm/build.sh
@@ -21,7 +21,7 @@ make -j$(nproc) clean all
 
 # build your fuzzer(s)
 $CC $CFLAGS -Isrc/tsm \
-    -o /out/libtsm_fuzzer \
-    /src/libtsm_fuzzer.c \
+    -o $out/libtsm_fuzzer \
+    $src/libtsm_fuzzer.c \
     .libs/libtsm.a \
     -lfuzzer $FUZZER_LDFLAGS

--- a/targets/libtsm/build.sh
+++ b/targets/libtsm/build.sh
@@ -21,7 +21,7 @@ make -j$(nproc) clean all
 
 # build your fuzzer(s)
 $CC $CFLAGS -Isrc/tsm \
-    -o $out/libtsm_fuzzer \
-    $src/libtsm_fuzzer.c \
+    -o $OUT/libtsm_fuzzer \
+    $SRC/libtsm_fuzzer.c \
     .libs/libtsm.a \
     -lfuzzer $FUZZER_LDFLAGS

--- a/targets/libxml2/Dockerfile
+++ b/targets/libxml2/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get install -y make autoconf automake libtool pkg-config
 RUN git clone git://git.gnome.org/libxml2
 WORKDIR libxml2
 
-COPY build.sh /src/
+COPY build.sh $SRC/
 COPY libxml2_xml_read_memory_fuzzer.* \
      libxml2_xml_regexp_compile_fuzzer.* \
-     xml.dict /src/
+     xml.dict $SRC/

--- a/targets/libxml2/build.sh
+++ b/targets/libxml2/build.sh
@@ -22,8 +22,8 @@ make -j$(nproc) clean all
 
 for fuzzer in libxml2_xml_read_memory_fuzzer libxml2_xml_regexp_compile_fuzzer; do
   $CXX $CXXFLAGS -std=c++11 -Iinclude/ \
-      /src/$fuzzer.cc -o /out/$fuzzer \
+      $src/$fuzzer.cc -o $out/$fuzzer \
       -lfuzzer .libs/libxml2.a $FUZZER_LDFLAGS
 done
 
-cp /src/*.dict /src/*.options /out/
+cp $src/*.dict $src/*.options $out/

--- a/targets/libxml2/build.sh
+++ b/targets/libxml2/build.sh
@@ -22,8 +22,8 @@ make -j$(nproc) clean all
 
 for fuzzer in libxml2_xml_read_memory_fuzzer libxml2_xml_regexp_compile_fuzzer; do
   $CXX $CXXFLAGS -std=c++11 -Iinclude/ \
-      $src/$fuzzer.cc -o $out/$fuzzer \
+      $SRC/$fuzzer.cc -o $OUT/$fuzzer \
       -lfuzzer .libs/libxml2.a $FUZZER_LDFLAGS
 done
 
-cp $src/*.dict $src/*.options $out/
+cp $SRC/*.dict $SRC/*.options $OUT/

--- a/targets/nss/Dockerfile
+++ b/targets/nss/Dockerfile
@@ -23,4 +23,4 @@ RUN hg clone https://hg.mozilla.org/projects/nss nss
 RUN git clone https://github.com/mozilla/nss-fuzzing-corpus.git nss-corpus
 
 WORKDIR nss
-COPY build.sh fuzzers/* /src/
+COPY build.sh fuzzers/* $SRC/

--- a/targets/nss/build.sh
+++ b/targets/nss/build.sh
@@ -52,17 +52,17 @@ FUZZERS="asn1_algorithmid_fuzzer \
 
 
 for fuzzer in $FUZZERS; do
-  $CXX $CXXFLAGS -std=c++11 $src/$fuzzer.cc \
+  $CXX $CXXFLAGS -std=c++11 $SRC/$fuzzer.cc \
      -I/work/nss/include \
      -lfuzzer \
      /work/nss/lib/libnss.a /work/nss/lib/libnssutil.a \
      /work/nss/lib/libnspr4.a /work/nss/lib/libplc4.a /work/nss/lib/libplds4.a \
-     /work/nss/lib/prlog2.o -o $out/$fuzzer $FUZZER_LDFLAGS
+     /work/nss/lib/prlog2.o -o $OUT/$fuzzer $FUZZER_LDFLAGS
 done
 
-# Archive and copy to $out seed corpus if the build succeeded.
-zip /work/nss/all_nss_seed_corpus.zip $src/nss-corpus/*/*
+# Archive and copy to $OUT seed corpus if the build succeeded.
+zip /work/nss/all_nss_seed_corpus.zip $SRC/nss-corpus/*/*
 
 for fuzzer in $FUZZERS; do
-  cp /work/nss/all_nss_seed_corpus.zip $out/${fuzzer}_seed_corpus.zip
+  cp /work/nss/all_nss_seed_corpus.zip $OUT/${fuzzer}_seed_corpus.zip
 done

--- a/targets/nss/build.sh
+++ b/targets/nss/build.sh
@@ -21,15 +21,15 @@ make CCC="$CXX" XCFLAGS="$CXXFLAGS" SANITIZER_CFLAGS="$CXXFLAGS" \
     nss_clean_all nss_build_all
 cd ..
 
-# Copy libraries and some objects to /work/nss/lib.
-mkdir -p /work/nss/lib
-cp dist/Linux*/lib/*.a /work/nss/lib
-cp nspr/Linux*/pr/src/misc/prlog2.o /work/nss/lib
+# Copy libraries and some objects to $WORK/nss/lib.
+mkdir -p $WORK/nss/lib
+cp dist/Linux*/lib/*.a $WORK/nss/lib
+cp nspr/Linux*/pr/src/misc/prlog2.o $WORK/nss/lib
 
-# Copy includes to /work/nss/include.
-mkdir -p /work/nss/include
-cp -rL dist/Linux*/include/* /work/nss/include
-cp -rL dist/{public,private}/nss/* /work/nss/include
+# Copy includes to $WORK/nss/include.
+mkdir -p $WORK/nss/include
+cp -rL dist/Linux*/include/* $WORK/nss/include
+cp -rL dist/{public,private}/nss/* $WORK/nss/include
 
 
 # Build the fuzzers.
@@ -53,16 +53,16 @@ FUZZERS="asn1_algorithmid_fuzzer \
 
 for fuzzer in $FUZZERS; do
   $CXX $CXXFLAGS -std=c++11 $SRC/$fuzzer.cc \
-     -I/work/nss/include \
+     -I$WORK/nss/include \
      -lfuzzer \
-     /work/nss/lib/libnss.a /work/nss/lib/libnssutil.a \
-     /work/nss/lib/libnspr4.a /work/nss/lib/libplc4.a /work/nss/lib/libplds4.a \
-     /work/nss/lib/prlog2.o -o $OUT/$fuzzer $FUZZER_LDFLAGS
+     $WORK/nss/lib/libnss.a $WORK/nss/lib/libnssutil.a \
+     $WORK/nss/lib/libnspr4.a $WORK/nss/lib/libplc4.a $WORK/nss/lib/libplds4.a \
+     $WORK/nss/lib/prlog2.o -o $OUT/$fuzzer $FUZZER_LDFLAGS
 done
 
 # Archive and copy to $OUT seed corpus if the build succeeded.
-zip /work/nss/all_nss_seed_corpus.zip $SRC/nss-corpus/*/*
+zip $WORK/nss/all_nss_seed_corpus.zip $SRC/nss-corpus/*/*
 
 for fuzzer in $FUZZERS; do
-  cp /work/nss/all_nss_seed_corpus.zip $OUT/${fuzzer}_seed_corpus.zip
+  cp $WORK/nss/all_nss_seed_corpus.zip $OUT/${fuzzer}_seed_corpus.zip
 done

--- a/targets/nss/build.sh
+++ b/targets/nss/build.sh
@@ -52,17 +52,17 @@ FUZZERS="asn1_algorithmid_fuzzer \
 
 
 for fuzzer in $FUZZERS; do
-  $CXX $CXXFLAGS -std=c++11 /src/$fuzzer.cc \
+  $CXX $CXXFLAGS -std=c++11 $src/$fuzzer.cc \
      -I/work/nss/include \
      -lfuzzer \
      /work/nss/lib/libnss.a /work/nss/lib/libnssutil.a \
      /work/nss/lib/libnspr4.a /work/nss/lib/libplc4.a /work/nss/lib/libplds4.a \
-     /work/nss/lib/prlog2.o -o /out/$fuzzer $FUZZER_LDFLAGS
+     /work/nss/lib/prlog2.o -o $out/$fuzzer $FUZZER_LDFLAGS
 done
 
-# Archive and copy to /out seed corpus if the build succeeded.
-zip /work/nss/all_nss_seed_corpus.zip /src/nss-corpus/*/*
+# Archive and copy to $out seed corpus if the build succeeded.
+zip /work/nss/all_nss_seed_corpus.zip $src/nss-corpus/*/*
 
 for fuzzer in $FUZZERS; do
-  cp /work/nss/all_nss_seed_corpus.zip /out/${fuzzer}_seed_corpus.zip
+  cp /work/nss/all_nss_seed_corpus.zip $out/${fuzzer}_seed_corpus.zip
 done

--- a/targets/openssl/Dockerfile
+++ b/targets/openssl/Dockerfile
@@ -19,4 +19,4 @@ MAINTAINER kurt@roeckx.be
 RUN apt-get install -y make
 RUN git clone https://github.com/openssl/openssl.git
 WORKDIR openssl
-COPY build.sh /src/
+COPY build.sh $SRC/

--- a/targets/openssl/build.sh
+++ b/targets/openssl/build.sh
@@ -21,7 +21,7 @@ make -j$(nproc) EX_LIBS="-ldl $FUZZER_LDFLAGS"
 fuzzers=$(find fuzz -executable -type f '!' -name \*.py '!' -name \*-test)
 for f in $fuzzers; do
 	fuzzer=$(basename $f)
-	cp $f /out
-	zip -j /out/${fuzzer}_seed_corpus.zip fuzz/corpora/${fuzzer}/*
+	cp $f $OUT/
+	zip -j $OUT/${fuzzer}_seed_corpus.zip fuzz/corpora/${fuzzer}/*
 done
 

--- a/targets/ots/Dockerfile
+++ b/targets/ots/Dockerfile
@@ -18,6 +18,6 @@ FROM ossfuzz/base-libfuzzer
 MAINTAINER mmoroz@chromium.org
 RUN apt-get install -y make autoconf automake libtool pkg-config zlib1g-dev
 RUN git clone https://github.com/khaledhosny/ots.git
-WORKDIR /src/ots
-COPY build.sh ots_fuzzer.* /src/
-COPY seed_corpus /src/seed_corpus
+WORKDIR ots
+COPY build.sh ots_fuzzer.* $SRC/
+COPY seed_corpus $SRC/seed_corpus

--- a/targets/ots/build.sh
+++ b/targets/ots/build.sh
@@ -24,9 +24,9 @@ make libots.a libwoff2.a libbrotli.a
 
 # Build the fuzzer.
 $CXX $CXXFLAGS -std=c++11 -Iinclude \
-    $src/ots_fuzzer.cc -o $out/ots_fuzzer \
-    -lfuzzer -lz $src/ots/libots.a $src/ots/libwoff2.a $src/ots/libbrotli.a \
+    $SRC/ots_fuzzer.cc -o $OUT/ots_fuzzer \
+    -lfuzzer -lz $SRC/ots/libots.a $SRC/ots/libwoff2.a $SRC/ots/libbrotli.a \
     $FUZZER_LDFLAGS
 
-cp $src/ots_fuzzer.options $out/
-zip $out/ots_fuzzer_seed_corpus.zip $src/seed_corpus/*
+cp $SRC/ots_fuzzer.options $OUT/
+zip $OUT/ots_fuzzer_seed_corpus.zip $SRC/seed_corpus/*

--- a/targets/ots/build.sh
+++ b/targets/ots/build.sh
@@ -24,9 +24,9 @@ make libots.a libwoff2.a libbrotli.a
 
 # Build the fuzzer.
 $CXX $CXXFLAGS -std=c++11 -Iinclude \
-    /src/ots_fuzzer.cc -o /out/ots_fuzzer \
-    -lfuzzer -lz /src/ots/libots.a /src/ots/libwoff2.a /src/ots/libbrotli.a \
+    $src/ots_fuzzer.cc -o $out/ots_fuzzer \
+    -lfuzzer -lz $src/ots/libots.a $src/ots/libwoff2.a $src/ots/libbrotli.a \
     $FUZZER_LDFLAGS
 
-cp /src/ots_fuzzer.options /out/
-zip /out/ots_fuzzer_seed_corpus.zip /src/seed_corpus/*
+cp $src/ots_fuzzer.options $out/
+zip $out/ots_fuzzer_seed_corpus.zip $src/seed_corpus/*

--- a/targets/pcre2/Dockerfile
+++ b/targets/pcre2/Dockerfile
@@ -19,4 +19,4 @@ MAINTAINER kcc@google.com
 RUN apt-get install -y make autoconf automake libtool subversion
 
 RUN svn co svn://vcs.exim.org/pcre2/code/trunk pcre2
-COPY build.sh /src/
+COPY build.sh $SRC/

--- a/targets/pcre2/build.sh
+++ b/targets/pcre2/build.sh
@@ -23,6 +23,6 @@ cd pcre2
 make -j$(nproc) clean all
 
 # Build the target.
-$CXX $CXXFLAGS -o /out/pcre2_fuzzer \
+$CXX $CXXFLAGS -o $OUT/pcre2_fuzzer \
     -lfuzzer .libs/libpcre2-fuzzsupport.a .libs/libpcre2-8.a \
     $FUZZER_LDFLAGS

--- a/targets/re2/Dockerfile
+++ b/targets/re2/Dockerfile
@@ -20,4 +20,4 @@ RUN apt-get install -y make autoconf automake libtool
 
 RUN git clone https://code.googlesource.com/re2
 WORKDIR re2
-COPY build.sh re2_fuzzer.* /src/
+COPY build.sh re2_fuzzer.* $SRC/

--- a/targets/re2/build.sh
+++ b/targets/re2/build.sh
@@ -29,7 +29,7 @@ make -j$(nproc) obj/libre2.a
 
 # Second, build our fuzzers.
 $CXX $CXXFLAGS -std=c++11 -I. \
-	$src/re2_fuzzer.cc -o $out/re2_fuzzer \
+	$SRC/re2_fuzzer.cc -o $OUT/re2_fuzzer \
 	-lfuzzer ./obj/libre2.a $FUZZER_LDFLAGS
 
-cp $src/*.options $out/
+cp $SRC/*.options $OUT/

--- a/targets/re2/build.sh
+++ b/targets/re2/build.sh
@@ -29,7 +29,7 @@ make -j$(nproc) obj/libre2.a
 
 # Second, build our fuzzers.
 $CXX $CXXFLAGS -std=c++11 -I. \
-	/src/re2_fuzzer.cc -o /out/re2_fuzzer \
+	$src/re2_fuzzer.cc -o $out/re2_fuzzer \
 	-lfuzzer ./obj/libre2.a $FUZZER_LDFLAGS
 
-cp /src/*.options /out/
+cp $src/*.options $out/

--- a/targets/sqlite3/Dockerfile
+++ b/targets/sqlite3/Dockerfile
@@ -20,12 +20,12 @@ RUN apt-get install -y make autoconf automake libtool fossil tcl
 
 # We won't be able to poll fossil for changes, so this will build
 # only once a day.
-RUN mkdir /src/sqlite3 && \
-    cd /src/sqlite3 && \
+RUN mkdir $SRC/sqlite3 && \
+    cd $SRC/sqlite3 && \
     fossil clone https://www.sqlite.org/src sqlite --user `whoami` && \
     fossil open sqlite
 
-RUN find /src/sqlite3 -name "*.test" | xargs zip /src/ossfuzz_seed_corpus.zip
+RUN find $SRC/sqlite3 -name "*.test" | xargs zip $SRC/ossfuzz_seed_corpus.zip
 
 WORKDIR sqlite3
-COPY build.sh *.dict *.options /src/
+COPY build.sh *.dict *.options $SRC/

--- a/targets/sqlite3/build.sh
+++ b/targets/sqlite3/build.sh
@@ -28,8 +28,8 @@ make -j$(nproc)
 make sqlite3.c
 
 $CC $CFLAGS -I. \
-    $src/sqlite3/test/ossfuzz.c -o $out/ossfuzz \
+    $SRC/sqlite3/test/ossfuzz.c -o $OUT/ossfuzz \
     -lfuzzer ./sqlite3.o $FUZZER_LDFLAGS
 
-cp $src/*.options $src/*.dict $src/*.zip $out/
+cp $SRC/*.options $SRC/*.dict $SRC/*.zip $OUT/
 

--- a/targets/sqlite3/build.sh
+++ b/targets/sqlite3/build.sh
@@ -28,8 +28,8 @@ make -j$(nproc)
 make sqlite3.c
 
 $CC $CFLAGS -I. \
-    /src/sqlite3/test/ossfuzz.c -o /out/ossfuzz \
+    $src/sqlite3/test/ossfuzz.c -o $out/ossfuzz \
     -lfuzzer ./sqlite3.o $FUZZER_LDFLAGS
 
-cp /src/*.options /src/*.dict /src/*.zip /out/
+cp $src/*.options $src/*.dict $src/*.zip $out/
 

--- a/targets/woff2/Dockerfile
+++ b/targets/woff2/Dockerfile
@@ -20,4 +20,4 @@ RUN apt-get install -y make autoconf automake libtool
 
 RUN git clone --recursive https://github.com/google/woff2
 WORKDIR woff2
-COPY build.sh convert_woff2ttf_fuzzer.* /src/
+COPY build.sh convert_woff2ttf_fuzzer.* $SRC/

--- a/targets/woff2/build.sh
+++ b/targets/woff2/build.sh
@@ -35,7 +35,7 @@ rm src/woff2_compress.o src/woff2_decompress.o
 # Build the fuzzer.
 fuzzer=convert_woff2ttf_fuzzer
 $CXX $CXXFLAGS -std=c++11 -Isrc \
-    $src/$fuzzer.cc -o $out/$fuzzer \
+    $SRC/$fuzzer.cc -o $OUT/$fuzzer \
     -lfuzzer src/*.o brotli/dec/*.o brotli/enc/*.o $FUZZER_LDFLAGS
 
-cp $src/*.options $out/
+cp $SRC/*.options $OUT/

--- a/targets/woff2/build.sh
+++ b/targets/woff2/build.sh
@@ -35,7 +35,7 @@ rm src/woff2_compress.o src/woff2_decompress.o
 # Build the fuzzer.
 fuzzer=convert_woff2ttf_fuzzer
 $CXX $CXXFLAGS -std=c++11 -Isrc \
-    /src/$fuzzer.cc -o /out/$fuzzer \
+    $src/$fuzzer.cc -o $out/$fuzzer \
     -lfuzzer src/*.o brotli/dec/*.o brotli/enc/*.o $FUZZER_LDFLAGS
 
-cp /src/*.options /out/
+cp $src/*.options $out/

--- a/targets/zlib/Dockerfile
+++ b/targets/zlib/Dockerfile
@@ -20,4 +20,4 @@ RUN apt-get install -y make autoconf automake libtool
 
 RUN git clone https://github.com/madler/zlib.git
 WORKDIR zlib
-COPY build.sh zlib_uncompress_fuzzer.cc /src/
+COPY build.sh zlib_uncompress_fuzzer.cc $SRC/

--- a/targets/zlib/build.sh
+++ b/targets/zlib/build.sh
@@ -4,5 +4,5 @@
 make -j$(nproc) clean all
 
 $CXX $CXXFLAGS -std=c++11 -I. \
-    /src/zlib_uncompress_fuzzer.cc -o /out/zlib_uncompress_fuzzer \
+    $src/zlib_uncompress_fuzzer.cc -o $out/zlib_uncompress_fuzzer \
     -lfuzzer ./libz.a $FUZZER_LDFLAGS

--- a/targets/zlib/build.sh
+++ b/targets/zlib/build.sh
@@ -4,5 +4,5 @@
 make -j$(nproc) clean all
 
 $CXX $CXXFLAGS -std=c++11 -I. \
-    $src/zlib_uncompress_fuzzer.cc -o $out/zlib_uncompress_fuzzer \
+    $SRC/zlib_uncompress_fuzzer.cc -o $OUT/zlib_uncompress_fuzzer \
     -lfuzzer ./libz.a $FUZZER_LDFLAGS


### PR DESCRIPTION
This will make it possible to run scripts outside of docker container.

I am not 100% sure about this one. WDYT? Will this make build scripts easier to write or not?

If yes, I'll update the documentation.