### PR TITLE
Add project myanmar-tools

### DIFF
--- a/projects/myanmar-tools/Dockerfile
+++ b/projects/myanmar-tools/Dockerfile
@@ -20,5 +20,4 @@ RUN apt-get update && apt-get -y install \
     cmake
 RUN git clone https://github.com/google/myanmar-tools.git
 WORKDIR $SRC/myanmar-tools/clients/cpp/
-RUN mkdir build && cd build && cmake ..
 COPY build.sh $SRC/

--- a/projects/myanmar-tools/Dockerfile
+++ b/projects/myanmar-tools/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER sffc@google.com
+
+RUN apt-get update && apt-get -y install \
+    build-essential \
+    cmake
+RUN git clone https://github.com/google/myanmar-tools.git
+WORKDIR $SRC/myanmar-tools/clients/cpp/
+RUN mkdir build && cd build && cmake ..
+COPY build.sh $SRC/

--- a/projects/myanmar-tools/build.sh
+++ b/projects/myanmar-tools/build.sh
@@ -21,8 +21,7 @@ make all
 # Note: don't use the myanmartools_fuzz CMake target directly because we want
 # to link with LIB_FUZZING_ENGINE instead of the default fuzzer.
 # Copy the .so file to $OUT as well as the executable.
-rm -r $OUT/*
-mkdir $OUT/lib
+mkdir -p $OUT/lib
 cp libmyanmartools.so $OUT/lib
 $CXX $CXXFLAGS -std=c++11 -I../public -L$OUT/lib \
     -Wl,-rpath $OUT/lib -lmyanmartools \

--- a/projects/myanmar-tools/build.sh
+++ b/projects/myanmar-tools/build.sh
@@ -15,7 +15,8 @@
 cd $SRC/myanmar-tools/clients/cpp
 mkdir build
 cd build
-cmake ..
+cmake -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" \
+    -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" ..
 make all
 
 # Note: don't use the myanmartools_fuzz CMake target directly because we want

--- a/projects/myanmar-tools/build.sh
+++ b/projects/myanmar-tools/build.sh
@@ -16,7 +16,8 @@ cd $SRC/myanmar-tools/clients/cpp
 mkdir build
 cd build
 cmake -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" \
-    -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" ..
+    -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+    -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ..
 make all
 
 # Note: don't use the myanmartools_fuzz CMake target directly because we want

--- a/projects/myanmar-tools/build.sh
+++ b/projects/myanmar-tools/build.sh
@@ -12,6 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cd $SRC/myanmar-tools/clients/cpp/build
-make myanmartools_fuzz
-cp myanmartools_fuzz $OUT/
+cd $SRC/myanmar-tools/clients/cpp
+mkdir build
+cd build
+cmake ..
+make all
+
+# Note: don't use the myanmartools_fuzz CMake target directly because we want
+# to link with LIB_FUZZING_ENGINE instead of the default fuzzer.
+# Copy the .so file to $OUT as well as the executable.
+rm -r $OUT/*
+mkdir $OUT/lib
+cp libmyanmartools.so $OUT/lib
+$CXX $CXXFLAGS -std=c++11 -I../public -L$OUT/lib \
+    -Wl,-rpath $OUT/lib -lmyanmartools \
+    -o $OUT/zawgyi_detector_fuzz_target \
+    ../zawgyi_detector_fuzz_target.cpp \
+    $LIB_FUZZING_ENGINE

--- a/projects/myanmar-tools/build.sh
+++ b/projects/myanmar-tools/build.sh
@@ -1,0 +1,17 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cd $SRC/myanmar-tools/clients/cpp/build
+make myanmartools_fuzz
+cp myanmartools_fuzz $OUT/

--- a/projects/myanmar-tools/project.yaml
+++ b/projects/myanmar-tools/project.yaml
@@ -15,4 +15,4 @@
 homepage: "https://github.com/googlei18n/myanmar-tools/"
 primary_contact: "sffc@google.com"
 auto_ccs:
-  - "ccornelius@gmail.com"
+  - "ccornelius@google.com"

--- a/projects/myanmar-tools/project.yaml
+++ b/projects/myanmar-tools/project.yaml
@@ -16,3 +16,6 @@ homepage: "https://github.com/googlei18n/myanmar-tools/"
 primary_contact: "sffc@google.com"
 auto_ccs:
   - "ccornelius@google.com"
+sanitizers:
+  - address
+  - memory

--- a/projects/myanmar-tools/project.yaml
+++ b/projects/myanmar-tools/project.yaml
@@ -1,0 +1,18 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+homepage: "https://github.com/googlei18n/myanmar-tools/"
+primary_contact: "sffc@google.com"
+auto_ccs:
+  - "ccornelius@gmail.com"


### PR DESCRIPTION
I am a Googler doing this as part of go/FuzzIt.  Internal bug: b/131230415

The project I'm fuzzing is a C++ project using CMake.  I added a fuzz target on the main project in https://github.com/google/myanmar-tools/commit/d5bd06b77007a389d6a20e5c12a5a4cef72a8de4.  That fuzz target runs fine on my local machine.  I then created the build.sh and Dockerfile.

I don't think I did everything correctly; for example, I am not reading from the LIB_FUZZING_ENGINE variable.  I think cmake already automatically reads from the other environment variables.

The image builds without errors, but when I run `sudo python infra/helper.py check_build myanmar-tools`, I get an error,

> /out/myanmartools_fuzz: error while loading shared libraries: libmyanmartools.so: cannot open shared object file: No such file or directory

(The iteration cycle is several minutes long, and I've already spent much more time than expected on this today, so this is where I stopped.)