### PR TITLE
Update build scripts for Botan

### DIFF
--- a/projects/botan/Dockerfile
+++ b/projects/botan/Dockerfile
@@ -18,5 +18,6 @@ FROM ossfuzz/base-libfuzzer
 MAINTAINER jack@randombit.net
 RUN apt-get install -y make python
 RUN git clone --depth 1 https://github.com/randombit/botan.git botan
+RUN git clone --depth 1 https://github.com/randombit/crypto-corpus.git crypto-corpus
 WORKDIR botan
 COPY build.sh $SRC/


### PR DESCRIPTION

- Disables the library's pool allocator, which does not play well with ASan. Oddly, the driver already tries to do this at runtime in LLVMFuzzerInitialize, but the CF coverage report shows LLVMFuzzerInitialize is never called and the allocator remains enabled. This seems strange to me, and I confirmed LLVMFuzzerInitialize is called if I run the fuzzers locally. I don't understand what's wrong here. But just disabling the allocator at build time is fine for the current purposes.

- Botan fuzzer drivers now enforce max len where needed, so no need to create .options files

- Uses corpus for certs, CRLs, and TLS flows.
