### PR TITLE
Clone Samba from the official GitLab mirror (rather than official repo on https://git.samba.org)

### DIFF
--- a/projects/samba/Dockerfile
+++ b/projects/samba/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 
-RUN git clone https://git.samba.org/samba.git samba
+RUN git clone https://gitlab.com/samba-team/samba samba
 RUN samba/lib/fuzzing/oss-fuzz/build_image.sh
 
 WORKDIR /home/samba


### PR DESCRIPTION
I'm not sure if using the official mirror is allowed, but it will be faster if OK.