### PR TITLE
oss-fuzz: add libaom project

### DIFF
--- a/projects/libaom/Dockerfile
+++ b/projects/libaom/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER urvang@google.com
+RUN apt-get update && apt-get install -y cmake yasm wget
+RUN git clone https://aomedia.googlesource.com/aom
+RUN wget -q https://storage.googleapis.com/aom-test-data/fuzzer/dec_fuzzer_seed_corpus.zip
+COPY build.sh av1_dec_fuzzer.cc $SRC/
+WORKDIR aom

--- a/projects/libaom/av1_dec_fuzzer.cc
+++ b/projects/libaom/av1_dec_fuzzer.cc
@@ -19,31 +19,17 @@ extern "C" void usage_exit(void) { exit(EXIT_FAILURE); }
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   FILE *const file = fmemopen((void *)data, size, "rb");
   if (file == nullptr) {
-    fprintf(stderr, "Failed to get file stream.\n");
     return 0;
   }
 
   char header[32];
   if (fread(header, 1, 32, file) != 32) {
-    fprintf(stderr, "Failed to get file header.\n");
     return 0;
   }
-  if (memcmp(kIVFSignature, header, 4) != 0) {
-    fprintf(stderr, "Wrong IVF signature.\n");
-    // Do not terminate.
-  }
-  if (mem_get_le16(header + 4) != 0) {
-    fprintf(stderr, "Wrong IVF version.\n");
-    // Do not terminate.
-  }
-
   const AvxInterface *decoder = get_aom_decoder_by_name("av1");
   if (decoder == nullptr) {
-    fprintf(stderr, "Unknown input codec.\n");
     return 0;
   }
-  fprintf(stderr, "Using %s\n",
-          aom_codec_iface_name(decoder->codec_interface()));
 
   aom_codec_ctx_t codec;
 
@@ -56,7 +42,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 #endif
   aom_codec_dec_cfg_t cfg = {threads, 0, 0};
   if (aom_codec_dec_init(&codec, decoder->codec_interface(), &cfg, 0)) {
-    fprintf(stderr, "Failed to initialize decoder.\n");
     aom_codec_destroy(&codec);
     return 0;
   }
@@ -69,10 +54,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   while (!ivf_read_frame(file, &buffer, &frame_size, &buffer_size, NULL)) {
     const aom_codec_err_t err = aom_codec_decode(
         &codec, buffer, static_cast<unsigned int>(frame_size), NULL);
-    if (err != AOM_CODEC_OK) {
-      fprintf(stderr, "Failed to decode frame %d; error code %d.\n",
-              frame_in_cnt, err);
-    }
     ++frame_in_cnt;
     aom_codec_iter_t iter = nullptr;
     aom_image_t *img = nullptr;
@@ -80,11 +61,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
       ++frame_out_cnt;
     }
   }
-  fprintf(stderr, "Processed %d frames.\n", frame_out_cnt);
 
-  if (aom_codec_destroy(&codec)) {
-    fprintf(stderr, "Failed to destroy codec\n");
-  }
   fclose(file);
   free(buffer);
   return 0;

