### PR TITLE
[libtorrent] corpus url changed

### DIFF
--- a/projects/libtorrent/Dockerfile
+++ b/projects/libtorrent/Dockerfile
@@ -19,7 +19,7 @@ MAINTAINER arvid@libtorrent.org
 RUN apt-get update && apt-get install -y wget libssl-dev
 
 RUN wget --no-verbose https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz
-RUN tar xvzf boost_1_69_0.tar.gz
+RUN tar xzf boost_1_69_0.tar.gz
 
 RUN git clone --depth 1 --single-branch --branch RC_1_2 --recurse-submodules https://github.com/arvidn/libtorrent.git
 WORKDIR libtorrent

--- a/projects/libtorrent/build.sh
+++ b/projects/libtorrent/build.sh
@@ -30,7 +30,7 @@ cd fuzzers
 b2 clang-ossfuzz -j$(nproc) crypto=openssl fuzz=external sanitize=off stage-large
 cp fuzzers/* $OUT
 
-wget https://github.com/arvidn/libtorrent/releases/download/libtorrent_1_2_1/corpus.zip
+wget https://github.com/arvidn/libtorrent/releases/download/libtorrent-1_2_1/corpus.zip
 unzip -q corpus.zip
 cd corpus
 for f in *; do

--- a/projects/libtorrent/build.sh
+++ b/projects/libtorrent/build.sh
@@ -30,7 +30,7 @@ cd fuzzers
 b2 clang-ossfuzz -j$(nproc) crypto=openssl fuzz=external sanitize=off stage-large
 cp fuzzers/* $OUT
 
-wget https://github.com/arvidn/libtorrent/releases/download/libtorrent-1_2_1/corpus.zip
+wget --no-verbose https://github.com/arvidn/libtorrent/releases/download/libtorrent-1_2_1/corpus.zip
 unzip -q corpus.zip
 cd corpus
 for f in *; do


### PR DESCRIPTION
An URL has changed on libtorrent, causing the build to fail (https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=14598)
This updates the url, and also reduces the unpack and download verbosity so the build log is shorter.
