### PR TITLE
Initialize fuzzing for CUPS

### DIFF
--- a/projects/cups/Dockerfile
+++ b/projects/cups/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER skau@chromium.org
+RUN apt-get update && apt-get install -y libgnutls-dev liblcms2-dev
+RUN git clone https://github.com/apple/cups.git cups
+WORKDIR cups
+COPY build.sh $SRC/

--- a/projects/cups/Dockerfile
+++ b/projects/cups/Dockerfile
@@ -1,3 +1,19 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER skau@chromium.org
 RUN apt-get update && apt-get install -y libgnutls-dev liblcms2-dev

--- a/projects/cups/build.sh
+++ b/projects/cups/build.sh
@@ -1,4 +1,20 @@
 #!/bin/bash
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
 ./buildconf.sh
 ./configure
 make clean

--- a/projects/cups/build.sh
+++ b/projects/cups/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+./buildconf.sh
+./configure
+make clean
+make

--- a/projects/cups/project.yaml
+++ b/projects/cups/project.yaml
@@ -2,6 +2,5 @@ homepage: "https://github.com/apple/cups"
 primary_contact: "skau@chromium.org"
 sanitizers:
   - address
-  - leak
   - memory
   - undefined

--- a/projects/cups/project.yaml
+++ b/projects/cups/project.yaml
@@ -1,0 +1,7 @@
+homepage: "https://github.com/apple/cups"
+primary_contact: "skau@chromium.org"
+sanitizers:
+  - address
+  - leak
+  - memory
+  - undefined


### PR DESCRIPTION
Intent is to ease reporting of fuzzing issues to the project maintainer for the Common Unix Printing system, the widely used printing system for all *nix systems.