### PR TITLE
Add proj.4 project

### DIFF
--- a/projects/proj4/Dockerfile
+++ b/projects/proj4/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER even.rouault@spatialys.com
+RUN apt-get update && apt-get install -y make autoconf automake libtool g++
+RUN git clone --depth 1 https://github.com/OSGeo/proj.4 proj.4
+WORKDIR proj.4
+COPY build.sh $SRC/

--- a/projects/proj4/build.sh
+++ b/projects/proj4/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -eu
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+./autogen.sh
+./configure
+make clean -s
+make -j$(nproc) -s
+
+./test/fuzzers/build_google_oss_fuzzers.sh
+./test/fuzzers/build_seed_corpus.sh

--- a/projects/proj4/project.yaml
+++ b/projects/proj4/project.yaml
@@ -1,0 +1,5 @@
+homepage: "http://proj4.org/"
+primary_contact: "even.rouault@gmail.com"
+auto_ccs:
+  - "hobu.inc@gmail.com"
+  - "kristianevers@gmail.com"


### PR DESCRIPTION
proj.4 is standard UNIX filter function which converts
geographic longitude and latitude coordinates into cartesian
coordinates (and vice versa), and it is a C API for software
developers to include coordinate transformation in their own
software.

See http://proj4.org/

Note: it is used by the GDAL library, already in OSS-Fuzz.