### PR TITLE
[infra] base-clang: add cross to aarch64 (bug #1754)

### DIFF
--- a/projects/zlib/checksum_fuzzer.c
+++ b/projects/zlib/checksum_fuzzer.c
@@ -17,7 +17,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataLen) {
   /* Checksum with a buffer of size equal to the first byte in the input. */
   uint32_t buffSize = data[0];
   uint32_t offset = 0;
-  z_crc_t op[32];
+  uint32_t op;
 
   /* Discard inputs larger than 1Mb. */
   static size_t kMaxSize = 1024 * 1024;
@@ -29,7 +29,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataLen) {
     ++buffSize;
 
   /* CRC32 */
-  crc32_combine_gen(op, buffSize);
+  op = crc32_combine_gen(buffSize);
   for (offset = 0; offset + buffSize <= dataLen; offset += buffSize) {
     uint32_t crc3 = crc32_z(crc0, data + offset, buffSize);
     uint32_t crc4 = crc32_combine_op(crc1, crc3, op);
@@ -45,7 +45,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataLen) {
          crc32_combine(crc1, crc1, dataLen));
 
   /* Fast CRC32 combine. */
-  crc32_combine_gen(op, dataLen);
+  op = crc32_combine_gen(dataLen);
   assert(crc32_combine_op(crc1, crc2, op) ==
          crc32_combine_op(crc2, crc1, op));
   assert(crc32_combine(crc1, crc2, dataLen) ==


### PR DESCRIPTION
This patch adds support for aarch64 cross compilation to the base-clang image.
fuzz-builders can then compile aarch64 fuzzers by specifying in their build.sh
extra flags like so:
CFLAGS="$CFLAGS -target aarch64-linux-gnu -I/usr/aarch64-linux-gnu/include"
The _fuzzer can then be renamed _fuzzer.aarch64 and one can create a wrap around
shell script to execute the fuzzer through qemu:
echo "qemu-aarch64 -L /usr/aarch64-linux-gnu _fuzzer.aarch64" > aarch64_fuzzer

Here is an example of how to build the new image and cross compile for aarch64:
$ cd oss-fuzz
$ ./infra/base-images/all.sh
$ docker run -t gcr.io/oss-fuzz-base/base-builder /bin/bash
$ echo "#include <stdio.h>
int main() {
printf(\"hello\n\");
return 0;
} " > s.c

$ /usr/local/bin/clang -target aarch64-linux-gnu -I/usr/aarch64-linux-gnu/include s.c -o a.out
$ file a.out
./a.out: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, not stripped
$ sudo apt install qemu-user
$ qemu-aarch64 -L /usr/aarch64-linux-gnu ./a.out
hello
$