### PR TITLE
[bignum-fuzzer] Revert to older Rust Nightly to fix build

### DIFF
--- a/projects/bignum-fuzzer/Dockerfile
+++ b/projects/bignum-fuzzer/Dockerfile
@@ -21,7 +21,7 @@ RUN add-apt-repository -y ppa:gophers/archive && apt-get update && apt-get insta
 RUN ln -s /usr/lib/go-1.9/bin/go /usr/bin/go
 
 # Install Rust nightly
-RUN curl -s https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly
+RUN curl -s https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly --date=2018-08-26
 
 RUN git clone --depth 1 https://github.com/guidovranken/bignum-fuzzer
 RUN git clone --depth 1 https://github.com/openssl/openssl


### PR DESCRIPTION
Fixes the failing build introduced by recent Rust Nightly by reverting a recent working version.

Build may still fail because https://gmplib.org/repo/gmp/ (from which it pulls libgmp) currently returns HTTP 500. Please try again tomorrow or so if you require that PR's must have succeeding builds. (And if it persists I'll disable libgmp later).