### PR TITLE
Miscellaneous cleanups.

### DIFF
--- a/projects/libaom/av1_dec_fuzzer.cc
+++ b/projects/libaom/av1_dec_fuzzer.cc
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <memory>
 
 #include "aom/aom_decoder.h"
 #include "aom/aomdx.h"
@@ -11,16 +12,19 @@
 
 static const char *const kIVFSignature = "DKIF";
 
+static void close_file(FILE *file) { fclose(file); }
+
 extern "C" void usage_exit(void) { exit(EXIT_FAILURE); }
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-  FILE *const file = fmemopen((void *)data, size, "rb");
+  std::unique_ptr<FILE, decltype(&close_file)> file(
+      fmemopen((void *)data, size, "rb"), &close_file);
   if (file == nullptr) {
     return 0;
   }
 
   char header[32];
-  if (fread(header, 1, 32, file) != 32) {
+  if (fread(header, 1, 32, file.get()) != 32) {
     return 0;
   }
   const AvxInterface *decoder = get_aom_decoder_by_name("av1");
@@ -29,7 +33,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   }
 
   aom_codec_ctx_t codec;
-
 #if defined(DECODE_MODE)
   const int threads = 1;
 #elif defined(DECODE_MODE_threaded)
@@ -39,7 +42,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 #endif
   aom_codec_dec_cfg_t cfg = {threads, 0, 0};
   if (aom_codec_dec_init(&codec, decoder->codec_interface(), &cfg, 0)) {
-    aom_codec_destroy(&codec);
     return 0;
   }
 
@@ -48,9 +50,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   uint8_t *buffer = nullptr;
   size_t buffer_size = 0;
   size_t frame_size = 0;
-  while (!ivf_read_frame(file, &buffer, &frame_size, &buffer_size, NULL)) {
-    const aom_codec_err_t err = aom_codec_decode(
-        &codec, buffer, static_cast<unsigned int>(frame_size), NULL);
+  while (!ivf_read_frame(file.get(), &buffer, &frame_size, &buffer_size,
+                         nullptr)) {
+    const aom_codec_err_t err =
+        aom_codec_decode(&codec, buffer, frame_size, nullptr);
     ++frame_in_cnt;
     aom_codec_iter_t iter = nullptr;
     aom_image_t *img = nullptr;
@@ -59,7 +62,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     }
   }
   aom_codec_destroy(&codec);
-  fclose(file);
   free(buffer);
   return 0;
 }


### PR DESCRIPTION
- Close 'file' before returning on errors.
- Don't call aom_codec_destroy() after an aom_codec_dec_init() failure.
- Remove a cast to unsigned int* that's no longer necessary.
- Change NULL to nullptr.