### PR TITLE
Add GNU wget2 to oss-fuzz

### DIFF
--- a/projects/wget2/Dockerfile
+++ b/projects/wget2/Dockerfile
@@ -1,0 +1,42 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER rockdaboot@gmail.com
+RUN apt-get update && apt-get install -y \
+ pkg-config \
+ gettext \
+ autopoint \
+ autoconf \
+ automake \
+ libtool \
+ texinfo \
+ flex \
+ liblzma-dev \
+ libidn2-0-dev \
+ libunistring-dev \
+ zlib1g-dev \
+ libbz2-dev \
+ gnutls-dev \
+ libpsl-dev \
+ libnghttp2-dev \
+ doxygen
+
+RUN git clone --depth=1 https://gitlab.com/gnuwget/wget2.git
+RUN cd wget2 && git submodule update --init
+
+WORKDIR wget2
+COPY build.sh $SRC/

--- a/projects/wget2/build.sh
+++ b/projects/wget2/build.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -eu
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+./bootstrap
+./configure --enable-static --disable-doc
+make
+
+cp -p fuzz/*.dict fuzz/*.options $OUT
+
+fuzzers=$(find fuzz/ -name "*_fuzzer.cc")
+
+for f in $fuzzers; do
+    fuzzer=$(basename "$f" ".cc")
+
+    $CXX $CXXFLAGS -std=c++11 -Iinclude/wget/ \
+        "fuzz/${fuzzer}.cc" -o "$OUT/${fuzzer}" \
+        libwget/.libs/libwget.a -lFuzzingEngine -Wl,-Bstatic \
+        -lidn2 -lunistring \
+        -Wl,-Bdynamic
+
+    if [ -f "$SRC/${fuzzer}_seed_corpus.zip" ]; then
+        cp "$SRC/${fuzzer}_seed_corpus.zip" "$OUT/"
+    fi
+
+    corpus_dir=$(basename "${fuzzer}" "_fuzzer")
+    if [ -d "fuzz/${corpus_dir}.in/" ]; then
+        zip -r "$OUT/${fuzzer}_seed_corpus.zip" "fuzz/${corpus_dir}.in/"
+    fi
+done

--- a/projects/wget2/project.yaml
+++ b/projects/wget2/project.yaml
@@ -1,0 +1,4 @@
+homepage: "https://gitlab.com/gnuwget/wget2"
+primary_contact: "rockdaboot@gmail.com"
+auto_ccs:
+  - "tim.ruehsen@gmx.de"


### PR DESCRIPTION
GNU Wget2 is the designated successor of GNU Wget. It comes with a libwget to provide wget functionality to other projects as well. It takes part in GSOC 2017 with 3 projects.

https://gitlab.com/gnuwget/wget2