### PR TITLE
Add the qpid-proton project

### DIFF
--- a/projects/qpid-proton/project.yaml
+++ b/projects/qpid-proton/project.yaml
@@ -1,0 +1,5 @@
+homepage: "https://qpid.apache.org/proton/"
+primary_contact: "jross@apache.org"
+auto_ccs:
+ - "security@apache.org"
+ - "jdanek@redhat.com"


### PR DESCRIPTION
Apache Qpid Proton is a set of AMQP 1.0 client libraries for various languages. The core is written in C and there are bindings for C++, Python, Go, ...

The project is notable and widely used with other Apache messaging software, like the Apache ActiveMQ and Apache Qpid.

For now, only the project manifest is included, because Fuzzers are not yet completely written and committed to the project; the unmerged PR with fuzzers is at https://github.com/apache/qpid-proton/pull/95