### PR TITLE
[libidn2] Added fuzzer for libidn2

### DIFF
--- a/projects/libidn2/Dockerfile
+++ b/projects/libidn2/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER n.mavrogiannopoulos@gmail.com
+RUN apt-get install -y make autoconf automake gettext libtool autopoint pkg-config gengetopt curl gperf
+
+RUN git clone --depth=1 https://gitlab.com/libidn/libidn2.git
+RUN cd libidn2 && git submodule update --init
+
+WORKDIR libidn2
+COPY build.sh $SRC/

--- a/projects/libidn2/build.sh
+++ b/projects/libidn2/build.sh
@@ -1,0 +1,41 @@
+#!/bin/bash -eu
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+./bootstrap
+./configure --enable-static --disable-doc
+make "-j$(nproc)" -C unistring
+make "-j$(nproc)" -C gl
+make "-j$(nproc)" -C lib
+
+fuzzers=$(find fuzz/ -name "*_fuzzer.cc")
+
+for f in $fuzzers; do
+    fuzzer=$(basename "$f" ".cc")
+    $CXX $CXXFLAGS -std=c++11 -Ilib/ \
+        "fuzz/${fuzzer}.cc" -o "$OUT/${fuzzer}" \
+        lib/.libs/libidn2.a -lFuzzingEngine -Wl,-Bstatic \
+        -Wl,-Bdynamic
+
+    if [ -f "$SRC/${fuzzer}_seed_corpus.zip" ]; then
+        cp "$SRC/${fuzzer}_seed_corpus.zip" "$OUT/"
+    fi
+
+    corpus_dir=$(basename "${fuzzer}" "_fuzzer")
+    if [ -d "fuzz/${corpus_dir}.in/" ]; then
+        zip -r "$OUT/${fuzzer}_seed_corpus.zip" "fuzz/${corpus_dir}.in/"
+    fi
+done

--- a/projects/libidn2/project.yaml
+++ b/projects/libidn2/project.yaml
@@ -1,0 +1,5 @@
+homepage: "https://gitlab.com/libidn/libidn2"
+primary_contact: "n.mavrogiannopoulos@gmail.com"
+auto_ccs:
+  - "rockdaboot@gmail.com"
+  - "simon@josefsson.org"


### PR DESCRIPTION
libidn2 is the successor of libidn, a library universally used to convert internationalized domain names to ascii equivalent format (ACE). It is used from glibc to various other projects, including systemd, curl, wget, lftp...

https://www.gnu.org/software/libidn/
https://gitlab.com/libidn/libidn2
