### PR TITLE
Disable AFL builds of mock gpu fuzzer

### DIFF
--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -47,16 +47,6 @@ $SRC/depot_tools/gn gen out/Fuzz\
     skia_enable_gpu=false
     extra_ldflags=["-lFuzzingEngine", "'"$CXXFLAGS_ARR"'"]'
 
-$SRC/depot_tools/gn gen out/GPU\
-    --args='cc="'$CC'"
-    cxx="'$CXX'"
-    is_debug=false
-    extra_cflags_c=["'"$CFLAGS_ARR"'"]
-    extra_cflags_cc=["'"$CXXFLAGS_ARR"'","-DIS_FUZZING","-DIS_FUZZING_WITH_LIBFUZZER"]
-    skia_use_system_freetype2=false
-    skia_use_fontconfig=false
-    skia_enable_gpu=true
-    extra_ldflags=["-lFuzzingEngine", "'"$CXXFLAGS_ARR"'"]'
 
 $SRC/depot_tools/ninja -C out/Fuzz_mem_constraints image_filter_deserialize \
                                                    textblob_deserialize api_raster_n32_canvas
@@ -66,9 +56,6 @@ $SRC/depot_tools/ninja -C out/Fuzz region_deserialize region_set_path \
                                    api_draw_functions api_gradients api_image_filter \
                                    api_path_measure api_null_canvas png_encoder \
                                    jpeg_encoder webp_encoder
-
-# Note: GPU is also with the mem constraints options.
-$SRC/depot_tools/ninja -C out/GPU api_mock_gpu_canvas
 
 cp out/Fuzz/region_deserialize $OUT/region_deserialize
 cp ./region_deserialize.options $OUT/region_deserialize.options
@@ -132,15 +119,6 @@ cp out/Fuzz/api_null_canvas $OUT/api_null_canvas
 cp ./api_null_canvas.options $OUT/api_null_canvas.options
 cp ./canvas_seed_corpus.zip $OUT/api_null_canvas_seed_corpus.zip
 
-# Remove unnecessary dependencies that aren't on runner containers.
-# Libraries found through trial and error (ldd command also helpful).
-patchelf --remove-needed libGLU.so.1 out/GPU/api_mock_gpu_canvas
-patchelf --remove-needed libGL.so.1 out/GPU/api_mock_gpu_canvas
-patchelf --remove-needed libX11.so.6 out/GPU/api_mock_gpu_canvas
-cp out/GPU/api_mock_gpu_canvas $OUT/api_mock_gpu_canvas
-cp ./api_mock_gpu_canvas.options $OUT/api_mock_gpu_canvas.options
-cp ./canvas_seed_corpus.zip $OUT/api_mock_gpu_canvas_seed_corpus.zip
-
 cp out/Fuzz/png_encoder $OUT/png_encoder
 cp ./encoder.options $OUT/png_encoder.options
 cp ./encoder_seed_corpus.zip $OUT/png_encoder_seed_corpus.zip
@@ -153,3 +131,29 @@ cp out/Fuzz/webp_encoder $OUT/webp_encoder
 cp ./encoder.options $OUT/webp_encoder.options
 cp ./encoder_seed_corpus.zip $OUT/webp_encoder_seed_corpus.zip
 
+# Don't build api_mock_gpu_canvas_fuzzer for AFL since it crashes on startup.
+# This would cause a build breakage now that AFL has build checks.
+if [ "$FUZZING_ENGINE" == "libfuzzer" ]
+then
+  $SRC/depot_tools/gn gen out/GPU\
+    --args='cc="'$CC'"
+        cxx="'$CXX'"
+        is_debug=false
+        extra_cflags_c=["'"$CFLAGS_ARR"'"]
+        extra_cflags_cc=["'"$CXXFLAGS_ARR"'","-DIS_FUZZING","-DIS_FUZZING_WITH_LIBFUZZER"]
+        skia_use_system_freetype2=false
+        skia_use_fontconfig=false
+        skia_enable_gpu=true
+        extra_ldflags=["-lFuzzingEngine", "'"$CXXFLAGS_ARR"'"]'
+
+  $SRC/depot_tools/ninja -C out/GPU api_mock_gpu_canvas
+  # Remove unnecessary dependencies that aren't on runner containers.
+  # Libraries found through trial and error (ldd command also helpful).
+  # Note: GPU is also with the mem constraints options.
+  patchelf --remove-needed libGLU.so.1 out/GPU/api_mock_gpu_canvas
+  patchelf --remove-needed libGL.so.1 out/GPU/api_mock_gpu_canvas
+  patchelf --remove-needed libX11.so.6 out/GPU/api_mock_gpu_canvas
+  cp out/GPU/api_mock_gpu_canvas $OUT/api_mock_gpu_canvas
+  cp ./api_mock_gpu_canvas.options $OUT/api_mock_gpu_canvas.options
+  cp ./canvas_seed_corpus.zip $OUT/api_mock_gpu_canvas_seed_corpus.zip
+fi

--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -133,6 +133,7 @@ cp ./encoder_seed_corpus.zip $OUT/webp_encoder_seed_corpus.zip
 
 # Don't build api_mock_gpu_canvas_fuzzer for AFL since it crashes on startup.
 # This would cause a build breakage now that AFL has build checks.
+# See https://github.com/google/oss-fuzz/issues/1338 for more details.
 if [ "$FUZZING_ENGINE" == "libfuzzer" ]
 then
   $SRC/depot_tools/gn gen out/GPU\


### PR DESCRIPTION
After AFL builds we will now check if fuzz targets crash immediately before uploading the build to CF.
That means we can't build broken fuzzers or else the entire build can break.
This disables AFL builds of the mock GPU fuzzer 