### PR TITLE
[DO NOT MERGE] Initial fuzzer for libpostal

### DIFF
--- a/projects/libpostal/Dockerfile
+++ b/projects/libpostal/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER alex.gaynor@gmail.com
+RUN apt-get update && apt-get install -y curl autoconf automake libtool pkg-config
+RUN git clone --depth 1 https://github.com/openvenues/libpostal
+WORKDIR libpostal
+COPY build.sh libpostal_parse_address_fuzzer.cc $SRC/

--- a/projects/libpostal/build.sh
+++ b/projects/libpostal/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -eu
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+export LDFLAGS="$CFLAGS"
+./bootstrap.sh
+./configure --datadir="$OUT" --prefix="$WORK" --disable-shared
+make "-j$(nproc)"
+make install
+
+$CXX $CXXFLAGS -std=c++11 "-I$WORK/include" ../libpostal_parse_address_fuzzer.cc \
+    -o "$OUT/libpostal_parse_address_fuzzer" $LIB_FUZZING_ENGINE "$WORK/lib/libpostal.a"

--- a/projects/libpostal/libpostal_parse_address_fuzzer.cc
+++ b/projects/libpostal/libpostal_parse_address_fuzzer.cc
@@ -1,0 +1,34 @@
+#include <stdint.h>
+#include <string>
+
+#include <libpostal/libpostal.h>
+
+
+struct PostalState {
+    PostalState() {
+        if (!libpostal_setup() || !libpostal_setup_parser()) {
+            exit(EXIT_FAILURE);
+        }
+        options = libpostal_get_address_parser_default_options();
+    }
+
+    libpostal_address_parser_options_t options;
+};
+
+PostalState kPostalState;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    std::string storage(reinterpret_cast<const char *>(data), size);
+    libpostal_address_parser_response_t *parsed = libpostal_parse_address(const_cast<char *>(storage.c_str()), kPostalState.options);
+    if (parsed) {
+        // Touch all the components to ensure they point to valid memory.
+        std::string value;
+        for (size_t i = 0; i < parsed->num_components; i++) {
+            value += parsed->labels[i];
+            value += parsed->components[i];
+        }
+        libpostal_address_parser_response_destroy(parsed);
+    }
+
+    return 0;
+}

--- a/projects/libpostal/project.yaml
+++ b/projects/libpostal/project.yaml
@@ -1,0 +1,7 @@
+homepage: "https://github.com/openvenues/libpostal"
+primary_contact: "alex.gaynor@gmail.com"
+auto_ccs: []
+sanitizers:
+  - address
+  - memory
+  - undefined


### PR DESCRIPTION
libpostal is a library for parsing and normalizing addresses. I've written an initial fuzzer, that seems to work ok based on "cov going up". However there's at least 3 problems, and I'm interested in feedback on:

1. It hangs almost immediately on inputs that are not well-formed utf8. I've filed https://github.com/openvenues/libpostal/issues/460 for this. Locally I've been testing with `-only_ascii=1`, however I wonder if there's not a better approach? Obviously upstream handling malformed utf-8 would be best, but maybe failing that I should put a check in the fuzzer itself, so it can explore utf8-but-not-ascii inputs?
2. It involves a machine learning model that takes about 2GB of RAM. The only way I've found to make this work is to disable the RSS checks
3. It has a _huge_ number of paths because it involves a significant amount of generated code. I haven't fully explored, but I think the number of human-authored codepaths is almost certainly a tiny tiny fraction of the generated code. This makes me doubtful that fuzzing is really capturing any value at all. Thoughts?

I also haven't discussed with the upstream maintainers yet, besides filing the hang bug.