### PR TITLE
[mupdf] Change the name of the library used.

### DIFF
--- a/projects/mupdf/build.sh
+++ b/projects/mupdf/build.sh
@@ -20,7 +20,7 @@ fuzz_target=pdf_fuzzer
 
 $CXX $CXXFLAGS -std=c++11 -Iinclude \
     source/fuzz/pdf_fuzzer.cc -o $OUT/$fuzz_target \
-    -lFuzzingEngine $WORK/libmupdf.a $WORK/libmupdfthird.a
+    -lFuzzingEngine $WORK/libmupdf.a $WORK/libmupdf-third.a
 
 mv $SRC/{*.zip,*.dict,*.options} $OUT
 


### PR DESCRIPTION
The library name in the upstream project has
changed recently, accommodate for that.

This PR would resolve oss-fuzz bug 8210.