### PR TITLE
[gRPC] Compile fuzzers with Clang++

### DIFF
--- a/projects/grpc/build.sh
+++ b/projects/grpc/build.sh
@@ -62,12 +62,9 @@ CXXFLAGS="${CXXFLAGS} -Iinclude -I. -stdlib=libc++"
 
 for file in $FUZZER_FILES; do
   fuzzer_name=$(basename $file .cc)
-  fuzzer_object="${file::-1}o"
   echo "Building fuzzer $fuzzer_name"
-  $CC $CFLAGS \
-    $file -c -o $fuzzer_object 
   $CXX $CXXFLAGS \
-    $fuzzer_object -o $OUT/$fuzzer_name \
+    $file -o $OUT/$fuzzer_name \
     -lFuzzingEngine ${FUZZER_LIBRARIES}
 done
 


### PR DESCRIPTION
Fixes #991 

Just verifying something: being able to successfully run `./infra/helper.py build_fuzzers grpc` means this should be fixed, right?