### PR TITLE
Enhances ntp project

### DIFF
--- a/projects/ntp/Dockerfile
+++ b/projects/ntp/Dockerfile
@@ -16,8 +16,9 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER security@ntp.org
-RUN apt-get update && apt-get install -y make autoconf automake libtool bison flex
+RUN apt-get update && apt-get install -y make autoconf automake libtool bison flex rsync lynx
 #TODO use bitkeeper repo from http://bk.ntp.org
+#or wait for update of RUN rsync -a archive.ntp.org::ntp-dev-src ntp-dev-src
 ADD http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-dev/ntp-dev-4.3.99.tar.gz ntp-dev.tar.gz
 WORKDIR $SRC
 COPY build.sh $SRC/

--- a/projects/ntp/build.sh
+++ b/projects/ntp/build.sh
@@ -18,7 +18,9 @@
 tar -xvf ntp-dev.tar.gz
 cd ntp-dev-4.3.99
 git apply ../patch.diff
-autoreconf -i
+#avoids https://bugs.llvm.org/show_bug.cgi?id=34636
+cp /usr/bin/ld.gold /usr/bin/ld
+./bootstrap
 ./configure --enable-fuzztargets
 make
 cp tests/fuzz/fuzz_ntpd_receive $OUT/


### PR DESCRIPTION
And I have a question remaining :

This works locally, but does not seem to work on oss-fuzz machines because we do not manage to create the listening ntpd sockets listening (ie the ntpd function `open_socket` errors)
Cf
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=16244
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=16773

How can I debug this ?
I do not see any limitations here https://github.com/google/oss-fuzz/blob/master/docs/further-reading/fuzzer_environment.md