### PR TITLE
Use apt-get update && apt-get install, per Docker best practices

### DIFF
--- a/projects/arduinojson/Dockerfile
+++ b/projects/arduinojson/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER oss-fuzz@benoitblanchon.fr
-RUN apt-get install -y make zip git
+RUN apt-get update && apt-get install -y make zip git
 RUN git clone --depth 1 https://github.com/bblanchon/ArduinoJson.git arduinojson
 WORKDIR arduinojson
 COPY build.sh $SRC/

--- a/projects/boringssl/Dockerfile
+++ b/projects/boringssl/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mike.aizatsky@gmail.com
-RUN apt-get install -y cmake ninja-build golang
+RUN apt-get update && apt-get install -y cmake ninja-build golang
 
 RUN git clone --depth 1 https://boringssl.googlesource.com/boringssl
 COPY build.sh $SRC/

--- a/projects/botan/Dockerfile
+++ b/projects/botan/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER jack@randombit.net
-RUN apt-get install -y make python
+RUN apt-get update && apt-get install -y make python
 RUN git clone --depth 1 https://github.com/randombit/botan.git botan
 RUN git clone --depth 1 https://github.com/randombit/crypto-corpus.git crypto-corpus
 WORKDIR botan

--- a/projects/brotli/Dockerfile
+++ b/projects/brotli/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER eustas@chromium.org
-RUN apt-get install -y cmake libtool make
+RUN apt-get update && apt-get install -y cmake libtool make
 
 RUN git clone --depth 1 https://github.com/google/brotli.git
 WORKDIR brotli

--- a/projects/c-ares/Dockerfile
+++ b/projects/c-ares/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mmoroz@chromium.org
-RUN apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/c-ares/c-ares.git
 WORKDIR c-ares
 COPY build.sh $SRC/

--- a/projects/curl/Dockerfile
+++ b/projects/curl/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER dvyukov@google.com
-RUN apt-get install -y make autoconf automake libtool libssl-dev zlib1g-dev
+RUN apt-get update && apt-get install -y make autoconf automake libtool libssl-dev zlib1g-dev
 
 RUN git clone --depth 1 https://github.com/curl/curl.git
 WORKDIR curl

--- a/projects/dlplibs/Dockerfile
+++ b/projects/dlplibs/Dockerfile
@@ -19,11 +19,10 @@ MAINTAINER dtardon@redhat.com
 # enable source repos
 RUN sed -i -e '/^#\s*deb-src.*\smain\s\+restricted/s/^#//' /etc/apt/sources.list
 # install build requirements
-RUN apt-get update
-RUN apt-get build-dep -y \
+RUN apt-get update && apt-get build-dep -y \
     libmspub librevenge libcdr libvisio libpagemaker libfreehand libwpd \
     libwpg libwps libmwaw libe-book libabw libetonyek
-RUN apt-get install -y liblzma-dev libpng-dev wget
+RUN apt-get update && apt-get install -y liblzma-dev libpng-dev wget
 ADD https://dev-www.libreoffice.org/src/lcms2-2.8.tar.gz $SRC/
 # download fuzzing corpora
 ADD https://dev-www.libreoffice.org/corpus/olefuzzer_seed_corpus.zip \

--- a/projects/expat/Dockerfile
+++ b/projects/expat/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mike.aizatsky@gmail.com
-RUN apt-get install -y make autoconf automake libtool docbook2x
+RUN apt-get update && apt-get install -y make autoconf automake libtool docbook2x
 
 RUN git clone --depth 1 https://github.com/libexpat/libexpat expat
 WORKDIR expat

--- a/projects/ffmpeg/Dockerfile
+++ b/projects/ffmpeg/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mmoroz@chromium.org
-RUN apt-get install -y make autoconf automake libtool build-essential \
+RUN apt-get update && apt-get install -y make autoconf automake libtool build-essential \
     libass-dev libfreetype6-dev libsdl1.2-dev \
     libvdpau-dev libxcb1-dev libxcb-shm0-dev \
     pkg-config texinfo libbz2-dev zlib1g-dev nasm yasm cmake mercurial wget \

--- a/projects/file/Dockerfile
+++ b/projects/file/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mike.aizatsky@gmail.com
-RUN apt-get install -y make autoconf automake libtool shtool
+RUN apt-get update && apt-get install -y make autoconf automake libtool shtool
 RUN git clone --depth 1 https://github.com/file/file.git
 WORKDIR file
 COPY build.sh magic_fuzzer.cc $SRC/

--- a/projects/freetype2/Dockerfile
+++ b/projects/freetype2/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mike.aizatsky@gmail.com
-RUN apt-get install -y make autoconf libtool libarchive-dev
+RUN apt-get update && apt-get install -y make autoconf libtool libarchive-dev
 
 # Get some files for the seed corpus
 ADD https://github.com/adobe-fonts/adobe-variable-font-prototype/releases/download/1.001/AdobeVFPrototype.otf $SRC/font-corpus/

--- a/projects/gnutls/Dockerfile
+++ b/projects/gnutls/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER alex.gaynor@gmail.com
-RUN apt-get install -y make autoconf automake libtool autopoint libnettle6 nettle-dev pkg-config gperf bison autogen texinfo curl
+RUN apt-get update && apt-get install -y make autoconf automake libtool autopoint libnettle6 nettle-dev pkg-config gperf bison autogen texinfo curl
 
 RUN git clone --depth=1 https://gitlab.com/gnutls/gnutls.git
 RUN cd gnutls && git submodule update --init

--- a/projects/grpc/Dockerfile
+++ b/projects/grpc/Dockerfile
@@ -17,10 +17,9 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mattkwong@google.com
 
-RUN apt-get install -y software-properties-common python-software-properties
+RUN apt-get update && apt-get install -y software-properties-common python-software-properties
 RUN add-apt-repository ppa:webupd8team/java
-RUN apt-get update
-RUN apt-get -y install  \
+RUN apt-get update && apt-get -y install  \
 	vim             \
 	build-essential \
 	openjdk-8-jdk   \

--- a/projects/guetzli/Dockerfile
+++ b/projects/guetzli/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER robryk@google.com
-RUN apt-get install -y make autoconf automake libtool libpng-dev pkg-config curl
+RUN apt-get update && apt-get install -y make autoconf automake libtool libpng-dev pkg-config curl
 
 RUN mkdir afl-testcases
 RUN cd afl-testcases/ && curl http://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz | tar -xz

--- a/projects/h2o/Dockerfile
+++ b/projects/h2o/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER jonathan.foote@gmail.com
-RUN apt-get install -y make autoconf automake libtool cmake zlib1g-dev pkg-config libssl-dev
+RUN apt-get update && apt-get install -y make autoconf automake libtool cmake zlib1g-dev pkg-config libssl-dev
 RUN git clone https://github.com/h2o/h2o
 WORKDIR h2o
 COPY build.sh $SRC/

--- a/projects/harfbuzz/Dockerfile
+++ b/projects/harfbuzz/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mmoroz@chromium.org
-RUN apt-get install -y make autoconf automake libtool ragel pkg-config
+RUN apt-get update && apt-get install -y make autoconf automake libtool ragel pkg-config
 
 RUN git clone --depth 1 https://anongit.freedesktop.org/git/harfbuzz.git
 WORKDIR harfbuzz

--- a/projects/icu/Dockerfile
+++ b/projects/icu/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mike.aizatsky@gmail.com
-RUN apt-get install -y make
+RUN apt-get update && apt-get install -y make
 
 RUN svn co http://source.icu-project.org/repos/icu/trunk/icu4c/ icu
 COPY build.sh *.cc *.h *.dict *.options $SRC/

--- a/projects/irssi/Dockerfile
+++ b/projects/irssi/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER joseph.bisch@gmail.com
-RUN apt-get install -y make autoconf automake libtool pkg-config libglib2.0-dev libncurses5-dev libssl-dev openssl lynx
+RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config libglib2.0-dev libncurses5-dev libssl-dev openssl lynx
 RUN git clone https://github.com/irssi/irssi
 
 WORKDIR irssi

--- a/projects/json/Dockerfile
+++ b/projects/json/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER vitalybuka@chromium.org
-RUN apt-get install -y binutils make
+RUN apt-get update && apt-get install -y binutils make
 
 RUN git clone --depth 1 -b develop https://github.com/nlohmann/json.git
 WORKDIR json/

