### PR TITLE
Add project dde-dock

### DIFF
--- a/projects/dde-dock/project.yaml
+++ b/projects/dde-dock/project.yaml
@@ -1,0 +1,5 @@
+homepage: "https://github.com/linuxdeepin/dde-dock"
+primary_contact: "mr.asianwang@gmail.com"
+auto_ccs:
+  - "mr.asianwang@gmail.com"
+  - "sbw@sbw.so"


### PR DESCRIPTION
Project dde-dock is a main component of deepin OS, a widely used the Linux distribution (we have users around the whole world). It's our duty to make sure that the code of this project is clean and secure, so please accept this pull request :)