### PR TITLE
Add jansson support to oss-fuzz

### DIFF
--- a/projects/jansson/Dockerfile
+++ b/projects/jansson/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER cmeister2@gmail.com
+
+RUN git clone --depth 1 https://github.com/akheron/jansson.git /src/jansson
+
+WORKDIR $SRC/jansson
+COPY build.sh $SRC/

--- a/projects/jansson/build.sh
+++ b/projects/jansson/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Run the OSS-Fuzz script in the project.
+./test/ossfuzz/ossfuzz.sh

--- a/projects/jansson/project.yaml
+++ b/projects/jansson/project.yaml
@@ -1,0 +1,7 @@
+homepage: "https://github.com/akheron/jansson"
+primary_contact: "git@cfware.com"
+auto_ccs:
+  - "cmeister2@gmail.com"
+sanitizers:
+  - address
+  - undefined


### PR DESCRIPTION
Tagging @coreyfarrell who's been handling the merging from the jansson project.

This adds in support for jansson to oss-fuzz; it's compatible with both flag and file LIB_FUZZING_ENGINE directives. Currently there is one fuzzer.

Primary email is git@cfware.com; @coreyfarell; to log into http://www.ossfuzz.com you need to use a Google account. If that email address is already a Google account then no problem! If not, let me know a Google account email address that can be added to the cc's list.