--- a/projects/lcms/Dockerfile
+++ b/projects/lcms/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER kcwu@google.com
-RUN apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/mm2/Little-CMS.git lcms
 WORKDIR lcms
 COPY build.sh cmsIT8_load_fuzzer.* cms_transform_fuzzer.* icc.dict $SRC/

--- a/projects/libarchive/Dockerfile
+++ b/projects/libarchive/Dockerfile
@@ -19,7 +19,7 @@ MAINTAINER kcwu@google.com
 
 # Installing optional libraries can utilize more code path and/or improve
 # performance (avoid calling external programs).
-RUN apt-get install -y make autoconf automake libtool pkg-config \
+RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config \
         libbz2-dev liblzo2-dev liblzma-dev liblz4-dev libz-dev \
         libxml2-dev libssl-dev libacl1-dev libattr1-dev
 RUN git clone --depth 1 https://github.com/libarchive/libarchive.git

--- a/projects/libass/Dockerfile
+++ b/projects/libass/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER eugeni.stepanov@gmail.com
-RUN apt-get install -y make autoconf automake libtool pkg-config libfreetype6-dev libfontconfig1-dev
+RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config libfreetype6-dev libfontconfig1-dev
 
 RUN git clone --depth 1 https://github.com/libass/libass.git
 RUN git clone --depth 1 https://github.com/behdad/fribidi.git

--- a/projects/libchewing/Dockerfile
+++ b/projects/libchewing/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER kcwu@csie.org
-RUN apt-get install -y make autoconf automake libtool texinfo
+RUN apt-get update && apt-get install -y make autoconf automake libtool texinfo
 
 RUN git clone --depth 1 https://github.com/chewing/libchewing.git
 WORKDIR libchewing

--- a/projects/libidn2/Dockerfile
+++ b/projects/libidn2/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER n.mavrogiannopoulos@gmail.com
-RUN apt-get install -y make autoconf automake gettext libtool autopoint pkg-config gengetopt curl gperf
+RUN apt-get update && apt-get install -y make autoconf automake gettext libtool autopoint pkg-config gengetopt curl gperf
 
 RUN git clone --depth=1 https://gitlab.com/libidn/libidn2.git
 RUN cd libidn2 && git submodule update --init

--- a/projects/libjpeg-turbo/Dockerfile
+++ b/projects/libjpeg-turbo/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER alex.gaynor@gmail.com
-RUN apt-get install -y make autoconf automake libtool nasm curl
+RUN apt-get update && apt-get install -y make autoconf automake libtool nasm curl
 RUN git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo
 
 RUN mkdir afl-testcases

--- a/projects/libplist/Dockerfile
+++ b/projects/libplist/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER nikias@gmx.li
-RUN apt-get install -y make autoconf automake libtool pkg-config
+RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config
 
 RUN git clone --depth 1 https://github.com/libimobiledevice/libplist
 WORKDIR libplist

--- a/projects/libpng/Dockerfile
+++ b/projects/libpng/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mmoroz@chromium.org
-RUN apt-get install -y make autoconf automake libtool zlib1g-dev
+RUN apt-get update && apt-get install -y make autoconf automake libtool zlib1g-dev
 
 RUN git clone --depth 1 https://github.com/glennrp/libpng.git
 WORKDIR libpng

--- a/projects/libprotobuf-mutator/Dockerfile
+++ b/projects/libprotobuf-mutator/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER vitalybuka@chromium.org
-RUN apt-get install -y make autoconf automake libtool pkg-config cmake \
+RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config cmake \
     ninja-build liblzma-dev libz-dev docbook2x
 
 RUN git clone --depth 1  https://github.com/google/libprotobuf-mutator.git

--- a/projects/libreoffice/Dockerfile
+++ b/projects/libreoffice/Dockerfile
@@ -19,9 +19,8 @@ MAINTAINER officesecurity@lists.freedesktop.org
 # enable source repos
 RUN sed -i -e '/^#\s*deb-src.*\smain\s\+restricted/s/^#//' /etc/apt/sources.list
 #build requirements
