### PR TITLE
Add PostGIS

### DIFF
--- a/projects/postgis/Dockerfile
+++ b/projects/postgis/Dockerfile
@@ -15,8 +15,8 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-MAINTAINER even.rouault@spatialys.com
+MAINTAINER lr@pcorp.us
 RUN apt-get update && apt-get install -y make autoconf automake libtool g++ postgresql-server-dev-9.5 libgeos-dev libproj-dev libxml2-dev pkg-config libjson-c-dev
-RUN git clone --branch ossfuzz --depth 1 https://github.com/rouault/postgis.git postgis
+RUN git clone --branch ossfuzz --depth 1 https://git.osgeo.org/gogs/postgis/postgis.git postgis
 WORKDIR postgis
 COPY build.sh $SRC/

--- a/projects/postgis/Dockerfile
+++ b/projects/postgis/Dockerfile
@@ -17,6 +17,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER lr@pcorp.us
 RUN apt-get update && apt-get install -y make autoconf automake libtool g++ postgresql-server-dev-9.5 libgeos-dev libproj-dev libxml2-dev pkg-config libjson-c-dev
-RUN git clone --branch ossfuzz --depth 1 https://git.osgeo.org/gogs/postgis/postgis.git postgis
+RUN git clone --depth 1 https://git.osgeo.org/gogs/postgis/postgis.git postgis
 WORKDIR postgis
 COPY build.sh $SRC/

--- a/projects/postgis/Dockerfile
+++ b/projects/postgis/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER even.rouault@spatialys.com
+RUN apt-get update && apt-get install -y make autoconf automake libtool g++ postgresql-server-dev-9.5 libgeos-dev libproj-dev libxml2-dev pkg-config libjson-c-dev
+RUN git clone --branch ossfuzz --depth 1 https://github.com/rouault/postgis.git postgis
+WORKDIR postgis
+COPY build.sh $SRC/

--- a/projects/postgis/build.sh
+++ b/projects/postgis/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -eu
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+./autogen.sh
+./configure --enable-static --without-raster --without-protobuf
+cd liblwgeom
+make clean -s
+make -j$(nproc) -s
+cd ..
+
+./fuzzers/build_google_oss_fuzzers.sh
+./fuzzers/build_seed_corpus.sh

--- a/projects/postgis/project.yaml
+++ b/projects/postgis/project.yaml
@@ -1,3 +1,6 @@
-homepage: "http://postgis.org/"
-primary_contact: "even.rouault@gmail.com"
-#auto_ccs:
+homepage: "http://postgis.net/"
+primary_contact: "lr@pcorp.us"
+auto_ccs:
+  - "even.rouault@gmail.com"
+  - "pramsey@cleverelephant.ca"
+  - "strk@kbt.io"

--- a/projects/postgis/project.yaml
+++ b/projects/postgis/project.yaml
@@ -1,0 +1,3 @@
+homepage: "http://postgis.org/"
+primary_contact: "even.rouault@gmail.com"
+#auto_ccs:


### PR DESCRIPTION
From https://postgis.net:
"""PostGIS adds support for geographic objects to the PostgreSQL object-relational database. In effect, PostGIS "spatially enables" the PostgreSQL server, allowing it to be used as a backend spatial database for geographic information systems (GIS), much like ESRI's SDE or Oracle's Spatial extension. PostGIS follows the OpenGIS "Simple Features Specification for SQL" and has been certified as compliant with the "Types and Functions" profile. """

PostGIS is GPL licensed.

The created fuzzers are for the liblwgeom sub-component of PostGIS that has functions that receive arbitrary user data. They have already been committed in https://git.osgeo.org/gogs/postgis/postgis/src/svn-trunk/fuzzers