### PR TITLE
Avoid yaml.load, and prefer yaml.safe_load

### DIFF
--- a/infra/auto-setup/sync.py
+++ b/infra/auto-setup/sync.py
@@ -63,7 +63,7 @@ def sync_jenkins_job(server, library):
   """Sync the config with jenkins."""
   target_yaml = os.path.join(OSSFUZZ_DIR, 'targets', library, 'target.yaml')
   with open(target_yaml, 'r') as f:
-    target_json_string = json.dumps(json.dumps(yaml.load(f)))
+    target_json_string = json.dumps(json.dumps(yaml.safe_load(f)))
                              
   job_name = 'targets/' + library
   job_definition = ET.parse(os.path.join(SCRIPT_DIR, 'jenkins_config',


### PR DESCRIPTION
yaml.load ought to be named yaml.danger_load: it can execute arbitrary code (http://pyyaml.org/wiki/PyYAMLDocumentation#LoadingYAML)