### PR TITLE
Hide wget output to reduce clutter

### DIFF
--- a/projects/django/Dockerfile
+++ b/projects/django/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER guidovranken@gmail.com
 RUN apt-get install -y build-essential libncursesw5-dev libreadline-dev libssl-dev libgdbm-dev libc6-dev libsqlite3-dev tk-dev libbz2-dev zlib1g-dev libffi-dev wget
-RUN wget https://github.com/python/cpython/archive/v3.8.0b2.tar.gz
+RUN wget -q https://github.com/python/cpython/archive/v3.8.0b2.tar.gz
 RUN git clone --depth 1 https://github.com/guidovranken/django-fuzzers.git
 RUN git clone --depth 1 https://github.com/django/django.git
 COPY build.sh $SRC/


### PR DESCRIPTION
When using wget to download files in a Dockerfile, the progress output of wget gets completely screwed up, making the build log almost impossible to read. By providing `-q` to wget the output will be hidden.