### PR TITLE
add libexif

### DIFF
--- a/projects/libexif/Dockerfile
+++ b/projects/libexif/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER paul.l.kehrer@gmail.com
+RUN apt-get update && apt-get install -y make autoconf automake libtool gettext autopoint
+RUN git clone --depth 1 https://github.com/libexif/libexif
+RUN git clone --depth 1 https://github.com/ianare/exif-samples
+WORKDIR libexif
+COPY exif_loader_fuzzer.cc build.sh $SRC/

--- a/projects/libexif/build.sh
+++ b/projects/libexif/build.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -eu
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+autoreconf -fiv
+./configure --disable-docs --enable-shared=no --prefix="$WORK"
+make -j$(nproc)
+make install
+
+pushd $SRC
+mkdir exif_corpus
+find exif-samples -type f -name '*.jpg' -exec mv -n {} exif_corpus/ \; -o -name '*.tiff' -exec mv -n {} exif_corpus/ \;
+zip -r "$OUT/exif_loader_fuzzer_seed_corpus.zip" exif_corpus/
+popd
+
+$CXX $CXXFLAGS -std=c++11 -I"$WORK/include" "$SRC/exif_loader_fuzzer.cc" -o $OUT/exif_loader_fuzzer -lFuzzingEngine "$WORK/lib/libexif.a"

--- a/projects/libexif/exif_loader_fuzzer.cc
+++ b/projects/libexif/exif_loader_fuzzer.cc
@@ -12,20 +12,20 @@ void data_func(ExifContent *content, void *user_data) {
   exif_content_foreach_entry(content, content_func, NULL);
 }
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   ExifLoader *loader = exif_loader_new();
-  ExifData *data;
+  ExifData *exif_data;
   if (!loader) {
     return 0;
   }
-  exif_loader_write(loader, (unsigned char *)Data, Size);
-  data = exif_loader_get_data(loader);
-  if(!data) {
+  exif_loader_write(loader, const_cast<unsigned char*>(data), size);
+  exif_data = exif_loader_get_data(loader);
+  if(!exif_data) {
     exif_loader_unref(loader);
     return 0;
   }
-  exif_data_foreach_content(data, data_func, NULL);
+  exif_data_foreach_content(exif_data, data_func, NULL);
   exif_loader_unref(loader);
-  exif_data_unref(data);
+  exif_data_unref(exif_data);
   return 0;
 }

--- a/projects/libexif/exif_loader_fuzzer.cc
+++ b/projects/libexif/exif_loader_fuzzer.cc
@@ -1,0 +1,21 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <libexif/exif-loader.h>
+
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+  ExifLoader *loader = exif_loader_new();
+  ExifData *data;
+  if (!loader) {
+    return 0;
+  }
+  exif_loader_write(loader, (unsigned char *)Data, Size);
+  data = exif_loader_get_data(loader);
+  if(!data) {
+    exif_loader_unref(loader);
+    return 0;
+  }
+  exif_loader_unref(loader);
+  exif_data_unref(data);
+  return 0;
+}

--- a/projects/libexif/exif_loader_fuzzer.cc
+++ b/projects/libexif/exif_loader_fuzzer.cc
@@ -3,6 +3,15 @@
 #include <libexif/exif-loader.h>
 
 
+void content_func(ExifEntry *entry, void *user_data) {
+  char buf[10000];
+  exif_entry_get_value(entry, buf, sizeof(buf));
+}
+
+void data_func(ExifContent *content, void *user_data) {
+  exif_content_foreach_entry(content, content_func, NULL);
+}
+
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
   ExifLoader *loader = exif_loader_new();
   ExifData *data;
@@ -15,6 +24,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     exif_loader_unref(loader);
     return 0;
   }
+  exif_data_foreach_content(data, data_func, NULL);
   exif_loader_unref(loader);
   exif_data_unref(data);
   return 0;

--- a/projects/libexif/project.yaml
+++ b/projects/libexif/project.yaml
@@ -1,0 +1,7 @@
+homepage: "https://libexif.github.io"
+primary_contact: "<primary_contact_email>"
+auto_ccs:
+  - paul.l.kehrer@gmail.com
+sanitizers:
+  - address
+  - memory

--- a/projects/libexif/project.yaml
+++ b/projects/libexif/project.yaml
@@ -1,5 +1,5 @@
 homepage: "https://libexif.github.io"
-primary_contact: "<primary_contact_email>"
+primary_contact: "dan@coneharvesters.com"
 auto_ccs:
   - paul.l.kehrer@gmail.com
 sanitizers:


### PR DESCRIPTION
This PR will add libexif, but is WIP (**Update: not WIP now**) for a few reasons:

1) I have not yet contacted the maintainers of libexif to see if they'd like to participate (so no primary maintainer is in the project.yaml). (**UPDATE: Done**)
2) It appears Google is already submitting bugs via autofuzz (https://sourceforge.net/p/libexif/bugs/133/). Is there a desire to move internal fuzzing to external or should this PR be closed? (**Verdict: No, we want it here in oss-fuzz**)

Additionally, the undefined fuzzer is not enabled because there are several left shifts that immediately trigger bugs and prevent useful coverage. Once those are fixed we can enable ubsan.