### PR TITLE
Reland "[infra] Use fuzz target basename in the coverage script." (#2896).

### DIFF
--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -19,7 +19,7 @@ cd $OUT
 if (( $# > 0 )); then
   FUZZ_TARGETS="$@"
 else
-  FUZZ_TARGETS="$(find . -maxdepth 1 -type f -executable)"
+  FUZZ_TARGETS="$(find . -maxdepth 1 -type f -executable -printf '%P\n')"
 fi
 
 DUMPS_DIR="$OUT/dumps"
@@ -77,7 +77,7 @@ function run_fuzz_target {
   local args="-merge=1 -timeout=100 -close_fd_mask=3 $corpus_dummy $corpus_real"
 
   export LLVM_PROFILE_FILE=$profraw_file
-  timeout $TIMEOUT $target $args &> $LOGS_DIR/$target.log
+  timeout $TIMEOUT $OUT/$target $args &> $LOGS_DIR/$target.log
   if (( $? != 0 )); then
     echo "Error occured while running $target:"
     cat $LOGS_DIR/$target.log


### PR DESCRIPTION
Was reverted in https://github.com/google/oss-fuzz/pull/2903 because the basename couldn't be used to run a binary. Appended `$OUT/` this time and running a test locally now.