### PR TITLE
Add files to run php-json fuzz

### DIFF
--- a/projects/php/Dockerfile
+++ b/projects/php/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER stas@php.net
+RUN apt-get update && apt-get install -y make autoconf automake libtool bison re2c make ca-certificates curl \
+	xz-utils dpkg-dev file libc-dev pkg-config libcurl4-openssl-dev libedit-dev libsqlite3-dev libssl-dev zlib1g-dev
+RUN git clone --depth 1 --branch master https://github.com/php/php-src.git php-src
+RUN git clone --depth 1 https://github.com/smalyshev/php-fuzzing-sapi.git php-src/sapi/fuzzer
+WORKDIR php-src
+COPY build.sh $SRC/
+# This ideally will be gone eventually, right now used for more flexibility in tweaking Makefile options
+# COPY Makefile.frag $SRC/php-src/sapi/fuzzer

--- a/projects/php/build.sh
+++ b/projects/php/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -eu
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# build project
+./buildconf
+./configure --enable-fuzzer --enable-option-checking=fatal --disable-libxml --disable-dom \
+	--disable-simplexml --disable-xml --disable-xmlreader --disable-xmlwriter --without-pear \
+	--enable-exif --disable-phpdbg --disable-cgi
+make
+cp sapi/fuzzer/json.dict $OUT/php-fuzz-json.dict
+cp sapi/fuzzer/php-fuzz-json $OUT/
+for fuzzerName in `ls sapi/fuzzer/corpus`; do
+	zip -j $OUT/php-fuzz-${fuzzerName}_seed_corpus.zip sapi/fuzzer/corpus/${fuzzerName}/*
+done

--- a/projects/php/project.yaml
+++ b/projects/php/project.yaml
@@ -1,0 +1,5 @@
+homepage: "http://php.net/"
+primary_contact: "stas@php.net"
+auto_ccs:
+ - "smalyshev@gmail.com"
+experimental: True


### PR DESCRIPTION
Initial configuration for fuzzing PHP (https://github.com/google/oss-fuzz/issues/1984)

Currently only enables JSON parser fuzzer. 