### PR TITLE
Libtorrent take2

### DIFF
--- a/projects/libtorrent/Dockerfile
+++ b/projects/libtorrent/Dockerfile
@@ -27,8 +27,8 @@ RUN cd boost_1_69_0 && ./bootstrap.sh --with-toolset=clang --prefix=/usr --with-
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.14.0/cmake-3.14.0-Linux-x86_64.sh
 RUN sh cmake-3.14.0-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
 
-RUN git clone --depth 10 https://github.com/pauldreik/fuzzlibtorrent.git
-RUN git -C fuzzlibtorrent submodule update --init --depth 10
-WORKDIR fuzzlibtorrent
+RUN git clone --single-branch --branch ossfuzz https://github.com/pauldreik/libtorrent.git
+
+WORKDIR libtorrent
 COPY build.sh $SRC/
 

--- a/projects/libtorrent/Dockerfile
+++ b/projects/libtorrent/Dockerfile
@@ -18,13 +18,13 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER oss-fuzz-libtorrent@pauldreik.se
 RUN echo "CXX=$CXX"
 RUN echo "CXXFLAGS=$CXXFLAGS"
-RUN apt-get update && apt-get install -y make wget libssl-dev libgeoip-dev pkg-config
+RUN apt-get update && apt-get install -y make ninja-build wget libssl-dev libgeoip-dev pkg-config
 
-RUN wget https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz
+RUN wget --no-verbose https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz
 RUN tar xvzf boost_1_69_0.tar.gz
-RUN cd boost_1_69_0 && ./bootstrap.sh --with-toolset=clang --prefix=/usr --with-libraries=system && ./b2 clean && ./b2 toolset=clang cxxflags="-stdlib=libc++" linkflags="-stdlib=libc++" install
+RUN cd boost_1_69_0 && ./bootstrap.sh --with-toolset=clang --prefix=/usr --with-libraries=system && ./b2 clean && ./b2 toolset=clang cxxflags="$CXXFLAGS" install
 
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.14.0/cmake-3.14.0-Linux-x86_64.sh
+RUN wget --no-verbose https://github.com/Kitware/CMake/releases/download/v3.14.0/cmake-3.14.0-Linux-x86_64.sh
 RUN sh cmake-3.14.0-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
 
 RUN git clone --single-branch --branch ossfuzz https://github.com/pauldreik/libtorrent.git

--- a/projects/libtorrent/build.sh
+++ b/projects/libtorrent/build.sh
@@ -15,12 +15,14 @@
 #
 ################################################################################
 
+#create zip files with initial corpus, taken from version control.
+for f in $(ls fuzzers/initial_corpus/) ;do
+  zip -j -r $OUT/fuzzer_${f}_seed_corpus.zip fuzzers/initial_corpus/$f
+done
+
 mkdir build
 cd build
 cmake ../fuzzers -Dexpose_internal_functions=On -Doss_fuzz_mode=On -DBUILD_SHARED_LIBS=Off -GNinja
 cmake --build .
 cp fuzzer_* $OUT
-pushd $OUT
-for f in bdecode http_parser magnet ; do
-wget https://www.pauldreik.se/fuzzer_${f}_seed_corpus.zip
-done  
+

--- a/projects/libtorrent/build.sh
+++ b/projects/libtorrent/build.sh
@@ -17,8 +17,8 @@
 
 mkdir build
 cd build
-cmake ../fuzzers -Dbuild_tests=On -Doss_fuzz_mode=On -DBUILD_SHARED_LIBS=Off
-make
+cmake ../fuzzers -Dexpose_internal_functions=On -Doss_fuzz_mode=On -DBUILD_SHARED_LIBS=Off -GNinja
+cmake --build .
 cp fuzzer_* $OUT
 pushd $OUT
 for f in bdecode http_parser magnet ; do

--- a/projects/libtorrent/build.sh
+++ b/projects/libtorrent/build.sh
@@ -17,9 +17,9 @@
 
 mkdir build
 cd build
-cmake -DBUILD_SHARED_LIBS=Off ..
+cmake ../fuzzers -Dbuild_tests=On -Doss_fuzz_mode=On -DBUILD_SHARED_LIBS=Off
 make
-cp fuzzers/fuzzer_* $OUT
+cp fuzzer_* $OUT
 pushd $OUT
 for f in bdecode http_parser magnet ; do
 wget https://www.pauldreik.se/fuzzer_${f}_seed_corpus.zip

--- a/projects/libtorrent/project.yaml
+++ b/projects/libtorrent/project.yaml
@@ -1,5 +1,6 @@
 homepage: "https://github.com/arvidn/libtorrent.git"
-primary_contact: "oss-fuzz-libtorrent@pauldreik.se"
+primary_contact: "pauldreikossfuzz@gmail.com"
 auto_ccs:
- - "pauldreikossfuzz@gmail.com"
+ - "oss-fuzz-libtorrent@pauldreik.se"
+ - "arvid.norberg@gmail.com"
 


### PR DESCRIPTION
Hi,
the initial attempt with libtorrent went fine (two issues found and fixed upstream!) so this is the next step towards getting the oss fuzz effort into the upstream libtorrent repo.
 - it lives in the same repository as the upstream project
 - more fuzz targets added
 - less clumsy way of supplying the initial corpus
 - add upstream author email (with permission)

Thanks,
Paul