### PR TITLE
projects/ffmpeg/build: Add -Os flag to reduce size

### DIFF
--- a/projects/ffmpeg/build.sh
+++ b/projects/ffmpeg/build.sh
@@ -152,7 +152,7 @@ PKG_CONFIG_PATH="$FFMPEG_DEPS_PATH/lib/pkgconfig" ./configure \
     --pkg-config-flags="--static" \
     --enable-ossfuzz \
     --libfuzzer=-lFuzzingEngine \
-    --optflags=-O1 \
+    --optflags='-O1 -Os' \
     --enable-gpl \
     --enable-libass \
     --enable-libfdk-aac \


### PR DESCRIPTION
This commit is under public domain

This is sadly not enough to get FFmpeg within the disk space constraint but its a good idea either way

Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>