### PR TITLE
Use FUZZER_OUT for libfuzzer

### DIFF
--- a/infra/base-images/base-runner/run_fuzzer
+++ b/infra/base-images/base-runner/run_fuzzer
@@ -86,7 +86,7 @@ elif [[ "$FUZZING_ENGINE" = honggfuzz ]]; then
   # -n: number of fuzzing threads (and processes)
   CMD_LINE="$OUT/honggfuzz -n 1 --exit_upon_crash -R /tmp/${FUZZER}_honggfuzz.report -W $FUZZER_OUT -v -z -P -f \"$CORPUS_DIR\" $(get_dictionary) $* -- \"$OUT/$FUZZER\""
 else
-  CMD_LINE="$OUT/$FUZZER $FUZZER_ARGS $* $CORPUS_DIR"
+  CMD_LINE="$OUT/$FUZZER $FUZZER_ARGS $* $CORPUS_DIR $FUZZER_OUT"
 
   OPTIONS_FILE="${FUZZER}.options"
   if [ -f $OPTIONS_FILE ]; then


### PR DESCRIPTION
This should complete #1922 for libfuzzer

We already place the findings of fuzzers run with `helper.py run_fuzzer` in $OUT for afl and hongfuzz, but not for libfuzzer.

My workaround is to run 
`python infra/helper.py run_fuzzer mysql-server fuzz_stmt_fetch /out/fuzz_stmt_execute_libfuzzer_address_out`
as directory FUZZER_OUT gets created anyways