### PR TITLE
[knot-dns] don't specify coverage flags for oss-fuzz builds

### DIFF
--- a/projects/knot-dns/build.sh
+++ b/projects/knot-dns/build.sh
@@ -62,7 +62,8 @@ make install
 cd $SRC/knot-dns
 autoreconf -if
 
-./configure --with-oss-fuzz=yes --disable-shared --enable-static --with-sanitize-fuzzer  --disable-daemon --disable-utilities --disable-documentation --disable-fastparser --with-module-dnsproxy=no --with-module-noudp=no --with-module-onlinesign=no --with-module-rrl=no --with-module-stats=no --with-module-synthrecord=no --with-module-whoami=no
+./configure --with-oss-fuzz=yes --disable-shared --enable-static --disable-daemon --disable-utilities --disable-documentation --disable-fastparser --with-module-dnsproxy=no --with-module-noudp=no --with-module-onlinesign=no --with-module-rrl=no --with-module-stats=no --with-module-synthrecord=no --with-module-whoami=no
+
 make -j$(nproc)
 cd $SRC/knot-dns/tests-fuzz
 make check


### PR DESCRIPTION
The knot-dns build script was errantly specifying `-fsanitize=fuzzer-no-link` for all builds, which was causing coverage builds to fail (since this flag is not compatible with `-fsanitize-coverage=` flags). This removes any `-fsanitize=fuzzer*` directives for oss-fuzz builds.

I tested this locally and it appears to address https://github.com/google/oss-fuzz/issues/1070