### PR TITLE
[infra] Use fuzz target basename in the coverage script.

### DIFF
--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -19,7 +19,7 @@ cd $OUT
 if (( $# > 0 )); then
   FUZZ_TARGETS="$@"
 else
-  FUZZ_TARGETS="$(find . -maxdepth 1 -type f -executable)"
+  FUZZ_TARGETS="$(find . -maxdepth 1 -type f -executable -printf '%P\n')"
 fi
 
 DUMPS_DIR="$OUT/dumps"


### PR DESCRIPTION
Noticed this while debugging #2892. Shouldn't be a big problem in general, but might lead to some instability for projects with many fuzz targets (maybe not).