### PR TITLE
[infra] exits with a non-zero code when a fuzzer doesn't pass the build checks

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -484,8 +484,9 @@ def check_build(args):
 
   if args.fuzzer_name:
     run_args += [
-        'bad_build_check',
-        os.path.join('/out', args.fuzzer_name)
+        'bash',
+        '-c',
+        '[[ $(bad_build_check {0} | tee /dev/tty | wc -l) -eq 0 ]]'.format(os.path.join('/out', args.fuzzer_name))
     ]
   else:
     run_args.append('test_all')


### PR DESCRIPTION
Closes https://github.com/google/oss-fuzz/issues/1987.