### PR TITLE
Adds unicorn project

### DIFF
--- a/projects/unicorn/Dockerfile
+++ b/projects/unicorn/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER unicorn.emu@gmail.com
+RUN apt-get update && apt-get install -y make python
+#TODO change to main repo
+RUN git clone --depth 1 --branch fuzz https://github.com/catenacyber/unicorn.git
+WORKDIR $SRC
+COPY build.sh $SRC/

--- a/projects/unicorn/Dockerfile
+++ b/projects/unicorn/Dockerfile
@@ -17,7 +17,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER unicorn.emu@gmail.com
 RUN apt-get update && apt-get install -y make python
-#TODO change to main repo
-RUN git clone --depth 1 --branch fuzz https://github.com/catenacyber/unicorn.git
+RUN git clone --depth 1 https://github.com/unicorn-engine/unicorn.git
 WORKDIR $SRC
 COPY build.sh $SRC/

--- a/projects/unicorn/build.sh
+++ b/projects/unicorn/build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -eu
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd unicorn
+./make.sh
+#we could test with make fuzz
+
+# build fuzz target
+cd fuzz
+ls fuzz_*.c | cut -d_ -f2-4 | cut -d. -f1 | while read target
+do
+    $CC $CFLAGS -I../include -c fuzz_$target.c -o fuzz_$target.o
+
+    $CXX $CXXFLAGS fuzz_$target.o -o $OUT/fuzz_$target ../libunicorn.a -lFuzzingEngine
+
+    #TODO corpuses
+    cp fuzz_emu.options $OUT/fuzz_$target.options
+done

--- a/projects/unicorn/build.sh
+++ b/projects/unicorn/build.sh
@@ -20,12 +20,12 @@ cd unicorn
 #we could test with make fuzz
 
 # build fuzz target
-cd fuzz
+cd tests/fuzz
 ls fuzz_*.c | cut -d_ -f2-4 | cut -d. -f1 | while read target
 do
-    $CC $CFLAGS -I../include -c fuzz_$target.c -o fuzz_$target.o
+    $CC $CFLAGS -I../../include -c fuzz_$target.c -o fuzz_$target.o
 
-    $CXX $CXXFLAGS fuzz_$target.o -o $OUT/fuzz_$target ../libunicorn.a -lFuzzingEngine
+    $CXX $CXXFLAGS fuzz_$target.o -o $OUT/fuzz_$target ../../libunicorn.a -lFuzzingEngine
 
     #TODO corpuses
     cp fuzz_emu.options $OUT/fuzz_$target.options

--- a/projects/unicorn/project.yaml
+++ b/projects/unicorn/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://www.unicorn-engine.org"
+primary_contact: "unicorn.emu@gmail.com"
+auto_ccs : "p.antoine@catenacyber.fr"
+
+sanitizers:
+- address
+- memory
+- undefined


### PR DESCRIPTION
Waiting for https://github.com/unicorn-engine/unicorn/pull/1000 for main repo

I have a warning message when building fuzzer with memory sanitizer : 
```
WARNING: Instrumented library not found for /lib/x86_64-linux-gnu/libm.so.6
WARNING: Instrumented library not found for /lib/x86_64-linux-gnu/libpthread.so.0
WARNING: Instrumented library not found for /lib/x86_64-linux-gnu/librt.so.1
WARNING: Instrumented library not found for /lib/x86_64-linux-gnu/libdl.so.2
WARNING: Instrumented library not found for /lib/x86_64-linux-gnu/libgcc_s.so.1
WARNING: Instrumented library not found for /lib/x86_64-linux-gnu/libc.so.6
```
Is this ok ?

And it looks like a lot of undefined shifts to be fixed...