### PR TITLE
[minizinc] License header and enable bug filing MSan

### DIFF
--- a/projects/minizinc/minizinc_fuzzer.cpp
+++ b/projects/minizinc/minizinc_fuzzer.cpp
@@ -1,3 +1,21 @@
+/*
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+*/
+
 #include <minizinc/solver.hh>
 
 using namespace std;

--- a/projects/minizinc/project.yaml
+++ b/projects/minizinc/project.yaml
@@ -6,4 +6,4 @@ auto_ccs:
 sanitizers:
   - address
   - memory:
-     experimental: True
+     experimental: False

--- a/projects/minizinc/project.yaml
+++ b/projects/minizinc/project.yaml
@@ -5,5 +5,4 @@ auto_ccs:
   - "guido.tack@monash.edu"
 sanitizers:
   - address
-  - memory:
-     experimental: False
+  - memory


### PR DESCRIPTION
This PR adds the license header in the fuzzer file and sets the experimental flag to False for the MemorySanitizer to enable bug filing in the issue tracker
