### PR TITLE
Build projects/wuffs as C, not C++

### DIFF
--- a/projects/wuffs/build.sh
+++ b/projects/wuffs/build.sh
@@ -19,13 +19,15 @@
 # Wuffs' generated C files are "drop-in libraries" a la
 # http://gpfault.net/posts/drop-in-libraries.txt.html
 
-for f in fuzz/c/std/*_fuzzer.cc; do
-  # Extract the format name, such as "gzip", from the C++ file name,
-  # "fuzz/c/std/gzip_fuzzer.cc".
-  b=$(basename $f _fuzzer.cc)
+for f in fuzz/c/std/*_fuzzer.c; do
+  # Extract the format name, such as "gzip", from the C file name,
+  # "fuzz/c/std/gzip_fuzzer.c".
+  b=$(basename $f _fuzzer.c)
 
-  # Make the "gzip_fuzzer" binary.
-  $CXX $CXXFLAGS -std=c++11 $f -o $OUT/${b}_fuzzer -lFuzzingEngine
+  # Make the "gzip_fuzzer" binary. First compile the (C) Wuffs code, then link
+  # the (C++) fuzzing library.
+  $CC $CFLAGS -c -std=c99 $f -o $WORK/${b}_fuzzer.o
+  $CXX $CXXFLAGS $WORK/${b}_fuzzer.o -o $OUT/${b}_fuzzer -lFuzzingEngine
 
   # Make the optional "gzip_fuzzer_seed_corpus.zip" archive. This means
   # extracting the "foo/bar/*.gz" out of the matching "gzip: foo/bar/*.gz"


### PR DESCRIPTION
The upstream Wuffs project is C, not C++. Having OSS-Fuzz compile Wuffs
as plain C, the way Wuffs' own build system does, should hopefully
lessen OSS-Fuzz build breakages such as issue #1373