### PR TITLE
infra: skip files whose names start with afl while looking for fuzz …

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -523,6 +523,9 @@ def _get_fuzz_targets(project_name):
   """Return names of fuzz targest build in the project's /out directory."""
   fuzz_targets = []
   for name in os.listdir(_get_output_dir(project_name)):
+    if name.startswith('afl-'):
+      continue
+
     path = os.path.join(_get_output_dir(project_name), name)
     if os.path.isfile(path) and os.access(path, os.X_OK):
       fuzz_targets.append(name)


### PR DESCRIPTION
…targets

This should help to get rid of the "WARNING: corpus for systemd_afl-showmap not found:"
messages (that are harmless but confusing a bit). In general _get_fuzz_targets
should probably be in sync with ./infra/base-images/base-runner/test_all (where a file
is considered a fuzz target if grep can find "ELF" in it and so on).