### PR TITLE
tweak cppcheck. moved fuzzer client to main cppcheck repo.

### DIFF
--- a/projects/cppcheck/Dockerfile
+++ b/projects/cppcheck/Dockerfile
@@ -17,8 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER daniel.marjamaki@gmail.com
 
-RUN git clone https://github.com/orbitcowboy/afl_cppcheck.git afl_cppcheck
-RUN git clone https://github.com/danmar/cppcheck.git afl_cppcheck/cppcheck
+RUN git clone https://github.com/danmar/cppcheck.git
 
 WORKDIR afl_cppcheck
 COPY build.sh $SRC/

--- a/projects/cppcheck/build.sh
+++ b/projects/cppcheck/build.sh
@@ -17,7 +17,7 @@
 
 # build fuzzer
 
-cd fuzzer-cli
+cd $SRC/cppcheck/oss-fuzz
 make oss-fuzz-client
 cp oss-fuzz-client $OUT/
 


### PR DESCRIPTION
I have had trouble reproducing findings so far. I hope that by moving the client to cppcheck repo it will be easier to reproduce.

I have tested with the commands below:

    python infra/helper.py build_image cppcheck
    python infra/helper.py build_fuzzers cppcheck
    python infra/helper.py check_build cppcheck
    python infra/helper.py run_fuzzer cppcheck oss-fuzz-client
