### PR TITLE
[zstd] Add fuzzers and cc emails

### DIFF
--- a/projects/zstd/Dockerfile
+++ b/projects/zstd/Dockerfile
@@ -24,6 +24,8 @@ ADD https://github.com/facebook/zstd/releases/download/fuzz-corpora/block_decomp
     https://github.com/facebook/zstd/releases/download/fuzz-corpora/simple_round_trip_seed_corpus.zip \
     https://github.com/facebook/zstd/releases/download/fuzz-corpora/stream_decompress_seed_corpus.zip \
     https://github.com/facebook/zstd/releases/download/fuzz-corpora/stream_round_trip_seed_corpus.zip \
+    https://github.com/facebook/zstd/releases/download/fuzz-corpora/dictionary_decompress_seed_corpus.zip \
+    https://github.com/facebook/zstd/releases/download/fuzz-corpora/dictionary_round_trip_seed_corpus.zip \
     $SRC/
 # Clone source
 RUN git clone --depth 1 https://github.com/facebook/zstd

--- a/projects/zstd/project.yaml
+++ b/projects/zstd/project.yaml
@@ -2,6 +2,8 @@ homepage: "http://facebook.github.io/zstd/"
 primary_contact: "NickRTerrell@gmail.com"
 auto_ccs:
   - "Yann.collet.73@gmail.com"
+  - "terrelln@fb.com"
+  - "cyan@fb.com"
 sanitizers:
   - address
   - memory


### PR DESCRIPTION
* Add corpora for two new fuzzers that fuzz dictionary (de)compression.
* Add two more emails to the CC list so we don't miss bug reports.

I tested that the new fuzzers build and run locally without crashes for a few hours.

Is there any new hotness since we integrated zstd that we should be using?