### PR TITLE
[irssi] Add Nei to auto_ccs

### DIFF
--- a/projects/irssi/project.yaml
+++ b/projects/irssi/project.yaml
@@ -3,6 +3,7 @@ primary_contact: "ahf@irssi.org"
 auto_ccs:
   - "dx@dxzone.com.ar"
   - "joseph.bisch@gmail.com"
+  - "ailin.nemui@gmail.com"
   - "staff@irssi.org"
 sanitizers:
   - address


### PR DESCRIPTION
Nei (@ailin-nemui) is an irssi developer. It would be useful to let Nei login and see the details of irssi bugs. Nei already gets emails for the bugs via the staff@irssi.org auto_cc, but can't view additional details only available via logging in to oss-fuzz.com.