### PR TITLE
projects/mpg123: silence library error messages

### DIFF
--- a/projects/mpg123/decode_fuzzer.cc
+++ b/projects/mpg123/decode_fuzzer.cc
@@ -19,7 +19,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     return 0;
   }
 
-  ret = mpg123_open_feed(handle);
+  ret = mpg123_param(handle, MPG123_ADD_FLAGS, MPG123_QUIET, 0.);
+  if(ret == MPG123_OK)
+    ret = mpg123_open_feed(handle);
   if (ret != MPG123_OK) {
     mpg123_delete(handle);
     return 0;

--- a/projects/mpg123/read_fuzzer.c
+++ b/projects/mpg123/read_fuzzer.c
@@ -63,7 +63,8 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
   int error;
   mpg123_handle* handle = mpg123_new(NULL, &error);
-  if (handle == NULL) {
+  if (handle == NULL || mpg123_param(handle,
+      MPG123_ADD_FLAGS, MPG123_QUIET, 0.) != MPG123_OK) {
     free(outmemory);
     fuzzer_release_tmpfile(filename);
     return 0;


### PR DESCRIPTION
This should silence error messages from libmpg123, if you prefer fuzzer targets being silent apart from the sanitizer crash message. Please note that I did not test this, as I did not deal with
the oss-fuzz clang/Docker stuff directly yet. I'm busy enough fixing my code …

Thanks for having a go at showing me bugs, anyway … but that is part of the reason that I
don't have time to play with things;-)