### PR TITLE
Added a fuzzer for clamav

### DIFF
--- a/projects/clamav/Dockerfile
+++ b/projects/clamav/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER alex.gaynor@gmail.com
+RUN apt-get update && apt-get install -y libssl-dev
+RUN git clone --depth 1 https://github.com/vrtadmin/clamav-devel
+WORKDIR clamav-devel
+COPY build.sh clamav_scanfile_fuzzer.cc $SRC/

--- a/projects/clamav/Dockerfile
+++ b/projects/clamav/Dockerfile
@@ -17,6 +17,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER alex.gaynor@gmail.com
 RUN apt-get update && apt-get install -y libssl-dev
-RUN git clone --depth 1 https://github.com/vrtadmin/clamav-devel
+RUN git clone --depth 1 https://github.com/Cisco-Talos/clamav-devel
 WORKDIR clamav-devel
 COPY build.sh clamav_scanfile_fuzzer.cc $SRC/

--- a/projects/clamav/build.sh
+++ b/projects/clamav/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -eu
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+./configure --enable-static=yes --enable-shared=no
+make -j"$(nproc)"
+
+$CXX $CXXFLAGS -std=c++11 -Ilibclamav/ \
+    $SRC/clamav_scanfile_fuzzer.cc -o $OUT/clamav_scanfile_fuzzer \
+    -lFuzzingEngine libclamav/.libs/libclamav.a \
+    -Wl,-Bstatic -lssl -lcrypto -lz -Wl,-Bdynamic

--- a/projects/clamav/build.sh
+++ b/projects/clamav/build.sh
@@ -24,7 +24,7 @@ $CXX $CXXFLAGS -std=c++11 -Ilibclamav/ \
     libclamav/libmspack-0.5alpha/.libs/libclammspack.a \
     -Wl,-Bstatic -lssl -lcrypto -lz -Wl,-Bdynamic -ldl
 
-for type in ARCHIVE MAIL OLE2 PDF HTML PE ALGORITHMIC ELF SWF XMLDOCS HWP3; do
+for type in ARCHIVE MAIL OLE2 PDF HTML PE ELF SWF XMLDOCS HWP3; do
     $CXX $CXXFLAGS -std=c++11 -Ilibclamav/ \
         $SRC/clamav_scanfile_fuzzer.cc \
         -o "${OUT}/clamav_scanfile_${type}_fuzzer" "-DCLAMAV_FUZZ_${type}" \

--- a/projects/clamav/build.sh
+++ b/projects/clamav/build.sh
@@ -19,16 +19,16 @@
 make -j"$(nproc)"
 
 $CXX $CXXFLAGS -std=c++11 -Ilibclamav/ \
-    $SRC/clamav_scanfile_fuzzer.cc -o $OUT/clamav_scanfile_fuzzer \
+    "$SRC/clamav_scanfile_fuzzer.cc" -o "$OUT/clamav_scanfile_fuzzer" \
     -lFuzzingEngine libclamav/.libs/libclamav.a \
-    libclamav/libmspack-0.5alpha/.libs/libclammspack.a \
+    libclamav/.libs/libclammspack.a \
     -Wl,-Bstatic -lssl -lcrypto -lz -Wl,-Bdynamic -ldl
 
 for type in ARCHIVE MAIL OLE2 PDF HTML PE ELF SWF XMLDOCS HWP3; do
     $CXX $CXXFLAGS -std=c++11 -Ilibclamav/ \
-        $SRC/clamav_scanfile_fuzzer.cc \
+        "$SRC/clamav_scanfile_fuzzer.cc" \
         -o "${OUT}/clamav_scanfile_${type}_fuzzer" "-DCLAMAV_FUZZ_${type}" \
         -lFuzzingEngine libclamav/.libs/libclamav.a \
-        libclamav/libmspack-0.5alpha/.libs/libclammspack.a \
+        libclamav/.libs/libclammspack.a \
         -Wl,-Bstatic -lssl -lcrypto -lz -Wl,-Bdynamic -ldl
 done

--- a/projects/clamav/build.sh
+++ b/projects/clamav/build.sh
@@ -22,3 +22,11 @@ $CXX $CXXFLAGS -std=c++11 -Ilibclamav/ \
     $SRC/clamav_scanfile_fuzzer.cc -o $OUT/clamav_scanfile_fuzzer \
     -lFuzzingEngine libclamav/.libs/libclamav.a \
     -Wl,-Bstatic -lssl -lcrypto -lz -Wl,-Bdynamic
+
+for type in ARCHIVE MAIL OLE2 PDF HTML PE ALGORITHMIC ELF SWF XMLDOCS HWP3; do
+    $CXX $CXXFLAGS -std=c++11 -Ilibclamav/ \
+        $SRC/clamav_scanfile_fuzzer.cc \
+        -o "${OUT}/clamav_scanfile_${type}_fuzzer" "-DCLAMAV_FUZZ_${type}" \
+        -lFuzzingEngine libclamav/.libs/libclamav.a \
+        -Wl,-Bstatic -lssl -lcrypto -lz -Wl,-Bdynamic
+done

