### PR TITLE
WIP: Add GNUAspell support to OSS Fuzz

### DIFF
--- a/projects/aspell/Dockerfile
+++ b/projects/aspell/Dockerfile
@@ -17,7 +17,8 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER cmeister2@gmail.com
 
-RUN git clone --depth 1 https://github.com/gnuaspell/aspell.git /src/aspell
+# RUN git clone --depth 1 https://github.com/gnuaspell/aspell.git /src/aspell
+RUN git clone --depth 1 -b cmeister2/ossfuzz https://github.com/cmeister2/aspell.git /src/aspell
 
 WORKDIR $SRC/aspell
 COPY build.sh $SRC/

--- a/projects/aspell/Dockerfile
+++ b/projects/aspell/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER cmeister2@gmail.com
+
+RUN git clone --depth 1 https://github.com/gnuaspell/aspell.git /src/aspell
+
+WORKDIR $SRC/aspell
+COPY build.sh $SRC/

--- a/projects/aspell/build.sh
+++ b/projects/aspell/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Run the OSS-Fuzz script in the project.
+./ossfuzz/ossfuzz.sh

--- a/projects/aspell/project.yaml
+++ b/projects/aspell/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/GNUAspell/aspell"
+primary_contact: "kevinatkn@gmail.com"
+auto_ccs:
+  - "cmeister2@gmail.com"
+sanitizers:
+  - address
+  - undefined
+  - memory:
+      experimental: true

--- a/projects/aspell/project.yaml
+++ b/projects/aspell/project.yaml
@@ -1,6 +1,7 @@
 homepage: "https://github.com/GNUAspell/aspell"
-primary_contact: "kevinatkn@gmail.com"
+primary_contact: "kevina@gnu.org"
 auto_ccs:
+  - "kevinatkn@gmail.com"
   - "cmeister2@gmail.com"
 sanitizers:
   - address


### PR DESCRIPTION
This commit adds support to OSS-Fuzz for GNUAspell.

It's currently blocked behind https://github.com/GNUAspell/aspell/pull/563 which @kevina is going to be reviewing in the near future. @kevina will be the primary contact for any bugs raised here.

The fuzzer installs dictionary files to /out/dict, which I _believe_ works (and appears to work when reproing locally), so hopefully will work live as well.