### PR TITLE
[bignum-fuzzer] Add target that fuzzes OpenSSL against Rust

### DIFF
--- a/projects/bignum-fuzzer/Dockerfile
+++ b/projects/bignum-fuzzer/Dockerfile
@@ -16,9 +16,12 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER guidovranken@gmail.com
-RUN apt-get update && apt-get install -y software-properties-common python-software-properties wget
+RUN apt-get update && apt-get install -y software-properties-common python-software-properties wget curl sudo
 RUN add-apt-repository -y ppa:gophers/archive && apt-get update && apt-get install -y golang-1.9-go
 RUN ln -s /usr/lib/go-1.9/bin/go /usr/bin/go
+
+# Install Rust nightly
+RUN curl -s https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly
 
 RUN git clone --depth 1 https://github.com/guidovranken/bignum-fuzzer
 RUN git clone --depth 1 https://github.com/openssl/openssl

--- a/projects/bignum-fuzzer/build.sh
+++ b/projects/bignum-fuzzer/build.sh
@@ -3,7 +3,7 @@ if [[ $CFLAGS = *sanitize=memory* ]]
 then
   CFLAGS+=" -DOPENSSL_NO_ASM=1"
 fi
-./config $CFLAGS
+./config
 make -j$(nproc)
 
 # Build OpenSSL module
@@ -14,18 +14,31 @@ OPENSSL_INCLUDE_PATH=$SRC/openssl/include OPENSSL_LIBCRYPTO_A_PATH=$SRC/openssl/
 cd $SRC/bignum-fuzzer/modules/go
 make
 
-CXXFLAGS+=" -DBNFUZZ_FLAG_NO_NEGATIVE=1 -DBNFUZZ_FLAG_NUM_LEN=1200 -DBNFUZZ_FLAG_ALL_OPERATIONS=1"
+# Build Rust module
+cd $SRC/bignum-fuzzer/modules/rust
+make
 
-# Build fuzzer
+BASE_CXXFLAGS=$CXXFLAGS
+
+# Build OpenSSL/Go fuzzer
 cd $SRC/bignum-fuzzer
 ./config-modules.sh openssl go
+CXXFLAGS="$BASE_CXXFLAGS -DBNFUZZ_FLAG_NO_NEGATIVE=1 -DBNFUZZ_FLAG_NUM_LEN=1200 -DBNFUZZ_FLAG_ALL_OPERATIONS=1"
 LIBFUZZER_LINK="-lFuzzingEngine" make
 
-cd $SRC
-
-# Copy fuzzer to the designated location
+# Copy OpenSSL/Go fuzzer to the designated location
 cp $SRC/bignum-fuzzer/fuzzer $OUT/fuzzer_openssl_go_no_negative_num_len_1200_all_operations
 
+# Build OpenSSL/Rust fuzzer
+cd $SRC/bignum-fuzzer
+make clean
+./config-modules.sh openssl rust
+CXXFLAGS="$BASE_CXXFLAGS -DBNFUZZ_FLAG_NUM_LEN=1200 -DBNFUZZ_FLAG_ALL_OPERATIONS=1 -DBNFUZZ_FLAG_NUM_LOOPS=1"
+LIBFUZZER_LINK="-lFuzzingEngine" make
 
-# Copy seed corpus to the designated location
+# Copy OpenSSL/Rust fuzzer to the designated location
+cp $SRC/bignum-fuzzer/fuzzer $OUT/fuzzer_openssl_rust_num_len_1200_all_operations_num_loops_1
+
+# Copy seed corpora to the designated location
 cp $SRC/bignum-fuzzer/corpora/fuzzer_openssl_go_no_negative_num_len_1200_all_operations_seed_corpus.zip $OUT
+cp $SRC/bignum-fuzzer/corpora/fuzzer_openssl_rust_num_len_1200_all_operations_num_loops_1_seed_corpus.zip $OUT


### PR DESCRIPTION
This adds the target 'fuzzer_openssl_rust_num_len_1200_all_operations_num_loops_1' which fuzzes OpenSSL's bignums against Rust's bignums.

The Rust code is instrumented with an LLVM flag passed to ```rustc``` and works well with the fuzzer.

This also fixes an OpenSSL build issue affecting all builds introduced with https://github.com/openssl/openssl/commit/fb174faaf51d8b11046873a6a51fc2d8d8c28952#diff-f1206f9fadc5ce41694f69129aecac26

Thanks.