### PR TITLE
[cpython] Fix coverage build

### DIFF
--- a/projects/cpython3/build.sh
+++ b/projects/cpython3/build.sh
@@ -25,7 +25,7 @@ case $SANITIZER in
     FLAGS+=("--with-undefined-behavior-sanitizer")
     ;;
 esac
-./configure "${FLAGS[@]}" --prefix $OUT
+./configure "${FLAGS[@]:-}" --prefix $OUT
 
 # We use altinstall to avoid having the Makefile create symlinks
 make -j$(nproc) altinstall

--- a/projects/python3-libraries/build.sh
+++ b/projects/python3-libraries/build.sh
@@ -52,7 +52,7 @@ cp $SRC/python-library-fuzzers/python_coverage.h Python/
 sed -i '1 s/^.*$/#include "python_coverage.h"/g' Python/ceval.c
 sed -i 's/case TARGET\(.*\): {/\0\nfuzzer_record_code_coverage(f->f_code, f->f_lasti);/g' Python/ceval.c
 
-./configure "${FLAGS[@]+"${FLAGS[@]}"}" --prefix=$CPYTHON_INSTALL_PATH
+./configure "${FLAGS[@]:-}" --prefix=$CPYTHON_INSTALL_PATH
 make -j$(nproc)
 make install
 


### PR DESCRIPTION
Older versions of bash apparently don't expand empty arrays into nothing but throw an error instead https://stackoverflow.com/a/39687362

This also changes the fix for `python3-libraries` implemented in https://github.com/google/oss-fuzz/pull/2600 as the `build.sh` files should be kept in sync with each other (and IMO this fix is way more readable than the other one).