### PR TITLE
[mruby] Add mruby to oss-fuzz

### DIFF
--- a/projects/mruby/Dockerfile
+++ b/projects/mruby/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool ruby \
+    bison
+RUN git clone --depth 1 https://github.com/mruby/mruby mruby
+RUN git clone --depth 1 https://github.com/bshastry/mruby_seeds.git mruby_seeds
+COPY build.sh $SRC
+WORKDIR mruby

--- a/projects/mruby/build.sh
+++ b/projects/mruby/build.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -eu
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# build project
+export LD=clang
+export LDFLAGS="$CFLAGS"
+./minirake clean && ./minirake -j$(nproc) all
+
+# build fuzzers
+FUZZ_TARGET=$SRC/mruby/oss-fuzz/mruby_fuzzer.c
+name=$(basename $FUZZ_TARGET .c)
+$CC -c $CFLAGS -Iinclude \
+     ${FUZZ_TARGET} -o $OUT/${name}.o
+$CXX $CXXFLAGS $OUT/${name}.o $LIB_FUZZING_ENGINE -lm \
+    $SRC/mruby/build/host/lib/libmruby.a -o $OUT/${name}
+rm -f $OUT/${name}.o
+
+# dict and config
+cp $SRC/mruby/oss-fuzz/config/mruby.dict $OUT
+cp $SRC/mruby/oss-fuzz/config/mruby_fuzzer.options $OUT
+
+# seeds
+find $SRC/mruby_seeds -exec zip -ujq \
+    $OUT/mruby_fuzzer_seed_corpus.zip "{}" \;

--- a/projects/mruby/project.yaml
+++ b/projects/mruby/project.yaml
@@ -1,0 +1,8 @@
+homepage: https://www.mruby.org/
+primary_contact: matz@ruby.or.jp
+auto_ccs:
+  - "bshas3@gmail.com"
+sanitizers:
+  - address
+  - memory
+  - undefined


### PR DESCRIPTION
Dear all, @matz

This PR (CC #402 )
  - adds [mruby](mruby.org) to oss-fuzz 
  - test harness merged into mruby repo (@matz)

Open question (discussion welcome)
  - Address potential timeout issues in this fuzzer
    - Since we are compiling and interpreting ruby code, it could happen that libFuzzer synthesizes a `while true` loop

TODO (near future)
  - Add proto based fuzzer

Note to self: I need to fix messed up git history in my fork of oss-fuzz