### PR TITLE
wds: Add to oss-fuzz

### DIFF
--- a/projects/wds/Dockerfile
+++ b/projects/wds/Dockerfile
@@ -1,0 +1,43 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER bshas3@gmail.com
+RUN apt-get update && apt-get install -y make autoconf automake libtool \
+    flex bison build-essential \
+    autopoint pkg-config gettext libffi-dev liblzma-dev \
+    libvorbis-dev libtheora-dev libogg-dev zlib1g-dev cmake
+RUN git clone --depth 1 -b ossfuzz https://github.com/bshastry/wds.git wds
+
+# Install static glib
+ADD https://ftp.gnome.org/pub/gnome/sources/glib/2.54/glib-2.54.2.tar.xz $SRC 
+RUN tar xvJf $SRC/glib-2.54.2.tar.xz -C /usr/src; \
+  cd /usr/src/glib-2.54.2; \
+  ./configure --prefix=/usr --enable-static --disable-shared --disable-libmount --with-pcre=internal; \
+  make -j; \
+  make install; \
+  rm -rf /usr/src/glib-2.54.2;
+
+# Install static gstreamer lib
+RUN git clone --depth 1 --recursive https://anongit.freedesktop.org/git/gstreamer/gstreamer /usr/src/gstreamer; \
+  mkdir -p build-gstreamer; \
+  cd build-gstreamer; \
+  /usr/src/gstreamer/autogen.sh --prefix=/usr --disable-shared --enable-static --disable-examples --disable-gtk-doc --disable-introspection --enable-static-plugins --disable-gst-tracer-hooks --disable-registry; \
+  make -j; \
+  make install; \
+  rm -rf /usr/src/gstreamer; 
+WORKDIR wds
+COPY build.sh $SRC/

--- a/projects/wds/build.sh
+++ b/projects/wds/build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -eu
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# build project
+mkdir -p build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="${CXXFLAGS}" -DWDS_OSSFUZZ=ON ..
+make libwds_rtsp_fuzzer
+
+# Copy fuzzer, dictionary and fuzzer options
+cp fuzz/libwds_rtsp_fuzzer $OUT
+rm -f $OUT/libwds_rtsp_fuzzer.dict
+for f in $SRC/wds/libwds/rtsp/tests/dict/*.dict;
+do
+  (cat "${f}"; echo) >> $OUT/libwds_rtsp_fuzzer.dict;
+done
+cat <<EOF >>$OUT/libwds_rtsp_fuzzer.options
+[libfuzzer]
+close_fd_mask = 3
+EOF

--- a/projects/wds/project.yaml
+++ b/projects/wds/project.yaml
@@ -1,0 +1,4 @@
+homepage: "https://github.com/intel/wds"
+primary_contact: "<primary_contact_email>"
+auto_ccs:
+  - "bshas3@gmail.com"


### PR DESCRIPTION
Depends on https://github.com/intel/wds/pull/190

Notes: 

If upstream pr is merged, then
  - change git repo url
  - add primary contact 

- wds is marked as a security critical dependency (https://github.com/chromium/chromium/blob/3a7f438e9ed78b555a3742987a96ebd48211bd69/third_party/wds/README.chromium#L6)
- Intel repo already contained fuzzers for real time streaming protocol parsing
- These fuzzers have been ported to a single libfuzzer style target
- A single dictionary file has been created by concatenating Intel's existing fuzzing dictionaries 