### PR TITLE
[php] Disable object-size sanitizer

### DIFF
--- a/projects/php/build.sh
+++ b/projects/php/build.sh
@@ -24,6 +24,10 @@ popd
 export ONIG_CFLAGS="-I$PWD/oniguruma/src"
 export ONIG_LIBS="-L$PWD/oniguruma/src/.libs -l:libonig.a"
 
+# PHP's zend_function union is incompatible with the object-size sanitizer
+export CFLAGS="$CFLAGS -fno-sanitize=object-size"
+export CXXFLAGS="$CXXFLAGS -fno-sanitize=object-size"
+
 # build project
 ./buildconf
 ./configure \


### PR DESCRIPTION
PHP uses a union which is only allocated to the size of the used union member, which is apparently incompatible with the object-size sanitizer. This is really hard for us to fix, so instead disable the sanitizer.