### PR TITLE
Build tor fuzzing binaries with static libevent linkage

### DIFF
--- a/projects/tor/Dockerfile
+++ b/projects/tor/Dockerfile
@@ -17,7 +17,7 @@
 FROM ossfuzz/base-builder
 MAINTAINER nickm@torproject.org
 RUN apt-get install -y zlib1g zlib1g-dev libevent-dev libevent-2.0 openssl autoconf automake libssl-dev make libc++-dev
-RUN true && true && true && true && true && git clone https://git.torproject.org/nickm/tor.git -b combined-fuzzing-v3
+RUN git clone https://git.torproject.org/nickm/tor.git -b combined-fuzzing-v3
 RUN git clone https://github.com/nmathewson/tor-fuzz-corpora.git
 WORKDIR tor
 COPY build.sh $SRC/

--- a/projects/tor/build.sh
+++ b/projects/tor/build.sh
@@ -37,7 +37,7 @@ TORLIBS="$TORLIBS src/common/libor-testing.a"
 TORLIBS="$TORLIBS src/common/libor-ctime-testing.a"
 TORLIBS="$TORLIBS src/common/libor-event-testing.a"
 TORLIBS="$TORLIBS src/trunnel/libor-trunnel-testing.a"
-TORLIBS="$TORLIBS -lz -lm -levent -lssl -lcrypto"
+TORLIBS="$TORLIBS -lz -lm -lssl -lcrypto -Wl,-Bstatic -levent -Wl,-Bdynamic"
 
 for fuzzer in src/test/fuzz/*.a; do
     output="${fuzzer%.a}"


### PR DESCRIPTION
Apparently libevent.so is not available on the execution environment.  This change statically links that library.

(More information about the bug on https://github.com/google/oss-fuzz/pull/265#issuecomment-271487203 )