### PR TITLE
[dropbear] Disable AFL

### DIFF
--- a/projects/dropbear/build.sh
+++ b/projects/dropbear/build.sh
@@ -34,3 +34,4 @@ make -C $SRC/dropbear/corpus
 cp -v $TARGETS $OUT/
 cp -v *.options $OUT/
 cp -v $SRC/dropbear/corpus/*.zip $OUT/
+cp -v $SRC/dropbear/corpus/*.dict $OUT/

--- a/projects/dropbear/project.yaml
+++ b/projects/dropbear/project.yaml
@@ -4,3 +4,5 @@ sanitizers:
   - address
   - undefined
   - memory
+fuzzing_engines:
+   - libfuzzer


### PR DESCRIPTION
Avoid the build check failing in AFL with a timeout at startup
https://oss-fuzz-build-logs.storage.googleapis.com/log-56b0ea26-8963-43f4-9940-405655713ff7.txt

The "once" initialisation takes longer than a second with -fsanitize. Adding `__AFL_INIT();`
 after initialisation seems like it should work but doesn't help.

https://github.com/mkj/dropbear/blob/fa116e983b4931010e1082dd5c8bf38bbc77718c/fuzzer-kexecdh.c#L36