### PR TITLE
[picotls] Fix build by disabling smaller fuzz targets

### DIFF
--- a/projects/picotls/build.sh
+++ b/projects/picotls/build.sh
@@ -18,7 +18,8 @@
 pushd $SRC/picotls
 cmake -DBUILD_FUZZER=ON -DOSS_FUZZ=ON .
 make
-cp ./fuzz-* $OUT/
+cp ./fuzz-client-hello $OUT/
+cp ./fuzz-server-hello $OUT/
 
 zip -jr $OUT/fuzz-client-hello_seed_corpus.zip $SRC/picotls/fuzz/fuzz-client-hello-corpus
 zip -jr $OUT/fuzz-server-hello_seed_corpus.zip $SRC/picotls/fuzz/fuzz-server-hello-corpus


### PR DESCRIPTION
As @inferno-chromium [suspected](https://github.com/google/oss-fuzz/pull/2222#issuecomment-471143666), it appears that the picotls `fuzz-asn1-type-and-length` and `fuzz-asn1-validation` fuzz targets not large enough to result in sufficient instrumentation for oss-fuzz. Output from executing the fuzz targets shows ~75 edges under clang 9 (failing `check_build`) and ~105 edges under clang 6. This PR changes `build.sh` so that it does not copy these fuzz targets into `$OUT`. This disables the fuzz targets so that they do not cause the build to fail.

```
 python infra/helper.py check_build picotls
Running: docker run --rm -i --privileged -e FUZZING_ENGINE=libfuzzer -e SANITIZER=address -v /home/foote/oss-fuzz.jfoote/build/out/picotls:/out -t gcr.io/oss-fuzz-base/base-runner test_all
INFO: performing bad build checks for /out/fuzz-client-hello.
INFO: performing bad build checks for /out/fuzz-server-hello.
2 fuzzers total, 0 seem to be broken (0%).
Check build passed.
```