### PR TITLE
firefox: more targets and more

### DIFF
--- a/projects/firefox/ContentParentIPC.options
+++ b/projects/firefox/ContentParentIPC.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+close_fd_mask = 2

--- a/projects/firefox/Dockerfile
+++ b/projects/firefox/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER pdknsk@gmail.com
 RUN apt-get update && apt-get install -y gawk mercurial
-RUN hg clone https://hg.mozilla.org/mozilla-central
+RUN hg clone --uncompressed https://hg.mozilla.org/mozilla-central
 RUN git clone --depth 1 https://github.com/mozillasecurity/fuzzdata
 WORKDIR mozilla-central
 COPY build.sh target.c *options $SRC/

--- a/projects/firefox/Dockerfile
+++ b/projects/firefox/Dockerfile
@@ -20,5 +20,6 @@ RUN apt-get update && \
     apt-get install -y apt-file gawk mercurial parallel && \
     apt-file --non-interactive update
 RUN hg clone https://hg.mozilla.org/mozilla-central
+RUN git clone --depth 1 https://github.com/mozillasecurity/fuzzdata
 WORKDIR mozilla-central
-COPY build.sh target.c $SRC/
+COPY build.sh target.c *options $SRC/

--- a/projects/firefox/Dockerfile
+++ b/projects/firefox/Dockerfile
@@ -16,9 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER pdknsk@gmail.com
-RUN apt-get update && \
-    apt-get install -y apt-file gawk mercurial parallel && \
-    apt-file --non-interactive update
+RUN apt-get update && apt-get install -y gawk mercurial
 RUN hg clone https://hg.mozilla.org/mozilla-central
 RUN git clone --depth 1 https://github.com/mozillasecurity/fuzzdata
 WORKDIR mozilla-central

--- a/projects/firefox/build.sh
+++ b/projects/firefox/build.sh
@@ -19,6 +19,7 @@
 FUZZ_TARGETS=(
   SdpParser
   StunParser
+  ContentParentIPC
   ContentSecurityPolicyParser
   # Qcms # needn't be enabled; has its own project with more sanitizers/engines
 )
@@ -126,6 +127,9 @@ find media/webrtc/trunk/webrtc/test/fuzzers/corpora/stun-corpus \
   -type f -exec zip -qju $OUT/StunParser_seed_corpus.zip "{}" \;
 cp media/webrtc/trunk/webrtc/test/fuzzers/corpora/stun.tokens \
   $OUT/StunParser.dict
+
+# ContentParentIPC
+cp $SRC/fuzzdata/settings/ipc/libfuzzer.content.blacklist.txt $OUT/firefox
 
 # ContentSecurityPolicyParser
 cp dom/security/fuzztest/csp_fuzzer.dict $OUT/ContentSecurityPolicyParser.dict

--- a/projects/firefox/build.sh
+++ b/projects/firefox/build.sh
@@ -51,14 +51,12 @@ mk_add_options CXXFLAGS=
 EOF
 fi
 
-# Remove existing cargo configs (if any). Otherwise, mach fails.
-if [ -d "$HOME/.cargo" ]; then rm -rf $HOME/.cargo; fi
-
-# Install dependencies.
+# Install dependencies. Note that bootstrap installs cargo, which must be added
+# to PATH via source. In a successive run (for a different sanitizer), the
+# cargo installation carries over, but bootstrap fails if cargo is not in PATH.
 export SHELL=/bin/bash
+[ -f "$HOME/.cargo/env" ] && source $HOME/.cargo/env
 ./mach bootstrap --no-interactive --application-choice browser
-
-# Set environment for rustc.
 source $HOME/.cargo/env
 
 # Update internal libFuzzer.

--- a/projects/firefox/build.sh
+++ b/projects/firefox/build.sh
@@ -19,6 +19,7 @@
 FUZZ_TARGETS=(
   SdpParser
   StunParser
+  ContentSecurityPolicyParser
   # Qcms # needn't be enabled; has its own project with more sanitizers/engines
 )
 
