### PR TITLE
[libfmt] use upstream repo

### DIFF
--- a/projects/libfmt/Dockerfile
+++ b/projects/libfmt/Dockerfile
@@ -20,12 +20,8 @@ RUN echo "CXX=$CXX"
 RUN echo "CXXFLAGS=$CXXFLAGS"
 RUN apt-get update && apt-get install -y cmake ninja-build
 
-RUN git clone --single-branch --branch fuzz \
-  https://github.com/pauldreik/fmt.git \
-  --recursive
-# this requires git>=2.9.0
-#--shallow-submodules
+RUN git clone --depth 1 --branch master \
+  https://github.com/fmtlib/fmt.git
 
 WORKDIR fmt
 COPY build.sh $SRC/
-

--- a/projects/libfmt/build.sh
+++ b/projects/libfmt/build.sh
@@ -40,4 +40,3 @@ cmake .. \
 cmake --build .
 
 cp bin/fuzzer_* $OUT
-

--- a/projects/libfmt/project.yaml
+++ b/projects/libfmt/project.yaml
@@ -1,5 +1,4 @@
-homepage: "https://github.com/pauldreik/fmt"
+homepage: "https://github.com/fmtlib/fmt"
 primary_contact: "pauldreikossfuzz@gmail.com"
 auto_ccs:
  - "victor.zverovich@gmail.com"
-


### PR DESCRIPTION
The fuzzers have been merged upstream, so it's time repointing
oss fuzz to upstream instead of my cloned repo.

see https://github.com/fmtlib/fmt/pull/1199

Thanks!
