### PR TITLE
ffmpeg: fix build by using nasm from ubuntu bionic

### DIFF
--- a/projects/ffmpeg/Dockerfile
+++ b/projects/ffmpeg/Dockerfile
@@ -16,16 +16,17 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mmoroz@chromium.org
+ADD bionic.list /etc/apt/sources.list.d/bionic.list
+ADD nasm_apt.pin /etc/apt/preferences
 RUN apt-get update && apt-get install -y make autoconf automake libtool build-essential \
     libass-dev libfreetype6-dev libsdl1.2-dev \
     libvdpau-dev libxcb1-dev libxcb-shm0-dev \
     pkg-config texinfo libbz2-dev zlib1g-dev yasm cmake mercurial wget \
-    xutils-dev libpciaccess-dev
+    xutils-dev libpciaccess-dev nasm
 
 RUN git clone https://git.ffmpeg.org/ffmpeg.git ffmpeg
 
 RUN wget ftp://ftp.alsa-project.org/pub/lib/alsa-lib-1.1.0.tar.bz2
-RUN wget http://www.nasm.us/pub/nasm/releasebuilds/2.13.01/nasm-2.13.01.tar.gz
 RUN git clone --depth 1 git://anongit.freedesktop.org/mesa/drm
 RUN git clone --depth 1 https://github.com/mstorsjo/fdk-aac.git
 ADD https://sourceforge.net/projects/lame/files/latest/download lame.tar.gz

--- a/projects/ffmpeg/bionic.list
+++ b/projects/ffmpeg/bionic.list
@@ -1,0 +1,2 @@
+# use nasm 2.13.02 from bionic
+deb http://archive.ubuntu.com/ubuntu/ bionic universe

--- a/projects/ffmpeg/build.sh
+++ b/projects/ffmpeg/build.sh
@@ -23,15 +23,6 @@ export CXXFLAGS="$CXXFLAGS -fno-sanitize=vptr"
 export FFMPEG_DEPS_PATH=$SRC/ffmpeg_deps
 mkdir -p $FFMPEG_DEPS_PATH
 
-# Build latest nasm without memory instrumentation.
-cd $SRC
-tar xzf nasm-*
-cd nasm-*
-CFLAGS="" CXXFLAGS="" ./configure --prefix="$FFMPEG_DEPS_PATH"
-make clean
-make -j$(nproc)
-make install
-
 export PATH="$FFMPEG_DEPS_PATH/bin:$PATH"
 export LD_LIBRARY_PATH="$FFMPEG_DEPS_PATH/lib"
 

--- a/projects/ffmpeg/nasm_apt.pin
+++ b/projects/ffmpeg/nasm_apt.pin
@@ -1,0 +1,7 @@
+Package: *
+Pin: release n=bionic
+Pin-Priority: 1
+
+Package: nasm
+Pin: release n=bionic
+Pin-Priority: 555


### PR DESCRIPTION
http://www.nasm.us was down for the last couple of days. nasm from
bionic can be used without dependencies. Same change as #2159 for dav1d.