### PR TITLE
Use travis_wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,4 +48,5 @@ matrix:
         - TRAVIS_SANITIZER=dataflow
         - TRAVIS_ARCHITECTURE=x86_64
 
-script: ./infra/travis/travis_build.py
+# Use travis_wait to allow up to 30 minutes with no log output.
+script: travis_wait 30 ./infra/travis/travis_build.py


### PR DESCRIPTION
Allow projects to go up to 30 minutes without outputting anything before being killed.
~20 projects take longer than 30 minutes to build on jenkins so it seem this will catch most cases of the problem.