### PR TITLE
change WORKDIR

### DIFF
--- a/projects/cppcheck/Dockerfile
+++ b/projects/cppcheck/Dockerfile
@@ -19,6 +19,6 @@ MAINTAINER daniel.marjamaki@gmail.com
 
 RUN git clone https://github.com/danmar/cppcheck.git
 
-WORKDIR afl_cppcheck
+WORKDIR cppcheck
 COPY build.sh $SRC/
 


### PR DESCRIPTION
I don't know if it actually makes a difference .. but this fixes the WORKDIR in the Dockerfile..

maybe now we don't need to use $SRC in build.sh but I think we can keep that for safety.

Tested with:

    python infra/helper.py build_image cppcheck
    python infra/helper.py build_fuzzers cppcheck
    python infra/helper.py check_build cppcheck
    python infra/helper.py run_fuzzer --sanitizer address cppcheck
