### PR TITLE
GDAL: add a patch to fix a leak in libnetcdf

### DIFF
--- a/projects/gdal/Dockerfile
+++ b/projects/gdal/Dockerfile
@@ -21,4 +21,4 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool g++ zlib
 # libpodofo-dev  libcrypto++-dev
 RUN git clone --depth 1 https://github.com/OSGeo/gdal gdal
 WORKDIR gdal
-COPY build.sh $SRC/
+COPY build.sh NC4_put_propattr_leak_fix.patch $SRC/

--- a/projects/gdal/NC4_put_propattr_leak_fix.patch
+++ b/projects/gdal/NC4_put_propattr_leak_fix.patch
@@ -1,0 +1,16 @@
+--- libsrc4/nc4info.c.ori	2017-06-07 10:28:11.478130590 +0200
++++ libsrc4/nc4info.c	2017-06-07 10:28:29.670268763 +0200
+@@ -174,11 +174,8 @@
+       herr = 0;
+     }
+  done:
+-    if(ncstat != NC_NOERR) {
+-      if(text != NULL) {
+-        free(text);
+-        text = NULL;
+-      }
++    if(text != NULL) {
++      free(text);
+     }
+ 
+     if(attid >= 0) HCHECK((H5Aclose(attid)));

--- a/projects/gdal/build.sh
+++ b/projects/gdal/build.sh
@@ -19,6 +19,7 @@
 curl ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.4.1.1.tar.gz > netcdf-4.4.1.1.tar.gz
 tar xvzf netcdf-4.4.1.1.tar.gz
 cd netcdf-4.4.1.1
+patch -p0 < $SRC/NC4_put_propattr_leak_fix.patch
 mkdir build
 cd build
 cmake .. -DCMAKE_INSTALL_PREFIX=$SRC/install -DHDF5_C_LIBRARY=libhdf5_serial.a -DHDF5_HL_LIBRARY=libhdf5_serial_hl.a -DHDF5_INCLUDE_DIR=/usr/include/hdf5/serial -DENABLE_DAP:BOOL=OFF -DBUILD_SHARED_LIBS:BOOL=OFF -DBUILD_UTILITIES:BOOL=OFF -DBUILD_TESTING:BOOL=OFF -DENABLE_TESTS:BOOL=OFF


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=2129 identified a leak
in libnetcdf itself.

Patch submitted upstream as
https://github.com/Unidata/netcdf-c/pull/415