### PR TITLE
[infra] Remove "null" check from UBSan options.

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get install -y git subversion jq python3 zip make libunwind8-dev binutil
 
 # Default build flags for various sanitizers.
 ENV SANITIZER_FLAGS_address "-fsanitize=address -fsanitize-address-use-after-scope"
-ENV SANITIZER_FLAGS_undefined "-fsanitize=bool,array-bounds,float-divide-by-zero,function,integer-divide-by-zero,null,return,shift,signed-integer-overflow,vla-bound,vptr -fno-sanitize-recover=undefined"
+ENV SANITIZER_FLAGS_undefined "-fsanitize=bool,array-bounds,float-divide-by-zero,function,integer-divide-by-zero,return,shift,signed-integer-overflow,vla-bound,vptr -fno-sanitize-recover=undefined"
 ENV SANITIZER_FLAGS_memory "-fsanitize=memory -fsanitize-memory-track-origins"
 
 # Default build flags for coverage.


### PR DESCRIPTION
There is not much value for us from this particular check:
- UBSan's "null" reports leading to real crashes are reported with ASan as well.
- Potential null references are not real crashes and might be considered
  as false positives, though it seems to be UB as per the standard.