### PR TITLE
Switch Tor git URLs to mainline Tor.

### DIFF
--- a/projects/tor/Dockerfile
+++ b/projects/tor/Dockerfile
@@ -17,7 +17,7 @@
 FROM ossfuzz/base-builder
 MAINTAINER nickm@torproject.org
 RUN apt-get install -y zlib1g zlib1g-dev libevent-dev libevent-2.0 openssl autoconf automake libssl-dev make
-RUN git clone https://git.torproject.org/nickm/tor.git -b combined-fuzzing-v3
-RUN git clone https://github.com/nmathewson/tor-fuzz-corpora.git
+RUN git clone https://git.torproject.org/tor.git
+RUN git clone https://git.torproject.org/fuzzing-corpora.git tor-fuzz-corpora
 WORKDIR tor
 COPY build.sh $SRC/


### PR DESCRIPTION
Now that we've merged the fuzzing support to mainline Tor [1], and
moved our fuzzing corpus repository into our main repository [2],
we no longer have to build the docker image off of my own branches.

[1] https://trac.torproject.org/projects/tor/ticket/20893
[2] https://gitweb.torproject.org/fuzzing-corpora.git