### PR TITLE
boost: Assert post conditions for match

### DIFF
--- a/projects/boost/Dockerfile
+++ b/projects/boost/Dockerfile
@@ -19,8 +19,5 @@ RUN apt-get update && apt-get install -y g++
 
 RUN git clone --recursive https://github.com/boostorg/boost.git
 WORKDIR boost
-# This bootstrap boost with the g++ toolchain.
-# The actual build will need to use CXX/CXXFLAGS provided by OSS-Fuzz.
-RUN ./bootstrap.sh && ./b2 headers
 # Preferably, move boost_regex_fuzzer.cc to the boost repository.
 COPY build.sh *.cc $SRC/

--- a/projects/boost/boost_regex_fuzzer.cc
+++ b/projects/boost/boost_regex_fuzzer.cc
@@ -1,16 +1,53 @@
 // From https://svn.boost.org/trac10/ticket/12818
 // This fuzz target can likely be enhanced to exercise more code.
 // The ideal place for this fuzz target is the boost repository.
+#ifdef DEBUG
+#include <iostream>
+#endif
+#include <vector>
+
+#include <boost/algorithm/string.hpp>
 #include <boost/regex.hpp>
+
+namespace {
+  void assertPostConditions(boost::match_results<std::string::const_iterator> const& match, boost::regex const& e)
+  {
+    // See https://www.boost.org/doc/libs/1_71_0/libs/regex/doc/html/boost_regex/ref/regex_match.html
+    assert(match.size() == e.mark_count() + 1);
+    assert(!match.empty());
+    assert(!match.prefix().matched);
+    assert(!match.suffix().matched);
+  }
+}
+
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
   try {
     std::string str((char *)Data, Size);
-    boost::regex e(str);
-    boost::match_results<std::string::const_iterator> what;
-    boost::regex_match(str, what, e,
-                       boost::match_default | boost::match_partial);
+    std::vector<std::string> strVector;
+    // Split fuzz input string by space
+    boost::split(strVector, str, [](char c){return c == ' ';});
+    // Bail if vector contains fewer than two items
+    if (strVector.size() < 2)
+      return 0;
 
-  } catch (const std::exception &) {
+    // First item is regexp pattern
+    boost::regex e(strVector[0]);
+    // Second (until last item concatenated) is string to be checked
+    std::string text;
+    for(std::vector<std::string>::const_iterator it = strVector.begin() + 1; it != strVector.end(); ++it)
+      text += *it;
+#ifdef DEBUG
+    std::cout << "Regexp: " << strVector[0] << "Size: " << strVector[0].size() << std::endl;
+    std::cout << "Text: " << text << "Size: " << text.size() << std::endl;
+#endif
+
+    boost::match_results<std::string::const_iterator> what;
+    bool match = boost::regex_match(text, what, e,
+                       boost::match_default | boost::match_partial);
+    if (match)
+      assertPostConditions(what, e);
+  }
+  catch (const std::runtime_error &) {
   }
   return 0;
 }

--- a/projects/boost/build.sh
+++ b/projects/boost/build.sh
@@ -15,9 +15,10 @@
 #
 ################################################################################
 
+# Build boost
+./bootstrap.sh && ./b2 headers
 
 # Very simple build rule, but sufficient here.
-
 #boost regexp
 $CXX $CXXFLAGS -I . ../boost_regex_fuzzer.cc libs/regex/src/*.cpp $LIB_FUZZING_ENGINE -o boost_regex_fuzzer
 

--- a/projects/boost/project.yaml
+++ b/projects/boost/project.yaml
@@ -5,4 +5,5 @@ homepage: "http://www.boost.org/"
 auto_ccs:  
    - "jz.maddock@googlemail.com"
    - "mclow@boost.org"
+   - "bshas3@gmail.com"
 #   - "someone-else@boost.org"


### PR DESCRIPTION
This PR
  - changes the logic of applying a regular expression against itself (which is non intuitive) to a new scheme where the regular expression and text to be matched are separated by a white space
  - adds post conditions as assertions that must hold when text fully matches regular expression

P.S. Boost's build was broken. The second commit in this PR fixes this.