### PR TITLE
libgit2: Let fuzzers user internal headers

### DIFF
--- a/projects/libgit2/build.sh
+++ b/projects/libgit2/build.sh
@@ -32,7 +32,9 @@ for fuzzer in ../fuzzers/*_fuzzer.c
 do
     fuzzer_name=$(basename "${fuzzer%.c}")
 
-    $CC $CFLAGS -c -I"$WORK/include" "$fuzzer" -o "$WORK/$fuzzer_name.o"
+    $CC $CFLAGS -c -I"$WORK/include" -I"$SRC/libgit2/src" \
+        -DLIBGIT2_NO_FEATURES_H \
+        "$fuzzer" -o "$WORK/$fuzzer_name.o"
     $CXX $CXXFLAGS -std=c++11 -o "$OUT/$fuzzer_name" \
         -lFuzzingEngine "$WORK/$fuzzer_name.o" "$WORK/lib/libgit2.a"
 


### PR DESCRIPTION
Ideally we should
(a) move `build.sh` into libgit2's own repository
(b) figure out how to use our `cmake` build in oss-fuzz

but I ran into a bunch of yak shaves with (b), since oss-fuzz needs us to link with `$CXX` and to pass `-lFuzzingEngine`. In the meanwhile, this fixes the build.

Alternately, maybe we should export `git_config_backend_from_string`?

cc @pks-t for your take.