### PR TITLE
[infra] Use 'coverage' and 'fuzzing' tags to filter builds (follow-up #1547).

### DIFF
--- a/infra/gcb/build_and_run_coverage.py
+++ b/infra/gcb/build_and_run_coverage.py
@@ -22,6 +22,8 @@ CORPUS_BACKUP_URL = ('/{0}-backup.clusterfuzz-external.appspot.com/corpus/'
 # Cloud Builder has a limit of 100 build steps and 100 arguments for each step.
 CORPUS_DOWNLOAD_BATCH_SIZE = 100
 
+COVERAGE_BUILD_TAG = 'coverage'
+
 # Needed for reading public target.list.* files.
 GCS_URL_BASENAME = 'https://storage.googleapis.com/'
 
@@ -189,7 +191,7 @@ def main():
 
   project_dir = sys.argv[1].rstrip(os.path.sep)
   steps, image = get_build_steps(project_dir)
-  build_project.run_build(steps, image)
+  build_project.run_build(steps, image, COVERAGE_BUILD_TAG)
 
 
 if __name__ == "__main__":

--- a/infra/gcb/build_project.py
+++ b/infra/gcb/build_project.py
@@ -21,6 +21,10 @@ from googleapiclient.discovery import build
 
 BUILD_TIMEOUT = 10 * 60 * 60
 
+FUZZING_BUILD_TAG = 'fuzzing'
+
+GCB_LOGS_BUCKET = 'oss-fuzz-gcb-logs'
+
 CONFIGURATIONS = {
     'sanitizer-address': ['SANITIZER=address'],
     'sanitizer-memory': ['SANITIZER=memory'],
@@ -331,7 +335,7 @@ def get_targets_list_url(bucket, project, sanitizer):
   return url
 
 
-def run_build(build_steps, image):
+def run_build(build_steps, image, tag):
   options = {}
   if 'GCB_OPTIONS' in os.environ:
     options = yaml.safe_load(os.environ['GCB_OPTIONS'])
@@ -340,8 +344,9 @@ def run_build(build_steps, image):
       'steps': build_steps,
       'timeout': str(BUILD_TIMEOUT) + 's',
       'options': options,
-      'logsBucket': 'oss-fuzz-gcb-logs',
+      'logsBucket': GCB_LOGS_BUCKET,
       'images': [ image ],
+      'tags': [ tag ],
   }
 
   credentials = GoogleCredentials.get_application_default()
@@ -360,7 +365,7 @@ def main():
 
   project_dir = sys.argv[1].rstrip(os.path.sep)
   steps, image = get_build_steps(project_dir)
-  run_build(steps, image)
+  run_build(steps, image, FUZZING_BUILD_TAG)
 
 
 if __name__ == '__main__':

--- a/infra/gcb/builds_status.py
+++ b/infra/gcb/builds_status.py
@@ -134,7 +134,7 @@ def main():
       continue
 
     builds = response['builds']
-    print(builds)
+
     last_build = find_last_build(builds)
     if not last_build:
       print >> sys.stderr, 'Failed to get build for', project

--- a/infra/gcb/builds_status.py
+++ b/infra/gcb/builds_status.py
@@ -16,6 +16,8 @@ from google.cloud import logging
 from google.cloud import storage
 from jinja2 import Environment, FileSystemLoader
 
+import build_project
+
 STATUS_BUCKET = 'oss-fuzz-build-logs'
 LOGS_BUCKET = 'oss-fuzz-gcb-logs'
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -79,7 +81,7 @@ def find_last_build(builds):
       storage_client = storage.Client()
 
       status_bucket = storage_client.get_bucket(STATUS_BUCKET)
-      gcb_bucket = storage_client.get_bucket(LOGS_BUCKET)
+      gcb_bucket = storage_client.get_bucket(build_project.GCB_LOGS_BUCKET)
       log_name = 'log-{0}.txt'.format(build['id'])
       log = gcb_bucket.blob(log_name)
       dest_log = status_bucket.blob(log_name)
@@ -119,7 +121,8 @@ def main():
   failures = []
   for project in scan_project_names(projects_dir):
     print project
-    query_filter = ('images="gcr.io/oss-fuzz/{0}"'.format(project))
+    query_filter = ('images="gcr.io/oss-fuzz/{0}" AND tags="{1}"'.format(
+        project, build_project.FUZZING_BUILD_TAG))
     try:
       response = execute_with_retries(cloudbuild.projects().builds().list(
           projectId='oss-fuzz', pageSize=2, filter=query_filter))
@@ -131,6 +134,7 @@ def main():
       continue
 
     builds = response['builds']
+    print(builds)
     last_build = find_last_build(builds)
     if not last_build:
       print >> sys.stderr, 'Failed to get build for', project

--- a/infra/gcb/builds_status.py
+++ b/infra/gcb/builds_status.py
@@ -19,7 +19,6 @@ from jinja2 import Environment, FileSystemLoader
 import build_project
 
 STATUS_BUCKET = 'oss-fuzz-build-logs'
-LOGS_BUCKET = 'oss-fuzz-gcb-logs'
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 RETRY_COUNT = 3
 RETRY_WAIT = 5


### PR DESCRIPTION
Otherwise build status page gets confused and might use logs from the coverage job instead of the fuzzing build.

Later, we might want to have a separate build failure page for the coverage job, or some other way to surface coverage job failures to users.