### PR TITLE
Add Xen hypervisor

### DIFF
--- a/projects/xen/project.yaml
+++ b/projects/xen/project.yaml
@@ -1,0 +1,2 @@
+homepage: "https://www.xenproject.org"
+primary_contact: "wei.liu2@citrix.com"


### PR DESCRIPTION
Hello

Xen Project Hypervisor is a Linux Foundation hosted collaborative project. It is used by various cloud providers such Amazon, Alibaba, Huawei, Rackspace and many other smaller ones.

I've talked with the Xen Project Hypervisor Security team, they think adding Xen hypervisor to oss-fuzz would be beneficial. We would be quite happy if our request is approved.

Let me know if you need more information. I'm a committer of the project and am happy to bridge between oss-fuzz and Xen hypervisor team.

Regards,
Wei.