### PR TITLE
Use a single tag for builds.

### DIFF
--- a/infra/gcb/build_project.py
+++ b/infra/gcb/build_project.py
@@ -356,8 +356,7 @@ def run_build(build_steps, project_name, tag):
       'options': options,
       'logsBucket': GCB_LOGS_BUCKET,
       'tags': [
-          project_name,
-          tag,
+          project_name + '-' + tag,
       ],
   }
 


### PR DESCRIPTION
Filtering on multiple tags doesn't seem to work.