### PR TITLE
Enable MSAN for curl, for real this time!

### DIFF
--- a/projects/curl/project.yaml
+++ b/projects/curl/project.yaml
@@ -6,6 +6,7 @@ auto_ccs:
 sanitizers:
   - address
   - undefined
+  - memory
 architectures:
   - x86_64
   - i386


### PR DESCRIPTION
I just fixed MSAN in curl by using `no-asm` for OpenSSL. Hopefully OSS-Fuzz will have some fun with it. 