### PR TITLE
[infra] Reland "Compile fuzzing engines w/o SANITIZER_FLAGS unless MSan is used" (#1575).

### DIFF
--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -22,13 +22,7 @@ if [ -z "${SANITIZER_FLAGS-}" ]; then
   export SANITIZER_FLAGS=${!FLAGS_VAR-}
 fi
 
-if [[ $FUZZING_ENGINE != "none" ]]; then
-  # compile script might override environment, use . to call it.
-  . compile_${FUZZING_ENGINE}
-fi
-
-if [[ $SANITIZER_FLAGS = *sanitize=memory* ]]
-then
+if [[ $SANITIZER_FLAGS = *sanitize=memory* ]]; then
   # Take all libraries from lib/msan and MSAN_LIBS_PATH
   # export CXXFLAGS_EXTRA="-L/usr/msan/lib $CXXFLAGS_EXTRA"
   cp -R /usr/msan/lib/* /usr/lib/
@@ -40,12 +34,20 @@ then
     # break non MSan compiled programs.
     (cd "$MSAN_LIBS_PATH" && find . -name '*.a' -exec cp --parents '{}' / ';')
   fi
+    export FUZZING_ENGINE_SANITIZER_FLAGS="$SANITIZER_FLAGS"
+else
+  # Do not need to compile fuzzing engine with sanitizers, unless MSan is used.
+  export FUZZING_ENGINE_SANITIZER_FLAGS=""
+fi
+
+if [[ $FUZZING_ENGINE != "none" ]]; then
+  # compile script might override environment, use . to call it.
+  . compile_${FUZZING_ENGINE}
 fi
 
 # Coverage flag overrides.
 COVERAGE_FLAGS_VAR="COVERAGE_FLAGS_${SANITIZER}"
-if [[ -n ${!COVERAGE_FLAGS_VAR+x} ]]
-then
+if [[ -n ${!COVERAGE_FLAGS_VAR+x} ]]; then
   export COVERAGE_FLAGS="${!COVERAGE_FLAGS_VAR}"
 fi
 

--- a/infra/base-images/base-builder/compile_libfuzzer
+++ b/infra/base-images/base-builder/compile_libfuzzer
@@ -18,8 +18,8 @@
 echo -n "Compiling libFuzzer to $LIB_FUZZING_ENGINE... "
 mkdir -p $WORK/libfuzzer
 pushd $WORK/libfuzzer > /dev/null
-$CXX $CXXFLAGS -std=c++11 -O2 $SANITIZER_FLAGS -fno-sanitize=vptr \
-    -c $SRC/libfuzzer/*.cpp -I$SRC/libfuzzer
+$CXX $CXXFLAGS -std=c++11 -O2 $FUZZING_ENGINE_SANITIZER_FLAGS \
+    -fno-sanitize=vptr -c $SRC/libfuzzer/*.cpp -I$SRC/libfuzzer
 ar r $LIB_FUZZING_ENGINE $WORK/libfuzzer/*.o
 popd > /dev/null
 rm -rf $WORK/libfuzzer

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -27,7 +27,7 @@ git clone https://chromium.googlesource.com/chromium/src/tools/clang
 cd clang
 
 OUR_LLVM_REVISION=334100  # For manual bumping.
-FORCE_OUR_REVISION=1  # To allow for manual downgrades.
+FORCE_OUR_REVISION=0  # To allow for manual downgrades.
 LLVM_REVISION=$(grep -Po "CLANG_REVISION = '\K\d+(?=')" scripts/update.py)
 
 if [ $OUR_LLVM_REVISION -gt $LLVM_REVISION ] || [ $FORCE_OUR_REVISION -ne 0 ]; then


### PR DESCRIPTION
I'm testing this locally now to make sure we won't get MSan errors from libFuzzer + that it's safe not to enforce our LLVM revision anymore.