### PR TITLE
curl: Move to using separated repository

### DIFF
--- a/projects/curl/Dockerfile
+++ b/projects/curl/Dockerfile
@@ -18,7 +18,8 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER dvyukov@google.com
 RUN apt-get update && apt-get install -y make autoconf automake libtool libssl-dev zlib1g-dev
 
-RUN git clone --depth 1 https://github.com/curl/curl.git
-WORKDIR curl
+RUN git clone --depth 1 https://github.com/curl/curl.git /tmp/curl
+RUN git clone --depth 1 https://github.com/curl/curl-fuzzer.git /tmp/curl_fuzzer
+WORKDIR /tmp/curl_fuzzer
 COPY build.sh *.options *.dict $SRC/
 

--- a/projects/curl/build.sh
+++ b/projects/curl/build.sh
@@ -21,13 +21,22 @@ echo "LIB_FUZZING_ENGINE: $LIB_FUZZING_ENGINE"
 echo "CFLAGS: $CFLAGS"
 echo "CXXFLAGS: $CXXFLAGS"
 
+# Make an install directory
+export INSTALLDIR=/tmp/curl_install
+
+# Compile curl
+pushd /tmp/curl
 ./buildconf
-./configure --disable-shared --enable-debug --enable-maintainer-mode --disable-symbol-hiding --disable-threaded-resolver --enable-ipv6 --with-random=/dev/null --without-ssl
+./configure --prefix=${INSTALLDIR} --disable-shared --enable-debug --enable-maintainer-mode --disable-symbol-hiding --disable-threaded-resolver --enable-ipv6 --with-random=/dev/null --without-ssl
 make -j$(nproc)
+make install
+popd
 
 # Build the fuzzer.
-cd tests/fuzz
-make all
+./buildconf
+./configure
+make
+make check
 make zip
 
 cp -v curl_fuzzer curl_fuzzer_seed_corpus.zip $OUT/


### PR DESCRIPTION
The curl fuzzer has been moved into its own repository,
http://github.com/curl/curl-fuzzer. For oss-fuzz this means it needs to
check out two codebases and compile them.

---

Tagging @bagder as curl owner. I've tested this locally and it works the same as the old code.