### PR TITLE
wireshark: fix build by adding ares dependency

### DIFF
--- a/projects/wireshark/Dockerfile
+++ b/projects/wireshark/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER Jakub Zawadzki <darkjames-ws@darkjames.pl>
 
 RUN apt-get update && apt-get install -y ninja-build cmake \
-                       flex bison \
+                       flex bison libc-ares-dev \
                        libglib2.0-dev libgcrypt20-dev
 
 RUN git clone --depth=1 https://code.wireshark.org/review/wireshark


### PR DESCRIPTION
Since wireshark commit v3.3.0rc0-15-g451a241e50, c-ares became a
required dependency.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=19095