### PR TITLE
[Wget] Add project

### DIFF
--- a/projects/wget/Dockerfile
+++ b/projects/wget/Dockerfile
@@ -1,0 +1,50 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER rockdaboot@gmail.com
+RUN apt-get update && apt-get install -y \
+ make \
+ pkg-config \
+ gettext \
+ autogen \
+ autopoint \
+ autoconf \
+ automake \
+ libtool \
+ texinfo \
+ flex \
+ bison \
+ gettext \
+ gengetopt \
+ curl \
+ gperf \
+ wget \
+ python \
+ rsync
+
+ENV GNULIB_TOOL $SRC/gnulib/gnulib-tool
+RUN git clone git://git.savannah.gnu.org/gnulib.git
+RUN git clone --depth=1 --recursive https://git.savannah.gnu.org/git/libunistring.git
+RUN git clone --depth=1 --recursive https://gitlab.com/libidn/libidn2.git
+RUN git clone --depth=1 --recursive https://github.com/rockdaboot/libpsl.git
+RUN git clone --depth=1 https://git.lysator.liu.se/nettle/nettle.git
+RUN git clone --depth=1 https://gitlab.com/gnutls/gnutls.git
+
+RUN git clone --recursive https://git.savannah.gnu.org/git/wget.git
+
+WORKDIR wget
+COPY build.sh $SRC/

--- a/projects/wget/build.sh
+++ b/projects/wget/build.sh
@@ -1,0 +1,108 @@
+#!/bin/bash -eu
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+export WGET_DEPS_PATH=$SRC/wget_deps
+export PKG_CONFIG_PATH=$WGET_DEPS_PATH/lib/pkgconfig
+export CPPFLAGS="-I$WGET_DEPS_PATH/include"
+export LDFLAGS="-L$WGET_DEPS_PATH/lib"
+export GNULIB_SRCDIR=$SRC/gnulib
+export LLVM_PROFILE_FILE=/tmp/prof.test
+
+cd $SRC/libunistring
+./autogen.sh
+./configure --enable-static --disable-shared --prefix=$WGET_DEPS_PATH --cache-file ../config.cache
+make -j$(nproc)
+make install
+
+cd $SRC/libidn2
+./bootstrap
+./configure --enable-static --disable-shared --disable-doc --disable-gcc-warnings --prefix=$WGET_DEPS_PATH --cache-file ../config.cache
+make -j$(nproc)
+make install
+
+cd $SRC/libpsl
+./autogen.sh
+./configure --enable-static --disable-shared --disable-gtk-doc --enable-runtime=libidn2 --enable-builtin=libidn2 --prefix=$WGET_DEPS_PATH --cache-file ../config.cache
+make -j$(nproc)
+make install
+
+GNUTLS_CONFIGURE_FLAGS=""
+NETTLE_CONFIGURE_FLAGS=""
+if [[ $CFLAGS = *sanitize=memory* ]]; then
+  GNUTLS_CONFIGURE_FLAGS="--disable-hardware-acceleration"
+  NETTLE_CONFIGURE_FLAGS="--disable-assembler --disable-fat"
+fi
+
+# We could use GMP from git repository to avoid false positives in
+# sanitizers, but GMP doesn't compile with clang. We use gmp-mini
+# instead.
+cd $SRC/nettle
+bash .bootstrap
+./configure --enable-mini-gmp --enable-static --disable-shared --disable-documentation --prefix=$WGET_DEPS_PATH $NETTLE_CONFIGURE_FLAGS --cache-file ../config.cache
+( make -j$(nproc) || make -j$(nproc) ) && make install
+if test $? != 0;then
+        echo "Failed to compile nettle"
+        exit 1
+fi
+
+cd $SRC/gnutls
+touch .submodule.stamp
+make bootstrap
+GNUTLS_CFLAGS=`echo $CFLAGS|sed s/-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION//`
+LIBS="-lunistring" \
+CFLAGS="$GNUTLS_CFLAGS" \
+./configure --with-nettle-mini --enable-gcc-warnings --enable-static --disable-shared --with-included-libtasn1 \
+    --with-included-unistring --without-p11-kit --disable-doc --disable-tests --disable-tools --disable-cxx \
+    --disable-maintainer-mode --disable-libdane --disable-gcc-warnings --prefix=$WGET_DEPS_PATH $GNUTLS_CONFIGURE_FLAGS
+make -j$(nproc)
+make install
+
+
+# avoid iconv() memleak on Ubuntu 16.04 image (breaks test suite)
+export ASAN_OPTIONS=detect_leaks=0
+
+cd $SRC/wget
+git checkout -b oss-fuzz origin/oss-fuzz
+./bootstrap
+
+# build and run non-networking tests
+LIBS="-lgnutls -lnettle -lhogweed -lidn2 -lunistring" \
+  ./configure -C
+make clean
+make -j$(nproc)
+make -j$(nproc) -C fuzz check
+
+# build for fuzzing
+LIBS="-lgnutls -lnettle -lhogweed -lidn2 -lunistring" \
+  ./configure --enable-fuzzing -C
+make clean
+make -j$(nproc) -C lib
+make -j$(nproc) -C src
+
+# build fuzzers
+cd fuzz
+make -j$(nproc) ../src/libunittest.a
+CXXFLAGS="$CXXFLAGS -L$WGET_DEPS_PATH/lib/" make oss-fuzz
+
+find . -name '*_fuzzer' -exec cp -v '{}' $OUT ';'
+find . -name '*_fuzzer.dict' -exec cp -v '{}' $OUT ';'
+find . -name '*_fuzzer.options' -exec cp -v '{}' $OUT ';'
+
+for dir in *_fuzzer.in; do
+  fuzzer=$(basename $dir .in)
+  zip -rj "$OUT/${fuzzer}_seed_corpus.zip" "${dir}/"
+done

