### PR TITLE
[fuzzing-puzzles] Disable AFL and add OnlySomeBytesTest for libFuzzer.

### DIFF
--- a/projects/fuzzing-puzzles/Dockerfile
+++ b/projects/fuzzing-puzzles/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mmoroz@chromium.org
 RUN apt-get update && apt-get install -y make autoconf automake libtool
-ADD https://raw.githubusercontent.com/llvm-mirror/compiler-rt/master/test/fuzzer/MultipleConstraintsOnSmallInputTest.cpp \
+ADD https://raw.githubusercontent.com/llvm-mirror/compiler-rt/master/test/fuzzer/OnlySomeBytesTest.cpp \
     $SRC/fuzzing-puzzles/
 WORKDIR fuzzing-puzzles
 COPY build.sh $SRC/

--- a/projects/fuzzing-puzzles/build.sh
+++ b/projects/fuzzing-puzzles/build.sh
@@ -15,6 +15,6 @@
 #
 ################################################################################
 
-$CXX $CXXFLAGS $SRC/fuzzing-puzzles/MultipleConstraintsOnSmallInputTest.cpp \
-    -o $OUT/multiple_constraints_on_small_input_afl_fuzzer \
+$CXX $CXXFLAGS $SRC/fuzzing-puzzles/OnlySomeBytesTest.cpp \
+    -o $OUT/only_some_bytes_test_fuzzer \
     -lFuzzingEngine

--- a/projects/fuzzing-puzzles/project.yaml
+++ b/projects/fuzzing-puzzles/project.yaml
@@ -7,7 +7,7 @@ auto_ccs:
   - "mmoroz@google.com"
 
 sanitizers:
-  - address
+  - undefined
 
 fuzzing_engines:
-  - afl
+  - libfuzzer


### PR DESCRIPTION
AFL is completely stuck for the past month: https://oss-fuzz.com/v2/fuzzer-stats/by-day/date-start/2018-06-01/date-end/2018-07-12/fuzzer/afl/job/afl_asan_fuzzing-puzzles

@kcc, do you want me to add .options file with `-focus_function=f0` parameter?
