### PR TITLE
[skia] Add encoder fuzzers

### DIFF
--- a/projects/skia/BUILD.gn.diff
+++ b/projects/skia/BUILD.gn.diff
@@ -194,3 +194,39 @@ test_app("api_null_canvas") {
     "//third_party/libpng",
   ]
 }
+
+test_app("png_encoder") {
+  sources = [
+    "fuzz/FuzzCommon.cpp",
+    "fuzz/FuzzEncoders.cpp",
+    "fuzz/oss_fuzz/FuzzPNGEncoder.cpp",
+  ]
+  deps = [
+    ":flags",
+    ":skia",
+  ]
+}
+
+test_app("jpeg_encoder") {
+  sources = [
+    "fuzz/FuzzCommon.cpp",
+    "fuzz/FuzzEncoders.cpp",
+    "fuzz/oss_fuzz/FuzzJPEGEncoder.cpp",
+  ]
+  deps = [
+    ":flags",
+    ":skia",
+  ]
+}
+
+test_app("webp_encoder") {
+  sources = [
+    "fuzz/FuzzCommon.cpp",
+    "fuzz/FuzzEncoders.cpp",
+    "fuzz/oss_fuzz/FuzzWEBPEncoder.cpp",
+  ]
+  deps = [
+    ":flags",
+    ":skia",
+  ]
+}

--- a/projects/skia/Dockerfile
+++ b/projects/skia/Dockerfile
@@ -52,6 +52,8 @@ RUN wget -O $SRC/skia/api_path_measure_seed_corpus.zip https://storage.googleapi
 
 RUN wget -O $SRC/skia/canvas_seed_corpus.zip https://storage.googleapis.com/skia-fuzzer/oss-fuzz/canvas_seed_corpus.zip
 
+RUN wget -O $SRC/skia/encoder_seed_corpus.zip https://storage.googleapis.com/skia-fuzzer/oss-fuzz/encoder_seed_corpus.zip
+
 COPY build.sh $SRC/
 
 COPY skia.diff $SRC/skia/skia.diff
@@ -65,6 +67,7 @@ COPY textblob_deserialize.options $SRC/skia/textblob_deserialize.options
 COPY path_deserialize.options $SRC/skia/path_deserialize.options
 COPY image_decode.options $SRC/skia/image_decode.options
 COPY animated_image_decode.options $SRC/skia/animated_image_decode.options
+COPY encoder.options $SRC/skia/encoder.options
 
 # API fuzzers can share options
 COPY api_fuzzers.options $SRC/skia/api_draw_functions.options

--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -49,7 +49,8 @@ $SRC/depot_tools/ninja -C out/Fuzz_mem_constraints image_filter_deserialize \
 $SRC/depot_tools/ninja -C out/Fuzz region_deserialize region_set_path \
                                    path_deserialize image_decode animated_image_decode \
                                    api_draw_functions api_gradients api_image_filter \
-                                   api_path_measure api_null_canvas
+                                   api_path_measure api_null_canvas png_encoder \
+                                   jpeg_encoder webp_encoder
 
 cp out/Fuzz/region_deserialize $OUT/region_deserialize
 cp ./region_deserialize.options $OUT/region_deserialize.options
@@ -112,3 +113,15 @@ cp ./canvas_seed_corpus.zip $OUT/api_raster_n32_canvas_seed_corpus.zip
 cp out/Fuzz/api_null_canvas $OUT/api_null_canvas
 cp ./api_null_canvas.options $OUT/api_null_canvas.options
 cp ./canvas_seed_corpus.zip $OUT/api_null_canvas_seed_corpus.zip
+
+cp out/Fuzz/png_encoder $OUT/png_encoder
+cp ./encoder.options $OUT/png_encoder.options
+cp ./encoder_seed_corpus.zip $OUT/png_encoder_seed_corpus.zip
+
+cp out/Fuzz/jpeg_encoder $OUT/jpeg_encoder
+cp ./encoder.options $OUT/jpeg_encoder.options
+cp ./encoder_seed_corpus.zip $OUT/jpeg_encoder_seed_corpus.zip
+
+cp out/Fuzz/webp_encoder $OUT/webp_encoder
+cp ./encoder.options $OUT/webp_encoder.options
+cp ./encoder_seed_corpus.zip $OUT/webp_encoder_seed_corpus.zip

--- a/projects/skia/encoder.options
+++ b/projects/skia/encoder.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 262150


### PR DESCRIPTION
Requires https://skia-review.googlesource.com/c/skia/+/117367 to land first.

The PNG encoder, for example, is used in Chrome's toDataURL() implementation