### PR TITLE
Fix tensorflow/build.sh after TF commit 44000ad64a

### DIFF
--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -17,8 +17,8 @@
 
 # First, determine the latest Bazel we can support
 BAZEL_VERSION=$(
-  grep 'current_bazel_version =' configure.py | \
-  cut -d, -f2 | cut -d\' -f2 | tr -d '[:space:]'
+  grep '_TF_MAX_BAZEL_VERSION =' configure.py | \
+  cut -d\' -f2 | tr -d '[:space:]'
 )
 if [ -z ${BAZEL_VERSION} ]; then
   echo "Couldn't find a valid bazel version in configure.py script"


### PR DESCRIPTION
We are changing the location of the maximum/minimum bazel version in the
configure.py script so we need to update the way we're looking for the
version to install.

Breaking commit: https://github.com/tensorflow/tensorflow/commit/44000ad64a30abaa38980af0de4f165a2e10be2d