### PR TITLE
set max input length option with pem_cert target

### DIFF
--- a/projects/wolfssl/Dockerfile
+++ b/projects/wolfssl/Dockerfile
@@ -23,4 +23,4 @@ RUN git clone https://github.com/wolfssl/oss-fuzz-targets --depth 1 $SRC/fuzz-ta
 
 WORKDIR wolfssl
 
-COPY build.sh $SRC/
+COPY build.sh *.options $SRC/

--- a/projects/wolfssl/pem_cert.options
+++ b/projects/wolfssl/pem_cert.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 25000


### PR DESCRIPTION
Avoid having a massive test file being passed into the target. Large test files caused it to execute for more than 25 seconds when parsing for PEM header/footer strings.