### PR TITLE
Update FreeType's Dockerfile: Add former erroneous inputs to the seed corpus

### DIFF
--- a/projects/freetype2/Dockerfile
+++ b/projects/freetype2/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install -y make autoconf libtool libarchive-dev
 # Get some files for the seed corpus
 ADD https://github.com/adobe-fonts/adobe-variable-font-prototype/releases/download/1.001/AdobeVFPrototype.otf $SRC/font-corpus/
 RUN git clone https://github.com/unicode-org/text-rendering-tests.git && cp text-rendering-tests/fonts/* $SRC/font-corpus
+RUN git clone --depth 1 https://github.com/cherusker/freetype2-testing.git && find freetype2-testing/fuzzing/corpora/legacy -type f -exec cp {} $SRC/font-corpus \;
 
 RUN git clone --depth 1 git://git.sv.nongnu.org/freetype/freetype2.git
 WORKDIR freetype2


### PR DESCRIPTION
I am working on FreeType's fuzzing support at the moment and would like to add former erroneous inputs to the seed corpus.

Currently, I am in the process of setting up FreeType's testing repository with my own GitHub account (hence <https://github.com/cherusker/...>) but the plan is to move that repository to FreeType's official GitHub account, once all the basics are up and running. I will issue a follow-up PR then to change the URL to <https://github.com/freetype/...>.

The `find ... -exec cp ... \;` structure is necessary to collect all input files which are organised in various subfolders.