### PR TITLE
[libvpx] Disable encoders in libvpx

### DIFF
--- a/projects/libvpx/build.sh
+++ b/projects/libvpx/build.sh
@@ -35,7 +35,9 @@ LDFLAGS="$CXXFLAGS" LD=$CXX $SRC/libvpx/configure \
     --size-limit=12288x12288 \
     --extra-cflags="${extra_c_flags}" \
     --disable-webm-io \
-    --enable-debug
+    --enable-debug \
+    --disable-vp8-encoder \
+    --disable-vp9-encoder
 make -j$(nproc) all
 popd
 


### PR DESCRIPTION
Disable encoders while building libvpx

Current tools_common.c requires y4minput.c when encoders are enabled.
Instead of adding y4minput while linking fuzzer binary, encoders are
disabled during libvpx configure.
This resolves undefined reference to functions in y4minput.c