### PR TITLE
ReadStat now requires gettext

### DIFF
--- a/projects/readstat/Dockerfile
+++ b/projects/readstat/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER emmiller@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool zip zlib1g-dev
+RUN apt-get update && apt-get install -y make autoconf automake gettext libtool zip zlib1g-dev
 
 RUN git clone --depth 1 https://github.com/WizardMac/ReadStat readstat
 WORKDIR readstat


### PR DESCRIPTION
Add `gettext` to the list of ReadStat's installed packages to prevent errors about `AM_ICONV`. Tested locally on Ubuntu 18.04.1 LTS.

Fixes #13012