### PR TITLE
[infra] Change COPY_SOURCES_CMD to preserve the links in code coverage builds (#2339).

### DIFF
--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -68,7 +68,7 @@ BUILD_CMD="bash -eux $SRC/build.sh"
 
 # We need to preserve source code files for generating a code coverage report.
 # We need exact files that were compiled, so copy both $SRC and $WORK dirs.
-COPY_SOURCES_CMD="cp -rL --parents $SRC $WORK /usr/include $OUT"
+COPY_SOURCES_CMD="cp -rP --parents $SRC $WORK /usr/include $OUT"
 
 if [ "${BUILD_UID-0}" -ne "0" ]; then
   adduser -u $BUILD_UID --disabled-password --gecos '' builder


### PR DESCRIPTION
Still testing, but looks good so far. Otherwise, the command skips cyclic links (e.g. link to "..") which apparently may break some projects.