### PR TITLE
[libarchive] correctly exit on read error in libarchive_fuzzer.cc (#305)

### DIFF
--- a/projects/libarchive/libarchive_fuzzer.cc
+++ b/projects/libarchive/libarchive_fuzzer.cc
@@ -34,6 +34,7 @@ ssize_t reader_callback(struct archive *a, void *client_data,
 }
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len) {
+  ssize_t r;
   struct archive *a = archive_read_new();
 
   archive_read_support_filter_all(a);
@@ -45,8 +46,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len) {
   std::vector<uint8_t> data_buffer(getpagesize(), 0);
   struct archive_entry *entry;
   while (archive_read_next_header(a, &entry) == ARCHIVE_OK) {
-    while (archive_read_data(a, data_buffer.data(), data_buffer.size()) > 0)
+    while ((r = archive_read_data(a, data_buffer.data(),
+            data_buffer.size()) > 0)
       ;
+    if (r == ARCHIVE_FATAL)
+      break;
   }
 
   archive_read_free(a);


### PR DESCRIPTION
If archive_read_data() returns ARCHIVE_FATAL, no more operatons should be performed and the archive should be closed.

This fixes a couple of false positives detected by OSS-Fuzz.