### PR TITLE
 libtorrent script to only build large fuzz targets

### DIFF
--- a/projects/libtorrent/build.sh
+++ b/projects/libtorrent/build.sh
@@ -27,10 +27,10 @@ echo "CXXFLAGS=$CXXFLAGS"
 echo "using clang : ossfuzz : $CXX : <compileflags>\"$CXXFLAGS\" <linkflags>\"$CXXFLAGS\" <linkflags>\"${LIB_FUZZING_ENGINE}\" ;" >project-config.jam
 cat project-config.jam
 cd fuzzers
-b2 clang-ossfuzz -j$(nproc) crypto=openssl fuzz=external sanitize=off stage
+b2 clang-ossfuzz -j$(nproc) crypto=openssl fuzz=external sanitize=off stage-large
 cp fuzzers/* $OUT
 
-wget https://github.com/arvidn/libtorrent/releases/download/libtorrent_1_2_0/corpus.zip
+wget https://github.com/arvidn/libtorrent/releases/download/libtorrent_1_2_1/corpus.zip
 unzip -q corpus.zip
 cd corpus
 for f in *; do


### PR DESCRIPTION
I added a new build target called `stage-large` which only builds (and stages) the "large" fuzz targets in libtorrent. i.e. the ones with a large input space.
I also updated the corpus to include samples for one of those fuzz targets that were very recently broken, and didn't actually fuzz anything.

I take it this corpus is merged with the OSSFuzz corpus at least some times.