### PR TITLE
Add initial support for i386 builds 

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -45,6 +45,7 @@ ENV COVERAGE_FLAGS_coverage "-fprofile-instr-generate -fcoverage-mapping -pthrea
 # Default sanitizer and fuzzing engine to use.
 ENV SANITIZER="address"
 ENV FUZZING_ENGINE="libfuzzer"
+ENV ARCHITECTURE="x86_64"
 
 # DEPRECATED - NEW CODE SHOULD NOT USE THIS. OLD CODE SHOULD STOP. Please use
 # LIB_FUZZING_ENGINE instead.

--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-clang
 MAINTAINER mike.aizatsky@gmail.com
-RUN apt-get install -y git subversion jq python3 zip make libunwind8-dev binutils-dev libblocksruntime-dev
+RUN apt-get install -y git subversion jq python3 zip make libunwind8-dev binutils-dev libblocksruntime-dev libc6-dev-i386
 
 # Default build flags for various sanitizers.
 ENV SANITIZER_FLAGS_address "-fsanitize=address -fsanitize-address-use-after-scope"

--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -16,7 +16,16 @@
 
 FROM gcr.io/oss-fuzz-base/base-clang
 MAINTAINER mike.aizatsky@gmail.com
-RUN apt-get install -y git subversion jq python3 zip make libunwind8-dev binutils-dev libblocksruntime-dev libc6-dev-i386
+RUN apt-get install -y git \
+    subversion \
+    jq \
+    python3 \
+    zip \
+    make \
+    libunwind8-dev \
+    binutils-dev \
+    libblocksruntime-dev \
+    libc6-dev-i386
 
 # Default build flags for various sanitizers.
 ENV SANITIZER_FLAGS_address "-fsanitize=address -fsanitize-address-use-after-scope"
@@ -42,7 +51,7 @@ ENV COVERAGE_FLAGS="-fsanitize=fuzzer-no-link"
 # messages which are treated as errors by some projects.
 ENV COVERAGE_FLAGS_coverage "-fprofile-instr-generate -fcoverage-mapping -pthread -Wl,--no-as-needed -Wl,-ldl -Wl,-lm -Wno-unused-command-line-argument"
 
-# Default sanitizer and fuzzing engine to use.
+# Default sanitizer, fuzzing engine and architecture to use.
 ENV SANITIZER="address"
 ENV FUZZING_ENGINE="libfuzzer"
 ENV ARCHITECTURE="x86_64"

--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -22,6 +22,10 @@ if [ -z "${SANITIZER_FLAGS-}" ]; then
   export SANITIZER_FLAGS=${!FLAGS_VAR-}
 fi
 
+if [[ $ARCHITECTURE == "i386" ]]; then
+    export CFLAGS="$CFLAGS -m32"
+    export CXXFLAGS="$CXXFLAGS -m32"
+fi
 if [[ $FUZZING_ENGINE != "none" ]]; then
   # compile script might override environment, use . to call it.
   . compile_${FUZZING_ENGINE}

--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -23,8 +23,8 @@ if [ -z "${SANITIZER_FLAGS-}" ]; then
 fi
 
 if [[ $ARCHITECTURE == "i386" ]]; then
-    export CFLAGS="$CFLAGS -m32"
-    export CXXFLAGS="$CXXFLAGS -m32"
+    export CFLAGS="-m32 $CFLAGS"
+    export CXXFLAGS_EXTRA="-L/usr/i386/lib $CXXFLAGS_EXTRA"
 fi
 if [[ $FUZZING_ENGINE != "none" ]]; then
   # compile script might override environment, use . to call it.

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -99,6 +99,21 @@ ninja
 ninja install
 rm -rf $WORK/llvm-stage1 $WORK/llvm-stage2
 
