### PR TITLE
curl: Download dependencies in Docker using the curl-fuzzer project scripts

### DIFF
--- a/projects/curl/Dockerfile
+++ b/projects/curl/Dockerfile
@@ -16,9 +16,12 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER dvyukov@google.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool libssl-dev zlib1g-dev
 
 RUN git clone --depth 1 https://github.com/curl/curl.git /src/curl
 RUN git clone --depth 1 https://github.com/curl/curl-fuzzer.git /src/curl_fuzzer
+
+# Use curl-fuzzer's scripts to get latest dependencies.
+RUN /src/curl_fuzzer/scripts/ossfuzzdeps.sh
+
 WORKDIR /src/curl_fuzzer
 COPY build.sh $SRC/


### PR DESCRIPTION
curl-fuzzer would like to use a script to define the dependencies
downloaded as part of oss-fuzz image generation, so that only one
repository needs updating in order to get future fuzzing builds running.

---
Basically - I think it makes place for these to get updated in one place (our repo) and for the overnight oss-fuzz to pick those up as and when. Let me know if you disagree.

I'm aiming to add nghttp2 support shortly and I think we'll need to also install pkg-config as a dependency, which is driving this change.