### PR TITLE
[libcoap] build.sh: disable DTLS

### DIFF
--- a/projects/libcoap/build.sh
+++ b/projects/libcoap/build.sh
@@ -16,6 +16,7 @@
 ################################################################################
 
 ./autogen.sh && ./configure --disable-doxygen --disable-manpages \
+                            --disable-dtls                       \
     && make -j$(nproc)
 
 # build all fuzzer targets


### PR DESCRIPTION
OSS fuzzing currently is done without DTLS support. As of
4.2.0-rc2, libcoap's configuration builds against OpenSSL by
default and thus `--disable-dtls` must be passed to the
configuration script.

Fixes issue 11309