### PR TITLE
Add options, dictionaries, and seed corpuses to gRPC

### DIFF
--- a/projects/grpc/Dockerfile
+++ b/projects/grpc/Dockerfile
@@ -36,4 +36,4 @@ RUN apt-get update && apt-get install -y bazel
 
 RUN git clone --recursive https://github.com/grpc/grpc grpc
 WORKDIR /src/grpc/
-COPY build.sh $SRC/
+COPY build.sh *.options $SRC/

--- a/projects/grpc/api_fuzzer.options
+++ b/projects/grpc/api_fuzzer.options
@@ -1,0 +1,3 @@
+[libfuzzer]
+max_len = 2048
+dict = api_fuzzer.dictionary

--- a/projects/grpc/build.sh
+++ b/projects/grpc/build.sh
@@ -32,6 +32,10 @@ test/core/end2end/fuzzers/server_fuzzer.c \
 # TODO: enable ssl server corpus after Bazel fuzzer rules written
 # test/core/security/ssl_server_fuzzer.c \
 
+FUZZER_DICTIONARIES="\
+test/core/end2end/fuzzers/api_fuzzer.dictionary \
+test/core/end2end/fuzzers/hpack.dictionary \
+"
 
 FUZZER_LIBRARIES="\
 bazel-bin/*.a \
@@ -67,19 +71,26 @@ for file in $FUZZER_FILES; do
     -lFuzzingEngine ${FUZZER_LIBRARIES}
 done
 
