### PR TITLE
[qubes-os] Remove buggy libqubes-rpc-filecopy for now

### DIFF
--- a/projects/qubes-os/Dockerfile
+++ b/projects/qubes-os/Dockerfile
@@ -21,17 +21,6 @@ RUN apt-get update && apt-get -y install build-essential automake libtool git py
 
 WORKDIR qubes-os
 
-RUN git clone --depth 1 https://github.com/qubesos/qubes-builder-debian.git $SRC/qubes-os/builder-debian && \
-    echo "deb [arch=amd64] http://deb.qubes-os.org/r4.0/vm stretch main" >> /etc/apt/sources.list && \
-    echo "deb [arch=amd64] http://deb.qubes-os.org/r4.0/vm stretch-testing main" >> /etc/apt/sources.list && \
-    apt-key add $SRC/qubes-os/builder-debian/keys/qubes-debian-r4.0.asc && \
-    apt-get update
-
-RUN git clone -b fuzz --single-branch https://github.com/paraschetal/qubes-linux-utils.git $SRC/qubes-os/linux-utils  && \
-    $SRC/qubes-os/builder-debian/scripts/debian-parser control --build-depends $SRC/qubes-os/linux-utils/debian/control | xargs apt-get -y install && \
-    $SRC/qubes-os/builder-debian/scripts/debian-parser control --qubes-build-depends debian $SRC/qubes-os/linux-utils/debian/control | xargs apt-get -y install && \
-    $SRC/qubes-os/builder-debian/scripts/debian-parser control --qubes-build-depends stretch $SRC/qubes-os/linux-utils/debian/control | xargs apt-get -y install
-
 RUN git        clone --single-branch https://github.com/QubesOS/qubes-app-linux-input-proxy $SRC/qubes-os/app-linux-input-proxy
 
 COPY build.sh *.options $SRC/

--- a/projects/qubes-os/build.sh
+++ b/projects/qubes-os/build.sh
@@ -15,21 +15,6 @@
 #
 ################################################################################
 
-cd $SRC/qubes-os/linux-utils/
-
-cd qrexec-lib
-
-$CC $CFLAGS -c ioall.c
-$CC $CFLAGS -c copy-file.c
-$CC $CFLAGS -c crc32.c
-$CC $CFLAGS -c pack.c
-$CC $CFLAGS -c unpack.c
-ar rcs libqubes-rpc-filecopy.a ioall.o copy-file.o crc32.o unpack.o pack.o
-
-$CXX $CXXFLAGS -o $OUT/libqubes-rpc-filecopy -I. -I./fuzzer fuzzer/fuzzer.cc -lFuzzingEngine libqubes-rpc-filecopy.a
-
-cp $SRC/*.options $OUT/
-
 cd $SRC/qubes-os/app-linux-input-proxy
  
 make -C fuzz

--- a/projects/qubes-os/libqubes-rpc-filecopy.options
+++ b/projects/qubes-os/libqubes-rpc-filecopy.options
@@ -1,2 +1,0 @@
-[libfuzzer]
-max_len = 10240


### PR DESCRIPTION
The libqubes-rpc-filecopy target seems to be broken. Fixes #1332 