### PR TITLE
[cryptofuzz] EverCrypt: Don't explicitly allow AVX instructions

### DIFF
--- a/projects/bignum-fuzzer/build.sh
+++ b/projects/bignum-fuzzer/build.sh
@@ -24,7 +24,7 @@ then
   CFLAGS+=" -DOPENSSL_NO_ASM=1"
 fi
 ./config --debug no-fips no-shared no-tests
-make || true
+make -j$(nproc)
 
 # Build libgmp
 cd $SRC/libgmp

--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -34,6 +34,6 @@ RUN git clone --depth 1 https://github.com/jedisct1/libsodium.git
 RUN git clone --depth 1 https://github.com/weidai11/cryptopp/
 RUN git clone --depth 1 https://dev.gnupg.org/source/libgcrypt.git
 RUN wget https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.36.tar.bz2
-RUN wget https://github.com/project-everest/hacl-star/archive/evercrypt-v0.1alpha1.tar.gz
+RUN wget https://github.com/project-everest/hacl-star/releases/download/evercrypt-v0.1alpha1/hacl-star-evercrypt-v0.1alpha1-bugfix.tar.gz
 
 COPY build.sh $SRC/

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -98,7 +98,7 @@ if [[ $CFLAGS != *sanitize=memory* ]]
 then
     # Compile EverCrypt (with assembly)
     cd $SRC/
-    tar zxvf evercrypt-v0.1alpha1.tar.gz
+    tar zxvf hacl-star-evercrypt-v0.1alpha1-bugfix.tar.gz
     mv hacl-star-evercrypt-v0.1alpha1 evercrypt
 
     cd $SRC/evercrypt/dist/generic

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -169,7 +169,7 @@ then
     # Compile Openssl (with assembly)
     cd $SRC/openssl
     ./config --debug enable-md2 enable-rc5
-    make || true
+    make -j$(nproc)
 
     # Compile Cryptofuzz OpenSSL (with assembly) module
     cd $SRC/cryptofuzz/modules/openssl
@@ -195,7 +195,7 @@ fi
 cd $SRC/openssl
 ./config --debug no-asm enable-md2 enable-rc5
 make clean
-make || true
+make -j$(nproc)
 
 # Compile Cryptofuzz OpenSSL (without assembly) module
 cd $SRC/cryptofuzz/modules/openssl

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -27,6 +27,9 @@ python gen_repository.py
 
 cd $SRC/openssl
 
+# This enables runtime checks for C++-specific undefined behaviour.
+export CXXFLAGS="$CXXFLAGS -D_GLIBCXX_DEBUG"
+
 export CXXFLAGS="$CXXFLAGS -I $SRC/cryptofuzz/fuzzing-headers/include"
 if [[ $CFLAGS = *sanitize=memory* ]]
 then


### PR DESCRIPTION
Recent crashes involving EverCrypt were found to be caused by
AVX instructions in the EverCrypt library. The Makefile explicitly
allowed the use of AVX instructions via hardcoded CFLAGS. The authors
have released a new version that should resolve this problem.