### PR TITLE
[nestegg] Update primary_contact

### DIFF
--- a/projects/nestegg/project.yaml
+++ b/projects/nestegg/project.yaml
@@ -1,5 +1,5 @@
 homepage: "https://github.com/kinetiknz/nestegg"
-primary_contact: "kinetik@mozilla.com"
+primary_contact: "mgregan@mozilla.com"
 sanitizers:
 - address
 - memory


### PR DESCRIPTION
kinetik@mozilla.com is an alias and seems not to work as a Google account, so use my real address which is mapped to a working Google account.