-RUN apt-get update
-RUN apt-get build-dep -y libreoffice
-RUN apt-get install -y wget yasm
+RUN apt-get update && apt-get build-dep -y libreoffice
+RUN apt-get update && apt-get install -y wget yasm
 #cache build dependencies
 ADD https://dev-www.libreoffice.org/src/c3c1a8ba7452950636e871d25020ce0d-pt-serif-font-1.0000W.tar.gz \
     https://dev-www.libreoffice.org/src/c74b7223abe75949b4af367942d96c7a-crosextrafonts-carlito-20130920.tar.gz \

--- a/projects/libssh/Dockerfile
+++ b/projects/libssh/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER alex.gaynor@gmail.com
-RUN apt-get install -y cmake zlib1g-dev libssl-dev
+RUN apt-get update && apt-get install -y cmake zlib1g-dev libssl-dev
 
 # Can't use --depth=1 because git.libssh.org is using the "dumb" HTTP
 # transport, which doesn't support it.

--- a/projects/libteken/Dockerfile
+++ b/projects/libteken/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER kcwu@csie.org
-RUN apt-get install -y pmake
+RUN apt-get update && apt-get install -y pmake
 RUN svn co https://svn.freebsd.org/base/head/sys/teken libteken
 WORKDIR libteken
 COPY build.sh libteken_fuzzer.c $SRC/

--- a/projects/libtsm/Dockerfile
+++ b/projects/libtsm/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER kcwu@csie.org
-RUN apt-get install -y make autoconf automake libtool pkg-config
+RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config
 
 RUN git clone --depth 1 git://people.freedesktop.org/~dvdhrm/libtsm
 WORKDIR libtsm

--- a/projects/libxml2/Dockerfile
+++ b/projects/libxml2/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER ochang@chromium.org
-RUN apt-get install -y make autoconf automake libtool pkg-config
+RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config
 
 RUN git clone --depth 1 git://git.gnome.org/libxml2
 WORKDIR libxml2

