### PR TITLE
libtiff support

### DIFF
--- a/projects/libtiff/Dockerfile
+++ b/projects/libtiff/Dockerfile
@@ -21,5 +21,6 @@ RUN git clone --depth 1 https://gitlab.com/libtiff/libtiff
 RUN git clone --depth 1 https://github.com/madler/zlib
 RUN git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo
 ADD http://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz afl_testcases.tgz
+ADD https://raw.githubusercontent.com/mcarpenter/afl/master/dictionaries/tiff.dict tiff.dict
 WORKDIR libtiff
 COPY build.sh tiff_read_rgba_fuzzer.cc $SRC/

--- a/projects/libtiff/Dockerfile
+++ b/projects/libtiff/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER paul.l.kehrer@gmail.com
+RUN apt-get update && apt-get install -y make autoconf automake libtool cmake nasm
+RUN git clone --depth 1 https://gitlab.com/libtiff/libtiff
+RUN git clone --depth 1 https://github.com/madler/zlib
+RUN git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo
+ADD http://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz afl_testcases.tgz
+WORKDIR libtiff
+COPY build.sh tiff_read_rgba_fuzzer.cc $SRC/

--- a/projects/libtiff/build.sh
+++ b/projects/libtiff/build.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -eu
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+
+# build zlib
+pushd "$SRC/zlib"
+./configure --static --prefix="$WORK"
+make -j$(nproc) CFLAGS="$CFLAGS -fPIC"
+make install
+popd
+
+# Build libjpeg-turbo
+pushd "$SRC/libjpeg-turbo"
+cmake . -DCMAKE_INSTALL_PREFIX=$WORK -DENABLE_STATIC=on -DENABLE_SHARED=off
+make -j$(nproc)
+make install
+popd
+
+cmake . -DCMAKE_INSTALL_PREFIX=$WORK -DBUILD_SHARED_LIBS=off
+make -j$(nproc)
+make install
+
+$CXX $CXXFLAGS -std=c++11 -I$WORK/include \
+    $SRC/tiff_read_rgba_fuzzer.cc -o $OUT/tiff_read_rgba_fuzzer \
+    -lFuzzingEngine $WORK/lib/libtiffxx.a $WORK/lib/libtiff.a $WORK/lib/libz.a $WORK/lib/libjpeg.a
+
+mkdir afl_testcases
+(cd afl_testcases; tar xf "$SRC/afl_testcases.tgz")
+mkdir tif
+find afl_testcases -type f -name '*.tif' -exec mv -n {} tif/ \;
+zip -rj tif.zip tif/
+cp tif.zip "$OUT/tiff_read_rgba_fuzzer_seed_corpus.zip"

--- a/projects/libtiff/build.sh
+++ b/projects/libtiff/build.sh
@@ -44,3 +44,4 @@ mkdir tif
 find afl_testcases -type f -name '*.tif' -exec mv -n {} tif/ \;
 zip -rj tif.zip tif/
 cp tif.zip "$OUT/tiff_read_rgba_fuzzer_seed_corpus.zip"
+cp "$SRC/tiff.dict" "$OUT/tiff_read_rgba_fuzzer.dict"

--- a/projects/libtiff/project.yaml
+++ b/projects/libtiff/project.yaml
@@ -1,0 +1,8 @@
+homepage: "http://www.libtiff.org"
+primary_contact: "even.rouault@gmail.com"
+auto_ccs:
+  - paul.l.kehrer@gmail.com
+sanitizers:
+  - address
+  - memory
+  - undefined

--- a/projects/libtiff/tiff_read_rgba_fuzzer.cc
+++ b/projects/libtiff/tiff_read_rgba_fuzzer.cc
@@ -1,0 +1,67 @@
+#include <cstdint>
+#include <sstream>
+#include <tiffio.h>
+#include <tiffio.hxx>
+
+
+/* stolen from tiffiop.h, which is a private header so we can't just include it */
+/* safe multiply returns either the multiplied value or 0 if it overflowed */
+#define __TIFFSafeMultiply(t,v,m) ((((t)(m) != (t)0) && (((t)(((v)*(m))/(m))) == (t)(v))) ? (t)((v)*(m)) : (t)0)
+
+const tmsize_t MAX_SIZE = 500000000;
+
+extern "C" void handle_error(const char *unused, const char *unused2, va_list unused3) {
+    return;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+  TIFFSetErrorHandler(handle_error);
+  TIFFSetWarningHandler(handle_error);
+  std::istringstream s(std::string(Data,Data+Size));
+  TIFF* tif = TIFFStreamOpen("MemTIFF", &s);
+  if (!tif) {
+      return 0;
+  }
+  uint32 w, h;
+  size_t npixels;
+  uint32* raster;
+
+  TIFFGetField(tif, TIFFTAG_IMAGEWIDTH, &w);
+  TIFFGetField(tif, TIFFTAG_IMAGELENGTH, &h);
+  /* don't continue if image has negative size or the file size is ludicrous */
+  if (TIFFTileSize(tif) > MAX_SIZE || w <=0 || h <= 0) {
+      TIFFClose(tif);
+      return 0;
+  }
+  tmsize_t bufsize = __TIFFSafeMultiply(tmsize_t, TIFFTileSize(tif), 4);
+  /* don't continue if the buffer size greater than the max allowed by the fuzzer */
+  if (bufsize > MAX_SIZE || bufsize == 0) {
+      TIFFClose(tif);
+      return 0;
+  }
+  /* another hack to work around an OOM in tif_fax3.c */
+  uint32 tilewidth = 0;
+  uint32 imagewidth = 0;
+  TIFFGetField(tif, TIFFTAG_TILEWIDTH, &tilewidth);
+  TIFFGetField(tif, TIFFTAG_IMAGEWIDTH, &imagewidth);
+  tilewidth = __TIFFSafeMultiply(uint32, tilewidth, 2);
+  imagewidth = __TIFFSafeMultiply(uint32, imagewidth, 2);
+  if (tilewidth * 2 > MAX_SIZE || imagewidth * 2 > MAX_SIZE || tilewidth == 0 || imagewidth == 0) {
+      TIFFClose(tif);
+      return 0;
+  }
+  npixels = w * h;
+  uint32 size = __TIFFSafeMultiply(uint32, w, h);
+  if (size > MAX_SIZE || size == 0) {
+      TIFFClose(tif);
+      return 0;
+  }
+  raster = (uint32*) _TIFFmalloc(npixels * sizeof (uint32));
+  if (raster != NULL) {
+      TIFFReadRGBAImage(tif, w, h, raster, 0);
+      _TIFFfree(raster);
+  }
+  TIFFClose(tif);
+
+  return 0;
+}


### PR DESCRIPTION
After some discussion on the libtiff mailing list there was generally support for adding libtiff to oss-fuzz, so here's the PR! Thanks to @rouault for being willing to act as primary contact here.

As with several of the other integrations I've done this PR adds the fuzzer code directly to this repo, but shortly after merge we'll migrate the build scripts/fuzzers into the libtiff source tree.

One quirk of this fuzzer is that it does quite a lot of work to reject inputs that will cause OOMs. At the moment libtiff does not attempt to constrain memory allocations so any fuzzer needs to do this sort of sanity check or else it will be unable to make progress.