### PR TITLE
Turn off cast-qual check

### DIFF
--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -26,7 +26,7 @@ $SRC/depot_tools/gn gen out/Fuzz\
     cxx="'$CXX'"
     is_debug=false
     extra_cflags=["'"$CXXFLAGS_ARR"'","-DIS_FUZZING",
-        "-Wno-zero-as-null-pointer-constant", "-Wno-unused-template"]
+        "-Wno-zero-as-null-pointer-constant", "-Wno-unused-template", "-Wno-cast-qual"]
     skia_use_system_freetype2=false
     skia_use_fontconfig=false
     skia_enable_gpu=false


### PR DESCRIPTION
This should fix #725  Skia does a lot of casting, especially void* so it's not feasible to align all of the consts and not consts, at least right now.