### PR TITLE
BoringSSL vs. mbed TLS differential bignum fuzzing

### DIFF
--- a/projects/bignum-fuzzer/Dockerfile
+++ b/projects/bignum-fuzzer/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER guidovranken@gmail.com
-RUN apt-get update && apt-get install -y software-properties-common python-software-properties wget curl sudo mercurial autoconf bison texinfo libboost-all-dev
+RUN apt-get update && apt-get install -y software-properties-common python-software-properties wget curl sudo mercurial autoconf bison texinfo libboost-all-dev cmake
 RUN add-apt-repository -y ppa:gophers/archive && apt-get update && apt-get install -y golang-1.9-go
 RUN ln -s /usr/lib/go-1.9/bin/go /usr/bin/go
 
@@ -26,4 +26,6 @@ RUN curl -s https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly
 RUN git clone --depth 1 https://github.com/guidovranken/bignum-fuzzer
 RUN git clone --depth 1 https://github.com/openssl/openssl
 RUN hg clone https://gmplib.org/repo/gmp/ libgmp/
+RUN git clone https://boringssl.googlesource.com/boringssl
+RUN git clone --depth 1 https://github.com/ARMmbed/mbedtls
 COPY build.sh $SRC/

--- a/projects/bignum-fuzzer/build.sh
+++ b/projects/bignum-fuzzer/build.sh
@@ -73,8 +73,39 @@ LIBFUZZER_LINK="-lFuzzingEngine" make
 # Copy OpenSSL/libgmp fuzzer to the designated location
 cp $SRC/bignum-fuzzer/fuzzer $OUT/fuzzer_openssl_libgmp_num_len_1200_all_operations_num_loops_1
 
+# Build mbedtls
+cd $SRC/mbedtls
+make lib -j$(nproc)
+
+# Build BoringSSL
+cd $SRC/boringssl
+mkdir build
+cd build
+cmake -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DCMAKE_C_FLAGS="$CFLAGS" ..
+make -j$(nproc)
+
+# Build BoringSSL module
+cd $SRC/bignum-fuzzer/modules/openssl
+make clean
+CFLAGS="$CFLAGS -DBIGNUM_FUZZER_BORINGSSL" OPENSSL_INCLUDE_PATH=$SRC/boringssl/include OPENSSL_LIBCRYPTO_A_PATH=$SRC/boringssl/build/crypto/libcrypto.a make
+
+# Build mbedtls module
+cd $SRC/bignum-fuzzer/modules/mbedtls
+MBEDTLS_LIBMBEDCRYPTO_A_PATH=$SRC/mbedtls/library/libmbedcrypto.a MBEDTLS_INCLUDE_PATH=$SRC/mbedtls/include make
+
+# Build BoringSSL/mbedtls fuzzer
+cd $SRC/bignum-fuzzer
+make clean
+./config-modules.sh boringssl mbedtls
+CXXFLAGS="$BASE_CXXFLAGS -DBNFUZZ_FLAG_NUM_LEN=1200 -DBNFUZZ_FLAG_ALL_OPERATIONS=1 -DBNFUZZ_FLAG_NUM_LOOPS=1"
+LIBFUZZER_LINK="-lFuzzingEngine" make
+
+# Copy BoringSSL/mbedtls fuzzer to the designated location
+cp $SRC/bignum-fuzzer/fuzzer $OUT/fuzzer_boringssl_mbedtls_num_len_1200_all_operations_num_loops_1
+
 # Copy seed corpora to the designated location
 cp $SRC/bignum-fuzzer/corpora/fuzzer_openssl_go_no_negative_num_len_1200_all_operations_seed_corpus.zip $OUT
 cp $SRC/bignum-fuzzer/corpora/fuzzer_openssl_rust_num_len_1200_all_operations_num_loops_1_seed_corpus.zip $OUT
 cp $SRC/bignum-fuzzer/corpora/fuzzer_openssl_cpp_boost_num_len_1200_all_operations_num_loops_1_seed_corpus.zip $OUT
 cp $SRC/bignum-fuzzer/corpora/fuzzer_openssl_libgmp_num_len_1200_all_operations_num_loops_1_seed_corpus.zip $OUT
