### PR TITLE
[rapidjson] Extended fuzzer

### DIFF
--- a/projects/rapidjson/build.sh
+++ b/projects/rapidjson/build.sh
@@ -20,5 +20,13 @@ then
     export CXXFLAGS="$CXXFLAGS -DMSAN"
 fi
 
+if [[ $CFLAGS = *sanitize=address* ]]
+then
+    export CXXFLAGS="$CXXFLAGS -DASAN"
+fi
+
 $CXX $CXXFLAGS -D_GLIBCXX_DEBUG -I $SRC/rapidjson/include fuzzer.cpp $LIB_FUZZING_ENGINE -o $OUT/fuzzer
 cp fuzzer_seed_corpus.zip $OUT
+
+cd $SRC/fuzzing-headers/tests
+$CXX $CXXFLAGS -std=c++17 -D_GLIBCXX_DEBUG -I $SRC/rapidjson/include -I ../include rapidjson.cpp $LIB_FUZZING_ENGINE -o $OUT/fuzzer-extended


### PR DESCRIPTION
I mentioned this in my request for the initial integration reward for rapidjson.

This extended fuzzer performs all kinds of tests on the parsed json, see https://github.com/guidovranken/fuzzing-headers/blob/master/include/fuzzing/testers/serialize/json.hpp

This compiles locally on my machine, but I can't get it to work in the Docker container, presumably because of the new Clang version.

```
/usr/local/bin/../include/c++/v1/optional:470:27: error: the parameter for this explicitly-defaulted copy assignment operator is const, but a member or base requires it to be non-const
    __optional_copy_base& operator=(const __optional_copy_base&) = default;
                          ^
/usr/local/bin/../include/c++/v1/optional:482:43: note: in instantiation of template class 'std::__1::__optional_copy_base<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >, false>' requested here
struct __optional_move_base<_Tp, false> : __optional_copy_base<_Tp>
                                          ^
/usr/local/bin/../include/c++/v1/optional:515:50: note: in instantiation of template class 'std::__1::__optional_move_base<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >, false>' requested here
struct __optional_copy_assign_base<_Tp, false> : __optional_move_base<_Tp>
                                                 ^
/usr/local/bin/../include/c++/v1/optional:547:50: note: in instantiation of template class 'std::__1::__optional_copy_assign_base<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >, false>' requested here
struct __optional_move_assign_base<_Tp, false> : __optional_copy_assign_base<_Tp>
                                                 ^
/usr/local/bin/../include/c++/v1/optional:585:15: note: in instantiation of template class 'std::__1::__optional_move_assign_base<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >, false>' requested here
    : private __optional_move_assign_base<_Tp>
              ^
rapidjson.cpp:11:41: note: in instantiation of template class 'std::__1::optional<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >' requested here
        std::optional<rapidjson::Value> StringToObject(const std::string& input) override {
```

If you can get this to work, please merge, otherwise just close this PR.