### PR TITLE
[infra] Compile fuzzing engine without SANITIZER_FLAGS unless MSan is used.

### DIFF
--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -22,13 +22,13 @@ if [ -z "${SANITIZER_FLAGS-}" ]; then
   export SANITIZER_FLAGS=${!FLAGS_VAR-}
 fi
 
-if [[ $FUZZING_ENGINE != "none" ]]; then
-  # compile script might override environment, use . to call it.
-  . compile_${FUZZING_ENGINE}
-fi
+if [[ $SANITIZER_FLAGS = *sanitize=memory* ]]; then
+  if [[ $FUZZING_ENGINE != "none" ]]; then
+    # if MSan is used, everything should be compiled with sanitizer flags.
+    # compile script might override environment, use . to call it.
+    . compile_${FUZZING_ENGINE}
+  fi
 
-if [[ $SANITIZER_FLAGS = *sanitize=memory* ]]
-then
   # Take all libraries from lib/msan and MSAN_LIBS_PATH
   # export CXXFLAGS_EXTRA="-L/usr/msan/lib $CXXFLAGS_EXTRA"
   cp -R /usr/msan/lib/* /usr/lib/
@@ -40,12 +40,17 @@ then
     # break non MSan compiled programs.
     (cd "$MSAN_LIBS_PATH" && find . -name '*.a' -exec cp --parents '{}' / ';')
   fi
+else
+  if [[ $FUZZING_ENGINE != "none" ]]; then
+    # compile fuzzing engine without sanitizer flags, unless MSan is used.
+    # compile script might override environment, use . to call it.
+    SANITIZER_FLAGS="" . compile_${FUZZING_ENGINE}
+  fi
 fi
 
 # Coverage flag overrides.
 COVERAGE_FLAGS_VAR="COVERAGE_FLAGS_${SANITIZER}"
-if [[ -n ${!COVERAGE_FLAGS_VAR+x} ]]
-then
+if [[ -n ${!COVERAGE_FLAGS_VAR+x} ]]; then
   export COVERAGE_FLAGS="${!COVERAGE_FLAGS_VAR}"
 fi
 

--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -22,13 +22,10 @@ if [ -z "${SANITIZER_FLAGS-}" ]; then
   export SANITIZER_FLAGS=${!FLAGS_VAR-}
 fi
 
-if [[ $SANITIZER_FLAGS = *sanitize=memory* ]]; then
-  if [[ $FUZZING_ENGINE != "none" ]]; then
-    # if MSan is used, everything should be compiled with sanitizer flags.
-    # compile script might override environment, use . to call it.
-    . compile_${FUZZING_ENGINE}
-  fi
+# We don't need to compile fuzzing engine with sanitizers, unless MSan is used.
+FUZZING_ENGINE_SANITIZER_FLAGS=""
 
+if [[ $SANITIZER_FLAGS = *sanitize=memory* ]]; then
   # Take all libraries from lib/msan and MSAN_LIBS_PATH
   # export CXXFLAGS_EXTRA="-L/usr/msan/lib $CXXFLAGS_EXTRA"
   cp -R /usr/msan/lib/* /usr/lib/
@@ -40,12 +37,13 @@ if [[ $SANITIZER_FLAGS = *sanitize=memory* ]]; then
     # break non MSan compiled programs.
     (cd "$MSAN_LIBS_PATH" && find . -name '*.a' -exec cp --parents '{}' / ';')
   fi
-else
-  if [[ $FUZZING_ENGINE != "none" ]]; then
-    # compile fuzzing engine without sanitizer flags, unless MSan is used.
-    # compile script might override environment, use . to call it.
-    SANITIZER_FLAGS="" . compile_${FUZZING_ENGINE}
-  fi
+
+  FUZZING_ENGINE_SANITIZER_FLAGS="$SANITIZER_FLAGS"
+fi
+
+if [[ $FUZZING_ENGINE != "none" ]]; then
+  # compile script might override environment, use . to call it.
+  SANITIZER_FLAGS="$FUZZING_ENGINE_SANITIZER_FLAGS" . compile_${FUZZING_ENGINE}
 fi
 
 # Coverage flag overrides.

--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -22,9 +22,6 @@ if [ -z "${SANITIZER_FLAGS-}" ]; then
   export SANITIZER_FLAGS=${!FLAGS_VAR-}
 fi
 
-# We don't need to compile fuzzing engine with sanitizers, unless MSan is used.
-FUZZING_ENGINE_SANITIZER_FLAGS=""
-
 if [[ $SANITIZER_FLAGS = *sanitize=memory* ]]; then
   # Take all libraries from lib/msan and MSAN_LIBS_PATH
   # export CXXFLAGS_EXTRA="-L/usr/msan/lib $CXXFLAGS_EXTRA"
@@ -38,12 +35,15 @@ if [[ $SANITIZER_FLAGS = *sanitize=memory* ]]; then
     (cd "$MSAN_LIBS_PATH" && find . -name '*.a' -exec cp --parents '{}' / ';')
   fi
 
-  FUZZING_ENGINE_SANITIZER_FLAGS="$SANITIZER_FLAGS"
+  export FUZZING_ENGINE_SANITIZER_FLAGS="$SANITIZER_FLAGS"
+else
+  # Do not need to compile fuzzing engine with sanitizers, unless MSan is used.
+  export FUZZING_ENGINE_SANITIZER_FLAGS=""
 fi
 
 if [[ $FUZZING_ENGINE != "none" ]]; then
   # compile script might override environment, use . to call it.
-  SANITIZER_FLAGS="$FUZZING_ENGINE_SANITIZER_FLAGS" . compile_${FUZZING_ENGINE}
+  . compile_${FUZZING_ENGINE}
 fi
 
 # Coverage flag overrides.

--- a/infra/base-images/base-builder/compile_libfuzzer
+++ b/infra/base-images/base-builder/compile_libfuzzer
@@ -18,8 +18,8 @@
 echo -n "Compiling libFuzzer to $LIB_FUZZING_ENGINE... "
 mkdir -p $WORK/libfuzzer
 pushd $WORK/libfuzzer > /dev/null
-$CXX $CXXFLAGS -std=c++11 -O2 $SANITIZER_FLAGS -fno-sanitize=vptr \
-    -c $SRC/libfuzzer/*.cpp -I$SRC/libfuzzer
+$CXX $CXXFLAGS -std=c++11 -O2 $FUZZING_ENGINE_SANITIZER_FLAGS \
+    -fno-sanitize=vptr -c $SRC/libfuzzer/*.cpp -I$SRC/libfuzzer
 ar r $LIB_FUZZING_ENGINE $WORK/libfuzzer/*.o
 popd > /dev/null
 rm -rf $WORK/libfuzzer


### PR DESCRIPTION
This should not only remove fuzzing engine sources from code coverage reports (requested in https://github.com/google/oss-fuzz/issues/799#issuecomment-397663875), but also make things a bit more faster / stable, e.g. if there is a UBSan error in libFuzzer, we might get it reported from multiple projects and real fuzzing of them might get blocked. With this change, it should not be possible.