### PR TITLE
Propose graphicsmagick for inclusion in OSS-Fuzz

### DIFF
--- a/projects/graphicsmagick/project.yaml
+++ b/projects/graphicsmagick/project.yaml
@@ -1,0 +1,6 @@
+homepage: "http://www.graphicsmagick.org/"
+primary_contact: "bobjfriesenhahn@gmail.com"
+auto_ccs:
+    - glennrp@gmail.com
+    - alex.gaynor@gmail.com
+    - paul.l.kehrer@gmail.com


### PR DESCRIPTION
graphicsmagick is a widely used fork of imagemagick -- they diverged sufficiently long ago that I believe fuzzing both is appropriate.

Submitting with the author's permission.