### PR TITLE
[skia] Move null gl fuzzer to use mock gl context

### DIFF
--- a/projects/skia/BUILD.gn.diff
+++ b/projects/skia/BUILD.gn.diff
@@ -170,7 +170,7 @@ test_app("api_raster_n32_canvas") {
   ]
 }
 
-test_app("api_mock_gl_canvas") {
+test_app("api_mock_gpu_canvas") {
   include_dirs = [
     "tools",
     "tools/debugger",
@@ -178,7 +178,7 @@ test_app("api_mock_gl_canvas") {
   sources = [
     "fuzz/FuzzCanvas.cpp",
     "fuzz/FuzzCommon.cpp",
-    "fuzz/oss_fuzz/FuzzMockGLCanvas.cpp",
+    "fuzz/oss_fuzz/FuzzMockGPUCanvas.cpp",
     "tools/UrlDataManager.cpp",
     "tools/debugger/SkDebugCanvas.cpp",
     "tools/debugger/SkDrawCommand.cpp",

--- a/projects/skia/BUILD.gn.diff
+++ b/projects/skia/BUILD.gn.diff
@@ -170,7 +170,7 @@ test_app("api_raster_n32_canvas") {
   ]
 }
 
-test_app("api_null_gl_canvas") {
+test_app("api_mock_gl_canvas") {
   include_dirs = [
     "tools",
     "tools/debugger",
@@ -178,7 +178,7 @@ test_app("api_null_gl_canvas") {
   sources = [
     "fuzz/FuzzCanvas.cpp",
     "fuzz/FuzzCommon.cpp",
-    "fuzz/oss_fuzz/FuzzNullGLCanvas.cpp",
+    "fuzz/oss_fuzz/FuzzMockGLCanvas.cpp",
     "tools/UrlDataManager.cpp",
     "tools/debugger/SkDebugCanvas.cpp",
     "tools/debugger/SkDrawCommand.cpp",

--- a/projects/skia/Dockerfile
+++ b/projects/skia/Dockerfile
@@ -76,7 +76,7 @@ COPY api_fuzzers.options $SRC/skia/api_image_filter.options
 COPY api_fuzzers.options $SRC/skia/api_path_measure.options
 COPY api_fuzzers.options $SRC/skia/api_raster_n32_canvas.options
 COPY api_fuzzers.options $SRC/skia/api_null_canvas.options
-COPY api_fuzzers.options $SRC/skia/api_mock_gl_canvas.options
+COPY api_fuzzers.options $SRC/skia/api_mock_gpu_canvas.options
 
 COPY BUILD.gn.diff $SRC/skia/BUILD.gn.diff
 RUN cat BUILD.gn.diff >> BUILD.gn

--- a/projects/skia/Dockerfile
+++ b/projects/skia/Dockerfile
@@ -76,6 +76,7 @@ COPY api_fuzzers.options $SRC/skia/api_image_filter.options
 COPY api_fuzzers.options $SRC/skia/api_path_measure.options
 COPY api_fuzzers.options $SRC/skia/api_raster_n32_canvas.options
 COPY api_fuzzers.options $SRC/skia/api_null_canvas.options
+COPY api_fuzzers.options $SRC/skia/api_mock_gl_canvas.options
 
 COPY BUILD.gn.diff $SRC/skia/BUILD.gn.diff
 RUN cat BUILD.gn.diff >> BUILD.gn

--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -63,7 +63,7 @@ $SRC/depot_tools/ninja -C out/Fuzz region_deserialize region_set_path \
                                    api_path_measure api_null_canvas png_encoder \
                                    jpeg_encoder webp_encoder
 
-$SRC/depot_tools/ninja -C out/GPU api_null_gl_canvas
+$SRC/depot_tools/ninja -C out/GPU api_mock_gl_canvas
 
 cp out/Fuzz/region_deserialize $OUT/region_deserialize
 cp ./region_deserialize.options $OUT/region_deserialize.options
@@ -129,10 +129,12 @@ cp ./canvas_seed_corpus.zip $OUT/api_null_canvas_seed_corpus.zip
 
 # Remove unnecessary dependencies that aren't on runner containers.
 # Libraries found through trial and error (ldd command also helpful).
-patchelf --remove-needed libGLU.so.1 out/GPU/api_null_gl_canvas
-patchelf --remove-needed libGL.so.1 out/GPU/api_null_gl_canvas
-patchelf --remove-needed libX11.so.6 out/GPU/api_null_gl_canvas
-cp out/GPU/api_null_gl_canvas $OUT/api_null_gl_canvas
+patchelf --remove-needed libGLU.so.1 out/GPU/api_mock_gl_canvas
+patchelf --remove-needed libGL.so.1 out/GPU/api_mock_gl_canvas
+patchelf --remove-needed libX11.so.6 out/GPU/api_mock_gl_canvas
+cp out/GPU/api_mock_gl_canvas $OUT/api_mock_gl_canvas
+cp ./api_mock_gl_canvas.options $OUT/mock_gl_canvas.options
+cp ./canvas_seed_corpus.zip $OUT/api_mock_gl_canvas_seed_corpus.zip
 
 cp out/Fuzz/png_encoder $OUT/png_encoder
 cp ./encoder.options $OUT/png_encoder.options

--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -63,7 +63,7 @@ $SRC/depot_tools/ninja -C out/Fuzz region_deserialize region_set_path \
                                    api_path_measure api_null_canvas png_encoder \
                                    jpeg_encoder webp_encoder
 
-$SRC/depot_tools/ninja -C out/GPU api_mock_gl_canvas
+$SRC/depot_tools/ninja -C out/GPU api_mock_gpu_canvas
 
 cp out/Fuzz/region_deserialize $OUT/region_deserialize
 cp ./region_deserialize.options $OUT/region_deserialize.options
@@ -129,12 +129,12 @@ cp ./canvas_seed_corpus.zip $OUT/api_null_canvas_seed_corpus.zip
 
 # Remove unnecessary dependencies that aren't on runner containers.
 # Libraries found through trial and error (ldd command also helpful).
-patchelf --remove-needed libGLU.so.1 out/GPU/api_mock_gl_canvas
-patchelf --remove-needed libGL.so.1 out/GPU/api_mock_gl_canvas
-patchelf --remove-needed libX11.so.6 out/GPU/api_mock_gl_canvas
-cp out/GPU/api_mock_gl_canvas $OUT/api_mock_gl_canvas
-cp ./api_mock_gl_canvas.options $OUT/mock_gl_canvas.options
-cp ./canvas_seed_corpus.zip $OUT/api_mock_gl_canvas_seed_corpus.zip
+patchelf --remove-needed libGLU.so.1 out/GPU/api_mock_gpu_canvas
+patchelf --remove-needed libGL.so.1 out/GPU/api_mock_gpu_canvas
+patchelf --remove-needed libX11.so.6 out/GPU/api_mock_gpu_canvas
+cp out/GPU/api_mock_gpu_canvas $OUT/api_mock_gpu_canvas
+cp ./api_mock_gpu_canvas.options $OUT/mock_gpu_canvas.options
+cp ./canvas_seed_corpus.zip $OUT/api_mock_gpu_canvas_seed_corpus.zip
 
 cp out/Fuzz/png_encoder $OUT/png_encoder
 cp ./encoder.options $OUT/png_encoder.options


### PR DESCRIPTION
I chatted with the Skia GPU team and they would prefer we use mock gl context, as it better simulates what actual GPUs do and is better maintained.