### PR TITLE
Build wxWidgets libraries statically

### DIFF
--- a/projects/wxwidgets/build.sh
+++ b/projects/wxwidgets/build.sh
@@ -16,8 +16,8 @@
 ################################################################################
 
 # build project
-./configure --without-subdirs --disable-sys-libs --disable-gui LDFLAGS="$CXXFLAGS"
-make -j$(nproc) wxbase
+./configure --without-subdirs --disable-shared --disable-sys-libs --disable-gui LDFLAGS="$CXXFLAGS"
+make -j$(nproc)
 
 # build fuzzers
 $CXX $CXXFLAGS -o $OUT/zip ./tests/fuzz/zip.cpp \


### PR DESCRIPTION
This ensures that the fuzzer can be ran from the output directory
without having to copy the shared libraries there too.

---

This should fix running the fuzzer, at least I can now do `./infra/helper.py shell wxwidgets` from #914 and run `/out/zip` -- and it even finds me an error, almost immediately and it's an apparently different one from the assert I had found before, so this code is even buggier than I thought (great?).