### PR TITLE
[systemd] add more addresses to CC

### DIFF
--- a/projects/systemd/project.yaml
+++ b/projects/systemd/project.yaml
@@ -7,3 +7,7 @@ sanitizers:
 auto_ccs:
   - jonathan@titanous.com
   - zbyszek@in.waw.pl
+  - dimitri.ledkov@canonical.com
+  - poettering@gmail.com
+  - watanabe.yu@gmail.com
+  - evvers@ya.ru


### PR DESCRIPTION
Backup address for Lennart Poettering, addresseses for Canonical
and systemd contributors who work on memory correctness issues.

Follow-up for #1084.