### PR TITLE
Add Lwan to OSS-Fuzz

### DIFF
--- a/projects/lwan/project.yaml
+++ b/projects/lwan/project.yaml
@@ -1,0 +1,4 @@
+homepage: "https://github.com/lpereira/lwan"
+primary_contact: "leandro.pereira@gmail.com"
+sanitizers:
+  - address


### PR DESCRIPTION
As suggested by @jonathanmetzman on Twitter, I'm opening this PR to add my personal project, [Lwan](https://lwan.ws), to oss-fuzz.  Right now I only have a fuzzing setup to test with asan, but will add more sanitizer options if the project is accepted.

(The majority of the commits on the project are made with an alternate email address, but that's not a Google account.)