### PR TITLE
[AFL][gnupg] Disable AFL to stop exceptions

### DIFF
--- a/projects/gnupg/project.yaml
+++ b/projects/gnupg/project.yaml
@@ -1,2 +1,4 @@
 homepage: "https://www.gnupg.org"
 primary_contact: "p.antoine@catenacyber.fr"
+fuzzing_engines:
+  - libfuzzer


### PR DESCRIPTION
ClusterFuzz exceptions because these fuzzers fail with AFL because they fill up the disk. Disabling AFL for now.

@catenacyber Please look into why this is filling up the disk and solve this problem. I'm not sure why it isn't crashing libFuzzer sessions but it does look like it is having a negative effect there too. If you look at the logs for [this fuzzer](https://console.cloud.google.com/storage/browser/gnupg-logs.clusterfuzz-external.appspot.com/libFuzzer_gnupg_fuzz_list/libfuzzer_asan_gnupg/2019-05-20/?project=clusterfuzz-external) for example, merging always fails and fork mode also fails.