### PR TITLE
Tor build.sh: Disable memory sentinels when fuzzing

### DIFF
--- a/projects/tor/build.sh
+++ b/projects/tor/build.sh
@@ -23,7 +23,7 @@ sh autogen.sh
 # test functions will fail.
 export ASAN_OPTIONS=detect_leaks=0
 
-./configure --disable-asciidoc --enable-oss-fuzz
+./configure --disable-asciidoc --enable-oss-fuzz --disable-memory-sentinels
 make clean
 make -j$(nproc) oss-fuzz-fuzzers
 


### PR DESCRIPTION
Tor has a few safety features that try to prevent bugs by using
memory more safely.  For example, by default, we terminate our IO
buffers with 0-valued bytes, so that accidental string operations
can't run off the end.  For another example, we do some of our
allocation in "memory areas" -- an obstack-style allocation in which
all objects are freed at once.

These features prevent a fairly large category of crash bugs, but
they also prevent asan from seeing our mistakes.  But when we're
fuzzing, we'd like to expose as many of our mistakes as possible.
With that in mind, we've added a --disable-memory-sentinels
configuration option to turn off a lot of these safety features when
we're fuzzing.  This feature turns it on for oss-fuzz.