### PR TITLE
[yara] Install pkg-config in build image.

### DIFF
--- a/projects/yara/Dockerfile
+++ b/projects/yara/Dockerfile
@@ -21,7 +21,8 @@ RUN \
   automake \
   autoconf \
   make \
-  libtool
+  libtool \
+  pkg-config
 
 RUN git clone --depth 1 https://github.com/VirusTotal/yara.git
 COPY build.sh $SRC/


### PR DESCRIPTION
YARA now needs pkg-config during the build process.