### PR TITLE
Install fonts-dejavu on base-runner

### DIFF
--- a/infra/base-images/base-runner/Dockerfile
+++ b/infra/base-images/base-runner/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-image
 MAINTAINER mike.aizatsky@gmail.com
-RUN apt-get install -y zip file libunwind8 binutils libblocksruntime0
+RUN apt-get install -y zip file libunwind8 binutils libblocksruntime0 fonts-dejavu
 COPY bad_build_check llvm-cov llvm-profdata llvm-symbolizer reproduce \
     run_fuzzer sancov test_all test_report minijail0 run_minijail /usr/local/bin/
 


### PR DESCRIPTION
Install a small (<10MB) font library on base-runner since some fuzzers (such as image_deserialize_fuzzer) expect them on a system.