### PR TITLE
[zstd] Move downloading seed corpora to build.sh

### DIFF
--- a/projects/zstd/Dockerfile
+++ b/projects/zstd/Dockerfile
@@ -16,17 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER nickrterrell@gmail.com
-RUN apt-get update && apt-get install -y make python
-# Add corpora
-ADD https://github.com/facebook/zstd/releases/download/fuzz-corpora/block_decompress_seed_corpus.zip \
-    https://github.com/facebook/zstd/releases/download/fuzz-corpora/block_round_trip_seed_corpus.zip \
-    https://github.com/facebook/zstd/releases/download/fuzz-corpora/simple_decompress_seed_corpus.zip \
-    https://github.com/facebook/zstd/releases/download/fuzz-corpora/simple_round_trip_seed_corpus.zip \
-    https://github.com/facebook/zstd/releases/download/fuzz-corpora/stream_decompress_seed_corpus.zip \
-    https://github.com/facebook/zstd/releases/download/fuzz-corpora/stream_round_trip_seed_corpus.zip \
-    https://github.com/facebook/zstd/releases/download/fuzz-corpora/dictionary_decompress_seed_corpus.zip \
-    https://github.com/facebook/zstd/releases/download/fuzz-corpora/dictionary_round_trip_seed_corpus.zip \
-    $SRC/
+RUN apt-get update && apt-get install -y make python wget
 # Clone source
 RUN git clone --depth 1 https://github.com/facebook/zstd
 WORKDIR zstd

--- a/projects/zstd/build.sh
+++ b/projects/zstd/build.sh
@@ -18,6 +18,9 @@
 
 cd tests/fuzz
 
+# Download the seed corpora
+make -j seedcorpora
+# Build all of the fuzzers
 ./fuzz.py build all
 
 for target in $(./fuzz.py list); do
@@ -33,5 +36,5 @@ for target in $(./fuzz.py list); do
         cp "$target.dict" "$OUT"
     fi
 
-    cp "$SRC/${target}_seed_corpus.zip" "$OUT"
+    cp "corpora/${target}_seed_corpus.zip" "$OUT"
 done


### PR DESCRIPTION
I just added a new fuzzer, `zstd_frame_info`, and want to be able to add new
fuzzers without submitting a pull request to oss-fuzz. This change uses zstd's
Makefile to download the corpora. Now I can add a new fuzzer to zstd and it will
automatically get built and download the seed corpus in oss-fuzz.

Tested by building and running every fuzzer, then checking that it found the seed corpus.