### PR TITLE
Libxls now requires gettext

### DIFF
--- a/projects/libxls/Dockerfile
+++ b/projects/libxls/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER emmiller@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get install -y make autoconf automake gettext libtool
 
 RUN git clone --depth 1 https://github.com/libxls/libxls libxls
 WORKDIR libxls


### PR DESCRIPTION
Add `gettext` to the list of libxls's installed packages to prevent errors about `AM_ICONV` during autoconf.