### PR TITLE
bind mount work dir

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -149,6 +149,7 @@ def build_fuzzers(build_args):
   command = [
         'docker', 'run', '--rm', '-i',
         '-v', '%s:/out' % os.path.join(BUILD_DIR, 'out', args.project_name),
+        '-v', '%s:/work' % os.path.join(BUILD_DIR, 'work', args.project_name),
         '-t', 'ossfuzz/' + args.project_name,
   ]
 
@@ -294,6 +295,7 @@ def shell(shell_args):
   command = [
         'docker', 'run', '--rm', '-i',
         '-v', '%s:/out' % os.path.join(BUILD_DIR, 'out', args.project_name),
+        '-v', '%s:/work' % os.path.join(BUILD_DIR, 'work', args.project_name),
         '-t', 'ossfuzz/' + args.project_name,
         '/bin/bash'
   ]


### PR DESCRIPTION
with python infra/helper.py build_fuzzers <PROJECT>

out of the box I get /work as a dir in the docker image root with approx 6 gigs
free after dependencies are installed, i.e.

Filesystem             Size  Used Avail Use% Mounted on
/dev/mapper/docker-..   10G  3.9G  6.2G  39% /

which is limiting for a very large project, how about binding /work to the host
like /out already is, eg. for me afterwards, plenty of work space

Filesystem      Size  Used Avail Use% Mounted on
/dev/sda1       440G  291G  128G  70% /work

(cherry picked from commit fffffb107dc7421b91b884c0019c62e43779c4b1)