### PR TITLE
[bignum-fuzzer] Build and use latest Golang

### DIFF
--- a/projects/bignum-fuzzer/Dockerfile
+++ b/projects/bignum-fuzzer/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y software-properties-common python-softw
 RUN add-apt-repository -y ppa:gophers/archive && apt-get update && apt-get install -y golang-1.9-go
 RUN ln -s /usr/lib/go-1.9/bin/go /usr/bin/go
 
+RUN git clone --recursive https://github.com/golang/go
 RUN git clone --depth 1 https://github.com/guidovranken/bignum-fuzzer
 RUN git clone --depth 1 https://github.com/openssl/openssl
 RUN hg clone https://gmplib.org/repo/gmp/ libgmp/

--- a/projects/bignum-fuzzer/build.sh
+++ b/projects/bignum-fuzzer/build.sh
@@ -1,3 +1,14 @@
+# Compile latest Go
+cd go/src
+./make.bash
+cd $SRC
+
+# Remove previous Go install (used for bootstrapping)
+apt-get remove golang-1.9-go -y
+rm /usr/bin/go
+
+export PATH=`realpath $SRC/go/bin`:$PATH
+
 # Install Rust nightly
 curl https://sh.rustup.rs -sSf | sh -s -- -y
 source $HOME/.cargo/env


### PR DESCRIPTION
Rather than using Go 1.9, this retrieves, builds and uses the latest development tree of Go. Go 1.9 is still used for bootstrapping, but then deleted.