### PR TITLE
[libfido2] Initial integration

### DIFF
--- a/projects/libfido2/Dockerfile
+++ b/projects/libfido2/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER g.kihlman@yubico.com
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN apt-get install -y cmake libudev-dev pkg-config chrpath
+RUN git clone --branch v0.5.0 https://github.com/PJK/libcbor
+RUN git clone --branch OpenSSL_1_1_1-stable https://github.com/openssl/openssl
+RUN git clone https://github.com/Yubico/libfido2
+WORKDIR libfido2
+COPY build.sh $SRC/

--- a/projects/libfido2/build.sh
+++ b/projects/libfido2/build.sh
@@ -1,0 +1,69 @@
+#!/bin/bash -eu
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Build libcbor, taken from oss-fuzz/projects/libcbor/build.sh
+# Note SANITIZE=OFF since it gets taken care of by $CFLAGS set by oss-fuzz
+cd ${SRC}/libcbor
+patch -l -p0 < ${SRC}/libfido2/fuzz/README
+mkdir build && cd build
+cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=${WORK} -DSANITIZE=OFF ..
+make -j$(nproc) VERBOSE=1
+make install
+
+# Build OpenSSL, taken from oss-fuzz/projects/openssl/build.sh
+cd ${SRC}/openssl
+CONFIGURE_FLAGS=""
+if [[ ${SANITIZER} = memory ]]
+then
+  CONFIGURE_FLAGS="no-asm"
+fi
+./config --debug no-tests ${CFLAGS} --prefix=${WORK} \
+	 --openssldir=${WORK}/openssl ${CONFIGURE_FLAGS}
+make -j$(nproc) LDCMD="${CXX} ${CXXFLAGS}"
+make install_sw
+
+# Building libfido2 with ${LIB_FUZZING_ENGINE} and chosen sanitizer
+cd ${SRC}/libfido2
+mkdir build && cd build
+cmake -DFUZZ=1 -DFUZZ_LDFLAGS=${LIB_FUZZING_ENGINE} \
+      -DPKG_CONFIG_USE_CMAKE_PREFIX_PATH=1 \
+      -DCMAKE_PREFIX_PATH=${WORK} \
+      -DCMAKE_INSTALL_PREFIX=${WORK} \
+      -DCMAKE_BUILD_TYPE=Debug ..
+make -j$(nproc)
+make install
+
+# Prepare ${OUT} with instrumented libs
+mkdir -p ${OUT}/lib
+for lib in `ls ${WORK}/lib/lib*.so*`; do
+    cp ${lib} ${OUT}/lib;
+done
+
+# Fixup rpath in the fuzzers so they use our libs
+for f in `ls fuzz/fuzz_*`; do
+    cp ${f} ${OUT}/
+    fuzzer=$(basename $f)
+    chrpath -r '$ORIGIN/lib' ${OUT}/${fuzzer}
+done
+
+ # Prepare seed corpora
+tar xzf ${SRC}/libfido2/fuzz/corpus.tgz
+(set -e ; cd fuzz_assert/corpus  ; zip -r ${OUT}/fuzz_assert_seed_corpus.zip .)
+(set -e ; cd fuzz_bio/corpus     ; zip -r ${OUT}/fuzz_bio_seed_corpus.zip .)
+(set -e ; cd fuzz_cred/corpus    ; zip -r ${OUT}/fuzz_cred_seed_corpus.zip .)
+(set -e ; cd fuzz_credman/corpus ; zip -r ${OUT}/fuzz_credman_seed_corpus.zip .)
+(set -e ; cd fuzz_mgmt/corpus    ; zip -r ${OUT}/fuzz_mgmt_seed_corpus.zip .)

--- a/projects/libfido2/project.yaml
+++ b/projects/libfido2/project.yaml
@@ -1,0 +1,8 @@
+homepage: https://github.com/Yubico/libfido2
+primary_contact: "g.kihlman@yubico.com"
+auto_ccs:
+        - "pedro@ambientworks.net"
+        - "marissa.nishimoto@yubico.com"
+sanitizers:
+        - address
+        - undefined

--- a/projects/libfido2/project.yaml
+++ b/projects/libfido2/project.yaml
@@ -6,3 +6,5 @@ auto_ccs:
 sanitizers:
         - address
         - undefined
+fuzzing_engines:
+        - libfuzzer


### PR DESCRIPTION
Hi,
This is a request for getting libfido2 integrated into oss-fuzz.
Libfido2 is a open source library for FIDO 2.0, including communication with a device over USB and possibly other transports in the future.

Libfido2 recently got imported into OpenBSD base for doing U2F/FIDO2 in OpenSSH and the community contributing is growing. I have done some small contributions to libfido2 and on CC is Pedro Martelletto, the main author of libfido2 who prefer me to be the maintainer of the oss-fuzz project.