### PR TITLE
[git] Fuzz against the upstream "next" branch.

### DIFF
--- a/projects/git/Dockerfile
+++ b/projects/git/Dockerfile
@@ -25,4 +25,5 @@ RUN apt-get update && \
         asciidoc docbook-xsl xmlto libssl-dev zip
 RUN git clone https://github.com/git/git git
 WORKDIR git
+RUN git checkout origin/next
 COPY build.sh $SRC/


### PR DESCRIPTION
The next branch is where relatively-stable changes live while testing
for stability. We should fuzz against this branch to give extra
confidence that these patches are bug-free before they are merged into
master.