### PR TITLE
libaom: Remove fuzzer name suffix for serial mode.

### DIFF
--- a/projects/libaom/av1_dec_fuzzer.cc
+++ b/projects/libaom/av1_dec_fuzzer.cc
@@ -30,12 +30,12 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   aom_codec_ctx_t codec;
 
-#if defined(DECODE_MODE_serial)
+#if defined(DECODE_MODE)
   const int threads = 1;
 #elif defined(DECODE_MODE_threaded)
   const int threads = 16;
 #else
-#error define one of DECODE_MODE_(serial|threaded)
+#error define one of DECODE_MODE or DECODE_MODE_threaded
 #endif
   aom_codec_dec_cfg_t cfg = {threads, 0, 0};
   if (aom_codec_dec_init(&codec, decoder->codec_interface(), &cfg, 0)) {

--- a/projects/libaom/build.sh
+++ b/projects/libaom/build.sh
@@ -36,14 +36,14 @@ $CC $CFLAGS -std=c99 -c \
   $SRC/aom/common/tools_common.c -o $WORK/tools_common.o
 
 # build fuzzers
-fuzzer_modes=( serial threaded )
+fuzzer_src_name=av1_dec_fuzzer
+fuzzer_modes=( '' '_threaded' )
 
 for mode in "${fuzzer_modes[@]}"; do
-  fuzzer_src_name=av1_dec_fuzzer
-  fuzzer_name=${fuzzer_src_name}_${mode}
+  fuzzer_name=${fuzzer_src_name}${mode}
 
   $CXX $CXXFLAGS -std=c++11 \
-    -DDECODE_MODE_${mode} \
+    -DDECODE_MODE${mode} \
     -I$SRC/aom \
     -I$WORK \
     -Wl,--start-group \


### PR DESCRIPTION
Based on review suggestions from earlier patch.