### PR TITLE
ovs: use zip -rq instead of zip -j *

### DIFF
--- a/projects/openvswitch/build.sh
+++ b/projects/openvswitch/build.sh
@@ -28,6 +28,6 @@ do
        corp_name=$(basename $file _target)
        corp_dir=$SRC/ovs-fuzzing-corpus/${corp_name}_seed_corpus
        if [ -d ${corp_dir} ]; then
-           zip -j $OUT/${name}_seed_corpus.zip ${corp_dir}/*
+           zip -rq $OUT/${name}_seed_corpus ${corp_dir}
        fi
 done


### PR DESCRIPTION
Hello,

This PR is just a precautionary measure because my use of zip command previously was not robust especially for large corpora.

So I replace `zip -j name.zip *` with  `zip -rq name dir_name`