### PR TITLE
[bignum-fuzzer] Compile OpenSSL debug mode

### DIFF
--- a/projects/bignum-fuzzer/build.sh
+++ b/projects/bignum-fuzzer/build.sh
@@ -23,7 +23,7 @@ if [[ $CFLAGS = *sanitize=memory* ]]
 then
   CFLAGS+=" -DOPENSSL_NO_ASM=1"
 fi
-./config
+./config --debug
 make -j$(nproc)
 
 # Build libgmp


### PR DESCRIPTION
This activates assert()s across the library that might help to detect
issues that other safeguards (sanitizers, differential testing)
aren't capable of.