### PR TITLE
Add outstanding LibFuzzer targets to Firefox

### DIFF
--- a/projects/firefox/Dockerfile
+++ b/projects/firefox/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2018 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,8 +16,14 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER pdknsk@gmail.com
-RUN apt-get update && apt-get install -y gawk mercurial
-RUN hg clone --uncompressed https://hg.mozilla.org/mozilla-central
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  python \
+  gawk \
+  software-properties-common
+RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+  libstdc++6
+RUN git clone --depth 1 https://github.com/mozilla/gecko-dev mozilla-central
 RUN git clone --depth 1 https://github.com/mozillasecurity/fuzzdata
 WORKDIR mozilla-central
 COPY build.sh target.c *.options mozconfig.* $SRC/

--- a/projects/firefox/ImageBMP.options
+++ b/projects/firefox/ImageBMP.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+close_fd_mask = 3

--- a/projects/firefox/ImageGIF.options
+++ b/projects/firefox/ImageGIF.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+close_fd_mask = 3

--- a/projects/firefox/build.sh
+++ b/projects/firefox/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2018 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,9 +20,11 @@ FUZZ_TARGETS=(
   SdpParser
   StunParser
   ContentParentIPC
-# Targets which are available but disabled.
-  # Qcms
-  # ContentSecurityPolicyParser
+  CompositorManagerParentIPC
+  ContentSecurityPolicyParser
+  ImageGIF
+  ImageICO
+  ImageBMP
 )
 
 # Firefox object (build) directory and configuration file.
@@ -40,7 +42,7 @@ source $HOME/.cargo/env
 # Update internal libFuzzer.
 (cd tools/fuzzing/libfuzzer && ./clone_libfuzzer.sh HEAD)
 
-# Build! Takes about 15 minutes on a 32 vCPU instance.
+# Build!
 ./mach build
 ./mach gtest buildbutdontrun
 
@@ -83,3 +85,13 @@ cp $SRC/fuzzdata/dicts/stun.dict $OUT/StunParser.dict
 
 # ContentParentIPC
 cp $SRC/fuzzdata/settings/ipc/libfuzzer.content.blacklist.txt $OUT/firefox
+
+# ImageGIF
+zip -rj $OUT/ImageGIF_seed_corpus.zip $SRC/fuzzdata/samples/gif
+cp $SRC/fuzzdata/dicts/gif.dict $OUT/ImageGIF.dict
+
+# ImageICO
+zip -rj $OUT/ImageICO_seed_corpus.zip $SRC/fuzzdata/samples/ico
+
+# ImageBMP
+zip -rj $OUT/ImageBMP_seed_corpus.zip $SRC/fuzzdata/samples/bmp


### PR DESCRIPTION
Add outstanding targets which are covered inside of Firefox only.

* CompositorManagerParentIPC
* ContentSecurityPolicyParser
* ImageGIF
* ImageICO
* ImageBMP

Notes:
* close_fd_mask=3 for ImageBMP and ImageGIF because those are very noisy.
