### PR TITLE
[libavc, libhevc, libmpeg2] use ossfuzz.sh from upstream project

### DIFF
--- a/projects/libavc/build.sh
+++ b/projects/libavc/build.sh
@@ -14,28 +14,5 @@
 # limitations under the License.
 #
 ################################################################################
-
-# Build libavc
-build_dir=$WORK/build
-rm -rf ${build_dir}
-mkdir -p ${build_dir}
-pushd ${build_dir}
-
-cmake $SRC/libavc
-make -j$(nproc)
-popd
-
-# build fuzzers
-$CXX $CXXFLAGS -std=c++11 \
-    -I$SRC/libavc \
-    -I$SRC/libavc/common \
-    -I$SRC/libavc/decoder \
-    -I${build_dir} \
-    -Wl,--start-group \
-    $LIB_FUZZING_ENGINE \
-    $SRC/libavc/fuzzer/avc_dec_fuzzer.cpp -o $OUT/avc_dec_fuzzer \
-    ${build_dir}/libavcdec.a \
-    -Wl,--end-group
-
-cp $SRC/avc_dec_fuzzer_seed_corpus.zip $OUT/avc_dec_fuzzer_seed_corpus.zip
-cp $SRC/libavc/fuzzer/avc_dec_fuzzer.dict $OUT/avcdec_fuzzer.dict
+# Run the OSS-Fuzz script in the project.
+$SRC/libavc/fuzzer/ossfuzz.sh

--- a/projects/libhevc/build.sh
+++ b/projects/libhevc/build.sh
@@ -14,28 +14,5 @@
 # limitations under the License.
 #
 ################################################################################
-
-# Build libhevc
-build_dir=$WORK/build
-rm -rf ${build_dir}
-mkdir -p ${build_dir}
-pushd ${build_dir}
-
-cmake $SRC/libhevc
-make -j$(nproc)
-popd
-
-# build fuzzers
-$CXX $CXXFLAGS -std=c++11 \
--I$SRC/libhevc \
--I$SRC/libhevc/common \
--I$SRC/libhevc/decoder \
--I${build_dir} \
--Wl,--start-group \
-$LIB_FUZZING_ENGINE \
-$SRC/libhevc/fuzzer/hevc_dec_fuzzer.cpp -o $OUT/hevc_dec_fuzzer \
-${build_dir}/libhevcdec.a \
--Wl,--end-group
-
-cp $SRC/hevc_dec_fuzzer_seed_corpus.zip $OUT/hevc_dec_fuzzer_seed_corpus.zip
-cp $SRC/libhevc/fuzzer/hevc_dec_fuzzer.dict $OUT/hevc_dec_fuzzer.dict
+# Run the OSS-Fuzz script in the project.
+$SRC/libhevc/fuzzer/ossfuzz.sh

--- a/projects/libmpeg2/build.sh
+++ b/projects/libmpeg2/build.sh
@@ -14,28 +14,5 @@
 # limitations under the License.
 #
 ################################################################################
-
-# Build libmpeg2
-build_dir=$WORK/build
-rm -rf ${build_dir}
-mkdir -p ${build_dir}
-pushd ${build_dir}
-
-cmake $SRC/libmpeg2
-make -j$(nproc)
-popd
-
-# build fuzzers
-$CXX $CXXFLAGS -std=c++11 \
--I$SRC/libmpeg2 \
--I$SRC/libmpeg2/common \
--I$SRC/libmpeg2/decoder \
--I${build_dir} \
--Wl,--start-group \
-$LIB_FUZZING_ENGINE \
-$SRC/libmpeg2/fuzzer/mpeg2_dec_fuzzer.cpp -o $OUT/mpeg2_dec_fuzzer \
-${build_dir}/libmpeg2dec.a \
--Wl,--end-group
-
-cp $SRC/mpeg2_dec_fuzzer_seed_corpus.zip $OUT/mpeg2_dec_fuzzer_seed_corpus.zip
-cp $SRC/libmpeg2/fuzzer/mpeg2_dec_fuzzer.dict $OUT/mpeg2_dec_fuzzer.dict
+# Run the OSS-Fuzz script in the project.
+$SRC/libmpeg2/fuzzer/ossfuzz.sh


### PR DESCRIPTION
Steps to build fuzz target are now maintained in upstream project