### PR TITLE
Add *ring*.

### DIFF
--- a/projects/ring/project.yaml
+++ b/projects/ring/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/briansmith/ring"
+primary_contact: "brian@briansmith.org"
+sanitizers:
+- address
+- memory
+- undefined


### PR DESCRIPTION
*ring* is a Rust cryptography project that is a fork of BoringSSL. It is used by many Rust-based projects; see https://crates.io/crates/ring/reverse_dependencies for the tip of the iceberg. Many projects use *ring* through Rustls, the Rust TLS implementation.