### PR TITLE
[bignum-fuzzer] Add BoringSSL+libmpdec fuzzer

### DIFF
--- a/projects/bignum-fuzzer/Dockerfile
+++ b/projects/bignum-fuzzer/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y software-properties-common python-softw
 RUN add-apt-repository -y ppa:gophers/archive && apt-get update && apt-get install -y golang-1.9-go
 RUN ln -s /usr/lib/go-1.9/bin/go /usr/bin/go
 
+RUN wget https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.4.2.tar.gz
 RUN git clone --recursive https://github.com/golang/go
 RUN git clone --depth 1 https://github.com/guidovranken/bignum-fuzzer
 RUN git clone --depth 1 https://github.com/openssl/openssl

--- a/projects/bignum-fuzzer/project.yaml
+++ b/projects/bignum-fuzzer/project.yaml
@@ -13,5 +13,6 @@ auto_ccs:
     - "davidben@google.com"
     - "svaldez@google.com"
     - "support-mbedtls@arm.com"
+    - "libmpdec@gmail.com"
 fuzzing_engines:
     - libfuzzer


### PR DESCRIPTION
This adds libmpdec, which Python uses as its bignum backend, to the project, testing it against BoringSSL.
The e-mail address added to ```project.yaml``` belongs to the author of libmpdec.