### PR TITLE
ffmpeg,build.sh: restrict libvpx frame sizes

### DIFF
--- a/projects/ffmpeg/build.sh
+++ b/projects/ffmpeg/build.sh
@@ -97,7 +97,9 @@ make install
 
 cd $SRC/libvpx
 LDFLAGS="$CXXFLAGS" ./configure --prefix="$FFMPEG_DEPS_PATH" \
-    --disable-examples --disable-unit-tests
+    --disable-examples --disable-unit-tests \
+    --size-limit=12288x12288 \
+    --extra-cflags="-DVPX_MAX_ALLOCABLE_MEMORY=1073741824"
 make clean
 make -j$(nproc) all
 make install


### PR DESCRIPTION
Restricting the maximum resolution and single allocation size will reduce OOM
frequency.