### PR TITLE
[docs][infra] Add build support for FuzzedDataProvider.

### DIFF
--- a/docs/new_project_guide.md
+++ b/docs/new_project_guide.md
@@ -180,6 +180,12 @@ When build.sh script is executed, the following locations are available within t
 While files layout is fixed within a container, the environment variables are
 provided to be able to write retargetable scripts.
 
+In case your fuzz target uses [FuzzedDataProvider] class, the OSS-Fuzz build
+image has `FuzzedDataProvider.h` header installed and available for use without
+any extra options.
+
+[FuzzedDataProvider]: https://github.com/google/fuzzing/blob/master/docs/split-inputs.md#fuzzed-data-provider
+
 ### Requirements
 
 Only binaries without any extension will be accepted as targets. Extensions are reserved for other artifacts like .dict, etc.

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -135,6 +135,10 @@ rm -rf $WORK/msan
 # Pull trunk libfuzzer.
 cd $SRC && svn co https://llvm.org/svn/llvm-project/compiler-rt/trunk/lib/fuzzer libfuzzer
 
+# Install the FuzzedDataProvider library, but don't fail the whole LLVM build if
+# it fails. The header might be eventually moved.
+cp libfuzzer/utils/FuzzedDataProvider.h /usr/include || true
+
 # Cleanup
 rm -rf $SRC/llvm
 rm -rf $SRC/chromium_tools


### PR DESCRIPTION
Discussion items:

1) What's the best way to make the header available? I was thinking to append `-I$SRC/libfuzzer/utils/`, but then realized that it's not good to put any custom paths into `$CXXFLAGS`. Having the header installed in the system location feels much cleaner, and the upstream projects can just have an extra `-I` argument for the builds outside of OSS-Fuzz, or they can pull in the header themselves and store next to the fuzzers -- seems like a good flexible solution to me.

2) Do we want any example of how it's used in OSS-Fuzz? In general, we don't teach people to write fuzzers here, but from the integration perspective at least one example might be helpful? Or maybe not, given that users have to do nothing, just `#include "FuzzedDataProvider.h"`?

Current ideas:
* update `example` project and add another fuzz target / maybe another API as well
* copy an existing fuzz target in Chromium for https://github.com/google/compact_enc_det or https://github.com/googlefonts/sfntly

WDYT? @kcc @jonathanmetzman @oliverchang 