### PR TITLE
make dlplibs play nicely with MSAN

### DIFF
--- a/projects/dlplibs/Dockerfile
+++ b/projects/dlplibs/Dockerfile
@@ -22,10 +22,11 @@ RUN sed -i -e '/^#\s*deb-src.*\smain\s\+restricted/s/^#//' /etc/apt/sources.list
 RUN apt-get update && apt-get build-dep -y \
     libmspub librevenge libcdr libvisio libpagemaker libfreehand libwpd \
     libwpg libwps libmwaw libe-book libabw libetonyek
-RUN apt-get update && apt-get install -y liblzma-dev wget
+RUN apt-get update && apt-get install -y wget
 ADD https://dev-www.libreoffice.org/src/lcms2-2.8.tar.gz \
     https://dev-www.libreoffice.org/src/zlib-1.2.11.tar.xz \
     https://dev-www.libreoffice.org/src/libpng-1.6.34.tar.xz \
+    https://dev-www.libreoffice.org/src/libxml2-2.9.6.tar.gz \
     $SRC/
 # download fuzzing corpora
 ADD https://dev-www.libreoffice.org/corpus/olefuzzer_seed_corpus.zip \

--- a/projects/dlplibs/Dockerfile
+++ b/projects/dlplibs/Dockerfile
@@ -27,6 +27,7 @@ ADD https://dev-www.libreoffice.org/src/lcms2-2.8.tar.gz \
     https://dev-www.libreoffice.org/src/zlib-1.2.11.tar.xz \
     https://dev-www.libreoffice.org/src/libpng-1.6.34.tar.xz \
     https://dev-www.libreoffice.org/src/libxml2-2.9.6.tar.gz \
+    https://dev-www.libreoffice.org/src/icu4c-59_1-src.tgz \
     $SRC/
 # download fuzzing corpora
 ADD https://dev-www.libreoffice.org/corpus/olefuzzer_seed_corpus.zip \

--- a/projects/dlplibs/Dockerfile
+++ b/projects/dlplibs/Dockerfile
@@ -22,9 +22,10 @@ RUN sed -i -e '/^#\s*deb-src.*\smain\s\+restricted/s/^#//' /etc/apt/sources.list
 RUN apt-get update && apt-get build-dep -y \
     libmspub librevenge libcdr libvisio libpagemaker libfreehand libwpd \
     libwpg libwps libmwaw libe-book libabw libetonyek
-RUN apt-get update && apt-get install -y liblzma-dev libpng-dev wget
+RUN apt-get update && apt-get install -y liblzma-dev wget
 ADD https://dev-www.libreoffice.org/src/lcms2-2.8.tar.gz \
     https://dev-www.libreoffice.org/src/zlib-1.2.11.tar.xz \
+    https://dev-www.libreoffice.org/src/libpng-1.6.34.tar.xz \
     $SRC/
 # download fuzzing corpora
 ADD https://dev-www.libreoffice.org/corpus/olefuzzer_seed_corpus.zip \

--- a/projects/dlplibs/Dockerfile
+++ b/projects/dlplibs/Dockerfile
@@ -23,7 +23,9 @@ RUN apt-get update && apt-get build-dep -y \
     libmspub librevenge libcdr libvisio libpagemaker libfreehand libwpd \
     libwpg libwps libmwaw libe-book libabw libetonyek
 RUN apt-get update && apt-get install -y liblzma-dev libpng-dev wget
-ADD https://dev-www.libreoffice.org/src/lcms2-2.8.tar.gz $SRC/
+ADD https://dev-www.libreoffice.org/src/lcms2-2.8.tar.gz \
+    https://dev-www.libreoffice.org/src/zlib-1.2.11.tar.xz \
+    $SRC/
 # download fuzzing corpora
 ADD https://dev-www.libreoffice.org/corpus/olefuzzer_seed_corpus.zip \
     https://dev-www.libreoffice.org/corpus/pubfuzzer_seed_corpus.zip \

--- a/projects/dlplibs/Dockerfile
+++ b/projects/dlplibs/Dockerfile
@@ -19,10 +19,9 @@ MAINTAINER dtardon@redhat.com
 # enable source repos
 RUN sed -i -e '/^#\s*deb-src.*\smain\s\+restricted/s/^#//' /etc/apt/sources.list
 # install build requirements
