### PR TITLE
xz: Add the xz/lzma decompressor to oss-fuzz

### DIFF
--- a/projects/xz/Dockerfile
+++ b/projects/xz/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER bshas3@email.com
+RUN apt-get update && apt-get install -y make autoconf autopoint libtool zip
+RUN git clone https://git.tukaani.org/xz.git
+COPY build.sh $SRC/
+WORKDIR xz

--- a/projects/xz/build.sh
+++ b/projects/xz/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -eu
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+./autogen.sh
+./configure \
+  --enable-static \
+  --disable-debug \
+  --disable-shared \
+  --disable-encoders \
+  --disable-xz \
+  --disable-xzdec \
+  --disable-lzmadec \
+  --disable-lzmainfo
+make clean
+make -j$(nproc) && make -C tests/ossfuzz && \
+    cp tests/ossfuzz/config/fuzz.options $OUT/ && \
+    cp tests/ossfuzz/config/fuzz.dict $OUT && \
+    find $SRC/xz/tests/files -name "*.xz" \
+    -exec zip -ujq $OUT/fuzz_seed_corpus.zip "{}" \;

--- a/projects/xz/project.yaml
+++ b/projects/xz/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://tukaani.org/xz/"
+primary_contact: "lasse.collin@tukaani.org"
+auto_ccs:
+  - "bshas3@gmail.com"
+sanitizers:
+  - address
+  - memory
+  - undefined


### PR DESCRIPTION
This PR (CC #402 )

- Adds xz/lzma decompressor to oss-fuzz
- Fuzzer target integrated in upstream xz
- Incorporates feedback from #1892 

Shout outs to 
- Lasse Collin whose timely feedback and interest were instrumental for this integration
- @pdknsk whose initial efforts gave momentum to this PR