### PR TITLE
Update regex for clang revision

### DIFF
--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -49,7 +49,7 @@ cd clang
 
 OUR_LLVM_REVISION=359254  # For manual bumping.
 FORCE_OUR_REVISION=0  # To allow for manual downgrades.
-LLVM_REVISION=$(grep -Po "CLANG_REVISION = '\K\d+(?=')" scripts/update.py)
+LLVM_REVISION=$(grep -Po "CLANG_SVN_REVISION = '\K\d+(?=')" scripts/update.py)
 
 if [ $OUR_LLVM_REVISION -gt $LLVM_REVISION ] || [ $FORCE_OUR_REVISION -ne 0 ]; then
   LLVM_REVISION=$OUR_LLVM_REVISION


### PR DESCRIPTION
This should fix the build breakage affecting base-clang and preventing all builds that was pointed out by @nico in #2459