### PR TITLE
Allow more file extensions in Wuffs' seed corpora

### DIFF
--- a/projects/wuffs/build.sh
+++ b/projects/wuffs/build.sh
@@ -20,7 +20,18 @@
 # http://gpfault.net/posts/drop-in-libraries.txt.html
 
 for f in fuzz/c/std/*_fuzzer.cc; do
+  # Extract the format name, such as "gzip", from the C++ file name,
+  # "fuzz/c/std/gzip_fuzzer.cc".
   b=$(basename $f _fuzzer.cc)
+
+  # Make the "gzip_fuzzer" binary.
   $CXX $CXXFLAGS -std=c++11 $f -o $OUT/${b}_fuzzer -lFuzzingEngine
-  zip --junk-paths $OUT/${b}_fuzzer_seed_corpus.zip test/data/*.$b
+
+  # Make the optional "gzip_fuzzer_seed_corpus.zip" archive. This means
+  # extracting the "foo/bar/*.gz" out of the matching "gzip: foo/bar/*.gz"
+  # lines in fuzz/c/std/seed_corpora.txt.
+  seeds=$(sed -n -e "/^$b:/s/^$b: *//p" fuzz/c/std/seed_corpora.txt)
+  if [ -n "$seeds" ]; then
+    zip --junk-paths $OUT/${b}_fuzzer_seed_corpus.zip $seeds
+  fi
 done


### PR DESCRIPTION
The Wuffs project handles multiple file formats, such as GIF and ZLIB
decoders. Prior to this commit, the format name and the file extension
were the same (case-insensitive) string: fuzz-testing the GIF format was
seeded with test files matching "*.gif", and "*.gif" was trivially
derived from the "gif_fuzzer.cc" file name.

For the GZIP file format, the conventional file extension is ".gz", not
".gzip". For the JPEG file format, both ".jpeg" and ".jpg" are widely
used. Building the seed corpus for future Wuffs codecs might require
mapping from the file format name to arbitrary file extensions.

Wuffs' fuzz/c/std/seed_corpora.txt file (added in
https://github.com/google/wuffs/commit/b6cc2d5e) provides that mapping.
This commit updates OSS-Fuzz's projects/wuffs/build.sh to use it.