### PR TITLE
Add htslib project files

### DIFF
--- a/projects/htslib/Dockerfile
+++ b/projects/htslib/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER rmd@sanger.ac.uk
+RUN apt-get update && apt-get install -y make autoconf automake zlib1g-dev libbz2-dev liblzma-dev libcurl4-gnutls-dev libssl-dev
+RUN git clone --depth 1 https://github.com/samtools/htslib.git htslib
+WORKDIR htslib
+COPY build.sh $SRC/

--- a/projects/htslib/build.sh
+++ b/projects/htslib/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -eu
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# build project
+autoconf
+autoheader
+./configure
+make -j$(nproc) libhts.a test/fuzz/hts_open_fuzzer.o
+
+# build fuzzers
+$CXX $CXXFLAGS -o "$OUT/hts_open_fuzzer" test/fuzz/hts_open_fuzzer.o -lFuzzingEngine libhts.a -lz -lbz2 -llzma -lcurl -lcrypto -lpthread

--- a/projects/htslib/build.sh
+++ b/projects/htslib/build.sh
@@ -22,4 +22,4 @@ autoheader
 make -j$(nproc) libhts.a test/fuzz/hts_open_fuzzer.o
 
 # build fuzzers
-$CXX $CXXFLAGS -o "$OUT/hts_open_fuzzer" test/fuzz/hts_open_fuzzer.o -lFuzzingEngine libhts.a -lz -lbz2 -llzma -lcurl -lcrypto -lpthread
+$CXX $CXXFLAGS -o "$OUT/hts_open_fuzzer" test/fuzz/hts_open_fuzzer.o $LIB_FUZZING_ENGINE libhts.a -lz -lbz2 -llzma -lcurl -lcrypto -lpthread

--- a/projects/htslib/project.yaml
+++ b/projects/htslib/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://www.htslib.org/"
+primary_contact: "rmd@sanger.ac.uk"
+auto_ccs:
+        - "aw7@sanger.ac.uk"
+        - "jkb@sanger.ac.uk"
+        - "vo2@sanger.ac.uk"


### PR DESCRIPTION
Only builds the library and `hts_open_fuzzer.o`.  The binaries are not needed and fail to build anyway due to missing libfuzzer symbols.

Fixes samtools/htslib#888
