### PR TITLE
[gnutls] removed memory sanitizer

### DIFF
--- a/projects/gnutls/project.yaml
+++ b/projects/gnutls/project.yaml
@@ -9,5 +9,4 @@ auto_ccs:
 
 sanitizers:
   - address
-  - memory
   - undefined


### PR DESCRIPTION
It reports several problems which are false positives such as:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=10125
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=10135
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=10136
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=10137
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=10138
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=10216

Signed-off-by: Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>