### PR TITLE
Increased PFFFT coverage

### DIFF
--- a/projects/pffft/Dockerfile
+++ b/projects/pffft/Dockerfile
@@ -19,4 +19,6 @@ MAINTAINER alessiob@webrtc.org
 RUN apt-get update && apt-get install -y mercurial
 RUN hg clone https://bitbucket.org/jpommier/pffft $SRC/pffft
 WORKDIR pffft
-COPY build.sh pffft_fuzzer.cc $SRC/
+COPY build.sh $SRC
+# TODO(alessiob): Move the fuzzing source code to pffft upstream.
+COPY pffft_fuzzer.cc $SRC/pffft

--- a/projects/pffft/build.sh
+++ b/projects/pffft/build.sh
@@ -18,14 +18,18 @@
 SRC_DIR=$SRC/pffft
 cd $WORK
 
-# Building PFFFT as a static library.
-if [ -f libpffft.a ]; then
-  rm libpffft.a
-fi
-$CXX $CXXFLAGS -c -msse2 -fPIC $SRC_DIR/pffft.c -o pffft.o
-ar rcs libpffft.a pffft.o
+build_fuzzer() {
+  # Aliases for the arguments.
+  fft_transform=$1
 
-# Building PFFFT fuzzers.
-$CXX $CXXFLAGS -std=c++11 -I$SRC_DIR \
-     $SRC/pffft_fuzzer.cc -o $OUT/pffft_real_fwbw_fuzzer \
-     -lFuzzingEngine $WORK/libpffft.a
+  fuzz_target_name=pffft_${fft_transform,,}_fuzzer
+  $CXX $CXXFLAGS -std=c++11 -msse2 \
+       -DTRANSFORM_${fft_transform} \
+       $SRC/pffft/pffft.c $SRC/pffft/pffft_fuzzer.cc \
+       -o $OUT/${fuzz_target_name} \
+       -lFuzzingEngine
+}
+
+# Build fuzzers.
+build_fuzzer REAL
+build_fuzzer COMPLEX


### PR DESCRIPTION
- Increasing the PFFFT coverage by adding a fuzzer for the complex FFT and by calling, both in the real and complex case, not just pffft_transform() but also pffft_zconvolve_accumulate() and pffft_transform_ordered().
- Static library compilation step removed