### PR TITLE
[infra] Execute test_all step (includes bad_build_check) for all builds.

### DIFF
--- a/infra/gcb/build.py
+++ b/infra/gcb/build.py
@@ -136,7 +136,8 @@ def get_build_steps(project_yaml, dockerfile_path):
   build_steps = [
       {
           'args': [
-              'clone', 'https://github.com/google/oss-fuzz.git',
+              # FIXME(mmoroz): remove custom branch checkout before landing!
+              'clone', '-b', 'test_builds', 'https://github.com/google/oss-fuzz.git',
           ],
           'name': 'gcr.io/cloud-builders/git',
       },
@@ -200,6 +201,17 @@ def get_build_steps(project_yaml, dockerfile_path):
               # Container Builder doesn't pass --rm to docker run yet.
               'rm -r /out && cd /src && cd {1} && mkdir -p {0} && compile && rm -rf /work && rm -rf /src'.format(out, workdir),
             ],
+          },
+          # test binaries
+          {'name': 'gcr.io/oss-fuzz-base/base-runner',
+            'env': env,
+            'args': [
+              'bash',
+              '-c',
+              # Verify that fuzzers have been built properly and are not broken.
+              # TODO(mmoroz): raise a notification if not passing the tests.
+              'test_all'
+            ]
           },
           # zip binaries
           {'name': image,

--- a/infra/gcb/build.py
+++ b/infra/gcb/build.py
@@ -136,8 +136,7 @@ def get_build_steps(project_yaml, dockerfile_path):
   build_steps = [
       {
           'args': [
-              # FIXME(mmoroz): remove custom branch checkout before landing!
-              'clone', '-b', 'test_builds', 'https://github.com/google/oss-fuzz.git',
+              'clone', 'https://github.com/google/oss-fuzz.git',
           ],
           'name': 'gcr.io/cloud-builders/git',
       },


### PR DESCRIPTION
That seems to work fine (tested on zlib, boringssl, example targets).

`example` project is failing the tests since there is a low hanging crash. @kcc, is it important to have that intentional bug in `example` target? If yes, I'll find a way to suppress build failure for that project. Otherwise, we have `bad_example` project that demonstrates different issues. Also, we may revisit 20 seconds limit in `test_all` script.

Other than that, I'd like to land this and to see how many of existing projects would be failing. Hopefully not too many :)
