### PR TITLE
[infra] Add UBSAN_OPTIONS=\"silence_unsigned_overflow=1\" to base-builder image (#1715).

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -26,6 +26,10 @@ ENV SANITIZER_FLAGS_undefined "-fsanitize=bool,array-bounds,float-divide-by-zero
 ENV SANITIZER_FLAGS_memory "-fsanitize=memory -fsanitize-memory-track-origins"
 ENV SANITIZER_FLAGS_profile "-fprofile-instr-generate -fcoverage-mapping -pthread"
 
+# We use unsigned-integer-overflow as an additional coverage signal and have to
+# suppress error messages. See https://github.com/google/oss-fuzz/issues/910.
+ENV UBSAN_OPTIONS="silence_unsigned_overflow=1"
+
 # Default build flags for coverage.
 ENV COVERAGE_FLAGS="-fsanitize=fuzzer-no-link"
 


### PR DESCRIPTION
PTAL, tested locally, base-runner already has it:

https://github.com/google/oss-fuzz/blob/master/infra/base-images/base-runner/Dockerfile#L31
