### PR TITLE
Capstone: use the new v4 branch

### DIFF
--- a/projects/capstone/Dockerfile
+++ b/projects/capstone/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER capstone.engine@gmail.com
 RUN apt-get update && apt-get install -y make cmake python python-setuptools
-RUN git clone --depth 1 --branch master https://github.com/aquynh/capstone.git capstonemaster
+RUN git clone --depth 1 --branch v4 https://github.com/aquynh/capstone.git capstonev4
 RUN git clone --depth 1 --branch next https://github.com/aquynh/capstone.git capstonenext
 WORKDIR $SRC
 COPY build.sh $SRC/

--- a/projects/capstone/build.sh
+++ b/projects/capstone/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 #add next branch
-for branch in master next
+for branch in v4 next
 do
     cd capstone$branch
     # build project


### PR DESCRIPTION
When we began fuzzing, `master` used to be v3 and `next` the beta version for v4

Now, `next` is still the branch with the new developments pour the future v5
And the branch `v4` got created and will be maintained for a while (and should be ok)