### PR TITLE
[ClamAV] Build script fix

### DIFF
--- a/projects/clamav/build.sh
+++ b/projects/clamav/build.sh
@@ -18,8 +18,8 @@
 #
 # Build the library.
 #
+rm -rf ${WORK}/build
 mkdir -p ${WORK}/build
-rm -r ${WORK}/build/*
 cd ${WORK}/build
 ${SRC}/clamav-devel/configure --enable-fuzz=yes --with-libjson=no --with-pcre=no --enable-static=yes --enable-shared=no --disable-llvm --host=x86_64-unknown-linux-gnu
 make clean


### PR DESCRIPTION
Correction to build.sh script so the script won't fail on clean checkout.
Follow-up to correct a mistake in https://github.com/google/oss-fuzz/pull/2102 
Sorry!