### PR TITLE
[infra] optionally allow running fuzzers with run_minijail during the build checks

### DIFF
--- a/infra/base-images/base-runner/bad_build_check
+++ b/infra/base-images/base-runner/bad_build_check
@@ -95,6 +95,10 @@ function check_startup_crash {
   if [[ "$FUZZING_ENGINE" = libfuzzer ]]; then
     $FUZZER -runs=$MIN_NUMBER_OF_RUNS &>$FUZZER_OUTPUT
     CHECK_PASSED=$(egrep "Done $MIN_NUMBER_OF_RUNS runs" -c $FUZZER_OUTPUT)
+    if [[ "$CHECK_PASSED" -ne "0" && "${RUN_MINIJAIL:-no}" = yes ]]; then
+      /usr/local/bin/run_minijail $FUZZER -runs=$MIN_NUMBER_OF_RUNS &>$FUZZER_OUTPUT
+      CHECK_PASSED=$(egrep "Done $MIN_NUMBER_OF_RUNS runs" -c $FUZZER_OUTPUT)
+    fi
   elif [[ "$FUZZING_ENGINE" = afl ]]; then
     AFL_NO_UI=1 SKIP_SEED_CORPUS=1 timeout --preserve-status -s INT 20s run_fuzzer $FUZZER_NAME &>$FUZZER_OUTPUT
     if [ $(egrep "target binary (crashed|terminated)" -c $FUZZER_OUTPUT) -eq 0 ]; then

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -98,6 +98,9 @@ def main():
   _add_engine_args(check_build_parser)
   _add_sanitizer_args(check_build_parser)
   _add_environment_args(check_build_parser)
+  check_build_parser.add_argument('--run-minijail', dest='run_minijail',
+                                    action='store_true',
+                                    help='run fuzzers with run-minijail.')
   check_build_parser.add_argument('project_name', help='name of the project')
   check_build_parser.add_argument('fuzzer_name', help='name of the fuzzer',
                                   nargs='?')
@@ -474,6 +477,8 @@ def check_build(args):
       'FUZZING_ENGINE=' + args.engine,
       'SANITIZER=' + args.sanitizer
   ]
+  if args.run_minijail:
+    env += ["RUN_MINIJAIL=yes"]
   if args.e:
     env += args.e
 


### PR DESCRIPTION
This should help catch issues like https://github.com/google/oss-fuzz/issues/1983,
which seems to be useful at least until minijail is removed.

It's turned off by default because apparently nobody else writes
monstrous fuzzers that try to create namespaces and mount fake filesystems :-)

Kind of a follow-up to 9aa11dbd251f393eee0e5d199797d0293e69cd71.