### PR TITLE
[infra] Add return value to bad_build_checks script (fixes #1987).

### DIFF
--- a/infra/base-images/base-runner/bad_build_check
+++ b/infra/base-images/base-runner/bad_build_check
@@ -60,7 +60,7 @@ function check_instrumentation {
       echo "BAD BUILD: $FUZZER does not seem to have coverage instrumentation."
 
       # Bail out as the further check does not make any sense, there are 0 PCs.
-      return
+      return 1
     fi
 
     local NUMBER_OF_EDGES=$(grep -Po "INFO: Loaded [[:digit:]]+ module.*\(.*(counters|guards)\):[[:space:]]+\K[[:digit:]]+" $FUZZER_OUTPUT)
@@ -77,12 +77,11 @@ function check_instrumentation {
     if (( $CHECK_FAILED > 0 )); then
       echo "BAD BUILD: $FUZZER does not seem to have coverage instrumentation."
     fi
-    return
-  else
-    # TODO: add checks for other fuzzing engines if possible.
-    return
+    return 1
   fi
 
+  # TODO: add checks for other fuzzing engines if possible.
+  return 0
 }
 
 # Verify that the given fuzz target has been built properly and works.
@@ -108,7 +107,10 @@ function check_startup_crash {
   if [ "$CHECK_PASSED" -eq "0" ]; then
     echo "BAD BUILD: $FUZZER seems to have either startup crash or exit:"
     cat $FUZZER_OUTPUT
+    return 1
   fi
+
+  return 0
 }
 
 # Mixed sanitizers check for ASan build.
@@ -121,15 +123,20 @@ function check_asan_build {
   # Perform all the checks for more detailed error message.
   if (( $ASAN_CALLS < $ASAN_CALLS_THRESHOLD_FOR_ASAN_BUILD )); then
     echo "BAD BUILD: $FUZZER does not seem to be compiled with ASan."
+    return 1
   fi
 
   if (( $MSAN_CALLS > $MSAN_CALLS_THRESHOLD_FOR_NON_MSAN_BUILD )); then
     echo "BAD BUILD: ASan build of $FUZZER seems to be compiled with MSan."
+    return 1
   fi
 
   if (( $UBSAN_CALLS > $UBSAN_CALLS_THRESHOLD_FOR_NON_UBSAN_BUILD )); then
     echo "BAD BUILD: ASan build of $FUZZER seems to be compiled with UBSan."
+    return 1
   fi
+
+  return 0
 }
 
 # Mixed sanitizers check for MSan build.
@@ -142,15 +149,20 @@ function check_msan_build {
   # Perform all the checks for more detailed error message.
   if (( $ASAN_CALLS > $ASAN_CALLS_THRESHOLD_FOR_NON_ASAN_BUILD )); then
     echo "BAD BUILD: MSan build of $FUZZER seems to be compiled with ASan."
+    return 1
   fi
 
   if (( $MSAN_CALLS < $MSAN_CALLS_THRESHOLD_FOR_MSAN_BUILD )); then
     echo "BAD BUILD: $FUZZER does not seem to be compiled with MSan."
+    return 1
   fi
 
   if (( $UBSAN_CALLS > $UBSAN_CALLS_THRESHOLD_FOR_NON_UBSAN_BUILD )); then
     echo "BAD BUILD: MSan build of $FUZZER seems to be compiled with UBSan."
+    return 1
   fi
+
+  return 0
 }
 
 # Mixed sanitizers check for UBSan build.
@@ -164,20 +176,23 @@ function check_ubsan_build {
     # Ignore UBSan checks for fuzzing engines other than libFuzzer because:
     # A) we (probably) are not going to use those with UBSan
     # B) such builds show indistinguishable number of calls to UBSan
-    return
+    return 0
   fi
 
   # Perform all the checks for more detailed error message.
   if (( $ASAN_CALLS > $ASAN_CALLS_THRESHOLD_FOR_NON_ASAN_BUILD )); then
     echo "BAD BUILD: UBSan build of $FUZZER seems to be compiled with ASan."
+    return 1
   fi
 
   if (( $MSAN_CALLS > $MSAN_CALLS_THRESHOLD_FOR_NON_MSAN_BUILD )); then
     echo "BAD BUILD: UBSan build of $FUZZER seems to be compiled with MSan."
+    return 1
   fi
 
   if (( $UBSAN_CALLS < $UBSAN_CALLS_THRESHOLD_FOR_UBSAN_BUILD )); then
     echo "BAD BUILD: $FUZZER does not seem to be compiled with UBSan."
+    return 1
   fi
 }
 
@@ -190,12 +205,14 @@ function check_mixed_sanitizers {
   local UBSAN_CALLS=$(objdump -dC $FUZZER | egrep "callq\s+[0-9a-f]+\s+<__ubsan" -c)
 
   if [[ "$SANITIZER" = address ]]; then
-    check_asan_build $FUZZER $ASAN_CALLS $MSAN_CALLS $UBSAN_CALLS
+    return $(check_asan_build $FUZZER $ASAN_CALLS $MSAN_CALLS $UBSAN_CALLS)
   elif [[ "$SANITIZER" = memory ]]; then
-    check_msan_build $FUZZER $ASAN_CALLS $MSAN_CALLS $UBSAN_CALLS
+    return $(check_msan_build $FUZZER $ASAN_CALLS $MSAN_CALLS $UBSAN_CALLS)
   elif [[ "$SANITIZER" = undefined ]]; then
-    check_ubsan_build $FUZZER $ASAN_CALLS $MSAN_CALLS $UBSAN_CALLS
+    return $(check_ubsan_build $FUZZER $ASAN_CALLS $MSAN_CALLS $UBSAN_CALLS)
   fi
+
+  return 0
 }
 
 # Verify that the given fuzz target doesn't crash on the seed corpus.
@@ -205,7 +222,7 @@ function check_seed_corpus {
   local FUZZER_OUTPUT="/tmp/$FUZZER_NAME.output"
 
   if [[ "$FUZZING_ENGINE" != libfuzzer ]]; then
-    return
+    return 0
   fi
 
   # Set up common fuzzing arguments, otherwise "run_fuzzer" errors out.
@@ -219,19 +236,33 @@ function check_seed_corpus {
   if [ $? -ne 0 ]; then
     echo "BAD BUILD: $FUZZER has a crashing input in its seed corpus:"
     cat $FUZZER_OUTPUT
+    return 1
   fi
+
+  return 0
 }
 
 
 function main {
   local FUZZER=$1
+  local checks_failed=0
+  local result=0
 
   check_instrumentation $FUZZER
+  result=$?
+  checks_failed=$(( $checks_failed + $result ))
+
   check_mixed_sanitizers $FUZZER
+  result=$?
+  checks_failed=$(( $checks_failed + $result ))
+
   check_startup_crash $FUZZER
+  result=$?
+  checks_failed=$(( $checks_failed + $result ))
 
   # TODO: re-enable after introducing bug auto-filing for bad builds.
   # check_seed_corpus $FUZZER
+  return $checks_failed
 }
 
 
@@ -244,3 +275,4 @@ fi
 FUZZER=$1
 
 main $FUZZER
+exit $?


### PR DESCRIPTION
```
$ python infra/helper.py check_build bad_example bad_example_startup_crash
Running: docker run --rm -i --privileged -e FUZZING_ENGINE=libfuzzer -e SANITIZER=address -v /usr/local/google/home/mmoroz/Projects/oss-fuzz/build/out/bad_example:/out -t gcr.io/oss-fuzz-base/base-runner bad_build_check /out/bad_example_startup_crash
BAD BUILD: /out/bad_example_startup_crash seems to have either startup crash or exit:
INFO: Seed: 677679582
INFO: Loaded 1 modules   (662 inline 8-bit counters): 662 [0x8cf3e8, 0x8cf67e), 
INFO: Loaded 1 PC tables (662 PCs): 662 [0x674900,0x677260), 
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
Check build failed.
$ echo $?
1
```