### PR TITLE
[docs] fix pcre2 link

### DIFF
--- a/docs/ideal_integration.md
+++ b/docs/ideal_integration.md
@@ -36,7 +36,7 @@ Examples:
 [FreeType](http://git.savannah.gnu.org/cgit/freetype/freetype2.git/tree/src/tools/ftfuzzer),
 [re2](https://github.com/google/re2/tree/master/re2/fuzzing),
 [harfbuzz](https://github.com/behdad/harfbuzz/tree/master/test/fuzzing),
-[pcre2](http://vcs.pcre.org/pcre2/code/trunk/src/pcre2_fuzzsupport.c?view=markup),
+[pcre2](https://vcs.pcre.org/pcre2/code/trunk/src/pcre2_fuzzsupport.c?view=markup),
 [ffmpeg](https://github.com/FFmpeg/FFmpeg/blob/master/tools/target_dec_fuzzer.c).
 
 ## Build support


### PR DESCRIPTION
pcre2's web server has a redirect to HTTPS that introduces a duplicate view
parameter, resulting in the eventual URL of
https://vcs.pcre.org/pcre2/code/trunk/src/pcre2_fuzzsupport.c?view=markup?view=markup
which fails to load. This seems like an error in their web server config, but
using an HTTPS URL to begin with works around this issue.

----

I haven't signed a CLA for something as trivial as this, so please feel free to take this as a suggestion or bug report and apply this with your own attribution.