### PR TITLE
[knot-dns] Fix build

### DIFF
--- a/projects/knot-dns/Dockerfile
+++ b/projects/knot-dns/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER jonathan.foote@gmail.com
 RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config
-RUN apt-get install -y texinfo gperf wget autopoint texinfo flex bison
+RUN apt-get install -y texinfo gperf wget autopoint texinfo flex bison gettext
 
 RUN git clone --depth=1 --recursive https://git.savannah.gnu.org/git/libunistring.git
 RUN git clone --depth=1 https://git.lysator.liu.se/nettle/nettle.git

--- a/projects/knot-dns/build.sh
+++ b/projects/knot-dns/build.sh
@@ -46,7 +46,6 @@ bash .bootstrap
 
 cd $SRC/gnutls
 touch .submodule.stamp
-apt-get install -y gettext
 make bootstrap
 GNUTLS_CFLAGS=`echo $CFLAGS|sed s/-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION//`
 LIBS="-lunistring" \

--- a/projects/knot-dns/build.sh
+++ b/projects/knot-dns/build.sh
@@ -46,6 +46,7 @@ bash .bootstrap
 
 cd $SRC/gnutls
 touch .submodule.stamp
+apt-get install -y gettext
 make bootstrap
 GNUTLS_CFLAGS=`echo $CFLAGS|sed s/-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION//`
 LIBS="-lunistring" \


### PR DESCRIPTION
The knot-dns fuzz target build appears to be failing due to `gettext` being a prerequisite for building `gnutls`, but it not being available in the build environment. This patch installs `gettext` before building gnutls.

/cc @salzmdan 