### PR TITLE
[infra] Enabling DataFlow build configuration (#1632).

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -23,7 +23,10 @@ ENV SANITIZER_FLAGS_address "-fsanitize=address -fsanitize-address-use-after-sco
 
 # Set of '-fsanitize' flags matches '-fno-sanitize-recover' + 'unsigned-integer-overflow'.
 ENV SANITIZER_FLAGS_undefined "-fsanitize=bool,array-bounds,float-divide-by-zero,function,integer-divide-by-zero,return,shift,signed-integer-overflow,unsigned-integer-overflow,vla-bound,vptr -fno-sanitize-recover=bool,array-bounds,float-divide-by-zero,function,integer-divide-by-zero,return,shift,signed-integer-overflow,vla-bound,vptr"
+
 ENV SANITIZER_FLAGS_memory "-fsanitize=memory -fsanitize-memory-track-origins"
+
+ENV SANITIZER_FLAGS_dataflow "-fsanitize=dataflow -fsanitize-coverage=trace-pc-guard,pc-table,func,trace-cmp"
 
 # Do not use any sanitizers in the coverage build.
 ENV SANITIZER_FLAGS_coverage ""
@@ -63,6 +66,7 @@ RUN mkdir honggfuzz && \
     tar -xzv --strip-components=1 -f $SRC/oss-fuzz.tar.gz && \
     rm -rf $SRC/oss-fuzz.tar.gz
 
-COPY compile compile_afl compile_libfuzzer compile_honggfuzz srcmap write_labels.py /usr/local/bin/
+COPY compile compile_afl compile_dataflow compile_libfuzzer compile_honggfuzz \
+    srcmap write_labels.py /usr/local/bin/
 
 CMD ["compile"]

--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -49,8 +49,8 @@ then
   export COVERAGE_FLAGS="${!COVERAGE_FLAGS_VAR}"
 fi
 
- # Don't need coverage instrumentation for engine-less builds.
-if [[ $FUZZING_ENGINE = "none" ]]; then
+ # Don't need coverage instrumentation for engine-less or DFSan builds.
+if [ $FUZZING_ENGINE = "none" ] || [ $FUZZING_ENGINE = "dataflow" ]; then
   export COVERAGE_FLAGS=
 fi
 

--- a/infra/base-images/base-builder/compile_dataflow
+++ b/infra/base-images/base-builder/compile_dataflow
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2016 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,13 +15,13 @@
 #
 ################################################################################
 
-echo -n "Compiling libFuzzer to $LIB_FUZZING_ENGINE... "
+echo -n "Compiling DataFlow to $LIB_FUZZING_ENGINE... "
 mkdir -p $WORK/libfuzzer
 pushd $WORK/libfuzzer > /dev/null
 
-# Use -fPIC to allow preloading (LD_PRELOAD).
-$CXX $CXXFLAGS -std=c++11 -O2 -fPIC $SANITIZER_FLAGS -fno-sanitize=vptr \
-    -c $SRC/libfuzzer/*.cpp -I$SRC/libfuzzer
+# Intentionally do not use $SANITIZER_FLAGS, we need -fsanitize=dataflow only.
+$CXX $CXXFLAGS -fsanitize=dataflow -std=c++11 -O2 -c \
+    $SRC/libfuzzer/dataflow/*.cpp
 ar r $LIB_FUZZING_ENGINE $WORK/libfuzzer/*.o
 popd > /dev/null
 rm -rf $WORK/libfuzzer

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -109,6 +109,9 @@ rm -rf $WORK/msan
 # Pull trunk libfuzzer.
 cd $SRC && svn co https://llvm.org/svn/llvm-project/compiler-rt/trunk/lib/fuzzer libfuzzer
 
+# Copy DataFlow script for collecting the traces.
+cp libfuzzer/scripts/collect_data_flow.py /usr/local/bin/
+
 # Cleanup
 rm -rf $SRC/llvm
 rm -rf $SRC/chromium_tools

--- a/infra/gcb/build_project.py
+++ b/infra/gcb/build_project.py
@@ -28,11 +28,13 @@ GCB_LOGS_BUCKET = 'oss-fuzz-gcb-logs'
 
 CONFIGURATIONS = {
     'sanitizer-address': ['SANITIZER=address'],
+    'sanitizer-dataflow': ['SANITIZER=dataflow'],
     'sanitizer-memory': ['SANITIZER=memory'],
     'sanitizer-undefined': ['SANITIZER=undefined'],
     'engine-libfuzzer': ['FUZZING_ENGINE=libfuzzer'],
     'engine-afl': ['FUZZING_ENGINE=afl'],
     'engine-honggfuzz': ['FUZZING_ENGINE=honggfuzz'],
+    'engine-dataflow': ['FUZZING_ENGINE=dataflow'],
     'engine-none': ['FUZZING_ENGINE=none'],
 }
 
@@ -52,6 +54,10 @@ ENGINE_INFO = {
         EngineInfo(
             upload_bucket='clusterfuzz-builds-honggfuzz',
             supported_sanitizers=['address', 'memory', 'undefined']),
+    'dataflow':
+        EngineInfo(
+            upload_bucket='clusterfuzz-builds-dataflow',
+            supported_sanitizers=['dataflow']),
     'none':
         EngineInfo(
             upload_bucket='clusterfuzz-builds-no-engine',

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -251,13 +251,14 @@ def _get_work_dir(project_name=''):
 def _add_engine_args(parser):
   """Add common engine args."""
   parser.add_argument('--engine', default='libfuzzer',
-                      choices=['libfuzzer', 'afl', 'honggfuzz', 'none'])
+                      choices=['libfuzzer', 'afl', 'honggfuzz', 'dataflow', 'none'])
 
 
 def _add_sanitizer_args(parser):
   """Add common sanitizer args."""
-  parser.add_argument('--sanitizer', default='address',
-                      choices=['address', 'memory', 'undefined', 'coverage'])
+  parser.add_argument(
+      '--sanitizer', default='address',
+      choices=['address', 'memory', 'undefined', 'coverage', 'dataflow'])
 
 
 def _add_environment_args(parser):


### PR DESCRIPTION
Still a draft, need to figure out linking issues:

```bash
+ for fuzzer in libxml2_xml_read_memory_fuzzer libxml2_xml_reader_for_file_fuzzer
+ clang++ -O1 -fno-omit-frame-pointer -gline-tables-only -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=dataflow -fsanitize-coverage=trace-pc-guard,pc-table,func,trace-cmp -stdlib=libc++ -std=c++11 -Iinclude/ /src/libxml2_xml_read_memory_fuzzer.cc -o /out/libxml2_xml_read_memory_fuzzer -lFuzzingEngine .libs/libxml2.a
/tmp/libxml2_xml_read_memory_fuzzer-fdfa6d.o: In function `dfs$LLVMFuzzerTestOneInput':
/src/libxml2_xml_read_memory_fuzzer.cc:48: undefined reference to `dfs$_ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEED2Ev'
/src/libxml2_xml_read_memory_fuzzer.cc:48: undefined reference to `dfs$_ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEED2Ev'
/tmp/libxml2_xml_read_memory_fuzzer-fdfa6d.o: In function `dfs$_ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEC2EPKcm':
/usr/local/bin/../include/c++/v1/string:1821: undefined reference to `dfs$_ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE6__initEPKcm'
/tmp/libxml2_xml_read_memory_fuzzer-fdfa6d.o: In function `dfs$_ZNSt3__120__throw_length_errorEPKc':
/usr/local/bin/../include/c++/v1/stdexcept:251: undefined reference to `dfs$__cxa_allocate_exception'
/usr/local/bin/../include/c++/v1/stdexcept:251: undefined reference to `dfs$_ZNSt12length_errorD1Ev'
/usr/local/bin/../include/c++/v1/stdexcept:251: undefined reference to `dfs$__cxa_throw'
/usr/local/bin/../include/c++/v1/stdexcept:251: undefined reference to `dfs$__cxa_free_exception'
/tmp/libxml2_xml_read_memory_fuzzer-fdfa6d.o: In function `dfs$_ZNSt3__117__libcpp_allocateEmm':
/usr/local/bin/../include/c++/v1/new:238: undefined reference to `dfs$_Znwm'
/tmp/libxml2_xml_read_memory_fuzzer-fdfa6d.o: In function `dfs$_ZNSt12length_errorC2EPKc':
/usr/local/bin/../include/c++/v1/stdexcept:153: undefined reference to `dfs$_ZNSt11logic_errorC2EPKc'
/tmp/libxml2_xml_read_memory_fuzzer-fdfa6d.o: In function `dfs$__clang_call_terminate':
libxml2_xml_read_memory_fuzzer.cc:(.text.dfs$__clang_call_terminate[__clang_call_terminate]+0x2): undefined reference to `dfs$__cxa_begin_catch'
libxml2_xml_read_memory_fuzzer.cc:(.text.dfs$__clang_call_terminate[__clang_call_terminate]+0x7): undefined reference to `dfs$_ZSt9terminatev'
/tmp/libxml2_xml_read_memory_fuzzer-fdfa6d.o: In function `dfs$_ZNSt3__117_DeallocateCaller9__do_callEPv':
/usr/local/bin/../include/c++/v1/new:319: undefined reference to `dfs$_ZdlPv'
/tmp/libxml2_xml_read_memory_fuzzer-fdfa6d.o:(.data.DW.ref.dfs$__gxx_personality_v0[DW.ref.dfs$__gxx_personality_v0]+0x0): undefined reference to `dfs$__gxx_personality_v0'
clang-9: error: linker command failed with exit code 1 (use -v to see invocation)
Fuzzers build failed.
```

