### PR TITLE
[libspectre] initial integration

### DIFF
--- a/projects/libspectre/Dockerfile
+++ b/projects/libspectre/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+MAINTAINER randy408@protonmail.com
+
+RUN apt-get update && \
+    apt-get install -y pkg-config make automake libtool wget
+
+RUN git clone --depth 1 --branch fuzz https://gitlab.freedesktop.org/randy408/libspectre.git
+
+WORKDIR libspectre
+COPY build.sh $SRC/

--- a/projects/libspectre/Dockerfile
+++ b/projects/libspectre/Dockerfile
@@ -21,7 +21,7 @@ MAINTAINER randy408@protonmail.com
 RUN apt-get update && \
     apt-get install -y pkg-config make automake libtool wget
 
-RUN git clone --depth 1 --branch fuzz https://gitlab.freedesktop.org/randy408/libspectre.git
+RUN git clone --depth 1 https://gitlab.freedesktop.org/libspectre/libspectre.git
 
 WORKDIR libspectre
 COPY build.sh $SRC/

--- a/projects/libspectre/build.sh
+++ b/projects/libspectre/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+# Run the OSS-Fuzz script in the project
+$SRC/libspectre/test/ossfuzz.sh

--- a/projects/libspectre/project.yaml
+++ b/projects/libspectre/project.yaml
@@ -1,4 +1,4 @@
 homepage: "https://www.freedesktop.org/wiki/Software/libspectre/"
-primary_contact: "aacid@kde.org"
+primary_contact: "tsdgeos@gmail.com"
 auto_ccs:
   - "randy440088@gmail.com"

--- a/projects/libspectre/project.yaml
+++ b/projects/libspectre/project.yaml
@@ -1,0 +1,4 @@
+homepage: "https://www.freedesktop.org/wiki/Software/libspectre/"
+primary_contact: "aacid@kde.org>"
+auto_ccs:
+  - "randy440088@gmail.com"

--- a/projects/libspectre/project.yaml
+++ b/projects/libspectre/project.yaml
@@ -1,4 +1,4 @@
 homepage: "https://www.freedesktop.org/wiki/Software/libspectre/"
-primary_contact: "aacid@kde.org>"
+primary_contact: "aacid@kde.org"
 auto_ccs:
   - "randy440088@gmail.com"


### PR DESCRIPTION
libspectre is a small library for rendering Postscript documents. It includes a PostScript parser and is a dependency of Evince and Okular.

Upstream issue: https://gitlab.freedesktop.org/libspectre/libspectre/issues/31