### PR TITLE
[systemd] add evverx's gmail address

### DIFF
--- a/projects/systemd/project.yaml
+++ b/projects/systemd/project.yaml
@@ -11,4 +11,5 @@ auto_ccs:
   - poettering@gmail.com
   - watanabe.yu@gmail.com
   - evvers@ya.ru
+  - evverx@gmail.com
   - Tixxdz@gmail.com


### PR DESCRIPTION
It turns out that some things are much easier to do when
a gmail account is used.