### PR TITLE
fix hg revision with uncommitted changes

### DIFF
--- a/infra/base-images/base-builder/srcmap
+++ b/infra/base-images/base-builder/srcmap
@@ -48,7 +48,7 @@ for DOT_HG_DIR in $(find $SRC -name ".hg" -type d); do
   HG_DIR=$(dirname $DOT_HG_DIR)
   cd $HG_DIR
   HG_URL=$(hg paths default)
-  HG_REV=$(hg --debug id -i)
+  HG_REV=$(hg --debug id -r. -i)
   jq_inplace $SRCMAP ".\"$HG_DIR\" = { type: \"hg\", url: \"$HG_URL\", rev: \"$HG_REV\" }"
 done
 


### PR DESCRIPTION
From the manual.
> Print a summary identifying the repository state [...], followed by a "+" if the working directory has
    uncommitted changes [...].
```Bash
$ hg --debug id -i
20d42e205b19be1d4c75640beed91dba04f6650d+
```
> Specify `-r.` to get information of the working directory parent without scanning uncommitted changes.
```
$ hg --debug id -r. -i
20d42e205b19be1d4c75640beed91dba04f6650d
```
Fixes https://github.com/google/oss-fuzz/issues/1842, I think.