### PR TITLE
[libpsl] Add fuzzers for conditional code paths

### DIFF
--- a/projects/libpsl/Dockerfile
+++ b/projects/libpsl/Dockerfile
@@ -35,6 +35,8 @@ RUN apt-get update && apt-get install -y \
 
 RUN git clone --depth=1 --recursive https://git.savannah.gnu.org/git/libunistring.git
 RUN git clone --depth=1 --recursive https://gitlab.com/libidn/libidn2.git
+RUN git clone --depth=1 https://git.savannah.gnu.org/git/libidn.git
+RUN wget http://download.icu-project.org/files/icu4c/59.1/icu4c-59_1-src.tgz && tar xvfz icu4c-59_1-src.tgz
 
 RUN git clone --depth=1 --recursive https://github.com/rockdaboot/libpsl.git
 

--- a/projects/libpsl/build.sh
+++ b/projects/libpsl/build.sh
@@ -20,10 +20,25 @@ export PKG_CONFIG_PATH=$DEPS_PATH/lib/pkgconfig
 export CPPFLAGS="-I$DEPS_PATH/include"
 export LDFLAGS="-L$DEPS_PATH/lib"
 
+cd $SRC/icu/source
+./configure --disable-shared --enable-static --disable-extras --disable-icuio --disable-layoutex \
+  --disable-tests --disable-samples --with-data-packaging=static --prefix=$DEPS_PATH
+# ugly hack to avoid build error
+echo '#include <locale.h>' >>i18n/digitlst.h
+make -j$(nproc)
+make install
+
 cd $SRC/libunistring
 ./autogen.sh
 ./configure --enable-static --disable-shared --prefix=$DEPS_PATH
 make -j$(nproc)
+make install
+
+cd $SRC/libidn
+make CFGFLAGS="--enable-static --disable-shared --disable-doc --prefix=$DEPS_PATH"
+make clean
+make -j1
+make -j$(nproc) check
 make install
 
 cd $SRC/libidn2
@@ -38,12 +53,21 @@ export ASAN_OPTIONS=detect_leaks=0
 
 cd $SRC/libpsl
 ./autogen.sh
-./configure --enable-static --disable-shared --disable-gtk-doc --enable-runtime=libidn2 --enable-builtin=libidn2 --prefix=$DEPS_PATH
-make -j$(nproc)
-make -j$(nproc) check
+export CXXFLAGS="$CXXFLAGS -L$DEPS_PATH/lib/"
+for build in libicu libidn2 libidn none; do
+  if test $build = "none"; then
+    BUILD_FLAGS="--disable-runtime --disable-builtin"
+  else
+    BUILD_FLAGS="--enable-runtime=$build --enable-builtin=$build"
+  fi
+  LIBS="-lstdc++" ./configure --enable-static --disable-shared --disable-gtk-doc $BUILD_FLAGS --prefix=$DEPS_PATH
+  make clean
+  make -j$(nproc)
+  make -j$(nproc) check
+  make -C fuzz oss-fuzz
+done
 
 cd fuzz
-CXXFLAGS="$CXXFLAGS -L$DEPS_PATH/lib/" make oss-fuzz
 find . -name '*_fuzzer.dict' -exec cp -v '{}' $OUT ';'
 find . -name '*_fuzzer.options' -exec cp -v '{}' $OUT ';'
 


### PR DESCRIPTION
Libpsl can either be built with libicu, libidn2, libidn or with
basic internal code. Each built uses different code paths via
conditional compilation. To cover all these paths during fuzzing
and regression testing, new fuzzer targets are added by this commit.