### PR TITLE
Use previous chromium clang

### DIFF
--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -47,7 +47,7 @@ cd $SRC/chromium_tools
 git clone https://chromium.googlesource.com/chromium/src/tools/clang
 cd clang
 
-OUR_LLVM_REVISION=359254  # For manual bumping.
+OUR_LLVM_REVISION=365097  # For manual bumping.
 FORCE_OUR_REVISION=1  # To allow for manual downgrades.
 LLVM_REVISION=$(grep -Po "CLANG_SVN_REVISION = '\K\d+(?=')" scripts/update.py)
 

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -48,7 +48,7 @@ git clone https://chromium.googlesource.com/chromium/src/tools/clang
 cd clang
 
 OUR_LLVM_REVISION=359254  # For manual bumping.
-FORCE_OUR_REVISION=0  # To allow for manual downgrades.
+FORCE_OUR_REVISION=1  # To allow for manual downgrades.
 LLVM_REVISION=$(grep -Po "CLANG_SVN_REVISION = '\K\d+(?=')" scripts/update.py)
 
 if [ $OUR_LLVM_REVISION -gt $LLVM_REVISION ] || [ $FORCE_OUR_REVISION -ne 0 ]; then


### PR DESCRIPTION
New roll breaks skia (and maybe others): https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=16777