### PR TITLE
solidity: Fix failing build

### DIFF
--- a/projects/solidity/build.sh
+++ b/projects/solidity/build.sh
@@ -66,7 +66,7 @@ rm -f $OUT/*.zip
 for dir in $SRC/solidity-fuzzing-corpus/*;
 do
 	name=$(basename $dir)
-	zip -ujq $OUT/$name.zip $dir/* &>/dev/null
+	zip -rjq $OUT/$name $dir
 done
 cp $SRC/solidity/test/tools/ossfuzz/config/*.options $OUT/
 cp $SRC/solidity/test/tools/ossfuzz/config/*.dict $OUT/


### PR DESCRIPTION
(closes #2379 )

Solidity has over 90k (minimized!) test inputs across 8 fuzzers with the highest seed corpus containing close to 25k files. The build was failing because we did this

```
$ zip -ujq <seed_corpus_dir.zip> seed_corpus_dir/* &> /dev/null
```

and bash wild card expansion complained that the argument list is too long. Moreover, it wasn't showing up in the logs because of the redirection of stdout/err to `/dev/null`.

The PR fixes this by doing

```
$ zip -rjq <seed_corpus_dir> seed_corpus_dir
```