### PR TITLE
Add project zstd

### DIFF
--- a/projects/zstd/Dockerfile
+++ b/projects/zstd/Dockerfile
@@ -1,0 +1,31 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER nickrterrell@gmail.com
+RUN apt-get update && apt-get install -y make python
+# Add corpora
+ADD https://github.com/facebook/zstd/releases/download/fuzz-corpora/block_decompress_seed_corpus.zip \
+    https://github.com/facebook/zstd/releases/download/fuzz-corpora/block_round_trip_seed_corpus.zip \
+    https://github.com/facebook/zstd/releases/download/fuzz-corpora/simple_decompress_seed_corpus.zip \
+    https://github.com/facebook/zstd/releases/download/fuzz-corpora/simple_round_trip_seed_corpus.zip \
+    https://github.com/facebook/zstd/releases/download/fuzz-corpora/stream_decompress_seed_corpus.zip \
+    https://github.com/facebook/zstd/releases/download/fuzz-corpora/stream_round_trip_seed_corpus.zip \
+    $SRC/
+# Clone source
+RUN git clone --depth 1 https://github.com/facebook/zstd
+WORKDIR zstd
+COPY build.sh $SRC/

--- a/projects/zstd/build.sh
+++ b/projects/zstd/build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -eu
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+
+cd tests/fuzz
+
+./fuzz.py build all
+
+for target in $(./fuzz.py list); do
+    cp "$target" "$OUT"
+
+    options=default.options
+    if [ -f "$target.options" ]; then
+        options="$target.options"
+    fi
+    cp "$options" "$OUT/$target.options"
+
+    if [ -f "$target.dict" ]; then
+        cp "$target.dict" "$OUT"
+    fi
+
+    cp "$SRC/${target}_seed_corpus.zip" "$OUT"
+done

--- a/projects/zstd/project.yaml
+++ b/projects/zstd/project.yaml
@@ -1,0 +1,8 @@
+homepage: "http://facebook.github.io/zstd/"
+primary_contact: "nickrterrell@gmail.com"
+auto_ccs:
+  - "Yann.collet.73@gmail.com"
+sanitizers:
+  - address
+  - memory
+  - undefined


### PR DESCRIPTION
zstd is a lossless data compression algorithm.

Upstream has initial corpora under the [fuzz-corpora release](https://github.com/facebook/zstd/releases/tag/fuzz-corpora) which will be updated with improved coverages and crashes. We build and run the fuzz targets on the corpora in our CI with a [regression test driver](https://github.com/facebook/zstd/blob/dev/tests/fuzz/regression_driver.c) with ASAN/MSAN/UBSAN.

We have 2 types of targets located in [tests/fuzz/](https://github.com/facebook/zstd/tree/dev/tests/fuzz):
* Round trip targets that make sure data round trips, and the compressor doesn't crash.
* Decompression targets which test decompressor on fuzzed input.