### PR TITLE
Re-enable unrar fuzzing by creating/clearing a temporary directory

### DIFF
--- a/projects/qpid-proton/c_tests_fuzz_CMakeLists.patch
+++ b/projects/qpid-proton/c_tests_fuzz_CMakeLists.patch
@@ -25,7 +25,7 @@ index b4470d59..211252c4 100644
 +    set(FUZZING_QPID_PROTON_CORE_LIBRARY qpid-proton-core)
 +  endif()
 +  target_link_libraries (${test} ${FUZZING_QPID_PROTON_CORE_LIBRARY} ${FUZZING_LIBRARY})
-+  # $LIB_FUZZING_ENGINE is a C++ library, which needs c++ std lib
++  # -lFuzzingEngine is a C++ library, which needs c++ std lib
 +  set_target_properties(${test} PROPERTIES LINKER_LANGUAGE CXX)
 +
    list(APPEND fuzz_test_src ${ARGN})

--- a/projects/unrar/build.sh
+++ b/projects/unrar/build.sh
@@ -29,4 +29,4 @@ rm -v $UNRAR_SRC_DIR/libunrar.so
 
 # build fuzzer
 $CXX $CXXFLAGS -I. $UNRAR_SRC_DIR/unrar_fuzzer.cc -o $OUT/unrar_fuzzer \
-     $UNRAR_DEFINES $LIB_FUZZING_ENGINE -L$UNRAR_SRC_DIR -lunrar
+     $UNRAR_DEFINES $LIB_FUZZING_ENGINE -L$UNRAR_SRC_DIR -lunrar -lc++fs

--- a/projects/unrar/project.yaml
+++ b/projects/unrar/project.yaml
@@ -6,4 +6,3 @@ sanitizers:
   - address
   - memory
   - undefined
-disabled: True

--- a/projects/unrar/unrar_fuzzer.cc
+++ b/projects/unrar/unrar_fuzzer.cc
@@ -1,9 +1,11 @@
+#include <stddef.h>
+#include <stdint.h>
+
+#include <filesystem>
 #include <fstream>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <unistd.h>
-#include <filesystem>
 
 #include "rar.hpp"
 

--- a/projects/unrar/unrar_fuzzer.cc
+++ b/projects/unrar/unrar_fuzzer.cc
@@ -3,10 +3,21 @@
 #include <sstream>
 #include <string>
 #include <unistd.h>
+#include <filesystem>
 
 #include "rar.hpp"
 
+namespace fs = std::__fs::filesystem;
+
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  // unrar likes to create files in the current directory.
+  // So, the following few lines created and 'cd' to a directory named 'o'
+  // in the current working directory.
+  fs::path original_path = fs::current_path();
+  fs::path out_path = original_path / "o";
+  bool created = fs::create_directory(out_path);
+  fs::current_path(out_path);
+
   static const std::string filename = "temp.rar";
   std::ofstream file(filename,
                      std::ios::binary | std::ios::out | std::ios::trunc);
@@ -30,5 +41,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   }
 
   unlink(filename.c_str());
+
+  // 'cd' back to the original directory and delete 'o' along with
+  // all its contents.
+  fs::current_path(original_path);
+  fs::remove_all(out_path);
   return 0;
 }


### PR DESCRIPTION
This CL re-enables the fuzzing of unrar library.

This was disabled via https://github.com/google/oss-fuzz/pull/2355
The reason for disabling was that the unrar library creates a number of temporary files
on disk in the current directory which caused internal exceptions due to disk space.

The fix is to `mkdir` and `cd` to a temporary directory before invoking unrar and cleaning
up the temporary directory after fuzzing completes successfully.