--- a/projects/clamav/build.sh
+++ b/projects/clamav/build.sh
@@ -21,6 +21,7 @@ make -j"$(nproc)"
 $CXX $CXXFLAGS -std=c++11 -Ilibclamav/ \
     $SRC/clamav_scanfile_fuzzer.cc -o $OUT/clamav_scanfile_fuzzer \
     -lFuzzingEngine libclamav/.libs/libclamav.a \
+    libclamav/libmspack-0.5alpha/.libs/libclammspack.a \
     -Wl,-Bstatic -lssl -lcrypto -lz -Wl,-Bdynamic
 
 for type in ARCHIVE MAIL OLE2 PDF HTML PE ALGORITHMIC ELF SWF XMLDOCS HWP3; do
@@ -28,5 +29,6 @@ for type in ARCHIVE MAIL OLE2 PDF HTML PE ALGORITHMIC ELF SWF XMLDOCS HWP3; do
         $SRC/clamav_scanfile_fuzzer.cc \
         -o "${OUT}/clamav_scanfile_${type}_fuzzer" "-DCLAMAV_FUZZ_${type}" \
         -lFuzzingEngine libclamav/.libs/libclamav.a \
+        libclamav/libmspack-0.5alpha/.libs/libclammspack.a \
         -Wl,-Bstatic -lssl -lcrypto -lz -Wl,-Bdynamic
 done

--- a/projects/clamav/build.sh
+++ b/projects/clamav/build.sh
@@ -22,7 +22,7 @@ $CXX $CXXFLAGS -std=c++11 -Ilibclamav/ \
     $SRC/clamav_scanfile_fuzzer.cc -o $OUT/clamav_scanfile_fuzzer \
     -lFuzzingEngine libclamav/.libs/libclamav.a \
     libclamav/libmspack-0.5alpha/.libs/libclammspack.a \
-    -Wl,-Bstatic -lssl -lcrypto -lz -Wl,-Bdynamic
+    -Wl,-Bstatic -lssl -lcrypto -lz -Wl,-Bdynamic -ldl
 
 for type in ARCHIVE MAIL OLE2 PDF HTML PE ALGORITHMIC ELF SWF XMLDOCS HWP3; do
     $CXX $CXXFLAGS -std=c++11 -Ilibclamav/ \
@@ -30,5 +30,5 @@ for type in ARCHIVE MAIL OLE2 PDF HTML PE ALGORITHMIC ELF SWF XMLDOCS HWP3; do
         -o "${OUT}/clamav_scanfile_${type}_fuzzer" "-DCLAMAV_FUZZ_${type}" \
         -lFuzzingEngine libclamav/.libs/libclamav.a \
         libclamav/libmspack-0.5alpha/.libs/libclammspack.a \
-        -Wl,-Bstatic -lssl -lcrypto -lz -Wl,-Bdynamic
+        -Wl,-Bstatic -lssl -lcrypto -lz -Wl,-Bdynamic -ldl
 done

--- a/projects/clamav/clamav_scanfile_fuzzer.cc
+++ b/projects/clamav/clamav_scanfile_fuzzer.cc
@@ -1,0 +1,70 @@
+/*
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+*/
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <memory>
+
+#include <clamav.h>
+
+
+void clamav_message_callback(enum cl_msg severity, const char *fullmsg,
+                             const char *msg, void *context) {
+}
+
+class ClamAVState {
+public:
+    ClamAVState() {
+        // Silence all the log messages, none of them are meaningful.
+        cl_set_clcb_msg(clamav_message_callback);
+
+        cl_init(CL_INIT_DEFAULT);
+        engine = cl_engine_new();
+        cl_engine_compile(engine);
+    }
+
+    ~ClamAVState() {
+        cl_engine_free(engine);
+    }
+
+    struct cl_engine *engine;
+};
+
+// Global with static initializer to setup an engine so we don't need to do
+// that on each execution.
+ClamAVState kClamAVState;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    cl_fmap_t *clamav_data = cl_fmap_open_memory(data, size);
+
+    const char *virus_name = nullptr;
+    unsigned long scanned = 0;
+    cl_scanmap_callback(
+        clamav_data,
+        &virus_name,
+        &scanned,
+        kClamAVState.engine,
+        CL_SCAN_STDOPT,
+        nullptr
+    );
+
+    cl_fmap_close(clamav_data);
+
+    return 0;
+}

--- a/projects/clamav/clamav_scanfile_fuzzer.cc
+++ b/projects/clamav/clamav_scanfile_fuzzer.cc
@@ -53,6 +53,33 @@ ClamAVState kClamAVState;
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     cl_fmap_t *clamav_data = cl_fmap_open_memory(data, size);
 
