### PR TITLE
[php] Enable i386 architecture

### DIFF
--- a/projects/php/Dockerfile
+++ b/projects/php/Dockerfile
@@ -16,11 +16,9 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER stas@php.net
-RUN apt-get update && apt-get install -y make autoconf automake libtool bison re2c make ca-certificates curl \
-	xz-utils dpkg-dev file libc-dev pkg-config libcurl4-openssl-dev libedit-dev libsqlite3-dev libssl-dev \
-	zlib1g-dev chrpath
-ADD cosmic.list /etc/apt/sources.list.d/cosmic.list
-RUN apt-get update && apt-get install -y libonig5 libonig-dev
+RUN apt-get update && \
+    apt-get install -y autoconf automake libtool bison re2c pkg-config
 RUN git clone --depth 1 --branch master https://github.com/php/php-src.git php-src
+RUN git clone https://github.com/kkos/oniguruma.git php-src/oniguruma
 WORKDIR php-src
 COPY build.sh *.options $SRC/

--- a/projects/php/project.yaml
+++ b/projects/php/project.yaml
@@ -6,3 +6,6 @@ auto_ccs:
 sanitizers:
  - address
  - undefined
+architectures:
+ - x86_64
+ - i386


### PR DESCRIPTION
This enables the i386 architecture for the PHP fuzzers.

To make that simpler, I've cut down the build to have less unnecessary dependencies -- there's no need to build a load of extensions that we aren't fuzzing.

Additionally I'm compiling and statically linking libonig from upstream now. This is better in any case because the library will be instrumented, and it also means I don't have to figure out how to get an i386 libonig from cosmic.