### PR TITLE
zlib-ng: add make check

### DIFF
--- a/projects/zlib-ng/build.sh
+++ b/projects/zlib-ng/build.sh
@@ -23,8 +23,7 @@ sed -i 's/$(CC) $(LDFLAGS)/$(CXX) $(LDFLAGS)/g' Makefile
 
 make -j$(nproc) clean
 make -j$(nproc) all
-# FIXME: enable make check once it passes with clang sanitizers.
-# make -j$(nproc) check
+make -j$(nproc) check
 
 find . -name 'compress_fuzzer' -exec cp -v '{}' $OUT ';'
 zip $OUT/compress_fuzzer_seed_corpus.zip *.*


### PR DESCRIPTION
All sanitizer errors have been fixed for `make check`:
enable `make check` after `make all`.