### PR TITLE
ovs: Fix build failure due to python3 upgrade

### DIFF
--- a/projects/openvswitch/Dockerfile
+++ b/projects/openvswitch/Dockerfile
@@ -17,9 +17,9 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER blp@ovn.org
 RUN apt-get update && apt-get install -y make autoconf automake \
-    libtool python python-pip \
+    libtool python python3-pip \
     libz-dev libssl-dev libssl1.0.0 wget
-RUN pip install six
+RUN pip3 install six
 RUN git clone --depth 1 https://github.com/openvswitch/ovs.git openvswitch
 RUN git clone --depth 1 https://github.com/openvswitch/ovs-fuzzing-corpus.git \
     ovs-fuzzing-corpus


### PR DESCRIPTION
Note: the afl build failure is a separate long standing issue that likely needs an upstream patch. merging this is recommended because it fixes the other builds that were failing due to upstream builds now using python 3 instead of python 2