### PR TITLE
spidermonkey: Don't compile tests

### DIFF
--- a/projects/spidermonkey/build.sh
+++ b/projects/spidermonkey/build.sh
@@ -28,6 +28,7 @@ cd build_DBG.OBJ
     --enable-optimize \
     --disable-shared-js \
     --disable-jemalloc \
+    --disable-tests \
     --enable-address-sanitizer
 
 make "-j$(nproc)"


### PR DESCRIPTION
We're not using them, and they slow down my local builds :-)