### PR TITLE
Add libpsl to oss-fuzz

### DIFF
--- a/projects/libpsl/Dockerfile
+++ b/projects/libpsl/Dockerfile
@@ -1,0 +1,33 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER rockdaboot@gmail.com
+RUN apt-get update && apt-get install -y \
+ pkg-config \
+ autopoint \
+ autoconf \
+ automake \
+ libtool \
+ libidn2-0-dev \
+ libunistring-dev \
+ gtk-doc-tools
+
+RUN git clone --depth=1 https://github.com/rockdaboot/libpsl.git
+RUN cd libpsl && git submodule update --init
+
+WORKDIR libpsl
+COPY build.sh $SRC/

--- a/projects/libpsl/build.sh
+++ b/projects/libpsl/build.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -eu
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# avoid iconv() memleak on Ubuntu 16.04 image (breaks test suite)
+export ASAN_OPTIONS=detect_leaks=0
+
+./autogen.sh
+./configure --enable-static --disable-gtk-doc --enable-runtime=libidn2 --enable-builtin=libidn2
+make clean
+make -j$(nproc)
+make -j$(nproc) check
+
+cd fuzz
+make oss-fuzz
+find . -name '*_fuzzer.dict' -exec cp -v '{}' $OUT ';'
+find . -name '*_fuzzer.options' -exec cp -v '{}' $OUT ';'
+
+for fuzzer in *_fuzzer; do
+    cp -p "${fuzzer}" "$OUT"
+
+    if [ -f "$SRC/${fuzzer}_seed_corpus.zip" ]; then
+        cp "$SRC/${fuzzer}_seed_corpus.zip" "$OUT/"
+    fi
+
+    if [ -d "${fuzzer}.in/" ]; then
+        zip -rj "$OUT/${fuzzer}_seed_corpus.zip" "${fuzzer}.in/"
+    fi
+done

--- a/projects/libpsl/project.yaml
+++ b/projects/libpsl/project.yaml
@@ -1,0 +1,4 @@
+homepage: "https://github.com/rockdaboot/libpsl"
+primary_contact: "rockdaboot@gmail.com"
+auto_ccs:
+  - "tim.ruehsen@gmx.de"


### PR DESCRIPTION
libpsl is for accessing the Mozilla Public Suffix List (PSL).

It is currently used for HTTP cookie domain verification in wget and curl/libcurl (and thus linked into all tools and libraries using libcurl). This library is essential for Debian based Linux distributions and likely essential to others as well.

Upstream already has a 'oss-fuzz' make target, tools to run clang and afl based fuzzing, fuzz code coverage reporting and is prepared for incoming crash/leak corpora to be included for regression testing.
