### PR TITLE
[llvm] Add clang-proto-fuzzer.

### DIFF
--- a/projects/llvm/Dockerfile
+++ b/projects/llvm/Dockerfile
@@ -28,10 +28,4 @@ RUN svn co http://llvm.org/svn/llvm-project/llvm/trunk llvm > svn.log 2>&1
 RUN cd llvm/tools && svn co http://llvm.org/svn/llvm-project/cfe/trunk clang -r $(cd ../ && svn info | grep Revision | awk '{print $2}') >> svn.log 2>&1 
 RUN cd llvm/projects && svn co http://llvm.org/svn/llvm-project/compiler-rt/trunk compiler-rt -r $(cd ../ && svn info | grep Revision | awk '{print $2}')  >> svn.log 2>&1 
 
-# Build plain LLVM (stage 0)
-RUN mkdir build0
-RUN unset CC CXX CFLAGS CXXFLAGS; cd build0 && cmake -GNinja -DCMAKE_BUILD_TYPE=Release ../llvm
-RUN cd build0 && ninja clang compiler-rt
-RUN cd build0 && ninja fuzzer
-
 COPY build.sh $SRC/

--- a/projects/llvm/Dockerfile
+++ b/projects/llvm/Dockerfile
@@ -23,7 +23,6 @@ RUN apt-get install -y autoconf automake libtool curl make g++ unzip wget git \
 
 # Get protobuf
 RUN wget -qO- https://github.com/google/protobuf/releases/download/v3.3.0/protobuf-cpp-3.3.0.tar.gz | tar zxf -
-RUN cd protobuf-3.3.0 && ./autogen.sh && ./configure && make -j $(nproc) && make check -j $(nproc) && make install && ldconfig
 # Get LLVM
 RUN svn co http://llvm.org/svn/llvm-project/llvm/trunk llvm
 RUN cd llvm/tools && svn co http://llvm.org/svn/llvm-project/cfe/trunk clang -r $(cd ../ && svn info | grep Revision | awk '{print $2}')

--- a/projects/llvm/build.sh
+++ b/projects/llvm/build.sh
@@ -23,15 +23,25 @@
 # TODO(kcc): honor CFLAGS/CXXFLAGS to allow building with msan/ubsan
 
 # Build and install protobuf
-pushd protobuf-3.3.0
-./autogen.sh
-./configure --disable-shared
-make -j $(nproc)
-make check -j $(nproc)
-make install
-ldconfig
-popd
 
+build_protobuf() {
+  ./autogen.sh
+  ./configure --disable-shared
+  make -j $(nproc)
+  make check -j $(nproc)
+  make install
+  ldconfig
+}
+
+(cd protobuf-3.3.0 && build_protobuf)
+
+readonly FUZZERS=( \
+  clang-fuzzer \
+  clang-proto-fuzzer \
+  clang-format-fuzzer \
+  llvm-dwarfdump-fuzzer \
+  llvm-isel-fuzzer \
+)
 case $SANITIZER in
   address) LLVM_SANITIZER="Address" ;;
   undefined) LLVM_SANITIZER="Undefined" ;;
@@ -39,40 +49,21 @@ case $SANITIZER in
   *) LLVM_SANITIZER="" ;;
 esac
 
-mkdir cpf-build
-pushd cpf-build
+mkdir build
+cd build
 cmake -GNinja -DCMAKE_BUILD_TYPE=Release ../llvm \
     -DLLVM_ENABLE_ASSERTIONS=ON \
     -DCMAKE_C_COMPILER="${CC}" \
     -DCMAKE_CXX_COMPILER="${CXX}" \
     -DCMAKE_C_FLAGS="${CFLAGS}" \
     -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
-    -DLIB_FUZZING_ENGINE="${LIB_FUZZING_ENGINE}" \
+    -DLLVM_LIB_FUZZING_ENGINE="${LIB_FUZZING_ENGINE}" \
     -DCLANG_ENABLE_PROTO_FUZZER=ON \
     -DLLVM_USE_SANITIZER="${LLVM_SANITIZER}"
-for fuzzer in clang-fuzzer clang-proto-fuzzer; do
-  ninja $fuzzer
-  cp bin/$fuzzer $OUT
-done
-popd
-
-mkdir build
-cd build
-
-unset CC CXX CFLAGS CXXFLAGS
-
-cmake -GNinja -DCMAKE_BUILD_TYPE=Release ../llvm \
-    -DLLVM_ENABLE_ASSERTIONS=ON \
-    -DCMAKE_C_COMPILER=`pwd`/../build0/bin/clang \
-    -DCMAKE_CXX_COMPILER=`pwd`/../build0/bin/clang++ \
-    -DLLVM_NO_DEAD_STRIP=ON \
-    -DLLVM_USE_SANITIZE_COVERAGE=YES \
-    -DLLVM_USE_SANITIZER=Address
-
-for fuzzer in clang-format-fuzzer llvm-dwarfdump-fuzzer llvm-isel-fuzzer; do
+for fuzzer in "${FUZZERS[@]}"; do
   ninja $fuzzer
   cp bin/$fuzzer $OUT
 done
 
-# isel-fuzzer encodes its default fags in the name.
+# isel-fuzzer encodes its default flags in the name.
 mv $OUT/llvm-isel-fuzzer $OUT/llvm-isel-fuzzer=aarch64-gisel


### PR DESCRIPTION
- Move protobuf build to build.sh to avoid container overflow false positive
- Build all fuzzers using OSS-Fuzz environment variables.
- Eliminate ToT clang build.

Building protobuf in build.sh allows us to build it with ASan and avoid container overflow false positives.  And if we ever want to use MSan, we will probably have to build in build.sh anyways.  However, it appears this prevents using UBSan due to undefined behavior in protobuf.

Also, we'll need further changes in LLVM (and protobuf-mutator?) to get MSan working with clang-proto-fuzzer since clang-proto-fuzzer links with protobuf-mutator which in turn links with other things.

Closes #790.