### PR TITLE
Revert "[ots] Increase OTS max_len (#606)"

### DIFF
--- a/projects/ots/ots-fuzzer.options
+++ b/projects/ots/ots-fuzzer.options
@@ -1,2 +1,2 @@
 [libfuzzer]
-max_len = 1000000
+max_len = 16800


### PR DESCRIPTION
This reverts commit 33c1ed629d4808238c5a25e994cd9c854fe5f8d5.

It seems to have caused considerable slowness and decreased coverage
considerably.