-RUN apt-get update && apt-get build-dep -y \
-    libmspub librevenge libcdr libvisio libpagemaker libfreehand libwpd \
-    libwpg libwps libmwaw libe-book libabw libetonyek
-RUN apt-get update && apt-get install -y wget
+RUN apt-get update && \
+    apt-get install -y wget xz-utils autoconf automake libtool pkg-config \
+        gperf libboost-dev libglm-dev libmdds-dev
 ADD https://dev-www.libreoffice.org/src/lcms2-2.8.tar.gz \
     https://dev-www.libreoffice.org/src/zlib-1.2.11.tar.xz \
     https://dev-www.libreoffice.org/src/libpng-1.6.34.tar.xz \

--- a/projects/dlplibs/build.sh
+++ b/projects/dlplibs/build.sh
@@ -81,19 +81,19 @@ popd
 
 pushd libcdr
 ./autogen.sh
-./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers
+./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers --disable-tests
 make -j$(nproc)
 popd
 
 pushd libvisio
 ./autogen.sh
-./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers
+./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers --disable-tests
 make -j$(nproc)
 popd
 
 pushd libzmf
 ./autogen.sh
-./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers
+./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers --disable-tests
 make -j$(nproc)
 popd
 
@@ -105,7 +105,7 @@ popd
 
 pushd libfreehand
 ./autogen.sh
-./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers
+./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers --disable-tests
 make -j$(nproc)
 popd
 
@@ -146,7 +146,8 @@ popd
 
 pushd libe-book
 ./autogen.sh
-./configure --without-docs --disable-werror --disable-shared --enable-static --without-tools --enable-fuzzers --without-liblangtag
+./configure --without-docs --disable-werror --disable-shared --enable-static \
+    --without-tools --enable-fuzzers --without-liblangtag --disable-tests
 make -j$(nproc)
 popd
 
@@ -159,13 +160,13 @@ popd
 pushd libetonyek
 ./autogen.sh
 ./configure --without-docs --disable-werror --disable-shared --enable-static \
-    --without-tools --enable-fuzzers --with-mdds=0.x --without-liblangtag
+    --without-tools --enable-fuzzers --with-mdds=0.x --without-liblangtag --disable-tests
 make -j$(nproc)
 popd
 
 pushd libqxp
 ./autogen.sh
-./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers
+./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers --disable-tests
 make -j$(nproc)
 popd
 

--- a/projects/dlplibs/build.sh
+++ b/projects/dlplibs/build.sh
@@ -15,12 +15,10 @@
 #
 ################################################################################
 
