### PR TITLE
[infra] Code Coverage: copy /usr/include headers and upload logs to GCS (follow-up #1547).

### DIFF
--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -68,7 +68,7 @@ BUILD_CMD="bash -eux $SRC/build.sh"
 
 # We need to preserve source code files for generating a code coverage report.
 # We need exact files that were compiled, so copy both $SRC and $WORK dirs.
-COPY_SOURCES_CMD="cp -rL $SRC $WORK $OUT"
+COPY_SOURCES_CMD="cp -rL --parents $SRC $WORK /usr/include $OUT"
 
 if [ "${BUILD_UID-0}" -ne "0" ]; then
   adduser -u $BUILD_UID --disabled-password --gecos '' builder

--- a/infra/gcb/build_and_run_coverage.py
+++ b/infra/gcb/build_and_run_coverage.py
@@ -29,9 +29,7 @@ GCS_URL_BASENAME = 'https://storage.googleapis.com/'
 
 # Where code coverage reports need to be uploaded to.
 COVERAGE_BUCKET_NAME = 'oss-fuzz-coverage'
-UPLOAD_FUZZER_STATS_URL_FORMAT = (
-    'gs://%s/{0}/fuzzer_stats/{1}' % COVERAGE_BUCKET_NAME)
-UPLOAD_REPORT_URL_FORMAT = 'gs://%s/{0}/reports/{1}' % COVERAGE_BUCKET_NAME
+UPLOAD_URL_FORMAT= 'gs://%s/{project}/{type}/{date}' % COVERAGE_BUCKET_NAME
 
 
 def skip_build(message):
@@ -151,7 +149,8 @@ def get_build_steps(project_dir):
           'args': [
               '-m', 'rsync', '-r', '-d',
               os.path.join(out, 'report'),
-              UPLOAD_REPORT_URL_FORMAT.format(project_name, report_date),
+              UPLOAD_URL_FORMAT.format(
+                  project=project_name, type='reports', date=report_date),
           ],
       },
       # Upload the fuzzer stats.
@@ -160,7 +159,18 @@ def get_build_steps(project_dir):
           'args': [
               '-m', 'rsync', '-r', '-d',
               os.path.join(out, 'fuzzer_stats'),
-              UPLOAD_FUZZER_STATS_URL_FORMAT.format(project_name, report_date),
+              UPLOAD_URL_FORMAT.format(
+                  project=project_name, type='fuzzer_stats', date=report_date),
+          ],
+      },
+      # Upload the fuzzer logs.
+      {
+          'name': 'gcr.io/cloud-builders/gsutil',
+          'args': [
+              '-m', 'rsync', '-r', '-d',
+              os.path.join(out, 'logs'),
+              UPLOAD_URL_FORMAT.format(
+                  project=project_name, type='logs', date=report_date),
           ],
       },
   ])


### PR DESCRIPTION
This should help with some issues identified in #1743, e.g. wireshark and irssi instrument some files from `/usr/include`, but the report generation failures later on as the files are not available.

Also uploading the logs from fuzz targets as per suggestion from @jonathanmetzman 
.