### PR TITLE
add ntpsec project

### DIFF
--- a/projects/ntpsec/project.yaml
+++ b/projects/ntpsec/project.yaml
@@ -1,0 +1,5 @@
+homepage: "https://ntpsec.org"
+primary_contact: "fallenpegasus@gmail.com"
+auto_ccs:
+  - "contact@ntpsec.org"
+


### PR DESCRIPTION
I am the project manager for the NTPsec Project   https://ntpsec.org/

We've started getting bug reports based on fuzzing, so we would like to formally join the oss-fuzz project to formalize that and make it easier for us to be fuzz tested.