### PR TITLE
[wireshark] fix build issue (#1347)

### DIFF
--- a/projects/wireshark/Dockerfile
+++ b/projects/wireshark/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER Jakub Zawadzki <darkjames-ws@darkjames.pl>
 
-RUN apt-get update && apt-get install -y make autoconf automake libtool libtool-bin \
+RUN apt-get update && apt-get install -y make cmake \
                        flex bison \
                        libglib2.0-dev libgcrypt20-dev
 


### PR DESCRIPTION
Dario Lombardo removed autotools support in https://code.wireshark.org/review/26969,
convert to cmake build system to fix build issue

This is initial cmake support just to fix build issue. It can be later improved, with fixed TODOs, or -G Ninja.

Unfortunate build problem also need fix upstream https://code.wireshark.org/review/27076/, which I would prefer to be reviewed (read: not merge it myself quick) I am new in cmake world.