-# HACK to force linking with static icu and libxml2
+# HACK to force linking with static icu
 mkdir static
 cp -pL \
     /usr/lib/*/libicu*.a \
-    /usr/lib/*/libxml2.a \
-    /usr/lib/*/liblzma.a \
     static
 staticlib=$(pwd)/static
 
@@ -46,6 +44,16 @@ pushd libpng-1.6.34
 make -j$(nproc)
 export LIBPNG_CFLAGS="-I$(pwd)"
 export LIBPNG_LIBS="-L$(pwd) -lpng16"
+popd
+
+tar -xzf $SRC/libxml2-2.9.6.tar.gz
+pushd libxml2-2.9.6
+./configure --disable-shared --enable-static --disable-ipv6 --without-python --without-zlib --without-lzma
+make -j$(nproc)
+export LIBXML_CFLAGS="-I$(pwd)/include"
+export LIBXML_LIBS="-L$(pwd) -lxml2"
+export XML_CFLAGS="$LIBXML_CFLAGS"
+export XML_LIBS="$LIBXML_LIBS"
 popd
 
 pushd librevenge
@@ -81,8 +89,7 @@ popd
 pushd libvisio
 ./autogen.sh
 ./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers \
-    LDFLAGS=-L$staticlib \
-    LIBXML_LIBS="-lxml2 -llzma"
+    LDFLAGS=-L$staticlib
 make -j$(nproc)
 popd
 
@@ -144,16 +151,14 @@ popd
 pushd libe-book
 ./autogen.sh
 ./configure --without-docs --disable-werror --disable-shared --enable-static --without-tools --enable-fuzzers --without-liblangtag \
-    LDFLAGS=-L$staticlib \
-    XML_LIBS="-lxml2 -llzma"
+    LDFLAGS=-L$staticlib
 make -j$(nproc)
 popd
 
 pushd libabw
 ./autogen.sh
 ./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers \
-    LDFLAGS=-L$staticlib \
-    LIBXML_LIBS="-lxml2 -llzma -licuuc -licudata"
+    LDFLAGS=-L$staticlib
 make -j$(nproc)
 popd
 
@@ -161,8 +166,7 @@ pushd libetonyek
 ./autogen.sh
 ./configure --without-docs --disable-werror --disable-shared --enable-static \
     --without-tools --enable-fuzzers --with-mdds=0.x --without-liblangtag \
-    LDFLAGS=-L$staticlib \
-    XML_LIBS="-lxml2 -llzma -licuuc -licudata"
+    LDFLAGS=-L$staticlib
 make -j$(nproc)
 popd
 

--- a/projects/dlplibs/build.sh
+++ b/projects/dlplibs/build.sh
@@ -29,8 +29,8 @@ tar -xzf $SRC/lcms2-2.8.tar.gz
 pushd lcms2-2.8
 ./configure --disable-shared --enable-static --without-jpeg --without-tiff
 make -C src -j$(nproc)
-lcmsinc=$(pwd)/include
-lcmslib=$(pwd)/src
+export LCMS2_CFLAGS="-I$(pwd)/include"
+export LCMS2_LIBS="-L$(pwd)/src -llcms2"
 popd
 
 pushd librevenge
@@ -39,16 +39,19 @@ pushd librevenge
 make -j$(nproc)
 rvnginc=$(pwd)/inc
 rvnglib=$(pwd)/src/lib
+export REVENGE_CFLAGS="-I$(pwd)/inc"
+export REVENGE_LIBS="-L$(pwd)/src/lib -lrevenge-0.0"
+export REVENGE_STREAM_CFLAGS="-I$(pwd)/inc"
+export REVENGE_STREAM_LIBS="-L$(pwd)/src/lib -lrevenge-stream-0.0"
+export REVENGE_GENERATORS_CFLAGS="-I$(pwd)/inc"
+export REVENGE_GENERATORS_LIBS="-L$(pwd)/src/lib -lrevenge-generators-0.0"
 popd
 
 pushd libmspub
 ./autogen.sh
 ./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers \
     ICU_CFLAGS="$(pkg-config --cflags icu-i18n)" \
-    ICU_LIBS="-L$staticlib $(pkg-config --libs icu-i18n)" \
-    REVENGE_CFLAGS=-I$rvnginc REVENGE_LIBS="-L$rvnglib -lrevenge-0.0" \
-    REVENGE_STREAM_CFLAGS=-I$rvnginc REVENGE_STREAM_LIBS="-L$rvnglib -lrevenge-stream-0.0" \
-    REVENGE_GENERATORS_CFLAGS=-I$rvnginc REVENGE_GENERATORS_LIBS="-L$rvnglib -lrevenge-generators-0.0"
+    ICU_LIBS="-L$staticlib $(pkg-config --libs icu-i18n)"
 make -j$(nproc)
 popd
 
@@ -56,11 +59,7 @@ pushd libcdr
 ./autogen.sh
 ./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers \
     ICU_CFLAGS="$(pkg-config --cflags icu-i18n)" \
-    ICU_LIBS="-L$staticlib $(pkg-config --libs icu-i18n)" \
-    LCMS2_CFLAGS=-I$lcmsinc LCMS2_LIBS="-L$lcmslib -llcms2" \
-    REVENGE_CFLAGS=-I$rvnginc REVENGE_LIBS="-L$rvnglib -lrevenge-0.0" \
-    REVENGE_STREAM_CFLAGS=-I$rvnginc REVENGE_STREAM_LIBS="-L$rvnglib -lrevenge-stream-0.0" \
-    REVENGE_GENERATORS_CFLAGS=-I$rvnginc REVENGE_GENERATORS_LIBS="-L$rvnglib -lrevenge-generators-0.0"
+    ICU_LIBS="-L$staticlib $(pkg-config --libs icu-i18n)"
 make -j$(nproc)
 popd
 
@@ -68,87 +67,60 @@ pushd libvisio
 ./autogen.sh
 ./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers \
     LDFLAGS=-L$staticlib \
-    LIBXML_LIBS="-lxml2 -llzma" \
-    REVENGE_CFLAGS=-I$rvnginc REVENGE_LIBS="-L$rvnglib -lrevenge-0.0" \
-    REVENGE_STREAM_CFLAGS=-I$rvnginc REVENGE_STREAM_LIBS="-L$rvnglib -lrevenge-stream-0.0" \
-    REVENGE_GENERATORS_CFLAGS=-I$rvnginc REVENGE_GENERATORS_LIBS="-L$rvnglib -lrevenge-generators-0.0"
+    LIBXML_LIBS="-lxml2 -llzma"
 make -j$(nproc)
 popd
 
 pushd libzmf
 ./autogen.sh
 ./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers \
-    LDFLAGS=-L$staticlib \
-    REVENGE_CFLAGS=-I$rvnginc REVENGE_LIBS="-L$rvnglib -lrevenge-0.0" \
-    REVENGE_STREAM_CFLAGS=-I$rvnginc REVENGE_STREAM_LIBS="-L$rvnglib -lrevenge-stream-0.0" \
-    REVENGE_GENERATORS_CFLAGS=-I$rvnginc REVENGE_GENERATORS_LIBS="-L$rvnglib -lrevenge-generators-0.0"
+    LDFLAGS=-L$staticlib
 make -j$(nproc)
 popd
 
 pushd libpagemaker
 ./autogen.sh
-./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers \
-    REVENGE_CFLAGS=-I$rvnginc REVENGE_LIBS="-L$rvnglib -lrevenge-0.0" \
-    REVENGE_STREAM_CFLAGS=-I$rvnginc REVENGE_STREAM_LIBS="-L$rvnglib -lrevenge-stream-0.0" \
-    REVENGE_GENERATORS_CFLAGS=-I$rvnginc REVENGE_GENERATORS_LIBS="-L$rvnglib -lrevenge-generators-0.0"
+./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers
 make -j$(nproc)
 popd
 
 pushd libfreehand
 ./autogen.sh
 ./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers \
-    LDFLAGS=-L$staticlib \
-    LCMS2_CFLAGS=-I$lcmsinc LCMS2_LIBS="-L$lcmslib -llcms2" \
-    REVENGE_CFLAGS=-I$rvnginc REVENGE_LIBS="-L$rvnglib -lrevenge-0.0" \
-    REVENGE_STREAM_CFLAGS=-I$rvnginc REVENGE_STREAM_LIBS="-L$rvnglib -lrevenge-stream-0.0" \
-    REVENGE_GENERATORS_CFLAGS=-I$rvnginc REVENGE_GENERATORS_LIBS="-L$rvnglib -lrevenge-generators-0.0"
+    LDFLAGS=-L$staticlib
 make -j$(nproc)
 popd
 
 pushd libwpd
 ./autogen.sh
-./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers \
-    REVENGE_CFLAGS=-I$rvnginc REVENGE_LIBS="-L$rvnglib -lrevenge-0.0" \
-    REVENGE_STREAM_CFLAGS=-I$rvnginc REVENGE_STREAM_LIBS="-L$rvnglib -lrevenge-stream-0.0" \
-    REVENGE_GENERATORS_CFLAGS=-I$rvnginc REVENGE_GENERATORS_LIBS="-L$rvnglib -lrevenge-generators-0.0"
+./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers
 make -j$(nproc)
-wpdinc=$(pwd)/inc
-wpdlib=$(pwd)/src/lib
+export WPD_CFLAGS=-I$(pwd)/inc
+export WPD_LIBS="-L$(pwd)/src/lib -lwpd-0.10"
 popd
 
 pushd libwpg
 ./autogen.sh
-./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers \
-    WPD_CFLAGS=-I$wpdinc WPD_LIBS="-L$wpdlib -lwpd-0.10" \
-    REVENGE_CFLAGS=-I$rvnginc REVENGE_LIBS="-L$rvnglib -lrevenge-0.0" \
-    REVENGE_STREAM_CFLAGS=-I$rvnginc REVENGE_STREAM_LIBS="-L$rvnglib -lrevenge-stream-0.0" \
-    REVENGE_GENERATORS_CFLAGS=-I$rvnginc REVENGE_GENERATORS_LIBS="-L$rvnglib -lrevenge-generators-0.0"
+./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers
 make -j$(nproc)
 popd
 
 pushd libstaroffice
 ./autogen.sh
-./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers \
-    REVENGE_CFLAGS=-I$rvnginc REVENGE_LIBS="-L$rvnglib -lrevenge-0.0" \
-    REVENGE_STREAM_CFLAGS=-I$rvnginc REVENGE_STREAM_LIBS="-L$rvnglib -lrevenge-stream-0.0" \
-    REVENGE_GENERATORS_CFLAGS=-I$rvnginc REVENGE_GENERATORS_LIBS="-L$rvnglib -lrevenge-generators-0.0"
+./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers
 make -j$(nproc)
 popd
 
 pushd libwps
 ./autogen.sh
-./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers \
-    REVENGE_CFLAGS=-I$rvnginc REVENGE_LIBS="-L$rvnglib -lrevenge-0.0" \
-    REVENGE_STREAM_CFLAGS=-I$rvnginc REVENGE_STREAM_LIBS="-L$rvnglib -lrevenge-stream-0.0" \
-    REVENGE_GENERATORS_CFLAGS=-I$rvnginc REVENGE_GENERATORS_LIBS="-L$rvnglib -lrevenge-generators-0.0"
+./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers
 make -j$(nproc)
 popd
 
 pushd libmwaw
 ./autogen.sh
 ./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --disable-zip --enable-fuzzers \
-    REVENGE_CFLAGS=-I$rvnginc REVENGE_LIBS="-L$rvnglib -lrevenge-0.0 -lrevenge-stream-0.0" \
-    REVENGE_GENERATORS_CFLAGS=-I$rvnginc REVENGE_GENERATORS_LIBS="-L$rvnglib -lrevenge-generators-0.0"
+    REVENGE_LIBS="$REVENGE_LIBS $REVENGE_STREAM_LIBS"
 make -C src/lib -j$(nproc)
 # Link with less parallelism to avoid memory problems on the builders
 make -j2
@@ -158,10 +130,7 @@ pushd libe-book
 ./autogen.sh
 ./configure --without-docs --disable-werror --disable-shared --enable-static --without-tools --enable-fuzzers --without-liblangtag \
     LDFLAGS=-L$staticlib \
-    XML_LIBS="-lxml2 -llzma" \
-    REVENGE_CFLAGS=-I$rvnginc REVENGE_LIBS="-L$rvnglib -lrevenge-0.0" \
-    REVENGE_STREAM_CFLAGS=-I$rvnginc REVENGE_STREAM_LIBS="-L$rvnglib -lrevenge-stream-0.0" \
-    REVENGE_GENERATORS_CFLAGS=-I$rvnginc REVENGE_GENERATORS_LIBS="-L$rvnglib -lrevenge-generators-0.0"
+    XML_LIBS="-lxml2 -llzma"
 make -j$(nproc)
 popd
 
@@ -169,10 +138,7 @@ pushd libabw
 ./autogen.sh
 ./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers \
     LDFLAGS=-L$staticlib \
-    LIBXML_LIBS="-lxml2 -llzma -licuuc -licudata" \
-    REVENGE_CFLAGS=-I$rvnginc REVENGE_LIBS="-L$rvnglib -lrevenge-0.0" \
-    REVENGE_STREAM_CFLAGS=-I$rvnginc REVENGE_STREAM_LIBS="-L$rvnglib -lrevenge-stream-0.0" \
-    REVENGE_GENERATORS_CFLAGS=-I$rvnginc REVENGE_GENERATORS_LIBS="-L$rvnglib -lrevenge-generators-0.0"
+    LIBXML_LIBS="-lxml2 -llzma -licuuc -licudata"
 make -j$(nproc)
 popd
 
@@ -181,20 +147,14 @@ pushd libetonyek
 ./configure --without-docs --disable-werror --disable-shared --enable-static \
     --without-tools --enable-fuzzers --with-mdds=0.x --without-liblangtag \
     LDFLAGS=-L$staticlib \
-    XML_LIBS="-lxml2 -llzma -licuuc -licudata" \
-    REVENGE_CFLAGS=-I$rvnginc REVENGE_LIBS="-L$rvnglib -lrevenge-0.0" \
-    REVENGE_STREAM_CFLAGS=-I$rvnginc REVENGE_STREAM_LIBS="-L$rvnglib -lrevenge-stream-0.0" \
-    REVENGE_GENERATORS_CFLAGS=-I$rvnginc REVENGE_GENERATORS_LIBS="-L$rvnglib -lrevenge-generators-0.0"
+    XML_LIBS="-lxml2 -llzma -licuuc -licudata"
 make -j$(nproc)
 popd
 
 pushd libqxp
 ./autogen.sh
 ./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers \
-    LDFLAGS=-L$staticlib \
-    REVENGE_CFLAGS=-I$rvnginc REVENGE_LIBS="-L$rvnglib -lrevenge-0.0" \
-    REVENGE_STREAM_CFLAGS=-I$rvnginc REVENGE_STREAM_LIBS="-L$rvnglib -lrevenge-stream-0.0" \
-    REVENGE_GENERATORS_CFLAGS=-I$rvnginc REVENGE_GENERATORS_LIBS="-L$rvnglib -lrevenge-generators-0.0"
+    LDFLAGS=-L$staticlib
 make -j$(nproc)
 popd
 

--- a/projects/dlplibs/build.sh
+++ b/projects/dlplibs/build.sh
@@ -33,7 +33,7 @@ popd
 
 tar -xJf $SRC/libpng-1.6.34.tar.xz
 pushd libpng-1.6.34
-./configure --disable-shared --enable-static
+./configure --disable-shared --enable-static CPPFLAGS="$ZLIB_CFLAGS" LDFLAGS="$ZLIB_LIBS"
 make -j$(nproc)
 export LIBPNG_CFLAGS="-I$(pwd)"
 export LIBPNG_LIBS="-L$(pwd) -lpng16"

--- a/projects/dlplibs/build.sh
+++ b/projects/dlplibs/build.sh
@@ -21,7 +21,6 @@ cp -pL \
     /usr/lib/*/libicu*.a \
     /usr/lib/*/libxml2.a \
     /usr/lib/*/liblzma.a \
