### PR TITLE
[simdjson] move the build script into the simdjson repo

### DIFF
--- a/projects/simdjson/Dockerfile
+++ b/projects/simdjson/Dockerfile
@@ -26,7 +26,7 @@ RUN wget --quiet https://github.com/Kitware/CMake/releases/download/v${CMAKEVER}
     ./cmake-${CMAKEVER}-Linux-x86_64.sh --skip-license --prefix="/usr/local"
 
 # point to https://github.com/lemire/simdjson.git once integrated
-RUN git clone --depth 1 --single-branch --branch paul/ossfuzz_step1 https://github.com/pauldreik/simdjson.git simdjson
+RUN git clone --depth 1 --single-branch --branch paul/ossfuzz_step2 https://github.com/pauldreik/simdjson.git simdjson
 WORKDIR simdjson
 COPY build.sh $SRC/
 

--- a/projects/simdjson/build.sh
+++ b/projects/simdjson/build.sh
@@ -15,26 +15,4 @@
 #
 ################################################################################
 
-# build the corpus (all inputs are json, the same corpus can be used for everyone)
-fuzz/build_corpus.sh
-
-mkdir build
-cd build
-
-cmake .. \
--GNinja \
--DCMAKE_BUILD_TYPE=Debug \
--DSIMDJSON_BUILD_STATIC=On \
--DENABLE_FUZZING=On \
--DSIMDJSON_FUZZ_LINKMAIN=Off \
--DSIMDJSON_FUZZ_LDFLAGS=$LIB_FUZZING_ENGINE
-
-cmake --build .
-
-cp fuzz/fuzz_* $OUT
-
-# all corpora are equal, they all take json as input
-for f in $OUT/fuzz* ; do
-   cp ../corpus.zip $(basename $f).zip
-done
-
+fuzz/ossfuzz.sh


### PR DESCRIPTION
oss-fuzz already found it's first bug in simdjson!

The next step is moving the build script into the simdjson repo, so it can be maintained and bugfixed upstream.

I also fixed a bug in the build, not copying the corpora zips to $OUT
