### PR TITLE
[cpython] Use `make altinstall` for cpython

### DIFF
--- a/projects/cpython3/build.sh
+++ b/projects/cpython3/build.sh
@@ -22,7 +22,7 @@ case $SANITIZER in
 esac
 ./configure $FLAGS --prefix $OUT
 
-make -j$(nproc) install
+make -j$(nproc) altinstall
 
 FUZZ_DIR=Modules/_xxtestfuzz
 for fuzz_test in $(cat $FUZZ_DIR/fuzz_tests.txt)


### PR DESCRIPTION
It looks like the MSan build is currently failing on gcloud: https://oss-fuzz-build-logs.storage.googleapis.com/log-5698d311-c09e-4f16-aef2-47e112bb9c5e.txt. It seems like it's because it uses symlinks for versioning, example `python3 -> python3.9` which breaks the patching script for MSan.

`make altinstall` will prevent the Makefile from making these symlinks which should hopefully fix the issue. If there's any better alternative solutions I'd love to hear about them.