### PR TITLE
Update ffmpeg fuzzer util file path

### DIFF
--- a/docs/ideal_integration.md
+++ b/docs/ideal_integration.md
@@ -28,7 +28,7 @@ Examples:
 [re2](https://github.com/google/re2/tree/master/re2/fuzzing),
 [harfbuzz](https://github.com/behdad/harfbuzz/tree/master/test/fuzzing),
 [pcre2](http://vcs.pcre.org/pcre2/code/trunk/src/pcre2_fuzzsupport.c?view=markup),
-[ffmpeg](https://github.com/FFmpeg/FFmpeg/blob/master/doc/examples/decoder_targeted.c).
+[ffmpeg](https://github.com/FFmpeg/FFmpeg/blob/master/tools/target_dec_fuzzer.c).
 
 
 ## Seed Corpus

--- a/docs/new_project_guide.md
+++ b/docs/new_project_guide.md
@@ -12,7 +12,7 @@
 [re2](https://github.com/google/re2/tree/master/re2/fuzzing),
 [harfbuzz](https://github.com/behdad/harfbuzz/tree/master/test/fuzzing),
 [pcre2](http://vcs.pcre.org/pcre2/code/trunk/src/pcre2_fuzzsupport.c?view=markup),
-[ffmpeg](https://github.com/FFmpeg/FFmpeg/blob/master/doc/examples/decoder_targeted.c).
+[ffmpeg](https://github.com/FFmpeg/FFmpeg/blob/master/tools/target_dec_fuzzer.c).
 
 - [Install Docker](installing_docker.md). ([Why Docker?](faq.md#why-do-you-use-docker))
 

--- a/projects/ffmpeg/build.sh
+++ b/projects/ffmpeg/build.sh
@@ -205,7 +205,7 @@ for codec in $CODEC_NAMES; do
   fuzzer_name=ffmpeg_${CODEC_TYPE}_${codec}_fuzzer
 
   $CC $CFLAGS -I${FFMPEG_DEPS_PATH}/include \
-      $SRC/ffmpeg/doc/examples/decoder_targeted.c \
+      $SRC/ffmpeg/tools/target_dec_fuzzer.c \
       -o $OUT/${fuzzer_name} \
       -DFFMPEG_CODEC=${codec} -DFUZZ_FFMPEG_${CODEC_TYPE}= \
       ${FFMPEG_FUZZERS_COMMON_FLAGS}
@@ -223,7 +223,7 @@ for codec in $CODEC_NAMES; do
   fuzzer_name=ffmpeg_${CODEC_TYPE}_${codec}_fuzzer
 
   $CC $CFLAGS -I${FFMPEG_DEPS_PATH}/include \
-      $SRC/ffmpeg/doc/examples/decoder_targeted.c \
+      $SRC/ffmpeg/tools/target_dec_fuzzer.c \
       -o $OUT/${fuzzer_name} \
       -DFFMPEG_CODEC=${codec} -DFUZZ_FFMPEG_${CODEC_TYPE}= \
       ${FFMPEG_FUZZERS_COMMON_FLAGS}
@@ -278,7 +278,7 @@ for codec in $CODEC_NAMES; do
   fuzzer_name=ffmpeg_${CODEC_TYPE}_${codec}_fuzzer
 
   $CC $CFLAGS -I${FFMPEG_DEPS_PATH}/include \
-      $SRC/ffmpeg/doc/examples/decoder_targeted.c \
+      $SRC/ffmpeg/tools/target_dec_fuzzer.c \
       -o $OUT/${fuzzer_name} \
       -DFFMPEG_CODEC=${codec} -DFUZZ_FFMPEG_${CODEC_TYPE}= \
       ${FFMPEG_FUZZERS_COMMON_FLAGS}


### PR DESCRIPTION
The fuzzer util in ffmpeg git has changed its path, this update makes oss-fuzz match the new path

Signed-off-by: Michael Niedermayer <michaelni@gmx.at>