### PR TITLE
[skia] Opt all fuzzers into GPU build

### DIFF
--- a/projects/skia/BUILD.gn.diff
+++ b/projects/skia/BUILD.gn.diff
@@ -14,17 +14,8 @@
 #
 ################################################################################
 
-template("fuzz_app") {
-  _executable = target_name
-  executable(_executable) {
-    forward_variables_from(invoker, "*", [ "is_shared_library" ])
-    configs += [ ":skia_private" ]
-    testonly = true
-  }
-}
-
 # Append this to build.gn in the skia repo and then build the targets
-fuzz_app("region_deserialize") {
+test_app("region_deserialize") {
   sources = [
     "fuzz/oss_fuzz/FuzzRegionDeserialize.cpp",
   ]
@@ -34,7 +25,7 @@ fuzz_app("region_deserialize") {
   ]
 }
 
-fuzz_app("image_filter_deserialize") {
+test_app("image_filter_deserialize") {
   sources = [
     "fuzz/oss_fuzz/FuzzImageFilterDeserialize.cpp",
   ]
@@ -44,7 +35,7 @@ fuzz_app("image_filter_deserialize") {
   ]
 }
 
-fuzz_app("region_set_path") {
+test_app("region_set_path") {
   sources = [
     "fuzz/FuzzCommon.cpp",
     "fuzz/oss_fuzz/FuzzRegionSetPath.cpp",
@@ -55,7 +46,7 @@ fuzz_app("region_set_path") {
   ]
 }
 
-fuzz_app("textblob_deserialize") {
+test_app("textblob_deserialize") {
   sources = [
     "fuzz/oss_fuzz/FuzzTextBlobDeserialize.cpp",
   ]
@@ -65,7 +56,7 @@ fuzz_app("textblob_deserialize") {
   ]
 }
 
-fuzz_app("path_deserialize") {
+test_app("path_deserialize") {
   sources = [
     "fuzz/oss_fuzz/FuzzPathDeserialize.cpp",
   ]
@@ -75,7 +66,7 @@ fuzz_app("path_deserialize") {
   ]
 }
 
-fuzz_app("image_decode") {
+test_app("image_decode") {
   sources = [
     "fuzz/oss_fuzz/FuzzImage.cpp",
   ]
@@ -85,7 +76,7 @@ fuzz_app("image_decode") {
   ]
 }
 
-fuzz_app("animated_image_decode") {
+test_app("animated_image_decode") {
   sources = [
     "fuzz/oss_fuzz/FuzzAnimatedImage.cpp",
   ]
@@ -95,7 +86,7 @@ fuzz_app("animated_image_decode") {
   ]
 }
 
-fuzz_app("api_draw_functions") {
+test_app("api_draw_functions") {
   sources = [
     "fuzz/FuzzDrawFunctions.cpp",
     "fuzz/oss_fuzz/FuzzDrawFunctions.cpp",
@@ -106,7 +97,7 @@ fuzz_app("api_draw_functions") {
   ]
 }
 
-fuzz_app("api_gradients") {
+test_app("api_gradients") {
   sources = [
     "fuzz/FuzzGradients.cpp",
     "fuzz/oss_fuzz/FuzzGradients.cpp",
@@ -117,7 +108,7 @@ fuzz_app("api_gradients") {
   ]
 }
 
-fuzz_app("api_image_filter") {
+test_app("api_image_filter") {
   include_dirs = [
     "tools",
     "tools/debugger",
@@ -141,7 +132,7 @@ fuzz_app("api_image_filter") {
   ]
 }
 
-fuzz_app("api_path_measure") {
+test_app("api_path_measure") {
   sources = [
     "fuzz/FuzzCommon.cpp",
     "fuzz/FuzzPathMeasure.cpp",
@@ -153,7 +144,7 @@ fuzz_app("api_path_measure") {
   ]
 }
 
-fuzz_app("api_raster_n32_canvas") {
+test_app("api_raster_n32_canvas") {
   include_dirs = [
     "tools",
     "tools/debugger",
@@ -177,7 +168,7 @@ fuzz_app("api_raster_n32_canvas") {
   ]
 }
 
-fuzz_app("api_mock_gpu_canvas") {
+test_app("api_mock_gpu_canvas") {
   include_dirs = [
     "tools",
     "tools/debugger",
@@ -202,7 +193,7 @@ fuzz_app("api_mock_gpu_canvas") {
   ]
 }
 
-fuzz_app("api_null_canvas") {
+test_app("api_null_canvas") {
   include_dirs = [
     "tools",
     "tools/debugger",
@@ -226,7 +217,7 @@ fuzz_app("api_null_canvas") {
   ]
 }
 
-fuzz_app("png_encoder") {
+test_app("png_encoder") {
   sources = [
     "fuzz/FuzzCommon.cpp",
     "fuzz/FuzzEncoders.cpp",
@@ -238,7 +229,7 @@ fuzz_app("png_encoder") {
   ]
 }
 
-fuzz_app("jpeg_encoder") {
+test_app("jpeg_encoder") {
   sources = [
     "fuzz/FuzzCommon.cpp",
     "fuzz/FuzzEncoders.cpp",
@@ -250,7 +241,7 @@ fuzz_app("jpeg_encoder") {
   ]
 }
 
-fuzz_app("webp_encoder") {
+test_app("webp_encoder") {
   sources = [
     "fuzz/FuzzCommon.cpp",
     "fuzz/FuzzEncoders.cpp",
@@ -262,7 +253,7 @@ fuzz_app("webp_encoder") {
   ]
 }
 
-fuzz_app("skottie_json") {
+test_app("skottie_json") {
   deps = [
     ":flags",
     ":skia",

--- a/projects/skia/BUILD.gn.diff
+++ b/projects/skia/BUILD.gn.diff
@@ -14,8 +14,17 @@
 #
 ################################################################################
 
+template("fuzz_app") {
+  _executable = target_name
+  executable(_executable) {
+    forward_variables_from(invoker, "*", [ "is_shared_library" ])
+    configs += [ ":skia_private" ]
+    testonly = true
+  }
+}
+
 # Append this to build.gn in the skia repo and then build the targets
-test_app("region_deserialize") {
+fuzz_app("region_deserialize") {
   sources = [
     "fuzz/oss_fuzz/FuzzRegionDeserialize.cpp",
   ]
@@ -25,7 +34,7 @@ test_app("region_deserialize") {
   ]
 }
 
-test_app("image_filter_deserialize") {
+fuzz_app("image_filter_deserialize") {
   sources = [
     "fuzz/oss_fuzz/FuzzImageFilterDeserialize.cpp",
   ]
@@ -35,7 +44,7 @@ test_app("image_filter_deserialize") {
   ]
 }
 
-test_app("region_set_path") {
+fuzz_app("region_set_path") {
   sources = [
     "fuzz/FuzzCommon.cpp",
     "fuzz/oss_fuzz/FuzzRegionSetPath.cpp",
@@ -46,7 +55,7 @@ test_app("region_set_path") {
   ]
 }
 
-test_app("textblob_deserialize") {
+fuzz_app("textblob_deserialize") {
   sources = [
     "fuzz/oss_fuzz/FuzzTextBlobDeserialize.cpp",
   ]
@@ -56,7 +65,7 @@ test_app("textblob_deserialize") {
   ]
 }
 
-test_app("path_deserialize") {
+fuzz_app("path_deserialize") {
   sources = [
     "fuzz/oss_fuzz/FuzzPathDeserialize.cpp",
   ]
@@ -66,7 +75,7 @@ test_app("path_deserialize") {
   ]
 }
 
-test_app("image_decode") {
+fuzz_app("image_decode") {
   sources = [
     "fuzz/oss_fuzz/FuzzImage.cpp",
   ]
@@ -76,7 +85,7 @@ test_app("image_decode") {
   ]
 }
 
-test_app("animated_image_decode") {
+fuzz_app("animated_image_decode") {
   sources = [
     "fuzz/oss_fuzz/FuzzAnimatedImage.cpp",
   ]
@@ -86,7 +95,7 @@ test_app("animated_image_decode") {
   ]
 }
 
-test_app("api_draw_functions") {
+fuzz_app("api_draw_functions") {
   sources = [
     "fuzz/FuzzDrawFunctions.cpp",
     "fuzz/oss_fuzz/FuzzDrawFunctions.cpp",
@@ -97,7 +106,7 @@ test_app("api_draw_functions") {
   ]
 }
 
-test_app("api_gradients") {
+fuzz_app("api_gradients") {
   sources = [
     "fuzz/FuzzGradients.cpp",
     "fuzz/oss_fuzz/FuzzGradients.cpp",
@@ -108,7 +117,7 @@ test_app("api_gradients") {
   ]
 }
 
-test_app("api_image_filter") {
+fuzz_app("api_image_filter") {
   include_dirs = [
     "tools",
     "tools/debugger",
@@ -132,7 +141,7 @@ test_app("api_image_filter") {
   ]
 }
 
-test_app("api_path_measure") {
+fuzz_app("api_path_measure") {
   sources = [
     "fuzz/FuzzCommon.cpp",
     "fuzz/FuzzPathMeasure.cpp",
@@ -144,7 +153,7 @@ test_app("api_path_measure") {
   ]
 }
 
-test_app("api_raster_n32_canvas") {
+fuzz_app("api_raster_n32_canvas") {
   include_dirs = [
     "tools",
     "tools/debugger",
@@ -168,7 +177,7 @@ test_app("api_raster_n32_canvas") {
   ]
 }
 
-test_app("api_mock_gpu_canvas") {
+fuzz_app("api_mock_gpu_canvas") {
   include_dirs = [
     "tools",
     "tools/debugger",
@@ -193,7 +202,7 @@ test_app("api_mock_gpu_canvas") {
   ]
 }
 
-test_app("api_null_canvas") {
+fuzz_app("api_null_canvas") {
   include_dirs = [
     "tools",
     "tools/debugger",
@@ -217,7 +226,7 @@ test_app("api_null_canvas") {
   ]
 }
 
-test_app("png_encoder") {
+fuzz_app("png_encoder") {
   sources = [
     "fuzz/FuzzCommon.cpp",
     "fuzz/FuzzEncoders.cpp",
@@ -229,7 +238,7 @@ test_app("png_encoder") {
   ]
 }
 
-test_app("jpeg_encoder") {
+fuzz_app("jpeg_encoder") {
   sources = [
     "fuzz/FuzzCommon.cpp",
     "fuzz/FuzzEncoders.cpp",
@@ -241,7 +250,7 @@ test_app("jpeg_encoder") {
   ]
 }
 
-test_app("webp_encoder") {
+fuzz_app("webp_encoder") {
   sources = [
     "fuzz/FuzzCommon.cpp",
     "fuzz/FuzzEncoders.cpp",
@@ -253,7 +262,7 @@ test_app("webp_encoder") {
   ]
 }
 
-test_app("skottie_json") {
+fuzz_app("skottie_json") {
   deps = [
     ":flags",
     ":skia",

--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -54,15 +54,14 @@ $SRC/depot_tools/gn gen out/Fuzz\
     extra_ldflags=["-lFuzzingEngine", "'"$CXXFLAGS_ARR"'"]'
 
 
-$SRC/depot_tools/ninja -C out/Fuzz_mem_constraints image_filter_deserialize \
-                                                   api_raster_n32_canvas
+$SRC/depot_tools/ninja -C out/Fuzz_mem_constraints image_filter_deserialize
 
-# Don't build api_mock_gpu_canvas_fuzzer for AFL since it crashes on startup.
+# Don't build these fuzzers for AFL since it crashes on startup.
 # This would cause a build breakage now that AFL has build checks.
 # See https://github.com/google/oss-fuzz/issues/1338 for more details.
 if [ "$FUZZING_ENGINE" == "libfuzzer" ]
 then
-  $SRC/depot_tools/ninja -C out/Fuzz_mem_constraints api_mock_gpu_canvas
+  $SRC/depot_tools/ninja -C out/Fuzz_mem_constraints api_raster_n32_canvas api_mock_gpu_canvas
 fi
 
 set +e
@@ -78,9 +77,17 @@ set -e
 
 $SRC/depot_tools/ninja -C out/Fuzz region_deserialize region_set_path \
                                    path_deserialize image_decode animated_image_decode \
-                                   api_draw_functions api_gradients api_image_filter \
-                                   api_path_measure api_null_canvas png_encoder \
+                                   api_draw_functions api_gradients \
+                                   api_path_measure  png_encoder \
                                    jpeg_encoder webp_encoder skottie_json textblob_deserialize
+
+# Don't build these fuzzers for AFL since it crashes on startup.
+# This would cause a build breakage now that AFL has build checks.
+# See https://github.com/google/oss-fuzz/issues/1338 for more details.
+if [ "$FUZZING_ENGINE" == "libfuzzer" ]
+then
+  $SRC/depot_tools/ninja -C out/Fuzz api_null_canvas api_image_filter
+fi
 
 set +e
 for f in out/Fuzz/*; do

--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -25,6 +25,10 @@ export CXXFLAGS="$CXXFLAGS $DISABLE -fno-sanitize=vptr"
 # This splits a space separated list into a quoted, comma separated list for gn.
 export CFLAGS_ARR=`echo $CFLAGS | sed -e "s/\s/\",\"/g"`
 export CXXFLAGS_ARR=`echo $CXXFLAGS | sed -e "s/\s/\",\"/g"`
+
+
+# Even though GPU is "enabled" for all these builds, none really
+# uses the gpu except for api_mock_gpu_canvas
 $SRC/depot_tools/gn gen out/Fuzz_mem_constraints\
     --args='cc="'$CC'"
     cxx="'$CXX'"
@@ -33,7 +37,7 @@ $SRC/depot_tools/gn gen out/Fuzz_mem_constraints\
     extra_cflags_cc=["'"$CXXFLAGS_ARR"'","-DIS_FUZZING","-DIS_FUZZING_WITH_LIBFUZZER"]
     skia_use_system_freetype2=false
     skia_use_fontconfig=false
-    skia_enable_gpu=false
+    skia_enable_gpu=true
     skia_enable_skottie=false
     extra_ldflags=["-lFuzzingEngine", "'"$CXXFLAGS_ARR"'"]'
 
@@ -45,7 +49,7 @@ $SRC/depot_tools/gn gen out/Fuzz\
     extra_cflags_cc=["'"$CXXFLAGS_ARR"'","-DIS_FUZZING_WITH_LIBFUZZER"]
     skia_use_system_freetype2=false
     skia_use_fontconfig=false
-    skia_enable_gpu=false
+    skia_enable_gpu=true
     skia_enable_skottie=true
     extra_ldflags=["-lFuzzingEngine", "'"$CXXFLAGS_ARR"'"]'
 
@@ -53,11 +57,41 @@ $SRC/depot_tools/gn gen out/Fuzz\
 $SRC/depot_tools/ninja -C out/Fuzz_mem_constraints image_filter_deserialize \
                                                    api_raster_n32_canvas
 
+# Don't build api_mock_gpu_canvas_fuzzer for AFL since it crashes on startup.
+# This would cause a build breakage now that AFL has build checks.
+# See https://github.com/google/oss-fuzz/issues/1338 for more details.
+if [ "$FUZZING_ENGINE" == "libfuzzer" ]
+then
+  $SRC/depot_tools/ninja -C out/Fuzz_mem_constraints api_mock_gpu_canvas
+fi
+
+set +e
+for f in out/Fuzz_mem_constraints/*; do
+  # Remove unnecessary dependencies that aren't on runner containers.
+  # Libraries found through trial and error (ldd command also helpful).
+  # Note: GPU is also with the mem constraints options.
+  patchelf --remove-needed libGLU.so.1 $f
+  patchelf --remove-needed libGL.so.1 $f
+  patchelf --remove-needed libX11.so.6 $f
+done
+set -e
+
 $SRC/depot_tools/ninja -C out/Fuzz region_deserialize region_set_path \
                                    path_deserialize image_decode animated_image_decode \
                                    api_draw_functions api_gradients api_image_filter \
                                    api_path_measure api_null_canvas png_encoder \
                                    jpeg_encoder webp_encoder skottie_json textblob_deserialize
+
+set +e
+for f in out/Fuzz/*; do
+  # Remove unnecessary dependencies that aren't on runner containers.
+  # Libraries found through trial and error (ldd command also helpful).
+  # Note: GPU is also with the mem constraints options.
+  patchelf --remove-needed libGLU.so.1 $f
+  patchelf --remove-needed libGL.so.1 $f
+  patchelf --remove-needed libX11.so.6 $f
+done
+set -e
 
 cp out/Fuzz/region_deserialize $OUT/region_deserialize
 cp ./region_deserialize.options $OUT/region_deserialize.options
@@ -86,7 +120,7 @@ cp out/Fuzz_mem_constraints/image_filter_deserialize $OUT/image_filter_deseriali
 cp ./image_filter_deserialize.options $OUT/image_filter_deserialize.options
 cp ./image_filter_deserialize_seed_corpus.zip $OUT/image_filter_deserialize_seed_corpus.zip
 
-# Only create the width version of image_filter_desrialize if building with
+# Only create the width version of image_filter_deserialize if building with
 # libfuzzer, since it depends on a libfuzzer specific flag.
 if [ "$FUZZING_ENGINE" == "libfuzzer" ]
 then
@@ -136,31 +170,9 @@ cp ./encoder_seed_corpus.zip $OUT/webp_encoder_seed_corpus.zip
 cp out/Fuzz/skottie_json $OUT/skottie_json
 cp ./skottie_json_seed_corpus.zip $OUT/skottie_json_seed_corpus.zip
 
-# Don't build api_mock_gpu_canvas_fuzzer for AFL since it crashes on startup.
-# This would cause a build breakage now that AFL has build checks.
-# See https://github.com/google/oss-fuzz/issues/1338 for more details.
 if [ "$FUZZING_ENGINE" == "libfuzzer" ]
 then
-  $SRC/depot_tools/gn gen out/GPU\
-    --args='cc="'$CC'"
-        cxx="'$CXX'"
-        is_debug=false
-        extra_cflags_c=["'"$CFLAGS_ARR"'"]
-        extra_cflags_cc=["'"$CXXFLAGS_ARR"'","-DIS_FUZZING","-DIS_FUZZING_WITH_LIBFUZZER"]
-        skia_use_system_freetype2=false
-        skia_use_fontconfig=false
-        skia_enable_gpu=true
-        skia_enable_skottie=false
-        extra_ldflags=["-lFuzzingEngine", "'"$CXXFLAGS_ARR"'"]'
-
-  $SRC/depot_tools/ninja -C out/GPU api_mock_gpu_canvas
-  # Remove unnecessary dependencies that aren't on runner containers.
-  # Libraries found through trial and error (ldd command also helpful).
-  # Note: GPU is also with the mem constraints options.
-  patchelf --remove-needed libGLU.so.1 out/GPU/api_mock_gpu_canvas
-  patchelf --remove-needed libGL.so.1 out/GPU/api_mock_gpu_canvas
-  patchelf --remove-needed libX11.so.6 out/GPU/api_mock_gpu_canvas
-  cp out/GPU/api_mock_gpu_canvas $OUT/api_mock_gpu_canvas
+  cp out/Fuzz_mem_constraints/api_mock_gpu_canvas $OUT/api_mock_gpu_canvas
   cp ./api_mock_gpu_canvas.options $OUT/api_mock_gpu_canvas.options
   cp ./canvas_seed_corpus.zip $OUT/api_mock_gpu_canvas_seed_corpus.zip
 fi


### PR DESCRIPTION
Since https://skia-review.googlesource.com/c/skia/+/131146 and the follow-up CL that cleans out some technical debt related to internal tools supporting no-gpu builds, the fuzzers can't (easily) be built with GPU disabled.

So, we turn on GPU and do the patchelf to remove the unnecessary linkages.  This allows us to go back to 2 builds instead of 3.