### PR TITLE
remove libunwind and libblocksruntime from base-runner.

### DIFF
--- a/infra/base-images/base-runner/Dockerfile
+++ b/infra/base-images/base-runner/Dockerfile
@@ -21,10 +21,8 @@ RUN apt-get install -y \
     file \
     fonts-dejavu \
     git \
-    libblocksruntime0 \
     libc6-dev-i386 \
     libcap2 \
-    libunwind8 \
     python3 \
     python3-pip \
     wget \


### PR DESCRIPTION
Fixes #2947.

honggfuzz is now linked statically with these libs.