### PR TITLE
envoy: modified identification of corpus path

### DIFF
--- a/projects/envoy/Dockerfile
+++ b/projects/envoy/Dockerfile
@@ -36,4 +36,4 @@ RUN apt-get update && apt-get install -y bazel
 
 RUN git clone https://github.com/envoyproxy/envoy.git
 WORKDIR /src/envoy/
-COPY build.sh $SRC/
+COPY find_corpus.py build.sh $SRC/

--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -61,11 +61,11 @@ bazel build --verbose_failures --dynamic_mode=off --spawn_strategy=standalone \
 # Copy out test binaries from bazel-bin/ and zip up related test corpuses.
 for t in ${FUZZER_TARGETS}
 do
-  CORPUS_TARGET=$(python "${SRC}"/find_corpus.py "$t")
+  TARGET_CORPUS=$(python "${SRC}"/find_corpus.py "$t")
   TARGET_BASE="$(expr "$t" : '.*/\(.*\)_fuzz_test')"
   cp bazel-bin/"${t}"_driverless "${OUT}"/"${TARGET_BASE}"_fuzz_test
   zip "${OUT}/${TARGET_BASE}"_fuzz_test_seed_corpus.zip \
-    "$(dirname "${t}")"/"${CORPUS_TARGET}"/*
+    "$(dirname "${t}")"/"${TARGET_CORPUS}"/*
 done
 
 # Copy dictionaries and options files to $OUT/

--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -22,8 +22,6 @@ export CXXFLAGS="$CXXFLAGS -fno-sanitize=vptr"
 declare -r FUZZER_TARGETS_CC=$(find . -name *_fuzz_test.cc)
 declare -r FUZZER_TARGETS="$(for t in ${FUZZER_TARGETS_CC}; do echo "${t:2:-3}"; done)"
 
-echo FUZZER_TARGETS_CC
-
 FUZZER_DICTIONARIES="\
 "
 
@@ -63,7 +61,7 @@ bazel build --verbose_failures --dynamic_mode=off --spawn_strategy=standalone \
 # Copy out test binaries from bazel-bin/ and zip up related test corpuses.
 for t in ${FUZZER_TARGETS}
 do
-  CORPUS_TARGET=`python $SRC/find_corpus.py $t`
+  CORPUS_TARGET=$(python "${SRC}"/find_corpus.py "$t")
   TARGET_BASE="$(expr "$t" : '.*/\(.*\)_fuzz_test')"
   cp bazel-bin/"${t}"_driverless "${OUT}"/"${TARGET_BASE}"_fuzz_test
   zip "${OUT}/${TARGET_BASE}"_fuzz_test_seed_corpus.zip \

--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -22,6 +22,8 @@ export CXXFLAGS="$CXXFLAGS -fno-sanitize=vptr"
 declare -r FUZZER_TARGETS_CC=$(find . -name *_fuzz_test.cc)
 declare -r FUZZER_TARGETS="$(for t in ${FUZZER_TARGETS_CC}; do echo "${t:2:-3}"; done)"
 
+echo FUZZER_TARGETS_CC
+
 FUZZER_DICTIONARIES="\
 "
 
@@ -61,10 +63,11 @@ bazel build --verbose_failures --dynamic_mode=off --spawn_strategy=standalone \
 # Copy out test binaries from bazel-bin/ and zip up related test corpuses.
 for t in ${FUZZER_TARGETS}
 do
+  CORPUS_TARGET=`python $SRC/find_corpus.py $t`
   TARGET_BASE="$(expr "$t" : '.*/\(.*\)_fuzz_test')"
   cp bazel-bin/"${t}"_driverless "${OUT}"/"${TARGET_BASE}"_fuzz_test
   zip "${OUT}/${TARGET_BASE}"_fuzz_test_seed_corpus.zip \
