### PR TITLE
Open vSwitch: Adds Toms Atteka to auto_ccs list

### DIFF
--- a/projects/openvswitch/project.yaml
+++ b/projects/openvswitch/project.yaml
@@ -5,6 +5,7 @@ auto_ccs:
   - "pfaffben@gmail.com" 
   - "pkusunyifeng@gmail.com"
   - "bshas3@gmail.com"
+  - "cpp.code.lv@gmail.com"
 sanitizers:
   - address
   - memory


### PR DESCRIPTION
This PR adds Toms Atteka to auto_ccs list for Open vSwitch. CC @blp