### PR TITLE
Add myself to the ACL for LLVM reports

### DIFF
--- a/projects/llvm/project.yaml
+++ b/projects/llvm/project.yaml
@@ -9,6 +9,7 @@ auto_ccs:
   - "igmyrj@gmail.com"
   - "mitchphillips@outlook.com"
   - "xpl0re@gmail.com"
+  - "hfinkel@anl.gov"
 
 # TODO(kcc): enable msan.
 sanitizers:


### PR DESCRIPTION
Please add me to the ACL so that I can see the report details for LLVM bugs.