### PR TITLE
Revert "Use "x86" instead of "i386" for better name recognition. (#26…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,11 +37,11 @@ matrix:
         - TRAVIS_ENGINE=none
         - TRAVIS_SANITIZER=address
         - TRAVIS_ARCHITECTURE=x86_64
-    - name: "libfuzzer address x86"
+    - name: "libfuzzer address i386"
       env:
         - TRAVIS_ENGINE=libfuzzer
         - TRAVIS_SANITIZER=address
-        - TRAVIS_ARCHITECTURE=x86
+        - TRAVIS_ARCHITECTURE=i386
     - name: "dataflow dataflow x86_64"
       env:
         - TRAVIS_ENGINE=dataflow

--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -27,7 +27,7 @@ if [ -z "${SANITIZER_FLAGS-}" ]; then
   export SANITIZER_FLAGS=${!FLAGS_VAR-}
 fi
 
-if [[ $ARCHITECTURE == "x86" ]]; then
+if [[ $ARCHITECTURE == "i386" ]]; then
     export CFLAGS="-m32 $CFLAGS"
     cp -R /usr/i386/lib/* /usr/lib
 fi

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -99,8 +99,8 @@ ninja
 ninja install
 rm -rf $WORK/llvm-stage1 $WORK/llvm-stage2
 
-mkdir -p $WORK/x86
-cd $WORK/x86
+mkdir -p $WORK/i386
+cd $WORK/i386
 cmake -G "Ninja" \
       -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
       -DCMAKE_INSTALL_PREFIX=/usr/i386/ -DLIBCXX_ENABLE_SHARED=OFF \
@@ -111,7 +111,7 @@ cmake -G "Ninja" \
 
 ninja cxx
 ninja install-cxx
-rm -rf $WORK/x86
+rm -rf $WORK/i386
 
 mkdir -p $WORK/msan
 cd $WORK/msan

--- a/infra/base-images/base-runner/bad_build_check
+++ b/infra/base-images/base-runner/bad_build_check
@@ -49,8 +49,8 @@ UBSAN_CALLS_THRESHOLD_FOR_UBSAN_BUILD=170
 # a big concern either way as the overhead for them would not be significant.
 UBSAN_CALLS_THRESHOLD_FOR_NON_UBSAN_BUILD=200
 
-# ASan builds on x86 generally have about 250 UBSan runtime calls.
-if [[ $ARCHITECTURE == 'x86' ]]
+# ASan builds on i386 generally have about 250 UBSan runtime calls.
+if [[ $ARCHITECTURE == 'i386' ]]
 then
   UBSAN_CALLS_THRESHOLD_FOR_NON_UBSAN_BUILD=280
 fi
@@ -279,7 +279,7 @@ function check_mixed_sanitizers {
   local FUZZER=$1
   local result=0
   local CALL_INSN=
-  if [[ $ARCHITECTURE == 'x86' ]]
+  if [[ $ARCHITECTURE == 'i386' ]]
   then
     CALL_INSN="call\s+[0-9a-f]+\s+<"
   else
@@ -352,7 +352,7 @@ function check_architecture {
   if [[ $ARCHITECTURE == "x86_64" ]]
   then
     echo $FILE_OUTPUT | grep "x86-64" > /dev/null
-  elif [[ $ARCHITECTURE == "x86" ]]
+  elif [[ $ARCHITECTURE == "i386" ]]
   then
     echo $FILE_OUTPUT | grep "80386" > /dev/null
   else

--- a/infra/gcb/build_project.py
+++ b/infra/gcb/build_project.py
@@ -46,7 +46,7 @@ ENGINE_INFO = {
         EngineInfo(
             upload_bucket='clusterfuzz-builds',
             supported_sanitizers=['address', 'memory', 'undefined'],
-            supported_architectures=['x86_64', 'x86']),
+            supported_architectures=['x86_64', 'i386']),
     'afl':
         EngineInfo(
             upload_bucket='clusterfuzz-builds-afl',
@@ -120,7 +120,7 @@ def get_signed_url(path, method='PUT', content_type=''):
 
 def is_supported_configuration(fuzzing_engine, sanitizer, architecture):
   fuzzing_engine_info = ENGINE_INFO[fuzzing_engine]
-  if architecture == 'x86' and sanitizer != 'address':
+  if architecture == 'i386' and sanitizer != 'address':
     return False
   return (sanitizer in fuzzing_engine_info.supported_sanitizers and
           architecture in fuzzing_engine_info.supported_architectures)

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -261,7 +261,7 @@ def _get_work_dir(project_name=''):
   return os.path.join(BUILD_DIR, 'work', project_name)
 
 
-def _add_architecture_args(parser, choices=('x86_64', 'x86')):
+def _add_architecture_args(parser, choices=('x86_64', 'i386')):
   """Add common architecture args."""
   parser.add_argument('--architecture', default='x86_64', choices=choices)
 


### PR DESCRIPTION
We're going to stick with i386 for good, since x86 doesn't imply 32bit intel as strongly.

This reverts commit 0c6cc5cae8ac393fb7158ae50e9988d0a37a4d82.