### PR TITLE
Add ReadStat project

### DIFF
--- a/projects/readstat/project.yaml
+++ b/projects/readstat/project.yaml
@@ -1,0 +1,2 @@
+homepage: "https://github.com/WizardMac/ReadStat"
+primary_contact: "emmiller@gmail.com"


### PR DESCRIPTION
I am the creator / maintainer of the ReadStat project, a C library for parsing binary data sets, with language bindings in R, Python, and Julia.

We previously received many helpful bug reports from the Google Autofuzz project. I would like to have ReadStat included in OSS-Fuzz so that fuzz-testing coverage can continue into the future.