### PR TITLE
Gnupg: avoids filling disk with logs

### DIFF
--- a/projects/gnupg/fuzz_decrypt.c
+++ b/projects/gnupg/fuzz_decrypt.c
@@ -113,7 +113,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         public_key_list (ctrlGlobal, sl, 0);
         free_strlist(sl);
         //no output for stderr
-        log_set_file("/tmp/fuzzdecrypt.log");
+        log_set_file("/dev/null");
         gcry_set_log_handler (my_gcry_logger, NULL);
         gnupg_initialize_compliance (GNUPG_MODULE_NAME_GPG);
         //overwrite output file

--- a/projects/gnupg/fuzz_import.c
+++ b/projects/gnupg/fuzz_import.c
@@ -124,7 +124,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         public_key_list (ctrlGlobal, sl, 0);
         free_strlist(sl);
         //no output for stderr
-        log_set_file("/tmp/fuzzimport.log");
+        log_set_file("/dev/null");
         gcry_set_log_handler (my_gcry_logger, NULL);
         gnupg_initialize_compliance (GNUPG_MODULE_NAME_GPG);
         initialized = true;

--- a/projects/gnupg/fuzz_list.c
+++ b/projects/gnupg/fuzz_list.c
@@ -124,7 +124,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         public_key_list (ctrlGlobal, sl, 0);
         free_strlist(sl);
         //no output for stderr
-        log_set_file("/tmp/fuzzlist.log");
+        log_set_file("/dev/null");
         gcry_set_log_handler (my_gcry_logger, NULL);
         gnupg_initialize_compliance (GNUPG_MODULE_NAME_GPG);
         opt.list_packets=1;

--- a/projects/gnupg/fuzz_verify.c
+++ b/projects/gnupg/fuzz_verify.c
@@ -113,7 +113,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         public_key_list (ctrlGlobal, sl, 0);
         free_strlist(sl);
         //no output for stderr
-        log_set_file("/tmp/fuzzverify.log");
+        log_set_file("/dev/null");
         gcry_set_log_handler (my_gcry_logger, NULL);
         gnupg_initialize_compliance (GNUPG_MODULE_NAME_GPG);
         initialized = true;


### PR DESCRIPTION
cc @jonathanmetzman cf #2447 

This should avoid filling the disks with logs (and still compute them)