### PR TITLE
Fixed inverted conditional in compile script

### DIFF
--- a/infra/base-images/base-libfuzzer/compile
+++ b/infra/base-images/base-libfuzzer/compile
@@ -43,7 +43,7 @@ echo "CXXFLAGS=$CXXFLAGS"
 echo "---------------------------------------------------------------"
 
 BUILD_CMD="bash -x $SRC/build.sh"
-if [ -z "${BUILD_UID+}" ]; then
+if [ -n "${BUILD_UID+}" ]; then
   adduser -u $BUILD_UID --disabled-password --no-create-home --gecos '' builder
   chown -R builder $SRC
   chown builder $OUT


### PR DESCRIPTION
Currently fails with:

```
root@7829c1ae6c7f:/src/gnutls# compile
---------------------------------------------------------------
Compiling libFuzzer to /usr/lib/libFuzzingEngine.a ...ar: creating /usr/lib/libFuzzingEngine.a
 done.
CC=clang
CXX=clang++
CFLAGS=-g -fsanitize=address -fsanitize-coverage=edge,indirect-calls,8bit-counters
CXXFLAGS=-g -fsanitize=address -fsanitize-coverage=edge,indirect-calls,8bit-counters -stdlib=libc++
---------------------------------------------------------------
/usr/local/bin/compile: line 47: BUILD_UID: unbound variable
```