### PR TITLE
Remove -L flag from rsync to make coverage builds run

### DIFF
--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -115,7 +115,7 @@ if [ "$SANITIZER" = "coverage" ]
 then
   declare -r REMAP_PATH=${OUT}/proc/self/cwd
   mkdir -p ${REMAP_PATH}
-  rsync -aLk ${SRC}/tensorflow ${REMAP_PATH}
+  rsync -ak ${SRC}/tensorflow ${REMAP_PATH}
 fi
 
 # Now that all is done, we just have to copy the existing corpora and


### PR DESCRIPTION
Tested locally and build passes pass this step, though it breaks at the end of the `compile` step, after executing everything from the script (I see the `rm -f` at the end being executed). The errors are

```
cp: cannot stat '/src/honggfuzz/hfuzz_cc/hfuzz-clang': No such file or directory
cp: cannot stat '/src/honggfuzz/hfuzz_cc/hfuzz-clang++': No such file or directory
cp: cannot stat '/src/honggfuzz/hfuzz_cc/hfuzz-g++': No such file or directory
cp: cannot stat '/src/honggfuzz/hfuzz_cc/hfuzz-gcc': No such file or directory
```

which probably only exist on the clusterfuzz infrastructure?