### PR TITLE
[infra] Invoke run_fuzzer from bad_build_check for regression testing (fixes #1355).

### DIFF
--- a/infra/base-images/base-runner/bad_build_check
+++ b/infra/base-images/base-runner/bad_build_check
@@ -54,7 +54,7 @@ function check_instrumentation {
     return 1
   fi
 
-  local NUMBER_OF_EDGES=$(grep -Po "INFO: Loaded [[:digit:]]+ module.*\(.*counters|guards\):[[:space:]]+\K[[:digit:]]+" $FUZZER_OUTPUT)
+  local NUMBER_OF_EDGES=$(grep -Po "INFO: Loaded [[:digit:]]+ module.*\(.*(counters|guards)\):[[:space:]]+\K[[:digit:]]+" $FUZZER_OUTPUT)
 
   if (( $NUMBER_OF_EDGES < $THRESHOLD_FOR_NUMBER_OF_EDGES )); then
     echo "BAD BUILD: the target seems to have only partial coverage instrumentation."
@@ -165,6 +165,24 @@ function check_mixed_sanitizers {
   fi
 }
 
+# Verify that the given fuzz target doesn't crash on the seed corpus.
+function check_seed_corpus {
+  local FUZZER=$1
+  local FUZZER_OUTPUT="/tmp/$(basename $FUZZER).output"
+
+  # Set up common fuzzing arguments, otherwise "run_fuzer" errors out.
+  if [ -z "$FUZZER_ARGS" ]; then
+    export FUZZER_ARGS="-rss_limit_mb=2048 -timeout=25"
+  fi
+
+  bash -c "run_fuzzer $(basename $FUZZER) -runs=0" &> $FUZZER_OUTPUT
+
+  # Don't output anything if fuzz target hasn't crashed.
+  if [ $? -ne 0 ]; then
+    cat $FUZZER_OUTPUT
+  fi
+}
+
 
 function main {
   local FUZZER=$1
@@ -172,6 +190,7 @@ function main {
   check_instrumentation $FUZZER
   check_mixed_sanitizers $FUZZER
   check_startup_crash $FUZZER
+  check_seed_corpus $FUZZER
 }
 
 

--- a/infra/base-images/base-runner/bad_build_check
+++ b/infra/base-images/base-runner/bad_build_check
@@ -168,17 +168,23 @@ function check_mixed_sanitizers {
 # Verify that the given fuzz target doesn't crash on the seed corpus.
 function check_seed_corpus {
   local FUZZER=$1
-  local FUZZER_OUTPUT="/tmp/$(basename $FUZZER).output"
+  local FUZZER_NAME="$(basename $FUZZER)"
+  local FUZZER_OUTPUT="/tmp/$FUZZER_NAME.output"
 
-  # Set up common fuzzing arguments, otherwise "run_fuzer" errors out.
+  if [[ "$FUZZING_ENGINE" != libfuzzer ]]; then
+    return
+  fi
+
+  # Set up common fuzzing arguments, otherwise "run_fuzzer" errors out.
   if [ -z "$FUZZER_ARGS" ]; then
     export FUZZER_ARGS="-rss_limit_mb=2048 -timeout=25"
   fi
 
-  bash -c "run_fuzzer $(basename $FUZZER) -runs=0" &> $FUZZER_OUTPUT
+  bash -c "run_fuzzer $FUZZER_NAME -runs=0" &> $FUZZER_OUTPUT
 
   # Don't output anything if fuzz target hasn't crashed.
   if [ $? -ne 0 ]; then
+    echo "$FUZZER_NAME has a crash input in its seed coprpus:"
     cat $FUZZER_OUTPUT
   fi
 }

--- a/infra/base-images/base-runner/run_fuzzer
+++ b/infra/base-images/base-runner/run_fuzzer
@@ -26,14 +26,12 @@ shift
 
 CORPUS_DIR="/tmp/${FUZZER}_corpus"
 
-rm -rf ${CORPUS_DIR} && mkdir ${CORPUS_DIR}/
+rm -rf $CORPUS_DIR && mkdir $CORPUS_DIR
 
-CORPUS=
 SEED_CORPUS="${FUZZER}_seed_corpus.zip"
 if [ -f $SEED_CORPUS ]; then
   echo "Using seed corpus: $SEED_CORPUS"
   unzip -d ${CORPUS_DIR}/ $SEED_CORPUS > /dev/null
-  CORPUS=${CORPUS_DIR}
 fi
 
 if [[ "$FUZZING_ENGINE" = afl ]]; then
@@ -46,15 +44,10 @@ if [[ "$FUZZING_ENGINE" = afl ]]; then
   rm -rf /tmp/afl_output && mkdir /tmp/afl_output
   # AFL expects at least 1 file in the input dir.
   echo input > ${CORPUS_DIR}/input
-  CMD_LINE="$OUT/afl-fuzz $AFL_FUZZER_ARGS -i /tmp/
-
-   -o /tmp/afl_output $@ $OUT/$FUZZER"
+  CMD_LINE="$OUT/afl-fuzz $AFL_FUZZER_ARGS -i $CORPUS_DIR -o /tmp/afl_output $@ $OUT/$FUZZER"
 elif [[ "$FUZZING_ENGINE" = honggfuzz ]]; then
-  if [ -z "$CORPUS" ]; then
-    CORPUS=${CORPUS_DIR}
-  fi
   # Honggfuzz expects at least 1 file in the input dir.
-  echo input > $CORPUS/input
+  echo input > $CORPUS_DIR/input
   rm -rf /tmp/honggfuzz_workdir && mkdir /tmp/honggfuzz_workdir
   # --exit_upon_crash: exit whith a first crash seen
   # -R (report): save report file to this location
@@ -66,7 +59,7 @@ elif [[ "$FUZZING_ENGINE" = honggfuzz ]]; then
   # -n: number of fuzzing threads (and processes)
   CMD_LINE="$OUT/honggfuzz -n 1 --exit_upon_crash -R /tmp/HONGGFUZZ.REPORT.TXT -W /tmp/honggfuzz_workdir -v -z -P -f \"$CORPUS\" $@ -- \"$OUT/$FUZZER\""
 else
-  CMD_LINE="$OUT/$FUZZER $FUZZER_ARGS $@ $CORPUS"
+  CMD_LINE="$OUT/$FUZZER $FUZZER_ARGS $@ $CORPUS_DIR"
 
   OPTIONS_FILE="${FUZZER}.options"
   if [ -f $OPTIONS_FILE ]; then

--- a/infra/base-images/base-runner/run_fuzzer
+++ b/infra/base-images/base-runner/run_fuzzer
@@ -24,14 +24,16 @@ cd $OUT
 FUZZER=$1
 shift
 
-rm -rf /tmp/input/ && mkdir /tmp/input/
+CORPUS_DIR="/tmp/${FUZZER}_corpus"
+
+rm -rf ${CORPUS_DIR} && mkdir ${CORPUS_DIR}/
 
 CORPUS=
 SEED_CORPUS="${FUZZER}_seed_corpus.zip"
 if [ -f $SEED_CORPUS ]; then
   echo "Using seed corpus: $SEED_CORPUS"
-  unzip -d /tmp/input/ $SEED_CORPUS > /dev/null
-  CORPUS=/tmp/input
+  unzip -d ${CORPUS_DIR}/ $SEED_CORPUS > /dev/null
+  CORPUS=${CORPUS_DIR}
 fi
 
 if [[ "$FUZZING_ENGINE" = afl ]]; then
@@ -43,11 +45,13 @@ if [[ "$FUZZING_ENGINE" = afl ]]; then
   export AFL_SKIP_CPUFREQ=1
   rm -rf /tmp/afl_output && mkdir /tmp/afl_output
   # AFL expects at least 1 file in the input dir.
-  echo input > /tmp/input/input
-  CMD_LINE="$OUT/afl-fuzz $AFL_FUZZER_ARGS -i /tmp/input -o /tmp/afl_output $@ $OUT/$FUZZER"
+  echo input > ${CORPUS_DIR}/input
+  CMD_LINE="$OUT/afl-fuzz $AFL_FUZZER_ARGS -i /tmp/
+
+   -o /tmp/afl_output $@ $OUT/$FUZZER"
 elif [[ "$FUZZING_ENGINE" = honggfuzz ]]; then
   if [ -z "$CORPUS" ]; then
-    CORPUS=/tmp/input
+    CORPUS=${CORPUS_DIR}
   fi
   # Honggfuzz expects at least 1 file in the input dir.
   echo input > $CORPUS/input

--- a/infra/base-images/base-runner/test_all
+++ b/infra/base-images/base-runner/test_all
@@ -46,17 +46,6 @@ for FUZZER_BINARY in $(find $OUT/ -executable -type f); do
     continue
   fi
 
-  if [ "$SKIP_TEST_TARGET_RUN" != "1" ]; then
-    if [[ "$FUZZING_ENGINE" = honggfuzz ]]; then
-      timeout --preserve-status -s INT 20s run_fuzzer $FUZZER
-    elif [[ "$FUZZING_ENGINE" = libfuzzer ]]; then
-      run_fuzzer $FUZZER -max_total_time=20
-    else
-      export AFL_NO_UI=1
-      timeout --preserve-status -s INT 20s run_fuzzer $FUZZER
-    fi
-  fi
-
   echo "INFO: performing bad build checks for $FUZZER_BINARY."
 
   LOG_PATH_FOR_BROKEN_TARGET="${BROKEN_TARGETS_DIR}/${FUZZER}"

--- a/infra/gcb/build.py
+++ b/infra/gcb/build.py
@@ -195,10 +195,6 @@ def get_build_steps(project_yaml, dockerfile_path):
       env.append('OUT=' + out)
       env.append('MSAN_LIBS_PATH=/workspace/msan')
 
-      # To disable running of all fuzz targets while doing |test_all| step, as
-      # that step is currently being used for performing bad build checks only.
-      env.append('SKIP_TEST_TARGET_RUN=1')
-
       workdir = workdir_from_dockerfile(dockerfile_path)
       if not workdir:
         workdir = '/src'


### PR DESCRIPTION
Please do not merge unless you're ready to monitor the build status page for possible breakages.

- the RegEx used to extract number of edges wan't perfect, fixed that
- added `check_seed_corpus` step that calls `run_fuzzer` to `bad_build_check` script. It's important to have it there rather than in `test_all` for better performance (`test_all` spawns multiple `bad_build_check` processes) and consistency in error reporting code (i.e. if log for a particular fuzz target is empty, there are no issues)
- updated `run_fuzzer` script to use unique corpus dir per fuzz target. The hardcoded name didn't work well due to multi-processing

Below is an example of artificially unsuccessful case:

```

root@f08947b3d6fb:/out# test_all
INFO: performing bad build checks for /out/curl_fuzzer_fnmatch.
INFO: performing bad build checks for /out/curl_fuzzer_scp.
INFO: performing bad build checks for /out/curl_fuzzer_smb.
INFO: performing bad build checks for /out/curl_fuzzer_ftp.
INFO: performing bad build checks for /out/curl_fuzzer_rtmp.
INFO: performing bad build checks for /out/curl_fuzzer_gopher.
INFO: performing bad build checks for /out/curl_fuzzer_pop3.
INFO: performing bad build checks for /out/curl_fuzzer.
INFO: performing bad build checks for /out/curl_fuzzer_file.
INFO: performing bad build checks for /out/curl_fuzzer_sftp.
INFO: performing bad build checks for /out/curl_fuzzer_imap.
INFO: performing bad build checks for /out/curl_fuzzer_ldap.
INFO: performing bad build checks for /out/curl_fuzzer_smtp.
INFO: performing bad build checks for /out/curl_fuzzer_https.
INFO: performing bad build checks for /out/curl_fuzzer_tftp.
INFO: performing bad build checks for /out/curl_fuzzer_dict.
INFO: performing bad build checks for /out/curl_fuzzer_http.
INFO: performing bad build checks for /out/curl_fuzzer_rtsp.
Broken fuzz targets (1):
curl_fuzzer_fnmatch:
Using seed corpus: curl_fuzzer_fnmatch_seed_corpus.zip
/out/curl_fuzzer_fnmatch -rss_limit_mb=2048 -timeout=25 -runs=0 /tmp/curl_fuzzer_fnmatch_corpus < /dev/null
INFO: Seed: 3318102592
INFO: Loaded 1 modules   (149 inline 8-bit counters): 149 [0x8a4a28, 0x8a4abd), 
INFO: Loaded 1 PC tables (149 PCs): 149 [0x8a4ac0,0x8a5410), 
INFO:        1 files found in /tmp/curl_fuzzer_fnmatch_corpus
<...>
ALARM: working on the last Unit for 25 seconds
       and the timeout value is 25 (use -timeout=N to change)
< ... here we got an error and a stacktrace ... >
    #21 0x41c9c8 in _start (/out/curl_fuzzer_fnmatch+0x41c9c8)

SUMMARY: libFuzzer: timeout
18 fuzzers total, 1 seem to be broken (5%).
```

