### PR TITLE
Add basic config for git fuzzing.

### DIFF
--- a/projects/git/Dockerfile
+++ b/projects/git/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER steadmon@google.com
+RUN apt-get update && \
+    apt-get install -y cvs cvsps gettext libcgi-pm-perl libcurl4-gnutls-dev \
+        libdbd-sqlite3-perl liberror-perl libexpat1-dev libhttp-date-perl \
+        libio-pty-perl libmailtools-perl libpcre2-dev libpcre3-dev libsvn-perl \
+        libtime-modules-perl libyaml-perl libz-dev python subversion tcl unzip \
+        asciidoc docbook-xsl xmlto libssl-dev
+RUN git clone --depth 1 https://github.com/git/git git
+WORKDIR git
+COPY build.sh $SRC/

--- a/projects/git/Dockerfile
+++ b/projects/git/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && \
         libdbd-sqlite3-perl liberror-perl libexpat1-dev libhttp-date-perl \
         libio-pty-perl libmailtools-perl libpcre2-dev libpcre3-dev libsvn-perl \
         libtime-modules-perl libyaml-perl libz-dev python subversion tcl unzip \
-        asciidoc docbook-xsl xmlto libssl-dev
+        asciidoc docbook-xsl xmlto libssl-dev zip
 RUN git clone --depth 1 https://github.com/git/git git
 WORKDIR git
 COPY build.sh $SRC/

--- a/projects/git/build.sh
+++ b/projects/git/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 # build fuzzers
-make -j$(nproc) CC=$CC CXX=$CXX CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS" \
+make -j$(nproc) CC=$CC CXX=$CXX CFLAGS="$CXXFLAGS" \
   LIB_FUZZING_ENGINE=$LIB_FUZZING_ENGINE fuzz-all
 
 # copy fuzzers

--- a/projects/git/build.sh
+++ b/projects/git/build.sh
@@ -19,7 +19,24 @@
 make -j$(nproc) CC=$CC CXX=$CXX CFLAGS="$CXXFLAGS" \
   LIB_FUZZING_ENGINE=$LIB_FUZZING_ENGINE fuzz-all
 
+FUZZERS="fuzz-pack-headers fuzz-pack-idx"
+
 # copy fuzzers
-for fuzzer in fuzz-pack-headers fuzz-pack-idx ; do
+for fuzzer in $FUZZERS ; do
   cp $fuzzer $OUT
+done
+
+# build corpora from Git's own packfiles
+zip -j $OUT/fuzz-pack-idx_seed_corpus.zip .git/objects/pack/*.idx
+for packfile in .git/objects/pack/*.pack ; do
+  dd ibs=1 skip=12 if=$packfile of=$packfile.trimmed
+done
+zip -j $OUT/fuzz-pack-headers_seed_corpus.zip .git/objects/pack/*.pack.trimmed
+
+# Mute stderr
+for fuzzer in $FUZZERS ; do
+  cat >$OUT/$fuzzer.options << EOF
+[libfuzzer]
+close_fd_mask = 2
+EOF
 done

--- a/projects/git/build.sh
+++ b/projects/git/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -eu
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# build fuzzers
+make -j$(nproc) CC=$CC CXX=$CXX CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS" \
+  LIB_FUZZING_ENGINE=$LIB_FUZZING_ENGINE fuzz-all
+
+# copy fuzzers
+for fuzzer in fuzz-pack-headers fuzz-pack-idx ; do
+  cp $fuzzer $OUT
+done

--- a/projects/git/project.yaml
+++ b/projects/git/project.yaml
@@ -1,0 +1,3 @@
+homepage: "https://git-scm.com"
+primary_contact: "steadmon@google.com"
+experimental: True


### PR DESCRIPTION
Add an experimental-mode config for fuzzing Git. These are new fuzzing targets, so we're not ready to send fuzz reports to any bug trackers or mailing lists just yet. I'll be keeping an eye on the dashboard and evaluating the results.