### PR TITLE
Don't use alias in project.yaml/web interface access

### DIFF
--- a/projects/nss/project.yaml
+++ b/projects/nss/project.yaml
@@ -1,7 +1,7 @@
 homepage: "https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS"
 primary_contact: "fkiefer@mozilla.com"
 auto_ccs:
-  - "jc@mozilla.com"
+  - "jjones@mozilla.com"
 fuzzing_engines:
   - libfuzzer
   - afl


### PR DESCRIPTION
Is access to oss-fuzz.com dependent on this? It looks like JC doesn't have access to the web interface with the given email address, which is an alias for `jjones@mozilla.com`.