### PR TITLE
[msgpack-c] move seeds to source repo

### DIFF
--- a/projects/msgpack-c/Dockerfile
+++ b/projects/msgpack-c/Dockerfile
@@ -18,6 +18,5 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER chriswwolfe@gmail.com
 RUN apt-get update && apt-get install -y cmake
 RUN git clone --depth 1 https://github.com/msgpack/msgpack-c.git msgpack-c
-RUN git clone --depth 1 https://github.com/derwolfe/msgpack-corpora.git msgpack-corpora
 WORKDIR msgpack-c
 COPY build.sh $SRC/

--- a/projects/msgpack-c/build.sh
+++ b/projects/msgpack-c/build.sh
@@ -21,10 +21,17 @@ cmake -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" \
 make -j$(nproc) all
 
 for f in $SRC/msgpack-c/fuzz/*_fuzzer.cpp; do
+
+    # NOTE(derwolfe): the naming scheme for fuzzers and seed corpora is:
+    # fuzzer = something_something_fuzzer.cpp
+    # seed corpus = something_something_fuzzer_seed_corpus
+
     fuzzer=$(basename "$f" _fuzzer.cpp)
     $CXX $CXXFLAGS -std=c++11 -Iinclude -I"$SRC/msgpack-c/include" \
          "$f" -o "$OUT/${fuzzer}_fuzzer" \
          -lFuzzingEngine "$SRC/msgpack-c/libmsgpackc.a"
-done
 
-zip -rj "$OUT/unpack_pack_fuzzer_seed_corpus.zip" "$SRC/msgpack-corpora/packed/"
+    if [ -d "$SRC/msgpack-c/fuzz/${fuzzer}_fuzzer_seed_corpus" ]; then
+        zip -rj "$OUT/${fuzzer}_fuzzer_seed_corpus.zip" "$SRC/msgpack-c/fuzz/${fuzzer}_fuzzer_seed_corpus/"
+    fi
+done

--- a/projects/msgpack-c/build.sh
+++ b/projects/msgpack-c/build.sh
@@ -21,17 +21,15 @@ cmake -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" \
 make -j$(nproc) all
 
 for f in $SRC/msgpack-c/fuzz/*_fuzzer.cpp; do
-
-    # NOTE(derwolfe): the naming scheme for fuzzers and seed corpora is:
+    # NOTE(derwolfe): the naming scheme for fuzzers and seed corpora is
     # fuzzer = something_something_fuzzer.cpp
     # seed corpus = something_something_fuzzer_seed_corpus
-
-    fuzzer=$(basename "$f" _fuzzer.cpp)
+    fuzzer=$(basename "$f" .cpp)
     $CXX $CXXFLAGS -std=c++11 -Iinclude -I"$SRC/msgpack-c/include" \
-         "$f" -o "$OUT/${fuzzer}_fuzzer" \
+         "$f" -o "$OUT/${fuzzer}" \
          -lFuzzingEngine "$SRC/msgpack-c/libmsgpackc.a"
 
-    if [ -d "$SRC/msgpack-c/fuzz/${fuzzer}_fuzzer_seed_corpus" ]; then
-        zip -rj "$OUT/${fuzzer}_fuzzer_seed_corpus.zip" "$SRC/msgpack-c/fuzz/${fuzzer}_fuzzer_seed_corpus/"
+    if [ -d "$SRC/msgpack-c/fuzz/${fuzzer}_seed_corpus" ]; then
+        zip -rj "$OUT/${fuzzer}_seed_corpus.zip" "$SRC/msgpack-c/fuzz/${fuzzer}_seed_corpus/"
     fi
 done


### PR DESCRIPTION
This updates the build script to pull the seeds out of the source repo instead my msgpack-corpora repo. It also makes the build script able to handle generating a corpus zip per fuzzer, rather than hard coding the directory for the unpack_pack_fuzzer.

Thanks!