### PR TITLE
[mupdf] Add mupdf fuzzer

### DIFF
--- a/projects/mupdf/Dockerfile
+++ b/projects/mupdf/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER jonathan@titanous.com
+RUN apt-get update && apt-get install -y make libtool pkg-config
+RUN git clone --recursive --depth 1 git://git.ghostscript.com/mupdf.git mupdf
+RUN git clone --depth 1 https://github.com/mozilla/pdf.js pdf.js && \
+    zip -q $SRC/pdf_fuzzer_seed_corpus.zip pdf.js/test/pdfs/*.pdf && \
+    rm -rf pdf.js
+ADD https://raw.githubusercontent.com/rc0r/afl-fuzz/master/dictionaries/pdf.dict $SRC/pdf_fuzzer.dict
+WORKDIR mupdf
+COPY *.cc source/fuzz/
+COPY build.sh $SRC/

--- a/projects/mupdf/Dockerfile
+++ b/projects/mupdf/Dockerfile
@@ -24,4 +24,4 @@ RUN git clone --depth 1 https://github.com/mozilla/pdf.js pdf.js && \
 ADD https://raw.githubusercontent.com/rc0r/afl-fuzz/master/dictionaries/pdf.dict $SRC/pdf_fuzzer.dict
 WORKDIR mupdf
 COPY *.cc source/fuzz/
-COPY build.sh $SRC/
+COPY build.sh *.options $SRC/

--- a/projects/mupdf/build.sh
+++ b/projects/mupdf/build.sh
@@ -22,7 +22,7 @@ $CXX $CXXFLAGS -std=c++11 -Iinclude \
     source/fuzz/pdf_fuzzer.cc -o $OUT/$fuzz_target \
     -lFuzzingEngine $WORK/libmupdf.a $WORK/libmupdfthird.a
 
-mv $SRC/*.zip $SRC/*.dict $OUT
+mv $SRC/{*.zip,*.dict,*.options} $OUT
 
 if [ ! -f "${OUT}/${fuzz_target}_seed_corpus.zip" ]; then
   echo "missing seed corpus"
@@ -31,5 +31,10 @@ fi
 
 if [ ! -f "${OUT}/${fuzz_target}.dict" ]; then
   echo "missing dictionary"
+  exit 1
+fi
+
+if [ ! -f "${OUT}/${fuzz_target}.options" ]; then
+  echo "missing options"
   exit 1
 fi

--- a/projects/mupdf/build.sh
+++ b/projects/mupdf/build.sh
@@ -15,12 +15,9 @@
 #
 ################################################################################
 
-rm -rf thirdparty/freeglut
-
 LDFLAGS="$CXXFLAGS" make -j$(nproc) HAVE_GLUT=no build=debug OUT=$WORK
 
-$CXX $CXXFLAGS -std=c++11 \
-    -Iinclude \
+$CXX $CXXFLAGS -std=c++11 -Iinclude \
     source/fuzz/pdf_fuzzer.cc -o $OUT/pdf_fuzzer \
     -lFuzzingEngine $WORK/libmupdf.a $WORK/libmupdfthird.a
 

--- a/projects/mupdf/build.sh
+++ b/projects/mupdf/build.sh
@@ -16,9 +16,20 @@
 ################################################################################
 
 LDFLAGS="$CXXFLAGS" make -j$(nproc) HAVE_GLUT=no build=debug OUT=$WORK
+fuzz_target=pdf_fuzzer
 
 $CXX $CXXFLAGS -std=c++11 -Iinclude \
-    source/fuzz/pdf_fuzzer.cc -o $OUT/pdf_fuzzer \
+    source/fuzz/pdf_fuzzer.cc -o $OUT/$fuzz_target \
     -lFuzzingEngine $WORK/libmupdf.a $WORK/libmupdfthird.a
 
 mv $SRC/*.zip $SRC/*.dict $OUT
+
+if [ ! -f "${OUT}/${fuzz_target}_seed_corpus.zip" ]; then
+  echo "missing seed corpus"
+  exit 1
+fi
+
+if [ ! -f "${OUT}/${fuzz_target}.dict" ]; then
+  echo "missing dictionary"
+  exit 1
+fi

--- a/projects/mupdf/build.sh
+++ b/projects/mupdf/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -eu
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+rm -rf thirdparty/freeglut
+
+LDFLAGS="$CXXFLAGS" make -j$(nproc) HAVE_GLUT=no build=debug OUT=$WORK
+
+$CXX $CXXFLAGS -std=c++11 \
+    -Iinclude \
+    source/fuzz/pdf_fuzzer.cc -o $OUT/pdf_fuzzer \
+    -lFuzzingEngine $WORK/libmupdf.a $WORK/libmupdfthird.a
+
+mv $SRC/*.zip $SRC/*.dict $OUT

--- a/projects/mupdf/pdf_fuzzer.cc
+++ b/projects/mupdf/pdf_fuzzer.cc
@@ -19,7 +19,6 @@
 #include <cstdint>
 
 #include <mupdf/fitz.h>
-#include <mupdf/pdf.h>
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   fz_context *ctx = fz_new_context(nullptr, nullptr, FZ_STORE_DEFAULT);
@@ -28,12 +27,12 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   fz_matrix ctm;
   fz_pixmap *pix;
   fz_try(ctx) {
-    pdf_document *doc = pdf_open_document_with_stream(ctx, stream);
-    for (int i = 0; i < pdf_count_pages(ctx, doc); i++) {
-      pix = fz_new_pixmap_from_page_number(ctx, &doc->super, i, &ctm, fz_device_rgb(ctx), 1);
+    fz_document *doc = fz_open_document_with_stream(ctx, "pdf", stream);
+    for (int i = 0; i < fz_count_pages(ctx, doc); i++) {
+      pix = fz_new_pixmap_from_page_number(ctx, doc, i, &ctm, fz_device_rgb(ctx), 0);
       fz_drop_pixmap(ctx, pix);
     }
-    pdf_drop_document(ctx, doc);
+    fz_drop_document(ctx, doc);
   }
   fz_catch(ctx) {}
 

--- a/projects/mupdf/pdf_fuzzer.cc
+++ b/projects/mupdf/pdf_fuzzer.cc
@@ -1,0 +1,44 @@
+/*
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+*/
+
+#include <cstdint>
+
+#include <mupdf/fitz.h>
+#include <mupdf/pdf.h>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  fz_context *ctx = fz_new_context(nullptr, nullptr, FZ_STORE_DEFAULT);
+
+  fz_stream *stream = fz_open_memory(ctx, data, size);
+  fz_matrix ctm;
+  fz_pixmap *pix;
+  fz_try(ctx) {
+    pdf_document *doc = pdf_open_document_with_stream(ctx, stream);
+    for (int i = 0; i < fz_count_pages(ctx, &doc->super); i++) {
+      pix = fz_new_pixmap_from_page_number(ctx, &doc->super, i, &ctm, fz_device_rgb(ctx), 1);
+      fz_drop_pixmap(ctx, pix);
+    }
+    pdf_drop_document(ctx, doc);
+  }
+  fz_catch(ctx) {}
+
+  fz_drop_stream(ctx, stream);
+  fz_drop_context(ctx);
+
+  return 0;
+}

