### PR TITLE
Correctly insert libc++ include path to use local version.

### DIFF
--- a/projects/llvm_libcxx/build.sh
+++ b/projects/llvm_libcxx/build.sh
@@ -30,5 +30,5 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   assert(result == 0); return 0;
 }
 EOF
-  $CXX $CXXFLAGS -std=c++11 ${f}_fuzzer.cc ./libcxx/fuzzing/fuzzing.cpp -I ./libcxx  -o $OUT/$f $LIB_FUZZING_ENGINE
+  $CXX $CXXFLAGS -std=c++11 ${f}_fuzzer.cc ./libcxx/fuzzing/fuzzing.cpp -cxx-isystem ./libcxx/include  -o $OUT/$f $LIB_FUZZING_ENGINE
 done


### PR DESCRIPTION
Previously we're using the installed libc++ headers.