### PR TITLE
ffmpeg: Remove external Encoder libraries

### DIFF
--- a/projects/ffmpeg/Dockerfile
+++ b/projects/ffmpeg/Dockerfile
@@ -29,7 +29,6 @@ RUN git clone https://git.ffmpeg.org/ffmpeg.git ffmpeg
 RUN wget https://www.alsa-project.org/files/pub/lib/alsa-lib-1.1.0.tar.bz2
 RUN git clone --depth 1 git://anongit.freedesktop.org/mesa/drm
 RUN git clone --depth 1 https://github.com/mstorsjo/fdk-aac.git
-ADD https://sourceforge.net/projects/lame/files/latest/download lame.tar.gz
 RUN git clone --depth 1 git://anongit.freedesktop.org/xorg/lib/libXext
 RUN git clone --depth 1 git://anongit.freedesktop.org/git/xorg/lib/libXfixes
 RUN git clone --depth 1 https://github.com/01org/libva
@@ -39,7 +38,5 @@ RUN git clone --depth 1 git://git.xiph.org/ogg.git
 RUN git clone --depth 1 git://git.xiph.org/opus.git
 RUN git clone --depth 1 git://git.xiph.org/theora.git
 RUN git clone --depth 1 git://git.xiph.org/vorbis.git
-RUN git clone --depth 1 git://git.videolan.org/git/x264.git
-RUN hg clone https://bitbucket.org/multicoreware/x265
 
 COPY build.sh group_seed_corpus.py $SRC/

--- a/projects/ffmpeg/build.sh
+++ b/projects/ffmpeg/build.sh
@@ -51,14 +51,6 @@ make clean
 make -j$(nproc) all
 make install
 
-cd $SRC
-tar xzf lame.tar.gz
-cd lame-*
-./configure --prefix="$FFMPEG_DEPS_PATH" --enable-static
-make clean
-make -j$(nproc)
-make install
-
 cd $SRC/libXext
 ./autogen.sh
 ./configure --prefix="$FFMPEG_DEPS_PATH" --enable-static
@@ -129,23 +121,6 @@ make clean
 make -j$(nproc)
 make install
 
-cd $SRC/x264
-LDFLAGS="$CXXFLAGS" ./configure --prefix="$FFMPEG_DEPS_PATH" \
-    --enable-static
-make clean
-make -j$(nproc)
-make install
-
-cd $SRC/x265/build/linux
-cmake -G "Unix Makefiles" \
-    -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX \
-    -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
-    -DCMAKE_INSTALL_PREFIX="$FFMPEG_DEPS_PATH" -DENABLE_SHARED:bool=off \
-    ../../source
-make clean
-make -j$(nproc) x265-static
-make install
-
 # Remove shared libraries to avoid accidental linking against them.
 rm $FFMPEG_DEPS_PATH/lib/*.so
 rm $FFMPEG_DEPS_PATH/lib/*.so.*
@@ -165,13 +140,10 @@ PKG_CONFIG_PATH="$FFMPEG_DEPS_PATH/lib/pkgconfig" ./configure \
     --enable-libass \
     --enable-libfdk-aac \
     --enable-libfreetype \
-    --enable-libmp3lame \
     --enable-libopus \
     --enable-libtheora \
     --enable-libvorbis \
     --enable-libvpx \
-    --enable-libx264 \
-    --enable-libx265 \
     --enable-nonfree \
     --disable-muxers \
     --disable-protocols \


### PR DESCRIPTION
The fuzzer is testing demuxer and decoding.
No need to build and link external encoder libraries for now.