### PR TITLE
strongswan: Run first fuzz target in fuzzing branch

### DIFF
--- a/projects/strongswan/Dockerfile
+++ b/projects/strongswan/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+##############################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER tobias@strongswan.org
+RUN apt-get update && apt-get install -y automake autoconf libtool pkg-config gettext perl python flex bison gperf lcov libgmp3-dev
+RUN git clone -b fuzzing --depth 1 https://github.com/strongswan/strongswan.git strongswan
+RUN git clone --depth 1 https://github.com/strongswan/fuzzing-corpora.git strongswan/fuzzing-corpora
+WORKDIR strongswan
+COPY build.sh $SRC/

--- a/projects/strongswan/build.sh
+++ b/projects/strongswan/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -eu
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+./autogen.sh
+
+./configure CFLAGS="$CFLAGS -DNO_CHECK_MEMWIPE" LDFLAGS='--coverage' --enable-fuzzing --enable-coverage --with-libfuzzer=$LIB_FUZZING_ENGINE --enable-monolithic --disable-shared --enable-static
+
+make -j$(nproc)
+
+fuzzers=$(find fuzz -maxdepth 1 -executable -type f -name \fuzz_*)
+for f in $fuzzers; do
+	fuzzer=$(basename $f)
+	cp $f $OUT/
+	corpus=${fuzzer#fuzz_}
+	corpus=${corpus%%_*}
+	if [ -d "fuzzing-corpora/${corpus}" ]; then
+		zip -rj $OUT/${fuzzer}_seed_corpus.zip fuzzing-corpora/${corpus}
+	fi
+done


### PR DESCRIPTION
Once the _fuzzing_ branch is merged to master we can remove the `-b fuzzing` option.

There is one issue with the strongSwan code base that causes lots of warnings when running the fuzz target. Due to our use of custom printf specifiers (e.g. via glibc's [register_printf_function](https://www.gnu.org/software/libc/manual/html_node/Customizing-Printf.html)) with `snprintf` (logging is disabled, but these are called anyway) we get lots of `unexpected format specifier in printf interceptor: %N` (or `...: %Y`) messages. The check that causes this could be disabled by adding `check_printf=0` to `ASAN_OPTIONS`, but unfortunately we can't customize that.