### PR TITLE
bzip2: Add bzip2 to oss-fuzz

### DIFF
--- a/projects/bzip2/Dockerfile
+++ b/projects/bzip2/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER bshas3@gmail.com
+RUN apt-get update && apt-get install -y make autoconf automake libtool wget
+RUN wget ftp://sources.redhat.com/pub/bzip2/v102/bzip2-1.0.2.tar.gz 
+COPY build.sh *.c $SRC/
+WORKDIR $SRC

--- a/projects/bzip2/build.sh
+++ b/projects/bzip2/build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -eu
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+tar xzf bzip2-*.tar.gz && rm -f bzip2-*.tar.gz
+cd bzip2-*
+SRCL=(blocksort.o huffman.o crctable.o randtable.o compress.o decompress.o bzlib.o)
+
+for source in ${SRCL[@]}; do
+    name=$(basename $source .o)
+    $CC $CFLAGS -c ${name}.c
+done
+rm -f libbz2.a
+ar cq libbz2.a ${SRCL[@]} && ranlib libbz2.a
+
+# build fuzzers
+for file in $SRC/*.c;
+do
+    name=$(basename $file .c)
+    $CC $CFLAGS -c -I . $SRC/${name}.c -o $OUT/${name}.o
+    $CXX $CXXFLAGS -o $OUT/${name} $OUT/${name}.o -lFuzzingEngine \
+    libbz2.a
+    rm -f $OUT/${name}.o
+done

--- a/projects/bzip2/bzip2_compress_target.c
+++ b/projects/bzip2/bzip2_compress_target.c
@@ -1,0 +1,67 @@
+/*
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###############################################################################
+*/
+
+#include "bzlib.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <string.h>
+
+extern int BZ2_bzBuffToBuffCompress(char* dest,
+                           unsigned int* destLen,
+                           char*         source,
+                           unsigned int  sourceLen,
+                           int           blockSize100k,
+                           int           verbosity,
+                           int           workFactor);
+
+extern int BZ2_bzBuffToBuffDecompress(char* dest,
+                                      unsigned int* destLen,
+                                      char*         source,
+                                      unsigned int  sourceLen,
+                                      int           small,
+                                      int           verbosity);
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    int r;
+    unsigned int nZ, nOut;
+    char *zbuf = malloc(size + 600 + (size / 100));
+
+    r = BZ2_bzBuffToBuffCompress(zbuf, &nZ, (char *)data, size, 9, 0, 30);
+    if (r != BZ_OK) {
+        fprintf(stdout, "Compression error: %d\n", r);
+        goto cleanup;
+    }
+
+    nOut = size*2;
+    char *outbuf = malloc(nOut);
+    r = BZ2_bzBuffToBuffDecompress(outbuf, &nOut, zbuf, nZ, 0, 0);
+    if (r != BZ_OK) {
+        fprintf(stdout, "Decompression error: %d\n", r);
+    }
+    else {
+        assert(nOut == size);
+        assert(memcmp(data, outbuf, size) == 0);
+    }
+    free(outbuf);
+cleanup:
+    free(zbuf);
+    return 0;
+}

--- a/projects/bzip2/bzip2_compress_target.c
+++ b/projects/bzip2/bzip2_compress_target.c
@@ -46,22 +46,28 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     r = BZ2_bzBuffToBuffCompress(zbuf, &nZ, (char *)data, size, 9, 0, 30);
     if (r != BZ_OK) {
+#ifdef __DEBUG__
         fprintf(stdout, "Compression error: %d\n", r);
-        goto cleanup;
+#endif
+        free(zbuf);
+        return 0;
     }
 
     nOut = size*2;
     char *outbuf = malloc(nOut);
     r = BZ2_bzBuffToBuffDecompress(outbuf, &nOut, zbuf, nZ, 0, 0);
     if (r != BZ_OK) {
+#ifdef __DEBUG__
         fprintf(stdout, "Decompression error: %d\n", r);
+#endif
+        free(zbuf);
+        free(outbuf);
+        return 0;
     }
-    else {
-        assert(nOut == size);
-        assert(memcmp(data, outbuf, size) == 0);
-    }
-    free(outbuf);
-cleanup:
+
+    assert(nOut == size);
+    assert(memcmp(data, outbuf, size) == 0);
     free(zbuf);
+    free(outbuf);
     return 0;
 }

--- a/projects/bzip2/bzip2_decompress_target.c
+++ b/projects/bzip2/bzip2_decompress_target.c
@@ -38,13 +38,17 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     nOut = size*2;
     char *outbuf = malloc(nOut);
     r = BZ2_bzBuffToBuffDecompress(outbuf, &nOut, (char *)data, size, 0, 0);
+
     if (r != BZ_OK) {
+#ifdef __DEBUG__
         fprintf(stdout, "Decompression error: %d\n", r);
+#endif
+        free(outbuf);
+        return 0;
     }
-    else {
-        assert(nOut == size);
-        assert(memcmp(data, outbuf, size) == 0);
-    }
+
+    assert(nOut == size);
+    assert(memcmp(data, outbuf, size) == 0);
     free(outbuf);
     return 0;
 }

--- a/projects/bzip2/bzip2_decompress_target.c
+++ b/projects/bzip2/bzip2_decompress_target.c
@@ -1,0 +1,50 @@
+/*
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###############################################################################
+*/
+
+#include "bzlib.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <string.h>
+
+extern int BZ2_bzBuffToBuffDecompress(char* dest,
+                                      unsigned int* destLen,
+                                      char*         source,
+                                      unsigned int  sourceLen,
+                                      int           small,
+                                      int           verbosity);
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    int r;
+    unsigned int nZ, nOut;
+
+    nOut = size*2;
+    char *outbuf = malloc(nOut);
+    r = BZ2_bzBuffToBuffDecompress(outbuf, &nOut, (char *)data, size, 0, 0);
+    if (r != BZ_OK) {
+        fprintf(stdout, "Decompression error: %d\n", r);
+    }
+    else {
+        assert(nOut == size);
+        assert(memcmp(data, outbuf, size) == 0);
+    }
+    free(outbuf);
+    return 0;
+}

--- a/projects/bzip2/project.yaml
+++ b/projects/bzip2/project.yaml
@@ -1,0 +1,8 @@
+homepage: "http://www.bzip.org/"
+primary_contact: "jseward@acm.org"
+auto_ccs:
+  - "bshas3@gmail.com"
+sanitizers:
+  - address
+  - undefined
+  - memory


### PR DESCRIPTION
This PR integrates bzip2 into oss-fuzz (CC #402 ).

- It contains two targets
  - comp/decompressor, and a standalone decompressor
  - should support all sanitizers
  - test harnesses out of source since there is no official bzip2 repo that seems to be maintained.

The decompressor target flags a wild read within seconds.