### PR TITLE
[Firefox] Remove redundant environment variables

### DIFF
--- a/projects/firefox/target.c
+++ b/projects/firefox/target.c
@@ -38,8 +38,6 @@ int main(int argc, char* argv[]) {
   // Expects LD_LIBRARY_PATH to not also be set by oss-fuzz.
   setenv("LD_LIBRARY_PATH", ld_path, 0);
   setenv("HOME", "/tmp", 0);
-  setenv("MOZ_RUN_GTEST", "1", 1);
-  setenv("LIBFUZZER", "1", 1);
   setenv("FUZZER", STRINGIFY(FUZZ_TARGET), 1);
 
   // ContentParentIPC

--- a/projects/spidermonkey-ufi/target.c
+++ b/projects/spidermonkey-ufi/target.c
@@ -38,7 +38,6 @@ int main(int argc, char* argv[]) {
   // Expects LD_LIBRARY_PATH to also be set by oss-fuzz.
   setenv("LD_LIBRARY_PATH", ld_path, 0);
   setenv("HOME", "/tmp", 0);
-  setenv("LIBFUZZER", "1", 1);
   setenv("FUZZER", STRINGIFY(FUZZ_TARGET), 1);
 
   char* options = getenv("ASAN_OPTIONS");


### PR DESCRIPTION
Adjustments due to: [Simplify required environment variables for fuzzing interface](https://bugzilla.mozilla.org/show_bug.cgi?id=1580128)