-    /usr/lib/*/libpng*.a \
     static
 staticlib=$(pwd)/static
 
@@ -39,6 +38,14 @@ pushd lcms2-2.8
 make -C src -j$(nproc)
 export LCMS2_CFLAGS="-I$(pwd)/include"
 export LCMS2_LIBS="-L$(pwd)/src -llcms2"
+popd
+
+tar -xJf $SRC/libpng-1.6.34.tar.xz
+pushd libpng-1.6.34
+./configure --disable-shared --enable-static
+make -j$(nproc)
+export LIBPNG_CFLAGS="-I$(pwd)"
+export LIBPNG_LIBS="-L$(pwd) -lpng16"
 popd
 
 pushd librevenge

--- a/projects/dlplibs/build.sh
+++ b/projects/dlplibs/build.sh
@@ -137,8 +137,7 @@ popd
 
 pushd libmwaw
 ./autogen.sh
-./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --disable-zip --enable-fuzzers \
-    REVENGE_LIBS="$REVENGE_LIBS $REVENGE_STREAM_LIBS"
+./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --disable-zip --enable-fuzzers
 make -C src/lib -j$(nproc)
 # Link with less parallelism to avoid memory problems on the builders
 make -j2

--- a/projects/dlplibs/build.sh
+++ b/projects/dlplibs/build.sh
@@ -25,6 +25,14 @@ cp -pL \
     static
 staticlib=$(pwd)/static
 
+tar -xJf $SRC/zlib-1.2.11.tar.xz
+pushd zlib-1.2.11
+./configure --static
+make -j$(nproc)
+export ZLIB_CFLAGS="-I$(pwd)"
+export ZLIB_LIBS="-L$(pwd) -lz"
+popd
+
 tar -xzf $SRC/lcms2-2.8.tar.gz
 pushd lcms2-2.8
 ./configure --disable-shared --enable-static --without-jpeg --without-tiff

--- a/projects/dlplibs/build.sh
+++ b/projects/dlplibs/build.sh
@@ -15,13 +15,6 @@
 #
 ################################################################################
 
-# HACK to force linking with static icu
-mkdir static
-cp -pL \
-    /usr/lib/*/libicu*.a \
-    static
-staticlib=$(pwd)/static
-
 tar -xJf $SRC/zlib-1.2.11.tar.xz
 pushd zlib-1.2.11
 ./configure --static
