### PR TITLE
[osquery] Add new osquery project

### DIFF
--- a/projects/osquery/Dockerfile
+++ b/projects/osquery/Dockerfile
@@ -1,0 +1,43 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER theopolis@osquery.io
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends python python3 bison flex make wget xz-utils
+
+# Install specific git version.
+RUN export GIT_VER=2.21.0 \
+ && apt-get install -y libz-dev gettext nano libssl-dev autoconf libcurl4-openssl-dev \
+ && wget https://github.com/git/git/archive/v$GIT_VER.tar.gz \
+ && tar xf v$GIT_VER.tar.gz \
+ && cd git-$GIT_VER/ \
+ && make configure \
+ && ./configure --with-openssl \
+ && make -j4 install
+
+# Installer newer cmake
+RUN wget -q https://github.com/Kitware/CMake/releases/download/v3.14.6/cmake-3.14.6-Linux-x86_64.tar.gz
+RUN tar xf cmake-3.14.6-Linux-x86_64.tar.gz -C /usr/local --strip 1
+
+# Install build toolchain
+RUN wget https://github.com/osquery/osquery-toolchain/releases/download/1.0.0/osquery-toolchain-1.0.0.tar.xz
+RUN tar xf osquery-toolchain-1.0.0.tar.xz -C /usr/local
+
+RUN git clone --depth 1 https://github.com/osquery/osquery osquery
+
+WORKDIR osquery
+COPY build.sh $SRC/

--- a/projects/osquery/build.sh
+++ b/projects/osquery/build.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -eu
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+PROJECT=osquery
+
+# Move the project content into the current overlay.
+# CMake builtin 'rename' will attempt a hardlink.
+( cd / &&\
+  mv "${SRC}/${PROJECT}" "${SRC}/${PROJECT}-dev" &&\
+  mv "${SRC}/${PROJECT}-dev" "${SRC}/${PROJECT}" )
+
+pushd "${SRC}/${PROJECT}"
+mkdir build && pushd build
+
+export CXXFLAGS="${CXXFLAGS} -Wl,-lunwind -Wl,-lc++abi"
+export CFLAGS="${CFLAGS} -Wl,-lunwind"
+
+cmake \
+  -DOSQUERY_VERSION:string=0.0.0-fuzz \
+  -DOSQUERY_FUZZ:BOOL=ON \
+  -DOSQUERY_BUILD_TESTS:BOOL=ON \
+  -DOSQUERY_TOOLCHAIN_SYSROOT=/usr/local/osquery-toolchain \
+  ..
+cmake \
+  -DCMAKE_EXE_LINKER_FLAGS=${LIB_FUZZING_ENGINE} \
+  ..
+cmake --build . -j$(nproc) --target osqueryfuzz-config
+cp osquery/main/osqueryfuzz-config "${OUT}/osqueryfuzz-config"

--- a/projects/osquery/project.yaml
+++ b/projects/osquery/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://osquery.io"
+primary_contact: "theopolis@osquery.io"
+sanitizers:
+ - address
+fuzzing_engines:
+ - libfuzzer


### PR DESCRIPTION
This adds a single harness for osquery, focused on testing oquery's configuration parsing. This callsite is a good use-case to test all of osquery's JSON parsing. There are some instances where JSON is read from a user-controllable path.

Follow up PRs will include:
- Additional harnesses
- Dictionaries (e.g., for our additions to SQL and general JSON)
- Seeds