### PR TITLE
Builds capstone corpus automatically

### DIFF
--- a/projects/capstone/Dockerfile
+++ b/projects/capstone/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER capstone.engine@gmail.com
-RUN apt-get update && apt-get install -y make cmake
+RUN apt-get update && apt-get install -y make cmake python python-setuptools
 RUN git clone --depth 1 --branch master https://github.com/aquynh/capstone.git capstonemaster
 RUN git clone --depth 1 --branch next https://github.com/aquynh/capstone.git capstonenext
 WORKDIR $SRC

--- a/projects/capstone/build.sh
+++ b/projects/capstone/build.sh
@@ -24,15 +24,14 @@ do
     # does not seem to work in source directory
     # + make.sh overwrites CFLAGS
     cd build
-    cmake -DCAPSTONE_BUILD_SHARED=1 ..
+    cmake -DCAPSTONE_BUILD_SHARED=0 ..
     make
 
+    cd ../bindings/python
+    python setup.py install
     cd ../suite
     mkdir fuzz/corpus
-    (
-    export LIBCAPSTONE_PATH=$SRC/capstone$branch/build/ PYTHONPATH=$SRC/capstone$branch/bindings/python/
     find MC/ -name *.cs | ./test_corpus.py
-    )
     cd fuzz
     zip -r fuzz_disasm$branch_seed_corpus.zip corpus/
     cp fuzz_disasm$branch_seed_corpus.zip $OUT/

--- a/projects/capstone/build.sh
+++ b/projects/capstone/build.sh
@@ -24,11 +24,18 @@ do
     # does not seem to work in source directory
     # + make.sh overwrites CFLAGS
     cd build
-    cmake -DCAPSTONE_BUILD_SHARED=0 ..
+    cmake -DCAPSTONE_BUILD_SHARED=1 ..
     make
 
-    cd ../suite/fuzz
-    # TODO corpus
+    cd ../suite
+    mkdir fuzz/corpus
+    (
+    export LIBCAPSTONE_PATH=$SRC/capstone$branch/build/ PYTHONPATH=$SRC/capstone$branch/bindings/python/
+    find MC/ -name *.cs | ./test_corpus.py
+    )
+    cd fuzz
+    zip -r fuzz_disasm$branch_seed_corpus.zip corpus/
+    cp fuzz_disasm$branch_seed_corpus.zip $OUT/
 
     # export other associated stuff
     cp fuzz_disasm.options $OUT/fuzz_disasm$branch.options


### PR DESCRIPTION
This does to work because shared library built for python binding misses symbols from libfuzzer  
```
Traceback (most recent call last):
  File "./test_corpus.py", line 5, in <module>
    from capstone import *
  File "/src/capstonemaster/bindings/python/capstone/__init__.py", line 240, in <module>
    _cs = _load_lib(_path)
  File "/src/capstonemaster/bindings/python/capstone/__init__.py", line 219, in _load_lib
    return ctypes.cdll.LoadLibrary(lib_file)
  File "/usr/lib/python2.7/ctypes/__init__.py", line 440, in LoadLibrary
    return self._dlltype(name)
  File "/usr/lib/python2.7/ctypes/__init__.py", line 362, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: /src/capstonemaster/build/libcapstone.so: undefined symbol: __sancov_lowest_stack
```

Do you see how to get this right ?