+    unsigned int scanopt =
+#if defined(CLAMAV_FUZZ_ARCHIVE)
+        CL_SCAN_ARCHIVE;
+#elif defined(CLAMAV_FUZZ_MAIL)
+        CL_SCAN_MAIL;
+#elif defined(CLAMAV_FUZZ_OLE2)
+        CL_SCAN_OLE2;
+#elif defined(CLAMAV_FUZZ_PDF)
+        CL_SCAN_PDF;
+#elif defined(CLAMAV_FUZZ_HTML)
+        CL_SCAN_HTML;
+#elif defined(CLAMAV_FUZZ_PE)
+        CL_SCAN_PE;
+#elif defined(CLAMAV_FUZZ_ALGORITHMIC)
+        CL_SCAN_ALGORITHMIC;
+#elif defined(CLAMAV_FUZZ_ELF)
+        CL_SCAN_ELF;
+#elif defined(CLAMAV_FUZZ_SWF)
+        CL_SCAN_SWF;
+#elif defined(CLAMAV_FUZZ_XMLDOCS)
+        CL_SCAN_XMLDOCS;
+#elif defined(CLAMAV_FUZZ_HWP3)
+        CL_SCAN_HWP3;
+#else
+        CL_SCAN_STDOPT;
+#endif
+
     const char *virus_name = nullptr;
     unsigned long scanned = 0;
     cl_scanmap_callback(
@@ -60,7 +87,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
         &virus_name,
         &scanned,
         kClamAVState.engine,
-        CL_SCAN_STDOPT,
+        scanopt,
         nullptr
     );
 

--- a/projects/clamav/clamav_scanfile_fuzzer.cc
+++ b/projects/clamav/clamav_scanfile_fuzzer.cc
@@ -53,32 +53,32 @@ ClamAVState kClamAVState;
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     cl_fmap_t *clamav_data = cl_fmap_open_memory(data, size);
 
-    unsigned int scanopt =
+    unsigned int parseopt =
 #if defined(CLAMAV_FUZZ_ARCHIVE)
-        CL_SCAN_ARCHIVE;
+        CL_SCAN_PARSE_ARCHIVE;
 #elif defined(CLAMAV_FUZZ_MAIL)
-        CL_SCAN_MAIL;
+        CL_SCAN_PARSE_MAIL;
 #elif defined(CLAMAV_FUZZ_OLE2)
-        CL_SCAN_OLE2;
+        CL_SCAN_PARSE_OLE2;
 #elif defined(CLAMAV_FUZZ_PDF)
-        CL_SCAN_PDF;
+        CL_SCAN_PARSE_PDF;
 #elif defined(CLAMAV_FUZZ_HTML)
-        CL_SCAN_HTML;
+        CL_SCAN_PARSE_HTML;
 #elif defined(CLAMAV_FUZZ_PE)
-        CL_SCAN_PE;
-#elif defined(CLAMAV_FUZZ_ALGORITHMIC)
-        CL_SCAN_ALGORITHMIC;
+        CL_SCAN_PARSE_PE;
 #elif defined(CLAMAV_FUZZ_ELF)
-        CL_SCAN_ELF;
+        CL_SCAN_PARSE_ELF;
 #elif defined(CLAMAV_FUZZ_SWF)
-        CL_SCAN_SWF;
+        CL_SCAN_PARSE_SWF;
 #elif defined(CLAMAV_FUZZ_XMLDOCS)
-        CL_SCAN_XMLDOCS;
+        CL_SCAN_PARSE_XMLDOCS;
 #elif defined(CLAMAV_FUZZ_HWP3)
-        CL_SCAN_HWP3;
+        CL_SCAN_PARSE_HWP3;
 #else
-        CL_SCAN_STDOPT;
+        ~0;
 #endif
+    struct cl_scan_options options = {0};
+    options.parse = parseopt;
 
     const char *virus_name = nullptr;
     unsigned long scanned = 0;
@@ -87,7 +87,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
         &virus_name,
         &scanned,
         kClamAVState.engine,
-        scanopt,
+        &options,
         nullptr
     );
 

--- a/projects/clamav/clamav_scanfile_fuzzer.cc
+++ b/projects/clamav/clamav_scanfile_fuzzer.cc
@@ -84,6 +84,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     unsigned long scanned = 0;
     cl_scanmap_callback(
         clamav_data,
+        nullptr,
         &virus_name,
         &scanned,
         kClamAVState.engine,

--- a/projects/clamav/project.yaml
+++ b/projects/clamav/project.yaml
@@ -1,0 +1,4 @@
+homepage: "https://www.clamav.net/>"
+primary_contact: "<primary_contact_email>"
+auto_ccs:
+    - alex.gaynor@gmail.com

--- a/projects/clamav/project.yaml
+++ b/projects/clamav/project.yaml
@@ -1,4 +1,4 @@
-homepage: "https://www.clamav.net/>"
+homepage: "https://www.clamav.net/"
 primary_contact: "<primary_contact_email>"
 auto_ccs:
     - alex.gaynor@gmail.com


### PR DESCRIPTION
Refs #402

One interesting thing about this fuzzer is that I think the most sensible way to fuzz it would be to have multiple distinct corpuses, potentially one per file format it can parse, even though they'll all share the same fuzzer source. Does that make sense to folks? If yes, should I just make a few copies of the binary in `$OUT` with different names and do that?

CCing @micah-at-talos who appears to be one of the ClamAV devs (Hi! I'm not involved in ClamAV itself, but it was an interesting target to fuzz.) It's be great to get the fuzzer source included in the ClamAV upstream.