### PR TITLE
[FreeType2] Remove `libarchive-dev'.

### DIFF
--- a/projects/freetype2/Dockerfile
+++ b/projects/freetype2/Dockerfile
@@ -21,7 +21,6 @@ RUN apt-get update &&  \
     apt-get install -y \
       autoconf         \
       cmake            \
-      libarchive-dev   \
       libpng-dev       \
       libtool          \
       pkg-config       \


### PR DESCRIPTION
As mentioned in #1641, this is the second part of moving over to building `libarchive` from sources. Thanks for merging.