### PR TITLE
[cpython] Add -rdynamic to fuzzing targets

### DIFF
--- a/projects/cpython3/build.sh
+++ b/projects/cpython3/build.sh
@@ -33,7 +33,7 @@ do
     -D _Py_FUZZ_ONE -D _Py_FUZZ_$fuzz_test -c -Wno-unused-function \
     -o $WORK/$fuzz_test.o
   # Link with C++ compiler to appease libfuzzer
-  $CXX $CXXFLAGS $WORK/$fuzz_test.o -o $OUT/$fuzz_test \
+  $CXX $CXXFLAGS -rdynamic $WORK/$fuzz_test.o -o $OUT/$fuzz_test \
     $LIB_FUZZING_ENGINE $($OUT/bin/python*-config --ldflags --embed)
 
   # Zip up and copy any seed corpus

--- a/projects/cpython3/project.yaml
+++ b/projects/cpython3/project.yaml
@@ -2,8 +2,8 @@ homepage: "https://python.org/"
 primary_contact: "gps@google.com"
 auto_ccs:
  - "alex.gaynor@gmail.com"
+ - "ammar@ammaraskar.com"
 sanitizers:
  - address
  - memory
  - undefined
-experimental: True


### PR DESCRIPTION
CPython needs the `-rdynamic` flag to expose its symbols. Currently when a fuzzing target goes to import a C module like `_json.c` it gets an error like: `undefined symbol: PyFloat_Type`