### PR TITLE
Import the double-conversion fuzz target into OSS-Fuzz.

### DIFF
--- a/projects/double-conversion/Dockerfile
+++ b/projects/double-conversion/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2018 Google Inc.
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/double-conversion/Dockerfile
+++ b/projects/double-conversion/Dockerfile
@@ -1,0 +1,29 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER sbucur@google.com
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        cmake ninja-build && \
+    apt-get clean
+
+RUN git clone --single-branch \
+    https://github.com/google/double-conversion.git double-conversion
+WORKDIR double-conversion
+COPY build.sh $SRC/
+COPY *.cc $SRC/

--- a/projects/double-conversion/build.sh
+++ b/projects/double-conversion/build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -eu
+#
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+mkdir -p ${WORK}/double-conversion
+cd ${WORK}/double-conversion
+
+cmake -GNinja ${SRC}/double-conversion/
+ninja
+
+fuzzer="string_to_double_fuzzer"
+
+${CXX} ${CXXFLAGS} -std=c++11 -I${SRC}/double-conversion/double-conversion \
+    -c ${SRC}/${fuzzer}.cc \
+    -o ${fuzzer}.o
+${CXX} ${CXXFLAGS} -std=c++11 ${fuzzer}.o \
+    -o ${OUT}/${fuzzer} "${LIB_FUZZING_ENGINE}" libdouble-conversion.a

--- a/projects/double-conversion/build.sh
+++ b/projects/double-conversion/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 #
-# Copyright 2018 Google Inc.
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/double-conversion/project.yaml
+++ b/projects/double-conversion/project.yaml
@@ -1,0 +1,11 @@
+homepage: "https://github.com/google/double-conversion"
+primary_contact: "florian@loitsch.com"
+auto_ccs:
+  - "sbucur@google.com"
+sanitizers:
+  - address
+  - memory
+  - undefined
+labels:
+  string_to_double_fuzzer:
+    - sundew

--- a/projects/double-conversion/string_to_double_fuzzer.cc
+++ b/projects/double-conversion/string_to_double_fuzzer.cc
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/double-conversion/string_to_double_fuzzer.cc
+++ b/projects/double-conversion/string_to_double_fuzzer.cc
@@ -1,0 +1,39 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+
+#include "double-conversion.h"
+
+using double_conversion::StringToDoubleConverter;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  StringToDoubleConverter converter(
+      StringToDoubleConverter::ALLOW_HEX |
+          StringToDoubleConverter::ALLOW_OCTALS |
+          StringToDoubleConverter::ALLOW_TRAILING_JUNK |
+          StringToDoubleConverter::ALLOW_LEADING_SPACES |
+          StringToDoubleConverter::ALLOW_TRAILING_SPACES |
+          StringToDoubleConverter::ALLOW_SPACES_AFTER_SIGN |
+          StringToDoubleConverter::ALLOW_CASE_INSENSIBILITY |
+          StringToDoubleConverter::ALLOW_HEX_FLOATS,
+      /*empty_string_value=*/0.0,
+      /*junk_string_value=*/0.0, "inf", "nan");
+  int num_digits_unused;
+  converter.StringToDouble(reinterpret_cast<const char*>(data), size,
+                           &num_digits_unused);
+  return 0;
+}


### PR DESCRIPTION
double-conversion is a V8 library for computing and parsing string representations of floating point numbers. The library is maintained by @floitsch, who has agreed to receive bug reports from the fuzzers.