### PR TITLE
Change botan build.sh to use new upstream framework for building fuzzers

### DIFF
--- a/projects/botan/Dockerfile
+++ b/projects/botan/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER jack@randombit.net
 RUN apt-get update && apt-get install -y make python
-RUN git clone --depth 1 https://github.com/randombit/botan.git botan
-RUN git clone --depth 1 https://github.com/randombit/crypto-corpus.git crypto-corpus
+RUN git clone --depth 1 https://github.com/randombit/botan.git --branch fuzzer-mode botan
+RUN git clone --depth 1 https://github.com/randombit/crypto-corpus.git fuzzer_corpus
 WORKDIR botan
 COPY build.sh $SRC/


### PR DESCRIPTION
I've made some modifications in botan (https://github.com/randombit/botan/pull/1158) to get closer to the ideal integration - for example now we test fuzz targets in CI against the corpus. This is the corresponding change to the OSS-Fuzz bits. I've tested the build locally in Docker and everything seems good.

Right now it is checking out `fuzzer-mode` branch because I have not merged the PR to master yet (mostly, to avoid breaking OSS-Fuzz). Once this PR is merged I will merge the upstream PR, then send a followup PR to OSS-Fuzz just changing `Dockerfile` to check out master again.