### PR TITLE
solidity: Add the solidity compiler to oss-fuzz

### DIFF
--- a/projects/solidity/Dockerfile
+++ b/projects/solidity/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool \
+    build-essential cmake libbz2-dev
+RUN git clone --depth 1 https://github.com/ethereum/solidity.git solidity
+RUN git clone --depth 1 https://github.com/holiman/solfuzzz.git sol_corpus
+RUN git clone --recursive -b boost-1.69.0 https://github.com/boostorg/boost.git boost
+COPY build.sh $SRC/

--- a/projects/solidity/build.sh
+++ b/projects/solidity/build.sh
@@ -1,0 +1,58 @@
+#!/bin/bash -eu
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Build boost statically, linking it against libc++
+cd $SRC/boost
+./bootstrap.sh --with-toolset=clang
+./b2 clean
+./b2 toolset=clang cxxflags="-stdlib=libc++" linkflags="-stdlib=libc++" headers
+./b2 toolset=clang cxxflags="-stdlib=libc++" linkflags="-stdlib=libc++" \
+     link=static variant=release runtime-link=static \
+     system regex filesystem unit_test_framework program_options \
+     install -j $(($(nproc)/2))
+
+# Build solidity
+cd $SRC/solidity
+git submodule update --init --recursive
+BASE_CXXFLAGS="$CXXFLAGS"
+CXXFLAGS="$BASE_CXXFLAGS -I/usr/local/include/c++/v1 -L/usr/local/lib"
+mkdir -p build && cd build && rm -rf *
+
+# This environment variable turns on fuzzer harness compilation/link
+cmake -DUSE_Z3=OFF -DUSE_CVC4=OFF -DOSSFUZZ=ON \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DBoost_FOUND=1 \
+  -DBoost_USE_STATIC_LIBS=1 \
+  -DBoost_USE_STATIC_RUNTIME=1 \
+  -DBoost_INCLUDE_DIR=/usr/local/include/ \
+  -DBoost_FILESYSTEM_LIBRARY=/usr/local/lib/libboost_filesystem.a \
+  -DBoost_FILESYSTEM_LIBRARIES=/usr/local/lib/libboost_filesystem.a \
+  -DBoost_PROGRAM_OPTIONS_LIBRARY=/usr/local/lib/libboost_program_options.a \
+  -DBoost_PROGRAM_OPTIONS_LIBRARIES=/usr/local/lib/libboost_program_options.a \
+  -DBoost_REGEX_LIBRARY=/usr/local/lib/libboost_regex.a \
+  -DBoost_REGEX_LIBRARIES=/usr/local/lib/libboost_regex.a \
+  -DBoost_SYSTEM_LIBRARY=/usr/local/lib/libboost_system.a \
+  -DBoost_SYSTEM_LIBRARIES=/usr/local/lib/libboost_system.a \
+  -DBoost_UNIT_TEST_FRAMEWORK_LIBRARY=/usr/local/lib/libboost_unit_test_framework.a \
+  -DBoost_UNIT_TEST_FRAMEWORK_LIBRARIES=/usr/local/lib/libboost_unit_test_framework.a \
+  $SRC/solidity
+make ossfuzz -j $(nproc) && cp test/tools/ossfuzz/*_ossfuzz $OUT/
+rm -f $OUT/*.zip
+find $SRC/solidity $SRC/sol_corpus -iname "*.sol" -exec zip -ujq \
+  $OUT/solc_opt_ossfuzz_seed_corpus.zip "{}" \;
+cp $OUT/solc_opt_ossfuzz_seed_corpus.zip \
+  $OUT/solc_noopt_ossfuzz_seed_corpus.zip

--- a/projects/solidity/project.yaml
+++ b/projects/solidity/project.yaml
@@ -1,0 +1,5 @@
+homepage: "https://solidity.readthedocs.io"
+primary_contact: "bshastry@ethereum.org"
+auto_ccs:
+  - "axic@ethereum.org"
+  - "christian@ethereum.org"


### PR DESCRIPTION
This PR adds the Ethereum foundation's Solidity compiler to oss-fuzz. (CC @chriseth @axic) (see also #402 )