### PR TITLE
Add wavpack to oss-fuzz

### DIFF
--- a/projects/wavpack/project.yaml
+++ b/projects/wavpack/project.yaml
@@ -1,0 +1,9 @@
+homepage: "http://www.wavpack.com" 
+primary_contact: "david@wavpack.com" 
+auto_ccs:
+- dvbryant@gmail.com
+- thuanpv.nus@gmail.com
+sanitizers: 
+- address 
+- memory 
+- undefined


### PR DESCRIPTION
WavPack is an audio codec and container format supporting lossless, lossy, and a hybrid compression mode.

It includes a library (libwavpack) and several command-line utilities (including a library tester).

Many projects optionally include libwavpack including gstreamer, FFmpeg, VLC, SoX, and Stream.

Gstreamer with libwavpack comes standard on many (most?) Linux distros.
