### PR TITLE
projects/zlib: add fuzzers upstream

### DIFF
--- a/projects/zlib/Dockerfile
+++ b/projects/zlib/Dockerfile
@@ -17,7 +17,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER inferno@chromium.org
 RUN apt-get update && apt-get install -y make autoconf automake libtool
-
-RUN git clone --depth 1 https://github.com/madler/zlib.git
+RUN git clone --depth 1 -b develop https://github.com/madler/zlib.git
 WORKDIR zlib
-COPY build.sh zlib_uncompress_fuzzer.cc $SRC/
+COPY build.sh zlib_uncompress_fuzzer.cc *_fuzzer.c $SRC/

--- a/projects/zlib/build.sh
+++ b/projects/zlib/build.sh
@@ -4,6 +4,19 @@
 make -j$(nproc) clean
 make -j$(nproc) all
 
+# Do not make check as there are tests that fail when compiled with MSAN.
+# make -j$(nproc) check
+
 $CXX $CXXFLAGS -std=c++11 -I. \
     $SRC/zlib_uncompress_fuzzer.cc -o $OUT/zlib_uncompress_fuzzer \
     -lFuzzingEngine ./libz.a
+
+zip $OUT/seed_corpus.zip *.*
+
+for f in $(find $SRC -name '*_fuzzer.c'); do
+    b=$(basename -s .c $f)
+    $CC $CFLAGS -I. $f -c -o /tmp/$b.o
+    $CXX $CXXFLAGS -o $OUT/$b /tmp/$b.o -stdlib=libc++ -lFuzzingEngine ./libz.a
+    rm -f /tmp/$b.o
+    ln -s $OUT/seed_corpus.zip $OUT/${b}_seed_corpus.zip
+done

--- a/projects/zlib/checksum_fuzzer.c
+++ b/projects/zlib/checksum_fuzzer.c
@@ -1,0 +1,52 @@
+#include <stdio.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <inttypes.h>
+#include "zlib.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataLen) {
+  uint32_t crc1 = crc32(0L, NULL, 0);
+  uint32_t crc2 = crc32(0L, NULL, 0);
+  uint32_t adler1 = adler32(0L, NULL, 0);
+  uint32_t adler2 = adler32(0L, NULL, 0);;
+  /* Checksum with a buffer of size equal to the first byte in the input. */
+  uint32_t buffSize = data[0];
+  uint32_t offset = 0;
+
+  /* Discard inputs larger than 1Mb. */
+  static size_t kMaxSize = 1024 * 1024;
+  if (dataLen < 1 || dataLen > kMaxSize)
+    return 0;
+
+  /* Make sure the buffer has at least a byte. */
+  if (buffSize == 0)
+    ++buffSize;
+
+  /* CRC32 */
+  for (offset = 0; offset + buffSize <= dataLen; offset += buffSize)
+    crc1 = crc32_z(crc1, data + offset, buffSize);
+  crc1 = crc32_z(crc1, data + offset, dataLen % buffSize);
+
+  crc2 = crc32_z(crc2, data, dataLen);
+
+  assert(crc1 == crc2);
+  assert(crc32_combine(crc1, crc2, dataLen) ==
+         crc32_combine(crc1, crc1, dataLen));
+
+  /* Adler32 */
+  for (offset = 0; offset + buffSize <= dataLen; offset += buffSize)
+    adler1 = adler32_z(adler1, data + offset, buffSize);
+  adler1 = adler32_z(adler1, data + offset, dataLen % buffSize);
+
+  adler2 = adler32_z(adler2, data, dataLen);
+
+  assert(adler1 == adler2);
+  assert(adler32_combine(adler1, adler2, dataLen) ==
+         adler32_combine(adler1, adler1, dataLen));
+
+  /* This function must return 0. */
+  return 0;
+}

