### PR TITLE
Initial stb_image integration

### DIFF
--- a/projects/stb/Dockerfile
+++ b/projects/stb/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+MAINTAINER randy408@protonmail.com
+
+RUN git clone --depth 1 --branch fuzz https://github.com/randy408/stb.git
+
+WORKDIR stb
+COPY build.sh $SRC/

--- a/projects/stb/build.sh
+++ b/projects/stb/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -eu
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+$CXX $CXXFLAGS -std=c++11 -I. \
+    $SRC/stb/tests/stb_png_read_fuzzer.cpp \
+    -o $OUT/stb_png_read_fuzzer \
+    -lFuzzingEngine
+
+find $SRC/stb/tests/pngsuite -name "*.png" | \
+     xargs zip $OUT/stb_png_read_fuzzer_seed_corpus.zip
+
+cp $SRC/stb/tests/stb_png.dict $OUT/

--- a/projects/stb/project.yaml
+++ b/projects/stb/project.yaml
@@ -1,0 +1,4 @@
+homepage: "https://github.com/nothings/stb"
+primary_contact: "sean@nothings.org"
+auto_ccs:
+  - "randy440088@gmail.com"


### PR DESCRIPTION
stb_image is a single-header library, it can read JPG, PNG, TGA, BMP, PSD, GIF, HDR, PIC, PNM images. Initial integration consists of a PNG-only fuzz target, it defines `STBI_ONLY_PNG` which basically `#ifdef`'s out support for anything else than PNG.

I'm not sure how to set up fuzzing for the rest of the formats, there should be a generic fuzz target in case the interaction between [format detection](https://github.com/nothings/stb/blob/787f1d646a981523297fa97f30986284dd245290/stb_image.h#L1005) and the parsers is vulnerable (see https://github.com/nothings/stb/issues/787).

The Dockerfile is pointing to my fork, I'll change it once it's upstreamed: https://github.com/nothings/stb/pull/737