### PR TITLE
dav1d: adapt build to upstream changes

### DIFF
--- a/projects/dav1d/build.sh
+++ b/projects/dav1d/build.sh
@@ -23,15 +23,8 @@ rm -rf ${build}
 mkdir -p ${build}
 
 # build library
-BUILD_ASM="true"
 
-# MemorySanitizer may report false positives if used with asm code.
-if [[ $CFLAGS = *sanitize=memory* ]]
-then
-  BUILD_ASM="false"
-fi
-
-meson -Dbuild_asm=$BUILD_ASM -Dbuild_tools=false -Dfuzzing_engine=oss-fuzz \
+meson -Denable_tools=false -Dfuzzing_engine=oss-fuzz \
       -Db_lundef=false -Ddefault_library=static -Dbuildtype=debugoptimized \
       -Dlogging=false -Dfuzzer_ldflags=$LIB_FUZZING_ENGINE \
       ${build}


### PR DESCRIPTION
dav1d renamed the options build_asm and build_tools. build_asm=false
is no longer needed since the upstream fuzzer target disables the asm
code path when it runs under memory sanitizer.
Use enable_tools=false to skip building the dav1d CLI tools.