### PR TITLE
Typo fix: hongfuzz -> honggfuzz

### DIFF
--- a/docs/reproducing.md
+++ b/docs/reproducing.md
@@ -81,6 +81,6 @@ Our infrastructure runs some sanity tests to make sure that your build was corre
 
 ```bash
 $ python infra/helper.py build_image $PROJECT_NAME
-$ python infra/helper.py build_fuzzers --sanitizer <address/memory/undefined> --engine <libfuzzer/afl/hongfuzz> $PROJECT_NAME
-$ python infra/helper.py check_build  --sanitizer <address/memory/undefined> --engine <libfuzzer/afl/hongfuzz> $PROJECT_NAME <fuzz_target_name>
+$ python infra/helper.py build_fuzzers --sanitizer <address/memory/undefined> --engine <libfuzzer/afl/honggfuzz> $PROJECT_NAME
+$ python infra/helper.py check_build  --sanitizer <address/memory/undefined> --engine <libfuzzer/afl/honggfuzz> $PROJECT_NAME <fuzz_target_name>
 ```


### PR DESCRIPTION
Fix typo'd engine name in the "Reproducing OSS-Fuzz issues" doc.