### PR TITLE
add project ntpsec https://ntpsec.org

### DIFF
--- a/projects/ntpsec/project.yaml
+++ b/projects/ntpsec/project.yaml
@@ -1,0 +1,5 @@
+homepage: "https://ntpsec.org"
+primary_contact: "fallenpegasus@gmail.com"
+auto_ccs:
+  - "contact@ntpsec.org"
+


### PR DESCRIPTION
I am the project manager for the NTPsec Project, webpage at http://ntpsec.org/

NTPsec is a secure, hardened, and improved implementation of Network Time Protocol derived from NTP Classic, Dave Mills’s original.  NTPsec, as its name implies, is a more secure NTP. Towards that end we seek out and apply best practices in secure software development, including fuzz testing.