### PR TITLE
[cryptofuzz] Add OpenSSL 1.0.2 and 1.1.0 targets

### DIFF
--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -34,7 +34,7 @@ RUN git clone --depth 1 https://github.com/jedisct1/libsodium.git
 RUN git clone --depth 1 https://github.com/weidai11/cryptopp/
 RUN git clone --depth 1 https://dev.gnupg.org/source/libgcrypt.git
 RUN wget https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.36.tar.bz2
-RUN wget https://github.com/project-everest/hacl-star/releases/download/evercrypt-v0.1alpha1/hacl-star-evercrypt-v0.1alpha1-bugfix.tar.gz
+RUN git clone --depth 1 -b oss-fuzz https://github.com/project-everest/hacl-star evercrypt
 RUN wget https://github.com/openssl/openssl/archive/OpenSSL_1_1_0-stable.zip
 RUN wget https://github.com/openssl/openssl/archive/OpenSSL_1_0_2-stable.zip
 

--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -35,5 +35,7 @@ RUN git clone --depth 1 https://github.com/weidai11/cryptopp/
 RUN git clone --depth 1 https://dev.gnupg.org/source/libgcrypt.git
 RUN wget https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.36.tar.bz2
 RUN wget https://github.com/project-everest/hacl-star/releases/download/evercrypt-v0.1alpha1/hacl-star-evercrypt-v0.1alpha1-bugfix.tar.gz
+RUN wget https://github.com/openssl/openssl/archive/OpenSSL_1_1_0-stable.zip
+RUN wget https://github.com/openssl/openssl/archive/OpenSSL_1_0_2-stable.zip
 
 COPY build.sh $SRC/

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -41,7 +41,7 @@ if [[ $CFLAGS != *sanitize=memory* ]]
 then
     # Compile cryptopp (with assembly)
     cd $SRC/cryptopp
-    make -j$(nproc)
+    make -j$(nproc) >/dev/null 2>&1
 
     export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_CRYPTOPP"
     export LIBCRYPTOPP_A_PATH="$SRC/cryptopp/libcryptopp.a"
@@ -60,7 +60,7 @@ then
     tar jxvf libgpg-error-1.36.tar.bz2
     cd libgpg-error-1.36/
     ./configure --enable-static
-    make -j$(nproc)
+    make -j$(nproc) >/dev/null 2>&1
     make install
     export LINK_FLAGS="$LINK_FLAGS $SRC/libgpg-error-1.36/src/.libs/libgpg-error.a"
 
@@ -68,7 +68,7 @@ then
     cd $SRC/libgcrypt
     autoreconf -ivf
     ./configure --enable-static --disable-doc
-    make -j$(nproc)
+    make -j$(nproc) >/dev/null 2>&1
 
     export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_LIBGCRYPT"
     export LIBGCRYPT_A_PATH="$SRC/libgcrypt/src/.libs/libgcrypt.a"
@@ -86,7 +86,7 @@ then
     cd $SRC/libsodium
     autoreconf -ivf
     ./configure
-    make -j$(nproc)
+    make -j$(nproc) >/dev/null 2>&1
 
     export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_LIBSODIUM"
     export LIBSODIUM_A_PATH="$SRC/libsodium/src/libsodium/.libs/libsodium.a"
@@ -101,8 +101,8 @@ if [[ $CFLAGS != *sanitize=memory* ]]
 then
     # Compile EverCrypt (with assembly)
     cd $SRC/evercrypt/dist
-    make -C portable -j$(nproc) libevercrypt.a
-    make -C kremlin/kremlib/dist/minimal -j$(nproc)
+    make -C portable -j$(nproc) libevercrypt.a >/dev/null 2>&1
+    make -C kremlin/kremlib/dist/minimal -j$(nproc) >/dev/null 2>&1
 
     export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_EVERCRYPT"
     export EVERCRYPT_A_PATH="$SRC/evercrypt/dist/portable/libevercrypt.a"
@@ -142,7 +142,7 @@ then
     rm -rf build ; mkdir build
     cd build
     cmake -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DCMAKE_C_FLAGS="$CFLAGS" ..
-    make -j$(nproc) crypto
+    make -j$(nproc) crypto >/dev/null 2>&1
 
     # Compile Cryptofuzz LibreSSL (with assembly) module
     cd $SRC/cryptofuzz/modules/openssl
@@ -150,7 +150,7 @@ then
 
     # Compile Cryptofuzz
     cd $SRC/cryptofuzz
