### PR TITLE
[libc++] Correctly remove the system stdlib includes using -nostdinc++

### DIFF
--- a/projects/llvm_libcxx/build.sh
+++ b/projects/llvm_libcxx/build.sh
@@ -31,6 +31,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 }
 EOF
   $CXX $CXXFLAGS -std=c++11 ${f}_fuzzer.cc ./libcxx/fuzzing/fuzzing.cpp \
-      -cxx-isystem ./libcxx/include -iquote ./libcxx \
+      -nostdinc++ -cxx-isystem ./libcxx/include -iquote ./libcxx \
       -o $OUT/$f $LIB_FUZZING_ENGINE
 done


### PR DESCRIPTION
This change was tested and verified to work by running:

1. git clone oss-fuzz
2. ./infra/helper.py build_image llvm_libcxx
3. ./infra/helper.py build_fuzzers llvm_libcxx

Third time's the charm?