### PR TITLE
[libpsl] Build and link with latest static dependencies

### DIFF
--- a/projects/libpsl/Dockerfile
+++ b/projects/libpsl/Dockerfile
@@ -17,21 +17,26 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER rockdaboot@gmail.com
 RUN apt-get update && apt-get install -y \
+ make \
  pkg-config \
+ autogen \
  autopoint \
  autoconf \
  automake \
  libtool \
- libunistring-dev \
- gtk-doc-tools \
- gettext gengetopt curl gperf
+ texinfo \
+ bison \
+ gettext \
+ gengetopt \
+ curl \
+ gperf \
+ wget \
+ python
 
-RUN git clone --depth=1 https://gitlab.com/libidn/libidn2.git
-RUN cd libidn2 && git submodule update --init
-RUN cd libidn2 && ./bootstrap && ./configure --enable-static --disable-doc && make && make install
+RUN git clone --depth=1 --recursive https://git.savannah.gnu.org/git/libunistring.git
+RUN git clone --depth=1 --recursive https://gitlab.com/libidn/libidn2.git
 
-RUN git clone --depth=1 https://github.com/rockdaboot/libpsl.git
-RUN cd libpsl && git submodule update --init
+RUN git clone --depth=1 --recursive https://github.com/rockdaboot/libpsl.git
 
 WORKDIR libpsl
 COPY build.sh $SRC/

--- a/projects/libpsl/build.sh
+++ b/projects/libpsl/build.sh
@@ -15,29 +15,40 @@
 #
 ################################################################################
 
+export DEPS_PATH=$SRC/deps
+export PKG_CONFIG_PATH=$DEPS_PATH/lib/pkgconfig
+export CPPFLAGS="-I$DEPS_PATH/include"
+export LDFLAGS="-L$DEPS_PATH/lib"
+
+cd $SRC/libunistring
+./autogen.sh
+./configure --enable-static --disable-shared --prefix=$DEPS_PATH
+make -j$(nproc)
+make install
+
+cd $SRC/libidn2
+./bootstrap
+./configure --enable-static --disable-shared --disable-doc --disable-gcc-warnings --prefix=$DEPS_PATH
+make -j$(nproc)
+make install
+
+
 # avoid iconv() memleak on Ubuntu 16.04 image (breaks test suite)
 export ASAN_OPTIONS=detect_leaks=0
 
-# let 'make check' survive
-export LD_LIBRARY_PATH=/usr/local/lib
-
+cd $SRC/libpsl
 ./autogen.sh
-LDFLAGS="-L/usr/local/lib" ./configure --enable-static --disable-gtk-doc --enable-runtime=libidn2 --enable-builtin=libidn2
-make clean
+./configure --enable-static --disable-shared --disable-gtk-doc --enable-runtime=libidn2 --enable-builtin=libidn2 --prefix=$DEPS_PATH
 make -j$(nproc)
 make -j$(nproc) check
 
 cd fuzz
-make oss-fuzz
+CXXFLAGS="$CXXFLAGS -L$DEPS_PATH/lib/" make oss-fuzz
 find . -name '*_fuzzer.dict' -exec cp -v '{}' $OUT ';'
 find . -name '*_fuzzer.options' -exec cp -v '{}' $OUT ';'
 
 for fuzzer in *_fuzzer; do
     cp -p "${fuzzer}" "$OUT"
-
-    if [ -f "$SRC/${fuzzer}_seed_corpus.zip" ]; then
-        cp "$SRC/${fuzzer}_seed_corpus.zip" "$OUT/"
-    fi
 
     if [ -d "${fuzzer}.in/" ]; then
         zip -rj "$OUT/${fuzzer}_seed_corpus.zip" "${fuzzer}.in/"


### PR DESCRIPTION
Git clone the latest dependencies, build static libraries and link them with the libpsl fuzzers.