### PR TITLE
[GDAL] Fix broken undefined builds

### DIFF
--- a/projects/gdal/build.sh
+++ b/projects/gdal/build.sh
@@ -36,19 +36,22 @@ fi
 cd poppler
 mkdir -p build
 cd build
+POPPLER_CFLAGS="$CFLAGS"
 POPPLER_CXXFLAGS="$CXXFLAGS"
 # we do not really want to deal with Poppler undefined behaviour bugs, such
 # as integer overflows
 if [ "$SANITIZER" = "undefined" ]; then
     if [ "$ARCHITECTURE" = "i386" ]; then
-        POPPLER_CXXFLAGS="-m32 -g -O1"
+        POPPLER_CFLAGS="-m32 -O1 -fno-omit-frame-pointer -gline-tables-only -stdlib=libc++"
     else
-        POPPLER_CXXFLAGS="-g -O1"
+        POPPLER_CFLAGS="-O1 -fno-omit-frame-pointer -gline-tables-only -stdlib=libc++"
     fi
+    POPPLER_CXXFLAGS="$POPPLER_CFLAGS"
 fi
 cmake .. \
   -DCMAKE_INSTALL_PREFIX=$SRC/install \
   -DCMAKE_BUILD_TYPE=debug \
+  -DCMAKE_C_FLAGS="$POPPLER_CFLAGS" \
   -DCMAKE_CXX_FLAGS="$POPPLER_CXXFLAGS" \
   -DENABLE_UNSTABLE_API_ABI_HEADERS=ON \
   -DBUILD_SHARED_LIBS=OFF \


### PR DESCRIPTION
The builds were broken due to inappropriate build flags being passed
during poppler build.