### PR TITLE
[libgit2] create build directory only if it doesn't exist yet

### DIFF
--- a/projects/libgit2/build.sh
+++ b/projects/libgit2/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 # build project
-mkdir build
+mkdir -p build
 cd build
 cmake .. -DCMAKE_INSTALL_PREFIX="$WORK" \
       -DBUILD_SHARED_LIBS=OFF \


### PR DESCRIPTION
Right now, we're always trying to create the project build directory,
even if it already exists. When building the fuzzer with an already
existing project directory, though, this may produce an error if the
build directory already exists. Fix this by adding the "-p" flag to
mkdir(1), which will not produce an error if the target already exists.