### PR TITLE
bzip2: Bug fixes

### DIFF
--- a/projects/bzip2/Dockerfile
+++ b/projects/bzip2/Dockerfile
@@ -17,6 +17,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER bshas3@gmail.com
 RUN apt-get update && apt-get install -y make autoconf automake libtool wget
-RUN wget ftp://sources.redhat.com/pub/bzip2/v102/bzip2-1.0.2.tar.gz 
+RUN wget https://fossies.org/linux/misc/bzip2-1.0.6.tar.gz
 COPY build.sh *.c $SRC/
 WORKDIR $SRC

--- a/projects/bzip2/bzip2_decompress_target.c
+++ b/projects/bzip2/bzip2_decompress_target.c
@@ -22,9 +22,6 @@
 #include <assert.h>
 #include <string.h>
 
-// See comments in bzip2_compress_target.c
-static const unsigned int blockSize = 1000*1000;
-
 extern int BZ2_bzBuffToBuffDecompress(char* dest,
                                       unsigned int* destLen,
                                       char*         source,
@@ -39,7 +36,7 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     unsigned int nZ, nOut;
 
     // See: https://github.com/google/bzip2-rpc/blob/master/unzcrash.c#L39
-    nOut = blockSize*2;
+    nOut = size*2;
     char *outbuf = malloc(nOut);
     small = size % 2;
     r = BZ2_bzBuffToBuffDecompress(outbuf, &nOut, (char *)data, size,

--- a/projects/bzip2/bzip2_decompress_target.c
+++ b/projects/bzip2/bzip2_decompress_target.c
@@ -35,14 +35,15 @@ extern int BZ2_bzBuffToBuffDecompress(char* dest,
 int
 LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-    int r;
+    int r, small;
     unsigned int nZ, nOut;
 
     // See: https://github.com/google/bzip2-rpc/blob/master/unzcrash.c#L39
     nOut = blockSize*2;
     char *outbuf = malloc(nOut);
+    small = size % 2;
     r = BZ2_bzBuffToBuffDecompress(outbuf, &nOut, (char *)data, size,
-            /*small=*/0, /*verbosity=*/0);
+            small, /*verbosity=*/0);
 
     if (r != BZ_OK) {
 #ifdef __DEBUG__

--- a/projects/bzip2/project.yaml
+++ b/projects/bzip2/project.yaml
@@ -4,5 +4,4 @@ auto_ccs:
   - "bshas3@gmail.com"
 sanitizers:
   - address
-  - undefined
   - memory


### PR DESCRIPTION
This PR
  - Bumps bzip2 version under test to `1.0.6`
  - Fixes bugs in #1887 
    - The first bug was that that the hard-coded buffer size was likely insufficient to carry out the (de)compression
    - Added citations to the original source (`unzcrash.c`) as future reference for choosing buffer sizes
    - The second bug was incorrect assertions in `bzip2_decompress_target.c` that has now been removed
  - Uses variable compression factor (`blockSize100k`), work factor, and small configurations ([see this doc](https://hackage.haskell.org/package/bzlib-0.5.0.5/docs/Codec-Compression-BZip.html), details quoted below)
    - compression factor
> The block size affects both the compression ratio achieved, and the amount of memory needed for compression and decompression.
> BlockSize 1 through BlockSize 9 specify the block size to be 100,000 bytes through 900,000 bytes respectively. The default is to use the maximum block size.
> Larger block sizes give rapidly diminishing marginal returns. Most of the compression comes from the first two or three hundred k of block size, a fact worth bearing in mind when using bzip2 on small machines. It is also important to appreciate that the decompression memory requirement is set at compression time by the choice of block size.
> In general, try and use the largest block size memory constraints allow, since that maximises the compression achieved.
> Compression and decompression speed are virtually unaffected by block size.
> Another significant point applies to files which fit in a single block - that means most files you'd encounter using a large block size. The amount of real memory touched is proportional to the size of the file, since the file is smaller than a block. For example, compressing a file 20,000 bytes long with the flag BlockSize 9 will cause the compressor to allocate around 7600k of memory, but only touch 400k + 20000 * 8 = 560 kbytes of it. Similarly, the decompressor will allocate 3700k but only touch 100k + 20000 * 4 = 180 kbytes.

    - work Factor
> The WorkFactor parameter controls how the compression phase behaves when presented with worst case, highly repetitive, input data. If compression runs into difficulties caused by repetitive data, the library switches from the standard sorting algorithm to a fallback algorithm. The fallback is slower than the standard algorithm by perhaps a factor of three, but always behaves reasonably, no matter how bad the input.
>Lower values of WorkFactor reduce the amount of effort the standard algorithm will expend before resorting to the fallback. You should set this parameter carefully; too low, and many inputs will be handled by the fallback algorithm and so compress rather slowly, too high, and your average-to-worst case compression times can become very large. The default value of 30 gives reasonable behaviour over a wide range of circumstances.
>Note that the compressed output generated is the same regardless of whether or not the fallback algorithm is used.

    - small [docu from here](https://www.mankier.com/1/bzip2#--small)
> Reduce memory usage, for compression, decompression and testing.  Files are decompressed and tested using a modified algorithm which only requires 2.5 bytes per block byte.  This means any file can be decompressed in 2300k of memory, albeit at about half the normal speed.
> During compression, -s selects a block size of 200k, which limits memory use to around the same figure, at the expense of your compression ratio.  In short, if your machine is low on memory (8 megabytes or less), use -s for everything.
  - Minor refactoring