### PR TITLE
[qpid-proton] add @astitcher to cc list

### DIFF
--- a/projects/qpid-proton/project.yaml
+++ b/projects/qpid-proton/project.yaml
@@ -2,6 +2,7 @@ homepage: "https://qpid.apache.org/proton/"
 primary_contact: "jross@apache.org"
 auto_ccs:
  - "security@apache.org"
+ - "astitcher@apache.org"
  - "jdanek@redhat.com"
 sanitizers:
  - address


### PR DESCRIPTION
Would it be also possible to CC @astitcher on all existing issues on the tracker? I apparently lack permissions for this action.

https://bugs.chromium.org/p/oss-fuzz/issues/list?q=label:Proj-qpid-proton