### PR TITLE
add netdata

### DIFF
--- a/projects/netdata/project.yaml
+++ b/projects/netdata/project.yaml
@@ -1,0 +1,2 @@
+homepage: "https://my-netdata.io"
+primary_contact: "costa@tsaousis.gr"


### PR DESCRIPTION
Hi, I am the founder of http://firehol.org and https://my-netdata.io

netdata (repo: https://github.com/firehol/netdata) is a new OSS real-time performance monitoring monitoring solution for Linux and recently FreeBSD.

As you can see at the home page of netdata, since Q2 2016 that it was released, it received quite some adoption. Currently it has about 17k github stars, 325k docker pulls and at least 140k users and 45k installations (at least because the global netdata registry is optional - that many users has decided to use it).

Is it also featured at [GitHub's state of the Octoverse 2016](https://octoverse.github.com/).

I would be honored to have netdata accepted here.

Note: my email is costa@tsaousis.gr (also in the commit log), which is an alias for costa@tsaousis.net that is a google account.

Thanks!
