### PR TITLE
Ignore hunter-installed dependencies in coverage test

### DIFF
--- a/projects/myanmar-tools/project.yaml
+++ b/projects/myanmar-tools/project.yaml
@@ -19,3 +19,4 @@ auto_ccs:
 sanitizers:
   - address
   - memory
+coverage_extra_args: -ignore-filename-regex=.*/\.hunter/.*


### PR DESCRIPTION
This is my attempt at fixing https://github.com/google/myanmar-tools/issues/36:

https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=18200
