### PR TITLE
Enable dataflow for 36 more projects.

### DIFF
--- a/projects/brotli/project.yaml
+++ b/projects/brotli/project.yaml
@@ -1,6 +1,11 @@
 homepage: "https://github.com/google/brotli"
 primary_contact: "eustas@chromium.org"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
   - address
+  - dataflow
   - memory
   - undefined

--- a/projects/bzip2/project.yaml
+++ b/projects/bzip2/project.yaml
@@ -2,6 +2,11 @@ homepage: "http://www.bzip.org/"
 primary_contact: "jseward@acm.org"
 auto_ccs:
   - "bshas3@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
   - address
+  - dataflow
   - memory

--- a/projects/capstone/project.yaml
+++ b/projects/capstone/project.yaml
@@ -1,8 +1,12 @@
 homepage: "https://www.capstone-engine.org"
 primary_contact: "capstone.engine@gmail.com"
 auto_ccs : "p.antoine@catenacyber.fr"
-
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
-- address
-- memory
-- undefined
+  - address
+  - dataflow
+  - memory
+  - undefined

--- a/projects/cmark/project.yaml
+++ b/projects/cmark/project.yaml
@@ -2,7 +2,12 @@ homepage: "http://commonmark.org"
 primary_contact: "jgm@berkeley.edu"
 auto_ccs:
   - "kivikakk@github.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
   - address
+  - dataflow
   - memory
   - undefined

--- a/projects/harfbuzz/project.yaml
+++ b/projects/harfbuzz/project.yaml
@@ -12,7 +12,12 @@ auto_ccs:
   - "cchapman@adobe.com"
   - "ariza@typekit.com"
   - "qxliu@google.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
- - address
- - undefined
- - memory
+  - address
+  - dataflow
+  - memory
+  - undefined

--- a/projects/hoextdown/project.yaml
+++ b/projects/hoextdown/project.yaml
@@ -1,2 +1,10 @@
 homepage: "https://github.com/kjdev/hoextdown"
 primary_contact: "kjclev@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
+sanitizers:
+  - address
+  - dataflow
+  - undefined

--- a/projects/lcms/project.yaml
+++ b/projects/lcms/project.yaml
@@ -1,7 +1,12 @@
 homepage: "http://www.littlecms.com/"
 primary_contact: "marti.maria.s@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
   - address
+  - dataflow
   - memory:
      experimental: True
   - undefined

--- a/projects/libexif/project.yaml
+++ b/projects/libexif/project.yaml
@@ -2,6 +2,11 @@ homepage: "https://libexif.github.io"
 primary_contact: "dan@coneharvesters.com"
 auto_ccs:
   - paul.l.kehrer@gmail.com
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
   - address
+  - dataflow
   - memory

--- a/projects/libgit2/project.yaml
+++ b/projects/libgit2/project.yaml
@@ -2,3 +2,11 @@ homepage: "https://libgit2.github.com/"
 primary_contact: "ps@pks.im"
 auto_ccs:
   - "nelhage@nelhage.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
+sanitizers:
+  - address
+  - dataflow
+  - undefined

--- a/projects/libidn2/project.yaml
+++ b/projects/libidn2/project.yaml
@@ -3,7 +3,12 @@ primary_contact: "rockdaboot@gmail.com"
 auto_ccs:
   - "n.mavrogiannopoulos@gmail.com"
   - "simon@josefsson.org"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
   - address
+  - dataflow
   - memory
   - undefined

--- a/projects/libldac/project.yaml
+++ b/projects/libldac/project.yaml
@@ -2,5 +2,10 @@ homepage: "https://android.googlesource.com/platform/external/libldac"
 primary_contact: "Chisato.Kenmochi@sony.com"
 auto_ccs:
   - "cdiehl@mozilla.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
   - address
+  - dataflow

--- a/projects/libpcap/project.yaml
+++ b/projects/libpcap/project.yaml
@@ -4,8 +4,12 @@ auto_ccs :
 - "p.antoine@catenacyber.fr"
 - "infra.station@gmail.com"
 - "guy@alum.mit.edu"
-
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
-- address
-- memory
-- undefined
+  - address
+  - dataflow
+  - memory
+  - undefined

