### PR TITLE
projects/cras: Add an rclient corpus

### DIFF
--- a/projects/cras/Dockerfile
+++ b/projects/cras/Dockerfile
@@ -24,7 +24,8 @@ RUN apt-get -y update && \
       libspeexdsp-dev \
       libtool \
       libudev-dev \
-      wget
+      wget \
+      zip
 RUN apt-get clean
 RUN cd /tmp && git clone https://github.com/ndevilla/iniparser.git && \
       cd iniparser && \

--- a/projects/cras/build.sh
+++ b/projects/cras/build.sh
@@ -19,3 +19,4 @@ $CXX $CXXFLAGS $FUZZER_LDFLAGS \
   -lpthread -lrt -ludev -ldl -lm \
   -lFuzzingEngine \
   -Wl,-Bstatic -liniparser -lasound -lspeexdsp -Wl,-Bdynamic
+zip -j ${OUT}/rclient_message_corpus.zip ${SRC}/adhd/cras/src/fuzz/corpus/*


### PR DESCRIPTION
Pull the corpus that exists in the cras repository and use it.
This corpus was generated by dumping incoming messages while going
through audio use cases on a chromebook.

Signed-off-by: Dylan Reid <dgreid@chromium.org>