### PR TITLE
[libzip] fix build

### DIFF
--- a/projects/libzip/Dockerfile
+++ b/projects/libzip/Dockerfile
@@ -19,7 +19,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 
 MAINTAINER randy408@protonmail.com
 
-RUN apt-get update && apt-get install -y cmake pkg-config zlib1g-dev
+RUN apt-get update && apt-get install -y cmake pkg-config zlib1g-dev liblzma-dev libbz2-dev
 
 RUN git clone --depth 1 https://github.com/nih-at/libzip.git
 


### PR DESCRIPTION
FYI I'm not getting emails for build failures, shouldn't the `MAINTAINER` in the Dockerfile also get a notification? I'm guessing the dashboard is reporting stats from an older build?

https://oss-fuzz-build-logs.storage.googleapis.com/index.html#libzip