--- a/projects/wget/project.yaml
+++ b/projects/wget/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://www.gnu.org/software/wget/"
+primary_contact: "rockdaboot@gmail.com"
+auto_ccs:
+  - "tim.ruehsen@gmx.de"
+  - "darnir@gmail.com"
+  - "gscrivan@redhat.com"


### PR DESCRIPTION
While working on Debian unstable with clang-6.0, I see this error when running in the oss-fuzz docker image:
```
==11== ERROR: libFuzzer: fuzz target exited
    #0 0x4f90f3 in __sanitizer_print_stack_trace /src/llvm/projects/compiler-rt/lib/asan/asan_stack.cc:38
    #1 0x605124 in fuzzer::Fuzzer::ExitCallback() /src/libfuzzer/FuzzerLoop.cpp:248:5
    #2 0x7f0690fb3ff7  (/lib/x86_64-linux-gnu/libc.so.6+0x39ff7)
    #3 0x7f0690fb4044 in exit (/lib/x86_64-linux-gnu/libc.so.6+0x3a044)
    #4 0x539800 in main_wget /src/wget/src/main.c
    #5 0x5295b2 in LLVMFuzzerTestOneInput /src/wget/fuzz/wget_options_fuzzer.c:141:2
    #6 0x608c31 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/libfuzzer/FuzzerLoop.cpp:517:13
    #7 0x60b9f9 in fuzzer::Fuzzer::ReadAndExecuteSeedCorpora(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, fuzzer::fuzzer_allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) /src/libfuzzer/FuzzerLoop.cpp:703:3
    #8 0x60c8f8 in fuzzer::Fuzzer::Loop(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, fuzzer::fuzzer_allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) /src/libfuzzer/FuzzerLoop.cpp:741:3
    #9 0x5ec3fe in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/libfuzzer/FuzzerDriver.cpp:754:6
    #10 0x5df37c in main /src/libfuzzer/FuzzerMain.cpp:20:10
    #11 0x7f0690f9a82f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
    #12 0x41e4c8 in _start (/out/wget_options_fuzzer+0x41e4c8)
```

The calls to exit() in the wget code base are catched using longjmp() and dlsym(). Does anything in the docker image prevent it ? Is there an 'official' way to get along with exit()s in fuzzed code ?