### PR TITLE
mpg123: limit fuzzer runtime

### DIFF
--- a/projects/mpg123/decode_fuzzer.cc
+++ b/projects/mpg123/decode_fuzzer.cc
@@ -36,7 +36,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   FuzzedDataProvider provider(data, size);
   while ((decode_ret != MPG123_ERR)) {
     if (decode_ret == MPG123_NEED_MORE) {
-      if (provider.remaining_bytes() == 0) {
+      if (provider.remaining_bytes() == 0
+          || mpg123_tellframe(handle) > 10000
+          || mpg123_tell_stream(handle) > 1<<20) {
         break;
       }
       const size_t next_size = provider.ConsumeIntegralInRange<size_t>(

--- a/projects/mpg123/read_fuzzer.c
+++ b/projects/mpg123/read_fuzzer.c
@@ -75,7 +75,8 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     do {
       size_t decoded_size;
       read_error = mpg123_read(handle, outmemory, outmemorysize, &decoded_size);
-    } while (read_error == MPG123_OK);
+    } while (read_error == MPG123_OK && mpg123_tellframe(handle) <= 10000
+          && mpg123_tell_stream(handle) <= 1<<20);
   }
 
   mpg123_close(handle);


### PR DESCRIPTION
As suggested in oss-fuzz issue 16671, I propose limiting the data parsed
by the fuzzer targets to avoid spurious timeout reports just because there
was too much input data. I chose 10000 frames (corresponding to a
typical radio track, if it's intact frames) and 1 MiB of stream size as limits.

The problematical case was 144k of bad frames, where the attempt
to decode them (even aborting early in the decoder and filling with zeroes)
triggered the timeout.