-    LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/libressl/include -DCRYPTOFUZZ_LIBRESSL $INCLUDE_PATH_FLAGS" make -B -j$(nproc)
+    LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/libressl/include -DCRYPTOFUZZ_LIBRESSL $INCLUDE_PATH_FLAGS" make -B -j$(nproc) >/dev/null 2>&1
 
     # Generate dictionary
     ./generate_dict
@@ -169,7 +169,7 @@ then
     # Compile Openssl (with assembly)
     cd $SRC/openssl
     ./config --debug enable-md2 enable-rc5
-    make -j$(nproc)
+    make -j$(nproc) >/dev/null 2>&1
 
     # Compile Cryptofuzz OpenSSL (with assembly) module
     cd $SRC/cryptofuzz/modules/openssl
@@ -177,7 +177,7 @@ then
 
     # Compile Cryptofuzz
     cd $SRC/cryptofuzz
-    LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl/include $INCLUDE_PATH_FLAGS" make -B -j$(nproc)
+    LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl/include $INCLUDE_PATH_FLAGS" make -B -j$(nproc) >/dev/null 2>&1
 
     # Generate dictionary
     ./generate_dict
@@ -195,7 +195,7 @@ fi
 cd $SRC/openssl
 ./config --debug no-asm enable-md2 enable-rc5
 make clean
-make -j$(nproc)
+make -j$(nproc) >/dev/null 2>&1
 
 # Compile Cryptofuzz OpenSSL (without assembly) module
 cd $SRC/cryptofuzz/modules/openssl
@@ -203,7 +203,7 @@ OPENSSL_INCLUDE_PATH="$SRC/openssl/include" OPENSSL_LIBCRYPTO_A_PATH="$SRC/opens
 
 # Compile Cryptofuzz
 cd $SRC/cryptofuzz
-LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl/include $INCLUDE_PATH_FLAGS" make -B -j$(nproc)
+LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl/include $INCLUDE_PATH_FLAGS" make -B -j$(nproc) >/dev/null 2>&1
 
 # Generate dictionary
 ./generate_dict
@@ -223,7 +223,7 @@ then
     rm -rf build ; mkdir build
     cd build
     cmake -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DCMAKE_C_FLAGS="$CFLAGS" -DBORINGSSL_ALLOW_CXX_RUNTIME=1 ..
-    make -j$(nproc) crypto
+    make -j$(nproc) crypto >/dev/null 2>&1
 
     # Compile Cryptofuzz BoringSSL (with assembly) module
     cd $SRC/cryptofuzz/modules/openssl
@@ -231,7 +231,7 @@ then
 
     # Compile Cryptofuzz
     cd $SRC/cryptofuzz
-    LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl/include $INCLUDE_PATH_FLAGS" make -B -j$(nproc)
+    LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl/include $INCLUDE_PATH_FLAGS" make -B -j$(nproc) >/dev/null 2>&1
 
     # Generate dictionary
     ./generate_dict
@@ -250,7 +250,7 @@ cd $SRC/boringssl
 rm -rf build ; mkdir build
 cd build
 cmake -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DCMAKE_C_FLAGS="$CFLAGS" -DBORINGSSL_ALLOW_CXX_RUNTIME=1 -DOPENSSL_NO_ASM=1 ..
-make -j$(nproc) crypto
+make -j$(nproc) crypto >/dev/null 2>&1
 
 # Compile Cryptofuzz BoringSSL (with assembly) module
 cd $SRC/cryptofuzz/modules/openssl
@@ -258,7 +258,7 @@ OPENSSL_INCLUDE_PATH="$SRC/boringssl/include" OPENSSL_LIBCRYPTO_A_PATH="$SRC/bor
 
 # Compile Cryptofuzz
 cd $SRC/cryptofuzz
-LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl/include $INCLUDE_PATH_FLAGS" make -B -j$(nproc)
+LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl/include $INCLUDE_PATH_FLAGS" make -B -j$(nproc) >/dev/null 2>&1
 
 # Generate dictionary
 ./generate_dict
@@ -281,7 +281,7 @@ then
     cd $SRC/openssl-OpenSSL_1_1_0-stable/
     ./config --debug enable-md2 enable-rc5 $CFLAGS
     make depend
-    make -j$(nproc)
+    make -j$(nproc) >/dev/null 2>&1
 
     # Compile Cryptofuzz OpenSSL 1.1.0 (with assembly) module
     cd $SRC/cryptofuzz/modules/openssl
@@ -289,7 +289,7 @@ then
 
     # Compile Cryptofuzz
     cd $SRC/cryptofuzz
