### PR TITLE
Add fuzzing targets for Lwan

### DIFF
--- a/projects/lwan/Dockerfile
+++ b/projects/lwan/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER leandro.pereira@gmail.com
+RUN apt-get update
+RUN apt-get install -y build-essential cmake git ninja-build zlib1g-dev
+
+RUN git clone --depth 1 git://github.com/lpereira/lwan
+WORKDIR lwan
+
+COPY build.sh $SRC/

--- a/projects/lwan/build.sh
+++ b/projects/lwan/build.sh
@@ -1,0 +1,39 @@
+#!/bin/bash -eu
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+
+mkdir -p $WORK/lwan
+cd $WORK/lwan
+
+cmake -GNinja \
+	-DCMAKE_BUILD_TYPE=Debug \
+	-DCMAKE_C_COMPILER="${CC}" \
+	-DCMAKE_C_FLAGS="${CFLAGS}" \
+	$SRC/lwan/
+
+ninja -v liblwan.a
+
+zip -jr $OUT/request_fuzzer_seed_corpus.zip $SRC/lwan/fuzz/corpus/corpus-request-*
+
+for fuzzer in $SRC/lwan/src/bin/fuzz/*_fuzzer.cc; do
+	executable=$(basename $fuzzer .cc)
+	$CXX $CXXFLAGS -std=c++11 \
+		-Wl,-whole-archive $WORK/lwan/src/lib/liblwan.a -Wl,-no-whole-archive \
+		-I$SRC/lwan/src/lib $fuzzer \
+		-lFuzzingEngine -lpthread -lz \
+		-o $OUT/$executable
+done


### PR DESCRIPTION
This PR adds fuzz targets for the Lwan project.  The corpora being used is generated automatically from the test suite.