@@ -125,3 +126,6 @@ find media/webrtc/trunk/webrtc/test/fuzzers/corpora/stun-corpus \
   -type f -exec zip -qju $OUT/StunParser_seed_corpus.zip "{}" \;
 cp media/webrtc/trunk/webrtc/test/fuzzers/corpora/stun.tokens \
   $OUT/StunParser.dict
+
+# ContentSecurityPolicyParser
+cp dom/security/fuzztest/csp_fuzzer.dict $OUT/ContentSecurityPolicyParser.dict

--- a/projects/firefox/build.sh
+++ b/projects/firefox/build.sh
@@ -117,16 +117,14 @@ done
 cd $SRC/mozilla-central
 
 # SdpParser
-find media/webrtc/trunk/webrtc/test/fuzzers/corpora/sdp-corpus \
-  -type f -exec zip -qju $OUT/SdpParser_seed_corpus.zip "{}" \;
-cp media/webrtc/trunk/webrtc/test/fuzzers/corpora/sdp.tokens \
-  $OUT/SdpParser.dict
+find media/webrtc -iname "*.sdp" \
+  -type f -exec zip -qu $OUT/SdpParser_seed_corpus.zip "{}" \;
+cp $SRC/fuzzdata/dicts/sdp.dict $OUT/SdpParser.dict
 
 # StunParser
-find media/webrtc/trunk/webrtc/test/fuzzers/corpora/stun-corpus \
-  -type f -exec zip -qju $OUT/StunParser_seed_corpus.zip "{}" \;
-cp media/webrtc/trunk/webrtc/test/fuzzers/corpora/stun.tokens \
-  $OUT/StunParser.dict
+find media/webrtc -iname "*.stun" \
+  -type f -exec zip -qu $OUT/StunParser_seed_corpus.zip "{}" \;
+cp $SRC/fuzzdata/dicts/stun.dict $OUT/StunParser.dict
 
 # ContentParentIPC
 cp $SRC/fuzzdata/settings/ipc/libfuzzer.content.blacklist.txt $OUT/firefox

--- a/projects/firefox/target.c
+++ b/projects/firefox/target.c
@@ -22,7 +22,7 @@ int main(int argc, char* argv[]) {
     strcat(path, "/");
   }
 
