### PR TITLE
libwebp

### DIFF
--- a/projects/libwebp/project.yaml
+++ b/projects/libwebp/project.yaml
@@ -1,0 +1,2 @@
+homepage: "https://developers.google.com/speed/webp/"
+primary_contact: "jzern@google.com"


### PR DESCRIPTION
The authors [have agreed](https://bugs.chromium.org/p/webp/issues/detail?id=376). This will be added in steps. Initially a simple fuzz target will be hosted here. Eventually it'll be moved to the `libwebp` repo, and integrated. Once that's done, additional fuzz targets will be added.