--- a/projects/zlib/compress_fuzzer.c
+++ b/projects/zlib/compress_fuzzer.c
@@ -1,0 +1,81 @@
+#include <stdio.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <inttypes.h>
+#include "zlib.h"
+
+static const uint8_t *data;
+static size_t dataLen;
+
+static void check_compress_level(uint8_t *compr, size_t comprLen,
+                                 uint8_t *uncompr, size_t uncomprLen,
+                                 int level) {
+  compress2(compr, &comprLen, data, dataLen, level);
+  uncompress(uncompr, &uncomprLen, compr, comprLen);
+
+  /* Make sure compress + uncompress gives back the input data. */
+  assert(dataLen == uncomprLen);
+  assert(0 == memcmp(data, uncompr, dataLen));
+}
+
+#define put_byte(s, i, c) {s[i] = (unsigned char)(c);}
+
+static void write_zlib_header(uint8_t *s) {
+  unsigned level_flags = 0; /* compression level (0..3) */
+  unsigned w_bits = 8; /* window size log2(w_size)  (8..16) */
+  unsigned int header = (Z_DEFLATED + ((w_bits-8)<<4)) << 8;
+  header |= (level_flags << 6);
+
+  header += 31 - (header % 31);
+
+  /* s is guaranteed to be longer than 2 bytes. */
+  put_byte(s, 0, (unsigned char)(header >> 8));
+  put_byte(s, 1, (unsigned char)(header & 0xff));
+}
+
+static void check_decompress(uint8_t *compr, size_t comprLen) {
+  /* We need to write a valid zlib header of size two bytes. Copy the input data
+     in a larger buffer. Do not modify the input data to avoid libFuzzer error:
+     fuzz target overwrites its const input. */
+  size_t copyLen = dataLen + 2;
+  uint8_t *copy = (uint8_t *)malloc(copyLen);
+  memcpy(copy + 2, data, dataLen);
+  write_zlib_header(copy);
+
+  uncompress(compr, &comprLen, copy, copyLen);
+  free(copy);
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *d, size_t size) {
+  /* compressBound does not provide enough space for low compression levels. */
+  size_t comprLen = 100 + 2 * compressBound(size);
+  size_t uncomprLen = size;
+  uint8_t *compr, *uncompr;
+
+  /* Discard inputs larger than 1Mb. */
+  static size_t kMaxSize = 1024 * 1024;
+
+  if (size < 1 || size > kMaxSize)
+    return 0;
+
+  data = d;
+  dataLen = size;
+  compr = (uint8_t *)calloc(1, comprLen);
+  uncompr = (uint8_t *)calloc(1, uncomprLen);
+
+  check_compress_level(compr, comprLen, uncompr, uncomprLen, 1);
+  check_compress_level(compr, comprLen, uncompr, uncomprLen, 3);
+  check_compress_level(compr, comprLen, uncompr, uncomprLen, 6);
+  check_compress_level(compr, comprLen, uncompr, uncomprLen, 7);
+
+  check_decompress(compr, comprLen);
+
+  free(compr);
+  free(uncompr);
+
+  /* This function must return 0. */
+  return 0;
+}

--- a/projects/zlib/example_dict_fuzzer.c
+++ b/projects/zlib/example_dict_fuzzer.c
@@ -1,0 +1,163 @@
+#include <stdio.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <inttypes.h>
+#include "zlib.h"
+
+#define CHECK_ERR(err, msg) { \
+    if (err != Z_OK) { \
+        fprintf(stderr, "%s error: %d\n", msg, err); \
+        exit(1); \
+    } \
+}
+
+static const uint8_t *data;
+static size_t dataLen;
+static alloc_func zalloc = NULL;
+static free_func zfree = NULL;
+static size_t dictionaryLen = 0;
+static unsigned long dictId; /* Adler32 value of the dictionary */
+
+/* ===========================================================================
+ * Test deflate() with preset dictionary
+ */
+void test_dict_deflate(unsigned char **compr, size_t *comprLen)
+{
+    z_stream c_stream; /* compression stream */
+    int err;
+    int level = data[0] % 11 - 1; /* [-1..9]
+      compression levels
+      #define Z_NO_COMPRESSION         0
+      #define Z_BEST_SPEED             1
+      #define Z_BEST_COMPRESSION       9
+      #define Z_DEFAULT_COMPRESSION  (-1) */
+
+    int method = Z_DEFLATED; /* The deflate compression method (the only one
+                                supported in this version) */
+    int windowBits = 8 + data[0] % 8; /* The windowBits parameter is the base
+      two logarithm of the window size (the size of the history buffer).  It
+      should be in the range 8..15 for this version of the library. */
+    int memLevel = 1 + data[0] % 9;   /* memLevel=1 uses minimum memory but is
+      slow and reduces compression ratio; memLevel=9 uses maximum memory for
+      optimal speed. */
+    int strategy = data[0] % 5;       /* [0..4]
+      #define Z_FILTERED            1
+      #define Z_HUFFMAN_ONLY        2
+      #define Z_RLE                 3
+      #define Z_FIXED               4
+      #define Z_DEFAULT_STRATEGY    0 */
+
+    /* deflate would fail for no-compression or for speed levels. */
+    if (level == 0 || level == 1)
+      level = -1;
+
+    c_stream.zalloc = zalloc;
+    c_stream.zfree = zfree;
+    c_stream.opaque = (void *)0;
+
+    err = deflateInit2(&c_stream, level, method, windowBits, memLevel, strategy);
+    CHECK_ERR(err, "deflateInit");
+
+    err = deflateSetDictionary(
+        &c_stream, (const unsigned char *)data, dictionaryLen);
+    CHECK_ERR(err, "deflateSetDictionary");
+
+    /* deflateBound does not provide enough space for low compression levels. */
+    *comprLen = 100 + 2 * deflateBound(&c_stream, dataLen);
+    *compr = (uint8_t *)calloc(1, *comprLen);
+
+    dictId = c_stream.adler;
+    c_stream.next_out = *compr;
+    c_stream.avail_out = (unsigned int)(*comprLen);
+
+    c_stream.next_in = (Bytef *)data;
+    c_stream.avail_in = dataLen;
+
+    err = deflate(&c_stream, Z_FINISH);
+    if (err != Z_STREAM_END) {
+        fprintf(stderr, "deflate dict should report Z_STREAM_END\n");
+        exit(1);
+    }
+    err = deflateEnd(&c_stream);
+    CHECK_ERR(err, "deflateEnd");
+}
+
+/* ===========================================================================
+ * Test inflate() with a preset dictionary
+ */
+void test_dict_inflate(unsigned char *compr, size_t comprLen) {
+  int err;
+  z_stream d_stream; /* decompression stream */
+  unsigned char *uncompr;
+
+  d_stream.zalloc = zalloc;
+  d_stream.zfree = zfree;
+  d_stream.opaque = (void *)0;
+
+  d_stream.next_in = compr;
+  d_stream.avail_in = (unsigned int)comprLen;
+
+  err = inflateInit(&d_stream);
+  CHECK_ERR(err, "inflateInit");
+
+  uncompr = (uint8_t *)calloc(1, dataLen);
+  d_stream.next_out = uncompr;
+  d_stream.avail_out = (unsigned int)dataLen;
+
+  for (;;) {
+    err = inflate(&d_stream, Z_NO_FLUSH);
+    if (err == Z_STREAM_END)
+      break;
+    if (err == Z_NEED_DICT) {
+      if (d_stream.adler != dictId) {
+        fprintf(stderr, "unexpected dictionary");
+        exit(1);
+      }
+      err = inflateSetDictionary(
+          &d_stream, (const unsigned char *)data, dictionaryLen);
+    }
+    CHECK_ERR(err, "inflate with dict");
+  }
+
+  err = inflateEnd(&d_stream);
+  CHECK_ERR(err, "inflateEnd");
+
+  if (memcmp(uncompr, data, dataLen)) {
+    fprintf(stderr, "bad inflate with dict\n");
+    exit(1);
+  }
+
+  free(uncompr);
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *d, size_t size) {
+  size_t comprLen = 0;
+  uint8_t *compr;
+
+  /* Discard inputs larger than 100Kb. */
+  static size_t kMaxSize = 100 * 1024;
+
+  if (size < 1 || size > kMaxSize)
+    return 0;
+
+  data = d;
+  dataLen = size;
+
+  /* Set up the contents of the dictionary.  The size of the dictionary is
+     intentionally selected to be of unusual size.  To help cover more corner
+     cases, the size of the dictionary is read from the input data.  */
+  dictionaryLen = data[0];
+  if (dictionaryLen > dataLen)
+    dictionaryLen = dataLen;
+
+  test_dict_deflate(&compr, &comprLen);
+  test_dict_inflate(compr, comprLen);
+
+  free(compr);
+
+  /* This function must return 0. */
+  return 0;
+}

