### PR TITLE
Do not instrument solidity dependencies except jsoncpp

### DIFF
--- a/projects/solidity/Dockerfile
+++ b/projects/solidity/Dockerfile
@@ -16,14 +16,69 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
-    build-essential cmake libbz2-dev ninja-build zlib1g-dev wget
+    build-essential libbz2-dev ninja-build zlib1g-dev wget
+# Install cmake 3.14 (minimum requirement is cmake 3.10)
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.14.5/cmake-3.14.5-Linux-x86_64.sh; \
+    chmod +x cmake-3.14.5-Linux-x86_64.sh; \
+    ./cmake-3.14.5-Linux-x86_64.sh --skip-license --prefix="/usr"
+
 RUN git clone --recursive https://github.com/ethereum/solidity.git solidity
 RUN git clone --depth 1 https://github.com/ethereum/solidity-fuzzing-corpus.git
-RUN git clone --recursive -b boost-1.69.0 https://github.com/boostorg/boost.git boost
+RUN git clone --recursive -b boost-1.69.0 https://github.com/boostorg/boost.git \
+    boost
 RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
-RUN (mkdir LPM && cd LPM && cmake ../libprotobuf-mutator -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="/usr" && ninja && ninja install && cd external.protobuf && cp -Rf bin lib include /usr)
-RUN git clone --branch="v0.1.0" --recurse-submodules https://github.com/ethereum/evmone.git
+RUN git clone --branch="v0.1.0" --recurse-submodules \
+    https://github.com/ethereum/evmone.git
 RUN git clone --branch="v0.2.0" https://github.com/chfast/intx.git
 RUN git clone --branch="v0.4.4" https://github.com/chfast/ethash.git
-RUN (wget https://github.com/Kitware/CMake/releases/download/v3.14.5/cmake-3.14.5-Linux-x86_64.sh && chmod +x cmake-3.14.5-Linux-x86_64.sh && mkdir -p /src/cmake-3.14.5 && ./cmake-3.14.5-Linux-x86_64.sh --skip-license --prefix="/src/cmake-3.14.5")
+
+# Install statically built dependencies in "/usr" directory
+# Install boost
+RUN cd $SRC/boost; \
+    ./bootstrap.sh --with-toolset=clang --prefix=/usr; \
+    ./b2 clean; \
+    ./b2 toolset=clang cxxflags="-stdlib=libc++" linkflags="-stdlib=libc++" \
+    headers; \
+    ./b2 toolset=clang cxxflags="-stdlib=libc++" linkflags="-stdlib=libc++" \
+    link=static variant=release runtime-link=static \
+    system regex filesystem unit_test_framework program_options \
+    install -j $(($(nproc)/2));
+
+# Install libprotobuf-mutator
+RUN mkdir $SRC/LPM; \
+    cd $SRC/LPM; \
+    cmake $SRC/libprotobuf-mutator -GNinja \
+    -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF \
+    -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="/usr"; \
+    ninja; \
+    ninja install; \
+    cd external.protobuf; \
+    cp -Rf bin lib include /usr;
+
+# Install evmone
+RUN cd $SRC/evmone; \
+    mkdir -p build; \
+    cd build; \
+    cmake .. -G Ninja -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX="/usr"; \
+    ninja; \
+    ninja install;
+
+# Install intx
+RUN cd $SRC/intx; \
+    mkdir -p build; \
+    cd build; \
+    cmake .. -G Ninja -DBUILD_SHARED_LIBS=OFF -DINTX_TESTING=OFF \
+    -DINTX_BENCHMARKING=OFF -DCMAKE_INSTALL_PREFIX="/usr"; \
+    ninja; \
+    ninja install;
+
+# Install ethash
+RUN cd $SRC/ethash; \
+    mkdir -p build; \
+    cd build; \
+    cmake .. -G Ninja -DBUILD_SHARED_LIBS=OFF -DETHASH_BUILD_TESTS=OFF \
+    -DCMAKE_INSTALL_PREFIX="/usr"; \
+    ninja; \
+    ninja install;
+
 COPY build.sh $SRC/


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/7249

This PR
  - moves builds of solidity dependencies out of build script and into dockerfile
    - boost
    - LPM
    - evmone
    - intx
    - ethash
  - upgrades cmake from 3.5 to 3.14

Fuzzing binaries should generally be faster because of lesser instrumentation.

CC @chriseth @ekpyron