### PR TITLE
zlib-ng: point to official git repo

### DIFF
--- a/projects/zlib-ng/Dockerfile
+++ b/projects/zlib-ng/Dockerfile
@@ -18,8 +18,6 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER sebpop@gmail.com
 RUN apt-get update && apt-get install -y make
 
-# FIXME: point to the official zlib-ng once the patch to enable oss-fuzz is accepted.
-# RUN git clone --depth 1 https://github.com/Dead2/zlib-ng.git
-RUN git clone --depth 1 https://github.com/sebpop/zlib-ng.git
+RUN git clone --depth 1 -b develop https://github.com/Dead2/zlib-ng.git
 WORKDIR zlib-ng
 COPY build.sh $SRC/


### PR DESCRIPTION
We now can point the git clone of oss-fuzz to the upstream project git:
https://github.com/Dead2/zlib-ng/commit/4999e84a04f62bb2f3f0c8cf0fd869f9dcdf29e4