### PR TITLE
solidity: update primary contact email

### DIFF
--- a/projects/solidity/project.yaml
+++ b/projects/solidity/project.yaml
@@ -1,5 +1,5 @@
 homepage: "https://solidity.readthedocs.io"
-primary_contact: "bshastry@ethereum.org"
+primary_contact: "bhargava.shastry@ethereum.org"
 auto_ccs:
   - "axic@ethereum.org"
   - "christian@ethereum.org"


### PR DESCRIPTION
This PR fixes a minor bug with primary contact email in #2108 which was that I had used an alias `bshastry` of my original email id `bhargava.shastry` and it seems the email address needs to be an exact match for me to be able to view the oss-fuzz dashboard.