### PR TITLE
[fuzzing-puzzles] Enable AFL fuzzing engine instead of libFuzzer + re…

### DIFF
--- a/projects/fuzzing-puzzles/build.sh
+++ b/projects/fuzzing-puzzles/build.sh
@@ -16,5 +16,5 @@
 ################################################################################
 
 $CXX $CXXFLAGS $SRC/fuzzing-puzzles/MultipleConstraintsOnSmallInputTest.cpp \
-    -o $OUT/multiple_constraints_on_small_input_fuzzer \
+    -o $OUT/multiple_constraints_on_small_input_afl_fuzzer \
     -lFuzzingEngine

--- a/projects/fuzzing-puzzles/project.yaml
+++ b/projects/fuzzing-puzzles/project.yaml
@@ -10,4 +10,4 @@ sanitizers:
   - undefined
 
 fuzzing_engines:
-  - libfuzzer
+  - afl


### PR DESCRIPTION
…name the target to prevent corpus re-use.

from https://github.com/google/oss-fuzz/pull/1485#issuecomment-395562174