### PR TITLE
[harfbuzz] Disable UBSan vptr again, since we still build with -fno-rtti

### DIFF
--- a/projects/harfbuzz/build.sh
+++ b/projects/harfbuzz/build.sh
@@ -15,6 +15,10 @@
 #
 ################################################################################
 
+# Disable:
+# 1. UBSan vptr since target built with -fno-rtti.
+export CFLAGS="$CFLAGS -fno-sanitize=function,vptr"
+
 # Build the library.
 ./autogen.sh
 ./configure


### PR DESCRIPTION
Fixes build breakage: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=10937

I suppose ubsan by default doesn't enable -fsanitize=vptr, since it seems to pass in our CI.  Anyway, disable it again.  The -fsanitize=function exception should not be needed, as I fixed those upstream.