### PR TITLE
Clarify honggfuzz situation

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -105,11 +105,11 @@ If you rename your fuzz targets, the existing bugs for those targets will get cl
 OSS-Fuzz *uses* [AFL](http://lcamtuf.coredump.cx/afl/) as one of its [fuzzing engines](glossary.md#fuzzing-engine) but this is an implementation detail. Just follow the [ideal integration guide](ideal_integration.md) and OSS-Fuzz will use all its fuzzing engines on your code.
 
 ## Does OSS-Fuzz support Honggfuzz?
-OSS-Fuzz (the service) does not use honggfuzz. It doesn't build fuzz targets to use honggfuzz nor does it use honggfuzz to find bugs.
+OSS-Fuzz (the service) does not use honggfuzz to find bugs.
 That is because [ClusterFuzz](https://github.com/google/clusterfuzz) (the infrastructure OSS-Fuzz runs on) does not support honggfuzz. 
-However, OSS-Fuzz (the open source project) supports **building** fuzz targets for use with honggfuzz, similar to the way it
-supports [AFL](#does-oss-fuzz-support-afl). Unlike AFL or libFuzzer though, these are not run on ClusterFuzz and can only be used
-locally.
+However, OSS-Fuzz supports **building** fuzz targets for use with honggfuzz, similar to the way it
+supports [AFL](#does-oss-fuzz-support-afl). 
+Currently OSS-Fuzz builders do builds for libFuzzer, AFL, and honggfuzz.
 
 ## What are the specs on your machines?
 OSS-Fuzz builders have 32CPU/28.8GB RAM.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -105,7 +105,11 @@ If you rename your fuzz targets, the existing bugs for those targets will get cl
 OSS-Fuzz *uses* [AFL](http://lcamtuf.coredump.cx/afl/) as one of its [fuzzing engines](glossary.md#fuzzing-engine) but this is an implementation detail. Just follow the [ideal integration guide](ideal_integration.md) and OSS-Fuzz will use all its fuzzing engines on your code.
 
 ## Does OSS-Fuzz support Honggfuzz?
-Analogically to [AFL](#does-oss-fuzz-support-afl).
+OSS-Fuzz (the service) does not use honggfuzz. It doesn't build fuzz targets to use honggfuzz nor does it use honggfuzz to find bugs.
+That is because [ClusterFuzz](https://github.com/google/clusterfuzz) (the infrastructure OSS-Fuzz runs on) does not support honggfuzz. 
+However, OSS-Fuzz (the open source project) supports **building** fuzz targets for use with honggfuzz, similar to the way it
+supports [AFL](#does-oss-fuzz-support-afl). Unlike AFL or libFuzzer though, these are not run on ClusterFuzz and can only be used
+locally.
 
 ## What are the specs on your machines?
 OSS-Fuzz builders have 32CPU/28.8GB RAM.


### PR DESCRIPTION
The current honggfuzz situation seems to be very confusing to people.
Many think that OSS-Fuzz (the service)/ClusterFuzz actually uses honggfuzz.
Clarify this by pointing out that OSS-Fuzz supports **building** targets for honggfuzz use, but doesn't
actually use them because ClusterFuzz does not support hongguzz.