### PR TITLE
Add another core committer

### DIFF
--- a/projects/msgpack-c/project.yaml
+++ b/projects/msgpack-c/project.yaml
@@ -1,6 +1,7 @@
 homepage: "https://msgpack.org/"
 primary_contact: "redboltz@gmail.com"
 auto_ccs:
+  - nobu.k.jp@gmail.com
   - chriswwolfe@gmail.com
 sanitizers:
   - address


### PR DESCRIPTION
This adds another core committer to the project so that they can access bug reports, etc.

cc @redboltz, references https://github.com/msgpack/msgpack-c/issues/669#issuecomment-382945010