### PR TITLE
When building Tor, get an up-to-date list of the static libraries

### DIFF
--- a/projects/tor/build.sh
+++ b/projects/tor/build.sh
@@ -68,16 +68,7 @@ export ASAN_OPTIONS=detect_leaks=0
 make clean
 make -j$(nproc) oss-fuzz-fuzzers
 
-TORLIBS="src/or/libtor-testing.a"
-TORLIBS="$TORLIBS src/common/libor-crypto-testing.a"
-TORLIBS="$TORLIBS src/ext/keccak-tiny/libkeccak-tiny.a"
-TORLIBS="$TORLIBS src/common/libcurve25519_donna.a"
-TORLIBS="$TORLIBS src/ext/ed25519/ref10/libed25519_ref10.a"
-TORLIBS="$TORLIBS src/ext/ed25519/donna/libed25519_donna.a"
-TORLIBS="$TORLIBS src/common/libor-testing.a"
-TORLIBS="$TORLIBS src/common/libor-ctime-testing.a"
-TORLIBS="$TORLIBS src/common/libor-event-testing.a"
-TORLIBS="$TORLIBS src/trunnel/libor-trunnel-testing.a"
+TORLIBS="`make show-testing-libs`"
 TORLIBS="$TORLIBS -lm -Wl,-Bstatic -lssl -lcrypto -levent -lz -L${TOR_DEPS}/lib"
 TORLIBS="$TORLIBS -Wl,-Bdynamic"
 


### PR DESCRIPTION
Tor's build process creates a bunch of static libraries, which need to be linked in to the final fuzzing binary.  We're refactoring now, and the list of these libraries is in flux.  Rather than try to keep the build.sh script up-to-date with Tor's build process, let's just ask Tor's build process to tell us the list of libraries we need.  Should resolve issue 9075.