### PR TITLE
libvpx: update memory limit for msan

### DIFF
--- a/projects/libvpx/build.sh
+++ b/projects/libvpx/build.sh
@@ -21,10 +21,19 @@ rm -rf ${build_dir}
 mkdir -p ${build_dir}
 pushd ${build_dir}
 
+# oss-fuzz has 2 GB total memory allocation limit. So, we limit per-allocation
+# limit in libvpx to 1 GB to avoid OOM errors. A smaller per-allocation is
+# needed for MemorySanitizer (see bug oss-fuzz:9497 and bug oss-fuzz:9499).
+if [[ $CFLAGS = *sanitize=memory* ]]; then
+  extra_c_flags='-DVPX_MAX_ALLOCABLE_MEMORY=536870912'
+else
+  extra_c_flags='-DVPX_MAX_ALLOCABLE_MEMORY=1073741824'
+fi
+
 LDFLAGS="$CXXFLAGS" LD=$CXX $SRC/libvpx/configure \
     --disable-unit-tests \
     --size-limit=12288x12288 \
-    --extra-cflags="-DVPX_MAX_ALLOCABLE_MEMORY=1073741824" \
+    --extra-cflags="${extra_c_flags}" \
     --disable-webm-io \
     --enable-debug
 make -j$(nproc) all


### PR DESCRIPTION
Reduce VPX_MAX_ALLOCABLE_MEMORY in msan builds as it has a higher overhead causing more frequent OOMs in this configuration. This matches the limits in libaom.