### PR TITLE
Adding Speex

### DIFF
--- a/projects/speex/project.yaml
+++ b/projects/speex/project.yaml
@@ -1,0 +1,2 @@
+homepage: "https://speex.org/"
+primary_contact: "tmatth@videolan.org"


### PR DESCRIPTION
I'd like to add the Speex codec to oss-fuzz. Speex is widely used in many applications, including the Google Mobile App for iOs, the Asterisk VoIP server and the Adobe Flash Player [1].

[1] https://en.wikipedia.org/wiki/Speex#Applications