### PR TITLE
Untested changes to fetch SQLite sources as a tarball using curl

### DIFF
--- a/projects/sqlite3/Dockerfile
+++ b/projects/sqlite3/Dockerfile
@@ -16,14 +16,14 @@
 
 FROM ossfuzz/base-builder
 MAINTAINER tanin@google.com
-RUN apt-get install -y make autoconf automake libtool fossil tcl
+RUN apt-get install -y make autoconf automake libtool curl tcl
 
 # We won't be able to poll fossil for changes, so this will build
 # only once a day.
 RUN mkdir $SRC/sqlite3 && \
     cd $SRC/sqlite3 && \
-    fossil clone https://www.sqlite.org/src sqlite --user `whoami` && \
-    fossil open sqlite
+    curl 'http://www.sqlite.org/src/tarball?uuid=trunk' -o sqlite3.tar.gz \
+    tar xzf sqlite3.tar.gz
 
 RUN find $SRC/sqlite3 -name "*.test" | xargs zip $SRC/ossfuzz_seed_corpus.zip
 

--- a/projects/sqlite3/Dockerfile
+++ b/projects/sqlite3/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get install -y make autoconf automake libtool curl tcl
 # only once a day.
 RUN mkdir $SRC/sqlite3 && \
     cd $SRC/sqlite3 && \
-    curl 'https://www.sqlite.org/src/tarball?uuid=trunk' -o sqlite3.tar.gz && \
+    curl 'http://www.sqlite.org/src/tarball?uuid=trunk' -o sqlite3.tar.gz \
     tar xzf sqlite3.tar.gz
 
 RUN find $SRC/sqlite3 -name "*.test" | xargs zip $SRC/ossfuzz_seed_corpus.zip

--- a/projects/sqlite3/Dockerfile
+++ b/projects/sqlite3/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get install -y make autoconf automake libtool curl tcl
 # only once a day.
 RUN mkdir $SRC/sqlite3 && \
     cd $SRC/sqlite3 && \
-    curl 'http://www.sqlite.org/src/tarball?uuid=trunk' -o sqlite3.tar.gz \
+    curl 'https://www.sqlite.org/src/tarball?uuid=trunk' -o sqlite3.tar.gz && \
     tar xzf sqlite3.tar.gz
 
 RUN find $SRC/sqlite3 -name "*.test" | xargs zip $SRC/ossfuzz_seed_corpus.zip


### PR DESCRIPTION
Untested changes to the Dockerfile for sqlite3 so that the latest sqlite3 sources are obtained as a tarball using curl, rather than going through the Fossil DVCS.

Fossil recently upgraded to use SHA3 hashes instead of SHA1.  You need version 2.0 or later of Fossil in order to retrieve the latest SQLite source code.  Rather than trying to figure out how to get the latest Fossil installed in Docker, it seems easier to just use curl to request a tarball from the Fossil server.  This is also more bandwidth efficient since it only has to pull down the latest version, rather than 17 years of development history.