### PR TITLE
Allow preloading external libFuzzer functions using LD_PRELOAD

### DIFF
--- a/infra/base-images/base-builder/compile_libfuzzer
+++ b/infra/base-images/base-builder/compile_libfuzzer
@@ -18,7 +18,8 @@
 echo -n "Compiling libFuzzer to $LIB_FUZZING_ENGINE... "
 mkdir -p $WORK/libfuzzer
 pushd $WORK/libfuzzer > /dev/null
-$CXX $CXXFLAGS -std=c++11 -O2 $SANITIZER_FLAGS -fno-sanitize=vptr \
+# Use -fPIC to allow use of LD_PRELOAD.
+$CXX $CXXFLAGS -std=c++11 -O2 -fPIC $SANITIZER_FLAGS -fno-sanitize=vptr \
     -c $SRC/libfuzzer/*.cpp -I$SRC/libfuzzer
 ar r $LIB_FUZZING_ENGINE $WORK/libfuzzer/*.o
 popd > /dev/null

--- a/infra/base-images/base-builder/compile_libfuzzer
+++ b/infra/base-images/base-builder/compile_libfuzzer
@@ -18,7 +18,7 @@
 echo -n "Compiling libFuzzer to $LIB_FUZZING_ENGINE... "
 mkdir -p $WORK/libfuzzer
 pushd $WORK/libfuzzer > /dev/null
-# Use -fPIC to allow use of LD_PRELOAD.
+# Use -fPIC to allow preloading (LD_PRELOAD).
 $CXX $CXXFLAGS -std=c++11 -O2 -fPIC $SANITIZER_FLAGS -fno-sanitize=vptr \
     -c $SRC/libfuzzer/*.cpp -I$SRC/libfuzzer
 ar r $LIB_FUZZING_ENGINE $WORK/libfuzzer/*.o


### PR DESCRIPTION
This PR compiles libFuzzer with `-fPIC` to allow preloading using `LD_PRELOAD`.
`-fPIC` is used to compile libFuzzer when it is compiled within LLVM.
Without `-fPIC`, `LD_PRELOAD` cannot be used to override `LLVMFuzzerCustomMutator`