### PR TITLE
Add image decoding fuzz targets to Skia

### DIFF
--- a/projects/skia/BUILD.gn.diff
+++ b/projects/skia/BUILD.gn.diff
@@ -64,3 +64,23 @@ test_app("path_deserialize") {
     ":skia",
   ]
 }
+
+test_app("image_decode") {
+  sources = [
+    "fuzz/oss_fuzz/FuzzImage.cpp",
+  ]
+  deps = [
+    ":flags",
+    ":skia",
+  ]
+}
+
+test_app("animated_image_decode") {
+  sources = [
+    "fuzz/oss_fuzz/FuzzAnimatedImage.cpp",
+  ]
+  deps = [
+    ":flags",
+    ":skia",
+  ]
+}

--- a/projects/skia/Dockerfile
+++ b/projects/skia/Dockerfile
@@ -38,6 +38,10 @@ RUN wget -O $SRC/skia/textblob_deserialize_seed_corpus.zip https://storage.googl
 
 RUN wget -O $SRC/skia/path_deserialize_seed_corpus.zip https://storage.googleapis.com/skia-fuzzer/oss-fuzz/path_deserialize_seed_corpus.zip
 
+RUN wget -O $SRC/skia/image_decode_seed_corpus.zip https://storage.googleapis.com/skia-fuzzer/oss-fuzz/image_decode_seed_corpus.zip
+
+RUN wget -O $SRC/skia/animated_image_decode_seed_corpus.zip https://storage.googleapis.com/skia-fuzzer/oss-fuzz/animated_image_decode_seed_corpus.zip
+
 COPY build.sh $SRC/
 
 COPY skia.diff $SRC/skia/skia.diff
@@ -48,6 +52,8 @@ COPY region_set_path.options $SRC/skia/region_set_path.options
 COPY image_filter_deserialize.options $SRC/skia/image_filter_deserialize.options
 COPY textblob_deserialize.options $SRC/skia/textblob_deserialize.options
 COPY path_deserialize.options $SRC/skia/path_deserialize.options
+COPY image_decode.options $SRC/skia/image_decode.options
+COPY animated_image_decode.options $SRC/skia/animated_image_decode.options
 
 COPY BUILD.gn.diff $SRC/skia/BUILD.gn.diff
 RUN cat BUILD.gn.diff >> BUILD.gn

--- a/projects/skia/animated_image_decode.options
+++ b/projects/skia/animated_image_decode.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 10240

--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -43,9 +43,9 @@ $SRC/depot_tools/gn gen out/Fuzz\
     skia_enable_gpu=false
     extra_ldflags=["-lFuzzingEngine", "'"$CXXFLAGS_ARR"'"]'
 
-$SRC/depot_tools/ninja -C out/Fuzz_mem_constraints image_filter_deserialize
+$SRC/depot_tools/ninja -C out/Fuzz_mem_constraints image_filter_deserialize textblob_deserialize
 
-$SRC/depot_tools/ninja -C out/Fuzz region_deserialize region_set_path textblob_deserialize \
+$SRC/depot_tools/ninja -C out/Fuzz region_deserialize region_set_path \
                                    path_deserialize image_decode animated_image_decode
 
 cp out/Fuzz/region_deserialize $OUT/region_deserialize
@@ -56,7 +56,7 @@ cp ./region_deserialize.options $OUT/region_deserialize.options
 # cp ./region_set_path.options $OUT/region_set_path.options
 # cp ./region_set_path_seed_corpus.zip $OUT/region_set_path_seed_corpus.zip
 
-cp out/Fuzz/textblob_deserialize $OUT/textblob_deserialize
+cp out/Fuzz_mem_constraints/textblob_deserialize $OUT/textblob_deserialize
 cp ./textblob_deserialize.options $OUT/textblob_deserialize.options
 cp ./textblob_deserialize_seed_corpus.zip $OUT/textblob_deserialize_seed_corpus.zip
 

--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -46,7 +46,7 @@ $SRC/depot_tools/gn gen out/Fuzz\
 $SRC/depot_tools/ninja -C out/Fuzz_mem_constraints image_filter_deserialize
 
 $SRC/depot_tools/ninja -C out/Fuzz region_deserialize region_set_path textblob_deserialize \
-                                   path_deserialize
+                                   path_deserialize image_decode animated_image_decode
 
 cp out/Fuzz/region_deserialize $OUT/region_deserialize
 cp ./region_deserialize.options $OUT/region_deserialize.options
