### PR TITLE
Add h2o url handler fuzz target

### DIFF
--- a/projects/h2o/build.sh
+++ b/projects/h2o/build.sh
@@ -18,10 +18,11 @@
 pushd $SRC/h2o
 cmake -DBUILD_FUZZER=ON -DOSS_FUZZ=ON -DOPENSSL_USE_STATIC_LIBS=TRUE .
 make
-cp ./h2o-fuzzer-http* $OUT/
+cp ./h2o-fuzzer-* $OUT/
 
 zip -jr $OUT/h2o-fuzzer-http1_seed_corpus.zip $SRC/h2o/fuzz/http1-corpus
 zip -jr $OUT/h2o-fuzzer-http2_seed_corpus.zip $SRC/h2o/fuzz/http2-corpus
+zip -jr $OUT/h2o-fuzzer-url_seed_corpus.zip $SRC/h2o/fuzz/url-corpus
 
 cp $SRC/*.options $SRC/h2o/fuzz/*.dict $OUT/
 popd

--- a/projects/h2o/h2o-fuzzer-url.options
+++ b/projects/h2o/h2o-fuzzer-url.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+close_fd_mask = 3


### PR DESCRIPTION
This PR adds a new `h2o-fuzzer-url` fuzz target to the h2o oss-fuzz build.