### PR TITLE
poppler: If the document is locked one can't use it

### DIFF
--- a/projects/poppler/pdf_fuzzer.cc
+++ b/projects/poppler/pdf_fuzzer.cc
@@ -29,7 +29,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   poppler::set_debug_error_function(nop_func, nullptr);
 
   poppler::document *doc = poppler::document::load_from_raw_data((const char *)data, size);
-  if (!doc) {
+  if (!doc || doc->is_locked()) {
     return 0;
   }
 


### PR DESCRIPTION
without unlocking but since we obviously don't have
a password for the random data we just return