### PR TITLE
qubes-os: disable ubsan

### DIFF
--- a/projects/qubes-os/project.yaml
+++ b/projects/qubes-os/project.yaml
@@ -4,3 +4,6 @@ auto_ccs:
  - "joanna@invisiblethingslab.com"
  - "marmarek@invisiblethingslab.com"
  - "paras.chetal@gmail.com"
+sanitizers:
+ - address
+ - memory


### PR DESCRIPTION
input-proxy (the only fuzzer target for now) have only 1 UBSan call right
now, which doesn't make much sense to fuzz. Disable it, until
input-proxy gets more complex for that.

Fixes #1332