### PR TITLE
[systemd] install libmount-devel

### DIFF
--- a/projects/systemd/Dockerfile
+++ b/projects/systemd/Dockerfile
@@ -16,7 +16,8 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER jonathan@titanous.com
-RUN apt-get update && apt-get install -y gperf m4 gettext libcap-dev python3-pip &&\
+RUN apt-get update &&\
+    apt-get install -y gperf m4 gettext libcap-dev python3-pip libmount-dev pkg-config &&\
     pip3 install meson ninja
 RUN git clone --depth 1 https://github.com/systemd/systemd systemd
 WORKDIR systemd


### PR DESCRIPTION
Right now systemd declares a requirement on libmount-devel >= 2.30.
But this is only because of fixes in libmount 2.30 that matter at
runtime. For fuzzing (and to build) any libmount version is enough.
https://github.com/systemd/systemd/commit/c0b4b0f8f548c755dee81b
relaxed the version check in systemd. To fix the build we need to
install libmount-dev (and pkg-config, because meson requires that
for pkg-config deps to actually work).

Fixes #1191.