### PR TITLE
Update PostGIS dependencies

### DIFF
--- a/projects/postgis/Dockerfile
+++ b/projects/postgis/Dockerfile
@@ -16,7 +16,8 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER lr@pcorp.us
-RUN apt-get update && apt-get install -y make autoconf automake libtool g++ postgresql-server-dev-9.5 libgeos-dev libproj-dev libxml2-dev pkg-config libjson-c-dev
+RUN echo deb http://archive.ubuntu.com/ubuntu/ disco main restricted universe multiverse >> /etc/apt/sources.list
+RUN apt-get update && apt-get install -y make autoconf automake libtool g++ postgresql-server-dev-11 libgeos-dev libproj-dev libxml2-dev pkg-config libjson-c-dev
 RUN git clone --depth 1 https://git.osgeo.org/gogs/postgis/postgis.git postgis
 WORKDIR postgis
 COPY build.sh $SRC/


### PR DESCRIPTION
PostGIS depends on GEOS, and recently requres GEOS 3.6 which cannot be found in ubuntu 16.04. 

With this change build will pull newest GEOS 3.7 from Ubuntu 19.04.