### PR TITLE
libaom: Add a threaded mode for the fuzzer.

### DIFF
--- a/projects/libaom/av1_dec_fuzzer.cc
+++ b/projects/libaom/av1_dec_fuzzer.cc
@@ -9,9 +9,6 @@
 #include "aom_ports/mem_ops.h"
 #include "aom/common/ivfdec.h"
 
-// TODO(urvang): Create a 2nd fuzz target that defines DECODE_MODE_threaded.
-#define DECODE_MODE_serial
-
 static const char *const kIVFSignature = "DKIF";
 
 extern "C" void usage_exit(void) { exit(EXIT_FAILURE); }

--- a/projects/libaom/build.sh
+++ b/projects/libaom/build.sh
@@ -35,17 +35,23 @@ $CC $CFLAGS -std=c99 -c \
   -I$WORK \
   $SRC/aom/common/tools_common.c -o $WORK/tools_common.o
 
-# build fuzzer
-fuzzer_name=av1_dec_fuzzer
+# build fuzzers
+fuzzer_modes=( serial threaded )
 
-$CXX $CXXFLAGS -std=c++11 \
-  -I$SRC/aom \
-  -I$WORK \
-  -Wl,--start-group \
-  -lFuzzingEngine \
-  $SRC/${fuzzer_name}.cc -o $OUT/${fuzzer_name} \
-  $WORK/libaom.a $WORK/ivfdec.o $WORK/tools_common.o \
-  -Wl,--end-group
+for mode in "${fuzzer_modes[@]}"; do
+  fuzzer_src_name=av1_dec_fuzzer
+  fuzzer_name=${fuzzer_src_name}_${mode}
 
-# copy seed corpus.
-cp $SRC/dec_fuzzer_seed_corpus.zip $OUT/${fuzzer_name}_seed_corpus.zip
+  $CXX $CXXFLAGS -std=c++11 \
+    -DDECODE_MODE_${mode} \
+    -I$SRC/aom \
+    -I$WORK \
+    -Wl,--start-group \
+    -lFuzzingEngine \
+    $SRC/${fuzzer_src_name}.cc -o $OUT/${fuzzer_name} \
+    $WORK/libaom.a $WORK/ivfdec.o $WORK/tools_common.o \
+    -Wl,--end-group
+
+  # copy seed corpus.
+  cp $SRC/dec_fuzzer_seed_corpus.zip $OUT/${fuzzer_name}_seed_corpus.zip
+done


### PR DESCRIPTION
First version had a single fuzz target that ran in serial mode.
This patch adds a 2nd target that runs the decoder in threaded mode.