### PR TITLE
[FreeType2] Add `pkg-config'.

### DIFF
--- a/projects/freetype2/Dockerfile
+++ b/projects/freetype2/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update &&  \
       libarchive-dev   \
       libpng-dev       \
       libtool          \
+      pkg-config       \
       zlib1g-dev       \
       make
 


### PR DESCRIPTION
Sorry guys for these recent micro PRs. This one is necessary to build `libarchive` from sources (which is necessary b/c `3.1.2` (which comes bundled with Xenial) has a mem leak - at least ASan complains about it).

As soon as I have updated the build process, I will issue another micro PR to remove `libarchive-dev` for good. Sorry, I wish there was a way without annoying you ❤️ 