### PR TITLE
[c-ares] Fixing build flags to have proper coverage + stack-traces.

### DIFF
--- a/targets/c-ares/build.sh
+++ b/targets/c-ares/build.sh
@@ -17,9 +17,9 @@
 
 # Build the target.
 ./buildconf
-./configure
+./configure CC="$CC $CFLAGS"
 make clean
-make -j$(nproc) V=1 all
+make CFLAGS= -j$(nproc) V=1 all
 
 # Build the fuzzer.
 $CXX $CXXFLAGS -std=c++11 -I. \

--- a/targets/c-ares/build.sh
+++ b/targets/c-ares/build.sh
@@ -17,9 +17,9 @@
 
 # Build the target.
 ./buildconf
-./configure CC="$CC $CFLAGS"
+./configure --enable-debug
 make clean
-make CFLAGS= -j$(nproc) V=1 all
+make -j$(nproc) V=1 all
 
 # Build the fuzzer.
 $CXX $CXXFLAGS -std=c++11 -I. \


### PR DESCRIPTION
The reason for this has been discussed in eae03b9. Mike @mikea,  please take a look.