### PR TITLE
Refs #925 -- Added build for spidermonkey

### DIFF
--- a/projects/spidermonkey/Dockerfile
+++ b/projects/spidermonkey/Dockerfile
@@ -22,5 +22,5 @@ RUN apt-get update && apt-get install -y \
   yasm
 
 RUN hg clone https://hg.mozilla.org/mozilla-central/
-WORKDIR mozilla-central
+WORKDIR mozilla-central/js/src/
 COPY build.sh $SRC/

--- a/projects/spidermonkey/Dockerfile
+++ b/projects/spidermonkey/Dockerfile
@@ -20,6 +20,6 @@ RUN apt-get update && apt-get install -y \
   autoconf2.13 \
   yasm
 
-RUN git clone --depth=1 https://github.com/mozilla/gecko-dev
+RUN git clone --depth=1 https://github.com/mozilla/gecko-dev mozilla-central
 WORKDIR mozilla-central/js/src/
 COPY build.sh $SRC/

--- a/projects/spidermonkey/Dockerfile
+++ b/projects/spidermonkey/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER agaynor@mozilla.com
+RUN apt-get update && apt-get install -y \
+  mercurial \
+  autoconf2.13 \
+  yasm
+
+RUN hg clone https://hg.mozilla.org/mozilla-central/
+WORKDIR mozilla-central
+COPY build.sh $SRC/

--- a/projects/spidermonkey/Dockerfile
+++ b/projects/spidermonkey/Dockerfile
@@ -17,10 +17,9 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER agaynor@mozilla.com
 RUN apt-get update && apt-get install -y \
-  mercurial \
   autoconf2.13 \
   yasm
 
-RUN hg clone https://hg.mozilla.org/mozilla-central/
+RUN git clone --depth=1 https://github.com/mozilla/gecko-dev
 WORKDIR mozilla-central/js/src/
 COPY build.sh $SRC/

--- a/projects/spidermonkey/build.sh
+++ b/projects/spidermonkey/build.sh
@@ -17,7 +17,6 @@
 
 # Required for some reason... I don't ask questions
 export SHELL=/bin/bash
-cd js/src/
 
 autoconf2.13
 
@@ -26,7 +25,6 @@ cd build_DBG.OBJ
 
 ../configure \
     --enable-debug \
-    --disable-optimize \
     --disable-shared-js \
     --disable-jemalloc \
     --enable-address-sanitizer

--- a/projects/spidermonkey/build.sh
+++ b/projects/spidermonkey/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -eu
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Required for some reason... I don't ask questions
+export SHELL=/bin/bash
+cd js/src/
+
+autoconf2.13
+
+mkdir build_DBG.OBJ
+cd build_DBG.OBJ
+
+../configure \
+    --enable-debug \
+    --disable-optimize \
+    --disable-shared-js \
+    --disable-jemalloc \
+    --enable-address-sanitizer
+
+make
+
+cp dist/bin/js $OUT

--- a/projects/spidermonkey/project.yaml
+++ b/projects/spidermonkey/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey"
+primary_contact: "agaynor@mozilla.com"
+fuzzing_engines:
+  - none
+sanitizers:
+  - address


### PR DESCRIPTION
Note that I'm neither on the Firefox JS team nor on the fuzzing team (I work on sandboxing :-)), but this seemed interesting.

Modeled after the Chakra integration -- I have no way of testing besides that `$OUT/js` works, since I don't know how your fuzzer works.