### PR TITLE
Changed email address for ImageMagick primary contact.

### DIFF
--- a/projects/imagemagick/project.yaml
+++ b/projects/imagemagick/project.yaml
@@ -1,5 +1,5 @@
 homepage: "https://www.imagemagick.org"
-primary_contact: "dirk@git.imagemagick.org"
+primary_contact: "dirk@lemstra.org"
 auto_ccs:
   - paul.l.kehrer@gmail.com
   - alex.gaynor@gmail.com


### PR DESCRIPTION
I can no longer the oss-fuzz site because I changed my google email address. This PR resolves that issue.