### PR TITLE
Remove code for copying dataflow scripts

### DIFF
--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -135,9 +135,6 @@ rm -rf $WORK/msan
 # Pull trunk libfuzzer.
 cd $SRC && svn co https://llvm.org/svn/llvm-project/compiler-rt/trunk/lib/fuzzer libfuzzer
 
-# Copy DataFlow scripts for collecting and merging the traces.
-cp libfuzzer/scripts/*_data_flow.py /usr/local/bin/
-
 # Cleanup
 rm -rf $SRC/llvm
 rm -rf $SRC/chromium_tools


### PR DESCRIPTION
Dataflow scripts are removed in
https://github.com/llvm-mirror/compiler-rt/commit/51570280afb827eea889ef8879bf2b8e8decf6a1