### PR TITLE
[giflib] Fix endianness inside proto converter

### DIFF
--- a/projects/giflib/ProtoToGif.cpp
+++ b/projects/giflib/ProtoToGif.cpp
@@ -233,19 +233,16 @@ void ProtoConverter::writeByte(uint8_t x)
 
 void ProtoConverter::writeWord(uint16_t x)
 {
-	x = __builtin_bswap16(x);
 	m_output.write((char *)&x, sizeof(x));
 }
 
 void ProtoConverter::writeInt(uint32_t x)
 {
-	x = __builtin_bswap32(x);
 	m_output.write((char *)&x, sizeof(x));
 }
 
 void ProtoConverter::writeLong(uint64_t x)
 {
-	x = __builtin_bswap64(x);
 	m_output.write((char *)&x, sizeof(x));
 }
 


### PR DESCRIPTION
Previously, the protobuf converter for giflib changed little endian to big endian before writing a value to native gif format. Turns out, this is not required.

This PR undoes the endianness conversion.