### PR TITLE
envoy: cleanup bazel symlinks.

### DIFF
--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -104,3 +104,7 @@ done
 for d in $FUZZER_DICTIONARIES; do
   cp "$d" "${OUT}"/
 done
+
+# Cleanup bazel- symlinks to avoid oss-fuzz trying to copy out of the build
+# cache.
+rm -f bazel-*


### PR DESCRIPTION
These were doing bad things to the profile builds, with symlink chasing
resulting in pretty terrible performance (and maybe build errors that the slowness was masking, I timed out on them).

Hopefully resolves
https://github.com/google/oss-fuzz/pull/1724#issuecomment-416322393.

Signed-off-by: Harvey Tuch <htuch@google.com>