### PR TITLE
libaom: Enable DO_RANGE_CHECK_CLAMP config.

### DIFF
--- a/projects/libaom/build.sh
+++ b/projects/libaom/build.sh
@@ -21,12 +21,14 @@ rm -rf ./*
 
 # oss-fuzz has 2 GB total memory allocation limit. So, we limit per-allocation
 # limit in libaom to 1 GB to avoid OOM errors.
-extra_c_flags='-DAOM_MAX_ALLOCABLE_MEMORY=1073741824'
+# Also, enable enable DO_RANGE_CHECK_CLAMP to suppress the noise of integer
+# overflows in the transform functions.
+extra_c_flags='-DAOM_MAX_ALLOCABLE_MEMORY=1073741824 -DDO_RANGE_CHECK_CLAMP=1'
 
 cmake $SRC/aom -DCONFIG_PIC=1 -DCONFIG_SCALABILITY=0 -DCONFIG_LOWBITDEPTH=1 \
   -DENABLE_EXAMPLES=0 -DENABLE_DOCS=0 -DCONFIG_UNIT_TESTS=0 \
   -DCONFIG_SIZE_LIMIT=1 -DDECODE_HEIGHT_LIMIT=12288 -DDECODE_WIDTH_LIMIT=12288 \
-  -DAOM_EXTRA_C_FLAGS=${extra_c_flags} -DAOM_EXTRA_CXX_FLAGS=${extra_c_flags}
+  -DAOM_EXTRA_C_FLAGS="${extra_c_flags}" -DAOM_EXTRA_CXX_FLAGS="${extra_c_flags}"
 make -j$(nproc)
 popd
 


### PR DESCRIPTION
This is to avoid some noise of integer overflow sanitizer errors in
transform functions, which are actually working as intended.

BUG=oss-fuzz:9065