### PR TITLE
Solidity: Use release build

### DIFF
--- a/projects/solidity/build.sh
+++ b/projects/solidity/build.sh
@@ -31,7 +31,9 @@ cd build
 rm -rf *
 
 # Build solidity
-cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/ossfuzz.cmake $SRC/solidity
+cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/ossfuzz.cmake \
+      -DCMAKE_BUILD_TYPE=Release \
+      $SRC/solidity
 make ossfuzz ossfuzz_proto ossfuzz_abiv2 -j $(nproc)
 
 # Copy fuzzer binary, seed corpus, fuzzer options, and dictionary


### PR DESCRIPTION
Took out cmake directive to build release binary in #2841  by mistake, but later was left wondering what is the right thing to do.

Switching back to release build after confirmation from @inferno-chromium (see https://github.com/google/oss-fuzz/issues/2846#issuecomment-532701182) that this is the right thing to do