### PR TITLE
Update FreeType's build process

### DIFF
--- a/projects/freetype2/Dockerfile
+++ b/projects/freetype2/Dockerfile
@@ -16,13 +16,13 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mike.aizatsky@gmail.com
-RUN apt-get update && apt-get install -y make autoconf libtool libarchive-dev
+RUN apt-get update && apt-get install -y autoconf cmake libarchive-dev libtool make
 
 # Get some files for the seed corpus
 ADD https://github.com/adobe-fonts/adobe-variable-font-prototype/releases/download/1.001/AdobeVFPrototype.otf $SRC/font-corpus/
 RUN git clone https://github.com/unicode-org/text-rendering-tests.git && cp text-rendering-tests/fonts/* $SRC/font-corpus
-RUN git clone --depth 1 https://github.com/cherusker/freetype2-testing.git && find freetype2-testing/fuzzing/corpora/legacy -type f -exec cp {} $SRC/font-corpus \;
 
-RUN git clone --depth 1 git://git.sv.nongnu.org/freetype/freetype2.git
-WORKDIR freetype2
+RUN git clone --depth 1 https://github.com/cherusker/freetype2-testing.git
+WORKDIR freetype2-testing
+
 COPY build.sh *.options $SRC/

--- a/projects/freetype2/build.sh
+++ b/projects/freetype2/build.sh
@@ -16,18 +16,15 @@
 #
 ################################################################################
 
-./autogen.sh
-sync
-./configure
-make -j$(nproc) clean
-make -j$(nproc) all
+# Tell CMake what fuzzing engine to link:
+export CMAKE_FUZZING_ENGINE="-lFuzzingEngine"
 
-$CXX $CXXFLAGS -std=c++11 \
-  -I./include -I. \
-  ./src/tools/ftfuzzer/ftfuzzer.cc -o $OUT/ftfuzzer \
-  ./objs/*.o -lFuzzingEngine \
-  /usr/lib/x86_64-linux-gnu/libarchive.a \
-  ./objs/.libs/libfreetype.a
+bash "fuzzing/scripts/build-fuzzers.sh"
+bash "fuzzing/scripts/prepare-oss-fuzz.sh"
 
-zip -j $OUT/ftfuzzer_seed_corpus.zip $SRC/font-corpus/*
-cp $SRC/*.options $OUT/
+# Rename the `legacy' target to `ftfuzzer' for historical reasons:
+for f in "${OUT}/legacy"*; do
+    mv "${f}" "${f/legacy/ftfuzzer}"
+done
+
+zip -ju "${OUT}/ftfuzzer_seed_corpus.zip" "${SRC}/font-corpus/"*

--- a/projects/freetype2/ftfuzzer.options
+++ b/projects/freetype2/ftfuzzer.options
@@ -1,2 +1,0 @@
-[libfuzzer]
-max_len = 30000


### PR DESCRIPTION
The idea is to move most of the build logic to a repository that is owned by FreeType. I am in the process of creating new fuzz targets that are also used for regression testing which makes the build process somewhat more complex. Having it live in a repository that is owned by FreeType makes it easier to add, pause, stop, and adjust the targets as well as the corpora at any time.

**Dockerfile**:

- Add `cmake`.
- Stop cloning [git://git.sv.nongnu.org/freetype/freetype2.git](git://git.sv.nongnu.org/freetype/freetype2.git) directly; the testing repository takes care of cloning the latest version of FreeType (submodule).
- The new build logic also takes care of adding samples from the testing repository.

**build.sh**:

- Have two scripts take care of building all fuzzers (`build-fuzzers.sh`) as well as preparing all corpora (`prepare-oss-fuzz.sh`).
- The old (legacy) fuzzer will be built by the new system and renamed to `ftfuzzer` - OSS-Fuzz should not see any difference when using that target.
- Since `prepare-oss-fuzz.sh` creates zip files for all targets, `build.sh` has to add (`-u`) samples to the existing archive.

**ftfuzzer.options**:

- `prepare-oss-fuzz.sh` takes care of creating `*.options` files for all targets.