--- a/projects/libplist/project.yaml
+++ b/projects/libplist/project.yaml
@@ -2,7 +2,12 @@ homepage: "https://github.com/libimobiledevice/libplist"
 primary_contact: "nikias.bassen@gmail.com"
 auto_ccs:
   - "nikias@gmx.li"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
   - address
+  - dataflow
   - memory
   - undefined

--- a/projects/libteken/project.yaml
+++ b/projects/libteken/project.yaml
@@ -1,6 +1,11 @@
 homepage: "http://svn.freebsd.org/base/head/sys/teken/"
 primary_contact: "ed@nuxi.nl"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
   - address
+  - dataflow
   - memory
   - undefined

--- a/projects/libtsm/project.yaml
+++ b/projects/libtsm/project.yaml
@@ -1,6 +1,11 @@
 homepage: "https://www.freedesktop.org/wiki/Software/kmscon/libtsm/"
 primary_contact: "dh.herrmann@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
   - address
+  - dataflow
   - memory
   - undefined

--- a/projects/libwebp/project.yaml
+++ b/projects/libwebp/project.yaml
@@ -1,10 +1,15 @@
 homepage: "https://developers.google.com/speed/webp/"
 primary_contact: "jzern@google.com"
-sanitizers:
-- address
-- undefined
-- memory
 auto_ccs:
 - pascal.massimino@gmail.com
 - vrabaud@google.com
 - yguyon@google.com
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
+sanitizers:
+  - address
+  - dataflow
+  - memory
+  - undefined

--- a/projects/libyaml/project.yaml
+++ b/projects/libyaml/project.yaml
@@ -2,7 +2,12 @@ homepage: https://github.com/yaml/libyaml
 primary_contact: "sigmavirus24@gmail.com"
 auto_ccs:
   - "alex.gaynor@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
   - address
+  - dataflow
   - memory
   - undefined

--- a/projects/lzo/project.yaml
+++ b/projects/lzo/project.yaml
@@ -2,6 +2,11 @@ homepage: "http://www.oberhumer.com"
 primary_contact: "info@oberhumer.com"
 auto_ccs:
   - "bshas3@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
   - address
+  - dataflow
   - memory

--- a/projects/mbedtls/project.yaml
+++ b/projects/mbedtls/project.yaml
@@ -1,3 +1,11 @@
 homepage: "https://tls.mbed.org"
 primary_contact: "support-mbedtls@arm.com"
 auto_ccs : "p.antoine@catenacyber.fr"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
+sanitizers:
+  - address
+  - dataflow
+  - undefined

--- a/projects/minizip/project.yaml
+++ b/projects/minizip/project.yaml
@@ -16,7 +16,12 @@
 
 homepage: "https://github.com/nmoinvaz/minizip"
 primary_contact: "nathan.moinvaziri@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
   - address
+  - dataflow
   - memory
   - undefined

--- a/projects/mupdf/project.yaml
+++ b/projects/mupdf/project.yaml
@@ -1,8 +1,13 @@
 homepage: "https://www.mupdf.com"
 primary_contact: tor.andersson@artifex.com
-sanitizers:
-  - address
-  - memory
 auto_ccs:
   - jonathan@titanous.com
   - sebastian.rasmussen@artifex.com
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
+sanitizers:
+  - address
+  - dataflow
+  - memory

--- a/projects/nestegg/project.yaml
+++ b/projects/nestegg/project.yaml
@@ -1,8 +1,13 @@
 homepage: "https://github.com/kinetiknz/nestegg"
 primary_contact: "mgregan@mozilla.com"
-sanitizers:
-- address
-- memory
-- undefined
 auto_ccs:
 - "twsmith@mozilla.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
+sanitizers:
+  - address
+  - dataflow
+  - memory
+  - undefined

--- a/projects/nghttp2/project.yaml
+++ b/projects/nghttp2/project.yaml
@@ -1,6 +1,11 @@
 homepage: "https://nghttp2.org/"
 primary_contact: "tatsuhiro.t@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
   - address
+  - dataflow
   - memory
   - undefined

--- a/projects/openjpeg/project.yaml
+++ b/projects/openjpeg/project.yaml
@@ -2,3 +2,11 @@ homepage: "http://www.openjpeg.org/"
 primary_contact: "antonin@gmail.com"
 auto_ccs:
   - "even.rouault@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