-    LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl-OpenSSL_1_1_0-stable/include $INCLUDE_PATH_FLAGS -DCRYPTOFUZZ_OPENSSL_110" make -B -j$(nproc)
+    LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl-OpenSSL_1_1_0-stable/include $INCLUDE_PATH_FLAGS -DCRYPTOFUZZ_OPENSSL_110" make -B -j$(nproc) >/dev/null 2>&1
 
     # Generate dictionary
     ./generate_dict
@@ -308,7 +308,7 @@ cd $SRC/openssl-OpenSSL_1_1_0-stable/
 make clean || true
 ./config --debug no-asm enable-md2 enable-rc5 $CFLAGS
 make depend
-make -j$(nproc)
+make -j$(nproc) >/dev/null 2>&1
 
 # Compile Cryptofuzz OpenSSL 1.1.0 (without assembly) module
 cd $SRC/cryptofuzz/modules/openssl
@@ -316,7 +316,7 @@ OPENSSL_INCLUDE_PATH="$SRC/openssl-OpenSSL_1_1_0-stable/include" OPENSSL_LIBCRYP
 
 # Compile Cryptofuzz
 cd $SRC/cryptofuzz
-LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl-OpenSSL_1_1_0-stable/include $INCLUDE_PATH_FLAGS -DCRYPTOFUZZ_OPENSSL_110" make -B -j$(nproc)
+LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl-OpenSSL_1_1_0-stable/include $INCLUDE_PATH_FLAGS -DCRYPTOFUZZ_OPENSSL_110" make -B -j$(nproc) >/dev/null 2>&1
 
 # Generate dictionary
 ./generate_dict
@@ -337,7 +337,7 @@ then
     cd $SRC/openssl-OpenSSL_1_0_2-stable/
     ./config --debug enable-md2 enable-rc5 $CFLAGS
     make depend
-    make -j$(nproc)
+    make -j$(nproc) >/dev/null 2>&1
 
     # Compile Cryptofuzz OpenSSL 1.0.2 (with assembly) module
     cd $SRC/cryptofuzz/modules/openssl
@@ -345,7 +345,7 @@ then
 
     # Compile Cryptofuzz
     cd $SRC/cryptofuzz
-    LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl-OpenSSL_1_0_2-stable/include $INCLUDE_PATH_FLAGS -DCRYPTOFUZZ_OPENSSL_102" make -B -j$(nproc)
+    LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl-OpenSSL_1_0_2-stable/include $INCLUDE_PATH_FLAGS -DCRYPTOFUZZ_OPENSSL_102" make -B -j$(nproc) >/dev/null 2>&1
 
     # Generate dictionary
     ./generate_dict
@@ -364,7 +364,7 @@ cd $SRC/openssl-OpenSSL_1_0_2-stable/
 make clean || true
 ./config --debug no-asm enable-md2 enable-rc5 $CFLAGS
 make depend
-make -j$(nproc)
+make -j$(nproc) >/dev/null 2>&1
 
 # Compile Cryptofuzz OpenSSL 1.0.2 (without assembly) module
 cd $SRC/cryptofuzz/modules/openssl
@@ -372,7 +372,7 @@ OPENSSL_INCLUDE_PATH="$SRC/openssl-OpenSSL_1_0_2-stable/include" OPENSSL_LIBCRYP
 
 # Compile Cryptofuzz
 cd $SRC/cryptofuzz
-LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl-OpenSSL_1_0_2-stable/include $INCLUDE_PATH_FLAGS -DCRYPTOFUZZ_OPENSSL_102" make -B -j$(nproc)
+LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl-OpenSSL_1_0_2-stable/include $INCLUDE_PATH_FLAGS -DCRYPTOFUZZ_OPENSSL_102" make -B -j$(nproc) >/dev/null 2>&1
 
 # Generate dictionary
 ./generate_dict

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -272,3 +272,117 @@ cp $SRC/cryptofuzz/cryptofuzz $OUT/cryptofuzz-boringssl-noasm
 cp $SRC/cryptofuzz/cryptofuzz-dict.txt $OUT/cryptofuzz-boringssl-noasm.dict
 # Copy seed corpus
 cp $SRC/cryptofuzz-corpora/boringssl_latest.zip $OUT/cryptofuzz-boringssl-noasm_seed_corpus.zip
