### PR TITLE
[wget2] Fixes and enhancements

### DIFF
--- a/projects/wget2/Dockerfile
+++ b/projects/wget2/Dockerfile
@@ -35,6 +35,8 @@ RUN apt-get update && apt-get install -y \
  wget \
  python
 
+ENV GNULIB_TOOL $SRC/gnulib/gnulib-tool
+RUN git clone git://git.savannah.gnu.org/gnulib.git
 RUN git clone --depth=1 --recursive https://git.savannah.gnu.org/git/libunistring.git
 RUN git clone --depth=1 --recursive https://gitlab.com/libidn/libidn2.git
 RUN git clone --depth=1 --recursive https://github.com/rockdaboot/libpsl.git

--- a/projects/wget2/build.sh
+++ b/projects/wget2/build.sh
@@ -19,6 +19,7 @@ export WGET2_DEPS_PATH=$SRC/wget2_deps
 export PKG_CONFIG_PATH=$WGET2_DEPS_PATH/lib/pkgconfig
 export CPPFLAGS="-I$WGET2_DEPS_PATH/include"
 export LDFLAGS="-L$WGET2_DEPS_PATH/lib"
+export GNULIB_SRCDIR=$SRC/gnulib
 
 cd $SRC/libunistring
 ./autogen.sh
@@ -58,8 +59,11 @@ if test $? != 0;then
 fi
 
 cd $SRC/gnutls
+touch .submodule.stamp
 make bootstrap
+GNUTLS_CFLAGS=`echo $CFLAGS|sed s/-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION//`
 LIBS="-lunistring" \
+CFLAGS="$GNUTLS_CFLAGS" \
 ./configure --with-nettle-mini --enable-gcc-warnings --enable-static --disable-shared --with-included-libtasn1 \
     --with-included-unistring --without-p11-kit --disable-doc --disable-tests --disable-tools --disable-cxx \
     --disable-maintainer-mode --disable-libdane --disable-gcc-warnings --prefix=$WGET2_DEPS_PATH $GNUTLS_CONFIGURE_FLAGS


### PR DESCRIPTION
* just one gnulib download when building image (saves bandwidth + cpu)
* suppress unneeded submodule initialization for GnuTLS (saves bandwidth)
* make GnuTLS production build to work with wget2 test suite (fixes wget2 build)