### PR TITLE
Revert "[infra] Use fuzz target basename in the coverage script."

### DIFF
--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -19,7 +19,7 @@ cd $OUT
 if (( $# > 0 )); then
   FUZZ_TARGETS="$@"
 else
-  FUZZ_TARGETS="$(find . -maxdepth 1 -type f -executable -printf '%P\n')"
+  FUZZ_TARGETS="$(find . -maxdepth 1 -type f -executable)"
 fi
 
 DUMPS_DIR="$OUT/dumps"


### PR DESCRIPTION
Reverts google/oss-fuzz#2896

Apparently I haven't tested this properly and all coverage jobs have failed today.