### PR TITLE
Add LZMA SDK

### DIFF
--- a/projects/lzma/Dockerfile
+++ b/projects/lzma/Dockerfile
@@ -1,0 +1,35 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+MAINTAINER mail@joachim-bauch.de
+
+RUN apt-get update && apt-get install -y \
+	autoconf \
+	automake \
+	libtool \
+	make
+
+RUN git clone \
+	--depth 1 \
+	--branch master \
+	https://github.com/fancycode/lzma-fuzz.git \
+	lzma-fuzz
+
+WORKDIR lzma-fuzz
+
+COPY build.sh $SRC/

--- a/projects/lzma/build.sh
+++ b/projects/lzma/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -eu
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# build and install fuzzers
+make clean
+make -j$(nproc)
+make install DEST=$OUT

--- a/projects/lzma/project.yaml
+++ b/projects/lzma/project.yaml
@@ -1,0 +1,2 @@
+homepage: "https://www.7-zip.org/sdk.html"
+primary_contact: "mail@joachim-bauch.de"

--- a/projects/lzma/project.yaml
+++ b/projects/lzma/project.yaml
@@ -1,2 +1,8 @@
 homepage: "https://www.7-zip.org/sdk.html"
-primary_contact: "mail@joachim-bauch.de"
+primary_contact: "ipavlov@users.sourceforge.net"
+auto_ccs:
+  - "mail@joachim-bauch.de"
+sanitizers:
+  - address
+  - memory
+  - undefined


### PR DESCRIPTION
As written in https://github.com/google/oss-fuzz/issues/402#issuecomment-476767251 here is the oss-fuzz integration of my LZMA SDK fuzzers.

I checked with the upstream author in https://sourceforge.net/p/sevenzip/feature-requests/1396/ and as he doesn't maintain a repository for the SDK, I created https://github.com/fancycode/lzma-fuzz and will maintain the fuzzers there together with the upstream SDK releases. The repository contains some initial fuzzers but I'm planing to add more shortly that cover more areas of the SDK code.