### PR TITLE
mruby: Move LPM build to dockerfile

### DIFF
--- a/projects/mruby/Dockerfile
+++ b/projects/mruby/Dockerfile
@@ -19,5 +19,10 @@ RUN apt-get update && apt-get install -y build-essential ruby bison ninja-build 
     cmake zlib1g-dev libbz2-dev
 RUN git clone --depth 1 https://github.com/mruby/mruby mruby
 RUN git clone --depth 1 https://github.com/bshastry/mruby_seeds.git mruby_seeds
-RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git 
+RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
+RUN mkdir LPM; \
+  cd LPM; \
+  cmake $SRC/libprotobuf-mutator -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release; \
+  ninja;
+
 COPY build.sh $SRC

--- a/projects/mruby/build.sh
+++ b/projects/mruby/build.sh
@@ -15,9 +15,6 @@
 #
 ################################################################################
 
-# Build LPM
-(mkdir LPM && cd LPM && cmake $SRC/libprotobuf-mutator -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release && ninja)
-
 # Instrument mruby
 (
 cd $SRC/mruby


### PR DESCRIPTION
Moves LPM build from `build.sh` to `Dockerfile` in order to reduce build time.