### PR TITLE
Fuzzer for avahi's core DNS parser

### DIFF
--- a/projects/avahi/Dockerfile
+++ b/projects/avahi/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER alex.gaynor@gmail.com
+RUN dpkg --add-architecture i386 && \
+    apt-get update && \
+    apt-get install -y autoconf gettext libtool m4 automake pkg-config libexpat-dev libexpat-dev:i386
+RUN git clone --depth 1 https://github.com/lathiat/avahi
+WORKDIR avahi
+COPY build.sh avahi_packet_consume_record_fuzzer.cc avahi_packet_consume_key_fuzzer.cc $SRC/

--- a/projects/avahi/avahi_packet_consume_key_fuzzer.cc
+++ b/projects/avahi/avahi_packet_consume_key_fuzzer.cc
@@ -1,0 +1,34 @@
+#include <stdint.h>
+#include <string.h>
+
+extern "C" {
+#include <avahi-common/malloc.h>
+#include <avahi-core/dns.h>
+#include <avahi-core/log.h>
+}
+
+void log_function(AvahiLogLevel level, const char *txt) {}
+
+struct AvahiState {
+    AvahiState() {
+        avahi_set_log_function(log_function);
+    }
+};
+
+AvahiState kGlobalSate;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    AvahiDnsPacket* packet = avahi_dns_packet_new(size + AVAHI_DNS_PACKET_EXTRA_SIZE);
+    memcpy(AVAHI_DNS_PACKET_DATA(packet), data, size);
+    packet->size = size;
+    AvahiKey* key = avahi_dns_packet_consume_key(packet, nullptr);
+    if (key) {
+        avahi_key_is_valid(key);
+        char *s = avahi_key_to_string(key);
+        avahi_free(s);
+        avahi_key_unref(key);
+    }
+    avahi_dns_packet_free(packet);
+
+    return 0;
+}

--- a/projects/avahi/avahi_packet_consume_record_fuzzer.cc
+++ b/projects/avahi/avahi_packet_consume_record_fuzzer.cc
@@ -1,0 +1,34 @@
+#include <stdint.h>
+#include <string.h>
+
+extern "C" {
+#include <avahi-common/malloc.h>
+#include <avahi-core/dns.h>
+#include <avahi-core/log.h>
+}
+
+void log_function(AvahiLogLevel level, const char *txt) {}
+
+struct AvahiState {
+    AvahiState() {
+        avahi_set_log_function(log_function);
+    }
+};
+
+AvahiState kGlobalSate;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    AvahiDnsPacket* packet = avahi_dns_packet_new(size + AVAHI_DNS_PACKET_EXTRA_SIZE);
+    memcpy(AVAHI_DNS_PACKET_DATA(packet), data, size);
+    packet->size = size;
+    AvahiRecord* rec = avahi_dns_packet_consume_record(packet, nullptr);
+    if (rec) {
+        avahi_record_is_valid(rec);
+        char *s = avahi_record_to_string(rec);
+        avahi_free(s);
+        avahi_record_unref(rec);
+    }
+    avahi_dns_packet_free(packet);
+
+    return 0;
+}

--- a/projects/avahi/build.sh
+++ b/projects/avahi/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -eu
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+
+sed -i 's/check_inconsistencies=yes/check_inconsistencies=no/' common/acx_pthread.m4
+sed -i 's/avahiinclude_HEADERS =/avahiinclude_HEADERS = dns.h hashmap.h/' avahi-core/Makefile.am
+
+./autogen.sh --disable-stack-protector --disable-qt3 --disable-qt4 --disable-qt5 --disable-gtk --disable-gtk3 --disable-dbus --disable-gdbm --disable-libdaemon --disable-python --disable-manpages --disable-mono --disable-monodoc --disable-glib --disable-gobject --disable-libevent --prefix="$WORK"
+make -j "$(nproc)"
+make install
+
+$CXX $CXXFLAGS -std=c++11 "-I$WORK/include/" \
+    "$SRC/avahi_packet_consume_record_fuzzer.cc" \
+    -o "$OUT/avahi_packet_consume_record_fuzzer" \
+    $LIB_FUZZING_ENGINE \
+    "$WORK/lib/libavahi-core.a" "$WORK/lib/libavahi-common.a"
+
+$CXX $CXXFLAGS -std=c++11 "-I$WORK/include/" \
+    "$SRC/avahi_packet_consume_key_fuzzer.cc" \
+    -o "$OUT/avahi_packet_consume_key_fuzzer" \
+    $LIB_FUZZING_ENGINE \
+    "$WORK/lib/libavahi-core.a" "$WORK/lib/libavahi-common.a"

--- a/projects/avahi/project.yaml
+++ b/projects/avahi/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://avahi.org/"
+primary_contact: trent@lloyd.id.au
+auto_ccs:
+  - alex.gaynor@gmail.com
+sanitizers:
+  - address
+  - memory
+  - undefined
+architectures:
+  - x86_64
+  - i386
+


### PR DESCRIPTION
Avahi is an _extremely_ widely used part of the Linux desktop (including on ChromeOS), it parses packets flying around on the network (mDNS) so the security implications are obvious.

Discussed with @lathiat (the upstream maintainer) by email.