### PR TITLE
statically link with nettle and hogweed and avoid using gmp

### DIFF
--- a/projects/gnutls/Dockerfile
+++ b/projects/gnutls/Dockerfile
@@ -16,11 +16,10 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER alex.gaynor@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool autopoint libnettle6 nettle-dev pkg-config gperf bison autogen texinfo curl
+RUN apt-get update && apt-get install -y make autoconf automake libtool autopoint pkg-config gperf bison autogen texinfo curl
 
 RUN git clone --depth=1 https://gitlab.com/gnutls/gnutls.git
-RUN cd gnutls && git submodule update --init
-
+RUN cd gnutls && git clone --depth=1 https://git.lysator.liu.se/nettle/nettle.git
 # clone OpenSSL to get its fuzzer testcases
 RUN git clone --depth=1 https://github.com/openssl/openssl
 


### PR DESCRIPTION
This allows the memory sanitizer to track all variable assignment
and use.