### PR TITLE
Pull corpus files from google cloud for libwebp

### DIFF
--- a/projects/libwebp/Dockerfile
+++ b/projects/libwebp/Dockerfile
@@ -19,6 +19,9 @@ MAINTAINER pdknsk@gmail.com
 RUN apt-get update && apt-get install -y autoconf make libtool zip
 RUN git clone https://chromium.googlesource.com/webm/libwebp
 RUN git clone https://chromium.googlesource.com/webm/libwebp-test-data
+ADD https://storage.googleapis.com/downloads.webmproject.org/webp/testdata/fuzzer/fuzz_seed_corpus.zip ./
+RUN unzip fuzz_seed_corpus.zip -d libwebp-test-data/
+RUN rm fuzz_seed_corpus.zip
 COPY build.sh fuzz.h fuzz.dict $SRC/
 COPY fuzz_simple_api.c $SRC/
 COPY fuzz_advanced_api.c $SRC/


### PR DESCRIPTION
Add remote zip containing fuzzer-friendly files which cover
basically all features.

Following [1], we'd rather not add these files to libwebp-test-data
because it's a repository for conformance images.
[1] https://bugs.chromium.org/p/webp/issues/detail?id=376