### PR TITLE
Add build.sh and Dockerfile for cpython3.

### DIFF
--- a/projects/cpython3/Dockerfile
+++ b/projects/cpython3/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER kusano@google.com
+RUN apt-get update && apt-get install -y make autoconf automake libtool \
+libssl-dev zlib1g-dev   libncurses5-dev libbz2-dev liblzma-dev libsqlite3-dev \
+libffi-dev tcl-dev libgdbm-dev libreadline-dev tk tk-dev
+RUN git clone --depth 1 https://github.com/python/cpython.git cpython
+WORKDIR cpython
+COPY build.sh $SRC/
+

--- a/projects/cpython3/build.sh
+++ b/projects/cpython3/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -eu
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Both configure and make execute programs that return non-zero exit codes due
+# to leaks.
+export ASAN_OPTIONS=detect_leaks=0
+./configure --without-pymalloc --disable-shared --prefix=$OUT LINKCC="$CXX" \
+  LDFLAGS="$CXXFLAGS"
+make -j$(nproc) && make install
+
+for test in $(cat Modules/_xxtestfuzz/fuzz_tests.txt)
+do
+$CC -D _Py_FUZZ_ONE -D _Py_FUZZ_$test $CXXFLAGS Modules/_xxtestfuzz/fuzzer.c \
+  $OUT/lib/libpython3.8.a $($OUT/bin/python3-config --includes) -ldl -lutil \
+  -lm -lFuzzingEngine -lc++ -o $OUT/$test
+done

--- a/projects/cpython3/project.yaml
+++ b/projects/cpython3/project.yaml
@@ -3,3 +3,8 @@ primary_contact: "gps@google.com"
 auto_ccs:
  - "jeanpierreda@google.com"
  - "alex.gaynor@gmail.com"
+ - "kusano@google.com"
+
+sanitizers:
+  - address
+  - undefined


### PR DESCRIPTION
Even when linked statically, it seems that cpython needs to have its
install prefix around. Otherwise, it fails at startup saying that it
can't find its installation prefix. Because of this, I've installed
cpython into $WORK/.

I've tested this with `python infra/helper.py check_build cpython3`.