### PR TITLE
[cryptofuzz] Compile Cityhash w/ SSE4.2 for more coverage

### DIFF
--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -62,7 +62,12 @@ fi
 
 # Compile Cityhash
 cd $SRC/cityhash
-./configure --disable-shared >/dev/null 2>&1
+if [[ $CFLAGS != *-m32* ]]
+then
+    CXXFLAGS="$CXXFLAGS -msse4.2" ./configure --disable-shared >/dev/null 2>&1
+else
+    ./configure --disable-shared >/dev/null 2>&1
+fi
 make -j$(nproc) >/dev/null 2>&1
 
 export CXXFLAGS="$CXXFLAGS -I$SRC/cityhash/src"


### PR DESCRIPTION
I want to get 100% file coverage of https://github.com/google/cityhash/blob/master/src/city.cc .
Two functions in there are only compiled if ```__SSE4_2__``` is defined.

This commit always (except on i386) builds Cityhash with -msse4.2, but at runtime I detect whether the CPU has SSE 4.2, and won't call the functions if it does not (in https://github.com/guidovranken/cryptofuzz/commit/73d0cc158f4715b7205a79fd62292fd2dbad78da which I'll merge as soon as this PR is merged).