### PR TITLE
Precise path for capstone library

### DIFF
--- a/projects/capstone/build.sh
+++ b/projects/capstone/build.sh
@@ -31,7 +31,10 @@ do
     python setup.py install
     cd ../suite
     mkdir fuzz/corpus
+    (
+    export LIBCAPSTONE_PATH=$SRC/capstone$branch/bindings/python/capstone/lib/
     find MC/ -name *.cs | ./test_corpus.py
+    )
     cd fuzz
     zip -r fuzz_disasm$branch_seed_corpus.zip corpus/
     cp fuzz_disasm$branch_seed_corpus.zip $OUT/


### PR DESCRIPTION
I am not sure why capstone #1527 is not working on oss-fuzz (working locally)

Python script is not finding the file `libcapstone.so`
Here is a fix, specifying one path in an environment variable
It would be better to debug `capstone/__init__.py`so that it prints `_path_list`before raising the error
