### PR TITLE
[python3-libraries] Fix coverage build

### DIFF
--- a/projects/python3-libraries/build.sh
+++ b/projects/python3-libraries/build.sh
@@ -52,7 +52,7 @@ cp $SRC/python-library-fuzzers/python_coverage.h Python/
 sed -i '1 s/^.*$/#include "python_coverage.h"/g' Python/ceval.c
 sed -i 's/case TARGET\(.*\): {/\0\nfuzzer_record_code_coverage(f->f_code, f->f_lasti);/g' Python/ceval.c
 
-./configure "${FLAGS[@]}" --prefix=$CPYTHON_INSTALL_PATH
+./configure "${FLAGS[@]+"${FLAGS[@]}"}" --prefix=$CPYTHON_INSTALL_PATH
 make -j$(nproc)
 make install
 


### PR DESCRIPTION
Coverage builds were failing due to FLAGS being empty which threw an 'unbound variable' error.