--- a/projects/zlib/example_flush_fuzzer.c
+++ b/projects/zlib/example_flush_fuzzer.c
@@ -1,0 +1,120 @@
+#include <stdio.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <inttypes.h>
+#include "zlib.h"
+
+#define CHECK_ERR(err, msg) { \
+    if (err != Z_OK) { \
+        fprintf(stderr, "%s error: %d\n", msg, err); \
+        exit(1); \
+    } \
+}
+
+static const uint8_t *data;
+static size_t dataLen;
+static alloc_func zalloc = NULL;
+static free_func zfree = NULL;
+
+/* ===========================================================================
+ * Test deflate() with full flush
+ */
+void test_flush(unsigned char *compr, z_size_t *comprLen) {
+  z_stream c_stream; /* compression stream */
+  int err;
+  unsigned int len = dataLen;
+
+  c_stream.zalloc = zalloc;
+  c_stream.zfree = zfree;
+  c_stream.opaque = (void *)0;
+
+  err = deflateInit(&c_stream, Z_DEFAULT_COMPRESSION);
+  CHECK_ERR(err, "deflateInit");
+
+  c_stream.next_in = (Bytef *)data;
+  c_stream.next_out = compr;
+  c_stream.avail_in = 3;
+  c_stream.avail_out = (unsigned int)*comprLen;
+  err = deflate(&c_stream, Z_FULL_FLUSH);
+  CHECK_ERR(err, "deflate flush 1");
+
+  compr[3]++; /* force an error in first compressed block */
+  c_stream.avail_in = len - 3;
+
+  err = deflate(&c_stream, Z_FINISH);
+  if (err != Z_STREAM_END) {
+    CHECK_ERR(err, "deflate flush 2");
+  }
+  err = deflateEnd(&c_stream);
+  CHECK_ERR(err, "deflateEnd");
+
+  *comprLen = (z_size_t)c_stream.total_out;
+}
+
+/* ===========================================================================
+ * Test inflateSync()
+ */
+void test_sync(unsigned char *compr, size_t comprLen, unsigned char *uncompr,
+               size_t uncomprLen) {
+  int err;
+  z_stream d_stream; /* decompression stream */
+
+  d_stream.zalloc = zalloc;
+  d_stream.zfree = zfree;
+  d_stream.opaque = (void *)0;
+
+  d_stream.next_in = compr;
+  d_stream.avail_in = 2; /* just read the zlib header */
+
+  err = inflateInit(&d_stream);
+  CHECK_ERR(err, "inflateInit");
+
+  d_stream.next_out = uncompr;
+  d_stream.avail_out = (unsigned int)uncomprLen;
+
+  err = inflate(&d_stream, Z_NO_FLUSH);
+  CHECK_ERR(err, "inflate");
+
+  d_stream.avail_in = (unsigned int)comprLen - 2; /* read all compressed data */
+  err = inflateSync(&d_stream); /* but skip the damaged part */
+  CHECK_ERR(err, "inflateSync");
+
+  err = inflate(&d_stream, Z_FINISH);
+  if (err != Z_DATA_ERROR) {
+    fprintf(stderr, "inflate should report DATA_ERROR\n");
+    /* Because of incorrect adler32 */
+    exit(1);
+  }
+  err = inflateEnd(&d_stream);
+  CHECK_ERR(err, "inflateEnd");
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *d, size_t size) {
+  size_t comprLen = 100 + 2 * compressBound(size);
+  size_t uncomprLen = size;
+  uint8_t *compr, *uncompr;
+
+  /* Discard inputs larger than 1Mb. */
+  static size_t kMaxSize = 1024 * 1024;
+
+  // This test requires at least 3 bytes of input data.
+  if (size <= 3 || size > kMaxSize)
+    return 0;
+
+  data = d;
+  dataLen = size;
+  compr = (uint8_t *)calloc(1, comprLen);
+  uncompr = (uint8_t *)calloc(1, uncomprLen);
+
+  test_flush(compr, &comprLen);
+  test_sync(compr, comprLen, uncompr, uncomprLen);
+
+  free(compr);
+  free(uncompr);
+
+  /* This function must return 0. */
+  return 0;
+}

