### PR TITLE
Add project Sorbet

### DIFF
--- a/projects/sorbet/Dockerfile
+++ b/projects/sorbet/Dockerfile
@@ -17,7 +17,8 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER sorbet@stripe.com
 
-RUN apt-get install -y curl python ruby libstdc++-5-dev
+RUN apt-cache search libstdc++
+RUN apt-get install -y curl python ruby libstdc++5 afl
 RUN curl -L -O https://github.com/bazelbuild/bazel/releases/download/0.27.0/bazel-0.27.0-installer-linux-x86_64.sh
 RUN chmod a+x bazel-0.27.0-installer-linux-x86_64.sh
 RUN bash ./bazel-0.27.0-installer-linux-x86_64.sh
@@ -25,4 +26,7 @@ RUN bash ./bazel-0.27.0-installer-linux-x86_64.sh
 RUN git clone --depth 1 https://github.com/sorbet/sorbet.git /src/sorbet
 
 WORKDIR /src/sorbet
+
+RUN git clone https://github.com/abseil/abseil-cpp.git /src/abseil
+
 COPY build.sh /src/build.sh

--- a/projects/sorbet/Dockerfile
+++ b/projects/sorbet/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/sorbet/Dockerfile
+++ b/projects/sorbet/Dockerfile
@@ -1,0 +1,28 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER sorbet@stripe.com
+
+RUN apt-get install -y curl python ruby libstdc++-5-dev
+RUN curl -L -O https://github.com/bazelbuild/bazel/releases/download/0.27.0/bazel-0.27.0-installer-linux-x86_64.sh
+RUN chmod a+x bazel-0.27.0-installer-linux-x86_64.sh
+RUN bash ./bazel-0.27.0-installer-linux-x86_64.sh
+
+RUN git clone --depth 1 https://github.com/sorbet/sorbet.git /src/sorbet
+
+WORKDIR /src/sorbet
+COPY build.sh /src/build.sh

--- a/projects/sorbet/Dockerfile
+++ b/projects/sorbet/Dockerfile
@@ -17,8 +17,10 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER sorbet@stripe.com
 
-RUN apt-cache search libstdc++
-RUN apt-get install -y curl python ruby libstdc++5 afl
+RUN apt-get install -y curl python ruby software-properties-common
+RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y g++8 libstdc++-8-dev
 RUN curl -L -O https://github.com/bazelbuild/bazel/releases/download/0.27.0/bazel-0.27.0-installer-linux-x86_64.sh
 RUN chmod a+x bazel-0.27.0-installer-linux-x86_64.sh
 RUN bash ./bazel-0.27.0-installer-linux-x86_64.sh
@@ -26,7 +28,5 @@ RUN bash ./bazel-0.27.0-installer-linux-x86_64.sh
 RUN git clone --depth 1 https://github.com/sorbet/sorbet.git /src/sorbet
 
 WORKDIR /src/sorbet
-
-RUN git clone https://github.com/abseil/abseil-cpp.git /src/abseil
 
 COPY build.sh /src/build.sh

--- a/projects/sorbet/build.sh
+++ b/projects/sorbet/build.sh
@@ -23,3 +23,4 @@ sed -i -e '/build --copt=-Werror --copt=-Wimplicit-fallthrough/d' .bazelrc
 sed -i -e '5i#include <vector>' common/Subprocess.h
 sed -i -e '7i#include <cassert>' third_party/parser/include/ruby_parser/pool.hh
 CXX="$CXX" CFLAGS="--std=c++17 --stdlib=libc++" CXXFLAGS="--std=c++17 --stdlib=libc++" bazel build --config=fuzz //test/fuzz:fuzz_dash_e
+cp bazel-bin/test/fuzz/fuzz_dash_e /out/.

--- a/projects/sorbet/build.sh
+++ b/projects/sorbet/build.sh
@@ -15,5 +15,9 @@
 #
 ################################################################################
 
-bazel build //test/fuzz:fuzz_dash_e --config=fuzz -c opt
-cp ./bazel-bin/test/fuzz/fuzz_dash_e $OUT/.
+FUZZERS=("fuzz_dash_e")
+PIPELINE_LIB=./bazel-bin/main/pipeline/libpipeline.a
+
+# export CC=/bin/false
+sed -i -e '/build --crosstool.*/d' .bazelrc
+CXX="$CXX" CFLAGS="--std=c++17 --stdlib=libstdc++" CXXFLAGS="--std=c++17 --stdlib=libstdc++" bazel build --config=fuzz //test/fuzz:fuzz_dash_e

--- a/projects/sorbet/build.sh
+++ b/projects/sorbet/build.sh
@@ -1,4 +1,19 @@
-#!/bin/bash -e
+#!/bin/bash -eu
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
 
 bazel build //test/fuzz:fuzz_dash_e --config=fuzz -c opt
 cp ./bazel-bin/test/fuzz/fuzz_dash_e $OUT/.

--- a/projects/sorbet/build.sh
+++ b/projects/sorbet/build.sh
@@ -18,6 +18,8 @@
 FUZZERS=("fuzz_dash_e")
 PIPELINE_LIB=./bazel-bin/main/pipeline/libpipeline.a
 
-# export CC=/bin/false
 sed -i -e '/build --crosstool.*/d' .bazelrc
-CXX="$CXX" CFLAGS="--std=c++17 --stdlib=libstdc++" CXXFLAGS="--std=c++17 --stdlib=libstdc++" bazel build --config=fuzz //test/fuzz:fuzz_dash_e
+sed -i -e '/build --copt=-Werror --copt=-Wimplicit-fallthrough/d' .bazelrc
+sed -i -e '5i#include <vector>' common/Subprocess.h
+sed -i -e '7i#include <cassert>' third_party/parser/include/ruby_parser/pool.hh
+CXX="$CXX" CFLAGS="--std=c++17 --stdlib=libc++" CXXFLAGS="--std=c++17 --stdlib=libc++" bazel build --config=fuzz //test/fuzz:fuzz_dash_e

--- a/projects/sorbet/build.sh
+++ b/projects/sorbet/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+bazel build //test/fuzz:fuzz_dash_e --config=fuzz -c opt
+cp ./bazel-bin/test/fuzz/fuzz_dash_e $OUT/.

--- a/projects/sorbet/project.yaml
+++ b/projects/sorbet/project.yaml
@@ -1,2 +1,18 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
 homepage: "https://sorbet.org"
 primary_contact: "sorbet@stripe.com"

--- a/projects/sorbet/project.yaml
+++ b/projects/sorbet/project.yaml
@@ -1,0 +1,2 @@
+homepage: "https://sorbet.org"
+primary_contact: "sorbet@stripe.com"


### PR DESCRIPTION
This adds the project.yaml as well as the Dockerfile and build.sh to fuzz-test [Sorbet](https://sorbet.org/), an open-source static type-checker for Ruby. Sorbet is an open-sourced project developed by Stripe that's now being used by several Ruby-using companies as well as in open-source projects.