### PR TITLE
[lame] Initial LAME mp3 encoder/decoder oss-fuzz integration

### DIFF
--- a/projects/lame/Dockerfile
+++ b/projects/lame/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER guidovranken@gmail.com
+RUN apt-get update && apt-get install -y make autoconf automake libtool subversion
+RUN git clone --depth 1 https://github.com/guidovranken/LAME-fuzzers
+RUN svn checkout https://svn.code.sf.net/p/lame/svn/trunk/lame $SRC/lame
+COPY build.sh $SRC/

--- a/projects/lame/build.sh
+++ b/projects/lame/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -eu
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC/lame
+./configure
+make -j$(nproc)
+
+cd $SRC/LAME-fuzzers
+if [[ $CXXFLAGS = *sanitize=memory* ]]
+then
+    export CXXFLAGS="$CXXFLAGS -DMSAN"
+fi
+
+$CXX -std=c++17 -Wall -Wextra -Werror $CXXFLAGS -I fuzzing-headers/include/ -I $SRC/lame/include/ fuzzer-encoder.cpp -lFuzzingEngine $SRC/lame/libmp3lame/.libs/libmp3lame.a -lm -o $OUT/fuzzer-encoder
+cp fuzzer-encoder_seed_corpus.zip $OUT/
+cp fuzzer-encoder.dict $OUT/

--- a/projects/lame/project.yaml
+++ b/projects/lame/project.yaml
@@ -1,0 +1,4 @@
+homepage: "https://sourceforge.net/projects/lame/"
+primary_contact: "guidovranken@gmail.com"
+sanitizers:
+ - address


### PR DESCRIPTION
RE https://github.com/google/oss-fuzz/issues/2247

With ASAN (or no sanitizer), the fuzzer currently works around some (probable) bugs it already found, so it does not crash on the included seed corpus.

UBSAN fuzzer not enabled in ```project.yaml``` due to crashing on the seed corpus (shift overflow).

MSAN compiles and seems to work as expected, but I got these warnings during the build:

```
WARNING: Instrumented library not found for /lib/x86_64-linux-gnu/libm.so.6
WARNING: Instrumented library not found for /lib/x86_64-linux-gnu/libpthread.so.0
WARNING: Instrumented library not found for /lib/x86_64-linux-gnu/librt.so.1
WARNING: Instrumented library not found for /lib/x86_64-linux-gnu/libdl.so.2
WARNING: Instrumented library not found for /lib/x86_64-linux-gnu/libgcc_s.so.1
WARNING: Instrumented library not found for /lib/x86_64-linux-gnu/libc.so.6
```

Trying to add these libraries as demonstrated in [this file](https://github.com/google/oss-fuzz/blob/master/infra/base-images/msan-builder/Dockerfile#L20) didn't work.

Awaiting response from LAME devs (https://sourceforge.net/p/lame/mailman/message/36616640/).

As far as I'm concerned we can start fuzzing, unless you prefer to wait until LAME devs green-light this.