### PR TITLE
add libmicrohttpd

### DIFF
--- a/projects/libmicrohttpd/project.yaml
+++ b/projects/libmicrohttpd/project.yaml
@@ -1,0 +1,4 @@
+homepage: "https://www.gnu.org/s/libmicrohttpd/"
+primary_contact: "christian@grothoff.org"
+auto_ccs:
+         - "k2k@narod.ru"


### PR DESCRIPTION
Proposing GNU libmicrohttpd as a new project for oss-fuzz.