### PR TITLE
[s2opc] Add build scripts

### DIFF
--- a/projects/s2opc/Dockerfile
+++ b/projects/s2opc/Dockerfile
@@ -1,0 +1,28 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER pab.systerel@gmail.com
+RUN apt-get update && apt-get install -y make cmake git curl
+
+# Sources and dependencies
+RUN git clone --depth 1 https://gitlab.com/systerel/S2OPC
+RUN git clone --depth 1 https://gitlab.com/systerel/S2OPC-fuzzing-data
+RUN curl -L https://tls.mbed.org/download/mbedtls-2.16.0-apache.tgz -o $SRC/mbedtls.tgz
+RUN curl -L https://github.com/libcheck/check/releases/download/0.12.0/check-0.12.0.tar.gz -o $SRC/check.tgz
+
+WORKDIR S2OPC
+COPY build.sh $SRC/

--- a/projects/s2opc/build.sh
+++ b/projects/s2opc/build.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -eu
+#
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+MBEDTLS_BUILD=$WORK/mbedtls
+S2OPC_BUILD=$WORK/s2opc
+SAMPLES=$SRC/S2OPC-fuzzing-data
+
+# Build the dependencies
+tar xzf $SRC/mbedtls.tgz -C $WORK
+mkdir -p $MBEDTLS_BUILD
+cd $MBEDTLS_BUILD
+cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON $WORK/mbedtls-2.*
+make -j$(nproc)
+make -j$(nproc) install
+
+tar xzf $SRC/check.tgz -C $WORK
+cd $WORK/check-0.*
+./configure --prefix=/usr/local --with-tcltk=no
+make -j$(nproc)
+make -j$(nproc) install
+
+# Build S2OPC and the fuzzers
+mkdir -p $S2OPC_BUILD
+cd $S2OPC_BUILD
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DCMAKE_C_COMPILER="$CC" -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_LINKER="$CXX" -DCMAKE_EXE_LINKER_FLAGS="$CXXFLAGS" \
+      -DWITH_OSS_FUZZ=ON \
+      $SRC/S2OPC
+cmake --build . --target fuzzers
+
+# Copy them and build the corpora
+cp bin/* $OUT
+
+cd $SAMPLES
+for dir in $(ls -d */); do
+    zip -j $OUT/${dir%/}_fuzzer_seed_corpus.zip ${dir}*
+done

--- a/projects/s2opc/project.yaml
+++ b/projects/s2opc/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://gitlab.com/systerel/S2OPC"
-primary_contact: "vincent.lacroix@systerel.fr"
+primary_contact: "pab.systerel@gmail.com"
 auto_ccs:
   - "mcl.systerel@gmail.com"
+  - "vincent.lacroix@systerel.fr"


### PR DESCRIPTION
Note: we add two fuzzers, but one of them does not pass the `check_build` step (`parse_tcp_uri`), even if it correctly fuzzes the tested function (coverage is good). This is probably due to not enough edges ?

With ASan, we have 82 inline 8-bit counters (required number seems to be 100), and the `bad_build_check` script fails with the following: `BAD BUILD: /out/parse_tcp_uri_fuzzer seems to have only partial coverage instrumentation.`

With UBSan, we have 101 inline 8-bit counters (required number seems to be 170) and the `bad_build_check` script fails with the following: `BAD BUILD: /out/parse_tcp_uri_fuzzer does not seem to be compiled with UBSan.`