### PR TITLE
[llvm] Remove proto fuzzers.

### DIFF
--- a/projects/llvm/Dockerfile
+++ b/projects/llvm/Dockerfile
@@ -21,8 +21,6 @@ RUN apt-get install -y autoconf automake libtool curl make g++ unzip wget git \
     binutils liblzma-dev libz-dev python-all cmake ninja-build subversion \
     pkg-config
 
-# Get protobuf
-RUN wget -qO- https://github.com/google/protobuf/releases/download/v3.3.0/protobuf-cpp-3.3.0.tar.gz | tar zxf -
 # Get LLVM
 RUN svn co http://llvm.org/svn/llvm-project/llvm/trunk llvm > svn.log 2>&1 
 RUN cd llvm/tools && svn co http://llvm.org/svn/llvm-project/cfe/trunk clang -r $(cd ../ && svn info | grep Revision | awk '{print $2}') >> svn.log 2>&1 

--- a/projects/llvm/build.sh
+++ b/projects/llvm/build.sh
@@ -16,22 +16,8 @@
 #
 ################################################################################
 
-build_protobuf() {
-  ./autogen.sh
-  ./configure --disable-shared
-  make -j $(nproc)
-  make check -j $(nproc)
-  make install
-  ldconfig
-}
-
-(cd protobuf-3.3.0 && build_protobuf)
-
 readonly FUZZERS=( \
   clang-fuzzer \
-  clang-proto-fuzzer \
-  clang-loop-proto-fuzzer \
-  clang-llvm-proto-fuzzer \
   clang-format-fuzzer \
   clangd-fuzzer \
   llvm-itanium-demangle-fuzzer \
@@ -58,7 +44,6 @@ cmake -GNinja -DCMAKE_BUILD_TYPE=Release ../llvm \
     -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
     -DLLVM_LIB_FUZZING_ENGINE="${LIB_FUZZING_ENGINE}" \
     -DLLVM_NO_DEAD_STRIP=ON \
-    -DCLANG_ENABLE_PROTO_FUZZER=ON \
     -DLLVM_USE_SANITIZER="${LLVM_SANITIZER}" \
     -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly
 for fuzzer in "${FUZZERS[@]}"; do


### PR DESCRIPTION
Proto fuzzers are slow and haven't found bugs in a long time.  Their
builds are also hard to maintain since they build in a different
configuration than any of the LLVM build bots.