### PR TITLE
[gnutls] updated reference to libtasn1 project

### DIFF
--- a/projects/gnutls/Dockerfile
+++ b/projects/gnutls/Dockerfile
@@ -39,7 +39,7 @@ RUN git clone git://git.savannah.gnu.org/gnulib.git
 RUN git clone --depth=1 https://git.savannah.gnu.org/git/libunistring.git
 RUN git clone --depth=1 https://gitlab.com/libidn/libidn2.git
 RUN hg clone https://gmplib.org/repo/gmp/ gmp
-RUN git clone --depth=1 https://git.savannah.gnu.org/git/libtasn1.git
+RUN git clone --depth=1 https://gitlab.com/gnutls/libtasn1.git
 RUN git clone --depth=1 https://git.lysator.liu.se/nettle/nettle.git
 
 RUN git clone --depth=1 --recursive https://gitlab.com/gnutls/gnutls.git


### PR DESCRIPTION
The project was moved to gitlab.

Closes #1101

Signed-off-by: Nikos Mavrogiannopoulos <nmav@redhat.com>