### PR TITLE
Add wxWidgets project

### DIFF
--- a/projects/wxwidgets/Dockerfile
+++ b/projects/wxwidgets/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER vadim@wxwidgets.org
+RUN apt-get update && apt-get install -y make
+RUN git clone --depth 1 https://github.com/wxWidgets/wxWidgets.git wxwidgets
+WORKDIR wxwidgets
+COPY build.sh $SRC/

--- a/projects/wxwidgets/build.sh
+++ b/projects/wxwidgets/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -eu
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# build project
+./configure --without-subdirs --disable-sys-libs --disable-gui
+make -j$(nproc) wxbase
+
+# build fuzzers
+$CXX $CXXFLAGS -o $OUT/zip ./tests/fuzz/zip.cpp \
+    -lFuzzingEngine `./wx-config --cxxflags --libs base`
+
+# and copy their corpora
+zip -j $OUT/zip_seed_corpus.zip $SRC/wxwidgets/tests/fuzz/corpus/zip/*

--- a/projects/wxwidgets/project.yaml
+++ b/projects/wxwidgets/project.yaml
@@ -1,0 +1,2 @@
+homepage: "https://www.wxwidgets.org/"
+primary_contact: "vzeitlin@gmail.com"


### PR DESCRIPTION
Add the project file and simple Dockerfile and the build script using
the fuzzer source in the main wxWidgets repository itself.

---

As discussed with @kcc at the GSoC summit on 2017-10-15, I'd like to test using this service for [wxWidgets](https://www.wxwidgets.org/), starting with a very simple fuzzer for the ZIP classes that I've just added to wxWidgets repository itself. Notice that I already found a bug in this code (an assert failure) while running the fuzzer locally, but I didn't fix it yet because I'd like to see how will the whole process work here. Please let me know if you'd prefer me to fix the bug before merging this PR.

TIA!