### PR TITLE
mercurial: also slurp down a Python tarball

### DIFF
--- a/projects/mercurial/Dockerfile
+++ b/projects/mercurial/Dockerfile
@@ -17,7 +17,8 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER security@mercurial-scm.org
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
-  python-dev mercurial
+  python-dev mercurial curl
+RUN cd / && curl https://www.python.org/ftp/python/2.7.15/Python-2.7.15.tgz | tar xzf -
 RUN hg clone https://www.mercurial-scm.org/repo/hg mercurial
 WORKDIR mercurial
 COPY build.sh $SRC/


### PR DESCRIPTION
An upcoming fuzzer need a Python install that was built with ASAN and
--without-pymalloc, so I need a tarball of Python to compile.