### PR TITLE
Add openjpeg to projects

### DIFF
--- a/projects/openjpeg/Dockerfile
+++ b/projects/openjpeg/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER antonin@gmail.com
+RUN apt-get update && apt-get install -y make cmake g++
+RUN git clone --depth 1 https://github.com/uclouvain/openjpeg openjpeg
+# openjpeg-data is used to create a seed corpus
+RUN git clone --depth 1 https://github.com/uclouvain/openjpeg-data openjpeg/data
+WORKDIR openjpeg
+COPY build.sh $SRC/

--- a/projects/openjpeg/build.sh
+++ b/projects/openjpeg/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -eu
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+mkdir build
+cd build
+cmake ..
+make clean -s
+make -j$(nproc) -s
+cd ..
+
+./tests/fuzzers/build_google_oss_fuzzers.sh
+./tests/fuzzers/build_seed_corpus.sh

--- a/projects/openjpeg/project.yaml
+++ b/projects/openjpeg/project.yaml
@@ -1,0 +1,4 @@
+homepage: "http://www.openjpeg.org/"
+primary_contact: "antonin@gmail.com"
+auto_ccs:
+  - "even.rouault@gmail.com"


### PR DESCRIPTION
From http://www.openjpeg.org/ :
"""
OpenJPEG is an open-source JPEG 2000 codec written in C language. It has
been developed in order to promote the use of JPEG 2000, a still-image
compression standard from the Joint Photographic Experts Group (JPEG).
Since may 2015, it is officially recognized by ISO/IEC and ITU-T as a
JPEG 2000 Reference Software
"""

I submit this integration of OpenJPEG into oss-fuzz on behalf of Antonin
Descampes (@detonin), one of the project leaders. The OpenJPEG side of the
integration has already been merged into openjpeg git master per
https://github.com/uclouvain/openjpeg/issues/965 /
https://github.com/uclouvain/openjpeg/commit/1a8eac6a90ca61f3703f9b97afc2ec4918f0ab55