### PR TITLE
[skia] re-enable certain compile warnings

### DIFF
--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -44,8 +44,7 @@ export SWIFTSHADER_LIB_PATH=$OUT
 popd
 # These are any clang warnings we need to silence.
 DISABLE="-Wno-zero-as-null-pointer-constant -Wno-unused-template
-         -Wno-cast-qual -Wno-self-assign -Wno-return-std-move-in-c++11
-         -Wno-extra-semi-stmt"
+         -Wno-cast-qual"
 # Disable UBSan vptr since target built with -fno-rtti.
 export CFLAGS="$CFLAGS $DISABLE -I$SWIFTSHADER_INCLUDE_PATH -DGR_EGL_TRY_GLES3_THEN_GLES2 -fno-sanitize=vptr"
 export CXXFLAGS="$CXXFLAGS $DISABLE -I$SWIFTSHADER_INCLUDE_PATH -DGR_EGL_TRY_GLES3_THEN_GLES2 -fno-sanitize=vptr "-DIS_FUZZING_WITH_LIBFUZZER""


### PR DESCRIPTION
The extra semi colons should be fixed in https://skia-review.googlesource.com/c/skia/+/180367

The other two have been fixed for some time.

This all builds locally for me.