### PR TITLE
Fix building cookie fuzzer

### DIFF
--- a/projects/wget2/Dockerfile
+++ b/projects/wget2/Dockerfile
@@ -17,27 +17,31 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER rockdaboot@gmail.com
 RUN apt-get update && apt-get install -y \
+ make \
  pkg-config \
  gettext \
+ autogen \
  autopoint \
  autoconf \
  automake \
  libtool \
  texinfo \
  flex \
- liblzma-dev \
- libidn11-dev \
- libidn2-0-dev \
- libunistring-dev \
- zlib1g-dev \
- libbz2-dev \
- gnutls-dev \
- libpsl-dev \
- libnghttp2-dev \
- doxygen
+ bison \
+ gettext \
+ gengetopt \
+ curl \
+ gperf \
+ wget \
+ python
 
-RUN git clone --depth=1 https://gitlab.com/gnuwget/wget2.git
-RUN cd wget2 && git submodule update --init
+RUN git clone --depth=1 --recursive https://git.savannah.gnu.org/git/libunistring.git
+RUN git clone --depth=1 --recursive https://gitlab.com/libidn/libidn2.git
+RUN git clone --depth=1 --recursive https://github.com/rockdaboot/libpsl.git
+RUN git clone --depth=1 https://git.lysator.liu.se/nettle/nettle.git
+RUN git clone --depth=1 https://gitlab.com/gnutls/gnutls.git
+
+RUN git clone --depth=1 --recursive https://gitlab.com/gnuwget/wget2.git
 
 WORKDIR wget2
 COPY build.sh $SRC/

--- a/projects/wget2/build.sh
+++ b/projects/wget2/build.sh
@@ -15,16 +15,70 @@
 #
 ################################################################################
 
+export WGET2_DEPS_PATH=$SRC/wget2_deps
+export PKG_CONFIG_PATH=$WGET2_DEPS_PATH/lib/pkgconfig
+export CPPFLAGS="-I$WGET2_DEPS_PATH/include"
+export LDFLAGS="-L$WGET2_DEPS_PATH/lib"
+
+cd $SRC/libunistring
+./autogen.sh
+./configure --enable-static --disable-shared --prefix=$WGET2_DEPS_PATH
+make -j$(nproc)
+make install
+
+cd $SRC/libidn2
+./bootstrap
+./configure --enable-static --disable-shared --disable-doc --disable-gcc-warnings --prefix=$WGET2_DEPS_PATH
+make -j$(nproc)
+make install
+
+cd $SRC/libpsl
+./autogen.sh
+./configure --enable-static --disable-shared --disable-gtk-doc --enable-runtime=libidn2 --enable-builtin=libidn2 --prefix=$WGET2_DEPS_PATH
+make -j$(nproc)
+make install
+
+GNUTLS_CONFIGURE_FLAGS=""
+NETTLE_CONFIGURE_FLAGS=""
+if [[ $CFLAGS = *sanitize=memory* ]]; then
+  GNUTLS_CONFIGURE_FLAGS="--disable-hardware-acceleration"
+  NETTLE_CONFIGURE_FLAGS="--disable-assembler --disable-fat"
+fi
+
+# We could use GMP from git repository to avoid false positives in
+# sanitizers, but GMP doesn't compile with clang. We use gmp-mini
+# instead.
+cd $SRC/nettle
+bash .bootstrap
+./configure --enable-mini-gmp --enable-static --disable-shared --disable-documentation --prefix=$WGET2_DEPS_PATH $NETTLE_CONFIGURE_FLAGS
+( make -j$(nproc) || make -j$(nproc) ) && make install
+if test $? != 0;then
+        echo "Failed to compile nettle"
+        exit 1
+fi
+
+cd $SRC/gnutls
+make bootstrap
+LIBS="-lunistring" \
+./configure --with-nettle-mini --enable-gcc-warnings --enable-static --disable-shared --with-included-libtasn1 \
+    --with-included-unistring --without-p11-kit --disable-doc --disable-tests --disable-tools --disable-cxx \
+    --disable-maintainer-mode --disable-libdane --disable-gcc-warnings --prefix=$WGET2_DEPS_PATH $GNUTLS_CONFIGURE_FLAGS
+make -j$(nproc)
+make install
+
+
 # avoid iconv() memleak on Ubuntu 16.04 image (breaks test suite)
 export ASAN_OPTIONS=detect_leaks=0
 
-! test -f lib/Makefile.in && ./bootstrap
-./configure --enable-static --disable-doc
+cd $SRC/wget2
+./bootstrap
+LIBS="-lgnutls -lnettle -lhogweed -lidn2 -lunistring" \
+./configure --enable-static --disable-shared --disable-doc --without-plugin-support
 make clean
 make -j$(nproc) all check
 
 cd fuzz
-make oss-fuzz
+CXXFLAGS="$CXXFLAGS -L$WGET2_DEPS_PATH/lib/" make oss-fuzz
 find . -name '*_fuzzer.dict' -exec cp -v '{}' $OUT ';'
 find . -name '*_fuzzer.options' -exec cp -v '{}' $OUT ';'
 


### PR DESCRIPTION
One of my new fuzzers needs a static libpsl - that has to be built from upstream and also needs latest (or recent) libidn2. This fix implements that.

Q: This change assumes a dynamic libgnutls being installed on your fuzzer machines. It is installed on your build image... so may I assume ... !? (Else I have to add all those dependencies in the right order... slightly tedious).
