### PR TITLE
[knot-dns] use libnettle 3.4.1 to build gnutls

### DIFF
--- a/projects/knot-dns/Dockerfile
+++ b/projects/knot-dns/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && \
                        gperf libtool make pkg-config texinfo wget
 
 RUN git clone --depth=1 --recursive https://git.savannah.gnu.org/git/libunistring.git
-RUN git clone --depth=1 https://git.lysator.liu.se/nettle/nettle.git
+RUN git clone https://git.lysator.liu.se/nettle/nettle.git
 RUN git clone --depth=1 https://gitlab.com/gnutls/gnutls.git
 
 RUN git clone --depth=1 https://gitlab.labs.nic.cz/knot/knot-dns

--- a/projects/knot-dns/build.sh
+++ b/projects/knot-dns/build.sh
@@ -39,7 +39,9 @@ if [[ $CFLAGS = *sanitize=memory* ]]; then
   NETTLE_CONFIGURE_FLAGS="--disable-assembler --disable-fat"
 fi
 
+
 cd $SRC/nettle
+git checkout tags/nettle_3.4.1_release_20181204
 bash .bootstrap
 ./configure --enable-mini-gmp --enable-static --disable-shared --disable-documentation --prefix=$DEPS_PATH $NETTLE_CONFIGURE_FLAGS
 ( make -j$(nproc) || make -j$(nproc) ) && make install


### PR DESCRIPTION
This patch fixes the knot-dns build.

`gnutls` is a dependency of the knot-dns fuzz target builds. The latest `gnutls` build now depends on `libnettle` version `3.4.1`, but the `nettle` master branch builds version 3.4. I'm not sure how the inconsistency between these two projects came to pass, but regardless this patch explicitly checks out the `libnettle 3.4.1` release from the `nettle` repo before building `gnutls`.

This may be a temporary fix: It is possible that at some point in the future `gnutls` will bump the `nettle` dependency up -- at that point we should consider switching back to the `nettle` master branch here.

/cc @salzmdan 