### PR TITLE
fix libjpeg-turbo build

### DIFF
--- a/projects/libjpeg-turbo/Dockerfile
+++ b/projects/libjpeg-turbo/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER alex.gaynor@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool nasm curl
+RUN apt-get update && apt-get install -y make autoconf automake libtool nasm curl cmake
 RUN git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo
 
 RUN mkdir afl-testcases

--- a/projects/libjpeg-turbo/build.sh
+++ b/projects/libjpeg-turbo/build.sh
@@ -15,12 +15,12 @@
 #
 ################################################################################
 
-autoreconf -fiv
-./configure
+cmake . -DCMAKE_INSTALL_PREFIX=$WORK -DENABLE_STATIC:bool=on
 make "-j$(nproc)"
+make install
 
 $CXX $CXXFLAGS -std=c++11 -I. \
     $SRC/libjpeg_turbo_fuzzer.cc -o $OUT/libjpeg_turbo_fuzzer \
-    -lFuzzingEngine ./.libs/libturbojpeg.a
+    -lFuzzingEngine "$WORK/lib/libturbojpeg.a"
 
 cp $SRC/libjpeg_turbo_fuzzer_seed_corpus.zip $OUT/


### PR DESCRIPTION
Looks like this has been broken for quite a while since the project moved to cmake from autoconf.

I also noticed the project.yaml has no primary contact or cc list?