### PR TITLE
Uninstall packages not used on bots

### DIFF
--- a/infra/base-images/base-runner/Dockerfile
+++ b/infra/base-images/base-runner/Dockerfile
@@ -17,14 +17,10 @@
 FROM gcr.io/oss-fuzz-base/base-image
 MAINTAINER mike.aizatsky@gmail.com
 RUN apt-get install -y \
-    binutils \
     file \
-    fonts-dejavu \
     git \
-    libblocksruntime0 \
     libc6-dev-i386 \
     libcap2 \
-    libunwind8 \
     python3 \
     python3-pip \
     wget \


### PR DESCRIPTION
There are honggfuzz deps. We don't have these on the bots so they can cause fuzzers to spuriously pass bad_build_check (see #2856)