### PR TITLE
giflib: Fix bug in test harness that led to low coverage.

### DIFF
--- a/projects/giflib/build.sh
+++ b/projects/giflib/build.sh
@@ -10,7 +10,7 @@ done
 ar rc libgif.a *.o
 
 cd $SRC
-$CC $CFLAGS -c -I giflib-code dgif_target.c -o dgif_target.o
+$CC $CFLAGS -Wall -c -I giflib-code dgif_target.c -o dgif_target.o
 $CXX $CXXFLAGS -std=c++11 -I giflib-code dgif_target.o \
         -o $OUT/dgif_target -lFuzzingEngine giflib-code/libgif.a
 

--- a/projects/giflib/dgif_target.c
+++ b/projects/giflib/dgif_target.c
@@ -1,76 +1,37 @@
 #include <stdlib.h>
-#include <stdio.h>
-#include <ctype.h>
-#include <string.h>
-#include <stdbool.h>
-#include <fcntl.h>
 #include <stdint.h>
-
+#include <string.h>
 #include "gif_lib.h"
 
 struct gifUserData {
 	size_t gifLen;
-	void *gifData;
+	uint8_t *gifData;
 };
 
 int stub_input_reader (GifFileType *gifFileType, GifByteType *gifByteType, int len) {
 	struct gifUserData *gud = gifFileType->UserData;
+	if (gud->gifLen == 0)
+		return 0;
 	int read_len = (len > gud->gifLen ? gud->gifLen : len);
 	memcpy(gifByteType, gud->gifData, read_len);
+	gud->gifData += read_len;
+	gud->gifLen -= read_len;
 	return read_len;
-}
-
-void sponge(GifFileType *GifFileIn, int *ErrorCode) {
-	GifFileType *GifFileOut = (GifFileType *)NULL;
-	if ((GifFileOut = EGifOpenFileHandle(1, ErrorCode)) == NULL) {
-		return;
-	}
-
-	/*
-	 * Your operations on in-core structures go here.
-	 * This code just copies the header and each image from the incoming file.
-	 */
-	GifFileOut->SWidth = GifFileIn->SWidth;
-	GifFileOut->SHeight = GifFileIn->SHeight;
-	GifFileOut->SColorResolution = GifFileIn->SColorResolution;
-	GifFileOut->SBackGroundColor = GifFileIn->SBackGroundColor;
-	if (GifFileIn->SColorMap) {
-		GifFileOut->SColorMap = GifMakeMapObject(
-				GifFileIn->SColorMap->ColorCount,
-				GifFileIn->SColorMap->Colors);
-	} else {
-		GifFileOut->SColorMap = NULL;
-	}
-
-	for (int i = 0; i < GifFileIn->ImageCount; i++)
-		(void) GifMakeSavedImage(GifFileOut, &GifFileIn->SavedImages[i]);
-
-	// We ignore error since it is irrelevant in the context of this
-	// test harness.
-	EGifSpew(GifFileOut);
-	return;
 }
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 {
 	GifFileType *GifFile;
 	int Error;
-	void *gifData = malloc(Size);
-	memcpy(gifData, (void *)Data, Size);
+	uint8_t *gifData = (uint8_t *)malloc(Size);
+	memcpy(gifData, Data, Size);
 	struct gifUserData gUData = {Size, gifData};
 
 	GifFile = DGifOpen((void *)&gUData, stub_input_reader, &Error);
-	if (GifFile == NULL){
-		goto freebuf;
+	if (GifFile != NULL) {
+		DGifSlurp(GifFile);
+		DGifCloseFile(GifFile, &Error);
 	}
-	if (DGifSlurp(GifFile) == GIF_ERROR) {
-		goto cleanup;
-	}
-	sponge(GifFile, &Error);
-
-cleanup:
-	DGifCloseFile(GifFile, &Error);
-freebuf:
 	free(gifData);
 	return 0;
 }


### PR DESCRIPTION
This PR fixes a bug in the giflib test harness that led to coverage saturation (see https://github.com/google/oss-fuzz/pull/2169#issuecomment-464229857)

However, the harness quickly rediscovers an old unfixed bug (ossfuzz issue 13009) in giflib.