### PR TITLE
Remove references to my mozilla email

### DIFF
--- a/projects/firefox/project.yaml
+++ b/projects/firefox/project.yaml
@@ -1,7 +1,7 @@
 homepage: "https://www.mozilla.org/firefox/"
-primary_contact: "agaynor@mozilla.com"
+primary_contact: "choller@mozilla.com"
 auto_ccs:
-  - choller@mozilla.com
+  - twsmith@mozilla.com
 fuzzing_engines:
   - libfuzzer
 sanitizers:

--- a/projects/spidermonkey/Dockerfile
+++ b/projects/spidermonkey/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-MAINTAINER agaynor@mozilla.com
+MAINTAINER alex.gaynor@gmail.com
 RUN apt-get update && apt-get install -y \
   autoconf2.13 \
   yasm \

--- a/projects/spidermonkey/project.yaml
+++ b/projects/spidermonkey/project.yaml
@@ -1,7 +1,5 @@
 homepage: "https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey"
-primary_contact: "agaynor@mozilla.com"
-auto_ccs:
-  - "choller@mozilla.com"
+primary_contact: "choller@mozilla.com"
 fuzzing_engines:
   - none
 sanitizers:

--- a/projects/vorbis/project.yaml
+++ b/projects/vorbis/project.yaml
@@ -2,7 +2,7 @@ homepage: "https://xiph.org/vorbis/"
 primary_contact: "daede003@umn.edu"
 auto_ccs:
   - paul.l.kehrer@gmail.com
-  - agaynor@mozilla.com
+  - alex.gaynor@gmail.com
 fuzzing_engines:
   - libfuzzer
   - afl


### PR DESCRIPTION
Mostly passes these over to other folks (which I should have done a long time ago). In two places switched to my personal email.