### PR TITLE
[libarchive] process archive_read_next_header() return codes like bsdtar

### DIFF
--- a/projects/libarchive/libarchive_fuzzer.cc
+++ b/projects/libarchive/libarchive_fuzzer.cc
@@ -34,6 +34,7 @@ ssize_t reader_callback(struct archive *a, void *client_data,
 }
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len) {
+  int ret;
   ssize_t r;
   struct archive *a = archive_read_new();
 
@@ -45,7 +46,12 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len) {
 
   std::vector<uint8_t> data_buffer(getpagesize(), 0);
   struct archive_entry *entry;
-  while (archive_read_next_header(a, &entry) == ARCHIVE_OK) {
+  while(1) {
+    ret = archive_read_next_header(a, &entry);
+    if (ret == ARCHIVE_EOF || ret == ARCHIVE_FATAL)
+      break;
+    if (ret == ARCHIVE_RETRY)
+      continue;
     while ((r = archive_read_data(a, data_buffer.data(),
             data_buffer.size())) > 0)
       ;


### PR DESCRIPTION
ARCHIVE_EOF and ARCHIVE_FATAL are the only valid exit codes
ARCHIVE_RETRY should read to re-entering the loop
All other codes (ARCHIVE_OK, ARCHIVE_WARN, ARCHIVE_FAILED) do not prohibit
the caller from reading data and next headers.

This behavior is identical with bsdtar (tar/read.c) and enables better
discovery of possible bugs by fuzzing.