### PR TITLE
[proxygen] Re-enable AFL; change build script to put libunwind in the…

### DIFF
--- a/projects/proxygen/Dockerfile
+++ b/projects/proxygen/Dockerfile
@@ -134,6 +134,9 @@ RUN apt-get install -y \
     libsodium-dev \
     libdouble-conversion-dev
 
+# Install patchelf so we can fix path to libunwind
+RUN apt-get install patchelf
+
 # Fetch source and copy over files
 RUN git clone --depth 1 https://github.com/facebook/proxygen.git proxygen
 WORKDIR proxygen

--- a/projects/proxygen/build.sh
+++ b/projects/proxygen/build.sh
@@ -16,8 +16,19 @@
 ################################################################################
 
 cd proxygen
+
+# Link to, and copy over, libunwind
 # We need to link to libunwind to ensure exception handling works
 # See https://clang.llvm.org/docs/Toolchain.html#unwind-library
 export LDFLAGS="-lunwind"
+mkdir -p $OUT/lib
+cp /usr/lib/x86_64-linux-gnu/libunwind.so.8 $OUT/lib/
+
+# Build everything
 ./build.sh -m --no-install-dependencies --build-for-fuzzing
+
+# Patch rpath so fuzzers can find libunwind
+find ./_build/proxygen/fuzzers -type f -executable -exec patchelf --set-rpath "$OUT/lib" {} \;
+
+# Copy fuzzers over to the destination
 find ./_build/proxygen/fuzzers -type f -executable -exec cp {} $OUT/ \;

--- a/projects/proxygen/project.yaml
+++ b/projects/proxygen/project.yaml
@@ -8,6 +8,7 @@ vendor_ccs:
   - "oss-fuzz@fb.com"
 fuzzing_engines:
   - libfuzzer
+  - afl
 sanitizers:
   - address
   - undefined


### PR DESCRIPTION
… generated directory and make the fuzzer find it

I'm re-enabling AFL since the issue with gmock's main being present was fixed in https://github.com/facebook/proxygen/commit/e8616a31f4df1486a522dde62fd337ae0d4e87e9

This libunwind changes solve the issues we were seeing with the fuzzers not running in the clusterfuzz bot environment. What this PR does, roughly:

* Copy the .so from the build image into `/out/lib`
* Patch the binaries so they have an rpath which specifies looking in `/out/lib` for libraries in addition to the normal search path

This will work *assuming* `/out/lib` is copied over in the bot environment and is available. I'm relying on code reviewers to let me know if this is true or not. If not, it should be an easy path update.

Test plan:

Verifying the AFL build was easy:

    python infra/helper.py build_fuzzers --sanitizer address --engine afl proxygen
    python infra/helper.py check_build --engine afl proxygen
    python infra/helper.py run_fuzzer --engine afl proxygen ProxygenHTTP1xFuzzer

I verified the libunwind changes by using the shell command (thanks for the tip, didn't know that was there!).

I first built the binary using this build script.

I then used `python infra/helper.py shell --sanitizer address proxygen`

In the shell, I:

* Ran `/out/ProxygenHTTP1xFuzzer` and verified it worked
* Ran `ldd` on it and showed it pointed to `/out/lib` for `libunwind.so.8`
* Uninstalled libunwind
* Verified it still worked
* Used `patchelf --print-rpath ProxygenHTTP1xFuzzer` to verify that the rpath was set as I expected (inside `/out/lib`)
* Removed the patch using `patchelf --remove-rpath to_patch`
* Verified that the fuzzer no longer runs (crashes on startup, complaining about missing `libunwind.so.8`)
* I verified that the binary still finds the system one if rpath isn't set, by reinstalling it, using `patchelf --print-rpath` again, verifying that it prints the path to the system `libunwind` when I run `ldd`, and that the fuzzer runs fine. This implies it can find other system libraries fine too (and I saw that in the `ldd` output)

I don't think I can do any further testing, so we will just have to hope that this works in the bot environment.