### PR TITLE
Add a reference to libFuzzer workshop in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ gives a list of publically viewable fixed bugs found by OSS-Fuzz.
 ## References
 * [libFuzzer documentation](http://libfuzzer.info)
 * [libFuzzer tutorial](http://tutorial.libfuzzer.info)
+* [libFuzzer workshop](https://github.com/Dor1s/libfuzzer-workshop)
 * [Chromium Fuzzing Page](https://chromium.googlesource.com/chromium/src/testing/libfuzzer/)
 * [ClusterFuzz](https://blog.chromium.org/2012/04/fuzzing-for-security.html)
 


### PR DESCRIPTION
Issue #278 reminded me that I've prepared a workshop in last November. It mostly follows examples from  [libFuzzer tutorial](http://tutorial.libfuzzer.info/) and [Fuzzer Test Suite](https://github.com/google/fuzzer-test-suite), but contains very detailed instructions for every lesson.