### PR TITLE
Dav1d: remove experimental flag

### DIFF
--- a/projects/dav1d/project.yaml
+++ b/projects/dav1d/project.yaml
@@ -11,3 +11,4 @@ sanitizers:
   - memory
   - undefined
 experimental: True
+coverage_extra_args: -ignore-filename-regex=.*dump.h

--- a/projects/dav1d/project.yaml
+++ b/projects/dav1d/project.yaml
@@ -10,5 +10,4 @@ sanitizers:
   - address
   - memory
   - undefined
-experimental: True
 coverage_extra_args: -ignore-filename-regex=.*dump.h


### PR DESCRIPTION
Also includes a debug only header from the coverage report.