### PR TITLE
projects/ffmpeg: Build based on decoder symbols instead of codec_ids

### DIFF
--- a/projects/ffmpeg/build.sh
+++ b/projects/ffmpeg/build.sh
@@ -182,13 +182,13 @@ export TEMP_VAR_CODEC="AV_CODEC_ID_H264"
 export TEMP_VAR_CODEC_TYPE="VIDEO"
 
 # Build fuzzers for decoders.
-CODEC_NAMES=`git grep 'AV_CODEC_ID_[A-Z0-9_]*,' libavcodec/avcodec.h | grep -v '_NONE' | sed 's/.*AV_CODEC_ID_\([^,]*\),.*/\1/' `
+CONDITIONALS=`grep 'DECODER 1$' config.h | sed 's/#define CONFIG_\(.*\)_DECODER 1/\1/'`
+for c in $CONDITIONALS ; do
+  fuzzer_name=ffmpeg_dec_${c}_fuzzer
+  symbol=`git grep 'REGISTER_[A-Z]*DEC[A-Z ]*('"$c"' *,' libavcodec/allcodecs.c | sed 's/.*, *\([^) ]*\)).*/\1/'`
 
-for codec in $CODEC_NAMES; do
-  fuzzer_name=ffmpeg_AV_CODEC_ID_${codec}_fuzzer
-
-  make tools/target_dec_${codec}_fuzzer
-  mv tools/target_dec_${codec}_fuzzer $OUT/${fuzzer_name}
+  make tools/target_dec_${symbol}_fuzzer
+  mv tools/target_dec_${symbol}_fuzzer $OUT/${fuzzer_name}
 
   echo -en "[libfuzzer]\nmax_len = 1000000\n" > $OUT/${fuzzer_name}.options
 done

--- a/projects/ffmpeg/group_seed_corpus.py
+++ b/projects/ffmpeg/group_seed_corpus.py
@@ -24,7 +24,7 @@ import zipfile
 
 
 logging.basicConfig(level=logging.INFO, format='INFO: %(message)s')
-CODEC_NAME_REGEXP = re.compile(r'codec_id_(.+?)_fuzzer')
+CODEC_NAME_REGEXP = re.compile(r'dec_(.+?)_fuzzer')
 
 
 def get_fuzzer_tags(fuzzer_name):


### PR DESCRIPTION
This with latest ffmpeg results in a significant reduction of disk space needed for the fuzzers

This patch is under public domain

Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>

With this the output directory needs 23gb