### PR TITLE
Don't use WORKDIR $SRC

### DIFF
--- a/projects/poppler/Dockerfile
+++ b/projects/poppler/Dockerfile
@@ -23,6 +23,6 @@ RUN git clone --depth 1 https://github.com/mozilla/pdf.js pdf.js && \
     zip -q $SRC/pdf_fuzzer_seed_corpus.zip pdf.js/test/pdfs/*.pdf && \
     rm -rf pdf.js
 ADD https://raw.githubusercontent.com/rc0r/afl-fuzz/master/dictionaries/pdf.dict $SRC/pdf_fuzzer.dict
-WORKDIR $SRC
-COPY *.cc poppler/fuzz/
+WORKDIR $SRC/poppler
+COPY *.cc $SRC/fuzz/
 COPY build.sh $SRC/

--- a/projects/poppler/build.sh
+++ b/projects/poppler/build.sh
@@ -46,9 +46,8 @@ make -j$(nproc) poppler poppler-cpp
 
 fuzz_target=pdf_fuzzer
 
-pushd $SRC/poppler
-$CXX $CXXFLAGS -std=c++11 -Icpp \
-    fuzz/pdf_fuzzer.cc -o $OUT/$fuzz_target \
+$CXX $CXXFLAGS -std=c++11 -I$SRC/poppler/cpp \
+    $SRC/fuzz/pdf_fuzzer.cc -o $OUT/$fuzz_target \
     -lFuzzingEngine $WORK/poppler/cpp/libpoppler-cpp.a $WORK/poppler/libpoppler.a $WORK/lib/libfreetype.a
 
 mv $SRC/{*.zip,*.dict} $OUT


### PR DESCRIPTION
otherwise
`   python infra/helper.py build_fuzzers --sanitizer memory poppler local_dir`
complains
`  Cannot use local checkout with "WORKDIR /src".`
