### PR TITLE
Correct cmark upstream repo name

### DIFF
--- a/projects/cmark/Dockerfile
+++ b/projects/cmark/Dockerfile
@@ -17,6 +17,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER philipturnbull@github.com
 RUN apt-get update && apt-get install -y make cmake
-RUN git clone --depth 1 https://github.com/jgm/cmark.git cmark
+RUN git clone --depth 1 https://github.com/commonmark/cmark.git cmark
 WORKDIR cmark
 COPY build.sh *.dict *.options $SRC/


### PR DESCRIPTION
The canonical name of this repo has changed; we recently hit an issue (https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=9980) where the redirect changed and was no longer hitting the intended repository.  While this issue has been fixed on GitHub's side, we should use the canonical name here for completeness anyway.