### PR TITLE
[infra] Put revisions of fuzzing engine and clang into $LIB_FUZZING_ENGINE.info file.

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -41,6 +41,8 @@ ENV FUZZER_LDFLAGS ""
 
 WORKDIR $SRC
 
+RUN git clone https://chromium.googlesource.com/chromium/llvm-project/llvm/lib/Fuzzer libfuzzer
+
 ADD http://lcamtuf.coredump.cx/afl/releases/afl-latest.tgz $SRC/
 RUN mkdir afl && \
     cd afl && \

--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -49,7 +49,7 @@ echo "CXXFLAGS=$CXXFLAGS"
 
 echo "---------------------------------------------------------------"
 
-BUILD_CMD="bash -eux $SRC/build.sh"
+BUILD_CMD="bash -eux $SRC/build.sh && bash -c cp $LIB_FUZZING_ENGINE.info $OUT/"
 if [ "${BUILD_UID-0}" -ne "0" ]; then
   adduser -u $BUILD_UID --disabled-password --gecos '' builder
   chown -R builder $SRC $OUT $WORK

--- a/infra/base-images/base-builder/compile_libfuzzer
+++ b/infra/base-images/base-builder/compile_libfuzzer
@@ -23,4 +23,10 @@ $CXX $CXXFLAGS -std=c++11 -O2 $SANITIZER_FLAGS -fno-sanitize=vptr \
 ar r $LIB_FUZZING_ENGINE $WORK/libfuzzer/*.o
 popd > /dev/null
 rm -rf $WORK/libfuzzer
+
+# Put build metadata into $LIB_FUZZING_ENGINE.info
+cd $SRC/libfuzzer
+echo "fuzzing engine revision: $(git log -n 1 | grep "lib/Fuzzer@\K[[:digit:]]+" -oP)" > $LIB_FUZZING_ENGINE.info
+echo "clang revision: $(clang --version | grep "\(trunk \K[[:digit:]]+" -oP)" >> $LIB_FUZZING_ENGINE.info
+
 echo " done."

--- a/infra/base-images/base-builder/compile_libfuzzer
+++ b/infra/base-images/base-builder/compile_libfuzzer
@@ -24,7 +24,7 @@ ar r $LIB_FUZZING_ENGINE $WORK/libfuzzer/*.o
 popd > /dev/null
 rm -rf $WORK/libfuzzer
 
-# Put build metadata into $LIB_FUZZING_ENGINE.info
+# Put build metadata into $LIB_FUZZING_ENGINE.info file.
 cd $SRC/libfuzzer
 echo "fuzzing engine revision: $(git log -n 1 | grep "lib/Fuzzer@\K[[:digit:]]+" -oP)" > $LIB_FUZZING_ENGINE.info
 echo "clang revision: $(clang --version | grep "\(trunk \K[[:digit:]]+" -oP)" >> $LIB_FUZZING_ENGINE.info

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -58,9 +58,6 @@ ninja cxx
 ninja install-cxx
 rm -rf $WORK/msan
 
-# Pull trunk libfuzzer.
-cd $SRC && git clone https://chromium.googlesource.com/chromium/llvm-project/llvm/lib/Fuzzer libfuzzer
-
 cp $SRC/llvm/tools/sancov/coverage-report-server.py /usr/local/bin/
 
 # Cleanup


### PR DESCRIPTION
Oliver, since we've discussed that it would be cool to store libFuzzer revision for every fuzzing run, I've been thinking about it and haven't gotten an idea better than something like this.

I also thought about adding `-version=1` option to libFuzzer, but haven't figured out a proper way to implement it. We might attempt to add to libFuzzer's `build.sh` something like:
```bash
...
LF_REVISION=$(git log -n 1 | grep "lib/Fuzzer@\K[[:digit:]]+" -oP)
CXXFLAGS="-DLIBFUZZER_REVISION=$LF_REVISION"
# then use $CXXFLAGS during compilation of libFuzzer
# and implement -version=1 handler printing LIBFUZZER_REVISION
...
```
but it feels like @kcc wouldn't approve that :)

So, what do you think about it? Any better ideas? :)
