### PR TITLE
Update solidity fuzzing corpus for solc and const_opt fuzzers.

### DIFF
--- a/projects/solidity/Dockerfile
+++ b/projects/solidity/Dockerfile
@@ -18,7 +18,6 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
     build-essential cmake libbz2-dev ninja-build zlib1g-dev
 RUN git clone --recursive https://github.com/ethereum/solidity.git solidity
-RUN git clone --depth 1 https://github.com/holiman/solfuzzz.git sol_corpus
 RUN git clone --depth 1 https://github.com/ethereum/solidity-fuzzing-corpus.git
 RUN git clone --recursive -b boost-1.69.0 https://github.com/boostorg/boost.git boost
 RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git

--- a/projects/solidity/build.sh
+++ b/projects/solidity/build.sh
@@ -63,10 +63,6 @@ make ossfuzz ossfuzz_proto -j $(nproc)
 # Copy fuzzer binary, seed corpus, fuzzer options, and dictionary
 cp test/tools/ossfuzz/*_ossfuzz $OUT/
 rm -f $OUT/*.zip
-find $SRC/solidity $SRC/sol_corpus -iname "*.sol" -exec zip -ujq \
-  $OUT/solc_opt_ossfuzz_seed_corpus.zip "{}" \;
-cp $OUT/solc_opt_ossfuzz_seed_corpus.zip \
-  $OUT/solc_noopt_ossfuzz_seed_corpus.zip
 for dir in $SRC/solidity-fuzzing-corpus/*;
 do
 	name=$(basename $dir)


### PR DESCRIPTION
This PR minimizes the existing seed corpus for solc and const_opt fuzzers. The new reduced corpus will replace the old one.

Also, from now on, corpus will be fetched from a separate repo called solidity-fuzzing-corpus that is hosted under the Ethereum organization. This makes it easier for updating/fine tuning the corpora from time to time.