### PR TITLE
[skia] Add an edge coverage version of image_filter_deserialize that uses edge coverage

### DIFF
--- a/projects/skia/BUILD.gn.diff
+++ b/projects/skia/BUILD.gn.diff
@@ -35,16 +35,6 @@ test_app("image_filter_deserialize") {
   ]
 }
 
-test_app("image_filter_deserialize_width") {
-  sources = [
-    "fuzz/oss_fuzz/FuzzImageFilterDeserialize.cpp",
-  ]
-  deps = [
-    ":flags",
-    ":skia",
-  ]
-}
-
 test_app("region_set_path") {
   sources = [
     "fuzz/oss_fuzz/FuzzRegionSetPath.cpp",

--- a/projects/skia/BUILD.gn.diff
+++ b/projects/skia/BUILD.gn.diff
@@ -35,6 +35,16 @@ test_app("image_filter_deserialize") {
   ]
 }
 
+test_app("image_filter_deserialize_width") {
+  sources = [
+    "fuzz/oss_fuzz/FuzzImageFilterDeserialize.cpp",
+  ]
+  deps = [
+    ":flags",
+    ":skia",
+  ]
+}
+
 test_app("region_set_path") {
   sources = [
     "fuzz/oss_fuzz/FuzzRegionSetPath.cpp",

--- a/projects/skia/Dockerfile
+++ b/projects/skia/Dockerfile
@@ -56,6 +56,7 @@ RUN git apply skia.diff
 COPY region_deserialize.options $SRC/skia/region_deserialize.options
 COPY region_set_path.options $SRC/skia/region_set_path.options
 COPY image_filter_deserialize.options $SRC/skia/image_filter_deserialize.options
+COPY image_filter_deserialize_width.options $SRC/skia/image_filter_deserialize_width.options
 COPY textblob_deserialize.options $SRC/skia/textblob_deserialize.options
 COPY path_deserialize.options $SRC/skia/path_deserialize.options
 COPY image_decode.options $SRC/skia/image_decode.options

--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -43,7 +43,9 @@ $SRC/depot_tools/gn gen out/Fuzz\
     skia_enable_gpu=false
     extra_ldflags=["-lFuzzingEngine", "'"$CXXFLAGS_ARR"'"]'
 
-$SRC/depot_tools/ninja -C out/Fuzz_mem_constraints image_filter_deserialize textblob_deserialize
+$SRC/depot_tools/ninja -C out/Fuzz_mem_constraints image_filter_deserialize \
+                                                   image_filter_deserialize_width \
+                                                   textblob_deserialize
 
 $SRC/depot_tools/ninja -C out/Fuzz region_deserialize region_set_path \
                                    path_deserialize image_decode animated_image_decode \
@@ -76,6 +78,10 @@ cp ./animated_image_decode_seed_corpus.zip $OUT/animated_image_decode_seed_corpu
 cp out/Fuzz_mem_constraints/image_filter_deserialize $OUT/image_filter_deserialize
 cp ./image_filter_deserialize.options $OUT/image_filter_deserialize.options
 cp ./image_filter_deserialize_seed_corpus.zip $OUT/image_filter_deserialize_seed_corpus.zip
+
+cp out/Fuzz_mem_constraints/image_filter_deserialize_width $OUT/image_filter_deserialize_width
+cp ./image_filter_deserialize_width.options $OUT/image_filter_deserialize_width.options
+cp ./image_filter_deserialize_seed_corpus.zip $OUT/image_filter_deserialize_width_seed_corpus.zip
 
 cp out/Fuzz/api_draw_functions $OUT/api_draw_functions
 cp ./api_draw_functions.options $OUT/api_draw_functions.options

--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -44,7 +44,6 @@ $SRC/depot_tools/gn gen out/Fuzz\
     extra_ldflags=["-lFuzzingEngine", "'"$CXXFLAGS_ARR"'"]'
 
 $SRC/depot_tools/ninja -C out/Fuzz_mem_constraints image_filter_deserialize \
-                                                   image_filter_deserialize_width \
                                                    textblob_deserialize
 
 $SRC/depot_tools/ninja -C out/Fuzz region_deserialize region_set_path \
@@ -79,9 +78,10 @@ cp out/Fuzz_mem_constraints/image_filter_deserialize $OUT/image_filter_deseriali
 cp ./image_filter_deserialize.options $OUT/image_filter_deserialize.options
 cp ./image_filter_deserialize_seed_corpus.zip $OUT/image_filter_deserialize_seed_corpus.zip
 
-cp out/Fuzz_mem_constraints/image_filter_deserialize_width $OUT/image_filter_deserialize_width
+# Use the same binary as image_filter_deserialize.
+cp out/Fuzz_mem_constraints/image_filter_deserialize $OUT/image_filter_deserialize_width
 cp ./image_filter_deserialize_width.options $OUT/image_filter_deserialize_width.options
-# Use same seed corpus as image_filter_deserialize.
+# Use the same seed corpus as image_filter_deserialize.
 cp ./image_filter_deserialize_seed_corpus.zip $OUT/image_filter_deserialize_width_seed_corpus.zip
 
 cp out/Fuzz/api_draw_functions $OUT/api_draw_functions

--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -81,6 +81,7 @@ cp ./image_filter_deserialize_seed_corpus.zip $OUT/image_filter_deserialize_seed
 
 cp out/Fuzz_mem_constraints/image_filter_deserialize_width $OUT/image_filter_deserialize_width
 cp ./image_filter_deserialize_width.options $OUT/image_filter_deserialize_width.options
+# Use same seed corpus as image_filter_deserialize.
 cp ./image_filter_deserialize_seed_corpus.zip $OUT/image_filter_deserialize_width_seed_corpus.zip
 
 cp out/Fuzz/api_draw_functions $OUT/api_draw_functions

--- a/projects/skia/image_filter_deserialize_width.options
+++ b/projects/skia/image_filter_deserialize_width.options
@@ -1,0 +1,4 @@
+[libfuzzer]
+max_len = 10024
+timeout = 10
+use_counters = 0


### PR DESCRIPTION
[skia] Add an edge coverage version of image_filter_deserialize

Add a version of image_filter_deserialize that does not use hit counts as a
feature. This should reduce the "fitness" of testcases causing pathological 
executions, hopefully making timeouts and OOMs less likely.

Name it image_filter_deserialize_width since this version cares about the number
of edges reached when executing a testcase (width) rather than the number of times 
each edge (depth) is hit (libFuzzer's default).