### PR TITLE
[botan] Update maintainer email to googlemail address

### DIFF
--- a/projects/botan/project.yaml
+++ b/projects/botan/project.yaml
@@ -2,7 +2,7 @@ homepage: "https://botan.randombit.net"
 primary_contact: "jack.lloyd@gmail.com"
 auto_ccs:
   - "r.korthaus@sirrix.com"
-  - "d.neus@sirrix.com"
+  - "daniel.neus@googlemail.com"
 sanitizers:
   - address
   - memory


### PR DESCRIPTION
As is Daniel only gets notification emails and can't access the clusterfuzz site (#243).