### PR TITLE
Portable GMP for nettle for ecc-diff-fuzzer

### DIFF
--- a/projects/ecc-diff-fuzzer/build.sh
+++ b/projects/ecc-diff-fuzzer/build.sh
@@ -21,7 +21,9 @@
 cd nettle
 tar -xvf ../gmp-6.1.2.tar.bz2
 cd gmp-6.1.2
-./configure
+#do not use assembly instructions as we do not know if they will be available on the machine who will run the fuzzer
+#we could do instead --enable-fat
+./configure --disable-assembly
 make
 make install
 cd ..


### PR DESCRIPTION
see https://gmplib.org/manual/Build-Options.html

Otherwise, we get a SIGILL signal : illegal instruction
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=10031
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=10032