### PR TITLE
Remove fuzzing_engines specification for proxygen.

### DIFF
--- a/projects/proxygen/project.yaml
+++ b/projects/proxygen/project.yaml
@@ -6,9 +6,6 @@ auto_ccs:
   - "lniccolini@fb.com"
 vendor_ccs:
   - "oss-fuzz@fb.com"
-fuzzing_engines:
-  - libfuzzer
-  - afl
 sanitizers:
   - address
   - undefined


### PR DESCRIPTION
This addresses review comments from #2856