--- a/projects/libyaml/Dockerfile
+++ b/projects/libyaml/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER alex.gaynor@gmail.com
-RUN apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get install -y make autoconf automake libtool
 
 RUN git clone --depth=1 https://github.com/yaml/libyaml
 RUN zip libyaml_fuzzer_seed_corpus.zip libyaml/examples/*

--- a/projects/llvm_libcxxabi/Dockerfile
+++ b/projects/llvm_libcxxabi/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER kcc@google.com
-RUN apt-get install -y subversion
+RUN apt-get update && apt-get install -y subversion
 
 RUN svn co https://llvm.org/svn/llvm-project/libcxxabi/trunk llvm_libcxxabi
 WORKDIR llvm_libcxxabi

--- a/projects/nghttp2/Dockerfile
+++ b/projects/nghttp2/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER tatsuhiro.t@gmail.com
-RUN apt-get install -y make autoconf automake libtool pkg-config
+RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config
 RUN git clone --depth 1 https://github.com/nghttp2/nghttp2.git
 WORKDIR nghttp2
 COPY build.sh *.options $SRC/

--- a/projects/nss/Dockerfile
+++ b/projects/nss/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mmoroz@chromium.org
-RUN apt-get install -y make mercurial zlib1g-dev gyp ninja-build libssl-dev
+RUN apt-get update && apt-get install -y make mercurial zlib1g-dev gyp ninja-build libssl-dev
 
 RUN hg clone https://hg.mozilla.org/projects/nspr nspr
 RUN hg clone https://hg.mozilla.org/projects/nss nss

--- a/projects/openssl/Dockerfile
+++ b/projects/openssl/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER kurt@roeckx.be
-RUN apt-get install -y make
+RUN apt-get update && apt-get install -y make
 RUN git clone --depth 1 https://github.com/openssl/openssl.git
 WORKDIR openssl
 COPY build.sh *.options $SRC/

--- a/projects/opus/Dockerfile
+++ b/projects/opus/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER flim@google.com
-RUN apt-get install -y make autoconf automake libtool wget
+RUN apt-get update && apt-get install -y make autoconf automake libtool wget
 
 RUN git clone https://git.xiph.org/opus.git
 RUN wget https://opus-codec.org/static/testvectors/opus_testvectors.tar.gz

--- a/projects/ots/Dockerfile
+++ b/projects/ots/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mmoroz@chromium.org
-RUN apt-get install -y make autoconf automake libtool pkg-config zlib1g-dev
+RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config zlib1g-dev
 RUN git clone --depth 1 https://github.com/khaledhosny/ots.git
 WORKDIR ots
 COPY build.sh ots-fuzzer.* $SRC/

--- a/projects/pcre2/Dockerfile
+++ b/projects/pcre2/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER kcc@google.com
-RUN apt-get install -y make autoconf automake libtool subversion
+RUN apt-get update && apt-get install -y make autoconf automake libtool subversion
 
 RUN svn co svn://vcs.exim.org/pcre2/code/trunk pcre2
 WORKDIR pcre2

--- a/projects/re2/Dockerfile
+++ b/projects/re2/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER wrengr@chromium.org
-RUN apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get install -y make autoconf automake libtool
 
 RUN git clone --depth 1 https://code.googlesource.com/re2
 WORKDIR re2

--- a/projects/sqlite3/Dockerfile
+++ b/projects/sqlite3/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER tanin@google.com
-RUN apt-get install -y make autoconf automake libtool curl tcl
+RUN apt-get update && apt-get install -y make autoconf automake libtool curl tcl
 
 # We won't be able to poll fossil for changes, so this will build
 # only once a day.

--- a/projects/tor/Dockerfile
+++ b/projects/tor/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER nickm@torproject.org
-RUN apt-get install -y zlib1g zlib1g-dev libevent-dev libevent-2.0 openssl autoconf automake libssl-dev make
+RUN apt-get update && apt-get install -y zlib1g zlib1g-dev libevent-dev libevent-2.0 openssl autoconf automake libssl-dev make
 RUN git clone https://git.torproject.org/tor.git
 RUN git clone https://git.torproject.org/fuzzing-corpora.git tor-fuzz-corpora
 WORKDIR tor

--- a/projects/tpm2/Dockerfile
+++ b/projects/tpm2/Dockerfile
@@ -5,7 +5,7 @@
 # Defines a docker image that can build fuzzers.
 #
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get install -y make libssl-dev binutils libgcc-5-dev
+RUN apt-get update && apt-get install -y make libssl-dev binutils libgcc-5-dev
 RUN git clone --depth 1 https://chromium.googlesource.com/chromiumos/third_party/tpm2
 WORKDIR tpm2
 RUN cp /src/tpm2/fuzz/build.sh /src/

--- a/projects/wireshark/Dockerfile
+++ b/projects/wireshark/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER Jakub Zawadzki <darkjames-ws@darkjames.pl>
 
-RUN apt-get install -y make autoconf automake libtool libtool-bin \
+RUN apt-get update && apt-get install -y make autoconf automake libtool libtool-bin \
                        flex bison \
                        libglib2.0-dev libgcrypt20-dev
 

--- a/projects/woff2/Dockerfile
+++ b/projects/woff2/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mmoroz@chromium.org
-RUN apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get install -y make autoconf automake libtool
 
 RUN git clone --depth 1 --recursive https://github.com/google/woff2
 WORKDIR woff2

--- a/projects/zlib/Dockerfile
+++ b/projects/zlib/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER inferno@chromium.org
-RUN apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get install -y make autoconf automake libtool
 
 RUN git clone --depth 1 https://github.com/madler/zlib.git
 WORKDIR zlib


### PR DESCRIPTION
https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/

I ran into this because I was getting errors locally, like:

    E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/d/dpkg/libdpkg-perl_1.18.4ubuntu1.1_all.deb  404  Not Found [IP: 91.189.88.149 80]

It turns out you get these if you don't update, and the official best practices are to `run apt-get update && apt-get install`. In fact, running _any_ `apt-get install` command without the `apt-get update &&` before it can result in unfortunate caching artifacts -- ctrl+f for "cache busting". (P.S. thanks to Peng on Freenode for helping me, I'm bad at Ubuntu.)

So:

    sed -re \
        's/RUN apt-get ((-y )?(install|build-dep))/RUN apt-get update \&\& apt-get \1/' -i \
        projects/**/Dockerfile

I also manually fixed the cases that already ran apt-get update in their Dockerfile:

- dlplibs/Dockerfile
- grpc/Dockerfile
- libreoffice/Dockerfile