### PR TITLE
Add ASAN and UBSAN for NSS

### DIFF
--- a/projects/nss/project.yaml
+++ b/projects/nss/project.yaml
@@ -2,3 +2,6 @@ homepage: "https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS"
 primary_contact: "ttaubert@mozilla.com"
 auto_ccs:
 - "fkiefer@mozilla.com"
+sanitizers:
+- address
+- undefined


### PR DESCRIPTION
I'm not sure why but ASAN and UBSAN were disabled in 70785be3ddeec1d4643bfc311ce6cf8abdb48069. We'd like to enable it again. If there were problems with this config we should fix the issues, not disable it.