@@ -63,6 +63,14 @@ cp ./textblob_deserialize_seed_corpus.zip $OUT/textblob_deserialize_seed_corpus.
 cp out/Fuzz/path_deserialize $OUT/path_deserialize
 cp ./path_deserialize.options $OUT/path_deserialize.options
 cp ./path_deserialize_seed_corpus.zip $OUT/path_deserialize_seed_corpus.zip
+
+cp out/Fuzz/image_decode $OUT/image_decode
+cp ./image_decode.options $OUT/image_decode.options
+cp ./image_decode_seed_corpus.zip $OUT/image_decode_seed_corpus.zip
+
+cp out/Fuzz/animated_image_decode $OUT/animated_image_decode
+cp ./animated_image_decode.options $OUT/animated_image_decode.options
+cp ./animated_image_decode_seed_corpus.zip $OUT/animated_image_decode_seed_corpus.zip
 
 cp out/Fuzz_mem_constraints/image_filter_deserialize $OUT/image_filter_deserialize
 cp ./image_filter_deserialize.options $OUT/image_filter_deserialize.options

--- a/projects/skia/image_decode.options
+++ b/projects/skia/image_decode.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 10240

--- a/projects/skia/skia.diff
+++ b/projects/skia/skia.diff
@@ -1,20 +1,20 @@
 diff --git a/src/core/SkDraw.cpp b/src/core/SkDraw.cpp
-index 3e4722be4d..ee49a24807 100644
+index 478617f828..f4ead536aa 100644
 --- a/src/core/SkDraw.cpp
 +++ b/src/core/SkDraw.cpp