+
+
+##############################################################################
+cd $SRC;
+unzip OpenSSL_1_1_0-stable.zip
+
+if [[ $CFLAGS != *sanitize=memory* ]]
+then
+    # Compile Openssl 1.1.0 (with assembly)
+    cd $SRC/openssl-OpenSSL_1_1_0-stable/
+    ./config --debug enable-md2 enable-rc5 $CFLAGS
+    make depend
+    make -j$(nproc)
+
+    # Compile Cryptofuzz OpenSSL 1.1.0 (with assembly) module
+    cd $SRC/cryptofuzz/modules/openssl
+    OPENSSL_INCLUDE_PATH="$SRC/openssl-OpenSSL_1_1_0-stable/include" OPENSSL_LIBCRYPTO_A_PATH="$SRC/openssl-OpenSSL_1_1_0-stable/libcrypto.a" CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_OPENSSL_110" make -B
+
+    # Compile Cryptofuzz
+    cd $SRC/cryptofuzz
+    LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl-OpenSSL_1_1_0-stable/include $INCLUDE_PATH_FLAGS -DCRYPTOFUZZ_OPENSSL_110" make -B -j$(nproc)
+
+    # Generate dictionary
+    ./generate_dict
+
+    # Copy fuzzer
+    cp $SRC/cryptofuzz/cryptofuzz $OUT/cryptofuzz-openssl-110
+    # Copy dictionary
+    cp $SRC/cryptofuzz/cryptofuzz-dict.txt $OUT/cryptofuzz-openssl-110.dict
+    # Copy seed corpus
+    cp $SRC/cryptofuzz-corpora/openssl_latest.zip $OUT/cryptofuzz-openssl_seed_corpus.zip
+fi
+
+##############################################################################
+# Compile Openssl 1.1.0 (without assembly)
+cd $SRC/openssl-OpenSSL_1_1_0-stable/
+make clean || true
+./config --debug no-asm enable-md2 enable-rc5 $CFLAGS
+make depend
+make -j$(nproc)
+
+# Compile Cryptofuzz OpenSSL 1.1.0 (without assembly) module
+cd $SRC/cryptofuzz/modules/openssl
+OPENSSL_INCLUDE_PATH="$SRC/openssl-OpenSSL_1_1_0-stable/include" OPENSSL_LIBCRYPTO_A_PATH="$SRC/openssl-OpenSSL_1_1_0-stable/libcrypto.a" CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_OPENSSL_110" make -B
+
+# Compile Cryptofuzz
+cd $SRC/cryptofuzz
+LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl-OpenSSL_1_1_0-stable/include $INCLUDE_PATH_FLAGS -DCRYPTOFUZZ_OPENSSL_110" make -B -j$(nproc)
+
+# Generate dictionary
+./generate_dict
+
+# Copy fuzzer
+cp $SRC/cryptofuzz/cryptofuzz $OUT/cryptofuzz-openssl-110-noasm
+# Copy dictionary
+cp $SRC/cryptofuzz/cryptofuzz-dict.txt $OUT/cryptofuzz-openssl-110-noasm.dict
+# Copy seed corpus
+cp $SRC/cryptofuzz-corpora/openssl_latest.zip $OUT/cryptofuzz-openssl-110-noasm_seed_corpus.zip
+##############################################################################
+cd $SRC;
+unzip OpenSSL_1_0_2-stable.zip
+
+if [[ $CFLAGS != *sanitize=memory* ]]
+then
+    # Compile Openssl 1.0.2 (with assembly)
+    cd $SRC/openssl-OpenSSL_1_0_2-stable/
+    ./config --debug enable-md2 enable-rc5 $CFLAGS
+    make depend
+    make -j$(nproc)
+
+    # Compile Cryptofuzz OpenSSL 1.0.2 (with assembly) module
+    cd $SRC/cryptofuzz/modules/openssl
+    OPENSSL_INCLUDE_PATH="$SRC/openssl-OpenSSL_1_0_2-stable/include" OPENSSL_LIBCRYPTO_A_PATH="$SRC/openssl-OpenSSL_1_0_2-stable/libcrypto.a" CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_OPENSSL_102" make -B
+
+    # Compile Cryptofuzz
+    cd $SRC/cryptofuzz
+    LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl-OpenSSL_1_0_2-stable/include $INCLUDE_PATH_FLAGS -DCRYPTOFUZZ_OPENSSL_102" make -B -j$(nproc)
+
+    # Generate dictionary
+    ./generate_dict
+
+    # Copy fuzzer
+    cp $SRC/cryptofuzz/cryptofuzz $OUT/cryptofuzz-openssl-102
+    # Copy dictionary
+    cp $SRC/cryptofuzz/cryptofuzz-dict.txt $OUT/cryptofuzz-openssl-102.dict
+    # Copy seed corpus
+    cp $SRC/cryptofuzz-corpora/openssl_latest.zip $OUT/cryptofuzz-openssl_seed_corpus.zip
+fi
+
+##############################################################################
+# Compile Openssl 1.0.2 (without assembly)
+cd $SRC/openssl-OpenSSL_1_0_2-stable/
+make clean || true
+./config --debug no-asm enable-md2 enable-rc5 $CFLAGS
+make depend
+make -j$(nproc)
+
+# Compile Cryptofuzz OpenSSL 1.0.2 (without assembly) module
+cd $SRC/cryptofuzz/modules/openssl
+OPENSSL_INCLUDE_PATH="$SRC/openssl-OpenSSL_1_0_2-stable/include" OPENSSL_LIBCRYPTO_A_PATH="$SRC/openssl-OpenSSL_1_0_2-stable/libcrypto.a" CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_OPENSSL_102" make -B
+
+# Compile Cryptofuzz
+cd $SRC/cryptofuzz
+LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl-OpenSSL_1_0_2-stable/include $INCLUDE_PATH_FLAGS -DCRYPTOFUZZ_OPENSSL_102" make -B -j$(nproc)
+
+# Generate dictionary
+./generate_dict
+
+# Copy fuzzer
+cp $SRC/cryptofuzz/cryptofuzz $OUT/cryptofuzz-openssl-102-noasm
+# Copy dictionary
+cp $SRC/cryptofuzz/cryptofuzz-dict.txt $OUT/cryptofuzz-openssl-102-noasm.dict
+# Copy seed corpus
+cp $SRC/cryptofuzz-corpora/openssl_latest.zip $OUT/cryptofuzz-openssl-102-noasm_seed_corpus.zip

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -101,7 +101,7 @@ if [[ $CFLAGS != *sanitize=memory* ]]
 then
     # Compile EverCrypt (with assembly)
     cd $SRC/evercrypt/dist
