### PR TITLE
[llvm] Enable MSan fuzzing.

### DIFF
--- a/projects/llvm/project.yaml
+++ b/projects/llvm/project.yaml
@@ -14,9 +14,9 @@ auto_ccs:
   - "eneyman@google.com"
   - "bigcheesegs@gmail.com"
 
-# TODO(kcc): enable msan.
 sanitizers:
   - address
+  - memory
 
 # The LLVM build currently supports only libFuzzer
 fuzzing_engines:


### PR DESCRIPTION
Now that proto fuzzers are gone, we don't have to deal with false
positives coming from protobuf libraries being uninstrumented.

Partially addresses https://github.com/google/oss-fuzz/issues/889.