### PR TITLE
Limits input size for gnupg list fuzz target

### DIFF
--- a/projects/gnupg/fuzz_list.c
+++ b/projects/gnupg/fuzz_list.c
@@ -137,7 +137,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 
     if (Size > MAX_LEN) {
         // limit maximum size to avoid long computing times
-        Size = MAX_LEN;
+        return 0;
     }
 
     memset(ctrlGlobal, 0, sizeof(*ctrlGlobal));


### PR DESCRIPTION
Should fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=16269