### PR TITLE
[myanmar-tools] Fix build by including libunwind.so.8 in lib/

### DIFF
--- a/projects/myanmar-tools/build.sh
+++ b/projects/myanmar-tools/build.sh
@@ -25,6 +25,10 @@ make all
 # Copy the .so file to $OUT as well as the executable.
 mkdir -p $OUT/lib
 cp libmyanmartools.so $OUT/lib
+# TODO(https://github.com/google/oss-fuzz/issues/2947): Link in libunwind
+# statically or stop copying if ClusterFuzz bot images get libunwind.
+# Copy libunwind since it isn't on the ClusterFuzz bot images.
+cp /usr/lib/x86_64-linux-gnu/libunwind.so.8 $OUT/lib/
 $CXX $CXXFLAGS -std=c++11 -I../public -L$OUT/lib \
     -Wl,-rpath,'$ORIGIN/lib' -lmyanmartools \
     -o $OUT/zawgyi_detector_fuzz_target \


### PR DESCRIPTION
The OSS-Fuzz builder and runner images have libunwind. Since
the OSS-Fuzz runner images aren't actually used to run fuzzers on
ClusterFuzz and are just actually used for testing(!) this passed
CI before even though it failed immediately on ClusterFuzz.
I've tested that with this fix, the fuzzer works on ClusterFuzz.