### PR TITLE
[libssh] Fix building libssh as a static library

### DIFF
--- a/projects/libssh/build.sh
+++ b/projects/libssh/build.sh
@@ -19,7 +19,7 @@ mkdir -p build
 pushd build
 cmake -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" \
     -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
-    -DWITH_STATIC_LIB=ON ..
+    -DBUILD_SHARED_LIBS=OFF ..
 make "-j$(nproc)"
 
 $CXX $CXXFLAGS -std=c++11 -I$SRC/libssh/include/ \


### PR DESCRIPTION
We honor BUILD_SHARED_LIBS from cmake now.

https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html