### PR TITLE
[qpid-proton] Initialize project with Dockerfile, build.sh and patches

### DIFF
--- a/projects/qpid-proton/Dockerfile
+++ b/projects/qpid-proton/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc.
+# Copyright 2018 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/qpid-proton/Dockerfile
+++ b/projects/qpid-proton/Dockerfile
@@ -1,0 +1,28 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER jdanek@redhat.com
+RUN apt-get update && \
+    apt-get install -y \
+        cmake
+
+RUN git clone git://git.apache.org/qpid-proton.git
+
+WORKDIR qpid-proton
+COPY build.sh $SRC/
+COPY c_tests_fuzz_CMakeLists.patch $SRC/
+COPY c_CMakeLists.patch $SRC/

--- a/projects/qpid-proton/build.sh
+++ b/projects/qpid-proton/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2017 Google Inc.
+# Copyright 2018 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ mkdir build
 pushd build
   cmake .. -DCMAKE_BUILD_TYPE=Release -DENABLE_FUZZ_TESTING=ON -DFUZZ_REGRESSION_TESTS=OFF
   pushd c/tests/fuzz/
-    make -j2
+    make -j $(nproc)
   popd
   cp c/tests/fuzz/{fuzz-connection-driver,fuzz-message-decode} $OUT/
 popd

--- a/projects/qpid-proton/build.sh
+++ b/projects/qpid-proton/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -eu
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+patch -p1 < $SRC/c_tests_fuzz_CMakeLists.patch
+patch -p1 < $SRC/c_CMakeLists.patch
+mkdir build
+pushd build
+  cmake .. -DCMAKE_BUILD_TYPE=Release -DENABLE_FUZZ_TESTING=ON -DFUZZ_REGRESSION_TESTS=OFF
+  pushd c/tests/fuzz/
+    make -j2
+  popd
+  cp c/tests/fuzz/{fuzz-connection-driver,fuzz-message-decode} $OUT/
+popd
+
+zip -j $OUT/fuzz-connection-driver_seed_corpus.zip c/tests/fuzz/fuzz-connection-driver/corpus/* c/tests/fuzz/fuzz-connection-driver/crash/*
+zip -j $OUT/fuzz-message-decode_seed_corpus.zip c/tests/fuzz/fuzz-message-decode/corpus/* c/tests/fuzz/fuzz-message-decode/crash/*

--- a/projects/qpid-proton/c_CMakeLists.patch
+++ b/projects/qpid-proton/c_CMakeLists.patch
@@ -1,0 +1,13 @@
+diff --git a/c/CMakeLists.txt b/c/CMakeLists.txt
+index 40b50374..2247e0f1 100644
+--- a/c/CMakeLists.txt
++++ b/c/CMakeLists.txt
+@@ -539,7 +539,7 @@ if (BUILD_WITH_CXX)
+ endif (BUILD_WITH_CXX)
+ 
+ add_library (
+-  qpid-proton-core SHARED
++  qpid-proton-core STATIC
+   ${qpid-proton-core}
+   ${qpid-proton-layers}
+   ${qpid-proton-platform}

--- a/projects/qpid-proton/c_tests_fuzz_CMakeLists.patch
+++ b/projects/qpid-proton/c_tests_fuzz_CMakeLists.patch
@@ -1,0 +1,13 @@
+diff --git a/c/tests/fuzz/CMakeLists.txt b/c/tests/fuzz/CMakeLists.txt
+index f870d617..054ec6d6 100644
+--- a/c/tests/fuzz/CMakeLists.txt
++++ b/c/tests/fuzz/CMakeLists.txt
+@@ -33,6 +33,8 @@ add_library (StandaloneFuzzTargetMain STATIC StandaloneFuzzTargetMain.c Standalo
+ macro (pn_add_fuzz_test test)
+   add_executable (${test} ${ARGN})
+   target_link_libraries (${test} qpid-proton-core ${FUZZING_LIBRARY})
++  # -lFuzzingEngine is a C++ library, which needs c++ std lib
++  set_target_properties(${test} PROPERTIES LINKER_LANGUAGE CXX)
+ 
+   if (FUZZ_REGRESSION_TESTS)
+     # StandaloneFuzzTargetMain cannot walk directory trees

--- a/projects/qpid-proton/project.yaml
+++ b/projects/qpid-proton/project.yaml
@@ -3,3 +3,7 @@ primary_contact: "jross@apache.org"
 auto_ccs:
  - "security@apache.org"
  - "jdanek@redhat.com"
+sanitizers:
+ - address
+ - memory
+ - undefined


### PR DESCRIPTION
### Patches

Due to the two following issues it is currently necessary to patch the source code to compile the fuzzers. The patches are part of this commit.

1. the fuzzing library needs c++ stdlib, but qpid-proton would link it with `clang` instead of `clang++`, so libc++ is not available
2. qpid-proton does not support switch for building `.a` static libraries, so the second patch forces this

### Testing

    python infra/helper.py build_fuzzers --sanitizer address qpid-proton
    python infra/helper.py build_fuzzers --sanitizer memory qpid-proton
    python infra/helper.py build_fuzzers --sanitizer undefined qpid-proton

    python infra/helper.py run_fuzzer qpid-proton fuzz-connection-driver
    python infra/helper.py run_fuzzer qpid-proton fuzz-message-decode

### Bugs

Currently, address/fuzz-message-decode and undefined/fuzz-connection-driver find bad input fairly quickly and they crash.