### PR TITLE
Clone zlib into the libpng project

### DIFF
--- a/projects/libpng/Dockerfile
+++ b/projects/libpng/Dockerfile
@@ -19,6 +19,7 @@ MAINTAINER glennrp@gmail.com
 RUN apt-get update && \
     apt-get install -y make autoconf automake libtool zlib1g-dev
 
+RUN git clone --depth 1 https://github.com/madler/zlib.git
 RUN git clone --depth 1 https://github.com/glennrp/libpng.git
 RUN cp libpng/contrib/oss-fuzz/build.sh $SRC
 WORKDIR libpng


### PR DESCRIPTION
I have a new libpng/build.sh ready once the zlib clone is checked in.