### PR TITLE
firefox: fix profile build, enable ubsan, more

### DIFF
--- a/projects/firefox/ContentSecurityPolicyParser.options
+++ b/projects/firefox/ContentSecurityPolicyParser.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 15360

--- a/projects/firefox/Dockerfile
+++ b/projects/firefox/Dockerfile
@@ -20,6 +20,6 @@ RUN apt-get update && apt-get install -y gawk mercurial
 RUN hg clone --uncompressed https://hg.mozilla.org/mozilla-central
 RUN git clone --depth 1 https://github.com/mozillasecurity/fuzzdata
 WORKDIR mozilla-central
-COPY build.sh target.c *options $SRC/
-COPY *diff $SRC/mozilla-central
+COPY build.sh target.c *.options mozconfig.* $SRC/
+COPY *.diff $SRC/mozilla-central/
 RUN hg patch --no-commit ContentSecurityPolicyParser.diff

--- a/projects/firefox/SdpParser.options
+++ b/projects/firefox/SdpParser.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 25600

--- a/projects/firefox/build.sh
+++ b/projects/firefox/build.sh
@@ -98,6 +98,7 @@ done
 find media/webrtc -iname "*.sdp" \
   -type f -exec zip -qu $OUT/SdpParser_seed_corpus.zip "{}" \;
 cp $SRC/fuzzdata/dicts/sdp.dict $OUT/SdpParser.dict
+cp $SRC/SdpParser.options $OUT
 
 # StunParser
 find media/webrtc -iname "*.stun" \

--- a/projects/firefox/build.sh
+++ b/projects/firefox/build.sh
@@ -34,7 +34,7 @@ export MOZCONFIG=$SRC/mozconfig.$SANITIZER
 # to PATH via source. In a successive run (for a different sanitizer), the
 # cargo installation carries over, but bootstrap fails if cargo is not in PATH.
 export SHELL=/bin/bash
-[ -f "$HOME/.cargo/env" ] && source $HOME/.cargo/env
+[[ -f "$HOME/.cargo/env" ]] && source $HOME/.cargo/env
 ./mach bootstrap --no-interactive --application-choice browser
 source $HOME/.cargo/env
 

--- a/projects/firefox/build.sh
+++ b/projects/firefox/build.sh
@@ -70,11 +70,12 @@ do
     $SRC/target.c -o $OUT/$FUZZ_TARGET
 done
 
