### PR TITLE
GDAL: add netCDF dependency

### DIFF
--- a/projects/gdal/Dockerfile
+++ b/projects/gdal/Dockerfile
@@ -16,8 +16,8 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER even.rouault@spatialys.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool g++ zlib1g-dev libsqlite3-dev libexpat-dev liblzma-dev libxerces-c-dev libpng12-dev libgif-dev libwebp-dev libicu-dev
-#   libgeos-dev libjpeg-dev libcurl4-gnutls-dev libproj-dev libxml2-dev libnetcdf-dev netcdf-bin libpoppler-dev libspatialite-dev libhdf4-alt-dev libhdf5-serial-dev  poppler-utils libfreexl-dev unixodbc-dev libepsilon-dev libpcre3-dev
+RUN apt-get update && apt-get install -y make autoconf automake libtool g++ zlib1g-dev libsqlite3-dev libexpat-dev liblzma-dev libxerces-c-dev libpng12-dev libgif-dev libwebp-dev libicu-dev libnetcdf-dev curl
+#   libgeos-dev libjpeg-dev libcurl4-gnutls-dev libproj-dev libxml2-dev netcdf-bin libpoppler-dev libspatialite-dev libhdf4-alt-dev libhdf5-serial-dev  poppler-utils libfreexl-dev unixodbc-dev libepsilon-dev libpcre3-dev
 # libpodofo-dev  libcrypto++-dev
 RUN git clone --depth 1 https://github.com/OSGeo/gdal gdal
 WORKDIR gdal

--- a/projects/gdal/Dockerfile
+++ b/projects/gdal/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER even.rouault@spatialys.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool g++ zlib1g-dev libsqlite3-dev libexpat-dev liblzma-dev libxerces-c-dev libpng12-dev libgif-dev libwebp-dev libicu-dev libnetcdf-dev curl
+RUN apt-get update && apt-get install -y make autoconf automake libtool g++ zlib1g-dev libsqlite3-dev libexpat-dev liblzma-dev libxerces-c-dev libpng12-dev libgif-dev libwebp-dev libicu-dev libnetcdf-dev curl cmake
 #   libgeos-dev libjpeg-dev libcurl4-gnutls-dev libproj-dev libxml2-dev netcdf-bin libpoppler-dev libspatialite-dev libhdf4-alt-dev libhdf5-serial-dev  poppler-utils libfreexl-dev unixodbc-dev libepsilon-dev libpcre3-dev
 # libpodofo-dev  libcrypto++-dev
 RUN git clone --depth 1 https://github.com/OSGeo/gdal gdal

--- a/projects/gdal/build.sh
+++ b/projects/gdal/build.sh
@@ -15,15 +15,17 @@
 #
 ################################################################################
 
-
+# build libnetcdf.a
 curl ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.4.1.1.tar.gz > netcdf-4.4.1.1.tar.gz
 tar xvzf netcdf-4.4.1.1.tar.gz
 cd netcdf-4.4.1.1
-./configure --enable-static --disable-netcdf-4 --disable-dap --prefix=$SRC/install
+mkdir build
+cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=$SRC/install -DHDF5_C_LIBRARY=libhdf5_serial.a -DHDF5_HL_LIBRARY=libhdf5_serial_hl.a -DHDF5_INCLUDE_DIR=/usr/include/hdf5/serial -DENABLE_DAP:BOOL=OFF -DBUILD_SHARED_LIBS:BOOL=OFF -DBUILD_UTILITIES:BOOL=OFF -DBUILD_TESTING:BOOL=OFF -DENABLE_TESTS:BOOL=OFF
 make clean -s
 make -j$(nproc) -s
 make install
-cd ..
+cd ../..
 
 # build gdal
 cd gdal
@@ -36,7 +38,7 @@ export EXTRA_LIBS="-Wl,-Bstatic -lwebp -llzma -lexpat -lsqlite3 -lgif -lpng12 -l
 # Xerces-C related
 export EXTRA_LIBS="$EXTRA_LIBS -lxerces-c -licuuc -licudata"
 # netCDF related
-export EXTRA_LIBS="$EXTRA_LIBS -L$SRC/install/lib -lnetcdf"
+export EXTRA_LIBS="$EXTRA_LIBS -L$SRC/install/lib -lnetcdf -lhdf5_serial_hl -lhdf5_serial -lsz -laec -lz"
 export EXTRA_LIBS="$EXTRA_LIBS -Wl,-Bdynamic -ldl -lpthread"
 ./fuzzers/build_google_oss_fuzzers.sh
 ./fuzzers/build_seed_corpus.sh

--- a/projects/gdal/build.sh
+++ b/projects/gdal/build.sh
@@ -15,13 +15,28 @@
 #
 ################################################################################
 
+
+curl ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.4.1.1.tar.gz > netcdf-4.4.1.1.tar.gz
+tar xvzf netcdf-4.4.1.1.tar.gz
+cd netcdf-4.4.1.1
+./configure --enable-static --disable-netcdf-4 --disable-dap --prefix=$SRC/install
+make clean -s
+make -j$(nproc) -s
+make install
+cd ..
+
 # build gdal
 cd gdal
 export LDFLAGS=${CXXFLAGS}
-./configure --without-libtool --with-liblzma --with-expat --with-sqlite3 --with-xerces --with-webp
+./configure --without-libtool --with-liblzma --with-expat --with-sqlite3 --with-xerces --with-webp --with-netcdf=$SRC/install --without-curl --without-hdf5 --with-jpeg=internal
 make clean -s
 make -j$(nproc) -s
 
-export EXTRA_LIBS="-Wl,-Bstatic -lwebp -llzma -lexpat -lsqlite3 -lgif -lpng12 -lz -lxerces-c -licuuc -licudata -Wl,-Bdynamic -ldl -lpthread"
+export EXTRA_LIBS="-Wl,-Bstatic -lwebp -llzma -lexpat -lsqlite3 -lgif -lpng12 -lz"
+# Xerces-C related
+export EXTRA_LIBS="$EXTRA_LIBS -lxerces-c -licuuc -licudata"
+# netCDF related
+export EXTRA_LIBS="$EXTRA_LIBS -L$SRC/install/lib -lnetcdf"
+export EXTRA_LIBS="$EXTRA_LIBS -Wl,-Bdynamic -ldl -lpthread"
 ./fuzzers/build_google_oss_fuzzers.sh
 ./fuzzers/build_seed_corpus.sh


### PR DESCRIPTION
Note that given the way GDAL will use it
(see https://trac.osgeo.org/gdal/changeset/38914 ), we won't fuzz netCDF files
themselves and test libnetcdf itself. Instead, for the purpose of oss-fuzz,
GDAL will use as input a text file (syntax of the ncdump/ncgen utilitis)
and will convert it to a (valid) netCDF file on-the-fly. This way we test how
the GDAL netCDF driver reacts, instead of potential bug in libnetcdf itself.