### PR TITLE
ffmpeg: Build fdk-aac with -fno-sanitize=shift-base

### DIFF
--- a/projects/ffmpeg/build.sh
+++ b/projects/ffmpeg/build.sh
@@ -54,6 +54,7 @@ make install
 
 cd $SRC/fdk-aac
 autoreconf -fiv
+CXXFLAGS="$CXXFLAGS -fno-sanitize=shift-base" \
 ./configure --prefix="$FFMPEG_DEPS_PATH" --disable-shared
 make clean
 make -j$(nproc) all


### PR DESCRIPTION
The upstream fdk-aac project at Fraunhofer currently have no active
plans to avoid left shifts of negative values, so disable this
checker to help find other potential issues.