### PR TITLE
[crc32c] Add to oss-fuzz

### DIFF
--- a/projects/crc32c/Dockerfile
+++ b/projects/crc32c/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER bshas3@gmail.com
+RUN apt-get update && apt-get install -y make autoconf automake libtool \
+    cmake
+RUN git clone -b libfuzzer --recursive https://github.com/bshastry/crc32c.git crc32c
+WORKDIR crc32c
+COPY build.sh $SRC/

--- a/projects/crc32c/build.sh
+++ b/projects/crc32c/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -eu
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# build project
+mkdir -p build;
+cd build;
+cmake .. -DCRC32C_FUZZING_BUILD=ON -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SHARED_LIBS=OFF -DCRC32C_USE_GLOG=OFF;
+
+# build fuzzers
+make crc32c_fuzzer;
+cp crc32c_fuzzer $OUT

--- a/projects/crc32c/project.yaml
+++ b/projects/crc32c/project.yaml
@@ -1,0 +1,13 @@
+homepage: "https://github.com/google/crc32c"
+primary_contact: "vadim.skipin@gmail.com"
+vendor_ccs:
+  - "Fangming.Fang@arm.com"
+auto_ccs:
+  - "bshas3@gmail.com"
+sanitizers:
+  - address
+  - memory
+  - undefined
+architectures:
+  - x86_64
+  - i386


### PR DESCRIPTION
Dear all

PR
- Depends on https://github.com/google/crc32c/pull/38
- `check_build` fails because there are `<100 PCs` (crc32c is a pretty small library). Making PR in any case because the library is marked security critical (see https://chromium.googlesource.com/chromium/src/+/master/third_party/crc32c/README.chromium#7)

CC @inferno-chromium @Dor1s 
