### PR TITLE
Request for libssh project

### DIFF
--- a/projects/libssh/project.yaml
+++ b/projects/libssh/project.yaml
@@ -1,0 +1,2 @@
+homepage: "https://libssh.org/"
+primary_contact: "asn@cryptomilk.org"


### PR DESCRIPTION
Hello,

this is a request to add the [libssh](https://libssh.org/) project. libssh allows to implement SSH clients and servers and is used in many FOSS  projects. For example the KDE projects uses libssh to implement kio_sftp and the Github SSH server to access git repositories is also based on libssh.