### PR TITLE
Add minizinc project

### DIFF
--- a/projects/minizinc/project.yaml
+++ b/projects/minizinc/project.yaml
@@ -1,0 +1,10 @@
+homepage: "http://www.minizinc.org/"
+primary_contact: "jip.dekker@monash.edu"
+auto_ccs:
+  - "jip.dekker@monash.edu"
+  - "guido.tack@monash.edu"
+sanitizers:
+  - address
+  - memory:
+     experimental: True
+  - undefined


### PR DESCRIPTION
Hi,

We're currently working on improving the testing framework of the MiniZinc modelling language. MiniZinc is a constraint modelling language used extensively in academia and in operational research. The main part of MiniZinc is a compiler for which fuzz testing seems to be an ideal way of testing. If fuzz testing end up working well, the project definition will be maintained by the MiniZinc team itself. Please let me know if you need any more information.

Kind regards,
Jip J. Dekker