### PR TITLE
[django] Compile CPython without ASAN, disable UBSAN

### DIFF
--- a/projects/django/project.yaml
+++ b/projects/django/project.yaml
@@ -8,4 +8,3 @@ fuzzing_engines:
   - libfuzzer
 sanitizers:
  - address
- - undefined


### PR DESCRIPTION
This compiles CPython without ASAN, even if it's an ASAN build. It also disables UBSAN builds.

Rationale: There are two reasons for timeouts. One is simply a high computational complexity (many instructions executed), the other is a large ASAN overhead. ASAN incurs a certain overhead to heap operations (malloc/free), so a large amount of heap operations, which are relatively inexpensive without sanitization, will result in timeouts if ASAN is enabled.

Case in point: https://oss-fuzz.com/testcase-detail/6280834314665984 takes ~ 40 seconds to run with ASAN, and 1-2 seconds after this patch.

With Django, we are primarily interested in the first type of timeouts, as this configuration reflects a Django production environment the most. The occurrence of many heap operations that transpire through timeouts in ASAN builds (like the one linked to) _may_ be hinting at an underlying complexity problem, but I think it's best to let the fuzzer evolve into inputs that are slow even without ASAN to prevent analysis of potentially false positives.

Both CPython code coverage and Python-level code coverage is still recorded via -fsanitize=fuzzer-no-link and extra counters respectively.

Further, from what I've seen with python3-libraries, I think CPython is stable enough to not warrant sanitization in this case, and this patch will cause a general speedup to fuzzing, allowing us to find bugs (if any) sooner.

Do you agree?