### PR TITLE
infra/helper: persist /root directory via bind mount.

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -309,6 +309,7 @@ def build_fuzzers(args):
         '%s:/src/%s' % (_get_absolute_path(args.source_path), args.project_name)
     ]
   command += [
+      '-v', '%s:/root' % os.path.join(BUILD_DIR, 'root', project_name),
       '-v', '%s:/out' % os.path.join(BUILD_DIR, 'out', project_name),
       '-v', '%s:/work' % os.path.join(BUILD_DIR, 'work', project_name),
       '-t', 'gcr.io/oss-fuzz/%s' % project_name


### PR DESCRIPTION
For Bazel builds, this preserves the Bazel cache across multiple
invocations of build_fuzzers, which significantly speeds up the build
and reduces the debug cycle for new projects.

Signed-off-by: Harvey Tuch <htuch@google.com>