### PR TITLE
[osquery] Improve harnesses by adding build cleanup logic

### DIFF
--- a/projects/osquery/Dockerfile
+++ b/projects/osquery/Dockerfile
@@ -27,15 +27,19 @@ RUN export GIT_VER=2.21.0 \
  && cd git-$GIT_VER/ \
  && make configure \
  && ./configure --with-openssl \
- && make -j4 install
+ && make -j4 install \
+ && cd .. \
+ && rm -rf v$GIT_VER.tar.gz git-$GIT_VER
 
 # Installer newer cmake
-RUN wget -q https://github.com/Kitware/CMake/releases/download/v3.14.6/cmake-3.14.6-Linux-x86_64.tar.gz
-RUN tar xf cmake-3.14.6-Linux-x86_64.tar.gz -C /usr/local --strip 1
+RUN wget -q https://github.com/Kitware/CMake/releases/download/v3.14.6/cmake-3.14.6-Linux-x86_64.tar.gz \
+ && tar xf cmake-3.14.6-Linux-x86_64.tar.gz -C /usr/local --strip 1 \
+ && rm cmake-3.14.6-Linux-x86_64.tar.gz
 
 # Install build toolchain
-RUN wget https://github.com/osquery/osquery-toolchain/releases/download/1.0.0/osquery-toolchain-1.0.0.tar.xz
-RUN tar xf osquery-toolchain-1.0.0.tar.xz -C /usr/local
+RUN wget https://github.com/osquery/osquery-toolchain/releases/download/1.0.0/osquery-toolchain-1.0.0.tar.xz \
+ && tar xf osquery-toolchain-1.0.0.tar.xz -C /usr/local \
+ && rm osquery-toolchain-1.0.0.tar.xz
 
 RUN git clone --depth 1 https://github.com/osquery/osquery osquery
 

--- a/projects/osquery/build.sh
+++ b/projects/osquery/build.sh
@@ -38,5 +38,14 @@ cmake \
 cmake \
   -DCMAKE_EXE_LINKER_FLAGS=${LIB_FUZZING_ENGINE} \
   ..
+
+# Build harnesses
 cmake --build . -j$(nproc) --target osqueryfuzz-config
+
+# Cleanup
+find . -type f -name '*.o' -delete
+rm -rf "${SRC}/${PROJECT}/libraries/cmake/source/libudev/src/test"
+rm -rf libs/src/patched-source/libudev/src/test
+
+# Move harnesses to output path
 cp osquery/main/osqueryfuzz-config "${OUT}/osqueryfuzz-config"


### PR DESCRIPTION
Coverage tests are currently failing. This is most likely due to exhausting the container disk space. This commit removes downloaded files and build artifacts, which are not needed for coverage tests.

See https://github.com/google/oss-fuzz/pull/2919 for additional debugging context/history.