### PR TITLE
[picotls] Update toru's email address

### DIFF
--- a/projects/picotls/project.yaml
+++ b/projects/picotls/project.yaml
@@ -4,5 +4,5 @@ auto_ccs:
   - "frederik.deweerdt@gmail.com"
   - "kazuhooku@gmail.com"
   - "i.nagata110@gmail.com"
-  - "toru@fastly.com"
+  - "tmaesaka@gmail.com"
   - "security@fastly.com"


### PR DESCRIPTION
Hello team! I would like to update my email address in the `picotls` project.yaml -- Couple of reasons:

1. `toru@` is an alias, which seemingly doesn't play well with the project authN/AuthY
2. It's more convenient to use my personal Google account

Thank you in advance.