### PR TITLE
Speculative fix for yajl migration: Reorder arguments

### DIFF
--- a/projects/yajl-ruby/build.sh
+++ b/projects/yajl-ruby/build.sh
@@ -22,7 +22,6 @@ zip -q $OUT/json_fuzzer_seed_corpus.zip $WORK/seed.json
 
 mv $SRC/*.dict $OUT/
 
-$CXX $CXXFLAGS -I. \
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE -I. \
     -x c yajl.c yajl_alloc.c yajl_buf.c yajl_lex.c yajl_parser.c yajl_encode.c \
-    ../../fuzz/json_fuzzer.c -o $OUT/json_fuzzer \
-    $LIB_FUZZING_ENGINE
+    ../../fuzz/json_fuzzer.c -o $OUT/json_fuzzer


### PR DESCRIPTION
Use $LIB_FUZZING_ENGINE before `-x c` which causes all subsequent files to be treated as C source,
including libFuzzingEngine.a during AFL builds.