### PR TITLE
[opencv] update build scripts

### DIFF
--- a/projects/opencv/Dockerfile
+++ b/projects/opencv/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y build-essential cmake pkg-config
 RUN git clone --depth 1 https://github.com/opencv/opencv.git opencv
-WORKDIR $SRC/
+WORKDIR opencv/
 
 COPY build.sh $SRC/
 COPY *.cc *.h $SRC/

--- a/projects/opencv/build.sh
+++ b/projects/opencv/build.sh
@@ -15,21 +15,25 @@
 #
 ################################################################################
 
-mkdir opencv/build
-pushd opencv/build
-cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=$WORK \
+build_dir=$WORK/build-$SANITIZER
+install_dir=$WORK/install-$SANITIZER
+
+mkdir -p $build_dir
+pushd $build_dir
+cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=$install_dir \
   -DBUILD_SHARED_LIBS=OFF -DOPENCV_GENERATE_PKGCONFIG=ON \
-  -DOPENCV_GENERATE_PKGCONFIG=ON -DOPENCV_FORCE_3RDPARTY_BUILD=ON ..
+  -DOPENCV_GENERATE_PKGCONFIG=ON -DOPENCV_FORCE_3RDPARTY_BUILD=ON \
+  -DBUILD_TESTS=OFF -DBUILD_PERF_TESTS=OFF -DBUILD_opencv_apps=OFF \
+  $SRC/opencv
 make -j$(nproc)
 make install
 popd
 
+pushd $SRC
 for fuzzer in imdecode_fuzzer imread_fuzzer; do
 $CXX $CXXFLAGS -lFuzzingEngine $fuzzer.cc -std=c++11 \
--I$WORK/include/opencv4/opencv \
--I$WORK/include/opencv4 -L$WORK/lib \
--L$WORK/lib/opencv4/3rdparty \
--L$SRC/opencv/build/lib \
+-I$install_dir/include/opencv4 -L$install_dir/lib \
+-L$install_dir/lib/opencv4/3rdparty \
 -lopencv_dnn -lopencv_objdetect -lopencv_photo -lopencv_ml -lopencv_gapi \
 -lopencv_stitching -lopencv_video -lopencv_calib3d -lopencv_features2d \
 -lopencv_highgui -lopencv_videoio -lopencv_imgcodecs -lopencv_imgproc \
@@ -38,3 +42,4 @@ $CXX $CXXFLAGS -lFuzzingEngine $fuzzer.cc -std=c++11 \
 -lippicv -lade -ldl -lm -lpthread -lrt \
 -o $OUT/$fuzzer
 done
+popd


### PR DESCRIPTION
- disable building of tests/apps (not used for fuzzing)
- unlock [using local source checkout](https://github.com/google/oss-fuzz/blob/master/docs/reproducing.md#reproduce-using-local-source-checkout)
  * `$SRC` - fuzzers sources
  * `$SRC/opencv` - opencv sources
  * `$WORK/build-$SANITIZER` - build directory

---

Validated locally using commands:
- `python infra/helper.py build_fuzzers --sanitizer address opencv /home/alalek/projects/opencv/dev`
- `python infra/helper.py reproduce opencv imdecode_fuzzer ...`