### PR TITLE
[infra] Set up project dir for coverage job properly.

### DIFF
--- a/infra/gcb/jenkins_config/coverage_job.xml
+++ b/infra/gcb/jenkins_config/coverage_job.xml
@@ -45,7 +45,8 @@ set -o nounset
 
 cd $WORKSPACE/oss-fuzz/infra/gcb
 pip install -r requirements.txt
-build_id=$(python build_and_run_coverage.py $WORKSPACE/oss-fuzz/$JOB_NAME)
+project_dir=$WORKSPACE/oss-fuzz/projects/$(coverage $JOB_NAME)
+build_id=$(python build_and_run_coverage.py $project_dir)
 python wait_for_build.py $build_id
 </command>
     </hudson.tasks.Shell>

--- a/infra/gcb/jenkins_config/coverage_job.xml
+++ b/infra/gcb/jenkins_config/coverage_job.xml
@@ -45,7 +45,7 @@ set -o nounset
 
 cd $WORKSPACE/oss-fuzz/infra/gcb
 pip install -r requirements.txt
-project_dir=$WORKSPACE/oss-fuzz/projects/$(coverage $JOB_NAME)
+project_dir=$WORKSPACE/oss-fuzz/coverage/$(basename $JOB_NAME)
 build_id=$(python build_and_run_coverage.py $project_dir)
 python wait_for_build.py $build_id
 </command>


### PR DESCRIPTION
@oliverchang, I wonder if we should do the same for base_job.xml. Otherwise, if we ever rename either `projects` job prefix or `projects` directory in the repo, the builds will break.