### PR TITLE
Use $LIB_FUZZING_ENGINE instead of -lFuzzingEngine in 4 different projects

### DIFF
--- a/projects/golang/build.sh
+++ b/projects/golang/build.sh
@@ -5,7 +5,7 @@ function compile_fuzzer {
     go-fuzz-build -libfuzzer -o $fuzzer.a github.com/dvyukov/go-fuzz-corpus/$fuzzer
 
     # Instrumented, compiled Go ($fuzzer.a) + libFuzzer = fuzzer binary
-    $CXX $CXXFLAGS -lFuzzingEngine $fuzzer.a -lpthread -o fuzzer-$fuzzer
+    $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -lpthread -o fuzzer-$fuzzer
 
     # Copy the fuzzer binary
     cp fuzzer-$fuzzer $OUT

--- a/projects/libpcap/build.sh
+++ b/projects/libpcap/build.sh
@@ -28,7 +28,7 @@ make
 for target in pcap filter both
 do
     $CC $CFLAGS -I.. -c ../testprogs/fuzz/fuzz_$target.c -o fuzz_$target.o
-    $CXX $CXXFLAGS fuzz_$target.o -o $OUT/fuzz_$target libpcap.a -lFuzzingEngine
+    $CXX $CXXFLAGS fuzz_$target.o -o $OUT/fuzz_$target libpcap.a $LIB_FUZZING_ENGINE
 done
 
 # export other associated stuff

--- a/projects/libvips/build.sh
+++ b/projects/libvips/build.sh
@@ -126,7 +126,7 @@ for fuzzer in fuzz/*_fuzzer.cc; do
     $WORK/lib/libwebpdemux.a \
     $WORK/lib/libwebp.a \
     $WORK/lib/libtiff.a \
-    -lFuzzingEngine \
+    $LIB_FUZZING_ENGINE \
     -Wl,-Bstatic \
     -lfftw3 -lgmodule-2.0 -lgobject-2.0 -lffi -lglib-2.0 -lpcre -lexpat \
     -Wl,-Bdynamic -pthread

--- a/projects/unicorn/build.sh
+++ b/projects/unicorn/build.sh
@@ -25,7 +25,7 @@ ls fuzz_*.c | cut -d_ -f2-4 | cut -d. -f1 | while read target
 do
     $CC $CFLAGS -I../../include -c fuzz_$target.c -o fuzz_$target.o
 
-    $CXX $CXXFLAGS fuzz_$target.o -o $OUT/fuzz_$target ../../libunicorn.a -lFuzzingEngine
+    $CXX $CXXFLAGS fuzz_$target.o -o $OUT/fuzz_$target ../../libunicorn.a $LIB_FUZZING_ENGINE
 
     # TODO corpuses
     cp fuzz_emu.options $OUT/fuzz_$target.options


### PR DESCRIPTION
Switch to more performant builds of libFuzzer (see #2164).
Projects were tested locally.