### PR TITLE
Fix weechat project.yaml typo

### DIFF
--- a/projects/weechat/project.yaml
+++ b/projects/weechat/project.yaml
@@ -1,4 +1,4 @@
-omepage: "https://github.com/weechat/weechat"
+homepage: "https://github.com/weechat/weechat"
 primary_contact: "flashcode@flashtux.org"
 auto_ccs:
   - "security@weechat.org"


### PR DESCRIPTION
Noticed a typo. I'm not sure whether the typo actually affects anything (i.e. I'm not sure if the oss-fuzz backend makes use of homepage), but figured I'd fix it anyway.