### PR TITLE
Drop -v from graphicsmagick clone

### DIFF
--- a/projects/graphicsmagick/Dockerfile
+++ b/projects/graphicsmagick/Dockerfile
@@ -17,8 +17,8 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER alex.gaynor@gmail.com
 RUN apt-get update && apt-get install -y mercurial
-RUN hg clone -v http://hg.code.sf.net/p/graphicsmagick/code graphicsmagick || \
-    hg clone -v http://hg.code.sf.net/p/graphicsmagick/code graphicsmagick || \
-    hg clone -v http://hg.code.sf.net/p/graphicsmagick/code graphicsmagick
+RUN hg clone http://hg.code.sf.net/p/graphicsmagick/code graphicsmagick || \
+    hg clone http://hg.code.sf.net/p/graphicsmagick/code graphicsmagick || \
+    hg clone http://hg.code.sf.net/p/graphicsmagick/code graphicsmagick
 WORKDIR graphicsmagick
 COPY build.sh $SRC/


### PR DESCRIPTION
Reduces the verbosity, and it was never that useful for debugging anyways.