### PR TITLE
coverage: docs and infra/helper.py fix.

### DIFF
--- a/docs/new_project_guide.md
+++ b/docs/new_project_guide.md
@@ -182,6 +182,7 @@ It's recommended to look at code coverage as a sanity check to make sure that
 [fuzz target](glossary.md#fuzz-target) gets to the code you expect.
 
 ```bash
+$ python infra/helper.py build_fuzzers --sanitizer coverage $PROJECT_NAME
 $ python infra/helper.py coverage $PROJECT_NAME <fuzz_target>
 ```
 

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -183,7 +183,7 @@ def _add_engine_args(parser):
 def _add_sanitizer_args(parser):
   """Add common sanitizer args."""
   parser.add_argument('--sanitizer', default='address',
-                      choices=['address', 'memory', 'undefined'])
+                      choices=['address', 'memory', 'undefined', 'coverage'])
 
 
 def _add_environment_args(parser):


### PR DESCRIPTION
While trying to get a coverage report for a new project (Envoy),
building with the coverage sanitizer seemed necessary to get the
coverage files dumped.

Signed-off-by: Harvey Tuch <htuch@google.com>