### PR TITLE
Enlarge png corpus, cosmetic changes to build.sh

### DIFF
--- a/projects/libpng/build.sh
+++ b/projects/libpng/build.sh
@@ -43,7 +43,7 @@ $CXX $CXXFLAGS -std=c++11 -I. \
      -lFuzzingEngine .libs/libpng16.a -lz
 
 # add seed corpus.
-find $SRC/libpng/contrib/pngsuite -name "*.png" | \
+find $SRC/libpng -name "*.png" | \
      xargs zip $OUT/libpng_read_fuzzer_seed_corpus.zip
 
 cp $SRC/libpng/contrib/oss-fuzz/*.dict \

--- a/projects/libpng/build.sh
+++ b/projects/libpng/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -eu
+# Copyright 2017 Glenn Randers-Pehrson
 # Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# Last changed in libpng 1.6.32 [August 24, 2017]
+#
+# Revisions by Glenn Randers-Pehson, 2017:
+# 1. Build only the library, not the tools (changed "make -j$(nproc) all" to
+#     "make -j$(nproc) libpng16.la").
+# 2. Disabled WARNING and WRITE options in pnglibconf.dfa.
 ################################################################################
 
 # Disable logging via library build configuration control.
@@ -31,10 +38,13 @@ make -j$(nproc) libpng16.la
 
 # build libpng_read_fuzzer.
 $CXX $CXXFLAGS -std=c++11 -I. \
-     $SRC/libpng/contrib/oss-fuzz/libpng_read_fuzzer.cc -o $OUT/libpng_read_fuzzer \
+     $SRC/libpng/contrib/oss-fuzz/libpng_read_fuzzer.cc \
+     -o $OUT/libpng_read_fuzzer \
      -lFuzzingEngine .libs/libpng16.a -lz
 
 # add seed corpus.
-find $SRC/libpng/contrib/pngsuite -name "*.png" | xargs zip $OUT/libpng_read_fuzzer_seed_corpus.zip
+find $SRC/libpng/contrib/pngsuite -name "*.png" | \
+     xargs zip $OUT/libpng_read_fuzzer_seed_corpus.zip
 
-cp $SRC/libpng/contrib/oss-fuzz/*.dict $SRC/libpng/contrib/oss-fuzz/*.options $OUT/
+cp $SRC/libpng/contrib/oss-fuzz/*.dict \
+     $SRC/libpng/contrib/oss-fuzz/*.options $OUT/


### PR DESCRIPTION
Puts all of the libpng PNG files in the corpus, not just those in contrib/pngsuite.