### PR TITLE
[picotls] Add picotls project.yaml

### DIFF
--- a/projects/picotls/project.yaml
+++ b/projects/picotls/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://github.com/h2o/picotls"
+primary_contact: "jonathan.foote@gmail.com"
+auto_ccs:
+  - "frederik.deweerdt@gmail.com"
+  - "kazuhooku@gmail.com"
+  - "i.nagata110@gmail.com"
+  - "toru@fastly.com"
+  - "security@fastly.com"


### PR DESCRIPTION
Hello,

I'd like to request integrating [picotls](https://github.com/h2o/picotls) with oss-fuzz. This project is maintained by largely the same team as [h2o](https://github.com/google/oss-fuzz/blob/master/projects/h2o/project.yaml); the CC's are the same except the addition of @toru, who is a picotls developer.

If you need any additional information just let me know.

Thanks,
Jon