### PR TITLE
[skia] Add custom help url

### DIFF
--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -17,7 +17,7 @@
 
 # These are any clang warnings we need to silence.
 DISABLE="-Wno-zero-as-null-pointer-constant -Wno-unused-template
-         -Wno-cast-qual -Wno-self-assign"
+         -Wno-cast-qual -Wno-self-assign -Wno-return-std-move-in-c++11"
 # Disable UBSan vptr since target built with -fno-rtti.
 export CFLAGS="$CFLAGS $DISABLE -fno-sanitize=vptr"
 export CXXFLAGS="$CXXFLAGS $DISABLE -fno-sanitize=vptr"

--- a/projects/skia/project.yaml
+++ b/projects/skia/project.yaml
@@ -5,9 +5,8 @@ auto_ccs:
   - "mtklein@chromium.org"
   - "reed@google.com"
   - "bsalomon@google.com"
-  - "caryclark@google.com"
-  - "liyuqian@google.com"
 sanitizers:
  - address
  - undefined
  - memory
+help_url: "https://skia.org/dev/testing/fuzz"


### PR DESCRIPTION
Also fix the build by silencing a warning.  We don't currently build with a new enough Clang to detect these before oss-fuzz does.  When we do, we'll unsilence it.

Since we can now better assign bugs to Skia folks, I'm removing a few people from getting CC'd on every bug to lower the noise for them.