### PR TITLE
[git] Add the new fuzz-commit-graph fuzzer.

### DIFF
--- a/projects/git/Dockerfile
+++ b/projects/git/Dockerfile
@@ -23,6 +23,6 @@ RUN apt-get update && \
         libio-pty-perl libmailtools-perl libpcre2-dev libpcre3-dev libsvn-perl \
         libtime-modules-perl libyaml-perl libz-dev python subversion tcl unzip \
         asciidoc docbook-xsl xmlto libssl-dev zip
-RUN git clone --depth 1 https://github.com/git/git git
+RUN git clone https://github.com/git/git git
 WORKDIR git
 COPY build.sh $SRC/

--- a/projects/git/build.sh
+++ b/projects/git/build.sh
@@ -19,7 +19,7 @@
 make -j$(nproc) CC=$CC CXX=$CXX CFLAGS="$CFLAGS" FUZZ_CXXFLAGS="$CXXFLAGS" \
   LIB_FUZZING_ENGINE=$LIB_FUZZING_ENGINE fuzz-all
 
-FUZZERS="fuzz-pack-headers fuzz-pack-idx"
+FUZZERS="fuzz-pack-headers fuzz-pack-idx fuzz-commit-graph"
 
 # copy fuzzers
 for fuzzer in $FUZZERS ; do
@@ -32,6 +32,10 @@ for packfile in .git/objects/pack/*.pack ; do
   dd ibs=1 skip=12 if=$packfile of=$packfile.trimmed
 done
 zip -j $OUT/fuzz-pack-headers_seed_corpus.zip .git/objects/pack/*.pack.trimmed
+
+# build commit-graph corpus
+./git commit-graph write
+zip -j $OUT/fuzz-commit-graph_seed_corpus .git/objects/info/commit-graph
 
 # Mute stderr
 for fuzzer in $FUZZERS ; do


### PR DESCRIPTION
We have a new fuzz target in Git, which we'd like to enable on OSS-Fuzz. Please note that this now requires a full clone of the git repo, in order to build a corpus for the new fuzzer.