### PR TITLE
[resiprocate] Add reSIProcate fuzzer

### DIFF
--- a/projects/resiprocate/Dockerfile
+++ b/projects/resiprocate/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER gjasny@googlemail.com
+RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config
+RUN git clone --depth 1 https://github.com/resiprocate/resiprocate.git resiprocate
+WORKDIR resiprocate
+COPY build.sh $SRC/

--- a/projects/resiprocate/build.sh
+++ b/projects/resiprocate/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+autoreconf --install
+./configure --disable-shared --enable-static
+make -j$(nproc) -C rutil/dns/ares aresfuzz aresfuzzname
+
+cp rutil/dns/ares/{aresfuzz,aresfuzzname} $OUT/

--- a/projects/resiprocate/project.yaml
+++ b/projects/resiprocate/project.yaml
@@ -1,0 +1,2 @@
+homepage: "https://www.resiprocate.org/"
+primary_contact: "Gregor Jasny <gjasny@googlemail.com>"

--- a/projects/resiprocate/project.yaml
+++ b/projects/resiprocate/project.yaml
@@ -1,2 +1,2 @@
 homepage: "https://www.resiprocate.org/"
-primary_contact: "Gregor Jasny <gjasny@googlemail.com>"
+primary_contact: "gjasny@googlemail.com"


### PR DESCRIPTION
Hello,

I'm a member of the [resiprocate](https://github.com/orgs/resiprocate/people) project and am actively extending fuzzing coverage across modules. It would be nice if the resiprocate project could be added to oss-fuzz.

Thanks,
Gregor