### PR TITLE
[infra] skip the rest of check_instrumentation if grep hasn't found anything

### DIFF
--- a/infra/base-images/base-runner/bad_build_check
+++ b/infra/base-images/base-runner/bad_build_check
@@ -65,6 +65,9 @@ function check_instrumentation {
 
     local NUMBER_OF_EDGES=$(grep -Po "INFO: Loaded [[:digit:]]+ module.*\(.*(counters|guards)\):[[:space:]]+\K[[:digit:]]+" $FUZZER_OUTPUT)
 
+    # If a fuzz target fails to start, grep won't find anything, so bail out early to let check_startup_crash deal with it.
+    [[ -z "$NUMBER_OF_EDGES" ]] && return
+
     if (( $NUMBER_OF_EDGES < $THRESHOLD_FOR_NUMBER_OF_EDGES )); then
       echo "BAD BUILD: $FUZZER seems to have only partial coverage instrumentation."
     fi


### PR DESCRIPTION
When a fuzzer is seriously broken (which happens occasionally during debug),
it's unlikely to start properly let alone provide some meaningful
output. In this case, it seems reasonable to skip some checks and prevent bash
from encountering the following syntax error:
```
/usr/local/bin/bad_build_check: line 68: ((: < 100 : syntax error: operand expected (error token is "< 100 ")
```

@Dor1s could you take a look?