### PR TITLE
[mupdf] Ensure document is always freed

### DIFF
--- a/projects/mupdf/pdf_fuzzer.cc
+++ b/projects/mupdf/pdf_fuzzer.cc
@@ -26,17 +26,20 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   fz_stream *stream = fz_open_memory(ctx, data, size);
   fz_matrix ctm;
-  fz_pixmap *pix;
+  fz_pixmap *pix = NULL;
+  fz_document *doc = NULL;
   fz_try(ctx) {
-    fz_document *doc = fz_open_document_with_stream(ctx, "pdf", stream);
+    doc = fz_open_document_with_stream(ctx, "pdf", stream);
     for (int i = 0; i < fz_count_pages(ctx, doc); i++) {
       pix = fz_new_pixmap_from_page_number(ctx, doc, i, &ctm, fz_device_rgb(ctx), 0);
       fz_drop_pixmap(ctx, pix);
     }
-    fz_drop_document(ctx, doc);
   }
   fz_catch(ctx) {}
 
+  if (doc) {
+    fz_drop_document(ctx, doc);
+  }
   fz_drop_stream(ctx, stream);
   fz_drop_context(ctx);
 


### PR DESCRIPTION
I saw at least one leak that could have been caused by this.