### PR TITLE
[bignum-fuzzer] Resolve build failure

### DIFF
--- a/projects/bignum-fuzzer/Dockerfile
+++ b/projects/bignum-fuzzer/Dockerfile
@@ -21,7 +21,7 @@ RUN add-apt-repository -y ppa:gophers/archive && apt-get update && apt-get insta
 RUN ln -s /usr/lib/go-1.9/bin/go /usr/bin/go
 
 # Install Rust nightly
-RUN curl -s https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly --date=2018-08-26
+RUN curl -s https://static.rust-lang.org/rustup.sh | sh -s --
 
 RUN git clone --depth 1 https://github.com/guidovranken/bignum-fuzzer
 RUN git clone --depth 1 https://github.com/openssl/openssl


### PR DESCRIPTION
Along with changes applied to https://github.com/guidovranken/bignum-fuzzer, this fixes the current build failure of bignum-fuzzer (succesfully tested locally).