### PR TITLE
disable msan

### DIFF
--- a/projects/clamav/project.yaml
+++ b/projects/clamav/project.yaml
@@ -5,4 +5,3 @@ auto_ccs:
 sanitizers:
  - address
  - undefined
- - memory


### PR DESCRIPTION
CC @micah-at-talos 

Try running `check_build` on an MSAN build locally. It looks like the targets are broken.
Disabling MSAN to stop build from failing.