### PR TITLE
Adding Opus

### DIFF
--- a/projects/opus/project.yaml
+++ b/projects/opus/project.yaml
@@ -1,0 +1,2 @@
+homepage: "https://opus-codec.org/"
+primary_contact: "jmvalin@jmvalin.ca"


### PR DESCRIPTION
I'd like to add the Opus codec to oss-fuzz. Opus is widely used in many Google products including Chrome and YouTube. It is the mandatory-to-implement codec for WebRTC and is used in WebM for VP9 files. 