### PR TITLE
[tensorflow] Reduce size of fuzzers by stripping them (66% reduction)

### DIFF
--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -110,6 +110,11 @@ for fuzzer in ${FUZZERS}; do
   ${CXX} ${CXXFLAGS} -lFuzzingEngine -o ${OUT}/${fz} ${LINK_ARGS} -Wl,@${lfile}
 done
 
+# Reduce the size of the fuzzers by just stripping them
+for fz in ${OUT}/*; do
+  strip $fz
+done
+
 # For coverage, we need one extra step, see the envoy and grpc projects.
 if [ "$SANITIZER" = "coverage" ]
 then

--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -108,11 +108,9 @@ for fuzzer in ${FUZZERS}; do
 
   # Manually link everything.
   ${CXX} ${CXXFLAGS} -lFuzzingEngine -o ${OUT}/${fz} ${LINK_ARGS} -Wl,@${lfile}
-done
 
-# Reduce the size of the fuzzers by just stripping them
-for fz in ${OUT}/*; do
-  strip $fz
+  # Reduce the size of the fuzzers by just stripping them
+  strip ${OUT}/$fz
 done
 
 # For coverage, we need one extra step, see the envoy and grpc projects.


### PR DESCRIPTION
Just discovered that by stripping the fuzzer binaries their sizes decreases a lot. This is not helping with the build taking too long or OOMing issue, but is a step forward on the path to a better integration