### PR TITLE
[libxml2] Fix broken build

### DIFF
--- a/projects/libxml2/Dockerfile
+++ b/projects/libxml2/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER ochang@chromium.org
-RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config
+RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config zlib1g-dev
 
 RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/libxml2.git
 WORKDIR libxml2

--- a/projects/libxml2/build.sh
+++ b/projects/libxml2/build.sh
@@ -27,7 +27,7 @@ zip -r $seed_corpus_temp_file $SRC/libxml2/test
 for fuzzer in libxml2_xml_read_memory_fuzzer libxml2_xml_reader_for_file_fuzzer; do
   $CXX $CXXFLAGS -std=c++11 -Iinclude/ \
       $SRC/$fuzzer.cc -o $OUT/$fuzzer \
-      $LIB_FUZZING_ENGINE .libs/libxml2.a
+      $LIB_FUZZING_ENGINE .libs/libxml2.a -lz
 
   cp $SRC/*.dict $OUT/$fuzzer.dict
   cp $seed_corpus_temp_file $OUT/${fuzzer}_seed_corpus.zip

--- a/projects/libxml2/project.yaml
+++ b/projects/libxml2/project.yaml
@@ -5,6 +5,7 @@ auto_ccs:
   - "benl@google.com"
   - "wellnhofer@aevum.de"
   - "akilsrin@apple.com"
+  - "bshas3@gmail.com"  
 sanitizers:
   - address
   - memory


### PR DESCRIPTION
When testing locally, I realized linking libxml2 fuzzer harness fails, this PR fixes it.