### PR TITLE
openssl: call configure with --debug

### DIFF
--- a/projects/openssl/build.sh
+++ b/projects/openssl/build.sh
@@ -15,7 +15,7 @@
 #
 ################################################################################
 
-./config enable-fuzz-libfuzzer -DPEDANTIC -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION no-shared enable-tls1_3 enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 enable-ssl3 enable-ssl3-method enable-nextprotoneg enable-weak-ssl-ciphers --with-fuzzer-lib=/usr/lib/libFuzzingEngine $CFLAGS -fno-sanitize=alignment
+./config --debug enable-fuzz-libfuzzer -DPEDANTIC -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION no-shared enable-tls1_3 enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 enable-ssl3 enable-ssl3-method enable-nextprotoneg enable-weak-ssl-ciphers --with-fuzzer-lib=/usr/lib/libFuzzingEngine $CFLAGS -fno-sanitize=alignment
 
 # openssl uses clang, not clang++ for linking. Add c++ libraries.
 EX_LIBS="-ldl /usr/local/lib/libc++.a"


### PR DESCRIPTION
Otherwise NDEBUG is set, and the asserts don't trigger.