### PR TITLE
[skia] Remove mem contraint checks from textblob deserialize

### DIFF
--- a/projects/skia/Dockerfile
+++ b/projects/skia/Dockerfile
@@ -28,7 +28,7 @@ RUN git clone https://skia.googlesource.com/skia.git
 # current directory for build script
 WORKDIR skia
 
-RUN python tools/git-sync-deps
+RUN bin/sync
 
 RUN wget -O $SRC/skia/image_filter_deserialize_seed_corpus.zip https://storage.googleapis.com/skia-fuzzer/oss-fuzz/image_filter_deserialize_seed_corpus.zip
 

--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -51,13 +51,13 @@ $SRC/depot_tools/gn gen out/Fuzz\
 
 
 $SRC/depot_tools/ninja -C out/Fuzz_mem_constraints image_filter_deserialize \
-                                                   textblob_deserialize api_raster_n32_canvas
+                                                   api_raster_n32_canvas
 
 $SRC/depot_tools/ninja -C out/Fuzz region_deserialize region_set_path \
                                    path_deserialize image_decode animated_image_decode \
                                    api_draw_functions api_gradients api_image_filter \
                                    api_path_measure api_null_canvas png_encoder \
-                                   jpeg_encoder webp_encoder skottie_json
+                                   jpeg_encoder webp_encoder skottie_json textblob_deserialize
 
 cp out/Fuzz/region_deserialize $OUT/region_deserialize
 cp ./region_deserialize.options $OUT/region_deserialize.options
@@ -66,7 +66,7 @@ cp out/Fuzz/region_set_path $OUT/region_set_path
 cp ./region_set_path.options $OUT/region_set_path.options
 cp ./region_set_path_seed_corpus.zip $OUT/region_set_path_seed_corpus.zip
 
-cp out/Fuzz_mem_constraints/textblob_deserialize $OUT/textblob_deserialize
+cp out/Fuzz/textblob_deserialize $OUT/textblob_deserialize
 cp ./textblob_deserialize.options $OUT/textblob_deserialize.options
 cp ./textblob_deserialize_seed_corpus.zip $OUT/textblob_deserialize_seed_corpus.zip
 

--- a/projects/skia/skia.diff
+++ b/projects/skia/skia.diff
@@ -250,36 +250,6 @@ index 2373e62d46..410fa8a276 100644
          if (0 == (dLeft | dRite)) {
              int L = SkFixedRoundToInt(left);
              int R = SkFixedRoundToInt(rite);
-diff --git a/src/core/SkTextBlob.cpp b/src/core/SkTextBlob.cpp
-index e2d3be4518..239ab7fb36 100644
---- a/src/core/SkTextBlob.cpp
-+++ b/src/core/SkTextBlob.cpp
-@@ -799,7 +799,11 @@ sk_sp<SkTextBlob> SkTextBlob::MakeFromBuffer(SkReadBuffer& reader) {
-             // End-of-runs marker.
-             break;
-         }
--
-+#if defined(IS_FUZZING)
-+        if (glyphCount > 1000) {
-+            return nullptr;
-+        }
-+#endif
-         PositioningAndExtended pe;
-         pe.intValue = reader.read32();
-         GlyphPositioning pos = pe.positioning;
-@@ -810,7 +814,11 @@ sk_sp<SkTextBlob> SkTextBlob::MakeFromBuffer(SkReadBuffer& reader) {
-         if (textSize < 0 || static_cast<size_t>(textSize) > reader.size()) {
-             return nullptr;
-         }
--
-+#if defined(IS_FUZZING)
-+        if (textSize > 1000) {
-+            return nullptr;
-+        }
-+#endif
-         SkPoint offset;
-         reader.readPoint(&offset);
-         SkPaint font;
 diff --git a/src/effects/Sk1DPathEffect.cpp b/src/effects/Sk1DPathEffect.cpp
 index 57f2d2b6ce..186ce5d25b 100644
 --- a/src/effects/Sk1DPathEffect.cpp


### PR DESCRIPTION
Proper checks were added in https://skia-review.googlesource.com/c/skia/+/126603 

local testing shows that we don't OOM quite as fast in the non memory constraint way, so I think it's worth it to take it off that specialized build.