### PR TITLE
iroha: build script migration step 1

### DIFF
--- a/projects/iroha/Dockerfile
+++ b/projects/iroha/Dockerfile
@@ -31,7 +31,7 @@ RUN git clone --depth 1 https://github.com/hyperledger/iroha.git
 
 WORKDIR iroha
 
-RUN cp -R $SRC/iroha/vcpkg /tmp/vcpkg-vars
+RUN cp -R $SRC/iroha/vcpkg_old /tmp/vcpkg-vars
 
 RUN set -e; \
     git clone https://github.com/microsoft/vcpkg /tmp/vcpkg; \


### PR DESCRIPTION
We are changing our vcpkg dependencies build script in an incompatible way. To keep oss-fuzz working, we added a copy of old build script that oss-fuzz will use while we change the primary script. Then we will switch oss-fuzz to the new version and delete the old copy. Classic seamless migration scheme.