### PR TITLE
firefox: fix ContentSecurityPolicyParser target

### DIFF
--- a/projects/firefox/ContentSecurityPolicyParser.diff
+++ b/projects/firefox/ContentSecurityPolicyParser.diff
@@ -1,0 +1,11 @@
+diff --git a/dom/security/nsCSPContext.cpp b/dom/security/nsCSPContext.cpp
+--- a/dom/security/nsCSPContext.cpp
++++ b/dom/security/nsCSPContext.cpp
+@@ -756,6 +756,7 @@ nsCSPContext::logToConsole(const char* a
+                            uint32_t aColumnNumber,
+                            uint32_t aSeverityFlag)
+ {
++  return;
+   // we are passing aName as the category so we can link to the
+   // appropriate MDN docs depending on the specific error.
+   nsDependentCString category(aName);

--- a/projects/firefox/Dockerfile
+++ b/projects/firefox/Dockerfile
@@ -21,3 +21,5 @@ RUN hg clone --uncompressed https://hg.mozilla.org/mozilla-central
 RUN git clone --depth 1 https://github.com/mozillasecurity/fuzzdata
 WORKDIR mozilla-central
 COPY build.sh target.c *options $SRC/
+COPY *diff $SRC/mozilla-central
+RUN hg patch --no-commit ContentSecurityPolicyParser.diff


### PR DESCRIPTION
The target fails immediately because of `oss-fuzz` runtime constraints, but it turns out only a minor or irrelevant part is affected. When the parser encounters a bogus policy, it queues a warning message to developer console, which is disabled by the simple patch. I ran the target locally with `run_minjail` for an hour without problems now.