-  if (strlen(path) + strlen(*argv) + 16 >= PATH_MAX) {
+  if (strlen(path) + strlen(*argv) + 40 >= PATH_MAX) {
     fprintf(stderr, "Path length would exceed PATH_MAX\n");
     exit(1);
   }
@@ -41,6 +41,12 @@ int main(int argc, char* argv[]) {
   setenv("MOZ_RUN_GTEST", "1", 1);
   setenv("LIBFUZZER", "1", 1);
   setenv("FUZZER", STRINGIFY(FUZZ_TARGET), 1);
+
+  // ContentParentIPC
+  char blacklist_path[PATH_MAX] = {0};
+  strcpy(blacklist_path, path);
+  strcat(blacklist_path, "/firefox/libfuzzer.content.blacklist.txt");
+  setenv("MOZ_IPC_MESSAGE_FUZZ_BLACKLIST", blacklist_path, 1);
 
   // Temporary (or permanent?) work-arounds for fuzzing interface bugs.
   char* options = getenv("ASAN_OPTIONS");

--- a/projects/firefox/target.c
+++ b/projects/firefox/target.c
@@ -13,31 +13,27 @@ static const char* magic __attribute__((used)) = "LLVMFuzzerTestOneInput";
 int main(int argc, char* argv[]) {
   char path[PATH_MAX] = {0};
 
+  // Handle (currently not used) relative binary path.
   if (**argv != '/') {
-    if (!getcwd(path, PATH_MAX)) {
-      perror("Couldn't get CWD");
+    if (!getcwd(path, PATH_MAX - 1)) {
+      perror("getcwd");
       exit(1);
     }
     strcat(path, "/");
   }
 
-  if (strlen(path) + strlen(*argv) + 20 > PATH_MAX) {
+  if (strlen(path) + strlen(*argv) + 16 >= PATH_MAX) {
     fprintf(stderr, "Path length would exceed PATH_MAX\n");
     exit(1);
   }
 
   strcat(path, *argv);
-
   char* solidus = strrchr(path, '/');
-  *solidus = 0; // terminate string before last /
+  *solidus = 0; // terminate path before last /
 
   char ld_path[PATH_MAX] = {0};
   strcpy(ld_path, path);
   strcat(ld_path, "/lib");
-
-  char ff_path[PATH_MAX] = {0};
-  strcpy(ff_path, path);
-  strcat(ff_path, "/firefox/firefox");
 
   // Expects LD_LIBRARY_PATH to not also be set by oss-fuzz.
   setenv("LD_LIBRARY_PATH", ld_path, 0);
@@ -46,20 +42,24 @@ int main(int argc, char* argv[]) {
   setenv("LIBFUZZER", "1", 1);
   setenv("FUZZER", STRINGIFY(FUZZ_TARGET), 1);
 
+  // Temporary (or permanent?) work-arounds for fuzzing interface bugs.
   char* options = getenv("ASAN_OPTIONS");
   if (options) {
-    // Temporary (or permanent?) work-arounds for fuzzing interface bugs.
-    char* new_options = strdup(options);
     char* ptr;
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=1477846
+    char* new_options = strdup(options);
+    // https://bugzilla.mozilla.org/1477846
     ptr = strstr(new_options, "detect_stack_use_after_return=1");
     if (ptr) ptr[30] = '0';
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=1477844
+    // https://bugzilla.mozilla.org/1477844
     ptr = strstr(new_options, "detect_leaks=1");
     if (ptr) ptr[13] = '0';
     setenv("ASAN_OPTIONS", new_options, 1);
     free(new_options);
   }
+
+  char ff_path[PATH_MAX] = {0};
+  strcpy(ff_path, path);
+  strcat(ff_path, "/firefox/firefox");
 
   int ret = execv(ff_path, argv);
   if (ret)

--- a/projects/firefox/target.c
+++ b/projects/firefox/target.c
@@ -40,22 +40,11 @@ int main(int argc, char* argv[]) {
   strcat(ff_path, "/firefox/firefox");
 
   // Expects LD_LIBRARY_PATH to not also be set by oss-fuzz.
-  // If it ever is, this has to be replaced with more complex code.
-  if (setenv("LD_LIBRARY_PATH", ld_path, 0)) {
-    perror("Error setting LD_LIBRARY_PATH");
-    exit(1);
-  }
-
-  if (setenv("MOZ_RUN_GTEST", "1", 1) || setenv("LIBFUZZER", "1", 1) ||
-      setenv("FUZZER", STRINGIFY(FUZZ_TARGET), 1)) {
-    perror("Error setting fuzzing variables");
-    exit(1);
-  }
-  
-  if (setenv("HOME", "/tmp", 0)) {
-    perror("Error setting HOME");
-    exit(1);
-  }
+  setenv("LD_LIBRARY_PATH", ld_path, 0);
+  setenv("HOME", "/tmp", 0);
+  setenv("MOZ_RUN_GTEST", "1", 1);
+  setenv("LIBFUZZER", "1", 1);
+  setenv("FUZZER", STRINGIFY(FUZZ_TARGET), 1);
 
   char* options = getenv("ASAN_OPTIONS");
   if (options) {
@@ -68,10 +57,7 @@ int main(int argc, char* argv[]) {
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1477844
     ptr = strstr(new_options, "detect_leaks=1");
     if (ptr) ptr[13] = '0';
-    if (setenv("ASAN_OPTIONS", new_options, 1)) {
-      perror("Error setting ASAN_OPTIONS");
-      exit(1);
-    }
+    setenv("ASAN_OPTIONS", new_options, 1);
     free(new_options);
   }
 


### PR DESCRIPTION
Adds two targets and improvements. Most notably the machinery to download and extract the required libraries is removed, because `bootstrap` already installs them to the system. Sometimes you don't notice the simple solution.