### PR TITLE
Upgrade Bazel pin in gRPC Dockerfile

### DIFF
--- a/projects/grpc/Dockerfile
+++ b/projects/grpc/Dockerfile
@@ -32,12 +32,12 @@ RUN apt-get update && apt-get -y install  \
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
 RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
 RUN apt-get update && apt-get install -y bazel
-# Downgrade Bazel to 0.4.4
-# Installing Bazel via apt-get first is required before installing 0.4.4 to
+# Downgrade Bazel to 0.10
+# Installing Bazel via apt-get first is required before installing 0.10 to
 # allow gRPC to build without errors
-RUN curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/0.4.4/bazel-0.4.4-installer-linux-x86_64.sh
-RUN chmod +x ./bazel-0.4.4-installer-linux-x86_64.sh
-RUN ./bazel-0.4.4-installer-linux-x86_64.sh
+RUN curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/0.10.0/bazel-0.10.0-installer-linux-x86_64.sh
+RUN chmod +x ./bazel-0.10.0-installer-linux-x86_64.sh
+RUN ./bazel-0.10.0-installer-linux-x86_64.sh
 
 RUN git clone --recursive https://github.com/grpc/grpc grpc
 WORKDIR /src/grpc/


### PR DESCRIPTION
Fixes #1157 - we changed our BUILD files to include features from newer Bazel versions.