### PR TITLE
Requesting bignum-fuzzer integration

### DIFF
--- a/projects/bignum-fuzzer/Dockerfile
+++ b/projects/bignum-fuzzer/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER guidovranken@gmail.com
+RUN apt-get update && apt-get install -y software-properties-common python-software-properties wget
+RUN add-apt-repository -y ppa:gophers/archive && apt-get update && apt-get install -y golang-1.9-go
+RUN ln -s /usr/lib/go-1.9/bin/go /usr/bin/go
+
+RUN git clone --depth 1 https://github.com/guidovranken/bignum-fuzzer
+RUN git clone --depth 1 https://github.com/openssl/openssl
+COPY build.sh *.options $SRC/

--- a/projects/bignum-fuzzer/build.sh
+++ b/projects/bignum-fuzzer/build.sh
@@ -1,0 +1,32 @@
+cd $SRC/openssl
+if [[ $CFLAGS = *sanitize=memory* ]]
+then
+  CFLAGS+=" -DOPENSSL_NO_ASM=1"
+fi
+./config $CFLAGS
+make -j$(nproc)
+
+# Build OpenSSL module
+cd $SRC/bignum-fuzzer/modules/openssl
+OPENSSL_INCLUDE_PATH=$SRC/openssl/include OPENSSL_LIBCRYPTO_A_PATH=$SRC/openssl/libcrypto.a make
+
+# Build Go module
+cd $SRC/bignum-fuzzer/modules/go
+make
+
+CXXFLAGS+=" -DBNFUZZ_FLAG_NO_NEGATIVE=1 -DBNFUZZ_FLAG_NUM_LEN=1200 -DBNFUZZ_FLAG_ALL_OPERATIONS=1"
+
+# Build fuzzer
+cd $SRC/bignum-fuzzer
+./config-modules.sh openssl go
+LIBFUZZER_LINK="-lFuzzingEngine" make
+
+cd $SRC
+
+# Copy fuzzer to the designated location
+cp $SRC/bignum-fuzzer/fuzzer $OUT/fuzzer_openssl_go_no_negative_num_len_1200_all_operations
+
+cp *.options $OUT/
+
+cd $OUT
+wget https://transfer.sh/gFacf/fuzzer_openssl_go_no_negative_num_len_1200_all_operations_seed_corpus.zip

--- a/projects/bignum-fuzzer/fuzzer_openssl_go_no_negative_num_len_1200_all_operations.options
+++ b/projects/bignum-fuzzer/fuzzer_openssl_go_no_negative_num_len_1200_all_operations.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 5000

--- a/projects/bignum-fuzzer/fuzzer_openssl_go_no_negative_num_len_1200_all_operations.options
+++ b/projects/bignum-fuzzer/fuzzer_openssl_go_no_negative_num_len_1200_all_operations.options
@@ -1,2 +1,0 @@
-[libfuzzer]
-max_len = 5000

--- a/projects/bignum-fuzzer/project.yaml
+++ b/projects/bignum-fuzzer/project.yaml
@@ -3,3 +3,5 @@ primary_contact: "guidovranken@gmail.com"
 auto_ccs:
     - "martin.swende@ethereum.org"
     - "cdetrio@ethereum.org"
+    - "openssl-security@openssl.org"
+    - "kurt@roeckx.be"

--- a/projects/bignum-fuzzer/project.yaml
+++ b/projects/bignum-fuzzer/project.yaml
@@ -1,0 +1,5 @@
+homepage: "https://github.com/guidovranken/bignum-fuzzer"
+primary_contact: "guidovranken@gmail.com"
+auto_ccs:
+    - "martin.swende@ethereum.org"
+    - "cdetrio@ethereum.org"


### PR DESCRIPTION
The current PR builds a fuzzer that performs differential fuzzing between the bignum libraries of OpenSSL (master) and Go. The core project also includes support for fuzzing mbed TLS, C++ Boost multiprecision and Rust, for which I will create targets in the future.