### PR TITLE
projects/ffmpeg/build: Disable components during build of libavformat which are not tested

### DIFF
--- a/projects/ffmpeg/build.sh
+++ b/projects/ffmpeg/build.sh
@@ -173,6 +173,9 @@ PKG_CONFIG_PATH="$FFMPEG_DEPS_PATH/lib/pkgconfig" ./configure \
     --enable-libx264 \
     --enable-libx265 \
     --enable-nonfree \
+    --disable-muxers \
+    --disable-protocols \
+    --disable-devices \
     --disable-shared
 make clean
 make -j$(nproc) install


### PR DESCRIPTION
This disables network protocol code, muxing and IO device code.
None of this is tested currently.

This reduces the filesize slightly and speeds up build slightly
This could matter if we switch to one binary tool per container format
for testing. Currently it probably doesnt matter much.

We may want to add support for testing muxing in the future but first
good coverage of the input (demuxing) side should be achieved.

Signed-off-by: Michael Niedermayer <michaelni@gmx.at>