### PR TITLE
[harfbuzz] remove harfbuzz/test/subset/data/fonts from corpus

### DIFF
--- a/projects/harfbuzz/build.sh
+++ b/projects/harfbuzz/build.sh
@@ -39,4 +39,4 @@ $CXX $CXXFLAGS -std=c++11 -Isrc \
 
 # Archive and copy to $OUT seed corpus if the build succeeded.
 zip -j -r $OUT/hb-shape-fuzzer_seed_corpus.zip $SRC/harfbuzz/test/shaping/data/in-house/fonts
-zip -j -r $OUT/hb-subset-fuzzer_seed_corpus.zip $SRC/harfbuzz/test/subset/data/fonts $SRC/harfbuzz/test/api/fonts
+zip -j -r $OUT/hb-subset-fuzzer_seed_corpus.zip $SRC/harfbuzz/test/api/fonts


### PR DESCRIPTION
it's mostly duplicates of whats in test/api/fonts and is breaking the build step for harfbuzz (due to duplicate file names).