### PR TITLE
Override $OUT in gcb build.

### DIFF
--- a/infra/gcb/build.py
+++ b/infra/gcb/build.py
@@ -105,6 +105,8 @@ def get_build_steps(project_yaml):
     srcmap_url = get_signed_url('/{0}/{1}/{2}'.format(
         UPLOAD_BUCKET, name, stamped_srcmap_file))
 
+    env['OUT'] = out
+
     build_steps.extend([
         # compile
         {'name': image,
@@ -112,7 +114,7 @@ def get_build_steps(project_yaml):
           'args': [
             'bash',
             '-c',
-            'cd /src/{1} && compile && mkdir -p {0} && cp -Rv /out/* {0}/'.format(out, name),
+            'cd /src/{1} && mkdir -p {0} && compile'.format(out, name),
             ],
           },
         # zip binaries

--- a/infra/gcb/build.py
+++ b/infra/gcb/build.py
@@ -95,7 +95,7 @@ def get_build_steps(project_yaml):
     ]
 
   for sanitizer in project_yaml['sanitizers']:
-    env = CONFIGURATIONS["sanitizer-" + sanitizer]
+    env = CONFIGURATIONS["sanitizer-" + sanitizer][:]
     out = '/workspace/out/' + sanitizer
     stamped_name = name + '-' + sanitizer + '-' + ts
     zip_file = stamped_name + '.zip'
@@ -105,7 +105,7 @@ def get_build_steps(project_yaml):
     srcmap_url = get_signed_url('/{0}/{1}/{2}'.format(
         UPLOAD_BUCKET, name, stamped_srcmap_file))
 
-    env['OUT'] = out
+    env.append('OUT=' + out)
 
     build_steps.extend([
         # compile


### PR DESCRIPTION
This prevents a copy from the builder container's /out to /workspace/out/sanitizer. Should hopefully fix ffmpeg's disk space issues.