### PR TITLE
Add neomutt

### DIFF
--- a/projects/neomutt/Dockerfile
+++ b/projects/neomutt/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER joseph.bisch@gmail.com
+RUN apt-get update && apt-get install -y make autoconf automake libtool xsltproc libncursesw5-dev libtinfo5 libxml2-dev libxml2-utils libidn11-dev
+RUN git clone https://github.com/josephbisch/neomutt neomutt
+WORKDIR neomutt
+COPY build.sh $SRC/

--- a/projects/neomutt/Dockerfile
+++ b/projects/neomutt/Dockerfile
@@ -17,6 +17,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER joseph.bisch@gmail.com
 RUN apt-get update && apt-get install -y make autoconf automake libtool xsltproc libncursesw5-dev libtinfo5 libxml2-dev libxml2-utils libidn11-dev
-RUN git clone https://github.com/josephbisch/neomutt neomutt
+RUN git clone https://github.com/neomutt/neomutt neomutt
 WORKDIR neomutt
 COPY build.sh $SRC/

--- a/projects/neomutt/build.sh
+++ b/projects/neomutt/build.sh
@@ -19,7 +19,8 @@ git checkout fuzzer
 ./configure --fuzzing --disable-doc --disable-nls --disable-idn
 make fuzz
 
-cp fuzz/address-fuzz $OUT/
-cp fuzz/corpus_address.zip $OUT/address-fuzz_seed_corpus.zip
-cp fuzz/rfc822_headers_dict.txt $OUT/address-fuzz.dict
-cp fuzz/address-fuzz.options $OUT/
+cd fuzz
+cp address-fuzz $OUT/
+zip -q -r $OUT/address-fuzz_seed_corpus.zip corpus_address
+cp rfc822_headers_dict.txt $OUT/address-fuzz.dict
+cp address-fuzz.options $OUT/

--- a/projects/neomutt/build.sh
+++ b/projects/neomutt/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -eu
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+git checkout fuzzer
+./configure --fuzzing --disable-doc --disable-nls --disable-idn
+make fuzz
+
+cp fuzz/address-fuzz $OUT/
+cp fuzz/corpus_address.zip $OUT/address-fuzz_seed_corpus.zip
+cp fuzz/rfc822_headers_dict.txt $OUT/address-fuzz.dict
+cp fuzz/address-fuzz.options $OUT/

--- a/projects/neomutt/project.yaml
+++ b/projects/neomutt/project.yaml
@@ -1,0 +1,2 @@
+homepage: "https://neomutt.org"
+primary_contact: "joseph.bisch@gmail.com"

--- a/projects/neomutt/project.yaml
+++ b/projects/neomutt/project.yaml
@@ -1,2 +1,4 @@
 homepage: "https://neomutt.org"
 primary_contact: "joseph.bisch@gmail.com"
+auto_ccs:
+  - "richard.russon@gmail.com"


### PR DESCRIPTION
@flatcap - This PR fuzzes message parsing code on Oss-Fuzz. Are you interested in neomutt being added to Oss-Fuzz? If so can you share email address(es) that are associated with Google accounts that you want to have access to bugs that the fuzzer might find? It also would be good to integrate the fuzz target into the upstream neomutt repo, since it is currently on the fuzzer branch of https://github.com/josephbisch/neomutt.