-@@ -1111,6 +1111,12 @@ void SkDraw::drawPath(const SkPath& origSrcPath, const SkPaint& origPaint,
+@@ -1120,6 +1120,12 @@ void SkDraw::drawPath(const SkPath& origSrcPath, const SkPaint& origPaint,
      // transform the path into device space
      pathPtr->transform(*matrix, devPathPtr);
-
+ 
 +#if defined(IS_FUZZING)
 +    if (devPathPtr->countPoints() > 1000) {
 +        return;
 +    }
 +#endif
 +
-     this->drawDevPath(*devPathPtr, *paint, drawCoverage, customBlitter, doFill);
+     this->drawDevPath(*devPathPtr, *paint, drawCoverage, customBlitter, doFill, iData);
  }
-
+ 
 diff --git a/src/core/SkImageFilter.cpp b/src/core/SkImageFilter.cpp
 index b2220a7651..9fa0b153ef 100644
 --- a/src/core/SkImageFilter.cpp
@@ -22,7 +22,7 @@ index b2220a7651..9fa0b153ef 100644
 @@ -122,6 +122,12 @@ bool SkImageFilter::Common::unflatten(SkReadBuffer& buffer, int expectedCount) {
          return false;
      }
-
+ 
 +#if defined(IS_FUZZING)
 +    if (count > 4) {
 +        return false;
@@ -49,13 +49,13 @@ index 2933e48cc4..1ae9dd0404 100644
      if (nullptr == addr) {
          return nullptr;
 diff --git a/src/core/SkMaskFilter.cpp b/src/core/SkMaskFilter.cpp
-index 59baa4fbff..93bd273058 100644
+index 347e828d0e..dd16dd81a4 100644
 --- a/src/core/SkMaskFilter.cpp
 +++ b/src/core/SkMaskFilter.cpp
-@@ -263,6 +263,11 @@ bool SkMaskFilterBase::filterPath(const SkPath& devPath, const SkMatrix& matrix,
-
+@@ -264,6 +264,11 @@ bool SkMaskFilterBase::filterPath(const SkPath& devPath, const SkMatrix& matrix,
+ 
      SkMask  srcM, dstM;
-
+ 
 +#if defined(IS_FUZZING)
 +    if (devPath.countVerbs() > 1000 || devPath.countPoints() > 1000) {
 +        return false;
@@ -82,12 +82,12 @@ index ab8bf2e1fc..975a849f5d 100644
      path->setIsVolatile(true);
      path->setFillType(SkPath::kWinding_FillType);
 diff --git a/src/core/SkPictureData.cpp b/src/core/SkPictureData.cpp
-index 2ca88ae841..b1c42138ed 100644
+index 2ca88ae841..3fc4ecf6bd 100644
 --- a/src/core/SkPictureData.cpp
 +++ b/src/core/SkPictureData.cpp
 @@ -495,6 +495,11 @@ bool new_array_from_buffer(SkReadBuffer& buffer, uint32_t inCount,
  }
-
+ 
  void SkPictureData::parseBufferTag(SkReadBuffer& buffer, uint32_t tag, uint32_t size) {
 +#if defined(IS_FUZZING)
 +    if (size > 1000) {
@@ -110,10 +110,10 @@ index 2ca88ae841..b1c42138ed 100644
                  for (int i = 0; i < count; i++) {
                      buffer.readPath(&fPaths[i]);
 diff --git a/src/core/SkReadBuffer.cpp b/src/core/SkReadBuffer.cpp
-index d82ec4a046..0e1c95a0b5 100644
+index 73e7af0fd7..1f2c87e0bb 100644
 --- a/src/core/SkReadBuffer.cpp
 +++ b/src/core/SkReadBuffer.cpp
-@@ -262,7 +262,12 @@ bool SkReadBuffer::readScalarArray(SkScalar* values, size_t size) {
+@@ -263,7 +263,12 @@ bool SkReadBuffer::readScalarArray(SkScalar* values, size_t size) {
  uint32_t SkReadBuffer::getArrayCount() {
      const size_t inc = sizeof(uint32_t);
      fError = fError || !IsPtrAlign4(fReader.peek()) || !fReader.isAvailable(inc);
@@ -124,11 +124,11 @@ index d82ec4a046..0e1c95a0b5 100644
      return fError ? 0 : *(uint32_t*)fReader.peek();
 +#endif
  }
-
+ 
  sk_sp<SkImage> SkReadBuffer::readImage() {
-@@ -297,6 +302,12 @@ sk_sp<SkImage> SkReadBuffer::readImage() {
+@@ -298,6 +303,12 @@ sk_sp<SkImage> SkReadBuffer::readImage() {
      }
-
+ 
      size_t size = SkAbs32(encoded_size);
 +#if defined(IS_FUZZING)
 +    if (size > 100000) {
@@ -140,12 +140,12 @@ index d82ec4a046..0e1c95a0b5 100644
      if (!this->readPad32(data->writable_data(), size)) {
          this->validate(false);
 diff --git a/src/core/SkScan_AAAPath.cpp b/src/core/SkScan_AAAPath.cpp
-index 06b3a276ed..f5984f991d 100644
+index e4e6701cea..c180f417c7 100644
 --- a/src/core/SkScan_AAAPath.cpp
 +++ b/src/core/SkScan_AAAPath.cpp
-@@ -1594,6 +1594,11 @@ static SK_ALWAYS_INLINE void aaa_fill_path(const SkPath& path, const SkIRect& cl
+@@ -1595,6 +1595,11 @@ static SK_ALWAYS_INLINE void aaa_fill_path(const SkPath& path, const SkIRect& cl
      SkASSERT(blitter);
-
+ 
      SkEdgeBuilder builder;
 +#if defined(IS_FUZZING)
 +    if (path.countPoints() > 1000) {
@@ -230,7 +230,7 @@ index 8a74c16cda..f6a5557914 100644
          }
      } while (meas.nextContour());
 @@ -65,6 +75,11 @@ SkPath1DPathEffect::SkPath1DPathEffect(const SkPath& path, SkScalar advance,
-
+ 
  bool SkPath1DPathEffect::filterPath(SkPath* dst, const SkPath& src,
                              SkStrokeRec* rec, const SkRect* cullRect) const {
 +#if defined(IS_FUZZING)
@@ -254,7 +254,7 @@ index e7ef54b6f7..727aa5221f 100644
 +        return;
 +    }
 +#endif
-
+ 
      const SkMatrix& mat = this->getMatrix();
      SkPoint src, dst;
 diff --git a/src/effects/SkDashPathEffect.cpp b/src/effects/SkDashPathEffect.cpp
@@ -278,7 +278,7 @@ index f188bfa818..44270f1675 100644
 --- a/src/effects/SkDiscretePathEffect.cpp
 +++ b/src/effects/SkDiscretePathEffect.cpp
 @@ -97,6 +97,11 @@ bool SkDiscretePathEffect::filterPath(SkPath* dst, const SkPath& src,
-
+ 
      do {
          SkScalar    length = meas.getLength();
 +#if defined(IS_FUZZING)
@@ -286,7 +286,7 @@ index f188bfa818..44270f1675 100644
 +            return false;
 +        }
 +#endif
-
+ 
          if (fSegLength * (2 + doFill) > length) {
              meas.getSegment(0, length, dst, true);  // to short for us to mangle
 diff --git a/src/effects/SkLayerDrawLooper.cpp b/src/effects/SkLayerDrawLooper.cpp
@@ -296,7 +296,7 @@ index 17aa7a123d..091a4bf9c7 100644
 @@ -262,6 +262,11 @@ void SkLayerDrawLooper::flatten(SkWriteBuffer& buffer) const {
  sk_sp<SkFlattenable> SkLayerDrawLooper::CreateProc(SkReadBuffer& buffer) {
      int count = buffer.readInt();
-
+ 
 +#if defined(IS_FUZZING)
 +    if (count > 100) {
 +        count = 100;
@@ -318,11 +318,11 @@ index 8a55b13390..e3c78b4e1f 100755
 +        return false;
 +    }
 +#endif
-
+ 
      int winding = get_winding(inputPolygonVerts, inputPolygonSize);
      if (0 == winding) {
 diff --git a/src/utils/SkShadowTessellator.cpp b/src/utils/SkShadowTessellator.cpp
-index 1a714076e7..18ef8d0235 100755
+index 11e8f2d5c6..60963ef288 100755
 --- a/src/utils/SkShadowTessellator.cpp
 +++ b/src/utils/SkShadowTessellator.cpp
 @@ -245,6 +245,11 @@ bool SkBaseShadowTessellator::addArc(const SkVector& nextNormal, bool finishArc)

--- a/projects/skia/skia.diff
+++ b/projects/skia/skia.diff
@@ -1,31 +1,3 @@
-diff --git a/include/private/SkMalloc.h b/include/private/SkMalloc.h
-index 178e1b83a7..d06dc3a4c2 100644
---- a/include/private/SkMalloc.h
-+++ b/include/private/SkMalloc.h
-@@ -64,6 +64,11 @@ static inline void* sk_calloc_throw(size_t size) {
- }
- 
- static inline void* sk_calloc_canfail(size_t size) {
-+#if defined(IS_FUZZING)
-+    if (size > 100000) {
-+        return nullptr;
-+    }
-+#endif
-     return sk_malloc_flags(size, SK_MALLOC_ZERO_INITIALIZE);
- }
- 
-@@ -76,6 +81,11 @@ SK_API extern void* sk_realloc_throw(void* buffer, size_t count, size_t elemSize
-  *  These variants return nullptr on failure
-  */
- static inline void* sk_malloc_canfail(size_t size) {
-+#if defined(IS_FUZZING)
-+    if (size > 100000) {
-+        return nullptr;
-+    }
-+#endif
-     return sk_malloc_flags(size, 0);
- }
- SK_API extern void* sk_malloc_canfail(size_t count, size_t elemSize);
 diff --git a/src/core/SkDraw.cpp b/src/core/SkDraw.cpp
 index 3e4722be4d..ee49a24807 100644
 --- a/src/core/SkDraw.cpp
@@ -33,7 +5,7 @@ index 3e4722be4d..ee49a24807 100644
 @@ -1111,6 +1111,12 @@ void SkDraw::drawPath(const SkPath& origSrcPath, const SkPaint& origPaint,
      // transform the path into device space
      pathPtr->transform(*matrix, devPathPtr);
- 
+
 +#if defined(IS_FUZZING)
 +    if (devPathPtr->countPoints() > 1000) {
 +        return;
@@ -42,7 +14,7 @@ index 3e4722be4d..ee49a24807 100644
 +
      this->drawDevPath(*devPathPtr, *paint, drawCoverage, customBlitter, doFill);
  }
- 
+
 diff --git a/src/core/SkImageFilter.cpp b/src/core/SkImageFilter.cpp
 index b2220a7651..9fa0b153ef 100644
 --- a/src/core/SkImageFilter.cpp
@@ -50,7 +22,7 @@ index b2220a7651..9fa0b153ef 100644
 @@ -122,6 +122,12 @@ bool SkImageFilter::Common::unflatten(SkReadBuffer& buffer, int expectedCount) {
          return false;
      }
- 
+
 +#if defined(IS_FUZZING)
 +    if (count > 4) {
 +        return false;
@@ -81,9 +53,9 @@ index 59baa4fbff..93bd273058 100644
 --- a/src/core/SkMaskFilter.cpp
 +++ b/src/core/SkMaskFilter.cpp
 @@ -263,6 +263,11 @@ bool SkMaskFilterBase::filterPath(const SkPath& devPath, const SkMatrix& matrix,
- 
+
      SkMask  srcM, dstM;
- 
+
 +#if defined(IS_FUZZING)
 +    if (devPath.countVerbs() > 1000 || devPath.countPoints() > 1000) {
 +        return false;
@@ -115,13 +87,13 @@ index 2ca88ae841..b1c42138ed 100644
 +++ b/src/core/SkPictureData.cpp
 @@ -495,6 +495,11 @@ bool new_array_from_buffer(SkReadBuffer& buffer, uint32_t inCount,
  }
- 
+
  void SkPictureData::parseBufferTag(SkReadBuffer& buffer, uint32_t tag, uint32_t size) {
 +#if defined(IS_FUZZING)
 +    if (size > 1000) {
 +        return;
 +    }
-+#endif    
++#endif
      switch (tag) {
          case SK_PICT_PAINT_BUFFER_TAG: {
              if (!buffer.validate(SkTFitsIn<int>(size))) {
@@ -152,11 +124,11 @@ index d82ec4a046..0e1c95a0b5 100644
      return fError ? 0 : *(uint32_t*)fReader.peek();
 +#endif
  }
- 
+
  sk_sp<SkImage> SkReadBuffer::readImage() {
 @@ -297,6 +302,12 @@ sk_sp<SkImage> SkReadBuffer::readImage() {
      }
- 
+
      size_t size = SkAbs32(encoded_size);
 +#if defined(IS_FUZZING)
 +    if (size > 100000) {
@@ -173,7 +145,7 @@ index 06b3a276ed..f5984f991d 100644
 +++ b/src/core/SkScan_AAAPath.cpp
 @@ -1594,6 +1594,11 @@ static SK_ALWAYS_INLINE void aaa_fill_path(const SkPath& path, const SkIRect& cl
      SkASSERT(blitter);
- 
+
      SkEdgeBuilder builder;
 +#if defined(IS_FUZZING)
 +    if (path.countPoints() > 1000) {
@@ -258,7 +230,7 @@ index 8a74c16cda..f6a5557914 100644
          }
      } while (meas.nextContour());
 @@ -65,6 +75,11 @@ SkPath1DPathEffect::SkPath1DPathEffect(const SkPath& path, SkScalar advance,
- 
+
  bool SkPath1DPathEffect::filterPath(SkPath* dst, const SkPath& src,
                              SkStrokeRec* rec, const SkRect* cullRect) const {
 +#if defined(IS_FUZZING)
@@ -282,7 +254,7 @@ index e7ef54b6f7..727aa5221f 100644
 +        return;
 +    }
 +#endif
- 
+
      const SkMatrix& mat = this->getMatrix();
      SkPoint src, dst;
 diff --git a/src/effects/SkDashPathEffect.cpp b/src/effects/SkDashPathEffect.cpp
@@ -306,7 +278,7 @@ index f188bfa818..44270f1675 100644
 --- a/src/effects/SkDiscretePathEffect.cpp
 +++ b/src/effects/SkDiscretePathEffect.cpp
 @@ -97,6 +97,11 @@ bool SkDiscretePathEffect::filterPath(SkPath* dst, const SkPath& src,
- 
+
      do {
          SkScalar    length = meas.getLength();
 +#if defined(IS_FUZZING)
@@ -314,7 +286,7 @@ index f188bfa818..44270f1675 100644
 +            return false;
 +        }
 +#endif
- 
+
          if (fSegLength * (2 + doFill) > length) {
              meas.getSegment(0, length, dst, true);  // to short for us to mangle
 diff --git a/src/effects/SkLayerDrawLooper.cpp b/src/effects/SkLayerDrawLooper.cpp
@@ -324,7 +296,7 @@ index 17aa7a123d..091a4bf9c7 100644
 @@ -262,6 +262,11 @@ void SkLayerDrawLooper::flatten(SkWriteBuffer& buffer) const {
  sk_sp<SkFlattenable> SkLayerDrawLooper::CreateProc(SkReadBuffer& buffer) {
      int count = buffer.readInt();
- 
+
 +#if defined(IS_FUZZING)
 +    if (count > 100) {
 +        count = 100;
@@ -346,7 +318,7 @@ index 8a55b13390..e3c78b4e1f 100755
 +        return false;
 +    }
 +#endif
- 
+
      int winding = get_winding(inputPolygonVerts, inputPolygonSize);
      if (0 == winding) {
 diff --git a/src/utils/SkShadowTessellator.cpp b/src/utils/SkShadowTessellator.cpp


### PR DESCRIPTION
This adds image_decode and animated_image_decode fuzz targets to Skia.  They are pretty bare-bone, but should allow us to detect errors in our decode logic and some rendering logic.

This also moves textblob_deserialize to run in the memory constrained build due to the fact that 100% of the textblob_deserialize runs are currently ending in OOM and I believe the memory constraints will alleviate it somewhat.