### PR TITLE
Set CXX cmake flags for linking with libFuzzer

### DIFF
--- a/projects/minizip/build.sh
+++ b/projects/minizip/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 # Build project
-cmake . -DCMAKE_C_FLAGS="$CFLAGS" -DBUILD_FUZZ_TEST=ON
+cmake . -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DBUILD_FUZZ_TEST=ON
 make clean
 make -j$(nproc)
 


### PR DESCRIPTION
This pull requests sets the cmake C++ flags since C++ is required for linking against libFuzzer.