--- a/projects/zlib/example_large_fuzzer.c
+++ b/projects/zlib/example_large_fuzzer.c
@@ -1,0 +1,137 @@
+#include <stdio.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <inttypes.h>
+#include "zlib.h"
+
+#define CHECK_ERR(err, msg) { \
+    if (err != Z_OK) { \
+        fprintf(stderr, "%s error: %d\n", msg, err); \
+        exit(1); \
+    } \
+}
+
+static const uint8_t *data;
+static size_t dataLen;
+static alloc_func zalloc = NULL;
+static free_func zfree = NULL;
+static unsigned int diff;
+
+/* ===========================================================================
+ * Test deflate() with large buffers and dynamic change of compression level
+ */
+void test_large_deflate(unsigned char *compr, size_t comprLen,
+                        unsigned char *uncompr, size_t uncomprLen) {
+  z_stream c_stream; /* compression stream */
+  int err;
+
+  c_stream.zalloc = zalloc;
+  c_stream.zfree = zfree;
+  c_stream.opaque = (void *)0;
+
+  err = deflateInit(&c_stream, Z_BEST_COMPRESSION);
+  CHECK_ERR(err, "deflateInit");
+
+  c_stream.next_out = compr;
+  c_stream.avail_out = (unsigned int)comprLen;
+
+  /* At this point, uncompr is still mostly zeroes, so it should compress
+   * very well:
+   */
+  c_stream.next_in = uncompr;
+  c_stream.avail_in = (unsigned int)uncomprLen;
+  err = deflate(&c_stream, Z_NO_FLUSH);
+  CHECK_ERR(err, "deflate large 1");
+  if (c_stream.avail_in != 0) {
+    fprintf(stderr, "deflate not greedy\n");
+    exit(1);
+  }
+
+  /* Feed in already compressed data and switch to no compression: */
+  deflateParams(&c_stream, Z_NO_COMPRESSION, Z_DEFAULT_STRATEGY);
+  c_stream.next_in = compr;
+  diff = (unsigned int)(c_stream.next_out - compr);
+  c_stream.avail_in = diff;
+  err = deflate(&c_stream, Z_NO_FLUSH);
+  CHECK_ERR(err, "deflate large 2");
+
+  /* Switch back to compressing mode: */
+  deflateParams(&c_stream, Z_BEST_COMPRESSION, Z_FILTERED);
+  c_stream.next_in = uncompr;
+  c_stream.avail_in = (unsigned int)uncomprLen;
+  err = deflate(&c_stream, Z_NO_FLUSH);
+  CHECK_ERR(err, "deflate large 3");
+
+  err = deflate(&c_stream, Z_FINISH);
+  if (err != Z_STREAM_END) {
+    fprintf(stderr, "deflate large should report Z_STREAM_END\n");
+    exit(1);
+  }
+  err = deflateEnd(&c_stream);
+  CHECK_ERR(err, "deflateEnd");
+}
+
+/* ===========================================================================
+ * Test inflate() with large buffers
+ */
+void test_large_inflate(unsigned char *compr, size_t comprLen,
+                        unsigned char *uncompr, size_t uncomprLen) {
+  int err;
+  z_stream d_stream; /* decompression stream */
+
+  d_stream.zalloc = zalloc;
+  d_stream.zfree = zfree;
+  d_stream.opaque = (void *)0;
+
+  d_stream.next_in = compr;
+  d_stream.avail_in = (unsigned int)comprLen;
+
+  err = inflateInit(&d_stream);
+  CHECK_ERR(err, "inflateInit");
+
+  for (;;) {
+    d_stream.next_out = uncompr; /* discard the output */
+    d_stream.avail_out = (unsigned int)uncomprLen;
+    err = inflate(&d_stream, Z_NO_FLUSH);
+    if (err == Z_STREAM_END)
+      break;
+    CHECK_ERR(err, "large inflate");
+  }
+
+  err = inflateEnd(&d_stream);
+  CHECK_ERR(err, "inflateEnd");
+
+  if (d_stream.total_out != 2 * uncomprLen + diff) {
+    fprintf(stderr, "bad large inflate: %zu\n", d_stream.total_out);
+    exit(1);
+  }
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *d, size_t size) {
+  size_t comprLen = 100 + 3 * size;
+  size_t uncomprLen = comprLen;
+  uint8_t *compr, *uncompr;
+
+  /* Discard inputs larger than 512Kb. */
+  static size_t kMaxSize = 512 * 1024;
+
+  if (size < 1 || size > kMaxSize)
+    return 0;
+
+  data = d;
+  dataLen = size;
+  compr = (uint8_t *)calloc(1, comprLen);
+  uncompr = (uint8_t *)calloc(1, uncomprLen);
+
+  test_large_deflate(compr, comprLen, uncompr, uncomprLen);
+  test_large_inflate(compr, comprLen, uncompr, uncomprLen);
+
+  free(compr);
+  free(uncompr);
+
+  /* This function must return 0. */
+  return 0;
+}

