### PR TITLE
[opendnp3] Fix build by installing modern CMake

### DIFF
--- a/projects/opendnp3/Dockerfile
+++ b/projects/opendnp3/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER info@automatak.com
-RUN apt-get update && apt-get install -y make cmake tshark
+RUN apt-get update && apt-get install -y make wget tshark
 RUN git clone --recursive --depth 1 https://github.com/automatak/dnp3.git opendnp3
 WORKDIR opendnp3
 COPY build.sh $SRC/

--- a/projects/opendnp3/Dockerfile
+++ b/projects/opendnp3/Dockerfile
@@ -17,6 +17,14 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER info@automatak.com
 RUN apt-get update && apt-get install -y make wget tshark
+# The CMake version that is available on Ubuntu 16.04 is 3.5.1. OpenDNP3
+# needs CMake 3.8 or higher, because of the C# bindings. Therefore, we
+# manually install a modern CMake until the OSS Fuzz environment updates
+# to a more recent Ubuntu.
+# This section was taken from JSC Dockerfile
+RUN wget -q -O - https://github.com/Kitware/CMake/releases/download/v3.14.4/cmake-3.14.4-Linux-x86_64.sh > /tmp/install_cmake.sh && \
+    cd /usr && bash /tmp/install_cmake.sh -- --skip-license && \
+    rm /tmp/install_cmake.sh
 RUN git clone --recursive --depth 1 https://github.com/automatak/dnp3.git opendnp3
 WORKDIR opendnp3
 COPY build.sh $SRC/

--- a/projects/opendnp3/build.sh
+++ b/projects/opendnp3/build.sh
@@ -15,6 +15,17 @@
 #
 ################################################################################
 
+
+# The cmake version that is available on Ubuntu 16.04 is 3.5.1. OpenDNP3
+# needs CMake 3.8 or higher, because of the C# bindings. Therefore, we
+# manually install a modern CMake until the OSS Fuzz environment updates
+# to a more recent Ubuntu.
+wget https://cmake.org/files/v3.12/cmake-3.12.0-Linux-x86_64.tar.gz
+tar -xzf cmake-3.12.0-Linux-x86_64.tar.gz
+cp -r cmake-3.12.0-Linux-x86_64/bin /usr/local
+cp -r cmake-3.12.0-Linux-x86_64/share /usr/local
+rm -rf cmake-3.12.0-Linux-x86_64 cmake-3.12.0-Linux-x86_64.tar.gz
+
 # build project
 cmake -DDNP3_FUZZING=ON -DSTATICLIBS=ON .
 make -j$(nproc) all

--- a/projects/opendnp3/build.sh
+++ b/projects/opendnp3/build.sh
@@ -15,17 +15,6 @@
 #
 ################################################################################
 
-
-# The cmake version that is available on Ubuntu 16.04 is 3.5.1. OpenDNP3
-# needs CMake 3.8 or higher, because of the C# bindings. Therefore, we
-# manually install a modern CMake until the OSS Fuzz environment updates
-# to a more recent Ubuntu.
-wget https://cmake.org/files/v3.12/cmake-3.12.0-Linux-x86_64.tar.gz
-tar -xzf cmake-3.12.0-Linux-x86_64.tar.gz
-cp -r cmake-3.12.0-Linux-x86_64/bin /usr/local
-cp -r cmake-3.12.0-Linux-x86_64/share /usr/local
-rm -rf cmake-3.12.0-Linux-x86_64 cmake-3.12.0-Linux-x86_64.tar.gz
-
 # build project
 cmake -DDNP3_FUZZING=ON -DSTATICLIBS=ON .
 make -j$(nproc) all

--- a/projects/opendnp3/project.yaml
+++ b/projects/opendnp3/project.yaml
@@ -1,8 +1,10 @@
 homepage: "http://www.automatak.com/opendnp3/"
 primary_contact: "info@automatak.com"
-auto_ccs : "p.antoine@catenacyber.fr"
+auto_ccs :
+  - "p.antoine@catenacyber.fr"
+  - "emile@automatak.com"
 
 sanitizers:
-- address
-- memory
-- undefined
+  - address
+  - memory
+  - undefined


### PR DESCRIPTION
The upstream repository now requires CMake 3.8 minimum. The `build.sh` now manually installs a modern CMake. I also added myself to the `auto_ccs`.