-    "$(dirname "${t}")"/"${TARGET_BASE}"_corpus/*
+    "$(dirname "${t}")"/"${CORPUS_TARGET}"/*
 done
 
 # Copy dictionaries and options files to $OUT/

--- a/projects/envoy/find_corpus.py
+++ b/projects/envoy/find_corpus.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python
+import os, sys, re
+fuzzer_target = sys.argv[1].split('/')
+directory, fuzz_test = fuzzer_target[:-1], fuzzer_target[-1]
+directory_string = "/".join(directory)
+path = "../envoy/" + directory_string + "/BUILD"
+with open(path, "r") as f:
+        searchlines = f.readlines()
+        for i, line in enumerate(searchlines):
+                if fuzz_test in line: 
+                    for l in searchlines[i:]:
+                        if "corpus =" in l:
+                              corpus_path = l 
+                              break
+print re.findall(r'"([^"]*)"', corpus_path)[0]

--- a/projects/envoy/find_corpus.py
+++ b/projects/envoy/find_corpus.py
@@ -1,23 +1,23 @@
-#!/usr/bin/pxython
+#!/usr/bin/python
 
 import os
 import sys
 import re
 
-fuzzer_target = sys.argv[1].split("/")
-(directory_segments, fuzz_test) = (fuzzer_target[:-1], fuzzer_target[-1])
+fuzzer_target = sys.argv[1].split('/')
+directory_segments, fuzz_test = fuzzer_target[:-1], fuzzer_target[-1]
 directory = '/'.join(directory_segments)
 path = '../envoy/' + directory + '/BUILD'
 corpus_path = ""
 
 with open(path, 'r') as f:
   searchlines = f.readlines()
-  for (i, line) in enumerate(searchlines):
+  for i, line in enumerate(searchlines):
     if fuzz_test in line:
       for l in searchlines[i:]:
         if 'corpus =' in l:
           corpus_path = l
           break
 if not corpus_path:
-    raise Exception("No corpus path for the given fuzz target")
+  raise Exception("No corpus path for the given fuzz target")
 print re.findall(r'"([^"]*)"', corpus_path)[0]

--- a/projects/envoy/find_corpus.py
+++ b/projects/envoy/find_corpus.py
@@ -4,20 +4,20 @@ import os
 import sys
 import re
 
-fuzzer_target = sys.argv[1].split('/')
-directory_segments, fuzz_test = fuzzer_target[:-1], fuzzer_target[-1]
-directory = '/'.join(directory_segments)
-path = '../envoy/' + directory + '/BUILD'
-corpus_path = ""
+fuzzer_target = sys.argv[1]
+directory, fuzzer_target_name = os.path.dirname(fuzzer_target), os.path.basename(fuzzer_target)
+path = os.path.join('..', 'envoy', directory, 'BUILD')
 
 with open(path, 'r') as f:
   searchlines = f.readlines()
   for i, line in enumerate(searchlines):
-    if fuzz_test in line:
-      for l in searchlines[i:]:
-        if 'corpus =' in l:
-          corpus_path = l
-          break
-if not corpus_path:
+      if fuzzer_target_name in line:
+        for l in searchlines[i:]:
+          if 'corpus =' in l:
+            corpus_path = l
+            break
+try:
+  corpus_path
+except NameError:  
   raise Exception("No corpus path for the given fuzz target")
 print re.findall(r'"([^"]*)"', corpus_path)[0]

--- a/projects/envoy/find_corpus.py
+++ b/projects/envoy/find_corpus.py
@@ -1,15 +1,23 @@
-#!/usr/bin/python
-import os, sys, re
-fuzzer_target = sys.argv[1].split('/')
-directory, fuzz_test = fuzzer_target[:-1], fuzzer_target[-1]
-directory_string = "/".join(directory)
-path = "../envoy/" + directory_string + "/BUILD"
-with open(path, "r") as f:
-        searchlines = f.readlines()
-        for i, line in enumerate(searchlines):
-                if fuzz_test in line: 
-                    for l in searchlines[i:]:
-                        if "corpus =" in l:
-                              corpus_path = l 
-                              break
+#!/usr/bin/pxython
+
+import os
+import sys
+import re
+
+fuzzer_target = sys.argv[1].split("/")
+(directory_segments, fuzz_test) = (fuzzer_target[:-1], fuzzer_target[-1])
+directory = '/'.join(directory_segments)
+path = '../envoy/' + directory + '/BUILD'
+corpus_path = ""
+
+with open(path, 'r') as f:
+  searchlines = f.readlines()
+  for (i, line) in enumerate(searchlines):
+    if fuzz_test in line:
+      for l in searchlines[i:]:
+        if 'corpus =' in l:
+          corpus_path = l
+          break
+if not corpus_path:
+    raise Exception("No corpus path for the given fuzz target")
 print re.findall(r'"([^"]*)"', corpus_path)[0]


### PR DESCRIPTION
[envoy] - A python script (`find_corpus.py`) along with `build.sh` and `Dockerfile` which reads the `BUILD` file to identify the exact corpus path for a specific fuzzer target, as of now it does an append `_corpus` which prevents from using custom corpus directory names or sharing of corpus among fuzz targets.

Signed-off-by: Anirudh M <m.anirudh18@gmail.com>