### PR TITLE
Disable AFL

### DIFF
--- a/projects/proxygen/project.yaml
+++ b/projects/proxygen/project.yaml
@@ -6,6 +6,9 @@ auto_ccs:
   - "lniccolini@fb.com"
 vendor_ccs:
   - "oss-fuzz@fb.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
 sanitizers:
   - address
   - undefined

--- a/projects/proxygen/project.yaml
+++ b/projects/proxygen/project.yaml
@@ -8,7 +8,6 @@ vendor_ccs:
   - "oss-fuzz@fb.com"
 fuzzing_engines:
   - libfuzzer
-  - afl
 sanitizers:
   - address
   - undefined


### PR DESCRIPTION
@mhlakhani: AFL build is [failing](https://oss-fuzz-build-logs.storage.googleapis.com/index.html#proxygen). It says because binary isn't instrumented. I find this surprising because you are using $LIB_FUZZING_ENGINE and not -fsanitize=fuzzer directly.

@oliverchang Is it possible that state is preserved from one build to another?