### PR TITLE
[cryptofuzz] Compile OpenSSL 1.0.2/noasm with -DPURIFY

### DIFF
--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -497,7 +497,7 @@ cd $SRC/openssl-OpenSSL_1_0_2-stable/
 make clean || true
 if [[ $CFLAGS != *-m32* ]]
 then
-    ./config --debug no-asm enable-md2 enable-rc5 $CFLAGS
+    ./config --debug no-asm enable-md2 enable-rc5 $CFLAGS -DPURIFY
 else
     setarch i386 ./config --debug no-asm enable-md2 enable-rc5 $CFLAGS
 fi


### PR DESCRIPTION
This prevents MSAN false positives in its bignum code.

Needed because I will soon add elliptic curve cryptography to Cryptofuzz (https://github.com/guidovranken/cryptofuzz/tree/ecc_ecdsa).