--- a/projects/zlib/example_small_fuzzer.c
+++ b/projects/zlib/example_small_fuzzer.c
@@ -1,0 +1,118 @@
+#include <stdio.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <inttypes.h>
+#include "zlib.h"
+
+#define CHECK_ERR(err, msg) { \
+    if (err != Z_OK) { \
+        fprintf(stderr, "%s error: %d\n", msg, err); \
+        exit(1); \
+    } \
+}
+
+static const uint8_t *data;
+static size_t dataLen;
+static alloc_func zalloc = NULL;
+static free_func zfree = NULL;
+
+/* ===========================================================================
+ * Test deflate() with small buffers
+ */
+void test_deflate(unsigned char *compr, size_t comprLen) {
+  z_stream c_stream; /* compression stream */
+  int err;
+  unsigned long len = dataLen;
+
+  c_stream.zalloc = zalloc;
+  c_stream.zfree = zfree;
+  c_stream.opaque = (void *)0;
+
+  err = deflateInit(&c_stream, Z_DEFAULT_COMPRESSION);
+  CHECK_ERR(err, "deflateInit");
+
+  c_stream.next_in = (Bytef *)data;
+  c_stream.next_out = compr;
+
+  while (c_stream.total_in != len && c_stream.total_out < comprLen) {
+    c_stream.avail_in = c_stream.avail_out = 1; /* force small buffers */
+    err = deflate(&c_stream, Z_NO_FLUSH);
+    CHECK_ERR(err, "deflate small 1");
+  }
+  /* Finish the stream, still forcing small buffers: */
+  for (;;) {
+    c_stream.avail_out = 1;
+    err = deflate(&c_stream, Z_FINISH);
+    if (err == Z_STREAM_END)
+      break;
+    CHECK_ERR(err, "deflate small 2");
+  }
+
+  err = deflateEnd(&c_stream);
+  CHECK_ERR(err, "deflateEnd");
+}
+
+/* ===========================================================================
+ * Test inflate() with small buffers
+ */
+void test_inflate(unsigned char *compr, size_t comprLen, unsigned char *uncompr,
+                  size_t uncomprLen) {
+  int err;
+  z_stream d_stream; /* decompression stream */
+
+  d_stream.zalloc = zalloc;
+  d_stream.zfree = zfree;
+  d_stream.opaque = (void *)0;
+
+  d_stream.next_in = compr;
+  d_stream.avail_in = 0;
+  d_stream.next_out = uncompr;
+
+  err = inflateInit(&d_stream);
+  CHECK_ERR(err, "inflateInit");
+
+  while (d_stream.total_out < uncomprLen && d_stream.total_in < comprLen) {
+    d_stream.avail_in = d_stream.avail_out = 1; /* force small buffers */
+    err = inflate(&d_stream, Z_NO_FLUSH);
+    if (err == Z_STREAM_END)
+      break;
+    CHECK_ERR(err, "inflate");
+  }
+
+  err = inflateEnd(&d_stream);
+  CHECK_ERR(err, "inflateEnd");
+
+  if (memcmp(uncompr, data, dataLen)) {
+    fprintf(stderr, "bad inflate\n");
+    exit(1);
+  }
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *d, size_t size) {
+  size_t comprLen = compressBound(size);
+  size_t uncomprLen = size;
+  uint8_t *compr, *uncompr;
+
+  /* Discard inputs larger than 1Mb. */
+  static size_t kMaxSize = 1024 * 1024;
+
+  if (size < 1 || size > kMaxSize)
+    return 0;
+
+  data = d;
+  dataLen = size;
+  compr = (uint8_t *)calloc(1, comprLen);
+  uncompr = (uint8_t *)calloc(1, uncomprLen);
+
+  test_deflate(compr, comprLen);
+  test_inflate(compr, comprLen, uncompr, uncomprLen);
+
+  free(compr);
+  free(uncompr);
+
+  /* This function must return 0. */
+  return 0;
+}

