### PR TITLE
corpora.md: fix markdown images

### DIFF
--- a/docs/corpora.md
+++ b/docs/corpora.md
@@ -11,15 +11,13 @@ Follow the instructions on the installation page to login with a Google account 
 
 The fuzzer statistics page for your project on [ClusterFuzz](clusterfuzz.md) will contain a link to the Google Cloud console for your corpus under the "corpus_size" column. You can browse and download individual test inputs in the corpus here.
 
-![viewing_corpus]
-(https://raw.githubusercontent.com/google/oss-fuzz/master/docs/images/viewing_corpus.png)
+![viewing_corpus](https://raw.githubusercontent.com/google/oss-fuzz/master/docs/images/viewing_corpus.png)
 
 ## Downloading the corpus 
 
 If you would like to download the entire corpus, from the cloud console link, copy the bucket path highlighted here:
 
-![corpus_path]
-(https://raw.githubusercontent.com/google/oss-fuzz/master/docs/images/corpus_path.png)
+![corpus_path](https://raw.githubusercontent.com/google/oss-fuzz/master/docs/images/corpus_path.png)
 
 And then run the following command to copy the corpus to a directory on your machine.
 


### PR DESCRIPTION
Newline breaks MD tag, so the images are not displayed.