### PR TITLE
Add cras fuzzer

### DIFF
--- a/projects/cras/Dockerfile
+++ b/projects/cras/Dockerfile
@@ -1,0 +1,57 @@
+# Copyright 2017 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+#
+# Defines a docker image that can build cras fuzzers.
+#
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER dgreid@chromium.org
+
+RUN apt-get -y update && \
+      apt-get install -y \
+      automake \
+      build-essential \
+      cmake \
+      g++ \
+      git \
+      ladspa-sdk \
+      libasound-dev \
+      libdbus-1-dev \
+      libgtest-dev \
+      libncurses5-dev \
+      libsbc-dev \
+      libsndfile-dev \
+      libspeexdsp-dev \
+      libtool \
+      libudev-dev \
+      wget
+RUN apt-get clean
+RUN cd /tmp && git clone https://github.com/ndevilla/iniparser.git && \
+      cd iniparser && \
+      make && \
+      cp libiniparser.* /usr/local/lib && \
+      cp src/dictionary.h src/iniparser.h /usr/local/include && \
+      chmod 644 /usr/local/include/dictionary.h /usr/local/include/iniparser.h && \
+      chmod 644 /usr/local/lib/libiniparser.a && \
+      chmod 755 /usr/local/lib/libiniparser.so.*
+RUN cd /usr/src/gtest && \
+      cmake . && \
+      make && \
+      chmod 644 *.a && \
+      cp *.a /usr/local/lib
+
+# Need to build and install alsa so there is a static lib.
+RUN mkdir -p /tmp/alsa-build && cd /tmp/alsa-build && \
+      wget ftp://ftp.alsa-project.org/pub/lib/alsa-lib-1.1.4.1.tar.bz2 && \
+      bzip2 -f -d alsa-lib-* && \
+      tar xf alsa-lib-* && \
+      cd alsa-lib-* && \
+      ./configure --enable-static --disable-shared && \
+      make clean && \
+      make -j$(nproc) all && \
+      make install
+
+
+RUN cd $SRC && git clone https://chromium.googlesource.com/chromiumos/third_party/adhd
+WORKDIR adhd/cras
+COPY build.sh $SRC/

--- a/projects/cras/build.sh
+++ b/projects/cras/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -eux
+# Copyright 2017 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+#
+# Builds fuzzers from within a container into /out/ directory.
+# Expects /src/cras to contain a cras checkout.
+
+cd ${SRC}/adhd/cras
+./git_prepare.sh
+./configure --disable-DBUS
+make -j$(nproc)
+
+$CXX $CXXFLAGS $FUZZER_LDFLAGS \
+  ${SRC}/adhd/cras/src/fuzz/rclient_message.cc -o ${OUT}/rclient_message \
+  -I ${SRC}/adhd/cras/src/server \
+  -I ${SRC}/adhd/cras/src/common \
+  ${SRC}/adhd/cras/src/.libs/libcrasserver.a \
+  -lpthread -lrt -ludev -ldl -lm \
+  -lFuzzingEngine \
+  -Wl,-Bstatic -liniparser -lasound -lspeexdsp -Wl,-Bdynamic

--- a/projects/cras/project.yaml
+++ b/projects/cras/project.yaml
@@ -1,0 +1,5 @@
+homepage: "https://www.chromium.org"
+primary_contact: "dgreid@chromium.org"
+auto_ccs:
+  - "hychao@chromium.org"
+  - "cychiang@chromium.org"


### PR DESCRIPTION
cras is the audio server that runs on ChromeOS.

The first cras fuzzer tests the client's message interface.

Signed-off-by: Dylan Reid <dgreid@chromium.org>