### PR TITLE
solidity: Upgrade evmone to v0.3.0 to fix build failure

### DIFF
--- a/projects/solidity/Dockerfile
+++ b/projects/solidity/Dockerfile
@@ -27,10 +27,8 @@ RUN git clone --depth 1 https://github.com/ethereum/solidity-fuzzing-corpus.git
 RUN git clone --recursive -b boost-1.69.0 https://github.com/boostorg/boost.git \
     boost
 RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
-RUN git clone --branch="v0.1.0" --recurse-submodules \
+RUN git clone --branch="v0.3.0" --recurse-submodules \
     https://github.com/ethereum/evmone.git
-RUN git clone --branch="v0.2.0" https://github.com/chfast/intx.git
-RUN git clone --branch="v0.4.4" https://github.com/chfast/ethash.git
 RUN git clone --branch="Z3-4.8.5" https://github.com/Z3Prover/z3.git
 
 # Install statically built dependencies in "/usr" directory
@@ -61,24 +59,6 @@ RUN cd $SRC/evmone; \
     mkdir -p build; \
     cd build; \
     cmake .. -G Ninja -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX="/usr"; \
-    ninja; \
-    ninja install;
-
-# Install intx
-RUN cd $SRC/intx; \
-    mkdir -p build; \
-    cd build; \
-    cmake .. -G Ninja -DBUILD_SHARED_LIBS=OFF -DINTX_TESTING=OFF \
-    -DINTX_BENCHMARKING=OFF -DCMAKE_INSTALL_PREFIX="/usr"; \
-    ninja; \
-    ninja install;
-
-# Install ethash
-RUN cd $SRC/ethash; \
-    mkdir -p build; \
-    cd build; \
-    cmake .. -G Ninja -DBUILD_SHARED_LIBS=OFF -DETHASH_BUILD_TESTS=OFF \
-    -DCMAKE_INSTALL_PREFIX="/usr"; \
     ninja; \
     ninja install;
 


### PR DESCRIPTION
Solidity build failed because a dependency had been internally updated (evmone: from 0.1.0 to 0.3.0) but this update was not reflected in the oss-fuzz Dockerfile. This PR fixes this and consequently the build failure.