### PR TITLE
Display commit version number while building libpng

### DIFF
--- a/projects/libpng/Dockerfile
+++ b/projects/libpng/Dockerfile
@@ -19,5 +19,6 @@ MAINTAINER glennrp@gmail.com
 RUN apt-get update && apt-get install -y make autoconf automake libtool zlib1g-dev
 
 RUN git clone --depth 1 https://github.com/glennrp/libpng.git
+RUN (cd libpng; git log | head -1)
 WORKDIR libpng
 COPY build.sh $SRC/


### PR DESCRIPTION
Showing the commit number in the build log helps knowing exactly what is happening.