### PR TITLE
Use CXXFLAGS also for linking when building wxWidgets

### DIFF
--- a/projects/wxwidgets/build.sh
+++ b/projects/wxwidgets/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 # build project
-./configure --without-subdirs --disable-sys-libs --disable-gui
+./configure --without-subdirs --disable-sys-libs --disable-gui LDFLAGS="$CXXFLAGS"
 make -j$(nproc) wxbase
 
 # build fuzzers


### PR DESCRIPTION
Otherwise the correct -stdlib=libc++ option, which is part of CXXFLAGS
defined in the Docker container, is not used resulting in link errors.

---

This should fix the problem in #913, at least the commands given there now run fine for me locally. I'm not sure if we really want to always use `CXXFLAGS` for linking in wxWidgets makefiles themselves, this could result in problems and just doesn't seem quite right, so I prefer to fix this just here, at least for now.
