### PR TITLE
Use latest developements for ntp project

### DIFF
--- a/projects/ntp/Dockerfile
+++ b/projects/ntp/Dockerfile
@@ -17,9 +17,11 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER security@ntp.org
 RUN apt-get update && apt-get install -y make autoconf automake libtool bison flex rsync lynx
-#TODO use bitkeeper repo from http://bk.ntp.org
-#or wait for update of RUN rsync -a archive.ntp.org::ntp-dev-src ntp-dev-src
-ADD http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-dev/ntp-dev-4.3.99.tar.gz ntp-dev.tar.gz
+ADD https://www.bitkeeper.org/downloads/7.3.3/bk-7.3.3-x86_64-glibc213-linux.bin bk-7.3.3-x86_64-glibc213-linux.bin
+RUN chmod +x bk-7.3.3-x86_64-glibc213-linux.bin
+RUN ./bk-7.3.3-x86_64-glibc213-linux.bin /usr/local/bitkeeper
+RUN ln -s /usr/local/bitkeeper/bk /usr/local/bin/bk
+RUN bk clone http://bk.ntp.org/ntp-dev
 WORKDIR $SRC
 COPY build.sh $SRC/
 COPY patch.diff $SRC/

--- a/projects/ntp/build.sh
+++ b/projects/ntp/build.sh
@@ -15,8 +15,7 @@
 #
 ################################################################################
 
-tar -xvf ntp-dev.tar.gz
-cd ntp-dev-4.3.99
+cd ntp-dev
 git apply ../patch.diff
 #avoids https://bugs.llvm.org/show_bug.cgi?id=34636
 cp /usr/bin/ld.gold /usr/bin/ld


### PR DESCRIPTION
First version was using a immutable archive.
Now, we get the latest commit with bitkeeper