### PR TITLE
Two fixes for ghostcript

### DIFF
--- a/projects/ghostscript/build.sh
+++ b/projects/ghostscript/build.sh
@@ -54,3 +54,10 @@ $CXX $CXXFLAGS $CUPS_LDFLAGS -std=c++11 -I. \
     -o "$OUT/gstoraster_fuzzer" \
     $CUPS_LIBS \
     $LIB_FUZZING_ENGINE bin/gs.a
+
+mkdir -p "$WORK/seeds"
+for f in examples/*.{ps,pdf}; do
+  s=$(sha1sum "$f" | awk '{print $1}')
+  cp "$f" "$WORK/seeds/$s"
+done
+zip -j "$OUT/gstoraster_fuzzer_seed_corpus.zip" "$WORK"/seeds/*

--- a/projects/ghostscript/gstoraster_fuzzer.cc
+++ b/projects/ghostscript/gstoraster_fuzzer.cc
@@ -37,7 +37,7 @@ static int gs_stdout(void *inst, const char *buf, int len)
 static int gs_to_raster_fuzz(const unsigned char *buf, size_t size)
 {
 	int ret;
-	void *gs;
+	void *gs = NULL;
 
 	/* Mostly stolen from cups-filters gstoraster. */
 	char *args[] = {


### PR DESCRIPTION
1. Fix an uninitialized pointer in the fuzzer that caused ghostcript to crash before doing anything fairly frequently.  I believe this will address https://crbug.com/oss-fuzz/15591.

2. Add a seed corpus based on the example files shipped with ghostscript.