### PR TITLE
Dropbear: Disable hardened build flags

### DIFF
--- a/projects/dropbear/build.sh
+++ b/projects/dropbear/build.sh
@@ -21,7 +21,7 @@ autoconf
 autoheader
 popd
 
-$SRC/dropbear/configure --enable-fuzz
+$SRC/dropbear/configure --enable-fuzz --disable-harden
 # force static zlib
 sed -i 's@-lz@/usr/lib/x86_64-linux-gnu/libz.a@' Makefile
 

--- a/projects/dropbear/fuzzer-preauth.options
+++ b/projects/dropbear/fuzzer-preauth.options
@@ -1,2 +1,0 @@
-[libfuzzer]
-max_len = 50000


### PR DESCRIPTION
-pic prevents linking with static libz.a

.options files are now generated in the project Makefile