### PR TITLE
[infra] Use stable version of AFL from the upstream repo.

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -93,11 +93,7 @@ ENV FUZZER_LDFLAGS ""
 
 WORKDIR $SRC
 
-ADD http://lcamtuf.coredump.cx/afl/releases/afl-latest.tgz $SRC/
-RUN mkdir afl && \
-    cd afl && \
-    tar -xzv --strip-components=1 -f $SRC/afl-latest.tgz && \
-    rm -rf $SRC/afl-latest.tgz
+RUN git clone -b stable https://github.com/google/AFL.git afl
 
 ADD https://github.com/google/honggfuzz/archive/oss-fuzz.tar.gz $SRC/
 RUN mkdir honggfuzz && \


### PR DESCRIPTION
Tested locally, seems to work fine. This way we'll always be using the latest release, but avoid checking out the master branch which can be unstable at times.