### PR TITLE
[wget2] Build MHD from latest tarball

### DIFF
--- a/projects/wget2/Dockerfile
+++ b/projects/wget2/Dockerfile
@@ -44,7 +44,7 @@ RUN git clone --depth=1 --recursive https://gitlab.com/libidn/libidn2.git
 RUN git clone --depth=1 --recursive https://github.com/rockdaboot/libpsl.git
 RUN git clone --depth=1 https://git.lysator.liu.se/nettle/nettle.git
 RUN git clone --depth=1 https://gitlab.com/gnutls/gnutls.git
-RUN git clone --depth=1 --recursive https://gnunet.org/git/libmicrohttpd.git
+RUN wget -O- https://ftp.gnu.org/pub/gnu/libmicrohttpd/libmicrohttpd-latest.tar.gz|tar xz
 
 RUN git clone --recursive https://gitlab.com/gnuwget/wget2.git
 

--- a/projects/wget2/build.sh
+++ b/projects/wget2/build.sh
@@ -71,8 +71,7 @@ CFLAGS="$GNUTLS_CFLAGS" \
 make -j$(nproc)
 make install
 
-cd $SRC/libmicrohttpd
-./bootstrap
+cd $SRC/libmicrohttpd-*
 LIBS="-lgnutls -lnettle -lhogweed -lidn2 -lunistring" \
 ./configure --prefix=$WGET2_DEPS_PATH --disable-doc --disable-examples --disable-shared --enable-static
 make -j$(nproc)


### PR DESCRIPTION
Building libmicrohttpd (MHD) from git repo requires an up-to-date version of gettext since the latest release. The OSS-Fuzz image is too old for that. Building from tarball doesn't have that requirement.