### PR TITLE
mercurial: disable msan, hopefully only for a while

### DIFF
--- a/projects/mercurial/project.yaml
+++ b/projects/mercurial/project.yaml
@@ -7,5 +7,7 @@ auto_ccs:
   - "martinvonz@google.com"
 sanitizers:
   - address
-  - memory
   - undefined
+  # TODO: re-enable memory when we figure out how to work with cpython
+  # and msan at the same time.
+  # - memory


### PR DESCRIPTION
Our new fuzzer requires CPython, and I'm getting extremely
confusing (and implausible-looking based on reading of CPython source)
msan issues, so let's disable msan for this project for now.