### PR TITLE
Add project.yaml for unrar

### DIFF
--- a/projects/unrar/project.yaml
+++ b/projects/unrar/project.yaml
@@ -1,0 +1,7 @@
+homepage: "http://www.rarlab.com/"
+primary_contact: "roshal@rarlab.com"
+sanitizers:
+  - address
+  - memory:
+     experimental: True
+  - undefined

--- a/projects/unrar/project.yaml
+++ b/projects/unrar/project.yaml
@@ -1,7 +1,8 @@
 homepage: "http://www.rarlab.com/"
 primary_contact: "roshal@rarlab.com"
+auto_ccs:
+  - "vakh@chromium.org"
 sanitizers:
   - address
-  - memory:
-     experimental: True
+  - memory
   - undefined


### PR DESCRIPTION
The unrar library is used to decompress files of type .RAR and other extensions.

Doing this with permission from the original author.