### PR TITLE
[harfbuzz] Add my another account

### DIFF
--- a/projects/harfbuzz/project.yaml
+++ b/projects/harfbuzz/project.yaml
@@ -3,6 +3,7 @@ primary_contact: "harfbuzz-admin@googlegroups.com"
 auto_ccs:
   - "behdad.esfahbod@gmail.com"
   - "behdad@google.com"
+  - "ebrahim@gnu.org"
   - "ebraminio@gmail.com"
   - "grieger@google.com"
   - "rsheeter@google.com"


### PR DESCRIPTION
My right-having login account in Chromium bug tracker is this one and I am
constantly switching between the accounts.