### PR TITLE
Fix coverage build for cpython

### DIFF
--- a/projects/cpython3/build.sh
+++ b/projects/cpython3/build.sh
@@ -34,3 +34,13 @@ do
   $CXX $CXXFLAGS $WORK/$fuzz_test.o -o $OUT/$fuzz_test \
     $LIB_FUZZING_ENGINE $($OUT/bin/python3-config --ldflags --embed)
 done
+
+# A little bit hacky but we have to copy $OUT/include to
+# $OUT/$OUT/include as the coverage build needs all source
+# files used in execution and expects it to be there.
+#   See projects/tensorflow/build.sh for prior art
+if [ "$SANITIZER" = "coverage" ]
+then
+  mkdir -p $OUT/$OUT
+  cp -r $OUT/include $OUT/$OUT/
+fi


### PR DESCRIPTION
Python's coverage builds are failing right now: https://oss-fuzz-build-logs.storage.googleapis.com/log-f7ba2c50-d7b0-4d75-8e29-2329769877a4.txt

because files from /out/include get compiled or used in the binary and clang's coverage goes looking for it in the wrong place. This is similar to https://github.com/google/oss-fuzz/blob/3049c50d48a8e712889104db25113c2b0be00301/projects/tensorflow/build.sh#L137-L152 on advice by @Dor1s 