### PR TITLE
[wget2] Add libmicrohttpd as new test suite dependency

### DIFF
--- a/projects/wget2/Dockerfile
+++ b/projects/wget2/Dockerfile
@@ -42,6 +42,7 @@ RUN git clone --depth=1 --recursive https://gitlab.com/libidn/libidn2.git
 RUN git clone --depth=1 --recursive https://github.com/rockdaboot/libpsl.git
 RUN git clone --depth=1 https://git.lysator.liu.se/nettle/nettle.git
 RUN git clone --depth=1 https://gitlab.com/gnutls/gnutls.git
+RUN git clone --depth=1 --recursive https://gnunet.org/git/libmicrohttpd.git
 
 RUN git clone --depth=1 --recursive https://gitlab.com/gnuwget/wget2.git
 

--- a/projects/wget2/build.sh
+++ b/projects/wget2/build.sh
@@ -71,6 +71,13 @@ CFLAGS="$GNUTLS_CFLAGS" \
 make -j$(nproc)
 make install
 
+cd $SRC/libmicrohttpd
+./bootstrap
+LIBS="-lgnutls -lnettle -lhogweed -lidn2 -lunistring" \
+./configure --prefix=$WGET2_DEPS_PATH --disable-doc --disable-examples --disable-shared --enable-static
+make -j$(nproc)
+make install
+
 
 # avoid iconv() memleak on Ubuntu 16.04 image (breaks test suite)
 export ASAN_OPTIONS=detect_leaks=0


### PR DESCRIPTION
This fixes the recent build failure for wget2.

There were two reasons to fail:
1. build failure in 'nettle' dependency, now fixed upstream
2. GSOC 2017 project merged (test suite now based on libmicrohttpd)