### PR TITLE
Fix a build failure in bignum fuzzer when building the Mbed TLS module

### DIFF
--- a/projects/bignum-fuzzer/Dockerfile
+++ b/projects/bignum-fuzzer/Dockerfile
@@ -26,5 +26,5 @@ RUN git clone --depth 1 https://github.com/guidovranken/bignum-fuzzer
 RUN git clone --depth 1 https://github.com/openssl/openssl
 RUN hg clone https://gmplib.org/repo/gmp/ libgmp/
 RUN git clone https://boringssl.googlesource.com/boringssl
-RUN git clone --depth 1 https://github.com/ARMmbed/mbedtls
+RUN git clone --recursive --depth 1 https://github.com/ARMmbed/mbedtls
 COPY build.sh $SRC/

--- a/projects/bignum-fuzzer/build.sh
+++ b/projects/bignum-fuzzer/build.sh
@@ -98,7 +98,7 @@ LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" make
 cp $SRC/bignum-fuzzer/fuzzer $OUT/fuzzer_openssl_libgmp_num_len_1200_all_operations_num_loops_1
 
 # Build mbedtls
-cd $SRC/mbedtls
+cd $SRC/mbedtls/crypto
 make lib -j$(nproc)
 
 # Build BoringSSL
@@ -115,7 +115,7 @@ CFLAGS="$CFLAGS -DBIGNUM_FUZZER_BORINGSSL" OPENSSL_INCLUDE_PATH=$SRC/boringssl/i
 
 # Build mbedtls module
 cd $SRC/bignum-fuzzer/modules/mbedtls
-MBEDTLS_LIBMBEDCRYPTO_A_PATH=$SRC/mbedtls/library/libmbedcrypto.a MBEDTLS_INCLUDE_PATH=$SRC/mbedtls/include make
+MBEDTLS_LIBMBEDCRYPTO_A_PATH=$SRC/mbedtls/crypto/library/libmbedcrypto.a MBEDTLS_INCLUDE_PATH=$SRC/mbedtls/crypto/include make
 
 # Build BoringSSL/mbedtls fuzzer
 cd $SRC/bignum-fuzzer


### PR DESCRIPTION
The cryptography library of Mbed TLS has been moved to a separate repository and to a new location in the directory hierarchy. This PR fixes the build failure caused by the change.