### PR TITLE
Integration of Racket

### DIFF
--- a/projects/racket/project.yaml
+++ b/projects/racket/project.yaml
@@ -1,0 +1,13 @@
+homepage: "https://racket-lang.org"
+primary_contact: "pocmatos@gmail.com"
+auto_ccs:
+  - samth@racket-lang.org
+sanitizers:
+ - undefined
+ - memory:
+    experimental: True
+ - address:
+    experimental: True
+architectures:
+ - x86_64
+ - i386

--- a/projects/racket/project.yaml
+++ b/projects/racket/project.yaml
@@ -4,10 +4,8 @@ auto_ccs:
   - samth@racket-lang.org
 sanitizers:
  - undefined
- - memory:
-    experimental: True
- - address:
-    experimental: True
+ - memory
+ - address
 architectures:
  - x86_64
  - i386


### PR DESCRIPTION
This is a request to integrate Racket with oss-fuzz.

Racket is a general-purpose programming language as well as the world’s first ecosystem for language-oriented programming. It supported by a diverse community and ran by the PLT team (https://www.racket-lang.org/team.html).

I am a regular contributor to Racket and SamTH (cc'ed) is part of the core Racket team.