--- a/projects/zlib/minigzip_fuzzer.c
+++ b/projects/zlib/minigzip_fuzzer.c
@@ -1,0 +1,514 @@
+/* minigzip.c -- simulate gzip using the zlib compression library
+ * Copyright (C) 1995-2006, 2010, 2011, 2016 Jean-loup Gailly
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ */
+
+/*
+ * minigzip is a minimal implementation of the gzip utility. This is
+ * only an example of using zlib and isn't meant to replace the
+ * full-featured gzip. No attempt is made to deal with file systems
+ * limiting names to 14 or 8+3 characters, etc... Error checking is
+ * very limited. So use minigzip only for testing; use gzip for the
+ * real thing.
+ */
+
+/* @(#) $Id$ */
+
+#include "zlib.h"
+#include <stdio.h>
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <inttypes.h>
+
+#ifdef USE_MMAP
+#  include <sys/types.h>
+#  include <sys/mman.h>
+#  include <sys/stat.h>
+#endif
+
+#ifndef UNALIGNED_OK
+#  include <malloc.h>
+#endif
+
+#if defined(WIN32) || defined(__CYGWIN__)
+#  include <fcntl.h>
+#  include <io.h>
+#  define SET_BINARY_MODE(file) setmode(fileno(file), O_BINARY)
+#else
+#  define SET_BINARY_MODE(file)
+#endif
+
+#if defined(_MSC_VER) && _MSC_VER < 1900
+#  define snprintf _snprintf
+#endif
+
+#if !defined(Z_HAVE_UNISTD_H) && !defined(_LARGEFILE64_SOURCE)
+#ifndef WIN32 /* unlink already in stdio.h for WIN32 */
+  extern int unlink (const char *);
+#endif
+#endif
+
+#ifndef GZ_SUFFIX
+#  define GZ_SUFFIX ".gz"
+#endif
+#define SUFFIX_LEN (sizeof(GZ_SUFFIX)-1)
+
+#define BUFLEN      16384        /* read buffer size */
+#define BUFLENW     (BUFLEN * 3) /* write buffer size */
+#define MAX_NAME_LEN 1024
+
+#ifdef Z_SOLO
+/* for Z_SOLO, create simplified gz* functions using deflate and inflate */
+
+#if defined(Z_HAVE_UNISTD_H) || defined(Z_LARGE)
+#  include <unistd.h>       /* for unlink() */
+#endif
+
+void *myalloc (void *, unsigned, unsigned);
+void myfree (void *, void *);
+
+void *myalloc(void *q, unsigned n, unsigned m)
+{
+    (void)q;
+#ifndef UNALIGNED_OK
+    return memalign(16, n * m);
+#else
+    return calloc(n, m);
+#endif
+}
+
+void myfree(void *q, void *p)
+{
+    (void)q;
+    free(p);
+}
+
+typedef struct gzFile_s {
+    FILE *file;
+    int write;
+    int err;
+    const char *msg;
+    z_stream strm;
+    unsigned char *buf;
+} *gzFile;
+
+gzFile gzopen(const char *, const char *);
+gzFile gzdopen(int, const char *);
+gzFile gz_open (const char *, int, const char *);
+
+gzFile gzopen(const char *path, const char *mode)
+{
+    return gz_open(path, -1, mode);
+}
+
+gzFile gzdopen(int fd, const char *mode)
+{
+    return gz_open(NULL, fd, mode);
+}
+
+gzFile gz_open(const char *path, int fd, const char *mode)
+{
+    gzFile gz;
+    int ret;
+    int level = Z_DEFAULT_COMPRESSION;
+    const char *plevel = mode;
+
+    gz = malloc(sizeof(struct gzFile_s));
+    if (gz == NULL)
+        return NULL;
+    gz->write = strchr(mode, 'w') != NULL;
+    gz->strm.zalloc = myalloc;
+    gz->strm.zfree = myfree;
+    gz->strm.opaque = NULL;
+    gz->buf = malloc(gz->write ? BUFLENW : BUFLEN);
+
+    if (gz->buf == NULL) {
+        free(gz);
+        return NULL;
+    }
+
+    while (*plevel) {
+        if (*plevel >= '0' && *plevel <= '9') {
+           level = *plevel - '0';
+           break;
+        }
+        plevel++;
+    }
+    if (gz->write)
+        ret = deflateInit2(&(gz->strm), level, 8, 15 + 16, 8, 0);
+    else {
+        gz->strm.next_in = NULL;
+        gz->strm.avail_in = 0;
+        ret = inflateInit2(&(gz->strm), 15 + 16);
+    }
+    if (ret != Z_OK) {
+        free(gz);
+        return NULL;
+    }
+    gz->file = path == NULL ? fdopen(fd, gz->write ? "wb" : "rb") :
+                              fopen(path, gz->write ? "wb" : "rb");
+    if (gz->file == NULL) {
+        gz->write ? deflateEnd(&(gz->strm)) : inflateEnd(&(gz->strm));
+        free(gz);
+        return NULL;
+    }
+    gz->err = 0;
+    gz->msg = "";
+    return gz;
+}
+
+int gzwrite(gzFile, const void *, unsigned);
+
+int gzwrite(gzFile gz, const void *buf, unsigned len)
+{
+    z_stream *strm;
+
+    if (gz == NULL || !gz->write)
+        return 0;
+    strm = &(gz->strm);
+    strm->next_in = (void *)buf;
+    strm->avail_in = len;
+    do {
+        strm->next_out = gz->buf;
+        strm->avail_out = BUFLENW;
+        (void)deflate(strm, Z_NO_FLUSH);
+        fwrite(gz->buf, 1, BUFLENW - strm->avail_out, gz->file);
+    } while (strm->avail_out == 0);
+    return len;
+}
+
+int gzread(gzFile, void *, unsigned);
+
+int gzread(gzFile gz, void *buf, unsigned len)
+{
+    z_stream *strm;
+
+    if (gz == NULL || gz->write || gz->err)
+        return 0;
+    strm = &(gz->strm);
+    strm->next_out = buf;
+    strm->avail_out = len;
+    do {
+        if (strm->avail_in == 0)
+        {
+            strm->next_in = gz->buf;
+            strm->avail_in = (uint32_t)fread(gz->buf, 1, BUFLEN, gz->file);
+        }
+        if (strm->avail_in > 0)
+        {
+            int ret = inflate(strm, Z_NO_FLUSH);
+            if (ret == Z_DATA_ERROR) {
+                gz->err = ret;
+                gz->msg = strm->msg;
+                return 0;
+            }
+            else if (ret == Z_STREAM_END)
+                inflateReset(strm);
+        }
+        else
+            break;
+    } while (strm->avail_out);
+    return len - strm->avail_out;
+}
+
+int gzclose(gzFile);
+
+int gzclose(gzFile gz)
+{
+    z_stream *strm;
+
+    if (gz == NULL)
+        return Z_STREAM_ERROR;
+    strm = &(gz->strm);
+    if (gz->write) {
+        strm->next_in = NULL;
+        strm->avail_in = 0;
+        do {
+            strm->next_out = gz->buf;
+            strm->avail_out = BUFLENW;
+            (void)deflate(strm, Z_FINISH);
+            fwrite(gz->buf, 1, BUFLENW - strm->avail_out, gz->file);
+        } while (strm->avail_out == 0);
+        deflateEnd(strm);
+    }
+    else
+        inflateEnd(strm);
+    free(gz->buf);
+    fclose(gz->file);
+    free(gz);
+    return Z_OK;
+}
+
+const char *gzerror(gzFile, int *);
+
+const char *gzerror(gzFile gz, int *err)
+{
+    *err = gz->err;
+    return gz->msg;
+}
+
+#endif
+
+static char *prog;
+
+void error            (const char *msg);
+void gz_compress      (FILE   *in, gzFile out);
+#ifdef USE_MMAP
+int  gz_compress_mmap (FILE   *in, gzFile out);
+#endif
+void gz_uncompress    (gzFile in, FILE   *out);
+void file_compress    (char  *file, char *mode);
+void file_uncompress  (char  *file);
+int  main             (int argc, char *argv[]);
+
+/* ===========================================================================
+ * Display error message and exit
+ */
+void error(const char *msg)
+{
+    fprintf(stderr, "%s: %s\n", prog, msg);
+    exit(1);
+}
+
+/* ===========================================================================
+ * Compress input to output then close both files.
+ */
+
+void gz_compress(FILE   *in, gzFile out)
+{
+    char buf[BUFLEN];
+    int len;
+    int err;
+
+#ifdef USE_MMAP
+    /* Try first compressing with mmap. If mmap fails (minigzip used in a
+     * pipe), use the normal fread loop.
+     */
+    if (gz_compress_mmap(in, out) == Z_OK) return;
+#endif
+    /* Clear out the contents of buf before reading from the file to avoid
+       MemorySanitizer: use-of-uninitialized-value warnings. */
+    memset(buf, 0, sizeof(buf));
+    for (;;) {
+        len = (int)fread(buf, 1, sizeof(buf), in);
+        if (ferror(in)) {
+            perror("fread");
+            exit(1);
+        }
+        if (len == 0) break;
+
+        if (gzwrite(out, buf, (unsigned)len) != len) error(gzerror(out, &err));
+    }
+    fclose(in);
+    if (gzclose(out) != Z_OK) error("failed gzclose");
+}
+
+#ifdef USE_MMAP /* MMAP version, Miguel Albrecht <malbrech@eso.org> */
+
+/* Try compressing the input file at once using mmap. Return Z_OK if
+ * if success, Z_ERRNO otherwise.
+ */
+int gz_compress_mmap(FILE   *in, gzFile out)
+{
+    int len;
+    int err;
+    int ifd = fileno(in);
+    caddr_t buf;    /* mmap'ed buffer for the entire input file */
+    off_t buf_len;  /* length of the input file */
+    struct stat sb;
+
+    /* Determine the size of the file, needed for mmap: */
+    if (fstat(ifd, &sb) < 0) return Z_ERRNO;
+    buf_len = sb.st_size;
+    if (buf_len <= 0) return Z_ERRNO;
+
+    /* Now do the actual mmap: */
+    buf = mmap((caddr_t) 0, buf_len, PROT_READ, MAP_SHARED, ifd, (off_t)0);
+    if (buf == (caddr_t)(-1)) return Z_ERRNO;
+
+    /* Compress the whole file at once: */
+    len = gzwrite(out, (char *)buf, (unsigned)buf_len);
+
+    if (len != (int)buf_len) error(gzerror(out, &err));
+
+    munmap(buf, buf_len);
+    fclose(in);
+    if (gzclose(out) != Z_OK) error("failed gzclose");
+    return Z_OK;
+}
+#endif /* USE_MMAP */
+
+/* ===========================================================================
+ * Uncompress input to output then close both files.
+ */
+void gz_uncompress(gzFile in, FILE   *out)
+{
+    char buf[BUFLENW];
+    int len;
+    int err;
+
+    for (;;) {
+        len = gzread(in, buf, sizeof(buf));
+        if (len < 0) error (gzerror(in, &err));
+        if (len == 0) break;
+
+        if ((int)fwrite(buf, 1, (unsigned)len, out) != len) {
+            error("failed fwrite");
+        }
+    }
+    if (fclose(out)) error("failed fclose");
+
+    if (gzclose(in) != Z_OK) error("failed gzclose");
+}
+
+
+/* ===========================================================================
+ * Compress the given file: create a corresponding .gz file and remove the
+ * original.
+ */
+void file_compress(char  *file, char  *mode)
+{
+    char outfile[MAX_NAME_LEN];
+    FILE  *in;
+    gzFile out;
+
+    if (strlen(file) + strlen(GZ_SUFFIX) >= sizeof(outfile)) {
+        fprintf(stderr, "%s: filename too long\n", prog);
+        exit(1);
+    }
+
+    snprintf(outfile, sizeof(outfile), "%s%s", file, GZ_SUFFIX);
+
+    in = fopen(file, "rb");
+    if (in == NULL) {
+        perror(file);
+        exit(1);
+    }
+    out = gzopen(outfile, mode);
+    if (out == NULL) {
+        fprintf(stderr, "%s: can't gzopen %s\n", prog, outfile);
+        exit(1);
+    }
+    gz_compress(in, out);
+
+    unlink(file);
+}
+
+
+/* ===========================================================================
+ * Uncompress the given file and remove the original.
+ */
+void file_uncompress(char  *file)
+{
+    char buf[MAX_NAME_LEN];
+    char *infile, *outfile;
+    FILE  *out;
+    gzFile in;
+    size_t len = strlen(file);
+
+    if (len + strlen(GZ_SUFFIX) >= sizeof(buf)) {
+        fprintf(stderr, "%s: filename too long\n", prog);
+        exit(1);
+    }
+
+    snprintf(buf, sizeof(buf), "%s", file);
+
+    if (len > SUFFIX_LEN && strcmp(file+len-SUFFIX_LEN, GZ_SUFFIX) == 0) {
+        infile = file;
+        outfile = buf;
+        outfile[len-3] = '\0';
+    } else {
+        outfile = file;
+        infile = buf;
+        snprintf(buf + len, sizeof(buf) - len, "%s", GZ_SUFFIX);
+    }
+    in = gzopen(infile, "rb");
+    if (in == NULL) {
+        fprintf(stderr, "%s: can't gzopen %s\n", prog, infile);
+        exit(1);
+    }
+    out = fopen(outfile, "wb");
+    if (out == NULL) {
+        perror(file);
+        exit(1);
+    }
+
+    gz_uncompress(in, out);
+
+    unlink(infile);
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataLen) {
+  char *inFileName = "/tmp/minigzip_fuzzer.out";
+  char *outFileName = "/tmp/minigzip_fuzzer.out.gz";
+  char outmode[20];
+  FILE *in;
+  char buf[BUFLEN];
+  uint32_t offset = 0;
+
+  /* Discard inputs larger than 1Mb. */
+  static size_t kMaxSize = 1024 * 1024;
+  if (dataLen < 1 || dataLen > kMaxSize)
+    return 0;
+
+  in = fopen(inFileName, "w");
+  if (fwrite(data, 1, (unsigned)dataLen, in) != dataLen)
+    error("failed fwrite");
+  if (fclose(in))
+    error("failed fclose");
+
+  memset(outmode, 0, sizeof(outmode));
+  snprintf(outmode, sizeof(outmode), "%s", "wb");
+
+  /* Compression level: [0..9]. */
+  outmode[2] = data[0] % 10;
+
+  switch (data[0] % 4) {
+  default:
+  case 0:
+    outmode[3] = 0;
+    break;
+  case 1:
+    /* compress with Z_FILTERED */
+    outmode[3] = 'f';
+    break;
+  case 2:
+    /* compress with Z_HUFFMAN_ONLY */
+    outmode[3] = 'h';
+    break;
+  case 3:
+    /* compress with Z_RLE */
+    outmode[3] = 'R';
+    break;
+  }
+
+  file_compress(inFileName, outmode);
+  file_uncompress(outFileName);
+
+  /* Check that the uncompressed file matches the input data. */
+  in = fopen(inFileName, "rb");
+  if (in == NULL) {
+    perror(inFileName);
+    exit(1);
+  }
+
+  memset(buf, 0, sizeof(buf));
+  for (;;) {
+    int len = (int)fread(buf, 1, sizeof(buf), in);
+    if (ferror(in)) {
+      perror("fread");
+      exit(1);
+    }
+    if (len == 0)
+      break;
+    assert(0 == memcmp(data + offset, buf, len));
+    offset += len;
+  }
+
+  if (fclose(in))
+    error("failed fclose");
+
+  /* This function must return 0. */
+  return 0;
+}

--- a/projects/zlib/project.yaml
+++ b/projects/zlib/project.yaml
@@ -1,5 +1,7 @@
 homepage: "http://www.zlib.net/"
 primary_contact: "glennrp@gmail.com"
+auto_ccs:
+  - "sebpop@gmail.com"
 sanitizers:
   - address
   - memory


### PR DESCRIPTION
This patch moves the fuzzers of project/zlib upstream.
It piggy backs on the fuzzers written for zlib-ng which are a super-set
of zlib_uncompress_fuzzer.cc that got deleted from oss-fuzz/projects/zlib.

