### PR TITLE
Add libcacard project

### DIFF
--- a/projects/libcacard/project.yaml
+++ b/projects/libcacard/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://gitlab.freedesktop.org/spice/libcacard"
+primary_contact: "jjelen@redhat.com"
+auto_ccs:
+ - "jakuje@gmail.com"
+sanitizers:
+ - address
+ - memory:
+    experimental: True
+ - undefined


### PR DESCRIPTION
libcacard is smart card emulation and mirroring library now used as part of [spice](https://www.spice-space.org/) project to share locally attached smart cards with virtual machines. It implements smart card interface, which is used to communicate with PC/SC daemon in VM through emulated USB device. In case of bugs and security vulnerabilities, this could be used by malicious code in VM for privilege escalation or executing malicious code in the client applications (generally [remote-viewer](https://linux.die.net/man/1/remote-viewer)).

This is just the initial submission for the for the project approval per the [getting started](https://google.github.io/oss-fuzz/getting-started/accepting-new-projects/). No fuzzers were made yet, but I already have experience with OpenSC and libssh projects, that are already fuzzing for some time.