### PR TITLE
Enable i386 fuzzing on 18 projects

### DIFF
--- a/projects/bloaty/project.yaml
+++ b/projects/bloaty/project.yaml
@@ -1,2 +1,5 @@
 homepage: "https://github.com/google/bloaty"
 primary_contact: "jhaberman@gmail.com"
+architectures:
+  - x86_64
+  - i386

--- a/projects/brotli/project.yaml
+++ b/projects/brotli/project.yaml
@@ -9,3 +9,6 @@ sanitizers:
   - dataflow
   - memory
   - undefined
+architectures:
+  - x86_64
+  - i386

--- a/projects/bzip2/project.yaml
+++ b/projects/bzip2/project.yaml
@@ -12,3 +12,6 @@ sanitizers:
   - dataflow
   - memory
   - undefined
+architectures:
+  - x86_64
+  - i386

--- a/projects/expat/project.yaml
+++ b/projects/expat/project.yaml
@@ -8,4 +8,6 @@ sanitizers:
   - address
   - memory
   - undefined
-
+architectures:
+  - x86_64
+  - i386

--- a/projects/file/project.yaml
+++ b/projects/file/project.yaml
@@ -4,4 +4,6 @@ sanitizers:
   - address
   - memory
   - undefined
-
+architectures:
+  - x86_64
+  - i386

--- a/projects/harfbuzz/project.yaml
+++ b/projects/harfbuzz/project.yaml
@@ -16,3 +16,6 @@ sanitizers:
  - address
  - undefined
  - memory
+architectures:
+  - x86_64
+  - i386

--- a/projects/jsonnet/project.yaml
+++ b/projects/jsonnet/project.yaml
@@ -12,3 +12,7 @@ sanitizers:
 labels:
   convert_jsonnet_fuzzer:
     - sundew
+
+architectures:
+  - x86_64
+  - i386

--- a/projects/lcms/project.yaml
+++ b/projects/lcms/project.yaml
@@ -5,3 +5,6 @@ sanitizers:
   - memory:
      experimental: True
   - undefined
+architectures:
+  - x86_64
+  - i386

--- a/projects/libsodium/project.yaml
+++ b/projects/libsodium/project.yaml
@@ -2,3 +2,6 @@ homepage: "https://libsodium.org"
 primary_contact: "ossfuzzz+sodium@gmail.com"
 auto_ccs:
  - "chriswwolfe@gmail.com"
+architectures:
+  - x86_64
+  - i386

--- a/projects/libxml2/project.yaml
+++ b/projects/libxml2/project.yaml
@@ -11,3 +11,6 @@ sanitizers:
 labels:
   libxml2_xml_reader_for_file_fuzzer:
     - sundew
+architectures:
+  - x86_64
+  - i386

--- a/projects/libyaml/project.yaml
+++ b/projects/libyaml/project.yaml
@@ -11,3 +11,6 @@ sanitizers:
   - dataflow
   - memory
   - undefined
+architectures:
+  - x86_64
+  - i386

--- a/projects/lzo/project.yaml
+++ b/projects/lzo/project.yaml
@@ -5,3 +5,6 @@ auto_ccs:
 sanitizers:
   - address
   - memory
+architectures:
+  - x86_64
+  - i386

--- a/projects/pcre2/project.yaml
+++ b/projects/pcre2/project.yaml
@@ -4,3 +4,6 @@ sanitizers:
   - address
   - memory
   - undefined
+architectures:
+  - x86_64
+  - i386

--- a/projects/pffft/project.yaml
+++ b/projects/pffft/project.yaml
@@ -12,3 +12,6 @@ sanitizers:
   - dataflow
   - memory
   - undefined
+architectures:
+  - x86_64
+  - i386

--- a/projects/re2/project.yaml
+++ b/projects/re2/project.yaml
@@ -4,3 +4,6 @@ sanitizers:
   - address
   - memory
   - undefined
+architectures:
+  - x86_64
+  - i386

--- a/projects/sqlite3/project.yaml
+++ b/projects/sqlite3/project.yaml
@@ -6,3 +6,6 @@ sanitizers:
   - address
   - memory
   - undefined
+architectures:
+  - x86_64
+  - i386

--- a/projects/zlib-ng/project.yaml
+++ b/projects/zlib-ng/project.yaml
@@ -22,3 +22,6 @@ sanitizers:
   - address
   - memory
   - undefined
+architectures:
+  - x86_64
+  - i386

--- a/projects/zlib/project.yaml
+++ b/projects/zlib/project.yaml
@@ -12,3 +12,6 @@ sanitizers:
   - dataflow
   - memory
   - undefined
+architectures:
+  - x86_64
+  - i386


### PR DESCRIPTION
These projects were tested locally or on travis to build with i386.

Maintainers who own these projects: If you don't want i386 fuzzing, feel free to disable, I figured it's generally desirable since it can find more bugs but most projects won't switch because of inertia.