### PR TITLE
[libfmt] needs recursive clone

### DIFF
--- a/projects/libfmt/Dockerfile
+++ b/projects/libfmt/Dockerfile
@@ -20,7 +20,11 @@ RUN echo "CXX=$CXX"
 RUN echo "CXXFLAGS=$CXXFLAGS"
 RUN apt-get update && apt-get install -y cmake ninja-build
 
-RUN git clone --single-branch --branch fuzz https://github.com/pauldreik/fmt.git
+RUN git clone --single-branch --branch fuzz \
+  https://github.com/pauldreik/fmt.git \
+  --recursive
+# this requires git>=2.9.0
+#--shallow-submodules
 
 WORKDIR fmt
 COPY build.sh $SRC/

--- a/projects/libfmt/build.sh
+++ b/projects/libfmt/build.sh
@@ -23,9 +23,16 @@
 mkdir build
 cd build
 
-cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug \
+# use C++ 14 instead of 17, because even if clang is
+# bleeding edge, cmake is old in the oss fuzz image.
+
+cmake .. \
+-GNinja \
+-DCMAKE_BUILD_TYPE=Debug \
+-DCMAKE_CXX_STANDARD=14 \
 -DFMT_DOC=Off \
 -DFMT_TEST=Off \
+-DFMT_SAFE_DURATION_CAST=On \
 -DFMT_FUZZ=On \
 -DFMT_FUZZ_LINKMAIN=Off \
 -DFMT_FUZZ_LDFLAGS=$LIB_FUZZING_ENGINE

--- a/projects/libfmt/project.yaml
+++ b/projects/libfmt/project.yaml
@@ -3,4 +3,3 @@ primary_contact: "pauldreikossfuzz@gmail.com"
 auto_ccs:
  - "victor.zverovich@gmail.com"
 
-


### PR DESCRIPTION
Hi!
The work with fmt continues - the formatting of std::chrono::durations [is now enabled, but with some problematic inputs rejected](https://github.com/pauldreik/fmt/commit/c8a028faec5d91728472f5de01ea8b1766fb929d) until the bugs (https://github.com/fmtlib/fmt/issues/1178, https://github.com/fmtlib/fmt/issues/1179) are fixed upstream. This requires a recursive clone for now, hence this pull request.
Plus fixing https://github.com/google/oss-fuzz/pull/2381#discussion_r281258704 :-)

Thanks,
Paul