### PR TITLE
Dropbear SSH fuzzer working

### DIFF
--- a/projects/dropbear/Dockerfile
+++ b/projects/dropbear/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER matt@ucc.asn.au
+RUN apt-get update && apt-get install -y libz-dev autoconf mercurial
+RUN hg clone -b fuzz https://secure.ucc.asn.au/hg/dropbear dropbear
+RUN hg clone https://secure.ucc.asn.au/hg/dropbear-fuzzcorpus dropbear/corpus
+WORKDIR dropbear
+COPY build.sh *.options $SRC/
+

--- a/projects/dropbear/build.sh
+++ b/projects/dropbear/build.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+
+pushd $SRC/dropbear
+autoconf
+autoheader
+popd
+
+$SRC/dropbear/configure --enable-fuzz
+# force static zlib
+sed -i 's@-lz@/usr/lib/x86_64-linux-gnu/libz.a@' Makefile
+
+make -j$(nproc) fuzz-targets FUZZLIB=$LIB_FUZZING_ENGINE
+
+TARGETS="$(make list-fuzz-targets)"
+
+make -C $SRC/dropbear/corpus
+
+cp -v $TARGETS $OUT/
+cp -v $SRC/*.options $OUT/
+cp -v $SRC/dropbear/corpus/*.zip $OUT/

--- a/projects/dropbear/fuzzer-preauth.options
+++ b/projects/dropbear/fuzzer-preauth.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 50000


### PR DESCRIPTION
An initial fuzzer for Dropbear, server-preauth.
Currently a bit slow probably due to repeated asymmetric crypto operations, I'll add targets that skip those later.

The fuzzing changes for Dropbear are in a separate branch for the time being. Eventually that should get merged if the changes can be kept small enough. 