### PR TITLE
go-fuzz: set explictly GO111MODULES=off

### DIFF
--- a/projects/golang/Dockerfile
+++ b/projects/golang/Dockerfile
@@ -23,4 +23,6 @@ RUN mkdir -p $GOPATH/src/github.com/dvyukov/ && \
 
 COPY build.sh $SRC/
 
+ENV GO111MODULE="off"
+
 WORKDIR $SRC/golang


### PR DESCRIPTION
This will prevent breaking OSS fuzz when go-fuzz will roll-out support for go modules
https://github.com/dvyukov/go-fuzz/issues/195

and addressing this issue:
https://github.com/google/oss-fuzz/issues/2878

cc @josharian @thepudds @Dor1s 