### PR TITLE
infra: allow folded style for coverage_extra_args

### DIFF
--- a/infra/gcb/build_and_run_coverage.py
+++ b/infra/gcb/build_and_run_coverage.py
@@ -137,7 +137,7 @@ def get_build_steps(project_dir):
           'name': 'gcr.io/oss-fuzz-base/base-runner',
           'env': env + [
               'HTTP_PORT=',
-              'COVERAGE_EXTRA_ARGS=%s' % project_yaml['coverage_extra_args']
+              'COVERAGE_EXTRA_ARGS=%s' % project_yaml['coverage_extra_args'].strip()
           ],
           'args': [
               'bash',


### PR DESCRIPTION
If you've got many items, [folded style](http://yaml.org/spec/1.2/spec.html#id2796251) is more readable.
```YAML
coverage_extra_args: >
 -object firefox/firefox
 -object firefox/libnspr4.so
 -object firefox/libplc4.so
 -object firefox/libplds4.so
 -object firefox/libxul.so
```
It's already *allowed* but can have `\n` as last character, which might throw `llvm-cov`.