### PR TITLE
Revert "Disable TensorFlow fuzzing project."

### DIFF
--- a/projects/tensorflow/project.yaml
+++ b/projects/tensorflow/project.yaml
@@ -1,4 +1,3 @@
-disabled: True
 homepage: "https://www.tensorflow.org"
 primary_contact: "mihaimaruseac@google.com"
 auto_ccs:


### PR DESCRIPTION
Reverts google/oss-fuzz#2770. Briefly discussed on the issue plus internally within OSS-Fuzz team. It sounds better to keep fuzzing with the latest available build for some time just to continue improving the corpus and possibly finding old-living bugs. If CF reports anything interesting in the meantime, that'll be another motivator to fix the build sooner :)