### PR TITLE
Use new FUZZ_CXXFLAGS when building git.

### DIFF
--- a/projects/git/build.sh
+++ b/projects/git/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 # build fuzzers
-make -j$(nproc) CC=$CC CXX=$CXX CFLAGS="$CXXFLAGS" \
+make -j$(nproc) CC=$CC CXX=$CXX CFLAGS="$CFLAGS" FUZZ_CXXFLAGS="$CXXFLAGS" \
   LIB_FUZZING_ENGINE=$LIB_FUZZING_ENGINE fuzz-all
 
 FUZZERS="fuzz-pack-headers fuzz-pack-idx"


### PR DESCRIPTION
This removes a ton of build warnings and prevents future build breakage
in the case where incompatible CFLAGS / CXXFLAGS are required.