### PR TITLE
Add libxls

### DIFF
--- a/projects/libxls/project.yaml
+++ b/projects/libxls/project.yaml
@@ -1,0 +1,2 @@
+homepage: "https://github.com/libxls/libxls"
+primary_contact: "emmiller@gmail.com"


### PR DESCRIPTION
libxls is a popular C library for reading in binary Excel files. The original, outdated project homepage is here:

http://libxls.sourceforge.net

I am in the process of taking over maintenance of libxls from @dhoerl. That process includes moving the code to GitHub and implementing fuzz-testing. The new project homepage will be here:

https://github.com/libxls/libxls

I have a fuzzing target running locally, and would like to begin the process of having it run on ClusterFuzz as part of OSS-Fuzz. My goal is to fix as many security-related bugs as possible before the next major release of libxls.