### PR TITLE
Link final openssl targets with CXX instead of clang++

### DIFF
--- a/projects/openssl/build.sh
+++ b/projects/openssl/build.sh
@@ -23,7 +23,7 @@ fi
 
 ./config --debug enable-fuzz-libfuzzer -DPEDANTIC -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION no-shared enable-tls1_3 enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 enable-ssl3 enable-ssl3-method enable-nextprotoneg enable-weak-ssl-ciphers --with-fuzzer-lib=/usr/lib/libFuzzingEngine $CFLAGS -fno-sanitize=alignment $CONFIGURE_FLAGS
 
-make -j$(nproc) LDCMD="clang++ $CXXFLAGS"
+make -j$(nproc) LDCMD="$CXX $CXXFLAGS"
 
 fuzzers=$(find fuzz -executable -type f '!' -name \*.py '!' -name \*-test)
 for f in $fuzzers; do


### PR DESCRIPTION
 Link final openssl targets with CXX instead of clang++ as afl/honggfuzz might be using custom compilers