### PR TITLE
Disable TensorFlow fuzzing project.

### DIFF
--- a/projects/tensorflow/project.yaml
+++ b/projects/tensorflow/project.yaml
@@ -1,3 +1,4 @@
+disabled: True
 homepage: "https://www.tensorflow.org"
 primary_contact: "mihaimaruseac@google.com"
 auto_ccs:


### PR DESCRIPTION
The current build rules for TensorFlow take too long and recently they
have been constantly killed. As we are now working on cleaning up the
build, we switched to using new compilers, there is work on making
TensorFlow easier to build, I think it's better to disable the project
for the remainder of the quarter.

Next quarter I'll come back with a better build script and re-enable the
project.