### PR TITLE
Add libheif

### DIFF
--- a/projects/libheif/Dockerfile
+++ b/projects/libheif/Dockerfile
@@ -1,0 +1,51 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+MAINTAINER mail@joachim-bauch.de
+
+RUN apt-get update && apt-get install -y \
+    autoconf \
+    automake \
+    build-essential \
+    cmake \
+    libtool \
+    make \
+    mercurial \
+    pkg-config \
+    yasm
+
+RUN git clone \
+    --depth 1 \
+    --branch master \
+    https://github.com/strukturag/libde265.git \
+    libde265
+
+RUN hg clone \
+    --branch stable \
+    http://hg.videolan.org/x265 \
+    x265
+
+RUN git clone \
+    --depth 1 \
+    --branch master \
+    https://github.com/strukturag/libheif.git \
+    libheif
+
+WORKDIR libheif
+
+COPY build.sh $SRC/

--- a/projects/libheif/build.sh
+++ b/projects/libheif/build.sh
@@ -1,0 +1,67 @@
+#!/bin/bash -eu
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Build dependencies.
+export DEPS_PATH=$SRC/deps
+mkdir -p $DEPS_PATH
+
+cd $SRC/x265/build/linux
+cmake -G "Unix Makefiles" \
+    -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX \
+    -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+    -DCMAKE_INSTALL_PREFIX="$DEPS_PATH" \
+    -DENABLE_SHARED:bool=off \
+    ../../source
+make clean
+make -j$(nproc) x265-static
+make install
+
+cd $SRC/libde265
+./autogen.sh
+./configure \
+    --prefix="$DEPS_PATH" \
+    --disable-shared \
+    --enable-static \
+    --disable-dec265 \
+    --disable-sherlock265 \
+    --disable-hdrcopy \
+    --disable-enc265 \
+    --disable-acceleration_speed
+make clean
+make -j$(nproc)
+make install
+
+# Remove shared libraries to avoid accidental linking against them.
+rm -f $DEPS_PATH/lib/*.so
+rm -f $DEPS_PATH/lib/*.so.*
+
+cd $SRC/libheif
+./autogen.sh
+PKG_CONFIG="pkg-config --static" PKG_CONFIG_PATH="$DEPS_PATH/lib/pkgconfig" ./configure \
+    --disable-shared \
+    --enable-static \
+    --disable-examples \
+    --disable-go \
+    --enable-libfuzzer
+make clean
+make -j$(nproc)
+
+cp libheif/*-fuzzer $OUT
+cp fuzzing/dictionary.txt $OUT/box-fuzzer.dict
+cp fuzzing/dictionary.txt $OUT/file-fuzzer.dict
+
+zip -r $OUT/file-fuzzer_seed_corpus.zip fuzzing/corpus/*.heic

--- a/projects/libheif/project.yaml
+++ b/projects/libheif/project.yaml
@@ -1,0 +1,4 @@
+homepage: "https://github.com/strukturag/libheif"
+primary_contact: "dirk.farin@gmail.com"
+auto_ccs:
+  - "mail@joachim-bauch.de"


### PR DESCRIPTION
I am one of the developers of [libheif](https://github.com/strukturag/libheif), an ISO/IEC 23008-12:2017 HEIF file format decoder and encoder.

libheif is used by various graphics tools like Gimp or [ImageMagick](https://github.com/google/oss-fuzz/blob/master/projects/imagemagick/Dockerfile#L23). We received a couple of fuzzing reports from ImageMagick and other projects, so we would like to join oss-fuzz directly.

We already perform some fuzzing as part of our CI, but being integrated in oss-fuzz would increase our code coverage.