### PR TITLE
[tensorflow] Updates to get coverage build pass

### DIFF
--- a/projects/tensorflow/Dockerfile
+++ b/projects/tensorflow/Dockerfile
@@ -30,10 +30,10 @@ RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8
 RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
 RUN apt-get update && apt-get install -y bazel
 
-# Downgrade Bazel to latest supported version (0.19.2)
-RUN curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/0.19.2/bazel-0.19.2-installer-linux-x86_64.sh
-RUN chmod +x ./bazel-0.19.2-installer-linux-x86_64.sh
-RUN ./bazel-0.19.2-installer-linux-x86_64.sh
+# Downgrade Bazel to latest supported version (0.21.0)
+RUN curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/0.21.0/bazel-0.21.0-installer-linux-x86_64.sh
+RUN chmod +x ./bazel-0.21.0-installer-linux-x86_64.sh
+RUN ./bazel-0.21.0-installer-linux-x86_64.sh
 
 RUN git clone --depth 1 https://github.com/tensorflow/tensorflow tensorflow
 WORKDIR $SRC/tensorflow

--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -18,7 +18,7 @@
 # Generate the list of fuzzers we have (only the base/op name).
 FUZZING_BUILD_FILE="tensorflow/core/kernels/fuzzing/BUILD"
 declare -r FUZZERS=$(
-  grep '^tf_ops_fuzz_target' ${FUZZING_BUILD_FILE} | cut -d'"' -f2
+  grep '^tf_ops_fuzz_target' ${FUZZING_BUILD_FILE} | cut -d'"' -f2 | head -n5
 )
 
 # Since Docker container has bazel-0.19 we need the following trick to allow


### PR DESCRIPTION
Looking at [the coverage logs](https://oss-fuzz-build-logs.storage.googleapis.com/log-9d3d3cd0-cd8c-4a2b-a126-33c1250a451e.txt) it seems the build fails because fuzzers are not running or not generating output, probably because [of lack of disk space](https://github.com/google/oss-fuzz/pull/2014#issuecomment-449231313).

Since reducing the size of the fuzzer binaries is hard at the moment, I'm just limiting to only building 5 fuzzers for now. If this works, I'll look into alternative ways