-    make -C portable -j$(npro) libevercrypt.a
+    make -C portable -j$(nproc) libevercrypt.a
     make -C kremlin/kremlib/dist/minimal -j$(nproc)
 
     export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_EVERCRYPT"

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -104,9 +104,6 @@ then
     make -C portable -j$(npro) libevercrypt.a
     make -C kremlin/kremlib/dist/minimal -j$(nproc)
 
-    cd $SRC/evercrypt/dist/generic
-    make -j$(nproc) || true
-
     export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_EVERCRYPT"
     export EVERCRYPT_A_PATH="$SRC/evercrypt/dist/portable/libevercrypt.a"
     export KREMLIN_A_PATH="$SRC/evercrypt/dist/kremlin/kremlib/dist/minimal/*.o"

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -100,15 +100,15 @@ fi
 if [[ $CFLAGS != *sanitize=memory* ]]
 then
     # Compile EverCrypt (with assembly)
-    cd $SRC/
-    tar zxvf hacl-star-evercrypt-v0.1alpha1-bugfix.tar.gz
-    mv hacl-star-evercrypt-v0.1alpha1 evercrypt
+    cd $SRC/evercrypt/dist
+    make -C portable -j$(npro) libevercrypt.a
+    make -C kremlin/kremlib/dist/minimal -j$(nproc)
 
     cd $SRC/evercrypt/dist/generic
     make -j$(nproc) || true
 
     export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_EVERCRYPT"
-    export EVERCRYPT_A_PATH="$SRC/evercrypt/dist/generic/libevercrypt.a"
+    export EVERCRYPT_A_PATH="$SRC/evercrypt/dist/portable/libevercrypt.a"
     export KREMLIN_A_PATH="$SRC/evercrypt/dist/kremlin/kremlib/dist/minimal/*.o"
     export EVERCRYPT_INCLUDE_PATH="$SRC/evercrypt/dist"
     export KREMLIN_INCLUDE_PATH="$SRC/evercrypt/dist/kremlin/include"


### PR DESCRIPTION
There are a bunch of bugs in 1.0.2 and 1.10 that will cause crashes, like https://github.com/openssl/openssl/issues/8980 and https://github.com/openssl/openssl/issues/8972

I still have to create bug reports for the other ones.

You can either merge it now and let ClusterFuzz detect these bugs, or wait until they are all fixed, whichever you prefer.

CC @mattcaswell @kroeckx 

I will remove these targets when they reach end-of-life later this year.