### PR TITLE
[docs] Add link to ClusterFuzz web interface from the main README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ gives the latest build logs for each project.
 
 ## Web Interface
 
-* [oss-fuzz.com](https://oss-fuzz.com)
+* The main page: [oss-fuzz.com](https://oss-fuzz.com)
 * [ClusterFuzz documentation](docs/clusterfuzz.md)
 
 ## Trophies

--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ gives the latest build logs for each project.
 
 (Internal only) [Builds dashboard](https://builder.oss-fuzz.com).
 
+## Web Interface
+
+* [oss-fuzz.com](https://oss-fuzz.com)
+* [ClusterFuzz documentation](docs/clusterfuzz.md)
+
 ## Trophies
 
 [This page](https://bugs.chromium.org/p/oss-fuzz/issues/list?can=1&q=status%3AFixed%2CVerified+Type%3ABug%2CBug-Security+-component%3AInfra+)


### PR DESCRIPTION
As per the feedback from @segfaulthunter 