### PR TITLE
Zip existing `file` testcases to create seed_corpus

### DIFF
--- a/projects/file/build.sh
+++ b/projects/file/build.sh
@@ -25,3 +25,4 @@ $CXX $CXXFLAGS -std=c++11 -Isrc/ \
 
 cp ./magic/magic.mgc $OUT/
 
+zip -j $OUT/magic_fuzzer_seed_corpus.zip ./tests/*.testfile


### PR DESCRIPTION
The `file` utility has an existing set of test-cases in the `tests` subdirectory (along with an accompanying "result" file.  This commit zips the tests and uses it to seed the testing corpus.