+mkdir -p $WORK/i386
+cd $WORK/i386
+cmake -G "Ninja" \
+      -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+      -DCMAKE_INSTALL_PREFIX=/usr/i386/ -DLIBCXX_ENABLE_SHARED=OFF \
+      -DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_C_FLAGS="-m32" -DCMAKE_CXX_FLAGS="-m32" \
+      -DLLVM_TARGETS_TO_BUILD="$TARGET_TO_BUILD" \
+      $SRC/llvm
+
+ninja cxx
+ninja install-cxx
+
+rm -rf $WORK/i386
+
 mkdir -p $WORK/msan
 cd $WORK/msan
 

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -15,7 +15,7 @@
 #
 ################################################################################
 
-LLVM_DEP_PACKAGES="build-essential make cmake ninja-build git subversion python2.7"
+LLVM_DEP_PACKAGES="build-essential make cmake ninja-build git subversion python2.7 g++-multilib"
 apt-get install -y $LLVM_DEP_PACKAGES
 
 # Checkout

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -111,7 +111,6 @@ cmake -G "Ninja" \
 
 ninja cxx
 ninja install-cxx
-
 rm -rf $WORK/i386
 
 mkdir -p $WORK/msan

--- a/infra/base-images/base-runner/Dockerfile
+++ b/infra/base-images/base-runner/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get install -y \
     fonts-dejavu \
     git \
     libblocksruntime0 \
+    libc6-dev-i386 \
     libcap2 \
     libunwind8 \
     python3 \

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -249,6 +249,11 @@ def _get_work_dir(project_name=''):
   return os.path.join(BUILD_DIR, 'work', project_name)
 
 
+def _add_architecture_args(parser, choices=('i386', 'x86_64')):
+  """Add common architecture args."""
+  parser.add_argument('--architecture', default='x86_64', choices=choices)
+
+
 def _add_engine_args(
         parser,
         choices=('libfuzzer', 'afl', 'honggfuzz', 'dataflow', 'none')):
@@ -416,7 +421,8 @@ def build_fuzzers(args):
 
   env = [
       'FUZZING_ENGINE=' + args.engine,
-      'SANITIZER=' + args.sanitizer
+      'SANITIZER=' + args.sanitizer,
+      'ARCHITECTURE=' + args.architecture
   ]
   if args.e:
     env += args.e

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -249,8 +249,9 @@ def _get_work_dir(project_name=''):
   return os.path.join(BUILD_DIR, 'work', project_name)
 
 
-def _add_architecture_args(parser, choices=('i386', 'x86_64')):
+def _add_architecture_args(parser, choices=('x86_64',)):
   """Add common architecture args."""
+  # TODO(metzman): Add 'i386' to choices when we are ready to support it.
   parser.add_argument('--architecture', default='x86_64', choices=choices)
 
 

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -78,6 +78,7 @@ def main():
 
   build_fuzzers_parser = subparsers.add_parser(
       'build_fuzzers', help='Build fuzzers for a project.')
+  _add_architecture_args(build_fuzzers_parser)
   _add_engine_args(build_fuzzers_parser)
   _add_sanitizer_args(build_fuzzers_parser)
   _add_environment_args(build_fuzzers_parser)
@@ -149,6 +150,7 @@ def main():
   shell_parser = subparsers.add_parser(
       'shell', help='Run /bin/bash within the builder container.')
   shell_parser.add_argument('project_name', help='name of the project')
+  _add_architecture_args(shell_parser)
   _add_engine_args(shell_parser)
   _add_sanitizer_args(shell_parser)
   _add_environment_args(shell_parser)

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -96,6 +96,7 @@ def main():
 
   check_build_parser = subparsers.add_parser(
       'check_build', help='Checks that fuzzers execute without errors.')
+  _add_architecture_args(check_build_parser)
   _add_engine_args(check_build_parser, choices=['libfuzzer', 'afl'])
   _add_sanitizer_args(
       check_build_parser, choices=['address', 'memory', 'undefined'])

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -251,9 +251,8 @@ def _get_work_dir(project_name=''):
   return os.path.join(BUILD_DIR, 'work', project_name)
 
 
-def _add_architecture_args(parser, choices=('x86_64',)):
+def _add_architecture_args(parser, choices=('x86_64', 'i386')):
   """Add common architecture args."""
