### PR TITLE
coreutils: add build script

### DIFF
--- a/projects/coreutils/Dockerfile
+++ b/projects/coreutils/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM ossfuzz/base-libfuzzer
+MAINTAINER P@draigBrady.com
+RUN apt-get install -y make autoconf automake bison gettext autopoint gperf xz-utils texinfo
+
+RUN git clone --depth 1 https://github.com/coreutils/coreutils
+RUN git clone --depth 1 https://github.com/coreutils/gnulib
+WORKDIR coreutils
+COPY build.sh $SRC/

--- a/projects/coreutils/build.sh
+++ b/projects/coreutils/build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -eu
+
+./bootstrap --gnulib-srcdir="$SRC/gnulib" --no-git --skip-po
+mkdir -p "$WORK/coreutils" && cd "$WORK/coreutils"
+
+# Hack to avoid clang bug https://llvm.org/bugs/show_bug.cgi?id=16404
+# which is triggered in xalloc_oversized() without the following
+CFLAGS="$CFLAGS -D__STRICT_ANSI__=1"
+
+# needed to allow configure run as root
+export FORCE_UNSAFE_CONFIGURE=1
+
+LIBS="-lfuzzer" "$SRC/coreutils/configure"
+
+make -j"$(nproc)" clean all
+make DESTDIR="$OUT" install-exec-am

--- a/projects/coreutils/project.yaml
+++ b/projects/coreutils/project.yaml
@@ -1,2 +1,4 @@
 homepage: "http://www.gnu.org/software/coreutils/"
 primary_contact: "P@draigBrady.com"
+auto_ccs:
+  - "coreutils@gnu.org"


### PR DESCRIPTION
Tested like:

  export PROJECT_NAME='coreutils'
  python infra/helper.py build_image $PROJECT_NAME
  python infra/helper.py build_fuzzers $PROJECT_NAME
  python infra/helper.py run_fuzzer $PROJECT_NAME \
    usr/local/bin/od -t fF -t fD -t fL /dev/null