@@ -56,6 +49,16 @@ export XML_CFLAGS="$LIBXML_CFLAGS"
 export XML_LIBS="$LIBXML_LIBS"
 popd
 
+tar -xzf $SRC/icu4c-59_1-src.tgz
+pushd icu/source
+./configure --disable-shared --enable-static --with-data-packaging=static --disable-dyload --disable-strict \
+    --disable-layout --disable-samples --disable-extras --disable-icuio --disable-plugins \
+    CPPFLAGS=-DU_USE_STRTOD_L=0
+make -j$(nproc)
+export ICU_CFLAGS="-I$(pwd) -I$(pwd)/i18n -I$(pwd)/common"
+export ICU_LIBS="-L$(pwd)/lib -licui18n -licuuc -licudata"
+popd
+
 pushd librevenge
 ./autogen.sh
 ./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tests --enable-fuzzers
@@ -72,31 +75,25 @@ popd
 
 pushd libmspub
 ./autogen.sh
-./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers \
-    ICU_CFLAGS="$(pkg-config --cflags icu-i18n)" \
-    ICU_LIBS="-L$staticlib $(pkg-config --libs icu-i18n)"
+./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers
 make -j$(nproc)
 popd
 
 pushd libcdr
 ./autogen.sh
-./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers \
-    ICU_CFLAGS="$(pkg-config --cflags icu-i18n)" \
-    ICU_LIBS="-L$staticlib $(pkg-config --libs icu-i18n)"
+./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers
 make -j$(nproc)
 popd
 
 pushd libvisio
 ./autogen.sh
