### PR TITLE
[tensorflow] Update Bazel version and check that it is compatible

### DIFF
--- a/projects/tensorflow/Dockerfile
+++ b/projects/tensorflow/Dockerfile
@@ -30,10 +30,10 @@ RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8
 RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
 RUN apt-get update && apt-get install -y bazel
 
-# Downgrade Bazel to latest supported version (0.21.0)
-RUN curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/0.21.0/bazel-0.21.0-installer-linux-x86_64.sh
-RUN chmod +x ./bazel-0.21.0-installer-linux-x86_64.sh
-RUN ./bazel-0.21.0-installer-linux-x86_64.sh
+# Downgrade Bazel to latest supported version (0.24.0)
+RUN curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/0.24.0/bazel-0.24.0-installer-linux-x86_64.sh
+RUN chmod +x ./bazel-0.24.0-installer-linux-x86_64.sh
+RUN ./bazel-0.24.0-installer-linux-x86_64.sh
 
 RUN git clone --depth 1 https://github.com/tensorflow/tensorflow tensorflow
 WORKDIR $SRC/tensorflow

--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -27,6 +27,9 @@ declare -r FUZZERS=$(
 CFLAGS="${CFLAGS} -fno-sanitize=vptr"
 CXXFLAGS="${CXXFLAGS} -fno-sanitize=vptr -std=c++11 -stdlib=libc++"
 
+# Make sure we run ./configure to detect when we are using a Bazel out of range
+yes "" | ./configure
+
 # See https://github.com/bazelbuild/bazel/issues/6697
 sed '/::kM..SeedBytes/d' -i tensorflow/stream_executor/rng.cc
 


### PR DESCRIPTION
TensorFlow [failed to build](https://oss-fuzz-build-logs.storage.googleapis.com/log-661590eb-a9f9-4e6e-ab72-eca775b81064.txt) because we used a Bazel version which is no longer supported.

We have checks for Bazel outside of range but they were not run on OSSFuzz since we were not running `./configure`. This has been fixed now, as well as picking the latest Bazel version which currently works.

Probably I should get a way to get the latest Bazel in `Dockerfile` by parsing TensorFlow's `configure.py`. Or get the latest Bazel in `build.sh` before doing any actual build? I'll think about this and get another PR this week.