### PR TITLE
[cras] Add more accounts to auto_ccs

### DIFF
--- a/projects/cras/project.yaml
+++ b/projects/cras/project.yaml
@@ -3,3 +3,6 @@ primary_contact: "dgreid@chromium.org"
 auto_ccs:
   - "hychao@chromium.org"
   - "cychiang@chromium.org"
+  - "wuchengli@chromium.org"
+  - "chinyue@chromium.org"
+  - "itspeter@chromium.org"


### PR DESCRIPTION
Add more accounts to auto_ccs so team member working on
CRAS can debug test failures.