### PR TITLE
mruby: Update Dockerfile and build scripts for proto fuzzer

### DIFF
--- a/projects/mruby/Dockerfile
+++ b/projects/mruby/Dockerfile
@@ -15,9 +15,9 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool ruby \
-    bison
+RUN apt-get update && apt-get install -y build-essential ruby bison ninja-build \
+    cmake zlib1g-dev libbz2-dev
 RUN git clone --depth 1 https://github.com/mruby/mruby mruby
 RUN git clone --depth 1 https://github.com/bshastry/mruby_seeds.git mruby_seeds
+RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git 
 COPY build.sh $SRC
-WORKDIR mruby

--- a/projects/mruby/build.sh
+++ b/projects/mruby/build.sh
@@ -15,7 +15,12 @@
 #
 ################################################################################
 
-# build project
+# Build LPM
+(mkdir LPM && cd LPM && cmake $SRC/libprotobuf-mutator -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release && ninja)
+
+# Instrument mruby
+(
+cd $SRC/mruby
 export LD=clang
 export LDFLAGS="$CFLAGS"
 ./minirake clean && ./minirake -j$(nproc) all
@@ -28,11 +33,33 @@ $CC -c $CFLAGS -Iinclude \
 $CXX $CXXFLAGS $OUT/${name}.o $LIB_FUZZING_ENGINE -lm \
     $SRC/mruby/build/host/lib/libmruby.a -o $OUT/${name}
 rm -f $OUT/${name}.o
+)
+
+# Build proto fuzzer: ASan and UBSan
+if [[ $CFLAGS != *sanitize=memory* ]]; then
+    PROTO_FUZZ_TARGET=$SRC/mruby/oss-fuzz/mruby_proto_fuzzer.cpp
+    PROTO_CONVERTER=$SRC/mruby/oss-fuzz/proto_to_ruby.cpp
+    rm -rf genfiles
+    mkdir genfiles
+    LPM/external.protobuf/bin/protoc --proto_path=mruby/oss-fuzz ruby.proto --cpp_out=genfiles
+    $CXX $CXXFLAGS $PROTO_FUZZ_TARGET genfiles/ruby.pb.cc $PROTO_CONVERTER \
+      -I genfiles -I mruby/oss-fuzz  -I libprotobuf-mutator/ -I .  \
+      -I LPM/external.protobuf/include \
+      -I mruby/include -lz -lm \
+      LPM/src/libfuzzer/libprotobuf-mutator-libfuzzer.a \
+      LPM/src/libprotobuf-mutator.a \
+      LPM/external.protobuf/lib/libprotobuf.a \
+      mruby/build/host/lib/libmruby.a \
+      $LIB_FUZZING_ENGINE \
+      -o $OUT/mruby_proto_fuzzer
+
+    # Copy config
+    cp $SRC/mruby/oss-fuzz/config/mruby_proto_fuzzer.options $OUT
+fi
 
 # dict and config
 cp $SRC/mruby/oss-fuzz/config/mruby.dict $OUT
 cp $SRC/mruby/oss-fuzz/config/mruby_fuzzer.options $OUT
 
 # seeds
-find $SRC/mruby_seeds -exec zip -ujq \
-    $OUT/mruby_fuzzer_seed_corpus.zip "{}" \;
+zip -rq $OUT/mruby_fuzzer_seed_corpus $SRC/mruby_seeds


### PR DESCRIPTION
This PR enables mruby proto fuzzing! The proto spec is far from ideal. It is a good beginning nonetheless. CC @matz

Already merged upstream:
- Relevant PR is [here](https://github.com/mruby/mruby/pull/4444)
- The proto spec is [here](https://github.com/mruby/mruby/blob/master/oss-fuzz/ruby.proto)
- The converter code is [here](https://github.com/mruby/mruby/blob/master/oss-fuzz/proto_to_ruby.cpp)

Plans for the future:
  - Make proto spec more precise
  - Add more ruby operations
  - Compare/contrast AST based fuzzing approach suggested by @jonathanmetzman 