### PR TITLE
RawSpeed: finish integration by adding fuzzing targets.

### DIFF
--- a/projects/librawspeed/Dockerfile
+++ b/projects/librawspeed/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER lebedev.ri@gmail.com
+RUN apt-get update && apt-get install -y cmake make
+RUN git clone --depth 1 https://github.com/darktable-org/rawspeed.git librawspeed
+WORKDIR librawspeed
+COPY build.sh $SRC/

--- a/projects/librawspeed/build.sh
+++ b/projects/librawspeed/build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -eu
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+set -e
+
+cd "$WORK"
+mkdir build
+cd build
+
+cmake \
+  -G"Unix Makefiles" \
+  -DWITH_PTHREADS=OFF -DWITH_OPENMP=OFF \
+  -DWITH_PUGIXML=OFF -DUSE_XMLLINT=OFF -DWITH_JPEG=OFF -DWITH_ZLIB=OFF \
+  -DBUILD_TESTING=OFF -DBUILD_TOOLS=OFF -DBUILD_BENCHMARKING=OFF \
+  -DCMAKE_BUILD_TYPE=FUZZ -DBUILD_FUZZERS=ON \
+  -DLIBFUZZER_ARCHIVE:FILEPATH="$LIB_FUZZING_ENGINE" \
+  -DCMAKE_INSTALL_PREFIX:PATH="$OUT" -DCMAKE_INSTALL_BINDIR:PATH="$OUT" \
+  "$SRC/librawspeed/"
+
+make -j$(nproc) all && make -j$(nproc) install
+
+cd "$SRC"
+rm -rf "$WORK/build"


### PR DESCRIPTION
As discussed in the original PR #588, it may be better to
start with empty corpus, and see what happens. Even though
i have the full corpus set to get full (80%+) coverage, it
is quite likely to result in horrible performance.

Currently, the library is built with no external
dependencies - jpeg, zlib - not too sure if it makes sense
to fuzz those indirectly. And if i can built zlib in-tree,
building jpeg in-tree will be more complicated because it
does not have CMake build system.

As you can see, more than one fuzzing target is provided.
The `RawSpeedFuzzer` is the most global one, it will be
able to eventually cover all the code, others are more
fine-grained, and will only be able to cover some small
portion of the code. Thus, i suppose both the performance
and the coverage may win.

I did test this locally. Both the address and the undefined
configurations work.

Questions:
- address and the undefined are different configurations?
  It does not make more sense to join them?
- rawspeed is fully clean as per `-fsanitize=undefined -fsanitize=integer`,
  but it seems like oss-fuzz enables only some sub-set
  of the Undefined sanitization. Is it possible/does it make
  sense to opt-in into the full set of Undefined sanitization?
