### PR TITLE
[libical] Fixed libical by using newer cmake

### DIFF
--- a/projects/libical/Dockerfile
+++ b/projects/libical/Dockerfile
@@ -17,6 +17,11 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER tsdgeos@gmail.com
 RUN apt-get update && apt-get install --yes cmake
+
+# libical requires cmake 3.11 whereas Ubuntu 16.04 only has 3.5.1
+ADD https://github.com/Kitware/CMake/releases/download/v3.14.3/cmake-3.14.3-Linux-x86_64.tar.gz $WORK
+RUN cd $WORK && tar -xzf cmake-3.14.3-Linux-x86_64.tar.gz && rm cmake-3.14.3-Linux-x86_64.tar.gz
+
 RUN git clone --depth 1 https://github.com/libical/libical.git
 COPY build.sh $SRC
 COPY libical_fuzzer.cc $SRC

--- a/projects/libical/build.sh
+++ b/projects/libical/build.sh
@@ -1,4 +1,4 @@
-cmake . -DSTATIC_ONLY=ON -DICAL_GLIB=False
+$WORK/cmake-3.14.3-Linux-x86_64/bin/cmake . -DSTATIC_ONLY=ON -DICAL_GLIB=False
 make install -j$(nproc)
 
 $CXX $CXXFLAGS -std=c++11 $SRC/libical_fuzzer.cc $LIB_FUZZING_ENGINE /usr/local/lib/libical.a -o $OUT/libical_fuzzer


### PR DESCRIPTION
libical recently changed its minimum cmake version to 3.11.