### PR TITLE
[tpm2-tss] Fix tpm2-tss build

### DIFF
--- a/projects/tpm2-tss/build.sh
+++ b/projects/tpm2-tss/build.sh
@@ -19,7 +19,9 @@ cd $SRC/tpm2-tss/
 
 export LD_LIBRARY_PATH=/usr/local/bin
 
-GEN_FUZZ=1 ./bootstrap
+export GEN_FUZZ=1
+
+./bootstrap
 ./configure \
   CC=clang \
   CXX=clang++ \

--- a/projects/tpm2-tss/project.yaml
+++ b/projects/tpm2-tss/project.yaml
@@ -1,5 +1,7 @@
 homepage: "https://github.com/tpm2-software/tpm2-tss"
 primary_contact: "tadeusz.struk@intel.com"
+auto_ccs:
+  - "john.s.andersen@intel.com"
 sanitizers:
   - address
   - memory


### PR DESCRIPTION
* New checks were added to configure which require that
  the GEN_FUZZ environment variable be set during both
  the bootstrap and configure scripts.

Fixes: #2203

Signed-off-by: John Andersen <john.s.andersen@intel.com>