### PR TITLE
[llvm] Add clang-objc-fuzzer with corpus

### DIFF
--- a/projects/llvm/build.sh
+++ b/projects/llvm/build.sh
@@ -19,6 +19,7 @@
 readonly FUZZERS=( \
   clang-fuzzer \
   clang-format-fuzzer \
+  clang-objc-fuzzer \
   clangd-fuzzer \
   llvm-itanium-demangle-fuzzer \
   llvm-microsoft-demangle-fuzzer \
@@ -128,4 +129,5 @@ build_corpus "llvm/test/Transforms/LoopStrengthReduce/" "llvm-opt-fuzzer--x86_64
 
 build_corpus "llvm/test/Transforms/IRCE/" "llvm-opt-fuzzer--x86_64-llvm-opt-fuzzer--x86_64-irce"
 
+zip -j "${OUT}/clang-objc-fuzzer_seed_corpus.zip"  llvm/tools/clang/tools/clang-fuzzer/corpus_examples/objc/*
 zip -j "${OUT}/clangd-fuzzer_seed_corpus.zip"  llvm/tools/clang/tools/extra/clangd/test/*

--- a/projects/llvm/project.yaml
+++ b/projects/llvm/project.yaml
@@ -13,6 +13,7 @@ auto_ccs:
   - "jfb@chromium.org"
   - "eneyman@google.com"
   - "bigcheesegs@gmail.com"
+  - "davg@google.com"
 
 sanitizers:
   - address


### PR DESCRIPTION
This was added to LLVM in https://reviews.llvm.org/D69171, hopefully will catch extra issues with Objective-C (as opposed to only C++ previously)