### PR TITLE
Switch botan build back to master branch

### DIFF
--- a/projects/botan/Dockerfile
+++ b/projects/botan/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER jack@randombit.net
 RUN apt-get update && apt-get install -y make python
-RUN git clone --depth 1 https://github.com/randombit/botan.git --branch fuzzer-mode botan
+RUN git clone --depth 1 https://github.com/randombit/botan.git botan
 RUN git clone --depth 1 https://github.com/randombit/crypto-corpus.git fuzzer_corpus
 WORKDIR botan
 COPY build.sh $SRC/


### PR DESCRIPTION
The relevant changes from https://github.com/randombit/botan/pull/1158 have been merged to master now. Thanks!