### PR TITLE
Prevent argv[0] from being modified in magic and chewing fuzzers.

### DIFF
--- a/projects/file/magic_fuzzer.cc
+++ b/projects/file/magic_fuzzer.cc
@@ -38,8 +38,11 @@ static Environment* env;
 
 extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv) {
   char* exe_path = (*argv)[0];
-  char* dir = dirname(exe_path);
+  // dirname() can modify its argument.
+  char* exe_path_copy = strdup(exe_path);
+  char* dir = dirname(exe_path_copy);
   env = new Environment(dir);
+  free(exe_path_copy);
   return 0;
 }
 

--- a/projects/libchewing/chewing_fuzzer_common.c
+++ b/projects/libchewing/chewing_fuzzer_common.c
@@ -3,14 +3,20 @@
 #include <libgen.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 static char userphrase_path[] = "/tmp/chewing_userphrase.db.XXXXXX";
 
 int LLVMFuzzerInitialize(int* argc, char*** argv) {
   char* exe_path = (*argv)[0];
-  char* dir = dirname(exe_path);
+
+  // dirname() can modify its argument.
+  char* exe_path_copy = strdup(exe_path);
+  char* dir = dirname(exe_path_copy);
+
   // Assume data files are at the same location as executable.
   setenv("CHEWING_PATH", dir, 0);
+  free(exe_path_copy);
 
   // Specify user db of this process. So we can run multiple fuzzers at the
   // same time.


### PR DESCRIPTION
dirname() may modify the input argument. Changing argv[0] breaks any
libFuzzer functionality that requires it to invoke itself (e.g.
failure-resistant merge, minimize).