### PR TITLE
Fix bad build check.

### DIFF
--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -46,6 +46,10 @@ function run_fuzz_target {
 
 # Run each fuzz target, generate raw coverage dumps.
 for fuzz_target in $FUZZ_TARGETS; do
+  if grep -va $FUZZER_BINARY "LLVMFuzzerTestOneInput" > /dev/null 2>&1; then
+    continue
+  fi
+
   echo "Running $fuzz_target"
   run_fuzz_target $fuzz_target &
   objects="$objects -object=$fuzz_target"

--- a/infra/base-images/base-runner/test_all
+++ b/infra/base-images/base-runner/test_all
@@ -38,6 +38,10 @@ for FUZZER_BINARY in $(find $OUT/ -maxdepth 1 -executable -type f); do
     continue
   fi
 
+  if grep -va $FUZZER_BINARY "LLVMFuzzerTestOneInput" > /dev/null 2>&1; then
+    continue
+  fi
+
   FUZZER=$(basename $FUZZER_BINARY)
   if [[ "$FUZZER" == afl-* ]]; then
     continue

--- a/infra/base-images/base-runner/test_report
+++ b/infra/base-images/base-runner/test_report
@@ -26,6 +26,11 @@ for FUZZER_BINARY in $(find $OUT/ -maxdepth 1 -executable -type f); do
   if file "$FUZZER_BINARY" | grep -v ELF > /dev/null 2>&1; then
     continue
   fi
+
+  if grep -va $FUZZER_BINARY "LLVMFuzzerTestOneInput" > /dev/null 2>&1; then
+    continue
+  fi
+
   if [[ "$FUZZER" == afl-* ]]; then
     continue
   fi
@@ -63,7 +68,7 @@ for FUZZER_BINARY in $(find $OUT/ -maxdepth 1 -executable -type f); do
   TESTNAME="${TEST_SUITE:-}$FUZZER"
 
   OUT_TXT=$(cat $FUZZER_STDOUT)
-  
+
   # Escape non-printable characters and CDATA end sequence.
   OUT_TXT=${OUT_TXT//[^[:print:]]/?}
   OUT_TXT=${OUT_TXT//]]>/?}


### PR DESCRIPTION
Bad build checks previously just checked that a file is an executable
ELF. This is insufficient because libraries are also executable ELFs.
Add a check that the file contains LLVMFuzzerTestOneInput, in order
to consider it a fuzz target.