### PR TITLE
[infra] Allow perma-links to project logs. Fixes #2690

### DIFF
--- a/infra/gcb/templates/bower.json
+++ b/infra/gcb/templates/bower.json
@@ -10,7 +10,8 @@
     "iron-icons": "PolymerElements/iron-icons#2.0-preview",
     "iron-ajax": "PolymerElements/iron-ajax#2.0-preview",
     "iron-flex-layout": "PolymerElements/iron-flex-layout#2.0-preview",
-    "paper-icon-button": "PolymerElements/paper-icon-button#2.0-preview"
+    "paper-icon-button": "PolymerElements/paper-icon-button#2.0-preview",
+    "app-route": "PolymerElements/app-route#2.0-preview"
   },
   "devDependencies": {
     "web-component-tester": "^6.0.0-prerelease.5",

--- a/infra/gcb/templates/src/build-status/build-status.html
+++ b/infra/gcb/templates/src/build-status/build-status.html
@@ -15,9 +15,16 @@
 <link rel="import" href="../../bower_components/iron-flex-layout/iron-flex-layout-classes.html">
 <link rel="import" href="../../bower_components/polymer/lib/elements/dom-if.html">
 <link rel="import" href="../../bower_components/polymer/lib/elements/dom-repeat.html">
+<link rel="import" href="../../bower_components/app-route/app-location.html">
+<link rel="import" href="../../bower_components/app-route/app-route.html">
 
 <dom-module id="build-status">
   <template>
+    <app-location route="{{route}}" use-hash-as-path></app-location>
+    <app-route route="{{route}}"
+      pattern=":project_name"
+      data="{{routeData}}">
+    </app-route>
     <style is="custom-style" include="iron-flex iron-flex-alignment">
     <style>
       .paper-item-link {
@@ -137,12 +144,38 @@
           }
         };
       }
+      static get observers() {
+        return [
+          '_routeChanged(route.*)'
+        ];
+      }
+
+      _routeChanged() {
+        if (!this.status || !this.routeData.project_name) {
+          // If our status json is loaded and there is a project_name specified
+          // in the URL, we can proceed to load that project's log.
+          return;
+        }
+        var project = this.getProjectByName(this.routeData.project_name);
+
+        this.$.logxhr.url = "/log-" + project.build_id + ".txt";
+        this.build_id = project.build_id;
+        this.log = '';
+        this.loading_log = true;
+      }
+
+      getProjectByName(project_name) {
+        return this.status.projects.find(p => p.name === project_name);
+      }
 
       onResponseForFuzzing(e) {
         this.status_fuzzing = e.detail.response;
         if (!this.status) {
           // Show status of the fuzzing builds by default.
           this.status = this.status_fuzzing;
+          // Manually invoke a _routeChanged call, in order to load the log for
+          // someone going directly to a project's URL.
+          this._routeChanged();
         }
       }
 
@@ -156,10 +189,9 @@
       }
 
       onTap(e) {
-        this.$.logxhr.url = "/log-" + e.model.project.build_id + ".txt";
-        this.build_id = e.model.project.build_id;
-        this.log = '';
-        this.loading_log = true;
+        // Change the route, this should auto-magically update the url in the
+        // browser and invoke the _routeChanged method.
+        this.set('routeData.project_name', e.model.project.name);
       }
 
       onChanged(e) {


### PR DESCRIPTION
Should be a pretty straightforward way to accomplish this in a polymer-centric way. 

This enables links like https://oss-fuzz-build-logs.storage.googleapis.com/index.html#aosp to actually load the `aosp` logs.

Looking at the actual fuzzer build logs should be 99% of use cases but maybe we also want to consider something like `#/coverage/aosp` to get to the coverage log?