+sanitizers:
+  - address
+  - dataflow
+  - undefined

--- a/projects/openthread/project.yaml
+++ b/projects/openthread/project.yaml
@@ -1,2 +1,10 @@
 homepage: "https://github.com/openthread/openthread"
 primary_contact: "jonhui@google.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
+sanitizers:
+  - address
+  - dataflow
+  - undefined

--- a/projects/openvswitch/project.yaml
+++ b/projects/openvswitch/project.yaml
@@ -6,7 +6,12 @@ auto_ccs:
   - "pkusunyifeng@gmail.com"
   - "bshas3@gmail.com"
   - "cpp.code.lv@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
   - address
+  - dataflow
   - memory
   - undefined

--- a/projects/opus/project.yaml
+++ b/projects/opus/project.yaml
@@ -2,7 +2,12 @@ homepage: "https://opus-codec.org/"
 primary_contact: "jmvalin@jmvalin.ca"
 auto_ccs:
 - "flim@google.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
   - address
+  - dataflow
   - memory
   - undefined

--- a/projects/pcre2/project.yaml
+++ b/projects/pcre2/project.yaml
@@ -1,6 +1,11 @@
 homepage: "http://www.pcre.org/"
 primary_contact: "philip.hazel@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
   - address
+  - dataflow
   - memory
   - undefined

--- a/projects/pffft/project.yaml
+++ b/projects/pffft/project.yaml
@@ -3,7 +3,12 @@ primary_contact: "pommier@modartt.com"
 auto_ccs:
   - "alessiob@webrtc.org"
   - "mbonadei@webrtc.org"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
   - address
+  - dataflow
   - memory
   - undefined

--- a/projects/radare2/project.yaml
+++ b/projects/radare2/project.yaml
@@ -2,6 +2,11 @@ homepage: "https://github.com/radare/radare2"
 primary_contact: "pancake@nopcode.org"
 auto_ccs:
   - "zlowram@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
   - address
+  - dataflow
 run_tests: False

--- a/projects/vorbis/project.yaml
+++ b/projects/vorbis/project.yaml
@@ -3,6 +3,11 @@ primary_contact: "daede003@umn.edu"
 auto_ccs:
   - paul.l.kehrer@gmail.com
   - agaynor@mozilla.com
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
   - address
+  - dataflow
   - memory

--- a/projects/wolfssl/project.yaml
+++ b/projects/wolfssl/project.yaml
@@ -5,8 +5,13 @@ auto_ccs:
  - "kaleb@wolfssl.com"
  - "levi@wolfssl.com"
  - "testing@wolfssl.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
- - address
- - memory:
+  - address
+  - dataflow
+  - memory:
     experimental: True
- - undefined
+  - undefined

--- a/projects/wuffs/project.yaml
+++ b/projects/wuffs/project.yaml
@@ -1,2 +1,11 @@
 homepage: "https://github.com/google/wuffs"
 primary_contact: "nigeltao@golang.org"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
+sanitizers:
+  - address
+  - dataflow
+  - memory
+  - undefined

--- a/projects/xz/project.yaml
+++ b/projects/xz/project.yaml
@@ -2,7 +2,12 @@ homepage: "https://tukaani.org/xz/"
 primary_contact: "lasse.collin@tukaani.org"
 auto_ccs:
   - "bshas3@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
   - address
+  - dataflow
   - memory
   - undefined

--- a/projects/yara/project.yaml
+++ b/projects/yara/project.yaml
@@ -3,7 +3,13 @@ primary_contact: "vmalvarez@google.com"
 auto_ccs:
   - "vmalvarez@virustotal.com"
   - "plusvic@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
   - address
+  - dataflow
   - memory
   - undefined
+  

--- a/projects/zlib/project.yaml
+++ b/projects/zlib/project.yaml
@@ -3,7 +3,12 @@ primary_contact: "glennrp@gmail.com"
 auto_ccs:
   - "sebpop@gmail.com"
   - "cblume@google.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - dataflow
 sanitizers:
   - address
+  - dataflow
   - memory
   - undefined


### PR DESCRIPTION
From the list of 41 projects in the list in https://github.com/google/oss-fuzz/issues/1632#issuecomment-494391214

skipped `giflib` and `qcms` as their builds are currently failing, also skipped `aosp` and `libchewing` as they are disabled.