### PR TITLE
Clean Shell Scripts

### DIFF
--- a/infra/base-images/all.sh
+++ b/infra/base-images/all.sh
@@ -15,8 +15,8 @@
 #
 ################################################################################
 
-docker build --pull -t gcr.io/oss-fuzz-base/base-image $@ infra/base-images/base-image
-docker build -t gcr.io/oss-fuzz-base/base-clang $@ infra/base-images/base-clang
-docker build -t gcr.io/oss-fuzz-base/base-builder -t gcr.io/oss-fuzz/base-libfuzzer $@ infra/base-images/base-builder
-docker build -t gcr.io/oss-fuzz-base/base-runner $@ infra/base-images/base-runner
-docker build -t gcr.io/oss-fuzz-base/base-runner-debug $@ infra/base-images/base-runner-debug
+docker build --pull -t gcr.io/oss-fuzz-base/base-image "$@" infra/base-images/base-image
+docker build -t gcr.io/oss-fuzz-base/base-clang "$@" infra/base-images/base-clang
+docker build -t gcr.io/oss-fuzz-base/base-builder -t gcr.io/oss-fuzz/base-libfuzzer "$@" infra/base-images/base-builder
+docker build -t gcr.io/oss-fuzz-base/base-runner "$@" infra/base-images/base-runner
+docker build -t gcr.io/oss-fuzz-base/base-runner-debug "$@" infra/base-images/base-runner-debug

--- a/projects/dropbear/build.sh
+++ b/projects/dropbear/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/projects/tinyxml2/build.sh
+++ b/projects/tinyxml2/build.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/projects/woff2/build.sh
+++ b/projects/woff2/build.sh
@@ -27,7 +27,7 @@ make -j$(nproc) CC="$CC $CFLAGS" CXX="$CXX $CXXFLAGS" CANONICAL_PREFIXES= all \
   NOISY_LOGGING=
 
 # Build fuzzers
-for fuzzer_archive in $(ls src/*fuzzer*.a); do
+for fuzzer_archive in src/*fuzzer*.a; do
   fuzzer_name=$(basename ${fuzzer_archive%.a})
   $CXX $CXXFLAGS -lFuzzingEngine $fuzzer_archive \
       -o $OUT/$fuzzer_name


### PR DESCRIPTION
Double quote array expansions, otherwise they're like `$*` and break on spaces.

In POSIX sh, `pushd` is not supported.
In POSIX sh, `popd` is not supported.

Iterating over `ls` output is fragile. Use globs.

Add shebang