### PR TITLE
Add the lz4 project to oss-fuzz

### DIFF
--- a/projects/lz4/Dockerfile
+++ b/projects/lz4/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER cmeister2@gmail.com
+
+RUN git clone --depth 1 https://github.com/lz4/lz4.git /src/lz4
+
+WORKDIR $SRC/lz4
+COPY build.sh $SRC/

--- a/projects/lz4/build.sh
+++ b/projects/lz4/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Run the OSS-Fuzz script in the project.
+./ossfuzz/ossfuzz.sh

--- a/projects/lz4/project.yaml
+++ b/projects/lz4/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/lz4/lz4"
+primary_contact: "Yann.collet.73@gmail.com"
+auto_ccs:
+  - "NickRTerrell@gmail.com"
+  - "cyan@fb.com"
+  - "terrelln@fb.com"
+sanitizers:
+  - address
+  - undefined

--- a/projects/lz4/project.yaml
+++ b/projects/lz4/project.yaml
@@ -6,4 +6,5 @@ auto_ccs:
   - "terrelln@fb.com"
 sanitizers:
   - address
+  - memory
   - undefined


### PR DESCRIPTION
This commit adds support for fuzzers in the lz4 project (https://github.com/lz4/lz4)

It is blocked behind the merge of https://github.com/lz4/lz4/pull/739, but I'm submitting this now as it's worth getting some eyeballs on the proposed options.

Tagging @cyan4973 and @terrelln as they will be the ones receiving all the fun bugs :smile: