### PR TITLE
gnutls: New fuzzing architecture

### DIFF
--- a/projects/gnutls/Dockerfile
+++ b/projects/gnutls/Dockerfile
@@ -16,10 +16,33 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER alex.gaynor@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool autopoint pkg-config gperf bison autogen texinfo curl
+RUN apt-get update && apt-get install -y \
+ make \
+ pkg-config \
+ autoconf \
+ automake \
+ autogen \
+ autopoint \
+ libtool \
+ gperf \
+ bison \
+ texinfo \
+ curl \
+ gettext \
+ gengetopt \
+ wget \
+ python \
+ mercurial
 
-RUN git clone --depth=1 https://gitlab.com/gnutls/gnutls.git
-RUN cd gnutls && git clone --depth=1 https://git.lysator.liu.se/nettle/nettle.git
+ENV GNULIB_TOOL $SRC/gnulib/gnulib-tool
+RUN git clone git://git.savannah.gnu.org/gnulib.git
+RUN git clone --depth=1 https://git.savannah.gnu.org/git/libunistring.git
+RUN git clone --depth=1 https://gitlab.com/libidn/libidn2.git
+RUN hg clone https://gmplib.org/repo/gmp/ gmp
+RUN git clone --depth=1 https://git.savannah.gnu.org/git/libtasn1.git
+RUN git clone --depth=1 https://git.lysator.liu.se/nettle/nettle.git
+
+RUN git clone --depth=1 --recursive https://gitlab.com/gnutls/gnutls.git
 
 WORKDIR gnutls
 COPY build.sh $SRC/

--- a/projects/gnutls/build.sh
+++ b/projects/gnutls/build.sh
@@ -15,49 +15,83 @@
 #
 ################################################################################
 
-CONFIGURE_FLAGS=""
+export DEPS_PATH=$SRC/deps
+export PKG_CONFIG_PATH=$DEPS_PATH/lib/pkgconfig
+export CPPFLAGS="-I$DEPS_PATH/include"
+export LDFLAGS="-L$DEPS_PATH/lib"
+export GNULIB_SRCDIR=$SRC/gnulib
+
+cd $SRC/libunistring
+./autogen.sh
+ASAN_OPTIONS=detect_leaks=0 \
+  ./configure --enable-static --disable-shared --prefix=$DEPS_PATH
+make -j$(nproc)
+make install
+
+cd $SRC/libidn2
+./bootstrap
+ASAN_OPTIONS=detect_leaks=0 \
+  ./configure --enable-static --disable-shared --disable-doc --disable-gcc-warnings --prefix=$DEPS_PATH
+make -j$(nproc)
+make install
+
+GMP_CONFIGURE_FLAGS=""
+if [[ $CFLAGS = *sanitize=memory* ]]; then
+  GMP_CONFIGURE_FLAGS="--disable-assembly --disable-fat"
+fi
+cd $SRC/gmp
+bash .bootstrap
+ASAN_OPTIONS=detect_leaks=0 \
+  ./configure --disable-shared --prefix=$DEPS_PATH
+make -j$(nproc)
+make install
+
+cd $SRC/libtasn1
+CFGFLAGS="--disable-gcc-warnings --disable-gtk-doc --disable-gtk-doc-pdf --disable-doc \
+  --disable-shared --enable-static --prefix=$DEPS_PATH" \
+  make bootstrap
+make -j$(nproc)
+make install
+
 NETTLE_CONFIGURE_FLAGS=""
-if [[ $CFLAGS = *sanitize=memory* ]]
-then
-  CONFIGURE_FLAGS="--disable-hardware-acceleration"
+if [[ $CFLAGS = *sanitize=memory* ]]; then
   NETTLE_CONFIGURE_FLAGS="--disable-assembler --disable-fat"
 fi
-
-# We could use GMP from git repository to avoid false positives in
-# sanitizers, but GMP doesn't compile with clang. We use gmp-mini
-# instead.
-
-pushd nettle
+cd $SRC/nettle
 bash .bootstrap
-./configure --enable-mini-gmp --disable-documentation --libdir=/opt/lib/ --prefix=/opt $NETTLE_CONFIGURE_FLAGS && ( make -j$(nproc) || make -j$(nproc) ) && make install
-if test $? != 0;then
-	echo "Failed to compile nettle"
-	exit 1
+ASAN_OPTIONS=detect_leaks=0 \
+  ./configure --enable-static --disable-shared --disable-documentation --prefix=$DEPS_PATH $NETTLE_CONFIGURE_FLAGS
+( make -j$(nproc) || make -j$(nproc) ) && make install
+if test $? != 0; then
+  echo "Failed to compile nettle"
+  exit 1
 fi
-popd
 
-make bootstrap
-PKG_CONFIG_PATH=/opt/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig ./configure --with-nettle-mini --enable-gcc-warnings --enable-static --with-included-libtasn1 \
-    --with-included-unistring --without-p11-kit --disable-doc $CONFIGURE_FLAGS
+
+GNUTLS_CONFIGURE_FLAGS=""
+if [[ $CFLAGS = *sanitize=memory* ]]; then
+  GNUTLS_CONFIGURE_FLAGS="--disable-hardware-acceleration"
+fi
+cd $SRC/gnutls
+make autoreconf
+ASAN_OPTIONS=detect_leaks=0 LIBS="-lunistring" CXXFLAGS="$CXXFLAGS -L$DEPS_PATH/lib" \
+  ./configure --disable-gcc-warnings --enable-static --disable-shared --disable-doc --disable-tests \
+    --disable-tools --disable-cxx --disable-maintainer-mode --disable-libdane --without-p11-kit $GNUTLS_CONFIGURE_FLAGS
 
 # Do not use the syscall interface for randomness in oss-fuzz, it seems
 # to confuse memory sanitizer.
 sed -i 's|include <sys/syscall.h>|include <sys/syscall.h>\n#undef SYS_getrandom|' lib/nettle/sysrng-linux.c
 
-make "-j$(nproc)" -C gl
-make "-j$(nproc)" -C lib
+make -j$(nproc) -C gl
+make -j$(nproc) -C lib
 
-fuzzers=$(find devel/fuzz/ -name "*_fuzzer.cc")
+cd fuzz
+make oss-fuzz
+find . -name '*_fuzzer' -exec cp -v '{}' $OUT ';'
+find . -name '*_fuzzer.dict' -exec cp -v '{}' $OUT ';'
+find . -name '*_fuzzer.options' -exec cp -v '{}' $OUT ';'
 
-for f in $fuzzers; do
-    fuzzer=$(basename "$f" ".cc")
-    $CXX $CXXFLAGS -std=c++11 -Ilib/includes \
-        "devel/fuzz/${fuzzer}.cc" -o "$OUT/${fuzzer}" \
-        lib/.libs/libgnutls.a -lFuzzingEngine -lpthread -Wl,-Bstatic \
-        /opt/lib/libhogweed.a /opt/lib/libnettle.a -Wl,-Bdynamic
-
-    corpus_dir=$(basename "${fuzzer}" "_fuzzer")
-    if [ -d "devel/fuzz/${corpus_dir}.in/" ]; then
-        zip -r "$OUT/${fuzzer}_seed_corpus.zip" "devel/fuzz/${corpus_dir}.in/"
-    fi
+for dir in *_fuzzer.in; do
+    fuzzer=$(basename $dir .in)
+    zip -rj "$OUT/${fuzzer}_seed_corpus.zip" "${dir}/"
 done


### PR DESCRIPTION
Requisites are build as static libraries and as these linked to the fuzzers.
p11-kit can't be build statically, thus our fuzzers are not using it.