### PR TITLE
[syzkaller] Initial integration.

### DIFF
--- a/projects/syzkaller/Dockerfile
+++ b/projects/syzkaller/Dockerfile
@@ -16,8 +16,12 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mmoroz@chromium.org
-RUN apt-get update && apt-get install -y golang-1.10-go
-RUN ln -s /usr/lib/go-1.10/bin/go /usr/bin/go
+ADD https://dl.google.com/go/go1.12.9.linux-amd64.tar.gz go.tar.gz
+RUN tar xzf go.tar.gz -C $SRC/
+ENV GOPATH $SRC
+ENV PATH $SRC/go/bin:$GOPATH/bin:$PATH
+
+RUN go get -u -d github.com/google/syzkaller/...
 
 RUN git clone --depth 1 https://github.com/google/syzkaller.git syzkaller
 WORKDIR syzkaller

--- a/projects/syzkaller/Dockerfile
+++ b/projects/syzkaller/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER mmoroz@chromium.org
+RUN apt-get update && apt-get install -y golang-1.10-go
+RUN ln -s /usr/lib/go-1.10/bin/go /usr/bin/go
+
+RUN git clone --depth 1 https://github.com/google/syzkaller.git syzkaller
+WORKDIR syzkaller
+COPY build.sh $SRC/

--- a/projects/syzkaller/build.sh
+++ b/projects/syzkaller/build.sh
@@ -15,24 +15,6 @@
 #
 ################################################################################
 
-# Bootstrap the latest go.
-pushd $SRC
-rm -rf go
-git clone --depth 1 https://github.com/golang/go go
-pushd go/src/
-./make.bash
-popd
-popd
-
-# Remove golang used to bootstrap the latest version.
-apt-get remove golang-1.10-go -y
-rm /usr/bin/go
-
-# Set up Golang env variables.
-export GOROOT="$SRC/go"
-export GOPATH="$GOROOT/packages"
-export PATH="$PATH:$GOROOT/bin:$GOPATH/bin"
-
 # Dependency of go-fuzz
 go get golang.org/x/tools/go/packages
 
@@ -55,5 +37,9 @@ function compile_fuzzer {
 compile_fuzzer ./pkg/compiler Fuzz compiler_fuzzer
 compile_fuzzer ./prog/test FuzzDeserialize prog_deserialize_fuzzer
 compile_fuzzer ./prog/test FuzzParseLog prog_parselog_fuzzer
-compile_fuzzer ./pkg/report Fuzz report_fuzzer
-compile_fuzzer ./tools/syz-trace2syz/proggen Fuzz trace2syz_fuzzer
+
+# This target fails to build.
+# compile_fuzzer ./pkg/report Fuzz report_fuzzer
+
+# This target is way too spammy and OOMs very quickly.
+# compile_fuzzer ./tools/syz-trace2syz/proggen Fuzz trace2syz_fuzzer

--- a/projects/syzkaller/build.sh
+++ b/projects/syzkaller/build.sh
@@ -1,0 +1,59 @@
+#!/bin/bash -eu
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Bootstrap the latest go.
+pushd $SRC
+rm -rf go
+git clone --depth 1 https://github.com/golang/go go
+pushd go/src/
+./make.bash
+popd
+popd
+
+# Remove golang used to bootstrap the latest version.
+apt-get remove golang-1.10-go -y
+rm /usr/bin/go
+
+# Set up Golang env variables.
+export GOROOT="$SRC/go"
+export GOPATH="$GOROOT/packages"
+export PATH="$PATH:$GOROOT/bin:$GOPATH/bin"
+
+# Dependency of go-fuzz
+go get golang.org/x/tools/go/packages
+
+# go-fuzz-build is the tool that instruments Go files.
+go get github.com/dvyukov/go-fuzz/go-fuzz-build
+
+# Based on the function from oss-fuzz/projects/golang/build.sh script.
+function compile_fuzzer {
+  path=$1
+  function=$2
+  fuzzer=$3
+
+   # Instrument all Go files relevant to this fuzzer
+  go-fuzz-build -libfuzzer -func $function -o $fuzzer.a $path 
+
+   # Instrumented, compiled Go ($fuzzer.a) + libFuzzer = fuzzer binary
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -lpthread -o $OUT/$fuzzer
+}
+
+compile_fuzzer ./pkg/compiler Fuzz compiler_fuzzer
+compile_fuzzer ./prog/test FuzzDeserialize prog_deserialize_fuzzer
+compile_fuzzer ./prog/test FuzzParseLog prog_parselog_fuzzer
+compile_fuzzer ./pkg/report Fuzz report_fuzzer
+compile_fuzzer ./tools/syz-trace2syz/proggen Fuzz trace2syz_fuzzer

--- a/projects/syzkaller/build.sh
+++ b/projects/syzkaller/build.sh
@@ -48,7 +48,7 @@ function compile_fuzzer {
    # Instrument all Go files relevant to this fuzzer
   go-fuzz-build -libfuzzer -func $function -o $fuzzer.a $path 
 
-   # Instrumented, compiled Go ($fuzzer.a) + libFuzzer = fuzzer binary
+   # Instrumented, compiled Go ($fuzzer.a) + fuzzing engine = fuzzer binary
   $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -lpthread -o $OUT/$fuzzer
 }
 

--- a/projects/syzkaller/project.yaml
+++ b/projects/syzkaller/project.yaml
@@ -1,0 +1,7 @@
+homepage: "https://github.com/google/syzkaller.git"
+primary_contact: "dvyukov@google.com"
+auto_ccs:
+  - "andreyknvl@google.com"
+  - "mmoroz@chromium.org"
+sanitizers:
+  - address


### PR DESCRIPTION
//cc @dvyukov @xairy 

I was trying to follow the golang integration scripts and the go-fuzz documentation, but got stuck with the following issue:

```
+ go get golang.org/x/tools/go/packages
+ go get github.com/dvyukov/go-fuzz/go-fuzz-build
+ compile_fuzzer ./pkg/compiler Fuzz compiler_fuzzer
+ path=./pkg/compiler
+ function=Fuzz
+ fuzzer=compiler_fuzzer
+ go-fuzz-build -libfuzzer -func Fuzz -o compiler_fuzzer.a ./pkg/compiler
-: go build github.com/google/syzkaller/pkg/ast: no Go files in 
go build github.com/google/syzkaller/prog: no Go files in 
go build github.com/google/syzkaller/sys/targets: no Go files in
typechecking of ./pkg/compiler failed
Fuzzers build failed.
```

Looks like some dependencies missing or paths are not specified. Any suggestions?