### PR TITLE
Update bzip2 homepage and primary contact address

### DIFF
--- a/projects/bzip2/project.yaml
+++ b/projects/bzip2/project.yaml
@@ -1,5 +1,5 @@
-homepage: "http://www.bzip.org/"
-primary_contact: "jseward@acm.org"
+homepage: "https://sourceware.org/bzip2/"
+primary_contact: "bzip2fuzzer@gmail.com"
 auto_ccs:
   - "bshas3@gmail.com"
   - "twsmith@mozilla.com"


### PR DESCRIPTION
This PR updates the following fields in bzip2's `project.yaml`
  - homepage
  - primary contact

CC Mark Wielaard (not on GitHub) who reached out to me requesting these changes. Mark is working on an upcoming bzip2 release (v1.0.7). He informs us that the link `bzip.org` is no longer under the control of the bzip2 development community.