### PR TITLE
[skia] Increase max size of serialized path

### DIFF
--- a/projects/skia/path_deserialize.options
+++ b/projects/skia/path_deserialize.options
@@ -1,2 +1,2 @@
 [libfuzzer]
-max_len = 512
+max_len = 2000


### PR DESCRIPTION
The new version 4 of the serialized paths can sometimes be a bit larger.  This accompanies an expanded corpus of serialized paths that exercise the new version.