### PR TITLE
Attempt to fix FFmpeg build diskspace issue

### DIFF
--- a/projects/ffmpeg/build.sh
+++ b/projects/ffmpeg/build.sh
@@ -164,6 +164,7 @@ PKG_CONFIG_PATH="$FFMPEG_DEPS_PATH/lib/pkgconfig" ./configure \
     --extra-ldflags="-L$FFMPEG_DEPS_PATH/lib" \
     --prefix="$FFMPEG_DEPS_PATH" \
     --pkg-config-flags="--static" \
+    --enable-ossfuzz \
     --libfuzzer=-lFuzzingEngine \
     --optflags=-O1 \
     --enable-gpl \


### PR DESCRIPTION
FFmpegs configure should no longer add fsanitize flags if there are already some
provided by the user. Also CONFIG_OSSFUZZ is needed currently to modify
the iterate API to prevent linking everything in. This should reduce
disk space requirements back to "pre iterate".

This reverts commit a83ce13c5466fb321b33c8b045412a44ae19d14b.
This commit is under public domain or any license you like.