### PR TITLE
Solidity 0.6.0: Add upcoming breaking release as a new project

### DIFF
--- a/projects/solidity_060/Dockerfile
+++ b/projects/solidity_060/Dockerfile
@@ -1,0 +1,93 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool \
+    build-essential libbz2-dev ninja-build zlib1g-dev wget python python-dev
+# Install cmake 3.14 (minimum requirement is cmake 3.10)
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.14.5/cmake-3.14.5-Linux-x86_64.sh; \
+    chmod +x cmake-3.14.5-Linux-x86_64.sh; \
+    ./cmake-3.14.5-Linux-x86_64.sh --skip-license --prefix="/usr"
+
+RUN git clone -b develop_060 --recursive https://github.com/ethereum/solidity.git solidity
+RUN git clone --depth 1 https://github.com/ethereum/solidity-fuzzing-corpus.git
+RUN git clone --recursive -b boost-1.69.0 https://github.com/boostorg/boost.git \
+    boost
+RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
+RUN git clone --branch="v0.1.0" --recurse-submodules \
+    https://github.com/ethereum/evmone.git
+RUN git clone --branch="v0.2.0" https://github.com/chfast/intx.git
+RUN git clone --branch="v0.4.4" https://github.com/chfast/ethash.git
+RUN git clone --branch="Z3-4.8.5" https://github.com/Z3Prover/z3.git
+
+# Install statically built dependencies in "/usr" directory
+# Install boost
+RUN cd $SRC/boost; \
+    ./bootstrap.sh --with-toolset=clang --prefix=/usr; \
+    ./b2 clean; \
+    ./b2 toolset=clang cxxflags="-stdlib=libc++" linkflags="-stdlib=libc++" \
+    headers; \
+    ./b2 toolset=clang cxxflags="-stdlib=libc++" linkflags="-stdlib=libc++" \
+    link=static variant=release runtime-link=static \
+    system regex filesystem unit_test_framework program_options \
+    install -j $(($(nproc)/2));
+
+# Install libprotobuf-mutator
+RUN mkdir $SRC/LPM; \
+    cd $SRC/LPM; \
+    cmake $SRC/libprotobuf-mutator -GNinja \
+    -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF \
+    -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="/usr"; \
+    ninja; \
+    ninja install; \
+    cd external.protobuf; \
+    cp -Rf bin lib include /usr;
+
+# Install evmone
+RUN cd $SRC/evmone; \
+    mkdir -p build; \
+    cd build; \
+    cmake .. -G Ninja -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX="/usr"; \
+    ninja; \
+    ninja install;
+
+# Install intx
+RUN cd $SRC/intx; \
+    mkdir -p build; \
+    cd build; \
+    cmake .. -G Ninja -DBUILD_SHARED_LIBS=OFF -DINTX_TESTING=OFF \
+    -DINTX_BENCHMARKING=OFF -DCMAKE_INSTALL_PREFIX="/usr"; \
+    ninja; \
+    ninja install;
+
+# Install ethash
+RUN cd $SRC/ethash; \
+    mkdir -p build; \
+    cd build; \
+    cmake .. -G Ninja -DBUILD_SHARED_LIBS=OFF -DETHASH_BUILD_TESTS=OFF \
+    -DCMAKE_INSTALL_PREFIX="/usr"; \
+    ninja; \
+    ninja install;
+
+# Install Z3
+RUN cd $SRC/z3; \
+    mkdir -p build; \
+    cd build; \
+    LDFLAGS=$CXXFLAGS cmake -DBUILD_LIBZ3_SHARED=OFF -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release ..; \
+    make libz3 -j; \
+    make install;
+
+COPY build.sh $SRC/

--- a/projects/solidity_060/build.sh
+++ b/projects/solidity_060/build.sh
@@ -1,0 +1,48 @@
+#!/bin/bash -eu
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Compile proto C++ bindings
+protoc \
+    --proto_path=$SRC/solidity/test/tools/ossfuzz yulProto.proto \
+    --cpp_out=$SRC/solidity/test/tools/ossfuzz
+protoc \
+    --proto_path=$SRC/solidity/test/tools/ossfuzz abiV2Proto.proto \
+    --cpp_out=$SRC/solidity/test/tools/ossfuzz
+
+# Build solidity
+cd $SRC/solidity
+CXXFLAGS="${CXXFLAGS} -I/usr/local/include/c++/v1"
+mkdir -p build
+cd build
+rm -rf *
+
+# Build solidity
+cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/ossfuzz.cmake \
+      -DCMAKE_BUILD_TYPE=Release \
+      $SRC/solidity
+make ossfuzz ossfuzz_proto ossfuzz_abiv2 -j $(nproc)
+
+# Copy fuzzer binary, seed corpus, fuzzer options, and dictionary
+cp test/tools/ossfuzz/*_ossfuzz $OUT/
+rm -f $OUT/*.zip
+for dir in $SRC/solidity-fuzzing-corpus/*;
+do
+	name=$(basename $dir)
+	zip -rjq $OUT/$name $dir
+done
+cp $SRC/solidity/test/tools/ossfuzz/config/*.options $OUT/
+cp $SRC/solidity/test/tools/ossfuzz/config/*.dict $OUT/

--- a/projects/solidity_060/project.yaml
+++ b/projects/solidity_060/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://solidity.readthedocs.io"
+primary_contact: "bhargava.shastry@ethereum.org"
+auto_ccs:
+  - "axic@ethereum.org"
+  - "christian@ethereum.org"
+  - "martin.swende@ethereum.org"


### PR DESCRIPTION
CC @Dor1s @chriseth

Pending approval, this PR adds development branch of solidity version `0.6.0` as a new project to oss-fuzz so that it can be fuzzed prior to release.

The reason this is being added as another project is because @Dor1s suggested that a new project is the clean way to do it (see #2991 for discussion on this).

Please let me know how to proceed.

Some context:
  - solidity version `0.6.0` is an upcoming "breaking" release which means it introduces new features not in previous compiler versions
  - these new features can benefit from continuous fuzzing
  - new features won't be backported to `0.5.x` releases i.e., currently integrated `solidity` project is not equipped to find bugs in these new features