### PR TITLE
[infra] Bump build timeout from 10h to 12h.

### DIFF
--- a/infra/gcb/build_project.py
+++ b/infra/gcb/build_project.py
@@ -20,7 +20,7 @@ from oauth2client.client import GoogleCredentials
 from oauth2client.service_account import ServiceAccountCredentials
 from googleapiclient.discovery import build
 
-BUILD_TIMEOUT = 10 * 60 * 60
+BUILD_TIMEOUT = 12 * 60 * 60
 
 FUZZING_BUILD_TAG = 'fuzzing'
 


### PR DESCRIPTION
libreoffice build fails to finish in <10h (fails on honggfuzz step)

@jonathanmetzman was suggesting to remove honggfuzz builds, as they take considerable amount of time and aren't used. @oliverchang do you have any concerns, as I think you've added honggfuzz builds initially?