### PR TITLE
[infra] Bump LLVM revision to r338452.

### DIFF
--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -47,7 +47,7 @@ cd $SRC/chromium_tools
 git clone https://chromium.googlesource.com/chromium/src/tools/clang
 cd clang
 
-OUR_LLVM_REVISION=334100  # For manual bumping.
+OUR_LLVM_REVISION=338452  # For manual bumping.
 FORCE_OUR_REVISION=0  # To allow for manual downgrades.
 LLVM_REVISION=$(grep -Po "CLANG_REVISION = '\K\d+(?=')" scripts/update.py)
 


### PR DESCRIPTION
This revision was rolled in Chromium on Aug 1st: https://chromium.googlesource.com/chromium/src/+/cc14e55b5cd9359e09aa9b8aa8795b100031abfb

But then reverted on Aug 10th: https://chromium.googlesource.com/chromium/src/+/8457b638ed3550460518321e4a4a21b08c2e30f9

Because of size regressions on iOS with `-O0`: https://bugs.chromium.org/p/chromium/issues/detail?id=870907

Shouldn't be an issue for us. Also, the Chromium version likely will be rolled again soon.