### PR TITLE
envoy: add ninja-build to base image.

### DIFF
--- a/projects/envoy/Dockerfile
+++ b/projects/envoy/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get -y install  \
 	build-essential \
 	openjdk-8-jdk   \
 	make            \
+    ninja-build     \
     curl            \
     autoconf        \
     libtool         \


### PR DESCRIPTION
This recently became a build-time dependency for Envoy.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=9586.

Signed-off-by: Harvey Tuch <htuch@google.com>