### PR TITLE
Fix parallel make command

### DIFF
--- a/projects/freetype2/build.sh
+++ b/projects/freetype2/build.sh
@@ -18,7 +18,8 @@
 
 ./autogen.sh
 ./configure
-make -j$(nproc) clean all
+make -j$(nproc) clean
+make -j$(nproc) all
 
 $CXX $CXXFLAGS -std=c++11 \
   -I./include -I. \

--- a/projects/libpng/build.sh
+++ b/projects/libpng/build.sh
@@ -23,7 +23,8 @@ mv scripts/pnglibconf.dfa.temp scripts/pnglibconf.dfa
 # build the library.
 autoreconf -f -i
 ./configure
-make -j$(nproc) clean all
+make -j$(nproc) clean
+make -j$(nproc) all
 
 # build libpng_read_fuzzer
 $CXX $CXXFLAGS -std=c++11 -I. -lz \

--- a/projects/libtsm/build.sh
+++ b/projects/libtsm/build.sh
@@ -17,7 +17,8 @@
 
 # build the library.
 ./autogen.sh
-make -j$(nproc) clean all
+make -j$(nproc) clean
+make -j$(nproc) all
 
 # build your fuzzer(s)
 $CC $CCFLAGS -c $SRC/libtsm_fuzzer.c -Isrc/tsm -o $SRC/libtsm_fuzzer.o

--- a/projects/libxml2/build.sh
+++ b/projects/libxml2/build.sh
@@ -18,7 +18,8 @@
 
 ./autogen.sh
 ./configure
-make -j$(nproc) clean all
+make -j$(nproc) clean
+make -j$(nproc) all
 
 for fuzzer in libxml2_xml_read_memory_fuzzer libxml2_xml_regexp_compile_fuzzer; do
   $CXX $CXXFLAGS -std=c++11 -Iinclude/ \

--- a/projects/pcre2/build.sh
+++ b/projects/pcre2/build.sh
@@ -20,7 +20,8 @@ cd pcre2
 # build project
 ./autogen.sh
 ./configure --enable-fuzz-support --enable-never-backslash-C --with-match-limit=1000 --with-match-limit-recursion=1000
-make -j$(nproc) clean all
+make -j$(nproc) clean
+make -j$(nproc) all
 
 # build fuzzer
 $CXX $CXXFLAGS -o $OUT/pcre2_fuzzer \

--- a/projects/woff2/build.sh
+++ b/projects/woff2/build.sh
@@ -26,7 +26,8 @@ cat Makefile | sed -e "s/-no-canonical-prefixes//" \
 mv Makefile.temp Makefile
 
 # woff2 uses LFLAGS instead of LDFLAGS.
-make -j$(nproc) CC="$CC $CFLAGS" CXX="$CXX $CXXFLAGS" clean all
+make clean
+make -j$(nproc) CC="$CC $CFLAGS" CXX="$CXX $CXXFLAGS" all
 
 # To avoid multiple main() definitions.
 rm src/woff2_compress.o src/woff2_decompress.o

--- a/projects/zlib/build.sh
+++ b/projects/zlib/build.sh
@@ -1,7 +1,8 @@
 #!/bin/bash -eu
 
 ./configure
-make -j$(nproc) clean all
+make -j$(nproc) clean
+make -j$(nproc) all
 
 $CXX $CXXFLAGS -std=c++11 -I. \
     $SRC/zlib_uncompress_fuzzer.cc -o $OUT/zlib_uncompress_fuzzer \


### PR DESCRIPTION
'make -j' will make targets parallelly. In other words, "clean" may run after "all" for 'make -j clean all' line.