### PR TITLE
[mdnsd] Add new mdnsd project

### DIFF
--- a/projects/mdnsd/Dockerfile
+++ b/projects/mdnsd/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER git@s.profanter.me
+RUN apt-get update && apt-get install -y make cmake
+RUN git clone --depth 1 https://github.com/Pro/mdnsd.git -bmaster mdnsd
+WORKDIR mdnsd
+RUN git submodule update --init --recursive
+COPY build.sh $SRC/

--- a/projects/mdnsd/build.sh
+++ b/projects/mdnsd/build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -eu
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+mkdir -p $WORK/mdnsd
+cd $WORK/mdnsd
+
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DMDNSD_BUILD_OSS_FUZZ=ON \
+      $SRC/mdnsd/
+
+# This also builds all the fuzz targets and places them in the $OUT directory
+make -j
+
+# Copy the corpus, dict and options to the $OUT dir
+$SRC/mdnsd/tests/fuzz/oss-fuzz-copy.sh
+
+echo "Built all fuzzer targets."

--- a/projects/mdnsd/project.yaml
+++ b/projects/mdnsd/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/Pro/mdnsd"
+primary_contact: "Stefan.Profanter@gmail.com"
+sanitizers:
+- address
+- undefined
+- memory


### PR DESCRIPTION
As mentioned in #724 this adds the mdns project to oss-fuzz.
It's a dependency of open62541.

If possible it would be better to have mdnsd project separated. If not, then I can also include the fuzzing of mdnsd into open62541