### PR TITLE
libwebp: fuzz target #1

### DIFF
--- a/projects/libwebp/Dockerfile
+++ b/projects/libwebp/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER pdknsk@gmail.com
+RUN apt-get update && apt-get install -y autoconf make libtool wget
+RUN git clone https://chromium.googlesource.com/webm/libwebp
+RUN wget -q http://cdn.pwmon.org/oss-fuzz/libwebp/fuzz_seed_corpus.zip
+COPY build.sh fuzz.dict fuzz_simple_api.cc fuzz_simple_api.options $SRC/
+WORKDIR libwebp

--- a/projects/libwebp/build.sh
+++ b/projects/libwebp/build.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -eu
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+./autogen.sh
+./configure \
+  --enable-libwebpdemux \
+  --disable-shared \
+  --disable-jpeg \
+  --disable-tiff \
+  --disable-gif \
+  --disable-wic
+make clean
+make -j$(nproc)
+
+cp $SRC/fuzz.dict $OUT
+
+# Simple Decoding API
+$CXX $CXXFLAGS -std=c++11 \
+  -Isrc \
+  -lFuzzingEngine \
+  $SRC/fuzz_simple_api.cc -o $OUT/fuzz_simple_api \
+  src/.libs/libwebp.a
+cp $SRC/fuzz_seed_corpus.zip $OUT/fuzz_simple_api_seed_corpus.zip
+cp $SRC/fuzz_simple_api.options $OUT

--- a/projects/libwebp/fuzz.dict
+++ b/projects/libwebp/fuzz.dict
@@ -1,0 +1,13 @@
+# https://developers.google.com/speed/webp/docs/riff_container
+
+name="ALPH"
+name="ANIM"
+name="ANMF"
+name="EXIF"
+name="ICCP"
+name="RIFF"
+name="VP8 "
+name="VP8L"
+name="VP8X"
+name="WEBP"
+name="XMP "

--- a/projects/libwebp/fuzz_simple_api.cc
+++ b/projects/libwebp/fuzz_simple_api.cc
@@ -1,0 +1,86 @@
+#include <stdlib.h>
+
+#include "webp/decode.h"
+
+// Arbitrary limit of 4MB buffer to prevent OOM, timeout, or slow execution.
+static const size_t px_limit = 1024 * 1024;
+
+// Reads and sums (up to) 128 spread-out bytes.
+static uint8_t hash(const uint8_t* data, size_t size) {
+  uint8_t value = 0;
+  size_t incr = size / 128;
+  if (!incr) incr = 1;
+  for (size_t i = 0; i < size; i += incr)
+    value += data[i];
+  return value;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  int w, h;
+  if (!WebPGetInfo(data, size, &w, &h))
+    return 0;
+  if ((size_t)w * h > px_limit)
+    return 0;
+
+  const uint8_t value = hash(data, size);
+  uint8_t* buf = nullptr;
+
+  // This is verbose, but covers all available variants.
+  // For functions that decode into an external buffer, an intentionally
+  // too small buffer can be given with low probability.
+  if (value < 0x16) {
+    buf = WebPDecodeRGBA(data, size, &w, &h);
+  } else if (value < 0x2b) {
+    buf = WebPDecodeARGB(data, size, &w, &h);
+  } else if (value < 0x40) {
+    buf = WebPDecodeBGRA(data, size, &w, &h);
+  } else if (value < 0x55) {
+    buf = WebPDecodeRGB(data, size, &w, &h);
+  } else if (value < 0x6a) {
+    buf = WebPDecodeBGR(data, size, &w, &h);
+  } else if (value < 0x7f) {
+    uint8_t *u, *v;
+    int stride, uv_stride;
+    buf = WebPDecodeYUV(data, size, &w, &h, &u, &v, &stride, &uv_stride);
+  } else if (value < 0xe8) {
+    int stride = (value < 0xbe ? 4 : 3) * w;
+    size_t buf_size = stride * h;
+    if (value % 0x10 == 0) buf_size--;
+    uint8_t* ext_buf = (uint8_t*)malloc(buf_size);
+    if (value < 0x94) {
+      WebPDecodeRGBAInto(data, size, ext_buf, buf_size, stride);
+    } else if (value < 0xa9) {
+      WebPDecodeARGBInto(data, size, ext_buf, buf_size, stride);
+    } else if (value < 0xbe) {
+      WebPDecodeBGRAInto(data, size, ext_buf, buf_size, stride);
+    } else if (value < 0xd3) {
+      WebPDecodeRGBInto(data, size, ext_buf, buf_size, stride);
+    } else {
+      WebPDecodeBGRInto(data, size, ext_buf, buf_size, stride);
+    }
+    free(ext_buf);
+  } else {
+    size_t luma_size = w * h;
+    int uv_stride = (w + 1) / 2;
+    size_t u_size = uv_stride * (h + 1) / 2;
+    size_t v_size = uv_stride * (h + 1) / 2;
+    if (value % 0x10 == 0) {
+      if (size & 1) luma_size--;
+      if (size & 2) u_size--;
+      if (size & 4) v_size--;
+    }
+    uint8_t* luma_buf = (uint8_t*)malloc(luma_size);
+    uint8_t* u_buf = (uint8_t*)malloc(u_size);
+    uint8_t* v_buf = (uint8_t*)malloc(v_size);
+    WebPDecodeYUVInto(data, size, luma_buf, luma_size, w /* luma_stride */,
+                      u_buf, u_size, uv_stride, v_buf, v_size, uv_stride);
+    free(luma_buf);
+    free(u_buf);
+    free(v_buf);
+  }
+
+  if (buf)
+    WebPFree(buf);
+
+  return 0;
+}

--- a/projects/libwebp/fuzz_simple_api.options
+++ b/projects/libwebp/fuzz_simple_api.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+dict = fuzz.dict

--- a/projects/libwebp/project.yaml
+++ b/projects/libwebp/project.yaml
@@ -1,2 +1,6 @@
 homepage: "https://developers.google.com/speed/webp/"
 primary_contact: "jzern@google.com"
+sanitizers:
+- address
+- undefined
+- memory


### PR DESCRIPTION
Note that `fuzz_simple_api.options` is currently redundant, but was already added in preparation for more fuzz targets. There are 2-3 additional targets to be added, likely when the code moves from here.

The corpus is small files made by me. There is an [official repository](https://chromium.googlesource.com/webm/libwebp-test-data) with many WebP files for regression testing, but it's not yet very suitable as a fuzzing corpus, as many files are large or very large.