+# Copy dictionaries and options files to $OUT/
+for dict in $FUZZER_DICTIONARIES; do
+  cp $dict $OUT/
+done
+
+cp $SRC/*.options $OUT/
+
 # We don't have a consistent naming convention between fuzzer files and corpus
 # directories so we resort to hard coding zipping corpuses
-zip -j $OUT/fuzzer_seed_corpus.zip test/core/json/corpus
-zip -j $OUT/uri_fuzzer_test_seed_corpus.zip test/core/client_channel/uri_corpus
-zip -j $OUT/request_fuzzer_seed_corpus.zip test/core/http/request_corpus
-zip -j $OUT/response_fuzzer_seed_corpus.zip test/core/http/response_corpus
-zip -j $OUT/fuzzer_response_seed_corpus.zip test/core/nanopb/response_corpus
-zip -j $OUT/fuzzer_serverlist_seed_corpus.zip test/core/nanopb/serverlist_corpus
-zip -j $OUT/percent_decode_fuzzer_seed_corpus.zip test/core/slice/percent_decode_corpus
-zip -j $OUT/percent_encode_fuzzer_seed_corpus.zip test/core/slice/percent_encode_corpus
-zip -j $OUT/hpack_parser_fuzzer_test_seed_corpus.zip test/core/transport/chttp2/hpack_parser_corpus
-zip -j $OUT/api_fuzzer_seed_corpus.zip test/core/end2end/fuzzers/api_fuzzer_corpus
-zip -j $OUT/client_fuzzer_seed_corpus.zip test/core/end2end/fuzzers/client_fuzzer_corpus
-zip -j $OUT/server_fuzzer_seed_corpus.zip test/core/end2end/fuzzers/server_fuzzer_corpus
+zip $OUT/fuzzer_seed_corpus.zip test/core/json/corpus
+zip $OUT/uri_fuzzer_test_seed_corpus.zip test/core/client_channel/uri_corpus
+zip $OUT/request_fuzzer_seed_corpus.zip test/core/http/request_corpus
+zip $OUT/response_fuzzer_seed_corpus.zip test/core/http/response_corpus
+zip $OUT/fuzzer_response_seed_corpus.zip test/core/nanopb/corpus_response
+zip $OUT/fuzzer_serverlist_seed_corpus.zip test/core/nanopb/corpus_serverlist
+zip $OUT/percent_decode_fuzzer_seed_corpus.zip test/core/slice/percent_decode_corpus
+zip $OUT/percent_encode_fuzzer_seed_corpus.zip test/core/slice/percent_encode_corpus
+zip $OUT/hpack_parser_fuzzer_test_seed_corpus.zip test/core/transport/chttp2/hpack_parser_corpus
+zip $OUT/api_fuzzer_seed_corpus.zip test/core/end2end/fuzzers/api_fuzzer_corpus
+zip $OUT/client_fuzzer_seed_corpus.zip test/core/end2end/fuzzers/client_fuzzer_corpus
+zip $OUT/server_fuzzer_seed_corpus.zip test/core/end2end/fuzzers/server_fuzzer_corpus
 # TODO: zip ssl server corpus after Bazel fuzzer rules written
 # test/core/security/corpus/ssl_server_corpus

--- a/projects/grpc/build.sh
+++ b/projects/grpc/build.sh
@@ -16,7 +16,6 @@
 ################################################################################
 
 FUZZER_FILES="\
-test/core/end2end/fuzzers/api_fuzzer.c \
 test/core/json/fuzzer.c \
 test/core/client_channel/uri_fuzzer_test.c \
 test/core/http/request_fuzzer.c \
@@ -26,10 +25,13 @@ test/core/nanopb/fuzzer_serverlist.c \
 test/core/slice/percent_decode_fuzzer.c \
 test/core/slice/percent_encode_fuzzer.c \
 test/core/transport/chttp2/hpack_parser_fuzzer_test.c \
+test/core/end2end/fuzzers/api_fuzzer.c \
 test/core/end2end/fuzzers/client_fuzzer.c \
 test/core/end2end/fuzzers/server_fuzzer.c \
-test/core/security/ssl_server_fuzzer.c \
 "
+# TODO: enable ssl server corpus after Bazel fuzzer rules written
+# test/core/security/ssl_server_fuzzer.c \
+
 
 FUZZER_LIBRARIES="\
 bazel-bin/*.a \
@@ -64,3 +66,20 @@ for file in $FUZZER_FILES; do
     $fuzzer_object -o $OUT/$fuzzer_name \
     -lFuzzingEngine ${FUZZER_LIBRARIES}
 done
+
+# We don't have a consistent naming convention between fuzzer files and corpus
+# directories so we resort to hard coding zipping corpuses
+zip -j $OUT/fuzzer_seed_corpus.zip test/core/json/corpus
+zip -j $OUT/uri_fuzzer_test_seed_corpus.zip test/core/client_channel/uri_corpus
+zip -j $OUT/request_fuzzer_seed_corpus.zip test/core/http/request_corpus
+zip -j $OUT/response_fuzzer_seed_corpus.zip test/core/http/response_corpus
+zip -j $OUT/fuzzer_response_seed_corpus.zip test/core/nanopb/response_corpus
+zip -j $OUT/fuzzer_serverlist_seed_corpus.zip test/core/nanopb/serverlist_corpus
+zip -j $OUT/percent_decode_fuzzer_seed_corpus.zip test/core/slice/percent_decode_corpus
+zip -j $OUT/percent_encode_fuzzer_seed_corpus.zip test/core/slice/percent_encode_corpus
+zip -j $OUT/hpack_parser_fuzzer_test_seed_corpus.zip test/core/transport/chttp2/hpack_parser_corpus
+zip -j $OUT/api_fuzzer_seed_corpus.zip test/core/end2end/fuzzers/api_fuzzer_corpus
+zip -j $OUT/client_fuzzer_seed_corpus.zip test/core/end2end/fuzzers/client_fuzzer_corpus
+zip -j $OUT/server_fuzzer_seed_corpus.zip test/core/end2end/fuzzers/server_fuzzer_corpus
+# TODO: zip ssl server corpus after Bazel fuzzer rules written
+# test/core/security/corpus/ssl_server_corpus

--- a/projects/grpc/client_fuzzer.options
+++ b/projects/grpc/client_fuzzer.options
@@ -1,0 +1,3 @@
+[libfuzzer]
+max_len = 2048
+dict = hpack.dictionary

--- a/projects/grpc/fuzzer.options
+++ b/projects/grpc/fuzzer.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 512

--- a/projects/grpc/fuzzer_response.options
+++ b/projects/grpc/fuzzer_response.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 128

--- a/projects/grpc/fuzzer_serverlist.options
+++ b/projects/grpc/fuzzer_serverlist.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 128

--- a/projects/grpc/hpack_parser_fuzzer_test.options
+++ b/projects/grpc/hpack_parser_fuzzer_test.options
@@ -1,0 +1,3 @@
+[libfuzzer]
+max_len = 512
+dict = hpack.dictionary

--- a/projects/grpc/percent_decode_fuzzer.options
+++ b/projects/grpc/percent_decode_fuzzer.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 32

--- a/projects/grpc/percent_encode_fuzzer.options
+++ b/projects/grpc/percent_encode_fuzzer.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 32

--- a/projects/grpc/request_fuzzer.options
+++ b/projects/grpc/request_fuzzer.options
@@ -1,0 +1,3 @@
+[libfuzzer]
+max_len = 2048
+

--- a/projects/grpc/response_fuzzer.options
+++ b/projects/grpc/response_fuzzer.options
@@ -1,0 +1,3 @@
+[libfuzzer]
+max_len = 2048
+

--- a/projects/grpc/server_fuzzer.options
+++ b/projects/grpc/server_fuzzer.options
@@ -1,0 +1,3 @@
+[libfuzzer]
+max_len = 2048
+dict = hpack.dictionary

--- a/projects/grpc/ssl_server_fuzzer.options
+++ b/projects/grpc/ssl_server_fuzzer.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 2048

--- a/projects/grpc/uri_fuzzer_test.options
+++ b/projects/grpc/uri_fuzzer_test.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 128


### PR DESCRIPTION
In addition to the changes described in the title, `test/core/security/ssl_server_fuzzer.c` will be temporarily disabled with the issue described in #373 and will be enabled in a future PR after gRPC Bazel rules are written for fuzzing.