### PR TITLE
av1_dec_fuzzer: set cfg.allow_lowbitdepth to CONFIG_LOWBITDEPTH

### DIFF
--- a/projects/libaom/av1_dec_fuzzer.cc
+++ b/projects/libaom/av1_dec_fuzzer.cc
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <memory>
 
+#include "config/aom_config.h"
 #include "aom/aom_decoder.h"
 #include "aom/aomdx.h"
 #include "aom_ports/mem_ops.h"
@@ -40,7 +41,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 #else
 #error define one of DECODE_MODE or DECODE_MODE_threaded
 #endif
-  aom_codec_dec_cfg_t cfg = {threads, 0, 0};
+  aom_codec_dec_cfg_t cfg = {threads, 0, 0, CONFIG_LOWBITDEPTH};
   if (aom_codec_dec_init(&codec, decoder->codec_interface(), &cfg, 0)) {
     return 0;
   }


### PR DESCRIPTION
If cfg.allow_lowbitdepth is 0, then seq_params->use_highbitdepth is
unconditionally set to 1 by the following code in av1_read_color_config():

seq_params->use_highbitdepth =
seq_params->bit_depth > AOM_BITS_8 || !allow_lowbitdepth;

aomdec.c sets cfg.allow_lowbitdepth to CONFIG_LOWBITDEPTH. (We usually
pass -DCONFIG_LOWBITDEPTH=1 to cmake.) Chromium defines
CONFIG_LOWBITDEPTH as 1 and sets cfg.allow_lowbitdepth to 1:
https://chromium-review.googlesource.com/c/chromium/src/+/1178938

Our fuzzing test binary should match the behavior of aomdec and Chromium.