### PR TITLE
[django] Correct CC

### DIFF
--- a/projects/django/project.yaml
+++ b/projects/django/project.yaml
@@ -1,7 +1,7 @@
 homepage: "https://www.djangoproject.com/"
 primary_contact: "guidovranken@gmail.com"
 auto_ccs:
- - "f.apolloner+django@gmail.com"
+ - "f.apolloner@gmail.com"
  - "info+django+security@markusholtermann.eu"
  - "jammamarkus@gmail.com"
 fuzzing_engines:


### PR DESCRIPTION
This user reports that he can log in to oss-fuzz.com, but cannot access reports (not authorized).
My thinking is that this is caused the ```+``` in his address.
Merge if you agree.