### PR TITLE
[qpid-proton] Fix .patch after upstream build script change

### DIFF
--- a/projects/qpid-proton/c_tests_fuzz_CMakeLists.patch
+++ b/projects/qpid-proton/c_tests_fuzz_CMakeLists.patch
@@ -1,9 +1,20 @@
+From a0d2345bec4e7538ad7df535323a8acd8bec2d36 Mon Sep 17 00:00:00 2001
+From: Jiri Danek <jdanek@redhat.com>
+Date: Thu, 13 Dec 2018 14:52:09 +0100
+Subject: [PATCH] NO-JIRA: c/test/fuzz patches from oss-fuzz
+
+* NO-JIRA: [c] prefer linking with static library in fuzz tests
+* NO-JIRA: [c] link fuzzing binaries using CXX linker
+---
+ c/tests/fuzz/CMakeLists.txt | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
 diff --git a/c/tests/fuzz/CMakeLists.txt b/c/tests/fuzz/CMakeLists.txt
-index f870d617..c9d46168 100644
+index b4470d59..211252c4 100644
 --- a/c/tests/fuzz/CMakeLists.txt
 +++ b/c/tests/fuzz/CMakeLists.txt
-@@ -32,7 +32,15 @@ add_library (StandaloneFuzzTargetMain STATIC StandaloneFuzzTargetMain.c Standalo
- 
+@@ -32,7 +32,16 @@ add_library (StandaloneFuzzTargetMain STATIC StandaloneFuzzTargetMain.c Standalo
+
  macro (pn_add_fuzz_test test)
    add_executable (${test} ${ARGN})
 -  target_link_libraries (${test} qpid-proton-core ${FUZZING_LIBRARY})
@@ -16,6 +27,9 @@ index f870d617..c9d46168 100644
 +  target_link_libraries (${test} ${FUZZING_QPID_PROTON_CORE_LIBRARY} ${FUZZING_LIBRARY})
 +  # -lFuzzingEngine is a C++ library, which needs c++ std lib
 +  set_target_properties(${test} PROPERTIES LINKER_LANGUAGE CXX)
- 
++
+   list(APPEND fuzz_test_src ${ARGN})
+
    if (FUZZ_REGRESSION_TESTS)
-     # StandaloneFuzzTargetMain cannot walk directory trees
+--
+2.16.5


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=11829

@astitcher We can either have this merged, or we can put it into qpid-proton directly with https://github.com/apache/qpid-proton/pull/172.