-./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers \
-    LDFLAGS=-L$staticlib
+./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers
 make -j$(nproc)
 popd
 
 pushd libzmf
 ./autogen.sh
-./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers \
-    LDFLAGS=-L$staticlib
+./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers
 make -j$(nproc)
 popd
 
@@ -108,8 +105,7 @@ popd
 
 pushd libfreehand
 ./autogen.sh
-./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers \
-    LDFLAGS=-L$staticlib
+./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers
 make -j$(nproc)
 popd
 
@@ -150,30 +146,26 @@ popd
 
 pushd libe-book
 ./autogen.sh
-./configure --without-docs --disable-werror --disable-shared --enable-static --without-tools --enable-fuzzers --without-liblangtag \
-    LDFLAGS=-L$staticlib
+./configure --without-docs --disable-werror --disable-shared --enable-static --without-tools --enable-fuzzers --without-liblangtag
 make -j$(nproc)
 popd
 
 pushd libabw
 ./autogen.sh
-./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers \
-    LDFLAGS=-L$staticlib
+./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers
 make -j$(nproc)
 popd
 
 pushd libetonyek
 ./autogen.sh
 ./configure --without-docs --disable-werror --disable-shared --enable-static \
-    --without-tools --enable-fuzzers --with-mdds=0.x --without-liblangtag \
-    LDFLAGS=-L$staticlib
+    --without-tools --enable-fuzzers --with-mdds=0.x --without-liblangtag
 make -j$(nproc)
 popd
 
 pushd libqxp
 ./autogen.sh
-./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers \
-    LDFLAGS=-L$staticlib
+./configure --without-docs --disable-werror --disable-shared --enable-static --disable-tools --enable-fuzzers
 make -j$(nproc)
 popd
 


### PR DESCRIPTION
This removes false positives caused by passing data through uninstrumented system libs (mainly zlib and icu, which are used by many DLP libs). As a side effect, it should finally solve https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=1021 , as the fix for that leak should be present in recent release(s) of libxml2.