### PR TITLE
lwan: Zip fuzzing corpus for new fuzzers without changing build.sh

### DIFF
--- a/projects/lwan/build.sh
+++ b/projects/lwan/build.sh
@@ -27,12 +27,14 @@ cmake -GNinja \
 
 ninja -v liblwan.a
 
-zip -jr $OUT/request_fuzzer_seed_corpus.zip $SRC/lwan/fuzz/corpus/corpus-request-*
-
 cp $SRC/lwan/fuzz/*.dict $OUT/
 
 for fuzzer in $SRC/lwan/src/bin/fuzz/*_fuzzer.cc; do
 	executable=$(basename $fuzzer .cc)
+	corpus_base=$(basename $fuzzer _fuzzer.cc)
+
+	zip -jr $OUT/${executable}_seed_corpus.zip $SRC/lwan/fuzz/corpus/corpus-${corpus_base}-*
+	
 	$CXX $CXXFLAGS -std=c++11 \
 		-Wl,-whole-archive $WORK/lwan/src/lib/liblwan.a -Wl,-no-whole-archive \
 		-I$SRC/lwan/src/lib $fuzzer \

--- a/projects/lwan/build.sh
+++ b/projects/lwan/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/bash -euv
 # Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Instead of hardcoding the archiving of corpus-request-* files in the Lwan repo into request_fuzzer_seed_corpus.zip, use the fuzzer driver filename to derive the ZIP file name and corpus file names as each fuzzer is being built.

This allows the Lwan project to add new fuzzers (with an appropriate corpus) without changing build.sh in this repo.