--- a/projects/mupdf/pdf_fuzzer.cc
+++ b/projects/mupdf/pdf_fuzzer.cc
@@ -29,7 +29,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   fz_pixmap *pix;
   fz_try(ctx) {
     pdf_document *doc = pdf_open_document_with_stream(ctx, stream);
-    for (int i = 0; i < fz_count_pages(ctx, &doc->super); i++) {
+    for (int i = 0; i < pdf_count_pages(ctx, doc); i++) {
       pix = fz_new_pixmap_from_page_number(ctx, &doc->super, i, &ctm, fz_device_rgb(ctx), 1);
       fz_drop_pixmap(ctx, pix);
     }

--- a/projects/mupdf/pdf_fuzzer.options
+++ b/projects/mupdf/pdf_fuzzer.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+close_fd_mask = 3

--- a/projects/mupdf/project.yaml
+++ b/projects/mupdf/project.yaml
@@ -1,5 +1,5 @@
 homepage: "https://www.mupdf.com"
-primary_contact: "<primary_contact_email>"
+primary_contact: tor.andersson@artifex.com
 sanitizers:
   - address
   - undefined

--- a/projects/mupdf/project.yaml
+++ b/projects/mupdf/project.yaml
@@ -1,0 +1,4 @@
+homepage: "https://www.mupdf.com"
+primary_contact: "<primary_contact_email>"
+auto_ccs:
+  - jonathan@titanous.com

--- a/projects/mupdf/project.yaml
+++ b/projects/mupdf/project.yaml
@@ -1,4 +1,8 @@
 homepage: "https://www.mupdf.com"
 primary_contact: "<primary_contact_email>"
+sanitizers:
+  - address
+  - undefined
+  - memory
 auto_ccs:
   - jonathan@titanous.com


### PR DESCRIPTION
mupdf was recently added as a dependency to the upcoming Ruby on Rails 5.2 for [PDF preview generation](https://github.com/rails/rails/blob/c09ebcf4a9d708de05025f669c4e6f018c0b3be5/activestorage/lib/active_storage/previewer/pdf_previewer.rb#L19).

CCing @ccxvii who appears to be a mupdf maintainer :wave:

If this looks okay, hopefully we can get the fuzzer included upstream and add more for other formats.