### PR TITLE
Added clamav project.

### DIFF
--- a/projects/clamav/Dockerfile
+++ b/projects/clamav/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright (C) 2018 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER clamav-fuzz@gmail.com
+RUN apt-get update && apt-get install -y libssl-dev
+RUN git clone --depth 1 https://github.com/Cisco-Talos/clamav-devel.git
+RUN git clone --depth 1 https://github.com/Cisco-Talos/clamav-fuzz-corpus.git
+
+WORKDIR clamav-devel
+COPY build.sh $SRC/

--- a/projects/clamav/build.sh
+++ b/projects/clamav/build.sh
@@ -1,0 +1,102 @@
+#!/bin/bash -eu
+# Copyright (C) 2018 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+export CXXFLAGS="-std=c++11 -stdlib=libc++ $CXXFLAGS"
+
+#
+# Build the library.
+#
+./configure --with-libjson=no --with-pcre=no --enable-static=yes --enable-shared=no --disable-llvm --host=x86_64-unknown-linux-gnu
+make clean
+make -j"$(nproc)"
+
+#
+# Build the fuzz targets.
+#
+
+# `scanmap`
+# ----------
+$CXX $CXXFLAGS -Ilibclamav/ ./fuzz/clamav_scanmap_fuzzer.cpp \
+	-o $OUT/clamav_scanmap_fuzzer \
+    ${LIB_FUZZING_ENGINE} libclamav/.libs/libclamav.a libclamav/.libs/libclammspack.a \
+    -Wl,-Bstatic -lssl -lcrypto -lz -Wl,-Bdynamic -lc -lpthread -ldl
+
+for type in ARCHIVE MAIL OLE2 PDF HTML PE ELF SWF XMLDOCS HWP3; do
+    $CXX $CXXFLAGS -Ilibclamav/ ./fuzz/clamav_scanmap_fuzzer.cpp \
+        -o "${OUT}/clamav_scanmap_${type}_fuzzer" "-DCLAMAV_FUZZ_${type}" \
+        ${LIB_FUZZING_ENGINE} libclamav/.libs/libclamav.a libclamav/.libs/libclammspack.a \
+        -Wl,-Bstatic -lssl -lcrypto -lz -Wl,-Bdynamic -lc -lpthread -ldl
+done
+
+# `scanfile`
+# ----------
+$CXX $CXXFLAGS -Ilibclamav/ ./fuzz/clamav_scanfile_fuzzer.cpp \
+	-o $OUT/clamav_scanfile_fuzzer \
+    ${LIB_FUZZING_ENGINE} libclamav/.libs/libclamav.a libclamav/.libs/libclammspack.a \
+    -Wl,-Bstatic -lssl -lcrypto -lz -Wl,-Bdynamic -lc -lpthread -ldl
+
+for type in ARCHIVE MAIL OLE2 PDF HTML PE ELF SWF XMLDOCS HWP3; do
+    $CXX $CXXFLAGS -Ilibclamav/ ./fuzz/clamav_scanfile_fuzzer.cpp \
+        -o "${OUT}/clamav_scanfile_${type}_fuzzer" "-DCLAMAV_FUZZ_${type}" \
+        ${LIB_FUZZING_ENGINE} libclamav/.libs/libclamav.a libclamav/.libs/libclammspack.a \
+        -Wl,-Bstatic -lssl -lcrypto -lz -Wl,-Bdynamic -lc -lpthread -ldl
+done
+
+# `dbload`
+# --------
+for type in CDB CFG CRB FP FTM HDB HSB IDB IGN IGN2 LDB MDB MSB NDB PDB WDB YARA; do
+    $CXX $CXXFLAGS -Ilibclamav/ ./fuzz/clamav_dbload_fuzzer.cpp \
+        -o "${OUT}/clamav_dbload_${type}_fuzzer" "-DCLAMAV_FUZZ_${type}" \
+        ${LIB_FUZZING_ENGINE} libclamav/.libs/libclamav.a libclamav/.libs/libclammspack.a \
+        -Wl,-Bstatic -lssl -lcrypto -lz -Wl,-Bdynamic -lc -lpthread -ldl
+done
+
+#
+# Collect the fuzz corpora.
+#
+
+# `scanfile` & `scanmap`
+# ----------
+mkdir all-scantype-seeds
+
+for type in ARCHIVE MAIL OLE2 PDF HTML PE ELF SWF XMLDOCS HWP3; do
+	# Prepare seed corpus for the type-specific fuzz targets.
+	zip $OUT/clamav_scanfile_${type}_fuzzer_seed_corpus.zip $SRC/clamav-fuzz-corpus/scantype/${type}/*
+	zip $OUT/clamav_scanmap_${type}_fuzzer_seed_corpus.zip $SRC/clamav-fuzz-corpus/scantype/${type}/*
+
+	# Prepare dictionary for the type-specific fuzz targets (may not exist for all types).
+	cp $SRC/clamav-fuzz-corpus/scantype/${type}.dict $OUT/clamav_scanfile_${type}_fuzzer.dict 2>/dev/null || :
+	cp $SRC/clamav-fuzz-corpus/scantype/${type}.dict $OUT/clamav_scanmap_${type}_fuzzer.dict 2>/dev/null || :
+
+	# Copy seeds for the generic fuzz target.
+	cp $SRC/clamav-fuzz-corpus/scantype/${type}/* all-scantype-seeds/
+done
+
+# Prepare seed corpus for the generic fuzz target.
+cp $SRC/clamav-fuzz-corpus/scantype/other/* all-scantype-seeds/
+zip $OUT/clamav_scanfile_fuzzer_seed_corpus.zip all-scantype-seeds/*
+zip $OUT/clamav_scanmap_fuzzer_seed_corpus.zip all-scantype-seeds/*
+
+# `dbload`
+# --------
+for type in CDB CFG CRB FP FTM HDB HSB IDB IGN IGN2 LDB MDB MSB NDB PDB WDB YARA; do
+	# Prepare seed corpus for the type-specific fuzz targets.
+	zip $OUT/clamav_dbload_${type}_fuzzer_seed_corpus.zip $SRC/clamav-fuzz-corpus/database/${type}/*
+
+	# Prepare dictionary for the type-specific fuzz targets (may not exist for all types).
+	cp $SRC/clamav-fuzz-corpus/database/${type}.dict $OUT/clamav_dbload_${type}_fuzzer.dict 2>/dev/null || :
+done

--- a/projects/clamav/clamav-scanfile-fuzzer.options
+++ b/projects/clamav/clamav-scanfile-fuzzer.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+timeout = 5

--- a/projects/clamav/project.yaml
+++ b/projects/clamav/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://www.clamav.net/"
+primary_contact: "clamav-fuzz@gmail.com"
+auto_ccs:
+    - clamav-bugs@external.cisco.com
+sanitizers:
+ - address
+ - undefined
+ - memory


### PR DESCRIPTION
Replacement PR for https://github.com/google/oss-fuzz/pull/1048 to add ClamAV using the ideal-integration strategy where fuzz targets exist in the project repository, and a fuzz corpus exists in a separate repository (these repositories are already configured, ready to go for oss-fuzz). 

I'm able to test the fuzzer targets locally using the instructions [here](https://github.com/google/oss-fuzz/blob/master/docs/new_project_guide.md#testing-locally). 

In addition, `make fuzz-check` in clamav-devel will test the standalone fuzz targets.  This requires:
1. A checkout of clamav-fuzz-corpus next to clamav-devel.
2. configuring clamav with `--enable-fuzz --with-libjson=no --with-pcre=no --enable-static=yes --enable-shared=no --disable-llvm`, along with -fsanitize, -fsanitize-coverage CFLAGS and CXXFLAGS configured if desired. 

I should point out a couple of things:
1. At present, my build.sh sets the -fsanitize, -fsanitize-coverage options CFLAGS and CXXFLAGS. Do I need to remove these so that oss-fuzz can set them itself?
2. Two of my fuzz target types (the [scanfile](https://github.com/Cisco-Talos/clamav-devel/blob/dev/0.102/fuzz/clamav_scanfile_fuzzer.cpp) and [dbload](https://github.com/Cisco-Talos/clamav-devel/blob/dev/0.102/fuzz/clamav_dbload_fuzzer.cpp) fuzzers) write the fuzz data to a file with a specific file extension, because the API's in question either require a specific file extension or the behavior may vary if an extension is provided. Is this is ok?
3. My .options file is very bare-bones.  Are there any options that you'd recommend I add/change?
4. I created a clamav-fuzz gmail account different from the account linked to my github account to use for Clusterfuzz login, per this requirement: https://github.com/google/oss-fuzz/blob/master/docs/faq.md#why-do-you-require-a-google-account-for-authentication 
