### PR TITLE
[wireshark] fix build, simplify build configuration

### DIFF
--- a/projects/wireshark/Dockerfile
+++ b/projects/wireshark/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER Jakub Zawadzki <darkjames-ws@darkjames.pl>
 
-RUN apt-get update && apt-get install -y make cmake \
+RUN apt-get update && apt-get install -y ninja-build cmake \
                        flex bison \
                        libglib2.0-dev libgcrypt20-dev
 

--- a/projects/wireshark/build.sh
+++ b/projects/wireshark/build.sh
@@ -18,47 +18,31 @@
 WIRESHARK_BUILD_PATH="$WORK/build"
 mkdir -p "$WIRESHARK_BUILD_PATH"
 
-export WIRESHARK_INSTALL_PATH="$WORK/install"
-mkdir -p "$WIRESHARK_INSTALL_PATH"
-
 # Prepare Samples directory
 export SAMPLES_DIR="$WORK/samples"
 mkdir -p "$SAMPLES_DIR"
 cp -a $SRC/wireshark-fuzzdb/samples/* "$SAMPLES_DIR"
 
 # compile static version of libs
-# XXX, with static wireshark linking each fuzzer binary is ~338 MB (just libwireshark.a is 623 MBs).
+# XXX, with static wireshark linking each fuzzer binary is ~346 MB (just libwireshark.a is 761 MB).
 # XXX, wireshark is not ready for including static plugins into binaries.
 CMAKE_DEFINES="-DENABLE_STATIC=ON -DENABLE_PLUGINS=OFF"
 
 # disable optional dependencies
 CMAKE_DEFINES="$CMAKE_DEFINES -DENABLE_PCAP=OFF -DENABLE_GNUTLS=OFF"
 
-# need only libs, disable programs
-# TODO, add something like --without-extcap, which would disable all extcap binaries
-CMAKE_DEFINES="$CMAKE_DEFINES -DBUILD_wireshark=OFF -DBUILD_tshark=OFF -DBUILD_sharkd=OFF \
-             -DBUILD_dumpcap=OFF -DBUILD_capinfos=OFF -DBUILD_captype=OFF -DBUILD_randpkt=OFF -DBUILD_dftest=OFF \
-             -DBUILD_editcap=OFF -DBUILD_mergecap=OFF -DBUILD_reordercap=OFF -DBUILD_text2pcap=OFF \
-             -DBUILD_fuzzshark=OFF \
-             -DBUILD_androiddump=OFF -DBUILD_randpktdump=OFF -DBUILD_udpdump=OFF \
-         "
-
-# Fortify and asan don't like each other ... :(
-# TODO, right now -D_FORTIFY_SOURCE=2 is not added in cmake builds.
-# sed -i '/AC_WIRESHARK_GCC_FORTIFY_SOURCE_CHECK/d' configure.ac
+# There is no need to manually disable programs via BUILD_xxx=OFF since the
+# all-fuzzers targets builds the minimum required binaries. However we do have
+# to disable the Qt GUI or else the cmake step will fail.
+CMAKE_DEFINES="$CMAKE_DEFINES -DBUILD_wireshark=OFF"
 
 cd "$WIRESHARK_BUILD_PATH"
 
-cmake -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX \
+cmake -GNinja \
+      -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX \
       -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
-      -DCMAKE_INSTALL_PREFIX="$WIRESHARK_INSTALL_PATH" $CMAKE_DEFINES -DDISABLE_WERROR=ON $SRC/wireshark/
+      -DDISABLE_WERROR=ON -DOSS_FUZZ=ON $CMAKE_DEFINES $SRC/wireshark/
 
-# disable leak checks, lemon is build with ASAN, and it leaks memory during building.
-export ASAN_OPTIONS="detect_leaks=0"
-make "-j$(nproc)"
-make install
-
-# make install didn't install config.h, install it manually
-cp "$WIRESHARK_BUILD_PATH/config.h" "$WIRESHARK_INSTALL_PATH/include/wireshark/"
+ninja all-fuzzers
 
 $SRC/wireshark/tools/oss-fuzzshark/build.sh all


### PR DESCRIPTION
Since Wireshark v2.9.0rc0-2266-g7e88bb5e53, building fuzzing binaries is
better integrated in the Wireshark build system. While that change was
supposed to be backwards compatible, unfortunately the resulting fuzzer
binaries are dynamically linked due to how cmake caches library paths.
The very first cmake invocation must be invoked with -DOSS_FUZZ=ON.

Changes:
- Use ninja for better control of parallel linker jobs.
- Installing files (make install) is no longer needed.
- Avoid setting a long list of cmake options (BUILD_xxx=OFF).
- Remove fortify comment, it does not belong here.
- Remove lemon workaround, it is fixed since v2.9.0rc0-2273-gbb2caa2a9f.
___
cc @jwzawadzki 

The Wireshark patch has been tested locally in an oss-fuzz Docker container, but only in combination with this configuration... I should have tested it with the original project config as well, ah well.

This PR has been validated with Wireshark v2.9.0rc0-2277-gd9b3c056d1 and:
```sh
python2 infra/helper.py build_image --no-pull wireshark
python2 infra/helper.py build_fuzzers --sanitizer address wireshark
python2 infra/helper.py check_build --sanitizer address wireshark fuzzshark_udp_port-dhcp
python2 infra/helper.py reproduce wireshark fuzzshark_ip_proto-udp clusterfuzz-testcase-minimized-fuzzshark_ip_proto-udp-5657352737390592
```