### PR TITLE
[picotls] Add ASN-1 target

### DIFF
--- a/projects/picotls/build.sh
+++ b/projects/picotls/build.sh
@@ -18,8 +18,7 @@
 pushd $SRC/picotls
 cmake -DBUILD_FUZZER=ON -DOSS_FUZZ=ON .
 make
-cp ./fuzz-client-hello $OUT/
-cp ./fuzz-server-hello $OUT/
+cp ./fuzz-* $OUT/
 
 zip -jr $OUT/fuzz-client-hello_seed_corpus.zip $SRC/picotls/fuzz/fuzz-client-hello-corpus
 zip -jr $OUT/fuzz-server-hello_seed_corpus.zip $SRC/picotls/fuzz/fuzz-server-hello-corpus


### PR DESCRIPTION
Hello,

In lieu of https://github.com/google/oss-fuzz/issues/2231, we have [expanded](https://github.com/h2o/picotls/pull/224) the ASN-1 fuzz target for picotls so it now passes `check_build`. This PR adds it to the oss-fuzz integration.

```
INFO: performing bad build checks for /out/fuzz-client-hello.
INFO: performing bad build checks for /out/fuzz-server-hello.
INFO: performing bad build checks for /out/fuzz-asn1.
3 fuzzers total, 0 seem to be broken (0%).
Check build passed.
```

Thanks,
Jon