--- a/projects/libaom/av1_dec_fuzzer.cc
+++ b/projects/libaom/av1_dec_fuzzer.cc
@@ -1,0 +1,91 @@
+// Fuzzing of AV1 decoder.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "aom/aom_decoder.h"
+#include "aom/aomdx.h"
+#include "aom_ports/mem_ops.h"
+#include "aom/common/ivfdec.h"
+
+// TODO(urvang): Create a 2nd fuzz target that defines DECODE_MODE_threaded.
+#define DECODE_MODE_serial
+
+static const char *const kIVFSignature = "DKIF";
+
+extern "C" void usage_exit(void) { exit(EXIT_FAILURE); }
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  FILE *const file = fmemopen((void *)data, size, "rb");
+  if (file == nullptr) {
+    fprintf(stderr, "Failed to get file stream.\n");
+    return 0;
+  }
+
+  char header[32];
+  if (fread(header, 1, 32, file) != 32) {
+    fprintf(stderr, "Failed to get file header.\n");
+    return 0;
+  }
+  if (memcmp(kIVFSignature, header, 4) != 0) {
+    fprintf(stderr, "Wrong IVF signature.\n");
+    // Do not terminate.
+  }
+  if (mem_get_le16(header + 4) != 0) {
+    fprintf(stderr, "Wrong IVF version.\n");
+    // Do not terminate.
+  }
+
+  const AvxInterface *decoder = get_aom_decoder_by_name("av1");
+  if (decoder == nullptr) {
+    fprintf(stderr, "Unknown input codec.\n");
+    return 0;
+  }
+  fprintf(stderr, "Using %s\n",
+          aom_codec_iface_name(decoder->codec_interface()));
+
+  aom_codec_ctx_t codec;
+
+#if defined(DECODE_MODE_serial)
+  const int threads = 1;
+#elif defined(DECODE_MODE_threaded)
+  const int threads = 16;
+#else
+#error define one of DECODE_MODE_(serial|threaded)
+#endif
+  aom_codec_dec_cfg_t cfg = {threads, 0, 0};
+  if (aom_codec_dec_init(&codec, decoder->codec_interface(), &cfg, 0)) {
+    fprintf(stderr, "Failed to initialize decoder.\n");
+    aom_codec_destroy(&codec);
+    return 0;
+  }
+
+  int frame_in_cnt = 0;
+  int frame_out_cnt = 0;
+  uint8_t *buffer = nullptr;
+  size_t buffer_size = 0;
+  size_t frame_size = 0;
+  while (!ivf_read_frame(file, &buffer, &frame_size, &buffer_size, NULL)) {
+    const aom_codec_err_t err = aom_codec_decode(
+        &codec, buffer, static_cast<unsigned int>(frame_size), NULL);
+    if (err != AOM_CODEC_OK) {
+      fprintf(stderr, "Failed to decode frame %d; error code %d.\n",
+              frame_in_cnt, err);
+    }
+    ++frame_in_cnt;
+    aom_codec_iter_t iter = nullptr;
+    aom_image_t *img = nullptr;
+    while ((img = aom_codec_get_frame(&codec, &iter)) != nullptr) {
+      ++frame_out_cnt;
+    }
+  }
+  fprintf(stderr, "Processed %d frames.\n", frame_out_cnt);
+
+  if (aom_codec_destroy(&codec)) {
+    fprintf(stderr, "Failed to destroy codec\n");
+  }
+  fclose(file);
+  free(buffer);
+  return 0;
+}

--- a/projects/libaom/build.sh
+++ b/projects/libaom/build.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -eu
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Build libaom
+pushd $WORK
+rm -rf ./*
+cmake $SRC/aom -DCONFIG_PIC=1 -DCONFIG_SCALABILITY=0 -DCONFIG_LOWBITDEPTH=1 \
+  -DENABLE_EXAMPLES=0 -DENABLE_DOCS=0 -DCONFIG_UNIT_TESTS=0 \
+  -DCONFIG_SIZE_LIMIT=1 -DDECODE_HEIGHT_LIMIT=12288 -DDECODE_WIDTH_LIMIT=12288
+make -j$(nproc)
+popd
+
+# Build some libaom utils that are not part of the core lib.
+$CC $CFLAGS -std=c99 -c \
+  -I$SRC/aom \
+  -I$WORK \
+  $SRC/aom/common/ivfdec.c -o $WORK/ivfdec.o
+
+$CC $CFLAGS -std=c99 -c \
+  -I$SRC/aom \
+  -I$WORK \
+  $SRC/aom/common/tools_common.c -o $WORK/tools_common.o
+
+# build fuzzer
+fuzzer_name=av1_dec_fuzzer
+
+$CXX $CXXFLAGS -std=c++11 \
+  -I$SRC/aom \
+  -I$WORK \
+  -Wl,--start-group \
+  -lFuzzingEngine \
+  $SRC/${fuzzer_name}.cc -o $OUT/${fuzzer_name} \
+  $WORK/libaom.a $WORK/ivfdec.o $WORK/tools_common.o \
+  -Wl,--end-group
+
+# copy seed corpus.
+cp $SRC/dec_fuzzer_seed_corpus.zip $OUT/${fuzzer_name}_seed_corpus.zip

--- a/projects/libaom/project.yaml
+++ b/projects/libaom/project.yaml
@@ -1,0 +1,7 @@
+homepage: "https://aomedia.org/av1-features/get-started/"
+primary_contact: "urvang@google.com"
+sanitizers:
+- address
+- undefined
+auto_ccs:
+- jzern@google.com


### PR DESCRIPTION
Here is a patch to add libaom project to oss-fuzz.
Includes:
- A fuzz target 
- Downloads seed corpus using wget.