### PR TITLE
[janus] First integration

### DIFF
--- a/projects/janus-gateway/Dockerfile
+++ b/projects/janus-gateway/Dockerfile
@@ -1,0 +1,46 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER atoppi@meetecho.com
+RUN apt-get update && apt-get install -y \
+	autoconf autoconf-archive \
+	automake \
+	gengetopt \
+	gtk-doc-tools \
+	libconfig-dev \
+	libglib2.0-dev \
+	libgnutls-dev \
+	libini-config-dev \
+	libjansson-dev \
+	libssl-dev \
+	libtool \
+	openssl \
+	pkg-config
+	
+# install libsrtp dep from source
+RUN git clone --single-branch --branch 2_2_x_throttle https://github.com/cisco/libsrtp.git libsrtp
+RUN cd libsrtp && ./configure --enable-openssl && make -j$(nproc) shared_library && make install
+
+# install libnice dep from source
+RUN git clone --single-branch --branch master https://gitlab.freedesktop.org/libnice/libnice.git libnice
+RUN cd libnice && git checkout 2e044ea1 && ./autogen.sh && ./configure --disable-gtk-doc --disable-gtk-doc-html && make -j$(nproc) && make install
+
+# fetch Janus code
+RUN git clone --single-branch --branch master https://github.com/meetecho/janus-gateway.git janus-gateway
+
+WORKDIR $SRC
+COPY build.sh $SRC/

--- a/projects/janus-gateway/build.sh
+++ b/projects/janus-gateway/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FUZZ_ENV=oss-fuzz $SRC/janus-gateway/fuzzers/build.sh

--- a/projects/janus-gateway/project.yaml
+++ b/projects/janus-gateway/project.yaml
@@ -1,0 +1,23 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+homepage: "https://github.com/meetecho/janus-gateway"
+primary_contact: "toppi.ale@gmail.com"
+sanitizers:
+  - address
+  - memory
+  - undefined
+coverage_extra_args: -ignore-filename-regex=.*glib.* -ignore-filename-regex=.*log.c


### PR DESCRIPTION
Hi OSS-Fuzz team,
I am one of the developers of [Janus](https://github.com/meetecho/janus-gateway), an open-source WebRTC server developed by Meetecho.
I've been working on fuzzing Janus core protocols in the last months and I aimed at OSS-Fuzz integration since the beginning in order to have a continuous and wide-covered fuzzing happening on our beloved server.

My efforts led me first to briefly describe my work at [FOSDEM19](https://fosdem.org/2019/schedule/event/janus_ml/) and then write a blogpost on [webrthacks](https://webrtchacks.com/fuzzing-janus/) where I describe my journey and also the benefits of the integration with Google fuzzing platform.

This PR integrates Janus in OSS-Fuzz, making use of the fuzzers for the RTP and RTCP parsers we already published on our repository. Soon other protocols, like SDP, will follow up.

In case there's anything missing or that needs to be changed, please let me know.

Thanks for your awesome work.

Alessandro