### PR TITLE
[wireshark] disable bulding fuzzshark

### DIFF
--- a/projects/wireshark/build.sh
+++ b/projects/wireshark/build.sh
@@ -35,7 +35,7 @@ CONFOPTS="$CONFOPTS --without-pcap --without-ssl --without-gnutls"
 CONFOPTS="$CONFOPTS --disable-wireshark --disable-tshark --disable-sharkd \
              --disable-dumpcap --disable-capinfos --disable-captype --disable-randpkt --disable-dftest \
              --disable-editcap --disable-mergecap --disable-reordercap --disable-text2pcap \
-             --without-extcap \
+             --without-extcap --disable-fuzzshark \
          "
 
 # Fortify and asan don't like each other ... :(


### PR DESCRIPTION
I added auto-building fuzzshark to wireshark, to avoid oss-fuzz build being broken,
but it actually broke the build:

Step #3:   CC       tools/oss-fuzzshark/fuzzshark-fuzzshark.o
Step #3:   CC       tools/oss-fuzzshark/fuzzshark-StandaloneFuzzTargetMain.o
Step #3:   CCLD     fuzzshark
Step #3: /usr/bin/ld: epan/.libs/libwireshark.a(packet-ipsec.o): undefined reference to symbol 'gpg_strerror@@GPG_ERROR_1.0'
Step #3: //lib/x86_64-linux-gnu/libgpg-error.so.0: error adding symbols: DSO missing from command line
Step #3: clang-6.0: error: linker command failed with exit code 1 (use -v to see invocation)
Step #3: Makefile:1821: recipe for target 'fuzzshark' failed