### PR TITLE
mercurial: move Python sources to $SRC and build in build.sh

### DIFF
--- a/projects/mercurial/Dockerfile
+++ b/projects/mercurial/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER security@mercurial-scm.org
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
   python-dev mercurial curl
-RUN cd / && curl https://www.python.org/ftp/python/2.7.15/Python-2.7.15.tgz | tar xzf -
+RUN cd $SRC && curl https://www.python.org/ftp/python/2.7.15/Python-2.7.15.tgz | tar xzf -
 RUN hg clone https://www.mercurial-scm.org/repo/hg mercurial
 WORKDIR mercurial
 COPY build.sh $SRC/


### PR DESCRIPTION
This will clean up the Makefile on the hg side considerably, and will
also fix the coverage build. Fixes #2076.

Bonus: I did some extra work in build.sh so that incremental rebuilds
of the fuzzers won't needlessly recompile $OUT/sanpy, shortening
development time on new fuzzers and avoiding issues caused by a $OUT
that was built for a different fuzz configuration.