### PR TITLE
[infra] make it possible to override the percentage of targets that c…

### DIFF
--- a/infra/base-images/base-runner/test_all
+++ b/infra/base-images/base-runner/test_all
@@ -16,7 +16,7 @@
 ################################################################################
 
 # Percentage threshold that needs to be reached for marking a build as failed.
-ALLOWED_BROKEN_TARGETS_PERCENTAGE=10
+ALLOWED_BROKEN_TARGETS_PERCENTAGE=${ALLOWED_BROKEN_TARGETS_PERCENTAGE:-10}
 
 # Test all fuzz targets in the $OUT/ dir.
 TOTAL_TARGETS_COUNT=0


### PR DESCRIPTION
…an be broken

10% is an absolutely sensible default in general especially for single-purpose
libraries like json-parsers. When large "umbrella" projects (like systemd) are
fuzzed with 30 fuzzers (and counting (hopefully :-)) covering code scattered all
over their repositories it's too easy to introduce a broken fuzzer or break a couple
of fuzzers accidentally even after running `check_build`. Waiting for two to three
days for ClusterFuzz to open an issue isn't ideal from the point of view of large
open-source project maintainers (where generally contributors come and go) so one
solution would be to run something like when PRs are opened
```sh
helper.py check_build -e ALLOWED_BROKEN_TARGETS_PERCENTAGE=0 ...
```
and catch issues as early as possible (and fix them while the context isn't
completely faded away).

I also considered changing this with `sed` and rebuilding `base-images/base-runner`
locally but it takes too much time, looks too kludgy (even to me) and is likely to be broken
in a week or so :-)