### PR TITLE
Add libldac for LDAC codec

### DIFF
--- a/projects/libldac/Dockerfile
+++ b/projects/libldac/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER cdiehl@mozilla.com
+
+RUN apt-get update && apt-get install -y automake libtool
+RUN git clone --depth 1 -b master https://android.googlesource.com/platform/external/libldac
+RUN svn export https://github.com/mozillasecurity/fuzzdata.git/trunk/samples/wav corpora
+
+WORKDIR libldac
+
+COPY build.sh libldac_encode_fuzzer.cc $SRC/

--- a/projects/libldac/build.sh
+++ b/projects/libldac/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -eu
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+$CC $CFLAGS -Iinc -c $SRC/libldac_encode_fuzzer.cc -o libldac_encode_fuzzer.o
+$CC $CFLAGS -Iinc -c src/ldaclib.c -o src/ldaclib.o
+$CC $CFLAGS -Iinc -c src/ldacBT.c -o src/ldacBT.o
+
+$CXX $CXXFLAGS -lFuzzingEngine \
+	libldac_encode_fuzzer.o \
+	src/ldaclib.o \
+	src/ldacBT.o \
+	-o $OUT/libldac_encode_fuzzer
+
+zip -q $OUT/libldac_encode_fuzzer_seed_corpus.zip $SRC/corpora/*

--- a/projects/libldac/libldac_encode_fuzzer.cc
+++ b/projects/libldac/libldac_encode_fuzzer.cc
@@ -1,0 +1,47 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <stdint.h>
+#include <stddef.h>
+#include "ldacBT.h"
+
+#define TESTFUNC_TYPE extern "C" int
+
+TESTFUNC_TYPE
+LLVMFuzzerTestOneInput(const uint8_t *buf, size_t size)
+{
+    if (size == 0) {
+    	return 0;
+    }
+    HANDLE_LDAC_BT hLdacBt;
+    int pcm_used, stream_sz, frame_num;
+    unsigned char p_stream[1024];
+
+    hLdacBt = ldacBT_get_handle();
+
+    ldacBT_init_handle_encode(
+        hLdacBt,
+        679,
+        LDACBT_EQMID_SQ,
+        LDACBT_CHANNEL_MODE_DUAL_CHANNEL,
+        LDACBT_SMPL_FMT_S16,
+        48000);
+
+    ldacBT_encode(
+        hLdacBt,
+        (void *)(&buf + 44),
+        &pcm_used,
+        p_stream,
+        &stream_sz,
+        &frame_num);
+
+    ldacBT_get_sampling_freq(hLdacBt);
+    ldacBT_get_bitrate(hLdacBt);
+    ldacBT_get_version();
+
+    ldacBT_close_handle(hLdacBt);
+    ldacBT_free_handle(hLdacBt);
+
+    return 0;
+}

--- a/projects/libldac/project.yaml
+++ b/projects/libldac/project.yaml
@@ -1,5 +1,5 @@
 homepage: "https://android.googlesource.com/platform/external/libldac"
-primary_contact: "chisato.kenmochi@sony.com"
+primary_contact: "Chisato.Kenmochi@sony.com"
 auto_ccs:
   - "cdiehl@mozilla.com"
 sanitizers:

--- a/projects/libldac/project.yaml
+++ b/projects/libldac/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://android.googlesource.com/platform/external/libldac"
+primary_contact: "chisato.kenmochi@sony.com"
+auto_ccs:
+  - "cdiehl@mozilla.com"
+sanitizers:
+  - address
+  - memory
+  - undefined


### PR DESCRIPTION
Hi,
I am not sure about the original author and used the one from the last commits.
Local tests for address, undefined, memory passed.
Entrypoint is https://android.googlesource.com/platform/external/libldac/+/master/src/ldaclib_api.c#668
