### PR TITLE
[libvpx] Remove depencency on tools_common.c.o

### DIFF
--- a/projects/libvpx/build.sh
+++ b/projects/libvpx/build.sh
@@ -32,6 +32,7 @@ fi
 
 LDFLAGS="$CXXFLAGS" LD=$CXX $SRC/libvpx/configure \
     --disable-unit-tests \
+    --disable-examples \
     --size-limit=12288x12288 \
     --extra-cflags="${extra_c_flags}" \
     --disable-webm-io \
@@ -54,7 +55,7 @@ for decoder in "${fuzzer_decoders[@]}"; do
     -Wl,--start-group \
     -lFuzzingEngine \
     $SRC/libvpx/examples/${fuzzer_src_name}.cc -o $OUT/${fuzzer_name} \
-    ${build_dir}/libvpx.a ${build_dir}/tools_common.c.o \
+    ${build_dir}/libvpx.a \
     -Wl,--end-group
   cp $SRC/vpx_fuzzer_seed_corpus.zip $OUT/${fuzzer_name}_seed_corpus.zip
   cp $SRC/vpx_dec_fuzzer.dict $OUT/${fuzzer_name}.dict


### PR DESCRIPTION
vpx_dec_fuzzer.cc now builds without any dependency on tools_common.c.o
Hence disable examples while configuring libvpx and remove
tools_common.c.o when linking fuzzer binaries