### PR TITLE
OpenSSL: Use -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION

### DIFF
--- a/projects/openssl/build.sh
+++ b/projects/openssl/build.sh
@@ -15,7 +15,7 @@
 #
 ################################################################################
 
-./config enable-fuzz-libfuzzer -DPEDANTIC no-shared --with-fuzzer-lib=/usr/lib/libfuzzer $CFLAGS
+./config enable-fuzz-libfuzzer -DPEDANTIC -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION no-shared --with-fuzzer-lib=/usr/lib/libfuzzer $CFLAGS
 make -j$(nproc) EX_LIBS="-ldl /usr/local/lib/libc++.a"
 
 fuzzers=$(find fuzz -executable -type f '!' -name \*.py '!' -name \*-test)


### PR DESCRIPTION
This should make the server fuzzer more reproducible.

Depends on https://github.com/openssl/openssl/pull/2023