### PR TITLE
Wire up graphicsmagick

### DIFF
--- a/projects/graphicsmagick/Dockerfile
+++ b/projects/graphicsmagick/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER alex.gaynor@gmail.com
+RUN apt-get update && apt-get install -y mercurial
+RUN hg clone http://hg.code.sf.net/p/graphicsmagick/code graphicsmagick
+WORKDIR graphicsmagick
+COPY build.sh $SRC/

--- a/projects/graphicsmagick/build.sh
+++ b/projects/graphicsmagick/build.sh
@@ -15,6 +15,4 @@
 #
 ################################################################################
 
-# TODO: remove me as soon as the chmod is resolved in the repo
-chmod +x fuzzing/oss-fuzz-build.sh
 ./fuzzing/oss-fuzz-build.sh

--- a/projects/graphicsmagick/build.sh
+++ b/projects/graphicsmagick/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -eu
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# TODO: remove me as soon as the chmod is resolved in the repo
+chmod +x fuzzing/oss-fuzz-build.sh
+./fuzzing/oss-fuzz-build.sh


### PR DESCRIPTION
Fuzz targets are landed in the upstream repository.

We should probably also enable msan, as I expect that to work, but let's get the initial integration landed first.