### PR TITLE
Disable unrar fuzzing since it is failing to build

### DIFF
--- a/projects/unrar/build.sh
+++ b/projects/unrar/build.sh
@@ -29,4 +29,4 @@ rm -v $UNRAR_SRC_DIR/libunrar.so
 
 # build fuzzer
 $CXX $CXXFLAGS -I. $UNRAR_SRC_DIR/unrar_fuzzer.cc -o $OUT/unrar_fuzzer \
-     $UNRAR_DEFINES $LIB_FUZZING_ENGINE -L$UNRAR_SRC_DIR -lunrar
+     $UNRAR_DEFINES $LIB_FUZZING_ENGINE -L$UNRAR_SRC_DIR -lunrar -lc++fs

--- a/projects/unrar/project.yaml
+++ b/projects/unrar/project.yaml
@@ -6,4 +6,3 @@ sanitizers:
   - address
   - memory
   - undefined
-disabled: True

--- a/projects/unrar/project.yaml
+++ b/projects/unrar/project.yaml
@@ -6,3 +6,4 @@ sanitizers:
   - address
   - memory
   - undefined
+disabled: True

--- a/projects/unrar/unrar_fuzzer.cc
+++ b/projects/unrar/unrar_fuzzer.cc
@@ -1,12 +1,32 @@
+#include <stddef.h>
+#include <stdint.h>
+
+#include <filesystem>
 #include <fstream>
 #include <memory>
-#include <sstream>
 #include <string>
+#include <system_error>
 #include <unistd.h>
 
 #include "rar.hpp"
 
+namespace fs = std::__fs::filesystem;
+
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  // unrar likes to create files in the current directory.
+  // So, the following few lines created and 'cd' to a directory named 'o'
+  // in the current working directory.
+  std::error_code code, ok;
+  fs::path original_path = fs::current_path(code);
+  if (code != ok) return code.value();
+
+  fs::path out_path = original_path / "o";
+  bool created = fs::create_directory(out_path, code);
+  if (code != ok) return code.value();
+
+  fs::current_path(out_path, code);
+  if (code != ok) return code.value();
+
   static const std::string filename = "temp.rar";
   std::ofstream file(filename,
                      std::ios::binary | std::ios::out | std::ios::trunc);
@@ -30,5 +50,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   }
 
   unlink(filename.c_str());
+
+  // 'cd' back to the original directory and delete 'o' along with
+  // all its contents.
+  fs::current_path(original_path);
+  fs::remove_all(out_path);
   return 0;
 }


### PR DESCRIPTION
Currently failing with the following error:

```
Step #4: + clang++ -O1 -fno-omit-frame-pointer -gline-tables-only -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=address -fsanitize-address-use-after-scope -fsanitize=fuzzer-no-link -stdlib=libc++ -I. /src/unrar/unrar_fuzzer.cc -o /workspace/out/address/unrar_fuzzer -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DRAR_SMP -DRARDLL -DSILENT -DNOVOLUME -fsanitize=fuzzer -L/src/unrar -lunrar -lc++fs
Step #4: /usr/bin/ld: cannot find -lc++fs
Step #4: clang-9: error: linker command failed with exit code 1 (use -v to see invocation)
```