### PR TITLE
ffmpeg: Add JB from VideoLan

### DIFF
--- a/projects/ffmpeg/project.yaml
+++ b/projects/ffmpeg/project.yaml
@@ -5,4 +5,5 @@ auto_ccs:
  - "jrummell@google.com"
  - "tfoucu@google.com"
  - "cdiehl@mozilla.com"
+ - "kempfjb@gmail.com"
 selective_unpack: true


### PR DESCRIPTION
Video Lan is using also ffmpeg and need to get access to the security issue from ffmpeg.