### PR TITLE
[TensorFlow] Ensure we're always using a valid Bazel

### DIFF
--- a/projects/tensorflow/Dockerfile
+++ b/projects/tensorflow/Dockerfile
@@ -30,11 +30,6 @@ RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8
 RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
 RUN apt-get update && apt-get install -y bazel
 
-# Downgrade Bazel to latest supported version (0.24.0)
-RUN curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/0.24.0/bazel-0.24.0-installer-linux-x86_64.sh
-RUN chmod +x ./bazel-0.24.0-installer-linux-x86_64.sh
-RUN ./bazel-0.24.0-installer-linux-x86_64.sh
-
 RUN git clone --depth 1 https://github.com/tensorflow/tensorflow tensorflow
 WORKDIR $SRC/tensorflow
 COPY build.sh $SRC/

--- a/projects/tensorflow/Dockerfile
+++ b/projects/tensorflow/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Bazel
+# Install Bazel from apt-get to ensure dependencies are there
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
 RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
 RUN apt-get update && apt-get install -y bazel

--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -15,6 +15,16 @@
 #
 ################################################################################
 
+# First, determine the latest Bazel we can support
+BAZEL_VERSION=$(
+  grep 'current_bazel_version =' configure.py | \
+  cut -d, -f2 | cut -d\' -f2 | tr -d '[:space:]'
+)
+if [ -z ${BAZEL_VERSION} ]; then
+  echo "Couldn't find a valid bazel version in configure.py script"
+  exit 1
+fi
+
 # Generate the list of fuzzers we have (only the base/op name).
 FUZZING_BUILD_FILE="tensorflow/core/kernels/fuzzing/BUILD"
 declare -r FUZZERS=$(

--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -30,6 +30,16 @@ curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERS
 chmod +x ./bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh
 ./bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh
 
+# Finally, check instalation before proceeding to compile
+INSTALLED_VERSION=$(
+  bazel version | grep 'Build label' | cut -d: -f2 | tr -d '[:space:]'
+)
+if [ ${INSTALLED_VERSION} != ${BAZEL_VERSION} ]; then
+  echo "Couldn't install required Bazel. "
+  echo "Want ${BAZEL_VERSION}. Got ${INSTALLED_VERSION}."
+  exit 1
+fi
+
 # Generate the list of fuzzers we have (only the base/op name).
 FUZZING_BUILD_FILE="tensorflow/core/kernels/fuzzing/BUILD"
 declare -r FUZZERS=$(

--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -25,6 +25,11 @@ if [ -z ${BAZEL_VERSION} ]; then
   exit 1
 fi
 
+# Then, install it
+curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh
+chmod +x ./bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh
+./bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh
+
 # Generate the list of fuzzers we have (only the base/op name).
 FUZZING_BUILD_FILE="tensorflow/core/kernels/fuzzing/BUILD"
 declare -r FUZZERS=$(


### PR DESCRIPTION
Follow-up from #2288.

If it is not ok to install Bazel in the build script then we can ignore this and I'll just have to keep sending PRs when the interval of Bazel versions that TF supports drifts away again. Hopefully at one point we will be able to support any/latest Bazel version, but not yet.