### PR TITLE
Qpdf ownership

### DIFF
--- a/projects/example/my-api-repo/Makefile
+++ b/projects/example/my-api-repo/Makefile
@@ -24,10 +24,10 @@ LIB_FUZZING_ENGINE ?= standalone_fuzz_target_runner.o
 # You may add extra compiler flags like this:
 CXXFLAGS += -std=c++11
 
+all: do_stuff_unittest do_stuff_fuzzer
+
 clean:
 	rm -fv *.a *.o *unittest *_fuzzer *_seed_corpus.zip crash-* *.zip
-
-all: do_stuff_unittest do_stuff_fuzzer
 
 # Continuos integration system should run "make clean && make check"
 check: all
@@ -40,7 +40,7 @@ do_stuff_unittest: do_stuff_unittest.cpp my_api.a
 
 # Fuzz target, links against $LIB_FUZZING_ENGINE, so that
 # you may choose which fuzzing engine to use.
-do_stuff_fuzzer: do_stuff_fuzzer.cpp my_api.a standalone_fuzz_target_runner.o
+do_stuff_fuzzer: do_stuff_fuzzer.cpp my_api.a ${LIB_FUZZING_ENGINE}
 	${CXX} ${CXXFLAGS} $< my_api.a ${LIB_FUZZING_ENGINE} -o $@
 	zip -q -r do_stuff_fuzzer_seed_corpus.zip do_stuff_test_data
 

--- a/projects/example/my-api-repo/README.md
+++ b/projects/example/my-api-repo/README.md
@@ -6,7 +6,7 @@ This directory contains an example software project that has most of the traits 
 Imagine that these files reside in your project's repository:
 
 * [my_api.h](my_api.h): and [my_api.cpp](my_api.cpp) implement the API we want to test/fuzz. The function `DoStuff()` inside [my_api.cpp](my_api.cpp) contains a bug. (Find it!)
-* [do_stuff_unittest.cpp](do_stuff_unittest.cpp): is a unit test for `DoStuff()`. Unit tests are not necessary for fuzzing, but are generally a good practice. 
+* [do_stuff_unittest.cpp](do_stuff_unittest.cpp): is a unit test for `DoStuff()`. Unit tests are not necessary for fuzzing but are generally a good practice.
 * [do_stuff_fuzzer.cpp](do_stuff_fuzzer.cpp): is a [fuzz target](http://libfuzzer.info/#fuzz-target) for `DoStuff()`.
 * [do_stuff_test_data](do_stuff_test_data): corpus directory for [do_stuff_fuzzer.cpp](do_stuff_fuzzer.cpp).
 * [do_stuff_fuzzer.dict](do_stuff_fuzzer.dict): a [fuzzing dictionary file](https://github.com/google/oss-fuzz/blob/master/docs/new_project_guide.md#dictionaries) for `DoStuff()`. Optional, but may improve fuzzing in many cases. 
@@ -15,12 +15,12 @@ Imagine that these files reside in your project's repository:
   * accepts external fuzzing engine via `$LIB_FUZZING_ENGINE`, by default uses [standalone_fuzz_target_runner.cpp](standalone_fuzz_target_runner.cpp)
   * builds the fuzz target(s) and their corpus archive(s)
   * `make check` executes [do_stuff_fuzzer.cpp](do_stuff_fuzzer.cpp) on [`do_stuff_test_data/*`](do_stuff_test_data), thus ensures that the fuzz target is up to date and uses it as a regression test.
-* [standalone_fuzz_target_runner.cpp](standalone_fuzz_target_runner.cpp): is a simple standalone runnner for fuzz targets. You may use it to execute a fuzz target on given files w/o having to link in libFuzzer or other fuzzing engine.
+* [standalone_fuzz_target_runner.cpp](standalone_fuzz_target_runner.cpp): is a simple standalone runner for fuzz targets. You may use it to execute a fuzz target on given files w/o having to link in libFuzzer or other fuzzing engine.
 
 ## Files in OSS-Fuzz repository
 * [oss-fuzz/projects/example](..)
   * [Dockerfile](../Dockerfile): sets up the build environment
-  * [build.sh](../build.sh): builds the fuzz target(s). The smaller this file the better, most of the logic should be inside the project's build system).
+  * [build.sh](../build.sh): builds the fuzz target(s). The smaller this file the better (most of the logic should be inside the project's build system).
   * [project.yaml](../project.yaml): short project description and contact info.
 
 ## Example bug

--- a/projects/example/my-api-repo/standalone_fuzz_target_runner.cpp
+++ b/projects/example/my-api-repo/standalone_fuzz_target_runner.cpp
@@ -30,6 +30,7 @@ int main(int argc, char **argv) {
     assert(in);
     LLVMFuzzerTestOneInput(reinterpret_cast<const uint8_t *>(bytes.data()),
                            bytes.size());
-    std::cout << "Execution successfull" << std::endl;
+    std::cout << "Execution successful (file " << argv[i] << ")" << std::endl;
   }
+  return 0;
 }

--- a/projects/example/my-api-repo/standalone_fuzz_target_runner.cpp
+++ b/projects/example/my-api-repo/standalone_fuzz_target_runner.cpp
@@ -30,7 +30,7 @@ int main(int argc, char **argv) {
     assert(in);
     LLVMFuzzerTestOneInput(reinterpret_cast<const uint8_t *>(bytes.data()),
                            bytes.size());
-    std::cout << "Execution successful (file " << argv[i] << ")" << std::endl;
+    std::cout << "Execution successful" << std::endl;
   }
   return 0;
 }

--- a/projects/qpdf/project.yaml
+++ b/projects/qpdf/project.yaml
@@ -1,5 +1,7 @@
 homepage: "http://qpdf.sourceforge.net/"
 primary_contact: "taking@google.com"
+auto_ccs:
+  - "qberkenbilt@gmail.com"
 
 sanitizers:
   - address


### PR DESCRIPTION
Later this week, I'm planning on working on an ideal integration of qpdf with oss-fuzz. This will include taking ownership of projects/qpdf, moving the fuzz targets, dictionary, and corpus into the qpdf repository, and updating build.sh to delegate control there.

In the meantime, as I've been studying this, I found a few typos in the example project (fixes here), and I'm also adding myself as an auto_cc for qpdf in hopes that this will give me access to the ClusterFuzz project information. I've also been having an email conversation as I try to figure out exactly what I'm supposed to do. I have a pretty good handle on it, but I am running into a few minor issues, mostly because of what seems to be omissions or minor errors in the docs. Once I get everything going, I will also submit a PR against any docs that didn't quite tell me what I needed to know. I am always telling people to do this with my docs -- write the doc you wish you had been able to read. :-)