-  # TODO(metzman): Add 'i386' to choices when we are ready to support it.
   parser.add_argument('--architecture', default='x86_64', choices=choices)
 
 

--- a/infra/travis/travis_build.py
+++ b/infra/travis/travis_build.py
@@ -117,5 +117,6 @@ def main():
     print('Failed projects:', ' '.join(failed_projects))
     exit(1)
 
+
 if __name__ == '__main__':
   main()

--- a/infra/travis/travis_build.py
+++ b/infra/travis/travis_build.py
@@ -54,11 +54,12 @@ def execute_helper_command(helper_command):
   subprocess.check_call(command)
 
 
-def build_fuzzers(project, sanitizer, engine):
+def build_fuzzers(project, sanitizer, engine, architecture='x86_64'):
   """Execute helper.py's build_fuzzers command on |project|. Build the fuzzers
   with |sanitizer| and |engine|."""
   execute_helper_command(
-      ['build_fuzzers', project, '--engine', engine, '--sanitizer', sanitizer])
+      ['build_fuzzers', project, '--engine', engine, '--sanitizer', sanitizer,
+       '--architecture', architecture])
 
 
 def check_build(project, sanitizer, engine):
@@ -95,6 +96,11 @@ def build_project(project):
 
   for sanitizer in project_yaml.get('sanitizers', DEFAULT_SANITIZERS):
     build_fuzzers(project, sanitizer, 'libfuzzer')
+    check_build(project, sanitizer, 'libfuzzer')
+
+  if 'i386' in project_yaml.get('architectures', ['x86_64']):
+    # i386 builds always use libFuzzer and ASAN.
+    build_fuzzers(project, 'address', 'libfuzzer', 'i386')
     check_build(project, sanitizer, 'libfuzzer')
 
 

--- a/infra/travis/travis_build.py
+++ b/infra/travis/travis_build.py
@@ -98,7 +98,7 @@ def build_project(project):
     build_fuzzers(project, sanitizer, 'libfuzzer')
     check_build(project, sanitizer, 'libfuzzer')
 
-  if 'i386' in project_yaml.get('architectures', ['x86_64']):
+  if 'i386' in project_yaml.get('architectures', []):
     # i386 builds always use libFuzzer and ASAN.
     build_fuzzers(project, 'address', 'libfuzzer', 'i386')
     check_build(project, 'address', 'libfuzzer')

--- a/infra/travis/travis_build.py
+++ b/infra/travis/travis_build.py
@@ -23,7 +23,6 @@ import re
 import subprocess
 import yaml
 
-
 DEFAULT_FUZZING_ENGINES = ['afl', 'libfuzzer']
 DEFAULT_SANITIZERS = ['address', 'undefined']
 
@@ -57,9 +56,10 @@ def execute_helper_command(helper_command):
 def build_fuzzers(project, sanitizer, engine, architecture='x86_64'):
   """Execute helper.py's build_fuzzers command on |project|. Build the fuzzers
   with |sanitizer| and |engine|."""
-  execute_helper_command(
-      ['build_fuzzers', project, '--engine', engine, '--sanitizer', sanitizer,
-       '--architecture', architecture])
+  execute_helper_command([
+      'build_fuzzers', project, '--engine', engine, '--sanitizer', sanitizer,
+      '--architecture', architecture
+  ])
 
 
 def check_build(project, sanitizer, engine):
@@ -101,7 +101,7 @@ def build_project(project):
   if 'i386' in project_yaml.get('architectures', ['x86_64']):
     # i386 builds always use libFuzzer and ASAN.
     build_fuzzers(project, 'address', 'libfuzzer', 'i386')
-    check_build(project, sanitizer, 'libfuzzer')
+    check_build(project, 'address', 'libfuzzer')
 
 
 def main():


### PR DESCRIPTION
Add initial support for i386 (ie: 32 bit/x86) builds.
Build + install i386 versions of clang libraries.
Build + install an i386 version of libc++.
Create a new build option ARCHITECTURE (that defaults to x86_64).
Use the correct CFLAGS and CXXFLAGS (to compile for i386 and use the right libc++) when ARCHITECTURE is i386.
