### PR TITLE
Don't overflow on multiplication in the libjpeg_turbo fuzzer

### DIFF
--- a/projects/libjpeg-turbo/libjpeg_turbo_fuzzer.cc
+++ b/projects/libjpeg-turbo/libjpeg_turbo_fuzzer.cc
@@ -32,8 +32,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
         jpegDecompressor, data, size, &width, &height, &subsamp, &colorspace);
 
     // Bail out if decompressing the headers failed, the width or height is 0,
-    // or the image is too large (avoids slowing down too much)
-    if (res != 0 || width == 0 || height == 0 || (width * height > (1024 * 1024))) {
+    // or the image is too large (avoids slowing down too much). Cast to size_t to
+    // avoid overflows on the multiplication
+    if (res != 0 || width == 0 || height == 0 || ((size_t)width * height > (1024 * 1024))) {
         tjDestroy(jpegDecompressor);
         return 0;
     }


### PR DESCRIPTION
Refs https://github.com/libjpeg-turbo/libjpeg-turbo/issues/127

(This is simpler than the `__builtin_mul_overflow` solution I started on before @kcc suggested this)