### PR TITLE
[skia] Disable empty expression check

### DIFF
--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -44,7 +44,8 @@ export SWIFTSHADER_LIB_PATH=$OUT
 popd
 # These are any clang warnings we need to silence.
 DISABLE="-Wno-zero-as-null-pointer-constant -Wno-unused-template
-         -Wno-cast-qual -Wno-self-assign -Wno-return-std-move-in-c++11"
+         -Wno-cast-qual -Wno-self-assign -Wno-return-std-move-in-c++11
+         -Wno-extra-semi-stmt"
 # Disable UBSan vptr since target built with -fno-rtti.
 export CFLAGS="$CFLAGS $DISABLE -I$SWIFTSHADER_INCLUDE_PATH -DGR_EGL_TRY_GLES3_THEN_GLES2 -fno-sanitize=vptr"
 export CXXFLAGS="$CXXFLAGS $DISABLE -I$SWIFTSHADER_INCLUDE_PATH -DGR_EGL_TRY_GLES3_THEN_GLES2 -fno-sanitize=vptr "-DIS_FUZZING_WITH_LIBFUZZER""


### PR DESCRIPTION
This hopefully fixes the build failures due to the new compile time check.

When I get back to a beefy build machine, I'll hopefully fix all these locations in Skia proper and we can turn it on.