### PR TITLE
Add mp4parse-rust as a project.

### DIFF
--- a/projects/mp4parse-rust/project.yaml
+++ b/projects/mp4parse-rust/project.yaml
@@ -1,0 +1,5 @@
+homepage: "https://github.com/mozilla/mp4parse-rust/"
+primary_contact: "giles@mozilla.com"
+auto_ccs:
+  - "kinetik@flim.org"
+  - "ajones@mozilla.com"


### PR DESCRIPTION
This project is a rust crate used to parse mp4 stream metadata
in the Firefox web browser. While the main parser is in rust,
we have an unsafe C wrapper which could use more verification.

Running afl on the pure rust portion has also found panic issues
in the the past.