### PR TITLE
[infra] Use more generic approach to skip code coverage for Go projects.

### DIFF
--- a/infra/gcb/build_and_run_coverage.py
+++ b/infra/gcb/build_and_run_coverage.py
@@ -44,8 +44,8 @@ LATEST_REPORT_INFO_URL = (
 # Link where to upload code coverage report files to.
 UPLOAD_URL_FORMAT = 'gs://' + COVERAGE_BUCKET_NAME + '/{project}/{type}/{date}'
 
-# TODO(#2817): gofuzz projects to skip code coverage job for.
-GO_FUZZ_PROJECTS = ['golang', 'syzkaller']
+# TODO(#2817): code coverage is not supported for Go projects.
+GO_FUZZ_BUILD_COMMAND = 'go-fuzz-build -libfuzzer'
 
 
 def skip_build(message):
@@ -69,9 +69,11 @@ def get_build_steps(project_dir):
   if project_yaml['disabled']:
     skip_build('Project "%s" is disabled.' % project_name)
 
-  if project_name in GO_FUZZ_PROJECTS:
-    skip_build('Project "%s" uses gofuzz, coverage is not supported yet.' %
-               project_name)
+  build_script_path = os.path.join(project_dir, 'build.sh')
+  with open(build_script_path) as fh:
+    if GO_FUZZ_BUILD_COMMAND in fh.read():
+      skip_build('Project "%s" uses go-fuzz, coverage is not supported yet.' %
+                 project_name)
 
   fuzz_targets = get_targets_list(project_name)
   if not fuzz_targets:


### PR DESCRIPTION
Not a perfect solution, as in theory the build script might live upstream (in case of an ideal integration) and this check woud be bypassed, but this is the best idea I have for now.

Another heuristic might be `RUN go get` command in Dockerfile, but not every Go project uses it:

```sh
$ egrep -r 'RUN go get' projects/
projects/kubernetes/Dockerfile:RUN go get -u -d github.com/dvyukov/go-fuzz/...
projects/kubernetes/Dockerfile:RUN go get github.com/ianlancetaylor/demangle
projects/syzkaller/Dockerfile:RUN go get -u -d github.com/google/syzkaller/...
projects/syzkaller/Dockerfile:RUN go get github.com/ianlancetaylor/demangle
projects/golang-protobuf/Dockerfile:RUN go get google.golang.org/protobuf/proto
projects/go-attestation/Dockerfile:RUN go get -u -d github.com/google/go-attestation/...


$ egrep -r 'go-fuzz-build -libfuzzer' projects/
projects/kubernetes/build.sh:  go-fuzz-build -libfuzzer -func "${function}" -o "${fuzzer}.a" "k8s.io/kubernetes/test/fuzz/${pkg}"
projects/syzkaller/build.sh:  go-fuzz-build -libfuzzer -func $function -o $fuzzer.a $path 
projects/golang-protobuf/build.sh:  go-fuzz-build -libfuzzer -func $function -o $fuzzer.a $path
projects/golang/build.sh:    go-fuzz-build -libfuzzer -o $fuzzer.a github.com/dvyukov/go-fuzz-corpus/$fuzzer
projects/go-attestation/build.sh:  go-fuzz-build -libfuzzer -func $function -o $fuzzer.a $package

```