### PR TITLE
[infra] Remove debug code breaking bad_build_check

### DIFF
--- a/infra/base-images/base-runner/bad_build_check
+++ b/infra/base-images/base-runner/bad_build_check
@@ -370,7 +370,6 @@ function check_architecture {
 }
 
 function main {
-  return 1
   local FUZZER=$1
   local checks_failed=0
   local result=0


### PR DESCRIPTION
Remove debug code that is causing bad_build_check to silently fail.
See  #2555