### PR TITLE
[cryptofuzz] Add libsodium, Whirlpool reference impl, Veracrypt, Monero

### DIFF
--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER guidovranken@gmail.com
 
-RUN apt-get update && apt-get install -y software-properties-common python-software-properties make autoconf automake libtool build-essential cmake
+RUN apt-get update && apt-get install -y software-properties-common python-software-properties make autoconf automake libtool build-essential cmake libboost-all-dev
 
 # BoringSSL needs Go to build
 RUN add-apt-repository -y ppa:gophers/archive && apt-get update && apt-get install -y golang-1.9-go
@@ -30,5 +30,6 @@ RUN git clone --depth 1 https://github.com/openssl/openssl
 RUN git clone --depth 1 https://boringssl.googlesource.com/boringssl
 RUN git clone --depth 1 https://github.com/libressl-portable/portable libressl
 RUN cd $SRC/libressl && ./update.sh
+RUN git clone --depth 1 https://github.com/jedisct1/libsodium.git
 
 COPY build.sh $SRC/

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -33,6 +33,42 @@ fi
 ##############################################################################
 if [[ $CFLAGS != *sanitize=memory* ]]
 then
+    # Compile libsodium (with assembly)
+    cd $SRC/libsodium
+    autoreconf -ivf
+    ./configure
+    make -j$(nproc)
+
+    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_LIBSODIUM"
+    export LIBSODIUM_A_PATH="$SRC/libsodium/src/libsodium/.libs/libsodium.a"
+    export LIBSODIUM_INCLUDE_PATH="$SRC/libsodium/src/libsodium/include"
+
+    # Compile Cryptofuzz libsodium (with assembly) module
+    cd $SRC/cryptofuzz/modules/libsodium
+    make -B
+fi
+
+##############################################################################
+# Compile Cryptofuzz reference (without assembly) module
+export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_REFERENCE"
+cd $SRC/cryptofuzz/modules/reference
+make -B
+
+##############################################################################
+# Compile Cryptofuzz Veracrypt (without assembly) module
+export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_VERACRYPT"
+cd $SRC/cryptofuzz/modules/veracrypt
+make -B
+
+##############################################################################
+# Compile Cryptofuzz Monero (without assembly) module
+export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_MONERO"
+cd $SRC/cryptofuzz/modules/monero
+make -B
+
+##############################################################################
+if [[ $CFLAGS != *sanitize=memory* ]]
+then
     # Compile LibreSSL (with assembly)
     cd $SRC/libressl
     rm -rf build ; mkdir build

--- a/projects/cryptofuzz/project.yaml
+++ b/projects/cryptofuzz/project.yaml
@@ -10,6 +10,7 @@ auto_ccs:
     - "beck@obtuse.com"
     - "joel.sing@gmail.com"
     - "kinichiro.inoguchi@gmail.com"
+    - "github@pureftpd.org"
 sanitizers:
  - address
  - undefined


### PR DESCRIPTION
Libsodium maintainer signed up for this here: https://github.com/jedisct1/libsodium/issues/829

I don't expect problems from Veracrypt and Monero as I've already extensively tested them locally. Should a bug in these libraries emerge, I'll report it upstream myself. They're still important to have for differential testing (the combination Veracrypt + LibreSSL found an incorrect implementation in LibreSSL).