### PR TITLE
[infra] Run tests on the builder after patching MSan libraries.

### DIFF
--- a/infra/gcb/build_project.py
+++ b/infra/gcb/build_project.py
@@ -256,15 +256,6 @@ def get_build_steps(project_dir):
                 ],
             })
 
-        if run_tests:
-          build_steps.append(
-              # test binaries
-              {
-                  'name': 'gcr.io/oss-fuzz-base/base-runner',
-                  'env': env,
-                  'args': ['bash', '-c', 'test_all'],
-              })
-
         if sanitizer == 'memory':
           # Patch dynamic libraries to use instrumented ones.
           build_steps.append({
@@ -278,6 +269,15 @@ def get_build_steps(project_dir):
                   'python /usr/local/bin/patch_build.py {0}'.format(out),
               ],
           })
+
+        if run_tests:
+          build_steps.append(
+              # test binaries
+              {
+                  'name': 'gcr.io/oss-fuzz-base/base-runner',
+                  'env': env,
+                  'args': ['bash', '-c', 'test_all'],
+              })
 
         if project_yaml['labels']:
           # write target labels

--- a/projects/njs/build.sh
+++ b/projects/njs/build.sh
@@ -16,12 +16,12 @@
 ################################################################################
 
 # Build pcre dependency to be linked statically.
-pushd $SRC/pcre
-./autogen.sh
-CFLAGS="$CFLAGS -fno-use-cxa-atexit" CXXFLAGS="$CXXFLAGS -fno-use-cxa-atexit" ./configure
-make -j$(nproc) clean
-make -j$(nproc) all
-popd
+# pushd $SRC/pcre
+# ./autogen.sh
+# CFLAGS="$CFLAGS -fno-use-cxa-atexit" CXXFLAGS="$CXXFLAGS -fno-use-cxa-atexit" ./configure
+# make -j$(nproc) clean
+# make -j$(nproc) all
+# popd
 
 # build project
 rm -rf build
@@ -37,7 +37,7 @@ $CC $CFLAGS -Inxt -Ibuild -Injs -c \
 $CXX $CXXFLAGS build/njs_process_script_fuzzer.o \
     -o $OUT/njs_process_script_fuzzer \
     $LIB_FUZZING_ENGINE build/libnxt.a build/libnjs.a \
-    $SRC/pcre/.libs/libpcre.a -lm -lreadline
+    -lpcre -lm -lreadline
 
 SEED_CORPUS_PATH=$OUT/njs_process_script_fuzzer_seed_corpus
 mkdir -p $SEED_CORPUS_PATH

--- a/projects/njs/build.sh
+++ b/projects/njs/build.sh
@@ -16,12 +16,12 @@
 ################################################################################
 
 # Build pcre dependency to be linked statically.
-# pushd $SRC/pcre
-# ./autogen.sh
-# CFLAGS="$CFLAGS -fno-use-cxa-atexit" CXXFLAGS="$CXXFLAGS -fno-use-cxa-atexit" ./configure
-# make -j$(nproc) clean
-# make -j$(nproc) all
-# popd
+pushd $SRC/pcre
+./autogen.sh
+CFLAGS="$CFLAGS -fno-use-cxa-atexit" CXXFLAGS="$CXXFLAGS -fno-use-cxa-atexit" ./configure
+make -j$(nproc) clean
+make -j$(nproc) all
+popd
 
 # build project
 rm -rf build
@@ -37,7 +37,7 @@ $CC $CFLAGS -Inxt -Ibuild -Injs -c \
 $CXX $CXXFLAGS build/njs_process_script_fuzzer.o \
     -o $OUT/njs_process_script_fuzzer \
     $LIB_FUZZING_ENGINE build/libnxt.a build/libnjs.a \
-    -lpcre -lm -lreadline
+    $SRC/pcre/.libs/libpcre.a -lm -lreadline
 
 SEED_CORPUS_PATH=$OUT/njs_process_script_fuzzer_seed_corpus
 mkdir -p $SEED_CORPUS_PATH


### PR DESCRIPTION
I've noticed previously that there was a mismatch between Travis and Jenkins when performing bad build check. I suspect that the root cause might be that we're doing build check on the builder (Jenkins) before patching MSan libraries. Wanna verify this first. Do not merge.