### PR TITLE
Enable more fuzzers for ReadStat

### DIFF
--- a/projects/readstat/build.sh
+++ b/projects/readstat/build.sh
@@ -32,6 +32,11 @@ zip $OUT/fuzz_format_sas7bdat_seed_corpus.zip corpus/sas7bdat*/test-case-*
 zip $OUT/fuzz_format_xport_seed_corpus.zip corpus/xpt*/test-case-*
 
 READSTAT_FUZZERS="
+    fuzz_compression_sav \
+    fuzz_grammar_spss_format \
+    fuzz_format_sas_commands \
+    fuzz_format_spss_commands \
+    fuzz_format_stata_dictionary \
     fuzz_format_dta \
     fuzz_format_por \
     fuzz_format_sav \


### PR DESCRIPTION
These additional fuzzers all pass the existing `check_build` heuristics.

In the future, they would probably benefit from an input grammar file or corpus.

See https://github.com/WizardMac/ReadStat/issues/181 for more context. There are a few fuzzers left (not included in this PR) which do not currently pass `check_build`.