### PR TITLE
[myanmar-tools] Link against $ORIGIN to unbreak builds

### DIFF
--- a/projects/myanmar-tools/build.sh
+++ b/projects/myanmar-tools/build.sh
@@ -26,7 +26,7 @@ make all
 mkdir -p $OUT/lib
 cp libmyanmartools.so $OUT/lib
 $CXX $CXXFLAGS -std=c++11 -I../public -L$OUT/lib \
-    -Wl,-rpath $OUT/lib -lmyanmartools \
+    -Wl,-rpath,'$ORIGIN/lib' -lmyanmartools \
     -o $OUT/zawgyi_detector_fuzz_target \
     ../zawgyi_detector_fuzz_target.cpp \
     $LIB_FUZZING_ENGINE


### PR DESCRIPTION
Usually this bug would have been caught by our build infra, but it was not because of a regression. The last build has failed I think because the regression was fixed.
We don't usually fix builds ourselves (since OSS-Fuzz is supposed to be self-service). but I'm doing it in this case because the bad builds that were let through are causing exceptions on our infra.