### PR TITLE
add util-linux project

### DIFF
--- a/projects/util-linux/project.yaml
+++ b/projects/util-linux/project.yaml
@@ -1,0 +1,4 @@
+homepage: "https://github.com/karelzak/util-linux"
+primary_contact: "ruediger.meier@ga-group.nl"
+auto_ccs:
+  - "kzak@redhat.com"


### PR DESCRIPTION
util-linux is the major collection of standard Linux utilities and
libraries. It's used by most Linux distributions during system
init (sysvinit, openrc, systemd) and by users or admins.

I've set my committer email address as primary contact and the
project maintainer (Karel Zak) on CC.

These are the official links to the project:

MAILING LIST:
      E-MAIL: util-linux@vger.kernel.org
      URL:    http://vger.kernel.org/vger-lists.html#util-linux

DOWNLOAD:
      ftp://ftp.kernel.org/pub/linux/utils/util-linux/

SOURCE CODE:
      Web interface:
          http://git.kernel.org/cgit/utils/util-linux/util-linux.git
          https://github.com/karelzak/util-linux

Signed-off-by: Ruediger Meier <ruediger.meier@ga-group.nl>