### PR TITLE
[ffmpeg] Add my main email address to the CC

### DIFF
--- a/projects/ffmpeg/project.yaml
+++ b/projects/ffmpeg/project.yaml
@@ -2,6 +2,7 @@ homepage: "https://www.ffmpeg.org/"
 primary_contact: "ffmpeg-security@ffmpeg.org"
 auto_ccs:
  - "michaelni@gmx.at"
+ - "michael@niedermayer.cc"
  - "jrummell@google.com"
  - "tfoucu@google.com"
  - "cdiehl@mozilla.com"


### PR DESCRIPTION
It seems mails from ossfuzz are not reliably received on *gmx
(that is michaelni@gmx.at in my case)
They sometimes appear days later or not at all.

Signed-off-by: Michael Niedermayer <michaelni@gmx.at>