### PR TITLE
Add POC fuzzer for Skia

### DIFF
--- a/projects/skia/BUILD.gn.diff
+++ b/projects/skia/BUILD.gn.diff
@@ -1,4 +1,3 @@
-#!/bin/bash -eu
 # Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,12 +13,16 @@
 # limitations under the License.
 #
 ################################################################################
-
-export CXXFLAGS_ARR=`echo $CXXFLAGS | sed -e "s/\s/\",\"/g"`
-$SRC/depot_tools/gn gen out/Fuzz --args='cc="'$CC'" cxx="'$CXX'" is_debug=false extra_cflags=["'"$CXXFLAGS_ARR"'","-DIS_FUZZING"] skia_use_system_freetype2=false skia_use_fontconfig=false skia_enable_gpu=false extra_ldflags=["-lFuzzingEngine", "'"$CXXFLAGS_ARR"'"]'
+# TODO(kjlubick): Move this into Skia proper
 
 
-
-$SRC/depot_tools/ninja -C out/Fuzz fuzz_region_deserialize
-
-cp out/Fuzz/fuzz_region_deserialize $OUT/fuzz_region_deserialize
+# Append this to build.gn in the skia repo and then build the targets
+test_app("fuzz_region_deserialize") {
+  sources = [
+    "fuzz/oss_fuzz/region_deserialize.cpp",
+  ]
+  deps = [
+    ":flags",
+    ":skia",
+  ]
+}

--- a/projects/skia/Dockerfile
+++ b/projects/skia/Dockerfile
@@ -31,9 +31,9 @@ WORKDIR skia
 RUN python tools/git-sync-deps
 
 COPY build.sh $SRC/
-COPY region_deserialize.options $OUT/region_deserialize.options
 
 # Dirty, ugly hacks until I land the final result in Skia proper
+COPY region_deserialize.options $SRC/skia/region_deserialize.options
 COPY BUILD.gn.diff $SRC/skia/BUILD.gn.diff
 RUN cat BUILD.gn.diff >> BUILD.gn
 COPY region_deserialize.cpp $SRC/skia/fuzz/oss_fuzz/region_deserialize.cpp

--- a/projects/skia/Dockerfile
+++ b/projects/skia/Dockerfile
@@ -1,0 +1,33 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER kjlubick@chromium.org
+
+RUN apt-get update && apt-get install -y python
+
+RUN git clone 'https://chromium.googlesource.com/chromium/tools/depot_tools.git'
+ENV PATH="${SRC}/depot_tools:${PATH}"
+
+# checkout all sources needed to build your project
+RUN git clone https://skia.googlesource.com/skia.git
+
+# current directory for build script
+WORKDIR skia
+
+RUN python tools/git-sync-deps
+
+COPY build.sh $SRC/

--- a/projects/skia/Dockerfile
+++ b/projects/skia/Dockerfile
@@ -31,3 +31,9 @@ WORKDIR skia
 RUN python tools/git-sync-deps
 
 COPY build.sh $SRC/
+COPY region_deserialize.options $OUT/region_deserialize.options
+
+# Dirty, ugly hacks until I land the final result in Skia proper
+COPY BUILD.gn.diff $SRC/skia/BUILD.gn.diff
+RUN cat BUILD.gn.diff >> BUILD.gn
+COPY region_deserialize.cpp $SRC/skia/fuzz/oss_fuzz/region_deserialize.cpp

--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -15,11 +15,19 @@
 #
 ################################################################################
 
+# This splits a space separated list into a quoted, comma separated list for gn.
 export CXXFLAGS_ARR=`echo $CXXFLAGS | sed -e "s/\s/\",\"/g"`
-$SRC/depot_tools/gn gen out/Fuzz --args='cc="'$CC'" cxx="'$CXX'" is_debug=false extra_cflags=["'"$CXXFLAGS_ARR"'","-DIS_FUZZING"] skia_use_system_freetype2=false skia_use_fontconfig=false skia_enable_gpu=false extra_ldflags=["-lFuzzingEngine", "'"$CXXFLAGS_ARR"'"]'
-
-
+$SRC/depot_tools/gn gen out/Fuzz\
+    --args='cc="'$CC'"
+    cxx="'$CXX'"
+    is_debug=false
+    extra_cflags=["'"$CXXFLAGS_ARR"'","-DIS_FUZZING"]
+    skia_use_system_freetype2=false
+    skia_use_fontconfig=false
+    skia_enable_gpu=false
+    extra_ldflags=["-lFuzzingEngine", "'"$CXXFLAGS_ARR"'"]'
 
 $SRC/depot_tools/ninja -C out/Fuzz fuzz_region_deserialize
 
-cp out/Fuzz/fuzz_region_deserialize $OUT/fuzz_region_deserialize
+cp out/Fuzz/fuzz_region_deserialize $OUT/region_deserialize
+cp ./region_deserialize.options $OUT/region_deserialize.options

--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+export CXXFLAGS_ARR=`echo $CXXFLAGS | sed -e "s/\s/\",\"/g"`
+$SRC/depot_tools/gn gen out/Fuzz --args='cc="'$CC'" cxx="'$CXX'" is_debug=false extra_cflags=["'"$CXXFLAGS_ARR"'","-DIS_FUZZING"] skia_use_system_freetype2=false skia_use_fontconfig=false skia_enable_gpu=false extra_ldflags=["-L'$LIB_FUZZING_ENGINE'", "'"$CXXFLAGS_ARR"'"]'
+
+
+
+$SRC/depot_tools/ninja -C out/Fuzz fuzz

--- a/projects/skia/project.yaml
+++ b/projects/skia/project.yaml
@@ -1,0 +1,4 @@
+homepage: "https://github.com/google/skia"
+primary_contact: "kjlubick@chromium.org"
+auto_ccs:
+  - "hcm@chromium.org"

--- a/projects/skia/region_deserialize.cpp
+++ b/projects/skia/region_deserialize.cpp
@@ -1,0 +1,39 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// TODO(kjlubick): Move this into Skia proper
+
+
+#include "SkCanvas.h"
+#include "SkPaint.h"
+#include "SkRegion.h"
+#include "SkSurface.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    SkRegion region;
+    if (!region.readFromMemory(data, size)) {
+        return 0;
+    }
+    region.computeRegionComplexity();
+    region.isComplex();
+    SkRegion r2;
+    if (region == r2) {
+        region.contains(0,0);
+    } else {
+        region.contains(1,1);
+    }
+    auto s = SkSurface::MakeRasterN32Premul(1024, 1024);
+    s->getCanvas()->drawRegion(region, SkPaint());
+    return 0;  // Non-zero return values are reserved for future use.
+}

--- a/projects/skia/region_deserialize.options
+++ b/projects/skia/region_deserialize.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 512


### PR DESCRIPTION
This gets Skia to compile with libfuzzer and ports one of the stable, existing fuzzers.  If this goes well, more will follow.