### PR TITLE
[GDAL] Fix build due to poppler git API change

### DIFF
--- a/projects/gdal/build.sh
+++ b/projects/gdal/build.sh
@@ -111,6 +111,7 @@ fi
 cd gdal
 export LDFLAGS=${CXXFLAGS}
 PKG_CONFIG_PATH=$SRC/install/lib/pkgconfig ./configure --without-libtool --with-liblzma --with-expat --with-sqlite3 --with-xerces --with-webp --with-netcdf=$SRC/install --with-curl=$SRC/install/bin/curl-config --without-hdf5 --with-jpeg=internal --with-proj=$SRC/install --with-poppler
+sed -i "s/POPPLER_MINOR_VERSION = 81/POPPLER_MINOR_VERSION = 82/" GDALmake.opt # temporary hack until poppler 0.82 is released
 make clean -s
 make -j$(nproc) -s static-lib
 


### PR DESCRIPTION
We use a hack to pretend this is Poppler 0.82, as currently
poppler git still advertizes 0.81