### PR TITLE
Add gdal project

### DIFF
--- a/projects/gdal/Dockerfile
+++ b/projects/gdal/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER even.rouault@spatialys.com
+RUN apt-get update && apt-get install -y make autoconf automake libtool g++
+# libpng12-dev libjpeg-dev libgif-dev liblzma-dev libgeos-dev libcurl4-gnutls-dev libproj-dev libxml2-dev libexpat-dev libxerces-c-dev libnetcdf-dev netcdf-bin libpoppler-dev libspatialite-dev libhdf4-alt-dev libhdf5-serial-dev  poppler-utils libfreexl-dev unixodbc-dev libwebp-dev libepsilon-dev libpcre3-dev
+# libpodofo-dev  libcrypto++-dev
+RUN git clone --depth 1 https://github.com/OSGeo/gdal gdal
+WORKDIR gdal
+COPY build.sh $SRC/

--- a/projects/gdal/build.sh
+++ b/projects/gdal/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -eu
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# build project
+cd gdal
+export LDFLAGS=${CXXFLAGS}
+./configure --without-libtool
+make clean -s
+make -j$(nproc) -s
+
+./fuzzers/build_google_oss_fuzzers.sh
+./fuzzers/build_seed_corpus.sh

--- a/projects/gdal/project.yaml
+++ b/projects/gdal/project.yaml
@@ -1,0 +1,5 @@
+homepage: "https://gdal.org"
+primary_contact: "even.rouault@spatialys.com"
+auto_ccs:
+  - "schwehr@gmail.com"
+  - "mateusz@loskot.net"


### PR DESCRIPTION
Extract from http://gdal.org/ :
GDAL is a translator library for raster and vector geospatial data
formats that is released under an X/MIT style Open Source license by
the Open Source Geospatial Foundation. As a library, it presents a
single raster abstract data model and single vector abstract data model
to the calling application for all supported formats. It also comes
with a variety of useful command line utilities for data translation
and processing

GDAL upstream ticket:
https://trac.osgeo.org/gdal/ticket/6883