### PR TITLE
Do not use thread in openssl for ecc-diff-fuzzer

### DIFF
--- a/projects/ecc-diff-fuzzer/build.sh
+++ b/projects/ecc-diff-fuzzer/build.sh
@@ -63,7 +63,7 @@ make -j$(nproc) all
 (
 cd openssl
 #option to not have the same exported function poly1305_blocks as in gcrypt
-./config no-poly1305
+./config no-poly1305 no-shared no-threads
 make build_generated libcrypto.a
 )
 


### PR DESCRIPTION
In order to fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=10913
```
Step #2: ../openssl/libcrypto.a(libcrypto-lib-threads_pthread.o): In function `fork_once_func':
Step #2: /src/openssl/crypto/threads_pthread.c:183: undefined reference to `pthread_atfork'
Step #2: clang-8: error: linker command failed with exit code 1 (use -v to see invocation)
```