### PR TITLE
Install python into the spidermonkey build env

### DIFF
--- a/projects/spidermonkey/Dockerfile
+++ b/projects/spidermonkey/Dockerfile
@@ -18,7 +18,8 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER agaynor@mozilla.com
 RUN apt-get update && apt-get install -y \
   autoconf2.13 \
-  yasm
+  yasm \
+  python
 
 RUN git clone --depth=1 https://github.com/mozilla/gecko-dev mozilla-central
 WORKDIR mozilla-central/js/src/


### PR DESCRIPTION
I didn't notice this earlier because it exists in the `shell` environment.