### PR TITLE
[libvips] Revert "Build with ImageMagick support (#2669)"

### DIFF
--- a/projects/libvips/Dockerfile
+++ b/projects/libvips/Dockerfile
@@ -34,7 +34,6 @@ RUN git clone --depth 1 https://github.com/madler/zlib.git
 RUN git clone --depth 1 https://github.com/libexif/libexif
 RUN git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo
 RUN git clone --depth 1 https://github.com/glennrp/libpng.git
-RUN git clone --depth 1 https://github.com/imagemagick/imagemagick
 RUN git clone --depth 1 https://git.code.sf.net/p/giflib/code libgif
 RUN git clone --depth 1 https://chromium.googlesource.com/webm/libwebp
 RUN git clone --depth 1 https://gitlab.com/libtiff/libtiff

--- a/projects/libvips/build.sh
+++ b/projects/libvips/build.sh
@@ -55,17 +55,6 @@ make -j$(nproc)
 make install
 popd
 
-# libmagick
-pushd $SRC/imagemagick
-./configure \
-  --disable-shared \
-  --disable-docs \
-  --with-utilities=no \
-  --prefix=$WORK
-make -j$(nproc)
-make install
-popd
-
 # libgif
 pushd $SRC/libgif
 make libgif.a libgif.so install-include install-lib OFLAGS="-O2" PREFIX=$WORK
@@ -131,7 +120,6 @@ for fuzzer in fuzz/*_fuzzer.cc; do
     $WORK/lib/libexif.a \
     $WORK/lib/libturbojpeg.a \
     $WORK/lib/libpng.a \
-    $WORK/lib/libMagickCore-7.Q16HDRI.a \
     $WORK/lib/libz.a \
     $WORK/lib/libgif.a \
     $WORK/lib/libwebpmux.a \


### PR DESCRIPTION
Do not build libvips with ImageMagick support (CC @jcupitt), as discussed in:

- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=16342
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=16339

This reverts commit 68fb445db17eaa680280bf72ebcbd0ca79b60a23. 