### PR TITLE
Switch email address to use gmail

### DIFF
--- a/projects/php/project.yaml
+++ b/projects/php/project.yaml
@@ -2,7 +2,7 @@ homepage: "http://php.net/"
 primary_contact: "stas@php.net"
 auto_ccs:
  - "smalyshev@gmail.com"
- - "nikic@php.net"
+ - "nikita.ppv@gmail.com"
 sanitizers:
  - address
  - undefined


### PR DESCRIPTION
Switch auto_ccs entry to my gmail address, as authentication in the bug tracker does not work otherwise.