### PR TITLE
[mtail] Fuzz the github.com/google/mtail project.

### DIFF
--- a/projects/mtail/Dockerfile
+++ b/projects/mtail/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER jaq@spacepants.org
+RUN mkdir -p github.com/google
+RUN git clone --depth 1 https://github.com/google/mtail github.com/google/mtail
+WORKDIR github.com/google/mtail
+COPY build.sh $SRC/

--- a/projects/mtail/build.sh
+++ b/projects/mtail/build.sh
@@ -23,4 +23,4 @@ export GOPATH=$GOPATH:/
 make GO111MODULE=off --debug install_deps
 go mod vendor
 
-make GO111MODULE=off --debug $OUT/vm-fuzzer.dict $OUT/vm-fuzzer
+make GO111MODULE=off --debug $OUT/vm-fuzzer.dict $OUT/vm-fuzzer_seed_corpus.zip $OUT/vm-fuzzer

--- a/projects/mtail/build.sh
+++ b/projects/mtail/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -eu
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# We've used git checkout, not go get to fetch the source so set up the GOPATH to find our source.
+export GOPATH=$GOPATH:/
+
+# go-fuzz-build doesn't like modules until https://github.com/dvyukov/go-fuzz/issues/195 is fixed
+# fetch and vendor all the dependencies so go-fuzz-build can find them
+make GO111MODULE=off --debug install_deps
+go mod vendor
+
+make GO111MODULE=off --debug $OUT/vm-fuzzer.dict $OUT/vm-fuzzer

--- a/projects/mtail/project.yaml
+++ b/projects/mtail/project.yaml
@@ -1,0 +1,2 @@
+homepage: https://github.com/google/mtail
+primary_contact: jaq@spacepants.org

--- a/projects/mtail/project.yaml
+++ b/projects/mtail/project.yaml
@@ -1,2 +1,6 @@
 homepage: https://github.com/google/mtail
 primary_contact: jaq@spacepants.org
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
This project doesn't go-get well so git clone it, then set up the GOPATH, and                                                                                                                                        
as go-fuzz-build doesn't like modules (which some of the dependencies are)                                                                                                                                           
vendor them and then build the fuzzer and dictionary. 