### PR TITLE
[infra] Enable bad build checks once again.

### DIFF
--- a/infra/base-images/base-runner/bad_build_check
+++ b/infra/base-images/base-runner/bad_build_check
@@ -38,12 +38,9 @@ function check_instrumentation {
 
     local NUMBER_OF_EDGES=$(cat $FUZZER_OUTPUT | grep -Po "INFO: Loaded [[:digit:]]+ module.*\(.*counters\):[[:space:]]+\K[[:digit:]]+")
 
-    # The "example" target has 93 when built with ASan and 67 with UBSan. Real
-    # targets have greater values (arduinojson: 413, libteken: 519, zlib: 586).
-    local THRESHOLD_FOR_NUMBER_OF_EDGES=90
-    if [[ $SANITIZER = undefined ]]; then
-      THRESHOLD_FOR_NUMBER_OF_EDGES=65
-    fi
+    # The "example" target has 73 with ASan, 65 with UBSan, and 6648 with MSan.
+    # Real world targets have greater values (arduinojson: 407, zlib: 664).
+    local THRESHOLD_FOR_NUMBER_OF_EDGES=256
 
     if (( $NUMBER_OF_EDGES < $THRESHOLD_FOR_NUMBER_OF_EDGES )); then
       echo "BAD BUILD: the target seems to have only partial coverage instrumentation." >> $LOG_PATH_FOR_BROKEN_TARGET

--- a/infra/base-images/base-runner/bad_build_check
+++ b/infra/base-images/base-runner/bad_build_check
@@ -19,34 +19,29 @@
 function check_instrumentation {
   local FUZZER=$1
   local CHECK_FAILED=0
+  local FUZZER_OUTPUT="/tmp/$(basename $FUZZER).output"
 
   if [[ "$FUZZING_ENGINE" = libfuzzer ]]; then
-    CHECK_FAILED=$($FUZZER -max_total_time=4 2>&1 | egrep "ERROR: no interesting inputs were found. Is the code instrumented" -c)
+    $FUZZER -runs=4 &>$FUZZER_OUTPUT
+    CHECK_FAILED=$(cat $FUZZER_OUTPUT | egrep "ERROR: no interesting inputs were found. Is the code instrumented" -c)
     if (( $CHECK_FAILED > 0 )); then
-      echo "BAD BUILD: the code does not seem to have coverage instrumentation."
+      echo "BAD BUILD: the target does not seem to have coverage instrumentation."
+      exit 1
     fi
-  fi
 
-  # honggfuzz is not fully integrated, avoid performing the following check.
-  if [[ "$FUZZING_ENGINE" != honggfuzz ]]; then
-    if (( $CHECK_FAILED == 0 )); then
-      # The "example" target has 93 when built with ASan and 67 with UBSan. Real
-      # targets have greater values (arduinojson: 413, libteken: 519, zlib: 586).
-      local THRESHOLD_FOR_NUMBER_OF_EDGES=90
-      if [[ $SANITIZER = undefined ]]; then
-        THRESHOLD_FOR_NUMBER_OF_EDGES=65
-      fi
+    local NUMBER_OF_EDGES=$(cat $FUZZER_OUTPUT | grep -Po "INFO: Loaded [[:digit:]]+ module.*\(.*counters\):[[:space:]]+\K[[:digit:]]+")
 
-      local NUMBER_OF_EDGES=$(sancov -print-coverage-pcs $FUZZER | wc -l)
-      if (( $NUMBER_OF_EDGES < $THRESHOLD_FOR_NUMBER_OF_EDGES )); then
-        echo "BAD BUILD: the code does not seem to have coverage instrumentation."
-        CHECK_FAILED=1
-      fi
+    # The "example" target has 93 when built with ASan and 67 with UBSan. Real
+    # targets have greater values (arduinojson: 413, libteken: 519, zlib: 586).
+    local THRESHOLD_FOR_NUMBER_OF_EDGES=90
+    if [[ $SANITIZER = undefined ]]; then
+      THRESHOLD_FOR_NUMBER_OF_EDGES=65
     fi
-  fi
 
-  if (( $CHECK_FAILED > 0 )); then
-    exit 1
+    if (( $NUMBER_OF_EDGES < $THRESHOLD_FOR_NUMBER_OF_EDGES )); then
+      echo "BAD BUILD: the target seems to have only partial coverage instrumentation."
+      exit 1
+    fi
   fi
 }
 

--- a/infra/base-images/base-runner/bad_build_check
+++ b/infra/base-images/base-runner/bad_build_check
@@ -1,4 +1,4 @@
-#!/bin/bash -ux
+#!/bin/bash -u
 # Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,7 @@
 # Verify that the given fuzzer has proper coverage instrumentation.
 function check_instrumentation {
   local FUZZER=$1
+  local LOG_PATH_FOR_BROKEN_TARGET=$2
   local CHECK_FAILED=0
   local FUZZER_OUTPUT="/tmp/$(basename $FUZZER).output"
 
@@ -25,7 +26,7 @@ function check_instrumentation {
     $FUZZER -runs=4 &>$FUZZER_OUTPUT
     CHECK_FAILED=$(cat $FUZZER_OUTPUT | egrep "ERROR: no interesting inputs were found. Is the code instrumented" -c)
     if (( $CHECK_FAILED > 0 )); then
-      echo "BAD BUILD: the target does not seem to have coverage instrumentation."
+      echo "BAD BUILD: the target does not seem to have coverage instrumentation." > $LOG_PATH_FOR_BROKEN_TARGET
       exit 1
     fi
 
@@ -39,7 +40,7 @@ function check_instrumentation {
     fi
 
     if (( $NUMBER_OF_EDGES < $THRESHOLD_FOR_NUMBER_OF_EDGES )); then
-      echo "BAD BUILD: the target seems to have only partial coverage instrumentation."
+      echo "BAD BUILD: the target seems to have only partial coverage instrumentation." > $LOG_PATH_FOR_BROKEN_TARGET
       exit 1
     fi
   fi
@@ -48,6 +49,7 @@ function check_instrumentation {
 # Verify that the given fuzzer has been built properly and works as expected.
 function check_startup_crash {
   local FUZZER=$1
+  local LOG_PATH_FOR_BROKEN_TARGET=$2
   local CHECK_PASSED=0
 
   if [[ "$FUZZING_ENGINE" = libfuzzer ]]; then
@@ -58,7 +60,7 @@ function check_startup_crash {
   fi
 
   if (( $CHECK_PASSED == 0 )); then
-    echo "BAD BUILD: the fuzzer seems to have either startup crash or exit."
+    echo "BAD BUILD: the fuzzer seems to have either startup crash or exit." > $LOG_PATH_FOR_BROKEN_TARGET
     exit 1
   fi
 }
@@ -66,25 +68,27 @@ function check_startup_crash {
 # Mixed sanitizers check for ASan build.
 function check_asan_build {
   local FUZZER=$1
-  local ASAN_CALLS=$2
-  local MSAN_CALLS=$3
-  local UBSAN_CALLS=$4
+  local LOG_PATH_FOR_BROKEN_TARGET=$2
+  local ASAN_CALLS=$3
+  local MSAN_CALLS=$4
+  local UBSAN_CALLS=$5
 
   # Perform all the checks for more verbose error message.
   local CHECK_FAILED=0
 
+  # Instrumentation checks can write several log messages, use >> rather than >.
   if (( $ASAN_CALLS < 1000 )); then
-    echo "BAD BUILD: $FUZZER does not seem to be compiled with ASan."
+    echo "BAD BUILD: $FUZZER does not seem to be compiled with ASan." >> $LOG_PATH_FOR_BROKEN_TARGET
     CHECK_FAILED=1
   fi
 
   if (( $MSAN_CALLS > 0 )); then
-    echo "BAD BUILD: ASan build of $FUZZER seems to be compiled with MSan."
+    echo "BAD BUILD: ASan build of $FUZZER seems to be compiled with MSan." >> $LOG_PATH_FOR_BROKEN_TARGET
     CHECK_FAILED=1
   fi
 
   if (( $UBSAN_CALLS > 250 )); then
-    echo "BAD BUILD: ASan build of $FUZZER seems to be compiled with UBSan."
+    echo "BAD BUILD: ASan build of $FUZZER seems to be compiled with UBSan." >> $LOG_PATH_FOR_BROKEN_TARGET
     CHECK_FAILED=1
   fi
 
@@ -96,25 +100,26 @@ function check_asan_build {
 # Mixed sanitizers check for MSan build.
 function check_msan_build {
   local FUZZER=$1
-  local ASAN_CALLS=$2
-  local MSAN_CALLS=$3
-  local UBSAN_CALLS=$4
+  local LOG_PATH_FOR_BROKEN_TARGET=$2
+  local ASAN_CALLS=$3
+  local MSAN_CALLS=$4
+  local UBSAN_CALLS=$5
 
   # Perform all the checks for more verbose error message.
   local CHECK_FAILED=0
 
   if (( $ASAN_CALLS > 0 )); then
-    echo "BAD BUILD: MSan build of $FUZZER seems to be compiled with ASan."
+    echo "BAD BUILD: MSan build of $FUZZER seems to be compiled with ASan." >> $LOG_PATH_FOR_BROKEN_TARGET
     CHECK_FAILED=1
   fi
 
   if (( $MSAN_CALLS < 1000 )); then
-    echo "BAD BUILD: $FUZZER does not seem to be compiled with UBSan."
+    echo "BAD BUILD: $FUZZER does not seem to be compiled with UBSan." >> $LOG_PATH_FOR_BROKEN_TARGET
     CHECK_FAILED=1
   fi
 
   if (( $UBSAN_CALLS > 250 )); then
-    echo "BAD BUILD: MSan build of $FUZZER seems to be compiled with UBSan."
+    echo "BAD BUILD: MSan build of $FUZZER seems to be compiled with UBSan." >> $LOG_PATH_FOR_BROKEN_TARGET
     CHECK_FAILED=1
   fi
 
@@ -126,9 +131,10 @@ function check_msan_build {
 # Mixed sanitizers check for UBSan build.
 function check_ubsan_build {
   local FUZZER=$1
-  local ASAN_CALLS=$2
-  local MSAN_CALLS=$3
-  local UBSAN_CALLS=$4
+  local LOG_PATH_FOR_BROKEN_TARGET=$2
+  local ASAN_CALLS=$3
+  local MSAN_CALLS=$4
+  local UBSAN_CALLS=$5
 
   if [[ "$FUZZING_ENGINE" != libfuzzer ]]; then
     # Ignore UBSan checks for fuzzing engines other than libFuzzer because:
@@ -141,17 +147,17 @@ function check_ubsan_build {
   local CHECK_FAILED=0
 
   if (( $ASAN_CALLS > 0 )); then
-    echo "BAD BUILD: UBSan build of $FUZZER seems to be compiled with ASan."
+    echo "BAD BUILD: UBSan build of $FUZZER seems to be compiled with ASan." >> $LOG_PATH_FOR_BROKEN_TARGET
     CHECK_FAILED=1
   fi
 
   if (( $MSAN_CALLS > 0 )); then
-    echo "BAD BUILD: UBSan build of $FUZZER seems to be compiled with MSan."
+    echo "BAD BUILD: UBSan build of $FUZZER seems to be compiled with MSan." >> $LOG_PATH_FOR_BROKEN_TARGET
     CHECK_FAILED=1
   fi
 
   if (( $UBSAN_CALLS < 250 )); then
-    echo "BAD BUILD: $FUZZER does not seem to be compiled with UBSan."
+    echo "BAD BUILD: $FUZZER does not seem to be compiled with UBSan." >> $LOG_PATH_FOR_BROKEN_TARGET
     CHECK_FAILED=1
   fi
 
@@ -163,6 +169,8 @@ function check_ubsan_build {
 # Verify that the given fuzz target is compiled with correct sanitizer.
 function check_mixed_sanitizers {
   local FUZZER=$1
+  local LOG_PATH_FOR_BROKEN_TARGET=$2
+
   local ASAN_CALLS=$(objdump -dC $FUZZER | egrep "callq\s+[0-9a-f]+\s+<__asan" -c)
   local MSAN_CALLS=$(objdump -dC $FUZZER | egrep "callq\s+[0-9a-f]+\s+<__msan" -c)
   local UBSAN_CALLS=$(objdump -dC $FUZZER | egrep "callq\s+[0-9a-f]+\s+<__ubsan" -c)
@@ -170,30 +178,41 @@ function check_mixed_sanitizers {
   local CHECK_FAILED=0
 
   if [[ "$SANITIZER" = address ]]; then
-    check_asan_build $FUZZER $ASAN_CALLS $MSAN_CALLS $UBSAN_CALLS
+    check_asan_build $FUZZER $LOG_PATH_FOR_BROKEN_TARGET $ASAN_CALLS $MSAN_CALLS $UBSAN_CALLS
   elif [[ "$SANITIZER" = memory ]]; then
-    check_msan_build $FUZZER $ASAN_CALLS $MSAN_CALLS $UBSAN_CALLS
+    check_msan_build $FUZZER $LOG_PATH_FOR_BROKEN_TARGET $ASAN_CALLS $MSAN_CALLS $UBSAN_CALLS
   elif [[ "$SANITIZER" = undefined ]]; then
-    check_ubsan_build $FUZZER $ASAN_CALLS $MSAN_CALLS $UBSAN_CALLS
+    check_ubsan_build $FUZZER $LOG_PATH_FOR_BROKEN_TARGET $ASAN_CALLS $MSAN_CALLS $UBSAN_CALLS
   fi
 }
 
 
 function main {
   local FUZZER=$1
+  local LOG_PATH_FOR_BROKEN_TARGET=$2
+
   echo "INFO: performing bad build checks for $FUZZER"
 
-  check_instrumentation $FUZZER
-  check_mixed_sanitizers $FUZZER
-  check_startup_crash $FUZZER
+  check_instrumentation $FUZZER $LOG_PATH_FOR_BROKEN_TARGET
+  check_mixed_sanitizers $FUZZER $LOG_PATH_FOR_BROKEN_TARGET
+  check_startup_crash $FUZZER $LOG_PATH_FOR_BROKEN_TARGET
 }
 
 
-if [ $# -ne 1 ]; then
-    echo "Usage: $0 <fuzz_target_binary>"
+if [ $# -ne 3 ]; then
+    echo "Usage: $0 <fuzz_target_binary> <valid_targets_dir> <broken_targets_dir>"
     exit 1
 fi
 
 FUZZER=$1
-main $FUZZER
-echo "INFO: $FUZZER has passed bad_build_check tests."
+VALID_TARGETS_DIR=$2
+BROKEN_TARGETS_DIR=$3
+
+TARGET_NAME="$(basename $FUZZER)"
+LOG_PATH_FOR_BROKEN_TARGET="${BROKEN_TARGETS_DIR}/${TARGET_NAME}"
+
+main $FUZZER $LOG_PATH_FOR_BROKEN_TARGET
+echo "INFO: $FUZZER has passed bad build checks."
+
+# Record valid fuzz target name into the valid targets dir.
+touch ${VALID_TARGETS_DIR}/${TARGET_NAME}

--- a/infra/base-images/base-runner/bad_build_check
+++ b/infra/base-images/base-runner/bad_build_check
@@ -15,7 +15,10 @@
 #
 ################################################################################
 
-# Verify that the given fuzzer has proper coverage instrumentation.
+# Global variable that can be overwritten by any check.
+BAD_BUILD_CHECK_FAILED=0
+
+# Verify that the given fuzz target has proper coverage instrumentation.
 function check_instrumentation {
   local FUZZER=$1
   local LOG_PATH_FOR_BROKEN_TARGET=$2
@@ -26,8 +29,11 @@ function check_instrumentation {
     $FUZZER -runs=4 &>$FUZZER_OUTPUT
     CHECK_FAILED=$(cat $FUZZER_OUTPUT | egrep "ERROR: no interesting inputs were found. Is the code instrumented" -c)
     if (( $CHECK_FAILED > 0 )); then
-      echo "BAD BUILD: the target does not seem to have coverage instrumentation." > $LOG_PATH_FOR_BROKEN_TARGET
-      exit 1
+      echo "BAD BUILD: the target does not seem to have coverage instrumentation." >> $LOG_PATH_FOR_BROKEN_TARGET
+      BAD_BUILD_CHECK_FAILED=1
+
+      # Bail out as the further check does not make any sense, there are 0 PCs.
+      return 1
     fi
 
     local NUMBER_OF_EDGES=$(cat $FUZZER_OUTPUT | grep -Po "INFO: Loaded [[:digit:]]+ module.*\(.*counters\):[[:space:]]+\K[[:digit:]]+")
@@ -40,13 +46,13 @@ function check_instrumentation {
     fi
 
     if (( $NUMBER_OF_EDGES < $THRESHOLD_FOR_NUMBER_OF_EDGES )); then
-      echo "BAD BUILD: the target seems to have only partial coverage instrumentation." > $LOG_PATH_FOR_BROKEN_TARGET
-      exit 1
+      echo "BAD BUILD: the target seems to have only partial coverage instrumentation." >> $LOG_PATH_FOR_BROKEN_TARGET
+      BAD_BUILD_CHECK_FAILED=1
     fi
   fi
 }
 
-# Verify that the given fuzzer has been built properly and works as expected.
+# Verify that the given fuzz target has been built properly and works.
 function check_startup_crash {
   local FUZZER=$1
   local LOG_PATH_FOR_BROKEN_TARGET=$2
@@ -59,9 +65,9 @@ function check_startup_crash {
     CHECK_PASSED=1
   fi
 
-  if (( $CHECK_PASSED == 0 )); then
-    echo "BAD BUILD: the fuzzer seems to have either startup crash or exit." > $LOG_PATH_FOR_BROKEN_TARGET
-    exit 1
+  if [ "$CHECK_PASSED" -eq "0" ]; then
+    echo "BAD BUILD: the fuzzer seems to have either startup crash or exit." >> $LOG_PATH_FOR_BROKEN_TARGET
+    BAD_BUILD_CHECK_FAILED=1
   fi
 }
 
@@ -73,27 +79,20 @@ function check_asan_build {
   local MSAN_CALLS=$4
   local UBSAN_CALLS=$5
 
-  # Perform all the checks for more verbose error message.
-  local CHECK_FAILED=0
-
-  # Instrumentation checks can write several log messages, use >> rather than >.
+  # Perform all the checks for more detailed error message.
   if (( $ASAN_CALLS < 1000 )); then
     echo "BAD BUILD: $FUZZER does not seem to be compiled with ASan." >> $LOG_PATH_FOR_BROKEN_TARGET
-    CHECK_FAILED=1
+    BAD_BUILD_CHECK_FAILED=1
   fi
 
   if (( $MSAN_CALLS > 0 )); then
     echo "BAD BUILD: ASan build of $FUZZER seems to be compiled with MSan." >> $LOG_PATH_FOR_BROKEN_TARGET
-    CHECK_FAILED=1
+    BAD_BUILD_CHECK_FAILED=1
   fi
 
   if (( $UBSAN_CALLS > 250 )); then
     echo "BAD BUILD: ASan build of $FUZZER seems to be compiled with UBSan." >> $LOG_PATH_FOR_BROKEN_TARGET
-    CHECK_FAILED=1
-  fi
-
-  if (( $CHECK_FAILED > 0 )); then
-    exit 1
+    BAD_BUILD_CHECK_FAILED=1
   fi
 }
 
@@ -105,26 +104,20 @@ function check_msan_build {
   local MSAN_CALLS=$4
   local UBSAN_CALLS=$5
 
-  # Perform all the checks for more verbose error message.
-  local CHECK_FAILED=0
-
+  # Perform all the checks for more detailed error message.
   if (( $ASAN_CALLS > 0 )); then
     echo "BAD BUILD: MSan build of $FUZZER seems to be compiled with ASan." >> $LOG_PATH_FOR_BROKEN_TARGET
-    CHECK_FAILED=1
+    BAD_BUILD_CHECK_FAILED=1
   fi
 
   if (( $MSAN_CALLS < 1000 )); then
     echo "BAD BUILD: $FUZZER does not seem to be compiled with UBSan." >> $LOG_PATH_FOR_BROKEN_TARGET
-    CHECK_FAILED=1
+    BAD_BUILD_CHECK_FAILED=1
   fi
 
   if (( $UBSAN_CALLS > 250 )); then
     echo "BAD BUILD: MSan build of $FUZZER seems to be compiled with UBSan." >> $LOG_PATH_FOR_BROKEN_TARGET
-    CHECK_FAILED=1
-  fi
-
-  if (( $CHECK_FAILED > 0 )); then
-    exit 1
+    BAD_BUILD_CHECK_FAILED=1
   fi
 }
 
@@ -143,26 +136,20 @@ function check_ubsan_build {
     return 0
   fi
 
-  # Perform all the checks for more verbose error message.
-  local CHECK_FAILED=0
-
+  # Perform all the checks for more detailed error message.
   if (( $ASAN_CALLS > 0 )); then
     echo "BAD BUILD: UBSan build of $FUZZER seems to be compiled with ASan." >> $LOG_PATH_FOR_BROKEN_TARGET
-    CHECK_FAILED=1
+    BAD_BUILD_CHECK_FAILED=1
   fi
 
   if (( $MSAN_CALLS > 0 )); then
     echo "BAD BUILD: UBSan build of $FUZZER seems to be compiled with MSan." >> $LOG_PATH_FOR_BROKEN_TARGET
-    CHECK_FAILED=1
+    BAD_BUILD_CHECK_FAILED=1
   fi
 
   if (( $UBSAN_CALLS < 250 )); then
     echo "BAD BUILD: $FUZZER does not seem to be compiled with UBSan." >> $LOG_PATH_FOR_BROKEN_TARGET
-    CHECK_FAILED=1
-  fi
-
-  if (( $CHECK_FAILED > 0 )); then
-    exit 1
+    BAD_BUILD_CHECK_FAILED=1
   fi
 }
 
@@ -174,8 +161,6 @@ function check_mixed_sanitizers {
   local ASAN_CALLS=$(objdump -dC $FUZZER | egrep "callq\s+[0-9a-f]+\s+<__asan" -c)
   local MSAN_CALLS=$(objdump -dC $FUZZER | egrep "callq\s+[0-9a-f]+\s+<__msan" -c)
   local UBSAN_CALLS=$(objdump -dC $FUZZER | egrep "callq\s+[0-9a-f]+\s+<__ubsan" -c)
-
-  local CHECK_FAILED=0
 
   if [[ "$SANITIZER" = address ]]; then
     check_asan_build $FUZZER $LOG_PATH_FOR_BROKEN_TARGET $ASAN_CALLS $MSAN_CALLS $UBSAN_CALLS
@@ -204,15 +189,28 @@ if [ $# -ne 3 ]; then
     exit 1
 fi
 
+# Fuzz target path.
 FUZZER=$1
+
+# Directory where names of valid fuzz targets will be written to. It's expected
+# to have an empty file for every valid fuzz target.
 VALID_TARGETS_DIR=$2
+
+# Directory where names of broken fuzz targets will be written to. It's expected
+# ti have a file with error message for every broken fuzz target.
 BROKEN_TARGETS_DIR=$3
 
 TARGET_NAME="$(basename $FUZZER)"
 LOG_PATH_FOR_BROKEN_TARGET="${BROKEN_TARGETS_DIR}/${TARGET_NAME}"
 
+# In case of an error, main function will write error(s) to the given log path.
 main $FUZZER $LOG_PATH_FOR_BROKEN_TARGET
-echo "INFO: $FUZZER has passed bad build checks."
 
-# Record valid fuzz target name into the valid targets dir.
-touch ${VALID_TARGETS_DIR}/${TARGET_NAME}
+if [ "$BAD_BUILD_CHECK_FAILED" -eq "0" ]; then
+  echo "INFO: $FUZZER has passed bad build checks."
+
+  # Record valid fuzz target name into the valid targets dir.
+  touch ${VALID_TARGETS_DIR}/${TARGET_NAME}
+else
+  echo "INFO: $FUZZER has failed bad build checks."
+fi

--- a/infra/base-images/base-runner/bad_build_check
+++ b/infra/base-images/base-runner/bad_build_check
@@ -39,22 +39,24 @@ function check_instrumentation {
   local CHECK_FAILED=0
   local FUZZER_OUTPUT="/tmp/$(basename $FUZZER).output"
 
-  if [[ "$FUZZING_ENGINE" = libfuzzer ]]; then
-    # Store fuzz target's output into a temp file to be used for further checks.
-    $FUZZER -runs=$MIN_NUMBER_OF_RUNS &>$FUZZER_OUTPUT
-    CHECK_FAILED=$(egrep "ERROR: no interesting inputs were found. Is the code instrumented" -c $FUZZER_OUTPUT)
-    if (( $CHECK_FAILED > 0 )); then
-      echo "BAD BUILD: the target does not seem to have coverage instrumentation."
+  if [[ "$FUZZING_ENGINE" != libfuzzer ]]; then
+    return
+  fi
 
-      # Bail out as the further check does not make any sense, there are 0 PCs.
-      return 1
-    fi
+  # Store fuzz target's output into a temp file to be used for further checks.
+  $FUZZER -runs=$MIN_NUMBER_OF_RUNS &>$FUZZER_OUTPUT
+  CHECK_FAILED=$(egrep "ERROR: no interesting inputs were found. Is the code instrumented" -c $FUZZER_OUTPUT)
+  if (( $CHECK_FAILED > 0 )); then
+    echo "BAD BUILD: the target does not seem to have coverage instrumentation."
 
-    local NUMBER_OF_EDGES=$(grep -Po "INFO: Loaded [[:digit:]]+ module.*\(.*counters\):[[:space:]]+\K[[:digit:]]+" $FUZZER_OUTPUT)
+    # Bail out as the further check does not make any sense, there are 0 PCs.
+    return 1
+  fi
 
-    if (( $NUMBER_OF_EDGES < $THRESHOLD_FOR_NUMBER_OF_EDGES )); then
-      echo "BAD BUILD: the target seems to have only partial coverage instrumentation."
-    fi
+  local NUMBER_OF_EDGES=$(grep -Po "INFO: Loaded [[:digit:]]+ module.*\(.*counters\):[[:space:]]+\K[[:digit:]]+" $FUZZER_OUTPUT)
+
+  if (( $NUMBER_OF_EDGES < $THRESHOLD_FOR_NUMBER_OF_EDGES )); then
+    echo "BAD BUILD: the target seems to have only partial coverage instrumentation."
   fi
 }
 

--- a/infra/base-images/base-runner/bad_build_check
+++ b/infra/base-images/base-runner/bad_build_check
@@ -15,36 +15,45 @@
 #
 ################################################################################
 
-# Global variable that can be overwritten by any check.
-BAD_BUILD_CHECK_FAILED=0
+# A minimal number of runs to test fuzz target with a non-empty input.
+MIN_NUMBER_OF_RUNS=4
+
+# The "example" target has 73 with ASan, 65 with UBSan, and 6648 with MSan.
+# Real world targets have greater values (arduinojson: 407, zlib: 664).
+THRESHOLD_FOR_NUMBER_OF_EDGES=256
+
+# Threshold values for different sanitizers used by instrumentation checks.
+ASAN_CALLS_THRESHOLD_FOR_ASAN_BUILD=1000
+ASAN_CALLS_THRESHOLD_FOR_NON_ASAN_BUILD=0
+
+MSAN_CALLS_THRESHOLD_FOR_MSAN_BUILD=1000
+MSAN_CALLS_THRESHOLD_FOR_NON_MSAN_BUILD=0
+
+UBSAN_CALLS_THRESHOLD_FOR_UBSAN_BUILD=350
+UBSAN_CALLS_THRESHOLD_FOR_NON_UBSAN_BUILD=200
+
 
 # Verify that the given fuzz target has proper coverage instrumentation.
 function check_instrumentation {
   local FUZZER=$1
-  local LOG_PATH_FOR_BROKEN_TARGET=$2
   local CHECK_FAILED=0
   local FUZZER_OUTPUT="/tmp/$(basename $FUZZER).output"
 
   if [[ "$FUZZING_ENGINE" = libfuzzer ]]; then
-    $FUZZER -runs=4 &>$FUZZER_OUTPUT
-    CHECK_FAILED=$(cat $FUZZER_OUTPUT | egrep "ERROR: no interesting inputs were found. Is the code instrumented" -c)
+    # Store fuzz target's output into a temp file to be used for further checks.
+    $FUZZER -runs=$MIN_NUMBER_OF_RUNS &>$FUZZER_OUTPUT
+    CHECK_FAILED=$(egrep "ERROR: no interesting inputs were found. Is the code instrumented" -c $FUZZER_OUTPUT)
     if (( $CHECK_FAILED > 0 )); then
-      echo "BAD BUILD: the target does not seem to have coverage instrumentation." >> $LOG_PATH_FOR_BROKEN_TARGET
-      BAD_BUILD_CHECK_FAILED=1
+      echo "BAD BUILD: the target does not seem to have coverage instrumentation."
 
       # Bail out as the further check does not make any sense, there are 0 PCs.
       return 1
     fi
 
-    local NUMBER_OF_EDGES=$(cat $FUZZER_OUTPUT | grep -Po "INFO: Loaded [[:digit:]]+ module.*\(.*counters\):[[:space:]]+\K[[:digit:]]+")
-
-    # The "example" target has 73 with ASan, 65 with UBSan, and 6648 with MSan.
-    # Real world targets have greater values (arduinojson: 407, zlib: 664).
-    local THRESHOLD_FOR_NUMBER_OF_EDGES=256
+    local NUMBER_OF_EDGES=$(grep -Po "INFO: Loaded [[:digit:]]+ module.*\(.*counters\):[[:space:]]+\K[[:digit:]]+" $FUZZER_OUTPUT)
 
     if (( $NUMBER_OF_EDGES < $THRESHOLD_FOR_NUMBER_OF_EDGES )); then
-      echo "BAD BUILD: the target seems to have only partial coverage instrumentation." >> $LOG_PATH_FOR_BROKEN_TARGET
-      BAD_BUILD_CHECK_FAILED=1
+      echo "BAD BUILD: the target seems to have only partial coverage instrumentation."
     fi
   fi
 }
@@ -52,79 +61,68 @@ function check_instrumentation {
 # Verify that the given fuzz target has been built properly and works.
 function check_startup_crash {
   local FUZZER=$1
-  local LOG_PATH_FOR_BROKEN_TARGET=$2
   local CHECK_PASSED=0
 
   if [[ "$FUZZING_ENGINE" = libfuzzer ]]; then
-    CHECK_PASSED=$($FUZZER -runs=4 2>&1 | egrep "Done 4 runs" -c)
+    CHECK_PASSED=$($FUZZER -runs=$MIN_NUMBER_OF_RUNS 2>&1 | egrep "Done $MIN_NUMBER_OF_RUNS runs" -c)
   else
     # TODO: add checks for another fuzzing engines if possible.
     CHECK_PASSED=1
   fi
 
   if [ "$CHECK_PASSED" -eq "0" ]; then
-    echo "BAD BUILD: the fuzzer seems to have either startup crash or exit." >> $LOG_PATH_FOR_BROKEN_TARGET
-    BAD_BUILD_CHECK_FAILED=1
+    echo "BAD BUILD: the fuzzer seems to have either startup crash or exit."
   fi
 }
 
 # Mixed sanitizers check for ASan build.
 function check_asan_build {
   local FUZZER=$1
-  local LOG_PATH_FOR_BROKEN_TARGET=$2
-  local ASAN_CALLS=$3
-  local MSAN_CALLS=$4
-  local UBSAN_CALLS=$5
+  local ASAN_CALLS=$2
+  local MSAN_CALLS=$3
+  local UBSAN_CALLS=$4
 
   # Perform all the checks for more detailed error message.
-  if (( $ASAN_CALLS < 1000 )); then
-    echo "BAD BUILD: $FUZZER does not seem to be compiled with ASan." >> $LOG_PATH_FOR_BROKEN_TARGET
-    BAD_BUILD_CHECK_FAILED=1
+  if (( $ASAN_CALLS < $ASAN_CALLS_THRESHOLD_FOR_ASAN_BUILD )); then
+    echo "BAD BUILD: $FUZZER does not seem to be compiled with ASan."
   fi
 
-  if (( $MSAN_CALLS > 0 )); then
-    echo "BAD BUILD: ASan build of $FUZZER seems to be compiled with MSan." >> $LOG_PATH_FOR_BROKEN_TARGET
-    BAD_BUILD_CHECK_FAILED=1
+  if (( $MSAN_CALLS > $MSAN_CALLS_THRESHOLD_FOR_NON_MSAN_BUILD )); then
+    echo "BAD BUILD: ASan build of $FUZZER seems to be compiled with MSan."
   fi
 
-  if (( $UBSAN_CALLS > 250 )); then
-    echo "BAD BUILD: ASan build of $FUZZER seems to be compiled with UBSan." >> $LOG_PATH_FOR_BROKEN_TARGET
-    BAD_BUILD_CHECK_FAILED=1
+  if (( $UBSAN_CALLS > $UBSAN_CALLS_THRESHOLD_FOR_NON_UBSAN_BUILD )); then
+    echo "BAD BUILD: ASan build of $FUZZER seems to be compiled with UBSan."
   fi
 }
 
 # Mixed sanitizers check for MSan build.
 function check_msan_build {
   local FUZZER=$1
-  local LOG_PATH_FOR_BROKEN_TARGET=$2
-  local ASAN_CALLS=$3
-  local MSAN_CALLS=$4
-  local UBSAN_CALLS=$5
+  local ASAN_CALLS=$2
+  local MSAN_CALLS=$3
+  local UBSAN_CALLS=$4
 
   # Perform all the checks for more detailed error message.
-  if (( $ASAN_CALLS > 0 )); then
-    echo "BAD BUILD: MSan build of $FUZZER seems to be compiled with ASan." >> $LOG_PATH_FOR_BROKEN_TARGET
-    BAD_BUILD_CHECK_FAILED=1
+  if (( $ASAN_CALLS > $ASAN_CALLS_THRESHOLD_FOR_NON_ASAN_BUILD )); then
+    echo "BAD BUILD: MSan build of $FUZZER seems to be compiled with ASan."
   fi
 
-  if (( $MSAN_CALLS < 1000 )); then
-    echo "BAD BUILD: $FUZZER does not seem to be compiled with UBSan." >> $LOG_PATH_FOR_BROKEN_TARGET
-    BAD_BUILD_CHECK_FAILED=1
+  if (( $MSAN_CALLS < $MSAN_CALLS_THRESHOLD_FOR_MSAN_BUILD )); then
+    echo "BAD BUILD: $FUZZER does not seem to be compiled with UBSan."
   fi
 
-  if (( $UBSAN_CALLS > 250 )); then
-    echo "BAD BUILD: MSan build of $FUZZER seems to be compiled with UBSan." >> $LOG_PATH_FOR_BROKEN_TARGET
-    BAD_BUILD_CHECK_FAILED=1
+  if (( $UBSAN_CALLS > $UBSAN_CALLS_THRESHOLD_FOR_NON_UBSAN_BUILD )); then
+    echo "BAD BUILD: MSan build of $FUZZER seems to be compiled with UBSan."
   fi
 }
 
 # Mixed sanitizers check for UBSan build.
 function check_ubsan_build {
   local FUZZER=$1
-  local LOG_PATH_FOR_BROKEN_TARGET=$2
-  local ASAN_CALLS=$3
-  local MSAN_CALLS=$4
-  local UBSAN_CALLS=$5
+  local ASAN_CALLS=$2
+  local MSAN_CALLS=$3
+  local UBSAN_CALLS=$4
 
   if [[ "$FUZZING_ENGINE" != libfuzzer ]]; then
     # Ignore UBSan checks for fuzzing engines other than libFuzzer because:
@@ -134,80 +132,52 @@ function check_ubsan_build {
   fi
 
   # Perform all the checks for more detailed error message.
-  if (( $ASAN_CALLS > 0 )); then
-    echo "BAD BUILD: UBSan build of $FUZZER seems to be compiled with ASan." >> $LOG_PATH_FOR_BROKEN_TARGET
-    BAD_BUILD_CHECK_FAILED=1
+  if (( $ASAN_CALLS > $ASAN_CALLS_THRESHOLD_FOR_NON_ASAN_BUILD )); then
+    echo "BAD BUILD: UBSan build of $FUZZER seems to be compiled with ASan."
   fi
 
-  if (( $MSAN_CALLS > 0 )); then
-    echo "BAD BUILD: UBSan build of $FUZZER seems to be compiled with MSan." >> $LOG_PATH_FOR_BROKEN_TARGET
-    BAD_BUILD_CHECK_FAILED=1
+  if (( $MSAN_CALLS > $MSAN_CALLS_THRESHOLD_FOR_NON_MSAN_BUILD )); then
+    echo "BAD BUILD: UBSan build of $FUZZER seems to be compiled with MSan."
   fi
 
-  if (( $UBSAN_CALLS < 250 )); then
-    echo "BAD BUILD: $FUZZER does not seem to be compiled with UBSan." >> $LOG_PATH_FOR_BROKEN_TARGET
-    BAD_BUILD_CHECK_FAILED=1
+  if (( $UBSAN_CALLS < $UBSAN_CALLS_THRESHOLD_FOR_UBSAN_BUILD )); then
+    echo "BAD BUILD: $FUZZER does not seem to be compiled with UBSan."
   fi
 }
 
 # Verify that the given fuzz target is compiled with correct sanitizer.
 function check_mixed_sanitizers {
   local FUZZER=$1
-  local LOG_PATH_FOR_BROKEN_TARGET=$2
 
   local ASAN_CALLS=$(objdump -dC $FUZZER | egrep "callq\s+[0-9a-f]+\s+<__asan" -c)
   local MSAN_CALLS=$(objdump -dC $FUZZER | egrep "callq\s+[0-9a-f]+\s+<__msan" -c)
   local UBSAN_CALLS=$(objdump -dC $FUZZER | egrep "callq\s+[0-9a-f]+\s+<__ubsan" -c)
 
   if [[ "$SANITIZER" = address ]]; then
-    check_asan_build $FUZZER $LOG_PATH_FOR_BROKEN_TARGET $ASAN_CALLS $MSAN_CALLS $UBSAN_CALLS
+    check_asan_build $FUZZER $ASAN_CALLS $MSAN_CALLS $UBSAN_CALLS
   elif [[ "$SANITIZER" = memory ]]; then
-    check_msan_build $FUZZER $LOG_PATH_FOR_BROKEN_TARGET $ASAN_CALLS $MSAN_CALLS $UBSAN_CALLS
+    check_msan_build $FUZZER $ASAN_CALLS $MSAN_CALLS $UBSAN_CALLS
   elif [[ "$SANITIZER" = undefined ]]; then
-    check_ubsan_build $FUZZER $LOG_PATH_FOR_BROKEN_TARGET $ASAN_CALLS $MSAN_CALLS $UBSAN_CALLS
+    check_ubsan_build $FUZZER $ASAN_CALLS $MSAN_CALLS $UBSAN_CALLS
   fi
 }
 
 
 function main {
   local FUZZER=$1
-  local LOG_PATH_FOR_BROKEN_TARGET=$2
 
-  echo "INFO: performing bad build checks for $FUZZER"
-
-  check_instrumentation $FUZZER $LOG_PATH_FOR_BROKEN_TARGET
-  check_mixed_sanitizers $FUZZER $LOG_PATH_FOR_BROKEN_TARGET
-  check_startup_crash $FUZZER $LOG_PATH_FOR_BROKEN_TARGET
+  check_instrumentation $FUZZER
+  check_mixed_sanitizers $FUZZER
+  check_startup_crash $FUZZER
 }
 
 
-if [ $# -ne 3 ]; then
-    echo "Usage: $0 <fuzz_target_binary> <valid_targets_dir> <broken_targets_dir>"
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <fuzz_target_binary>"
     exit 1
 fi
 
 # Fuzz target path.
 FUZZER=$1
 
-# Directory where names of valid fuzz targets will be written to. It's expected
-# to have an empty file for every valid fuzz target.
-VALID_TARGETS_DIR=$2
-
-# Directory where names of broken fuzz targets will be written to. It's expected
-# ti have a file with error message for every broken fuzz target.
-BROKEN_TARGETS_DIR=$3
-
-TARGET_NAME="$(basename $FUZZER)"
-LOG_PATH_FOR_BROKEN_TARGET="${BROKEN_TARGETS_DIR}/${TARGET_NAME}"
-
-# In case of an error, main function will write error(s) to the given log path.
-main $FUZZER $LOG_PATH_FOR_BROKEN_TARGET
-
-if [ "$BAD_BUILD_CHECK_FAILED" -eq "0" ]; then
-  echo "INFO: $FUZZER has passed bad build checks."
-
-  # Record valid fuzz target name into the valid targets dir.
-  touch ${VALID_TARGETS_DIR}/${TARGET_NAME}
-else
-  echo "INFO: $FUZZER has failed bad build checks."
-fi
+main $FUZZER

--- a/infra/base-images/base-runner/test_all
+++ b/infra/base-images/base-runner/test_all
@@ -15,6 +15,9 @@
 #
 ################################################################################
 
+# Percentage threshold that needs to be reached for marking a build as failed.
+ALLOWED_BROKEN_TARGETS_PERCENTAGE=10
+
 # Test all fuzz targets in the $OUT/ dir.
 TOTAL_TARGETS_COUNT=0
 
@@ -115,13 +118,13 @@ fi
 BROKEN_TARGETS_PERCENTAGE=$[$BROKEN_TARGETS_COUNT*100/$TOTAL_TARGETS_COUNT]
 
 
-if [ "$BROKEN_TARGETS_PERCENTAGE" -gt "90" ]; then
+if [ "$BROKEN_TARGETS_PERCENTAGE" -gt "$ALLOWED_BROKEN_TARGETS_PERCENTAGE" ]; then
   echo "ERROR: $BROKEN_TARGETS_PERCENTAGE% of fuzz targets seem to be broken." \
        "See the list above for a detailed information."
 
   # TODO: figure out how to not fail the "special" cases handled below. Those
   # are from "example" and "c-ares" projects and are too small targets to pass.
-  if [ "(ls $OUT/do_stuff_fuzzer $OUT/ares_*_fuzzer | wc -l)" -gt "0" ]; then
+  if [ "$(ls $OUT/do_stuff_fuzzer $OUT/ares_*_fuzzer 2>/dev/null | wc -l)" -gt "0" ]; then
     exit 0
   fi
 

--- a/infra/base-images/base-runner/test_all
+++ b/infra/base-images/base-runner/test_all
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/bash -u
 # Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,8 @@
 
 # Test every fuzzer. Fails on first fuzzer failure.
 
-N=0
+TOTAL_TARGETS_COUNT=0
+BROKEN_TARGETS_COUNT=0
 for FUZZER_BINARY in $(find $OUT/ -executable -type f); do
   if file "$FUZZER_BINARY" | grep -v ELF > /dev/null 2>&1; then
     continue
@@ -45,13 +46,24 @@ for FUZZER_BINARY in $(find $OUT/ -executable -type f); do
   fi
 
   bad_build_check $FUZZER_BINARY
-  N=$[$N+1]
+  if [ $? -ne 0 ]; then
+    BROKEN_TARGETS_COUNT=$[$BROKEN_TARGETS_COUNT+1]
+  fi
+  TOTAL_TARGETS_COUNT=$[$TOTAL_TARGETS_COUNT+1]
 done
 
-if [ "$N" -eq "0" ]; then
+if [ "$TOTAL_TARGETS_COUNT" -eq "0" ]; then
   echo "ERROR: no fuzzers found in $OUT/"
   ls -al $OUT
   exit 1
 fi
 
-echo "$N fuzzers total"
+BROKEN_TARGETS_PERCENTAGE=$[$BROKEN_TARGETS_COUNT*100/$TOTAL_TARGETS_COUNT]
+
+if [ "$BROKEN_TARGETS_PERCENTAGE" -gt "90" ]; then
+  echo "ERROR: $BROKEN_TARGETS_PERCENTAGE % of fuzz targets seem to be broken"
+  exit 1
+fi
+
+echo "$TOTAL_TARGETS_COUNT fuzzers total, $BROKEN_TARGETS_COUNT seem to be " \
+     "broken ($BROKEN_TARGETS_PERCENTAGE%)"

--- a/infra/base-images/base-runner/test_all
+++ b/infra/base-images/base-runner/test_all
@@ -15,20 +15,21 @@
 #
 ################################################################################
 
-# Test every fuzzer. Fails on first fuzzer failure.
-
+# Test all fuzz targets in the $OUT/ dir.
 TOTAL_TARGETS_COUNT=0
 
+# Number of CPUs available, this is needed for running tests in parallel.
 NPROC=$(nproc)
+
+# Directories where bad build check results will be written to.
 VALID_TARGETS_DIR="/tmp/valid_fuzz_targets"
 BROKEN_TARGETS_DIR="/tmp/broken_fuzz_targets"
-
 rm -rf $VALID_TARGETS_DIR
 rm -rf $BROKEN_TARGETS_DIR
-
 mkdir $VALID_TARGETS_DIR
 mkdir $BROKEN_TARGETS_DIR
 
+# Main loop that iterates through all fuzz targets and runs the check.
 for FUZZER_BINARY in $(find $OUT/ -executable -type f); do
   if file "$FUZZER_BINARY" | grep -v ELF > /dev/null 2>&1; then
     continue
@@ -53,10 +54,13 @@ for FUZZER_BINARY in $(find $OUT/ -executable -type f); do
     fi
   fi
 
+  # Launch bad build check process in the background.
   bad_build_check $FUZZER_BINARY $VALID_TARGETS_DIR $BROKEN_TARGETS_DIR &
 
+  # Count total number of fuzz targets being tested.
   TOTAL_TARGETS_COUNT=$[$TOTAL_TARGETS_COUNT+1]
 
+  # Do not spawn more processes than the number of CPUs available.
   n_child_proc=$(jobs -p | wc -l)
   while [ "$n_child_proc" -eq "$NPROC" ]; do
     sleep 4
@@ -64,17 +68,21 @@ for FUZZER_BINARY in $(find $OUT/ -executable -type f); do
   done
 done
 
+# Wait for background processes to finish.
 wait
 
-VALID_TARGETS_COUNT=$(ls $VALID_TARGETS_DIR | wc -l)
-BROKEN_TARGETS_COUNT=$(ls $BROKEN_TARGETS_DIR | wc -l)
-
+# Sanity check in case there are no fuzz targets in the $OUT/ dir.
 if [ "$TOTAL_TARGETS_COUNT" -eq "0" ]; then
   echo "ERROR: no fuzzers found in $OUT/"
   ls -al $OUT
   exit 1
 fi
 
+# Calculate number of valid and broken fuzz targets.
+VALID_TARGETS_COUNT=$(ls $VALID_TARGETS_DIR | wc -l)
+BROKEN_TARGETS_COUNT=$(ls $BROKEN_TARGETS_DIR | wc -l)
+
+# Sanity check to make sure that bad build check doesn't skip any fuzz target.
 if [ "$TOTAL_TARGETS_COUNT" -ne "$[$VALID_TARGETS_COUNT+$BROKEN_TARGETS_COUNT]" ]; then
   echo "ERROR: bad_build_check seems to have a bug, total number of fuzz" \
        "does not match number of fuzz targets tested."
@@ -87,21 +95,25 @@ if [ "$TOTAL_TARGETS_COUNT" -ne "$[$VALID_TARGETS_COUNT+$BROKEN_TARGETS_COUNT]" 
   exit 1
 fi
 
-BROKEN_TARGETS_PERCENTAGE=$[$BROKEN_TARGETS_COUNT*100/$TOTAL_TARGETS_COUNT]
-
-RETURN_VALUE=0
-
-if [ "$BROKEN_TARGETS_PERCENTAGE" -gt "90" ]; then
-  echo "ERROR: $BROKEN_TARGETS_PERCENTAGE % of fuzz targets seem to be broken"
-  RETURN_VALUE=1
-else
-  echo "$TOTAL_TARGETS_COUNT fuzzers total, $BROKEN_TARGETS_COUNT seem to be" \
-       "broken ($BROKEN_TARGETS_PERCENTAGE%)"
+# Build info about all broken fuzz targets (if any).
+if [ "$BROKEN_TARGETS_COUNT" -gt "0" ]; then
+  echo "Broken fuzz targets ($BROKEN_TARGETS_COUNT):"
+  for target in $(ls $BROKEN_TARGETS_DIR); do
+    echo "${target}:"
+    cat ${BROKEN_TARGETS_DIR}/${target}
+  done
 fi
 
-if [ "$BROKEN_TARGETS_COUNT" -gt "0" ]; then
-  echo "Broken fuzz targets ($BROKEN_TARGETS_COUNT)"
-  for target in $(ls $BROKEN_TARGETS_DIR); do
-    echo "${target}: $(cat ${BROKEN_TARGETS_DIR}/${target})"
-  done
+# Calculate the percentage of broken fuzz targets and make the finel decision.
+BROKEN_TARGETS_PERCENTAGE=$[$BROKEN_TARGETS_COUNT*100/$TOTAL_TARGETS_COUNT]
+
+
+if [ "$BROKEN_TARGETS_PERCENTAGE" -gt "90" ]; then
+  echo "ERROR: $BROKEN_TARGETS_PERCENTAGE% of fuzz targets seem to be broken." \
+       "See the list above for a detailed information."
+  exit 1
+else
+  echo "$TOTAL_TARGETS_COUNT fuzzers total, $BROKEN_TARGETS_COUNT seem to be" \
+       "broken ($BROKEN_TARGETS_PERCENTAGE%)."
+  exit 0
 fi

--- a/infra/base-images/base-runner/test_all
+++ b/infra/base-images/base-runner/test_all
@@ -115,7 +115,7 @@ if [ "$BROKEN_TARGETS_PERCENTAGE" -gt "90" ]; then
   # TODO: figure out how to not fail the "special" cases handled below. Those
   # are from "example" and "c-ares" projects and are too small targets to pass.
   if [ "(ls $OUT/do_stuff_fuzzer $OUT/ares_*_fuzzer | wc -l)" -gt "0" ]; then
-    exit 0;
+    exit 0
   fi
 
   exit 1

--- a/infra/base-images/base-runner/test_all
+++ b/infra/base-images/base-runner/test_all
@@ -54,8 +54,12 @@ for FUZZER_BINARY in $(find $OUT/ -executable -type f); do
     fi
   fi
 
+  echo "INFO: performing bad build checks for $FUZZER_BINARY."
+
+  LOG_PATH_FOR_BROKEN_TARGET="${BROKEN_TARGETS_DIR}/${FUZZER}"
+
   # Launch bad build check process in the background.
-  bad_build_check $FUZZER_BINARY $VALID_TARGETS_DIR $BROKEN_TARGETS_DIR &
+  bad_build_check $FUZZER_BINARY > $LOG_PATH_FOR_BROKEN_TARGET &
 
   # Count total number of fuzz targets being tested.
   TOTAL_TARGETS_COUNT=$[$TOTAL_TARGETS_COUNT+1]
@@ -77,6 +81,9 @@ if [ "$TOTAL_TARGETS_COUNT" -eq "0" ]; then
   ls -al $OUT
   exit 1
 fi
+
+# An empty log file indicated that corresponding fuzz target is not broken.
+find $BROKEN_TARGETS_DIR -empty -exec mv {} $VALID_TARGETS_DIR \;
 
 # Calculate number of valid and broken fuzz targets.
 VALID_TARGETS_COUNT=$(ls $VALID_TARGETS_DIR | wc -l)

--- a/infra/base-images/base-runner/test_all
+++ b/infra/base-images/base-runner/test_all
@@ -18,7 +18,17 @@
 # Test every fuzzer. Fails on first fuzzer failure.
 
 TOTAL_TARGETS_COUNT=0
-BROKEN_TARGETS_COUNT=0
+
+NPROC=$(nproc)
+VALID_TARGETS_DIR="/tmp/valid_fuzz_targets"
+BROKEN_TARGETS_DIR="/tmp/broken_fuzz_targets"
+
+rm -rf $VALID_TARGETS_DIR
+rm -rf $BROKEN_TARGETS_DIR
+
+mkdir $VALID_TARGETS_DIR
+mkdir $BROKEN_TARGETS_DIR
+
 for FUZZER_BINARY in $(find $OUT/ -executable -type f); do
   if file "$FUZZER_BINARY" | grep -v ELF > /dev/null 2>&1; then
     continue
@@ -32,8 +42,6 @@ for FUZZER_BINARY in $(find $OUT/ -executable -type f); do
     continue
   fi
 
-  echo "testing $FUZZER"
-
   if [ "$SKIP_TEST_TARGET_RUN" != "1" ]; then
     if [[ "$FUZZING_ENGINE" = honggfuzz ]]; then
       timeout --preserve-status -s INT 20s run_fuzzer $FUZZER
@@ -45,12 +53,21 @@ for FUZZER_BINARY in $(find $OUT/ -executable -type f); do
     fi
   fi
 
-  bad_build_check $FUZZER_BINARY
-  if [ $? -ne 0 ]; then
-    BROKEN_TARGETS_COUNT=$[$BROKEN_TARGETS_COUNT+1]
-  fi
+  bad_build_check $FUZZER_BINARY $VALID_TARGETS_DIR $BROKEN_TARGETS_DIR &
+
   TOTAL_TARGETS_COUNT=$[$TOTAL_TARGETS_COUNT+1]
+
+  n_child_proc=$(jobs -p | wc -l)
+  while [ "$n_child_proc" -eq "$NPROC" ]; do
+    sleep 4
+    n_child_proc=$(jobs -p | wc -l)
+  done
 done
+
+wait
+
+VALID_TARGETS_COUNT=$(ls $VALID_TARGETS_DIR | wc -l)
+BROKEN_TARGETS_COUNT=$(ls $BROKEN_TARGETS_DIR | wc -l)
 
 if [ "$TOTAL_TARGETS_COUNT" -eq "0" ]; then
   echo "ERROR: no fuzzers found in $OUT/"
@@ -58,12 +75,33 @@ if [ "$TOTAL_TARGETS_COUNT" -eq "0" ]; then
   exit 1
 fi
 
-BROKEN_TARGETS_PERCENTAGE=$[$BROKEN_TARGETS_COUNT*100/$TOTAL_TARGETS_COUNT]
-
-if [ "$BROKEN_TARGETS_PERCENTAGE" -gt "90" ]; then
-  echo "ERROR: $BROKEN_TARGETS_PERCENTAGE % of fuzz targets seem to be broken"
+if [ "$TOTAL_TARGETS_COUNT" -ne "$[$VALID_TARGETS_COUNT+$BROKEN_TARGETS_COUNT]" ]; then
+  echo "ERROR: bad_build_check seems to have a bug, total number of fuzz" \
+       "does not match number of fuzz targets tested."
+  echo "Total fuzz targets ($TOTAL_TARGETS_COUNT):"
+  ls -al $OUT
+  echo "Valid fuzz targets ($VALID_TARGETS_COUNT):"
+  ls -al $VALID_TARGETS_DIR
+  echo "Total fuzz targets ($BROKEN_TARGETS_COUNT):"
+  ls -al $BROKEN_TARGETS_DIR
   exit 1
 fi
 
-echo "$TOTAL_TARGETS_COUNT fuzzers total, $BROKEN_TARGETS_COUNT seem to be " \
-     "broken ($BROKEN_TARGETS_PERCENTAGE%)"
+BROKEN_TARGETS_PERCENTAGE=$[$BROKEN_TARGETS_COUNT*100/$TOTAL_TARGETS_COUNT]
+
+RETURN_VALUE=0
+
+if [ "$BROKEN_TARGETS_PERCENTAGE" -gt "90" ]; then
+  echo "ERROR: $BROKEN_TARGETS_PERCENTAGE % of fuzz targets seem to be broken"
+  RETURN_VALUE=1
+else
+  echo "$TOTAL_TARGETS_COUNT fuzzers total, $BROKEN_TARGETS_COUNT seem to be" \
+       "broken ($BROKEN_TARGETS_PERCENTAGE%)"
+fi
+
+if [ "$BROKEN_TARGETS_COUNT" -gt "0" ]; then
+  echo "Broken fuzz targets ($BROKEN_TARGETS_COUNT)"
+  for target in $(ls $BROKEN_TARGETS_DIR); do
+    echo "${target}: $(cat ${BROKEN_TARGETS_DIR}/${target})"
+  done
+fi

--- a/infra/base-images/base-runner/test_all
+++ b/infra/base-images/base-runner/test_all
@@ -111,6 +111,13 @@ BROKEN_TARGETS_PERCENTAGE=$[$BROKEN_TARGETS_COUNT*100/$TOTAL_TARGETS_COUNT]
 if [ "$BROKEN_TARGETS_PERCENTAGE" -gt "90" ]; then
   echo "ERROR: $BROKEN_TARGETS_PERCENTAGE% of fuzz targets seem to be broken." \
        "See the list above for a detailed information."
+
+  # TODO: figure out how to not fail the "special" cases handled below. Those
+  # are from "example" and "c-ares" projects and are too small targets to pass.
+  if [ "(ls $OUT/do_stuff_fuzzer $OUT/ares_*_fuzzer | wc -l)" -gt "0" ]; then
+    exit 0;
+  fi
+
   exit 1
 else
   echo "$TOTAL_TARGETS_COUNT fuzzers total, $BROKEN_TARGETS_COUNT seem to be" \

--- a/infra/gcb/build.py
+++ b/infra/gcb/build.py
@@ -228,7 +228,7 @@ def get_build_steps(project_yaml, dockerfile_path):
               # Verify that fuzzers have been built properly and are not broken.
               # TODO(mmoroz): raise a notification if not passing the tests.
               'test_all'
-            ]
+            ],
           },
       ])
 

--- a/infra/gcb/build.py
+++ b/infra/gcb/build.py
@@ -195,7 +195,8 @@ def get_build_steps(project_yaml, dockerfile_path):
       env.append('OUT=' + out)
       env.append('MSAN_LIBS_PATH=/workspace/msan')
 
-      # To disable running of all fuzz targets while doing |test_all| step.
+      # To disable running of all fuzz targets while doing |test_all| step, as
+      # that step is currently being used for performing bad build checks only.
       env.append('SKIP_TEST_TARGET_RUN=1')
 
       workdir = workdir_from_dockerfile(dockerfile_path)

--- a/infra/gcb/build.py
+++ b/infra/gcb/build.py
@@ -195,27 +195,42 @@ def get_build_steps(project_yaml, dockerfile_path):
       env.append('OUT=' + out)
       env.append('MSAN_LIBS_PATH=/workspace/msan')
 
+      # To disable running of all fuzz targets while doing |test_all| step.
+      env.append('SKIP_TEST_TARGET_RUN=1')
+
       workdir = workdir_from_dockerfile(dockerfile_path)
       if not workdir:
         workdir = '/src'
 
-      build_steps.append({
+      build_steps.extend([
           # compile
-          'name': image,
-          'env': env,
-          'args': [
-            'bash',
-            '-c',
-            # Remove /out to break loudly when a build script incorrectly uses
-            # /out instead of $OUT.
-            # `cd /src && cd {workdir}` (where {workdir} is parsed from the
-            # Dockerfile). Container Builder overrides our workdir so we need to add
-            # this step to set it back.
-            # We also remove /work and /src to save disk space after a step.
-            # Container Builder doesn't pass --rm to docker run yet.
-            'rm -r /out && cd /src && cd {1} && mkdir -p {0} && compile && rm -rf /work && rm -rf /src'.format(out, workdir),
-          ],
-      })
+          {'name': image,
+           'env': env,
+           'args': [
+             'bash',
+             '-c',
+             # Remove /out to break loudly when a build script incorrectly uses
+             # /out instead of $OUT.
+             # `cd /src && cd {workdir}` (where {workdir} is parsed from the
+             # Dockerfile). Container Builder overrides our workdir so we need to add
+             # this step to set it back.
+             # We also remove /work and /src to save disk space after a step.
+             # Container Builder doesn't pass --rm to docker run yet.
+             'rm -r /out && cd /src && cd {1} && mkdir -p {0} && compile && rm -rf /work && rm -rf /src'.format(out, workdir),
+           ],
+          },
+          # test binaries
+          {'name': 'gcr.io/oss-fuzz-base/base-runner',
+            'env': env,
+            'args': [
+              'bash',
+              '-c',
+              # Verify that fuzzers have been built properly and are not broken.
+              # TODO(mmoroz): raise a notification if not passing the tests.
+              'test_all'
+            ]
+          },
+      ])
 
       if sanitizer == 'memory':
         # Patch dynamic libraries to use instrumented ones.

--- a/projects/bad_example/build.sh
+++ b/projects/bad_example/build.sh
@@ -40,7 +40,7 @@ make -j$(nproc) clean
 make -j$(nproc) all
 
 $CXX -fsanitize=$SANITIZER $CXXFLAGS_ORIG -std=c++11 -I. \
-    $SRC/bad_example_fuzzer.cc -o $OUT/bad_example_bad_instrumentation \
+    $SRC/bad_example_fuzzer.cc -o $OUT/bad_example_partial_instrumentation \
     -lFuzzingEngine ./libz.a
 
 

--- a/projects/bad_example/build.sh
+++ b/projects/bad_example/build.sh
@@ -28,8 +28,9 @@ if [[ $SANITIZER = *coverage* ]] || [[ $SANITIZER = *profile* ]]; then
 fi
 
 
-# Testcase 3. Ignore the flags provided by OSS-Fuzz.
+# Testcase 3. Partially ignore the flags provided by OSS-Fuzz.
 ################################################################################
+export CFLAGS_ORIG="$CFLAGS"
 export CFLAGS="-O1"
 export CXXFLAGS_ORIG="$CXXFLAGS"
 export CXXFLAGS="-O1 -stdlib=libc++"
@@ -43,7 +44,18 @@ $CXX -fsanitize=$SANITIZER $CXXFLAGS_ORIG -std=c++11 -I. \
     -lFuzzingEngine ./libz.a
 
 
-# Testcase 4. Enable multiple sanitizers.
+# Testcase 4. Completely ignore the flags provided by OSS-Fuzz.
+################################################################################
+./configure
+make -j$(nproc) clean
+make -j$(nproc) all
+
+$CXX -fsanitize=$SANITIZER $CXXFLAGS -std=c++11 -I. \
+    $SRC/bad_example_fuzzer.cc -o $OUT/bad_example_no_instrumentation \
+    -lFuzzingEngine ./libz.a
+
+
+# Testcase 5. Enable multiple sanitizers.
 ################################################################################
 # Add UBSan to ASan or MSan build. Add ASan to UBSan build.
 EXTRA_SANITIZER="undefined"
@@ -51,8 +63,8 @@ if [[ $SANITIZER = *undefined* ]]; then
   EXTRA_SANITIZER="address"
 fi
 
-export CFLAGS="-O1 -fsanitize=$SANITIZER,$EXTRA_SANITIZER -fsanitize-coverage=trace-pc-guard,trace-cmp"
-export CXXFLAGS="-O1 -fsanitize=$SANITIZER,$EXTRA_SANITIZER -fsanitize-coverage=trace-pc-guard,trace-cmp -stdlib=libc++"
+export CFLAGS="$CFLAGS_ORIG -fsanitize=$EXTRA_SANITIZER"
+export CXXFLAGS="$CXXFLAGS_ORIG -fsanitize=$EXTRA_SANITIZER"
 
 ./configure
 make -j$(nproc) clean

--- a/projects/bad_example/build.sh
+++ b/projects/bad_example/build.sh
@@ -31,14 +31,15 @@ fi
 # Testcase 3. Ignore the flags provided by OSS-Fuzz.
 ################################################################################
 export CFLAGS="-O1"
+export CXXFLAGS_ORIG="$CXXFLAGS"
 export CXXFLAGS="-O1 -stdlib=libc++"
 
 ./configure
 make -j$(nproc) clean
 make -j$(nproc) all
 
-$CXX -fsanitize=$SANITIZER $CXXFLAGS -std=c++11 -I. \
-    $SRC/bad_example_fuzzer.cc -o $OUT/bad_example_no_instrumentation \
+$CXX -fsanitize=$SANITIZER $CXXFLAGS_ORIG -std=c++11 -I. \
+    $SRC/bad_example_fuzzer.cc -o $OUT/bad_example_bad_instrumentation \
     -lFuzzingEngine ./libz.a
 
 


### PR DESCRIPTION
We probably need to wait a bit, there are the following issues still open:

- ~~https://github.com/google/oss-fuzz/issues/815~~: one of two c-ares targets is very tiny
- https://github.com/google/oss-fuzz/issues/817: ffmpeg, startup crash with UBSan
- ~~https://github.com/google/oss-fuzz/issues/822~~: libxml2, should get fixed after landing https://reviews.llvm.org/D37632
- ~~https://github.com/google/oss-fuzz/issues/823~~: llvm, waiting for clang roll
- ~~https://github.com/google/oss-fuzz/issues/824~~: openssl, same as libxml2
- ~~https://github.com/google/oss-fuzz/issues/826~~: resiprocate, too tiny fuzz targets
