### PR TITLE
[proj4] Fix coverage build

### DIFF
--- a/projects/proj4/build.sh
+++ b/projects/proj4/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 ./autogen.sh
-./configure
+./configure --disable-shared
 make clean -s
 (cd src && make -j$(nproc) -s)
 


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=12891

Shared library builds failed with
hidden symbol `atexit' in /usr/lib/x86_64-linux-gnu/libc_nonshared.a(atexit.oS) is referenced by DSO

So ./configure --disable-shared