### PR TITLE
fix link failure with libtiff

### DIFF
--- a/projects/libvips/Dockerfile
+++ b/projects/libvips/Dockerfile
@@ -36,11 +36,6 @@ RUN git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo
 RUN git clone --depth 1 https://github.com/glennrp/libpng.git
 RUN git clone --depth 1 https://git.code.sf.net/p/giflib/code libgif
 RUN git clone --depth 1 https://chromium.googlesource.com/webm/libwebp
-# as of 20 Nov 2019, git master libtiff will not work on systems without lzma
-# dur to a bug introduced by their switch to cmake ... for now, pin to 4.1.0,
-# the current stable version
-RUN git clone --depth 1 https://gitlab.com/libtiff/libtiff \
-	&& cd libtiff \
-	&& git checkout v4.1.0
+RUN git clone --depth 1 https://gitlab.com/libtiff/libtiff 
 WORKDIR libvips
 COPY build.sh $SRC/

--- a/projects/libvips/Dockerfile
+++ b/projects/libvips/Dockerfile
@@ -36,6 +36,11 @@ RUN git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo
 RUN git clone --depth 1 https://github.com/glennrp/libpng.git
 RUN git clone --depth 1 https://git.code.sf.net/p/giflib/code libgif
 RUN git clone --depth 1 https://chromium.googlesource.com/webm/libwebp
-RUN git clone --depth 1 https://gitlab.com/libtiff/libtiff
+# as of 20 Nov 2019, git master libtiff will not work on systems without lzma
+# dur to a bug introduced by their switch to cmake ... for now, pin to 4.1.0,
+# the current stable version
+RUN git clone --depth 1 https://gitlab.com/libtiff/libtiff \
+	&& cd libtiff \
+	&& git checkout v4.1.0
 WORKDIR libvips
 COPY build.sh $SRC/

--- a/projects/libvips/build.sh
+++ b/projects/libvips/build.sh
@@ -78,10 +78,12 @@ make -j$(nproc)
 make install
 popd
 
-# libtiff
+# libtiff ... a bug in libtiff master as of 20 Nov 2019 means we have to 
+# explicitly disable lzma
 pushd $SRC/libtiff
 autoreconf -fi
 ./configure \
+  --disable-lzma \
   --disable-shared \
   --disable-dependency-tracking \
   --prefix=$WORK

--- a/projects/libvips/build.sh
+++ b/projects/libvips/build.sh
@@ -128,7 +128,7 @@ for fuzzer in fuzz/*_fuzzer.cc; do
     $WORK/lib/libtiff.a \
     $LIB_FUZZING_ENGINE \
     -Wl,-Bstatic \
-    -lfftw3 -lgmodule-2.0 -lgobject-2.0 -lffi -lglib-2.0 -lpcre -lexpat -llzma \
+    -lfftw3 -lgmodule-2.0 -lgobject-2.0 -lffi -lglib-2.0 -lpcre -lexpat \
     -Wl,-Bdynamic -pthread
   ln -sf "seed_corpus.zip" "$OUT/${target}_seed_corpus.zip"
 done

--- a/projects/libvips/build.sh
+++ b/projects/libvips/build.sh
@@ -128,7 +128,7 @@ for fuzzer in fuzz/*_fuzzer.cc; do
     $WORK/lib/libtiff.a \
     $LIB_FUZZING_ENGINE \
     -Wl,-Bstatic \
-    -lfftw3 -lgmodule-2.0 -lgobject-2.0 -lffi -lglib-2.0 -lpcre -lexpat \
+    -lfftw3 -lgmodule-2.0 -lgobject-2.0 -lffi -lglib-2.0 -lpcre -lexpat -llzma \
     -Wl,-Bdynamic -pthread
   ln -sf "seed_corpus.zip" "$OUT/${target}_seed_corpus.zip"
 done


### PR DESCRIPTION
The fuzz targets were failing to link with:

```
Step #4: /work/lib/libtiff.a(tif_lzma.o): In function `TIFFInitLZMA':
Step #4: /src/libtiff/libtiff/tif_lzma.c:465: undefined reference to
`lzma_lzma_preset'
```

It looks like it's become necessary to explicitly link -llzma, see:

https://gitlab.com/libtiff/libtiff/commit/4159bda6db2f8cf8e848d8095b5d37d49ba67a10

oss-fuzz issue:

https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=18928#c4

Thanks to @lovell.