### PR TITLE
[bignum-fuzzer] Add OpenSSL/C++ Boost multiprecision target

### DIFF
--- a/projects/bignum-fuzzer/Dockerfile
+++ b/projects/bignum-fuzzer/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER guidovranken@gmail.com
-RUN apt-get update && apt-get install -y software-properties-common python-software-properties wget curl sudo
+RUN apt-get update && apt-get install -y software-properties-common python-software-properties wget curl sudo libboost-all-dev
 RUN add-apt-repository -y ppa:gophers/archive && apt-get update && apt-get install -y golang-1.9-go
 RUN ln -s /usr/lib/go-1.9/bin/go /usr/bin/go
 

--- a/projects/bignum-fuzzer/build.sh
+++ b/projects/bignum-fuzzer/build.sh
@@ -18,6 +18,10 @@ make
 cd $SRC/bignum-fuzzer/modules/rust
 make
 
+# Build C++-Boost module
+cd $SRC/bignum-fuzzer/modules/cpp_boost
+make
+
 BASE_CXXFLAGS=$CXXFLAGS
 
 # Build OpenSSL/Go fuzzer
@@ -39,6 +43,17 @@ LIBFUZZER_LINK="-lFuzzingEngine" make
 # Copy OpenSSL/Rust fuzzer to the designated location
 cp $SRC/bignum-fuzzer/fuzzer $OUT/fuzzer_openssl_rust_num_len_1200_all_operations_num_loops_1
 
+# Build OpenSSL/C++-Boost fuzzer
+cd $SRC/bignum-fuzzer
+make clean
+./config-modules.sh openssl cpp_boost
+CXXFLAGS="$BASE_CXXFLAGS -DBNFUZZ_FLAG_NUM_LEN=1200 -DBNFUZZ_FLAG_ALL_OPERATIONS=1 -DBNFUZZ_FLAG_NUM_LOOPS=1"
+LIBFUZZER_LINK="-lFuzzingEngine" make
+
+# Copy OpenSSL/C++-Boost fuzzer to the designated location
+cp $SRC/bignum-fuzzer/fuzzer $OUT/fuzzer_openssl_cpp_boost_num_len_1200_all_operations_num_loops_1
+
 # Copy seed corpora to the designated location
 cp $SRC/bignum-fuzzer/corpora/fuzzer_openssl_go_no_negative_num_len_1200_all_operations_seed_corpus.zip $OUT
 cp $SRC/bignum-fuzzer/corpora/fuzzer_openssl_rust_num_len_1200_all_operations_num_loops_1_seed_corpus.zip $OUT
+cp $SRC/bignum-fuzzer/corpora/fuzzer_openssl_cpp_boost_num_len_1200_all_operations_num_loops_1_seed_corpus.zip $OUT

--- a/projects/bignum-fuzzer/project.yaml
+++ b/projects/bignum-fuzzer/project.yaml
@@ -5,3 +5,4 @@ auto_ccs:
     - "cdetrio@ethereum.org"
     - "openssl-security@openssl.org"
     - "kurt@roeckx.be"
+    - "security@golang.org"


### PR DESCRIPTION
This adds a target for the C++ Boost multiprecision library vs OpenSSL.

I will be reaching out to the Boost people and ask at which address they prefer to receive bug reports, and I will add that CC later.

This also adds ```security@golang.org``` to the CCs (Russ Cox' suggestion).

Thanks