### PR TITLE
[open62541] simplify build script

### DIFF
--- a/projects/open62541/Dockerfile
+++ b/projects/open62541/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER git@s.profanter.me
 RUN apt-get update && apt-get install -y make cmake
-RUN git clone --depth 1 https://github.com/open62541/open62541.git -bfeature/fuzzing open62541
+RUN git clone --depth 1 https://github.com/open62541/open62541.git -bmaster open62541
 WORKDIR open62541
 RUN git submodule update --init --recursive
 COPY build.sh $SRC/

--- a/projects/open62541/project.yaml
+++ b/projects/open62541/project.yaml
@@ -1,7 +1,7 @@
 homepage: "https://open62541.org/"
 primary_contact: "Stefan.Profanter@gmail.com"
 auto_ccs:
- - "julius.pfrommer@iosb.fraunhofer.de"
+ - "julius.pfrommer@gmail.com"
  - "f.palm@plt.rwth-aachen.de"
  - "chris_paul.iatrou@tu-dresden.de"
 sanitizers:


### PR DESCRIPTION
This moves all the build logic into CMake according to the `Ideal Integration` howto.
The fuzzer targets will now also checked in a basic way using travis.