### PR TITLE
[postgis] fix build

### DIFF
--- a/projects/postgis/build.sh
+++ b/projects/postgis/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 ./autogen.sh
-./configure --enable-static --without-raster --without-protobuf --without-wagyu
+./configure --enable-static --without-raster --without-protobuf --without-wagyu --enable-debug
 cd liblwgeom
 make clean -s
 make -j$(nproc) -s


### PR DESCRIPTION
Upstream enables link time optimization that breaks fuzzers build. Link time optimization is automatically disabled in --enable-debug mode.