### PR TITLE
use SYS_PTRACE capability

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -147,7 +147,7 @@ def build_fuzzers(build_args):
     return 1
 
   command = [
-        'docker', 'run', '--rm', '-i',
+        'docker', 'run', '--rm', '-i', '--cap-add', 'SYS_PTRACE',
         '-v', '%s:/out' % os.path.join(BUILD_DIR, 'out', args.project_name),
         '-v', '%s:/work' % os.path.join(BUILD_DIR, 'work', args.project_name),
         '-t', 'ossfuzz/' + args.project_name,
@@ -183,7 +183,7 @@ def run_fuzzer(run_args):
     return 1
 
   command = [
-      'docker', 'run', '--rm', '-i',
+      'docker', 'run', '--rm', '-i', '--cap-add', 'SYS_PTRACE',
       '-v', '%s:/out' % os.path.join(BUILD_DIR, 'out', args.project_name),
       '-t', 'ossfuzz/base-runner',
       'run_fuzzer',
@@ -217,7 +217,7 @@ def coverage(run_args):
   temp_dir = tempfile.mkdtemp()
 
   command = [
-      'docker', 'run', '--rm', '-i',
+      'docker', 'run', '--rm', '-i', '--cap-add', 'SYS_PTRACE',
       '-v', '%s:/out' % os.path.join(BUILD_DIR, 'out', args.project_name),
       '-v', '%s:/cov' % temp_dir,
       '-w', '/cov',
@@ -235,7 +235,7 @@ def coverage(run_args):
     pipe.communicate()
 
   command = [
-        'docker', 'run', '--rm', '-i',
+        'docker', 'run', '--rm', '-i', '--cap-add', 'SYS_PTRACE',
         '-v', '%s:/out' % os.path.join(BUILD_DIR, 'out', args.project_name),
         '-v', '%s:/cov' % temp_dir,
         '-w', '/cov',
@@ -293,7 +293,7 @@ def shell(shell_args):
     return 1
 
   command = [
-        'docker', 'run', '--rm', '-i',
+        'docker', 'run', '--rm', '-i', '--cap-add', 'SYS_PTRACE',
         '-v', '%s:/out' % os.path.join(BUILD_DIR, 'out', args.project_name),
         '-v', '%s:/work' % os.path.join(BUILD_DIR, 'work', args.project_name),
         '-t', 'ossfuzz/' + args.project_name,


### PR DESCRIPTION
I'm finding that with e.g.

python infra/helper.py build_fuzzers libpng

all builds fail for me with...

configure:3443: checking whether we are cross compiling
configure:3451: clang -o conftest -g -fsanitize=address -fsanitize-coverage=edge,indirect-calls,8bit-counters   conftest.c  >&5
configure:3455: $? = 0
configure:3462: ./conftest
==1014==LeakSanitizer has encountered a fatal error.
==1014==HINT: For debugging, try setting environment variable LSAN_OPTIONS=verbosity=1:log_threads=1
==1014==HINT: LeakSanitizer does not work under ptrace (strace, gdb, etc)
configure:3466: $? = 1
configure:3473: error: in `/src/libpng':
configure:3475: error: cannot run C compiled programs.

with the defaults of...
CC=clang
CXX=clang++
CFLAGS=-g -fsanitize=address -fsanitize-coverage=edge,indirect-calls,8bit-counters
CXXFLAGS=-g -fsanitize=address -fsanitize-coverage=edge,indirect-calls,8bit-counters -stdlib=libc++

but adding --cap-add SYS_PTRACE makes it work