### PR TITLE
[infra] Roll clang to r359254

### DIFF
--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -47,7 +47,7 @@ cd $SRC/chromium_tools
 git clone https://chromium.googlesource.com/chromium/src/tools/clang
 cd clang
 
-OUR_LLVM_REVISION=356356  # For manual bumping.
+OUR_LLVM_REVISION=359254  # For manual bumping.
 FORCE_OUR_REVISION=0  # To allow for manual downgrades.
 LLVM_REVISION=$(grep -Po "CLANG_REVISION = '\K\d+(?=')" scripts/update.py)
 


### PR DESCRIPTION
Roll clang to r359254 to uptake fixes for exception handling and MSAN.
Chrome's libFuzzer clang bot [passes at this revision](https://ci.chromium.org/p/chromium/builders/ci/ToTLinuxASanLibfuzzer/3207).