### PR TITLE
envoy: coverage support for cmake_external deps.

### DIFF
--- a/projects/envoy/project.yaml
+++ b/projects/envoy/project.yaml
@@ -8,4 +8,4 @@ auto_ccs:
   - "jmarantz@google.com"
   - "lizan@tetrate.io"
   - "envoy-security@googlegroups.com"
-coverage_extra_args: -ignore-filename-regex=.*\.cache.*
+coverage_extra_args: -ignore-filename-regex=.*\.cache.*envoy_deps_cache.*


### PR DESCRIPTION
This now lets us visualize nghttp2 coverage.

Tested via:

python infra/helper.py build_fuzzers --sanitizer=coverage envoy
python infra/helper.py coverage envoy -- "-ignore-filename-regex=.*\.cache.*envoy_deps_cache.*"

Requires https://github.com/envoyproxy/envoy/pull/6036 to yield useful
results.

Signed-off-by: Harvey Tuch <htuch@google.com>