### PR TITLE
[infra] Add retry wrapper to LLVM checkout commands.

### DIFF
--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -25,16 +25,19 @@ function checkout_with_retries {
   LOCAL_PATH=$2
   CHECKOUT_RETURN_CODE=1
 
-  set -e
+  # Disable exit on error since we might encounter some failures while retrying.
+  set +e
   for i in $(seq 1 $CHECKOUT_RETRIES); do
     rm -rf $LOCAL_PATH
-    CHECKOUT_RETURN_CODE=$(svn co $REPOSITORY $LOCAL_PATH)
+    svn co $REPOSITORY $LOCAL_PATH
+    CHECKOUT_RETURN_CODE=$?
     if [ $CHECKOUT_RETURN_CODE -eq 0 ]; then
       break
     fi
   done
 
-  set +e
+  # Re-enable exit on error. If checkout failed, we'll exit.
+  set -e
   return $CHECKOUT_RETURN_CODE
 }
 
@@ -54,7 +57,7 @@ fi
 
 echo "Using LLVM revision: $LLVM_REVISION"
 
-cd $SRC && checkout_with_retries https://llvm123.org/svn/llvm-project/llvm/trunk@$LLVM_REVISION llvm
+cd $SRC && checkout_with_retries https://llvm.org/svn/llvm-project/llvm/trunk@$LLVM_REVISION llvm
 cd $SRC/llvm/tools && checkout_with_retries https://llvm.org/svn/llvm-project/cfe/trunk@$LLVM_REVISION clang
 cd $SRC/llvm/projects && checkout_with_retries https://llvm.org/svn/llvm-project/compiler-rt/trunk@$LLVM_REVISION compiler-rt
 cd $SRC/llvm/projects && checkout_with_retries https://llvm.org/svn/llvm-project/libcxx/trunk@$LLVM_REVISION libcxx

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -23,22 +23,19 @@ CHECKOUT_RETRIES=10
 function checkout_with_retries {
   REPOSITORY=$1
   LOCAL_PATH=$2
-  CHECKOUT_FAILED=1
+  CHECKOUT_RETURN_CODE=1
 
   set -e
   for i in $(seq 1 $CHECKOUT_RETRIES); do
-    rm -rf $LOCAL_PATH && svn co $REPOSITORY $LOCAL_PATH
-    if [ $? -eq 0 ]; then
-      CHECKOUT_FAILED=0
+    rm -rf $LOCAL_PATH
+    CHECKOUT_RETURN_CODE=$(svn co $REPOSITORY $LOCAL_PATH)
+    if [ $CHECKOUT_RETURN_CODE -eq 0 ]; then
       break
     fi
   done
-  set +e
 
-  # If checkout failed after all retires, do one more desperate attempt with +e.
-  if [ $CHECKOUT_FAILED -eq 1 ]; then
-      rm -rf $LOCAL_PATH && svn co $REPOSITORY $LOCAL_PATH
-  fi
+  set +e
+  return $CHECKOUT_RETURN_CODE
 }
 
 # Use chromium's clang revision
@@ -57,7 +54,7 @@ fi
 
 echo "Using LLVM revision: $LLVM_REVISION"
 
-cd $SRC && checkout_with_retries https://llvm.org/svn/llvm-project/llvm/trunk@$LLVM_REVISION llvm
+cd $SRC && checkout_with_retries https://llvm123.org/svn/llvm-project/llvm/trunk@$LLVM_REVISION llvm
 cd $SRC/llvm/tools && checkout_with_retries https://llvm.org/svn/llvm-project/cfe/trunk@$LLVM_REVISION clang
 cd $SRC/llvm/projects && checkout_with_retries https://llvm.org/svn/llvm-project/compiler-rt/trunk@$LLVM_REVISION compiler-rt
 cd $SRC/llvm/projects && checkout_with_retries https://llvm.org/svn/llvm-project/libcxx/trunk@$LLVM_REVISION libcxx

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -19,6 +19,27 @@ LLVM_DEP_PACKAGES="build-essential make cmake ninja-build git subversion python2
 apt-get install -y $LLVM_DEP_PACKAGES
 
 # Checkout
+CHECKOUT_RETRIES=10
+function checkout_with_retries {
+  REPOSITORY=$1
+  LOCAL_PATH=$2
+  CHECKOUT_FAILED=1
+
+  set -e
+  for i in $(seq 1 $CHECKOUT_RETRIES); do
+    rm -rf $LOCAL_PATH && svn co $REPOSITORY $LOCAL_PATH
+    if [ $? -eq 0 ]; then
+      $CHECKOUT_FAILED=0
+      break
+    fi
+  done
+  set +e
+
+  # If checkout failed after all retires, do one more desperate attempt with +e.
+  if [ $CHECKOUT_FAILED -eq 1 ]; then
+      rm -rf $LOCAL_PATH && svn co $REPOSITORY $LOCAL_PATH
+  fi
+}
 
 # Use chromium's clang revision
 mkdir $SRC/chromium_tools
@@ -36,11 +57,11 @@ fi
 
 echo "Using LLVM revision: $LLVM_REVISION"
 
-cd $SRC && svn co https://llvm.org/svn/llvm-project/llvm/trunk@$LLVM_REVISION llvm
-cd $SRC/llvm/tools && svn co https://llvm.org/svn/llvm-project/cfe/trunk@$LLVM_REVISION clang
-cd $SRC/llvm/projects && svn co https://llvm.org/svn/llvm-project/compiler-rt/trunk@$LLVM_REVISION compiler-rt
-cd $SRC/llvm/projects && svn co https://llvm.org/svn/llvm-project/libcxx/trunk@$LLVM_REVISION libcxx
-cd $SRC/llvm/projects && svn co https://llvm.org/svn/llvm-project/libcxxabi/trunk@$LLVM_REVISION libcxxabi
+cd $SRC && checkout_with_retries https://llvm.org/svn/llvm-project/llvm/trunk@$LLVM_REVISION llvm
+cd $SRC/llvm/tools && checkout_with_retries https://llvm.org/svn/llvm-project/cfe/trunk@$LLVM_REVISION clang
+cd $SRC/llvm/projects && checkout_with_retries https://llvm.org/svn/llvm-project/compiler-rt/trunk@$LLVM_REVISION compiler-rt
+cd $SRC/llvm/projects && checkout_with_retries https://llvm.org/svn/llvm-project/libcxx/trunk@$LLVM_REVISION libcxx
+cd $SRC/llvm/projects && checkout_with_retries https://llvm.org/svn/llvm-project/libcxxabi/trunk@$LLVM_REVISION libcxxabi
 
 # Build & install
 mkdir -p $WORK/llvm

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -29,7 +29,7 @@ function checkout_with_retries {
   for i in $(seq 1 $CHECKOUT_RETRIES); do
     rm -rf $LOCAL_PATH && svn co $REPOSITORY $LOCAL_PATH
     if [ $? -eq 0 ]; then
-      $CHECKOUT_FAILED=0
+      CHECKOUT_FAILED=0
       break
     fi
   done

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -36,7 +36,7 @@ function checkout_with_retries {
     fi
   done
 
-  # Re-enable exit on error. If checkout failed, we'll exit.
+  # Re-enable exit on error. If checkout failed, script will exit.
   set -e
   return $CHECKOUT_RETURN_CODE
 }


### PR DESCRIPTION
Given that changing IP address of the builder didn't help, I'd suspect that there might be some network issues not allowing us to finish the checkout successfully. 