### PR TITLE
Include submodules in wxWidgets checkout

### DIFF
--- a/projects/wxwidgets/Dockerfile
+++ b/projects/wxwidgets/Dockerfile
@@ -17,6 +17,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER vadim@wxwidgets.org
 RUN apt-get update && apt-get install -y make
-RUN git clone --depth 1 https://github.com/wxWidgets/wxWidgets.git wxwidgets
+RUN git clone --recurse-submodules --depth 1 https://github.com/wxWidgets/wxWidgets.git wxwidgets
 WORKDIR wxwidgets
 COPY build.sh $SRC/


### PR DESCRIPTION
Third party libraries are now submodules and not subdirectories, so
clone them too.

---

This should fix the build, see #980.