### PR TITLE
mruby: simplify zip command

### DIFF
--- a/projects/mruby/build.sh
+++ b/projects/mruby/build.sh
@@ -34,5 +34,4 @@ cp $SRC/mruby/oss-fuzz/config/mruby.dict $OUT
 cp $SRC/mruby/oss-fuzz/config/mruby_fuzzer.options $OUT
 
 # seeds
-find $SRC/mruby_seeds -exec zip -ujq \
-    $OUT/mruby_fuzzer_seed_corpus.zip "{}" \;
+zip -rq $OUT/mruby_fuzzer_seed_corpus $SRC/mruby_seeds


### PR DESCRIPTION
Hopefully fixes mruby's failing build (monorail issue 14788)

CC @matz

P.S. In the meantime, ossfuzz build bot tells me that the failing build was somehow fixed. Nonetheless, this PR makes the zip command less error-prone, so I'd suggest merging.