### PR TITLE
GDAL: add more dependencies by using system static libraries

### DIFF
--- a/projects/gdal/Dockerfile
+++ b/projects/gdal/Dockerfile
@@ -16,17 +16,9 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER even.rouault@spatialys.com
-# curl needed to fetch sqlite3
-# tcl needed to build sqlite3
-# docbook2x needed o build expat
-RUN apt-get update && apt-get install -y make autoconf automake libtool g++ curl tcl docbook2x
-# libpng12-dev libjpeg-dev libgif-dev liblzma-dev libgeos-dev libcurl4-gnutls-dev libproj-dev libxml2-dev libexpat-dev libxerces-c-dev libnetcdf-dev netcdf-bin libpoppler-dev libspatialite-dev libhdf4-alt-dev libhdf5-serial-dev  poppler-utils libfreexl-dev unixodbc-dev libwebp-dev libepsilon-dev libpcre3-dev
+RUN apt-get update && apt-get install -y make autoconf automake libtool g++ zlib1g-dev libsqlite3-dev libexpat-dev liblzma-dev libxerces-c-dev libpng12-dev libgif-dev libwebp-dev libicu-dev
+#   libgeos-dev libjpeg-dev libcurl4-gnutls-dev libproj-dev libxml2-dev libnetcdf-dev netcdf-bin libpoppler-dev libspatialite-dev libhdf4-alt-dev libhdf5-serial-dev  poppler-utils libfreexl-dev unixodbc-dev libepsilon-dev libpcre3-dev
 # libpodofo-dev  libcrypto++-dev
 RUN git clone --depth 1 https://github.com/OSGeo/gdal gdal
-RUN git clone --depth 1 https://github.com/libexpat/libexpat gdal/libexpat
-RUN mkdir gdal/sqlite3 && \
-    cd gdal/sqlite3 && \
-    curl 'https://www.sqlite.org/src/tarball?uuid=trunk' -o sqlite3.tar.gz && \
-    tar xzf sqlite3.tar.gz
 WORKDIR gdal
 COPY build.sh $SRC/

--- a/projects/gdal/build.sh
+++ b/projects/gdal/build.sh
@@ -15,44 +15,13 @@
 #
 ################################################################################
 
-# build expat
-cd libexpat/expat
-./buildconf.sh
-./configure --disable-shared --prefix=$SRC/install
-make clean -s
-make -j$(nproc) -s
-make install
-cd ../..
-
-# build sqlite3
-# Taken from https://github.com/google/oss-fuzz/blob/master/projects/sqlite3/build.sh
-
-export ASAN_OPTIONS=detect_leaks=0
-
-# Limit max length of data blobs and sql queries to prevent irrelevant OOMs.
-# Also limit max memory page count to avoid creating large databases.
-OLD_CFLAGS=$CFLAGS
-export CFLAGS="$CFLAGS -DSQLITE_MAX_LENGTH=128000000 \
-               -DSQLITE_MAX_SQL_LENGTH=128000000 \
-               -DSQLITE_MAX_MEMORY=25000000 \
-               -DSQLITE_PRINTF_PRECISION_LIMIT=1048576 \
-               -DSQLITE_DEBUG=1 \
-               -DSQLITE_MAX_PAGE_COUNT=16384" 
-
-cd sqlite3
-./configure --disable-shared --prefix=$SRC/install
-make clean -s
-make -j$(nproc) -s
-make install
-cd ..
-export CFLAGS=$OLD_CFLAGS
-
 # build gdal
 cd gdal
 export LDFLAGS=${CXXFLAGS}
-./configure --without-libtool --with-expat=$SRC/install --with-sqlite3=$SRC/install
+./configure --without-libtool --with-liblzma --with-expat --with-sqlite3 --with-xerces --with-webp
 make clean -s
 make -j$(nproc) -s
 
+export EXTRA_LIBS="-Wl,-Bstatic -lwebp -llzma -lexpat -lsqlite3 -lgif -lpng12 -lz -lxerces-c -licuuc -licudata -Wl,-Bdynamic -ldl -lpthread"
 ./fuzzers/build_google_oss_fuzzers.sh
 ./fuzzers/build_seed_corpus.sh


### PR DESCRIPTION
Use static versions of Ubuntu -dev libraries.
Add: lzma, xerces, webp
Use external version of libz, libpng, libgif instead of GDAL internal copies.