### PR TITLE
[GraphicsFuzz-spirv] Disable since project can't run without Java

### DIFF
--- a/projects/graphicsfuzz-spirv/project.yaml
+++ b/projects/graphicsfuzz-spirv/project.yaml
@@ -15,3 +15,5 @@ sanitizers:
 architectures:
   - x86_64
   - i386
+
+disabled: True


### PR DESCRIPTION
May delete entirely if we can't run this in OSS-Fuzz.
(Though the build set up is very convenient and can probably be reused by whatever system we do go with).