### PR TITLE
[mupdf] Update to latest version of API provided by MuPDF.

### DIFF
--- a/projects/mupdf/pdf_fuzzer.cc
+++ b/projects/mupdf/pdf_fuzzer.cc
@@ -124,7 +124,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     doc = fz_open_document_with_stream(ctx, "pdf", stream);
 
     for (int i = 0; i < fz_count_pages(ctx, doc); i++) {
-      pix = fz_new_pixmap_from_page_number(ctx, doc, i, fz_identity, fz_device_rgb(ctx), NULL, 0);
+      pix = fz_new_pixmap_from_page_number(ctx, doc, i, fz_identity, fz_device_rgb(ctx), 0);
       fz_drop_pixmap(ctx, pix);
       pix = NULL;
     }


### PR DESCRIPTION
This reverts commit 7fa021dfbecf30aa04613d8497954f6a482dbb09
because the corresponding API was reverted in the upstream project.