### PR TITLE
gRPC improvements

### DIFF
--- a/projects/grpc/Dockerfile
+++ b/projects/grpc/Dockerfile
@@ -43,12 +43,6 @@ RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 t
 #========================
 # Bazel installation
 
-ENV DISABLE_BAZEL_WRAPPER 1
-
-RUN apt-get update && apt-get install -y wget && apt-get clean
-RUN wget -q https://github.com/bazelbuild/bazel/releases/download/0.26.0/bazel-0.26.0-linux-x86_64 -O /usr/local/bin/bazel
-RUN chmod 755 /usr/local/bin/bazel
-
 RUN git clone --recursive https://github.com/grpc/grpc grpc
 WORKDIR $SRC/grpc/
 COPY build.sh $SRC/


### PR DESCRIPTION
- Use grpc internal script to decide which version of bazel to use, this will not require changing bazel version in the future
- Add a missing fuzzer
- Fix coverage build