### PR TITLE
use updated version of cmake

### DIFF
--- a/projects/envoy/Dockerfile
+++ b/projects/envoy/Dockerfile
@@ -25,7 +25,6 @@ RUN apt-get update && apt-get -y install  \
     curl            \
     autoconf        \
     libtool         \
-    cmake           \
     wget            \
     golang          \
     python
@@ -34,6 +33,11 @@ RUN apt-get update && apt-get -y install  \
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
 RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
 RUN apt-get update && apt-get install -y bazel
+
+# Install cmake
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.14.5/cmake-3.14.5-Linux-x86_64.sh; \
+    chmod +x cmake-3.14.5-Linux-x86_64.sh; \
+    ./cmake-3.14.5-Linux-x86_64.sh --skip-license --prefix="/usr/local"
 
 RUN git clone https://github.com/envoyproxy/envoy.git
 WORKDIR $SRC/envoy/


### PR DESCRIPTION
Installs CMake 3.14. 

Our Envoy fuzz build is failing at "ln: File exists" symlink error on our foreign cc builds. This updates CMake so that we are using a version with updated `symlink_to_dir` functions. Related, making a change to update our rules_foreign_cc version upstream (https://github.com/envoyproxy/envoy/pull/8330). 
@irengrig

Signed-off-by: Asra Ali <asraa@google.com>