### PR TITLE
Pin Bazel version to 0.4.4 for gRPC

### DIFF
--- a/projects/grpc/Dockerfile
+++ b/projects/grpc/Dockerfile
@@ -31,8 +31,14 @@ RUN apt-get -y install  \
 
 # Install Bazel
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
-RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -    
+RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
 RUN apt-get update && apt-get install -y bazel
+# Downgrade Bazel to 0.4.4
+# Installing Bazel via apt-get first is required before installing 0.4.4 to
+# allow gRPC to build without errors
+RUN curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/0.4.4/bazel-0.4.4-installer-linux-x86_64.sh
+RUN chmod +x ./bazel-0.4.4-installer-linux-x86_64.sh
+RUN ./bazel-0.4.4-installer-linux-x86_64.sh
 
 RUN git clone --recursive https://github.com/grpc/grpc grpc
 WORKDIR /src/grpc/


### PR DESCRIPTION
Fixes #468 

The Bazel 0.4.5 release broke gRPC building, so pinning Bazel's version to 0.4.4. should fix this. I'm not sure why, but installing Bazel with 

```
RUN curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/0.4.4/bazel-0.4.4-installer-linux-x86_64.sh
RUN chmod +x ./bazel-0.4.4-installer-linux-x86_64.sh
RUN ./bazel-0.4.4-installer-linux-x86_64.sh
```
without first doing
```
RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add - 
RUN apt-get update && apt-get install -y bazel
```
causes a different build issue than when trying to build with 0.4.5. 