### PR TITLE
libical: Fix undefined sanitizer not building

### DIFF
--- a/projects/libical/build.sh
+++ b/projects/libical/build.sh
@@ -1,4 +1,4 @@
-cmake . -DBUILD_SHARED_LIBS=OFF -DICAL_GLIB=False
+cmake . -DSTATIC_ONLY=ON -DICAL_GLIB=False
 make install -j$(nproc)
 
 $CXX $CXXFLAGS -std=c++11 $SRC/libical_fuzzer.cc -lFuzzingEngine /usr/local/lib/libical.a -o $OUT/libical_fuzzer

--- a/projects/libical/project.yaml
+++ b/projects/libical/project.yaml
@@ -5,3 +5,4 @@ auto_ccs:
 sanitizers:
   - address
   - memory
+  - undefined


### PR DESCRIPTION
The cmake option for disabling shared libs was not the correct one
and the compilation was getting confused