### PR TITLE
envoy: coverage_extra_args to ignore external deps.

### DIFF
--- a/projects/envoy/project.yaml
+++ b/projects/envoy/project.yaml
@@ -5,3 +5,4 @@ auto_ccs:
   - "alyssar@google.com"
   - "groebert@google.com"
   - "envoy-security@googlegroups.com"
+coverage_extra_args: -ignore-filename-regex='.*\.cache.*'


### PR DESCRIPTION
This is necessary due to a known limitation in how Envoy's Bazel build
of external deps works.

Signed-off-by: Harvey Tuch <htuch@google.com>