### PR TITLE
Enable i386 for curl

### DIFF
--- a/projects/curl/project.yaml
+++ b/projects/curl/project.yaml
@@ -6,3 +6,6 @@ auto_ccs:
 sanitizers:
   - address
   - undefined
+architectures:
+  - x86_64
+  - i386


### PR DESCRIPTION
Might as well get in on all the fun and enable MSAN and i386 support for curl :smile:

@bagder for info!