### PR TITLE
Fix irssi fuzzer

### DIFF
--- a/projects/irssi/Dockerfile
+++ b/projects/irssi/Dockerfile
@@ -20,4 +20,4 @@ RUN apt-get install -y make autoconf automake libtool pkg-config libglib2.0-dev 
 RUN git clone https://github.com/irssi/irssi
 
 WORKDIR irssi
-COPY build.sh $SRC/
+COPY build.sh *.options $SRC/

--- a/projects/irssi/build.sh
+++ b/projects/irssi/build.sh
@@ -15,9 +15,33 @@
 #
 ################################################################################
 
-# configure script doesn't like the oss-fuzz CFLAGS
-./autogen.sh CFLAGS=
-./configure --without-textui --with-fuzzer --with-fuzzer-lib=$LIB_FUZZING_ENGINE CC=$CC CXX=$CXX CFLAGS= CXXFLAGS="$CXXFLAGS"
-make "-j$(nproc)" CFLAGS="$CFLAGS"
+# configure script needs leak checking disabled to not fail
+export ASAN_OPTIONS=detect_leaks=0
+./autogen.sh
+./configure --with-perl=no --disable-shared --without-textui --with-fuzzer \
+	--with-fuzzer-lib=$LIB_FUZZING_ENGINE \
+	CC=$CC CXX=$CXX PKG_CONFIG="pkg-config --static"
+make clean
+make "-j$(nproc)" CFLAGS="-static -DSUPPRESS_PRINTF_FALLBACK $CFLAGS" CXXFLAGS="-static $CXXFLAGS"
 
-cp $SRC/irssi/src/fe-fuzz/irssi-fuzz $OUT/
+# now build irssi-fuzz itself
+
+export GLIB_CFLAGS="$(pkg-config --static --cflags glib-2.0)"
+export GLIB_LIBS="$(pkg-config --static --libs glib-2.0)"
+
+CORE_LIBS="src/core/libcore.a"
+CORE_LIBS="$CORE_LIBS src/lib-config/libirssi_config.a"
+
+FE_COMMON_LIBS="src/irc/libirc.a"
+FE_COMMON_LIBS="$FE_COMMON_LIBS src/irc/core/libirc_core.a"
+FE_COMMON_LIBS="$FE_COMMON_LIBS src/fe-common/irc/libfe_common_irc.a"
+FE_COMMON_LIBS="$FE_COMMON_LIBS src/fe-common/core/libfe_common_core.a"
+
+FE_FUZZ_CFLAGS="-I. -Isrc -Isrc/core/ -Isrc/irc/core/ -Isrc/fe-common/core/"
+
+${CXX} ${CXXFLAGS} -DHAVE_CONFIG_H -lFuzzingEngine ${FE_FUZZ_CFLAGS} ${GLIB_CFLAGS} \
+	src/fe-fuzz/irssi.o src/fe-fuzz/module-formats.o -lm \
+	-Wl,-Bstatic ${FE_COMMON_LIBS} ${CORE_LIBS} -lssl -lcrypto ${GLIB_LIBS} -lgmodule-2.0 -lz \
+	-Wl,-Bdynamic -o $OUT/irssi-fuzz
+
+cp $SRC/*.options $OUT/

--- a/projects/irssi/irssi-fuzz.options
+++ b/projects/irssi/irssi-fuzz.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 2048


### PR DESCRIPTION
Build static irssi fuzzer.

This time, I pulled latest oss-fuzz and _then_ I tested instead of the other way around. :)