### PR TITLE
Update the maintainer of FreeType's `Dockerfile`

### DIFF
--- a/projects/freetype2/Dockerfile
+++ b/projects/freetype2/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-MAINTAINER mike.aizatsky@gmail.com
+MAINTAINER prince.cherusker@gmail.com
 
 RUN apt-get update &&  \
     apt-get install -y \


### PR DESCRIPTION
I am not sure if there is any meaning to the `MAINTAINER` named in the `Dockerfile` of projects (all the more since Mike seems to maintain quite a lot of different projects 😄 - a copy&paste product I suppose?) Anyways, I would set it to myself for now since I will continue to spend some time with FreeType's fuzzers in the near future.