### PR TITLE
[picotls] Remove ASN-1/minicrypto backend fuzzer

### DIFF
--- a/projects/picotls/build.sh
+++ b/projects/picotls/build.sh
@@ -18,7 +18,8 @@
 pushd $SRC/picotls
 cmake -DBUILD_FUZZER=ON -DOSS_FUZZ=ON .
 make
-cp ./fuzz-* $OUT/
+cp ./fuzz-client-hello $OUT/
+cp ./fuzz-server-hello $OUT/
 
 zip -jr $OUT/fuzz-client-hello_seed_corpus.zip $SRC/picotls/fuzz/fuzz-client-hello-corpus
 zip -jr $OUT/fuzz-server-hello_seed_corpus.zip $SRC/picotls/fuzz/fuzz-server-hello-corpus


### PR DESCRIPTION
I discussed [oss-fuzz bug 15127](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=15127) with the picotls team. The group decided that the minicrypto backend that is exercised by the ASN-1 fuzz target will be treated as "experimental," and that we should not devote time and fuzzing resources to it for the time being. So, this PR disables the ASN-1 fuzz target accordingly.

/cc @kazuho