### PR TITLE
Solidity: Add fuzzing dictionary

### DIFF
--- a/projects/solidity/Dockerfile
+++ b/projects/solidity/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
     build-essential cmake libbz2-dev
-RUN git clone --depth 1 https://github.com/ethereum/solidity.git solidity
+RUN git clone --recursive https://github.com/ethereum/solidity.git solidity
 RUN git clone --depth 1 https://github.com/holiman/solfuzzz.git sol_corpus
 RUN git clone --recursive -b boost-1.69.0 https://github.com/boostorg/boost.git boost
 COPY build.sh $SRC/

--- a/projects/solidity/build.sh
+++ b/projects/solidity/build.sh
@@ -27,12 +27,13 @@ cd $SRC/boost
 
 # Build solidity
 cd $SRC/solidity
-git submodule update --init --recursive
 BASE_CXXFLAGS="$CXXFLAGS"
 CXXFLAGS="$BASE_CXXFLAGS -I/usr/local/include/c++/v1 -L/usr/local/lib"
-mkdir -p build && cd build && rm -rf *
+mkdir -p build
+cd build
+rm -rf *
 
-# This environment variable turns on fuzzer harness compilation/link
+# Build solidity
 cmake -DUSE_Z3=OFF -DUSE_CVC4=OFF -DOSSFUZZ=ON \
   -DCMAKE_BUILD_TYPE=Release \
   -DBoost_FOUND=1 \
@@ -50,9 +51,14 @@ cmake -DUSE_Z3=OFF -DUSE_CVC4=OFF -DOSSFUZZ=ON \
   -DBoost_UNIT_TEST_FRAMEWORK_LIBRARY=/usr/local/lib/libboost_unit_test_framework.a \
   -DBoost_UNIT_TEST_FRAMEWORK_LIBRARIES=/usr/local/lib/libboost_unit_test_framework.a \
   $SRC/solidity
-make ossfuzz -j $(nproc) && cp test/tools/ossfuzz/*_ossfuzz $OUT/
+make ossfuzz -j $(nproc)
+
+# Copy fuzzer binary, seed corpus, fuzzer options, and dictionary
+cp test/tools/ossfuzz/*_ossfuzz $OUT/
 rm -f $OUT/*.zip
 find $SRC/solidity $SRC/sol_corpus -iname "*.sol" -exec zip -ujq \
   $OUT/solc_opt_ossfuzz_seed_corpus.zip "{}" \;
 cp $OUT/solc_opt_ossfuzz_seed_corpus.zip \
   $OUT/solc_noopt_ossfuzz_seed_corpus.zip
+cp $SRC/solidity/test/tools/ossfuzz/config/*.options $OUT/
+cp $SRC/solidity/test/tools/ossfuzz/config/solidity.dict $OUT/


### PR DESCRIPTION
This PR incorporates some comments in #2108 . Specifically, the following
  - add a fuzzing dictionary and config options for Solidity fuzzers
  - break lines in the build script for long commands
  - move `git update submodule` call from within the build script to Dockerfile as `git clone --recursive` to facilitate caching

CC @axic @chriseth