### PR TITLE
[libpsl] Install latest libidn2

### DIFF
--- a/projects/libpsl/Dockerfile
+++ b/projects/libpsl/Dockerfile
@@ -22,9 +22,13 @@ RUN apt-get update && apt-get install -y \
  autoconf \
  automake \
  libtool \
- libidn2-0-dev \
  libunistring-dev \
- gtk-doc-tools
+ gtk-doc-tools \
+ gettext gengetopt curl gperf
+
+RUN git clone --depth=1 https://gitlab.com/libidn/libidn2.git
+RUN cd libidn2 && git submodule update --init
+RUN cd libidn2 && ./bootstrap && ./configure --enable-static --disable-doc && make && make install
 
 RUN git clone --depth=1 https://github.com/rockdaboot/libpsl.git
 RUN cd libpsl && git submodule update --init

--- a/projects/libpsl/build.sh
+++ b/projects/libpsl/build.sh
@@ -18,8 +18,11 @@
 # avoid iconv() memleak on Ubuntu 16.04 image (breaks test suite)
 export ASAN_OPTIONS=detect_leaks=0
 
+# let 'make check' survive
+export LD_LIBRARY_PATH=/usr/local/lib
+
 ./autogen.sh
-./configure --enable-static --disable-gtk-doc --enable-runtime=libidn2 --enable-builtin=libidn2
+LDFLAGS="-L/usr/local/lib" ./configure --enable-static --disable-gtk-doc --enable-runtime=libidn2 --enable-builtin=libidn2
 make clean
 make -j$(nproc)
 make -j$(nproc) check


### PR DESCRIPTION
libpsl_load_fuzzer was struck by an issue in the old libidn2 of Ubunutu (see https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=2262#c2).

This PR installs the latest libidn2 in the docker image to link with libpsl.
