### PR TITLE
[skcms] Increase maximum iccprofile size

### DIFF
--- a/projects/skcms/iccprofile.options
+++ b/projects/skcms/iccprofile.options
@@ -1,3 +1,3 @@
 [libfuzzer]
-max_len = 10024
+max_len = 200000
 timeout = 10


### PR DESCRIPTION
The skcms devs tell me that ICC profiles are not a very compact format.  This PR is paired with a bigger corpus (in GCS) that includes several examples of larger ICC profiles (i.e. greater than 10kb)