### PR TITLE
gstreamer: Add other maintainers to CC list

### DIFF
--- a/projects/gstreamer/project.yaml
+++ b/projects/gstreamer/project.yaml
@@ -2,5 +2,6 @@ homepage: "https://gstreamer.freedesktop.org/"
 primary_contact: "gstreamer-security@lists.freedesktop.org"
 auto_ccs:
  - "bilboed@bilboed.com"
-
+ - "tim@centricular.com"
+ - "slomo@coaxion.net"
 


### PR DESCRIPTION
I thought the emails sent to the security mailing lists would have provided access to those on it, but apparently not. So adding two other GStreamer maintainers to the CC list.