### PR TITLE
[harfbuzz] Copy shared libraries to out

### DIFF
--- a/projects/harfbuzz/build.sh
+++ b/projects/harfbuzz/build.sh
@@ -36,6 +36,8 @@ $CXX $CXXFLAGS -std=c++11 -Isrc \
     ./test/fuzzing/hb-subset-fuzzer.cc -o $OUT/hb-subset-fuzzer \
     -lFuzzingEngine ./src/.libs/libharfbuzz-subset.so ./src/.libs/libharfbuzz.so
 
+cp ./src/.libs/libharfbuzz-subset.so.* ./src/.libs/libharfbuzz.so.* $OUT
+
 # Archive and copy to $OUT seed corpus if the build succeeded.
 mkdir all-fonts
 for d in \


### PR DESCRIPTION
Now that we link against shared libraries, this is necessary.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=11384