### PR TITLE
use new ChakraCoreEng@microsoft.com email address

### DIFF
--- a/projects/chakra/project.yaml
+++ b/projects/chakra/project.yaml
@@ -1,5 +1,5 @@
 homepage: "https://github.com/Microsoft/ChakraCore"
-primary_contact: "ChakraCore@microsoft.com"
+primary_contact: "ChakraCoreEng@microsoft.com"
 fuzzing_engines:
   - none
 sanitizers:


### PR DESCRIPTION
use ChakraCoreEng@ms.com instead of ChakraCore@ms.com which folks use for social media comms.