### PR TITLE
libaom: call codec_destroy at the end.

### DIFF
--- a/projects/libaom/av1_dec_fuzzer.cc
+++ b/projects/libaom/av1_dec_fuzzer.cc
@@ -58,7 +58,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
       ++frame_out_cnt;
     }
   }
-
+  aom_codec_destroy(&codec);
   fclose(file);
   free(buffer);
   return 0;


### PR DESCRIPTION
This call was mistakenly missing earlier.

BUG=oss-fuzz:8849
BUG=oss-fuzz:8853