### PR TITLE
Improve support for GraphicsFuzz

### DIFF
--- a/projects/graphicsfuzz-spirv/Dockerfile
+++ b/projects/graphicsfuzz-spirv/Dockerfile
@@ -15,19 +15,19 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y cmake ninja-build
+RUN apt-get update && apt-get install -y cmake ninja-build && apt-get install -y maven && apt-get install -y openjdk-8-jdk-headless && apt-get install -y wget
 
 RUN mkdir -p graphicsfuzz-spirv
 
 RUN git clone --depth=1 https://github.com/KhronosGroup/glslang.git graphicsfuzz-spirv/glslang
 RUN git clone --depth=1 https://github.com/KhronosGroup/SPIRV-Cross.git graphicsfuzz-spirv/SPIRV-Cross
-
 RUN git clone --depth=1 https://github.com/KhronosGroup/SPIRV-Tools.git graphicsfuzz-spirv/SPIRV-Tools
 RUN git clone --depth=1 https://github.com/KhronosGroup/SPIRV-Headers graphicsfuzz-spirv/SPIRV-Tools/external/spirv-headers
 RUN git clone --depth=1 https://github.com/google/effcee graphicsfuzz-spirv/SPIRV-Tools/external/effcee
 RUN git clone --depth=1 https://github.com/google/re2 graphicsfuzz-spirv/SPIRV-Tools/external/re2
 
-# TODO(metzman): Build GraphicsFuzz and bundle it so that the blackbox fuzzer is always using the latest version.
+# Cloning with --depth=1 does not work for GraphicsFuzz due to GraphicsFuzz doing a git commit check during its build process.
+RUN git clone https://github.com/google/graphicsfuzz.git graphicsfuzz-spirv/graphicsfuzz
 
 COPY build.sh $SRC/
 

--- a/projects/graphicsfuzz-spirv/build.sh
+++ b/projects/graphicsfuzz-spirv/build.sh
@@ -39,4 +39,12 @@ pushd SPIRV-Cross/build
 cmake -G "Ninja" -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" ..
 ninja
 cp spirv-cross $OUT/
+popd
 
+pushd graphicsfuzz
+mvn package -Dmaven.test.skip=True
+cp -r graphicsfuzz/target/graphicsfuzz $OUT/
+popd
+
+wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u232-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u232b09.tar.gz
+tar xzf OpenJDK8U-jdk_x64_linux_hotspot_8u232b09.tar.gz -C $OUT


### PR DESCRIPTION
The Dockerfile and build script for graphicsfuzz-spirv now checks out
and builds GraphicsFuzz, and downloads OpenJDK so that the
GraphicsFuzz Java classes can be executed during fuzzing.