### PR TITLE
Dav1d: fix build and disable logging

### DIFF
--- a/projects/dav1d/Dockerfile
+++ b/projects/dav1d/Dockerfile
@@ -16,9 +16,12 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER janne-vlc@jannau.net
-RUN apt-get update && apt-get install -y curl python3-pip wget && \
+
+ADD bionic.list /etc/apt/sources.list.d/bionic.list
+ADD nasm_apt.pin /etc/apt/preferences
+
+RUN apt-get update && apt-get install -y curl python3-pip nasm && \
     pip3 install meson ninja
-RUN wget http://www.nasm.us/pub/nasm/releasebuilds/2.13.02/nasm-2.13.02.tar.gz
 RUN curl --silent -O https://storage.googleapis.com/aom-test-data/fuzzer/dec_fuzzer_seed_corpus.zip
 RUN curl --silent -O https://jannau.net/dav1d_fuzzer_seed_corpus.zip
 RUN git clone --depth 1 https://code.videolan.org/videolan/dav1d.git dav1d

--- a/projects/dav1d/Dockerfile
+++ b/projects/dav1d/Dockerfile
@@ -23,4 +23,4 @@ RUN curl --silent -O https://storage.googleapis.com/aom-test-data/fuzzer/dec_fuz
 RUN curl --silent -O https://jannau.net/dav1d_fuzzer_seed_corpus.zip
 RUN git clone --depth 1 https://code.videolan.org/videolan/dav1d.git dav1d
 WORKDIR dav1d
-COPY build.sh fuzzer.options $SRC/
+COPY build.sh $SRC/

--- a/projects/dav1d/bionic.list
+++ b/projects/dav1d/bionic.list
@@ -1,0 +1,2 @@
+# use nasm 2.13.02 from bionic
+deb http://archive.ubuntu.com/ubuntu/ bionic universe

--- a/projects/dav1d/build.sh
+++ b/projects/dav1d/build.sh
@@ -29,23 +29,6 @@ BUILD_ASM="true"
 if [[ $CFLAGS = *sanitize=memory* ]]
 then
   BUILD_ASM="false"
-else
-	# Build the specific nasm version without memory instrumentation.
-	pushd $SRC
-
-	BUILD_DEPS="$SRC/build_deps"
-	mkdir -p $BUILD_DEPS
-
-	tar xzf nasm-*
-	cd nasm-*
-	CFLAGS="" CXXFLAGS="" ./configure --prefix="$BUILD_DEPS"
-	make clean
-	make -j$(nproc)
-	make install
-
-	export PATH="$BUILD_DEPS/bin:$PATH"
-	export LD_LIBRARY_PATH="$BUILD_DEPS/lib"
-	popd
 fi
 
 meson -Dbuild_asm=$BUILD_ASM -Dbuild_tools=false -Dfuzzing_engine=oss-fuzz \

--- a/projects/dav1d/build.sh
+++ b/projects/dav1d/build.sh
@@ -50,6 +50,7 @@ fi
 
 meson -Dbuild_asm=$BUILD_ASM -Dbuild_tools=false -Dfuzzing_engine=oss-fuzz \
       -Db_lundef=false -Ddefault_library=static -Dbuildtype=debugoptimized \
+      -Dlogging=false \
       ${build}
 ninja -j $(nproc) -C ${build}
 
@@ -64,5 +65,4 @@ cp $SRC/dec_fuzzer_seed_corpus.zip ${WORK}/tmp/seed_corpus.zip
 for fuzzer in $(find ${build} -name 'dav1d_fuzzer*'); do
 	cp "${fuzzer}" $OUT/
 	cp ${WORK}/tmp/seed_corpus.zip $OUT/$(basename "$fuzzer")_seed_corpus.zip
-	cp $SRC/fuzzer.options $OUT/$(basename "$fuzzer").options
 done

--- a/projects/dav1d/fuzzer.options
+++ b/projects/dav1d/fuzzer.options
@@ -1,3 +1,0 @@
-[libfuzzer]
-# TODO: remove this when error logging can be suppressed during compilation.
-close_fd_mask = 2

--- a/projects/dav1d/nasm_apt.pin
+++ b/projects/dav1d/nasm_apt.pin
@@ -1,0 +1,7 @@
+Package: *
+Pin: release n=bionic
+Pin-Priority: 1
+
+Package: nasm
+Pin: release n=bionic
+Pin-Priority: 555


### PR DESCRIPTION
https://www.nasm.us is currently not available causing build failures. Use nasm package from ubuntu bionic instead of downloading and building nasm from source.

Logging can be now disabled at build time so remove fuzzer.options.