### PR TITLE
Fix unbound compile reallocarray failure.

### DIFF
--- a/projects/unbound/build.sh
+++ b/projects/unbound/build.sh
@@ -23,6 +23,9 @@ make -j6 all
 
 $CC $CFLAGS -I. -DSRCDIR=. -c -o parse_packet_fuzzer.o parse_packet_fuzzer.c
 
+# get the LIBOBJS with the replaced functions needed for linking.
+LIBOBJS=`make --eval 'echolibobjs: ; @echo "$(LIBOBJS)"' echolibobjs`
+
 $CXX $CXXFLAGS -std=c++11 \
   $LIB_FUZZING_ENGINE \
   -lssl -lcrypto -pthread \
@@ -39,9 +42,8 @@ $CXX $CXXFLAGS -std=c++11 \
   validator.o val_kcache.o val_kentry.o val_neg.o val_nsec3.o val_nsec.o \
   val_secalgo.o val_sigcrypt.o val_utils.o dns64.o cachedb.o redis.o authzone.o \
   respip.o netevent.o listen_dnsport.o outside_network.o ub_event.o keyraw.o \
-  sbuffer.o wire2str.o parse.o parseutil.o rrdef.o str2wire.o strlcat.o \
-  getentropy_linux.o reallocarray.o libunbound.o \
-  explicit_bzero.o libworker.o context.o \
-  strlcpy.o arc4random.o arc4random_uniform.o arc4_lock.o
+  sbuffer.o wire2str.o parse.o parseutil.o rrdef.o str2wire.o libunbound.o \
+  libworker.o context.o \
+  $LIBOBJS
 
 wget --directory-prefix $OUT https://github.com/jsha/unbound/raw/fuzzing-corpora/testdata/parse_packet_fuzzer_seed_corpus.zip


### PR DESCRIPTION
This fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=14648
Caused by reallocarray test succeeding in the docker image used by the
build worker.  But the build.sh script assumes reallocarray is not
available and attempts to link in reallocarray.o replacement code, that
is not there, because the build image support linking with reallocarray.
This can be seen in the script lines in log above where ./configure
detects that that works.  But this does not link if the instructions
are followed to reproduce the build, that docker image has no
reallocarray.  The fix is to fetch the correct list of replaced
functions so that the build can succeed regardless of the version of
the base system that is used.

This PR is a copy of #2391, which the author has dedicated to the
public domain.