+cp $SRC/*.options $OUT
+
 # SdpParser
 find media/webrtc -iname "*.sdp" \
   -type f -exec zip -qu $OUT/SdpParser_seed_corpus.zip "{}" \;
 cp $SRC/fuzzdata/dicts/sdp.dict $OUT/SdpParser.dict
-cp $SRC/SdpParser.options $OUT
 
 # StunParser
 find media/webrtc -iname "*.stun" \
@@ -83,7 +84,6 @@ cp $SRC/fuzzdata/dicts/stun.dict $OUT/StunParser.dict
 
 # ContentParentIPC
 cp $SRC/fuzzdata/settings/ipc/libfuzzer.content.blacklist.txt $OUT/firefox
-cp $SRC/ContentParentIPC.options $OUT
 
 # ContentSecurityPolicyParser
 cp dom/security/fuzztest/csp_fuzzer.dict $OUT/ContentSecurityPolicyParser.dict

--- a/projects/firefox/build.sh
+++ b/projects/firefox/build.sh
@@ -15,6 +15,8 @@
 #
 ################################################################################
 
+[[ $SANITIZER = "coverage" ]] && touch $OUT/exit && exit 0
+
 # Case-sensitive names of internal Firefox fuzzing targets. Edit to add more.
 FUZZ_TARGETS=(
   SdpParser
@@ -24,32 +26,9 @@ FUZZ_TARGETS=(
   # Qcms # needn't be enabled; has its own project with more sanitizers/engines
 )
 
-# Firefox object (build) directory.
-OBJDIR=$WORK/obj-fuzz
-
-[[ $SANITIZER = "coverage" ]] && touch $OUT/empty && exit 0
-
-# Firefox fuzzing build configuration.
-cat << EOF > mozconfig
-ac_add_options --disable-debug
-ac_add_options --disable-elf-hack
-ac_add_options --disable-jemalloc
-ac_add_options --disable-crashreporter
-ac_add_options --enable-fuzzing
-ac_add_options --enable-optimize=-O1
-ac_add_options --enable-debug-symbols=-gline-tables-only
-ac_add_options --enable-address-sanitizer
-mk_add_options MOZ_OBJDIR=${OBJDIR}
-mk_add_options MOZ_MAKE_FLAGS=-j$(nproc)
-EOF
-
-if [[ $SANITIZER = "address" ]]
-then
-cat << EOF >> mozconfig
-mk_add_options CFLAGS=
-mk_add_options CXXFLAGS=
-EOF
-fi
+# Firefox object (build) directory and configuration file.
+export MOZ_OBJDIR=$WORK/obj-fuzz
+export MOZCONFIG=$SRC/mozconfig.$SANITIZER
 
 # Install dependencies. Note that bootstrap installs cargo, which must be added
 # to PATH via source. In a successive run (for a different sanitizer), the

--- a/projects/firefox/build.sh
+++ b/projects/firefox/build.sh
@@ -47,11 +47,11 @@ source $HOME/.cargo/env
 
 # Packages Firefox only to immediately extract the archive. Some files are
 # replaced with gtest-variants, which is required by the fuzzing interface.
-# Weighs in shy of 1GB afterwards.
-make -j$(nproc) -C $OBJDIR package
-tar -xf $OBJDIR/dist/firefox*bz2 -C $OUT
-mv $OBJDIR/toolkit/library/gtest/libxul.so $OUT/firefox
-mv $OUT/firefox/dependentlibs.list $OUT/firefox/dependentlibs.list.gtest
+# Weighs in shy of 1GB afterwards. About double for profile builds.
+make -j$(nproc) -C $MOZ_OBJDIR package
+tar -xf $MOZ_OBJDIR/dist/firefox*bz2 -C $OUT
+cp -L $MOZ_OBJDIR/dist/bin/gtest/libxul.so $OUT/firefox
+cp $OUT/firefox/dependentlibs.list $OUT/firefox/dependentlibs.list.gtest
 
 # Get the absolute paths of the required system libraries.
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:$OUT/firefox

--- a/projects/firefox/mozconfig.address
+++ b/projects/firefox/mozconfig.address
@@ -1,10 +1,6 @@
-ac_add_options --disable-debug
-ac_add_options --disable-elf-hack
-ac_add_options --disable-jemalloc
-ac_add_options --disable-crashreporter
-ac_add_options --enable-fuzzing
-ac_add_options --enable-optimize=-O1
-ac_add_options --enable-debug-symbols=-gline-tables-only
+. $SRC/mozconfig.profile
+
 ac_add_options --enable-address-sanitizer
+
 unset CFLAGS
 unset CXXFLAGS

--- a/projects/firefox/mozconfig.address
+++ b/projects/firefox/mozconfig.address
@@ -1,0 +1,10 @@
+ac_add_options --disable-debug
+ac_add_options --disable-elf-hack
+ac_add_options --disable-jemalloc
+ac_add_options --disable-crashreporter
+ac_add_options --enable-fuzzing
+ac_add_options --enable-optimize=-O1
+ac_add_options --enable-debug-symbols=-gline-tables-only
+ac_add_options --enable-address-sanitizer
+unset CFLAGS
+unset CXXFLAGS

--- a/projects/firefox/mozconfig.profile
+++ b/projects/firefox/mozconfig.profile
@@ -1,0 +1,7 @@
+ac_add_options --disable-debug
+ac_add_options --disable-elf-hack
+ac_add_options --disable-jemalloc
+ac_add_options --disable-crashreporter
+ac_add_options --enable-fuzzing
+ac_add_options --enable-optimize=-O1
+ac_add_options --enable-debug-symbols=-gline-tables-only

--- a/projects/firefox/mozconfig.undefined
+++ b/projects/firefox/mozconfig.undefined
@@ -1,0 +1,6 @@
+. $SRC/mozconfig.profile
+
+ac_add_options --enable-undefined-sanitizer=bool,bounds,return,pointer-overflow,signed-integer-overflow,vla-bound
+
+unset CFLAGS
+unset CXXFLAGS

--- a/projects/firefox/project.yaml
+++ b/projects/firefox/project.yaml
@@ -7,6 +7,7 @@ fuzzing_engines:
   - libfuzzer
 sanitizers:
   - address
+  - undefined
 run_tests: False
 # libraries from $OUT/firefox/dependentlibs.list
 coverage_extra_args: >

--- a/projects/firefox/project.yaml
+++ b/projects/firefox/project.yaml
@@ -8,3 +8,18 @@ fuzzing_engines:
 sanitizers:
   - address
 run_tests: False
+# libraries from $OUT/firefox/dependentlibs.list
+coverage_extra_args: >
+ -object firefox/firefox
+ -object firefox/libnspr4.so
+ -object firefox/libplc4.so
+ -object firefox/libplds4.so
+ -object firefox/libmozsandbox.so
+ -object firefox/liblgpllibs.so
+ -object firefox/libnssutil3.so
+ -object firefox/libnss3.so
+ -object firefox/libsmime3.so
+ -object firefox/libmozsqlite3.so
+ -object firefox/libssl3.so
+ -object firefox/libmozgtk.so
+ -object firefox/libxul.so


### PR DESCRIPTION
Fixes *profile* and makes it compile without sanitizers. Enables *undefined* with a conservative set of checks.