### PR TITLE
Add new project : S2OPC

### DIFF
--- a/projects/s2opc/project.yaml
+++ b/projects/s2opc/project.yaml
@@ -1,0 +1,4 @@
+homepage: "https://gitlab.com/systerel/S2OPC"
+primary_contact: "vincent.lacroix@systerel.fr"
+auto_ccs:
+  - "mcl.systerel@gmail.com"


### PR DESCRIPTION
This is a request for S2OPC to be added to OSS-fuzz program.

S2OPC is an Apache 2 licenced open-source OPC-UA Toolkit.

[OPC-UA](https://en.wikipedia.org/wiki/OPC_Unified_Architecture) is a protocol which is being largely adopted for industrial automation.