### PR TITLE
Limit the amount of parallel bazel jobs to not get into an OOM

### DIFF
--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -97,7 +97,7 @@ declare -r LINK_ARGS="\
 "
 
 # This should always look as successful despite linking error mentioned above.
-bazel build ${EXTRA_FLAGS} -k //tensorflow/core/kernels/fuzzing:all || true
+bazel build --jobs=2 ${EXTRA_FLAGS} -k //tensorflow/core/kernels/fuzzing:all || true
 
 # For each fuzzer target, we only have to link it manually to get the binary.
 for fuzzer in ${FUZZERS}; do


### PR DESCRIPTION
The failure in https://github.com/google/oss-fuzz/pull/1937#issuecomment-445867485 seems to indicate an OOM during the bazel build. Limit the number of jobs to prevent it