### PR TITLE
add mozilla security ogg corpus

### DIFF
--- a/projects/vorbis/Dockerfile
+++ b/projects/vorbis/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-conf
 RUN git clone https://git.xiph.org/ogg.git
 RUN git clone https://git.xiph.org/vorbis.git
 ADD decode_fuzzer.cc $SRC/
+RUN svn export https://github.com/mozillasecurity/fuzzdata.git/trunk/samples/ogg decode_corpus
 RUN wget --cut-dirs 3 --recursive --level=1 -A ".ogg" https://people.xiph.org/~xiphmont/test-vectors/vorbis/
 WORKDIR vorbis
 COPY build.sh $SRC/

--- a/projects/vorbis/build.sh
+++ b/projects/vorbis/build.sh
@@ -17,7 +17,7 @@
 
 cd $SRC
 
-mv people.xiph.org decode_corpus
+mv people.xiph.org/*.ogg decode_corpus/
 zip -r "$OUT/decode_fuzzer_seed_corpus.zip" decode_corpus/
 
 cd $SRC/ogg


### PR DESCRIPTION
These are (mostly) smaller files and noticeably increase the initial coverage (old corpus gave cov: 755 ft: 1927, new cov: 798 ft: 3245)