+cp $SRC/bignum-fuzzer/corpora/fuzzer_boringssl_mbedtls_num_len_1200_all_operations_num_loops_1_seed_corpus.zip $OUT

--- a/projects/bignum-fuzzer/build.sh
+++ b/projects/bignum-fuzzer/build.sh
@@ -97,15 +97,15 @@ MBEDTLS_LIBMBEDCRYPTO_A_PATH=$SRC/mbedtls/library/libmbedcrypto.a MBEDTLS_INCLUD
 cd $SRC/bignum-fuzzer
 make clean
 ./config-modules.sh boringssl mbedtls
-CXXFLAGS="$BASE_CXXFLAGS -DBNFUZZ_FLAG_NUM_LEN=1200 -DBNFUZZ_FLAG_ALL_OPERATIONS=1 -DBNFUZZ_FLAG_NUM_LOOPS=1"
+CXXFLAGS="$BASE_CXXFLAGS -DBNFUZZ_FLAG_NUM_LEN=100 -DBNFUZZ_FLAG_ALL_OPERATIONS=1 -DBNFUZZ_FLAG_NUM_LOOPS=1"
 LIBFUZZER_LINK="-lFuzzingEngine" make
 
 # Copy BoringSSL/mbedtls fuzzer to the designated location
-cp $SRC/bignum-fuzzer/fuzzer $OUT/fuzzer_boringssl_mbedtls_num_len_1200_all_operations_num_loops_1
+cp $SRC/bignum-fuzzer/fuzzer $OUT/fuzzer_boringssl_mbedtls_num_len_100_all_operations_num_loops_1
 
 # Copy seed corpora to the designated location
 cp $SRC/bignum-fuzzer/corpora/fuzzer_openssl_go_no_negative_num_len_1200_all_operations_seed_corpus.zip $OUT
 cp $SRC/bignum-fuzzer/corpora/fuzzer_openssl_rust_num_len_1200_all_operations_num_loops_1_seed_corpus.zip $OUT
 cp $SRC/bignum-fuzzer/corpora/fuzzer_openssl_cpp_boost_num_len_1200_all_operations_num_loops_1_seed_corpus.zip $OUT
 cp $SRC/bignum-fuzzer/corpora/fuzzer_openssl_libgmp_num_len_1200_all_operations_num_loops_1_seed_corpus.zip $OUT
-cp $SRC/bignum-fuzzer/corpora/fuzzer_boringssl_mbedtls_num_len_1200_all_operations_num_loops_1_seed_corpus.zip $OUT
+cp $SRC/bignum-fuzzer/corpora/fuzzer_boringssl_mbedtls_num_len_100_all_operations_num_loops_1_seed_corpus.zip $OUT

--- a/projects/bignum-fuzzer/build.sh
+++ b/projects/bignum-fuzzer/build.sh
@@ -81,7 +81,7 @@ make lib -j$(nproc)
 cd $SRC/boringssl
 mkdir build
 cd build
-cmake -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DCMAKE_C_FLAGS="$CFLAGS" ..
+cmake -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DCMAKE_C_FLAGS="$CFLAGS" -DBORINGSSL_ALLOW_CXX_RUNTIME=1 ..
 make -j$(nproc)
 
 # Build BoringSSL module

--- a/projects/bignum-fuzzer/project.yaml
+++ b/projects/bignum-fuzzer/project.yaml
@@ -9,3 +9,6 @@ auto_ccs:
     - "caswell.matt@googlemail.com"
     - "jz.maddock@gmail.com"
     - "jz.maddock@googlemail.com"
+    - "agl@google.com"
+    - "davidben@google.com"
+    - "svaldez@google.com"


### PR DESCRIPTION
This PR adds a fuzzer target that performs differential fuzzing of bignums between BoringSSL and mbed TLS.

I've reached out to ARM (of mbed TLS) to collect a CC e-mail address but they have not responded yet.
David Benjamin of BoringSSL consented to using the same e-mail CC's configured in the existing boringssl project for this project.

This fuzzer uses a much smaller maximum bignum size (100 decimals) than the other fuzzers (1200 decimals). Fuzzing is much faster but the downside is that bugs in code specifically designed to process large bignums will not be found (such code exists in OpenSSL, at least). Let's see how this trade-off works out.