### PR TITLE
[llvm-opt-fuzzer] Set max_len to 0

### DIFF
--- a/projects/llvm/build.sh
+++ b/projects/llvm/build.sh
@@ -93,7 +93,7 @@ function build_corpus {
 
   rm -r "${WORK}/corpus-tmp"
 
-  echo -e "[libfuzzer]\n max_len = 0" > "${OUT}"/"${fuzzer_name}".options
+  echo -e "[libfuzzer]\nmax_len = 0" > "${OUT}"/"${fuzzer_name}".options
 }
 
 build_corpus "llvm/test/Transforms/InstCombine/" "llvm-opt-fuzzer--x86_64-instcombine"

--- a/projects/llvm/build.sh
+++ b/projects/llvm/build.sh
@@ -92,6 +92,8 @@ function build_corpus {
   zip -j "${OUT}/${fuzzer_name}_seed_corpus.zip"  "${WORK}"/corpus-tmp/*
 
   rm -r "${WORK}/corpus-tmp"
+
+  echo -e "[libfuzzer]\n max_len = 0" > "${OUT}"/"${fuzzer_name}".options
 }
 
 build_corpus "llvm/test/Transforms/InstCombine/" "llvm-opt-fuzzer--x86_64-instcombine"


### PR DESCRIPTION
There is no much sense in having random max_len for the llvm-opt-fuzzer. It causes two different problems:
- Runs with the small max_len don't produce any useful coverage.
- We truncate corpus files producing invalid inputs. This uncovers obscure bugs in the llvm bitcode reader. Even though they are valid bugs, I think it's better if we concentrate on the actual fuzzing target.
