### PR TITLE
[libzip] enable lzma support

### DIFF
--- a/projects/libzip/Dockerfile
+++ b/projects/libzip/Dockerfile
@@ -19,7 +19,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 
 MAINTAINER randy408@protonmail.com
 
-RUN apt-get update && apt-get install -y cmake pkg-config zlib1g-dev liblzma-dev libbz2-dev
+RUN apt-get update && apt-get install -y cmake pkg-config zlib1g-dev liblzma-dev
 
 RUN git clone --depth 1 https://github.com/nih-at/libzip.git
 

--- a/projects/libzip/Dockerfile
+++ b/projects/libzip/Dockerfile
@@ -19,7 +19,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 
 MAINTAINER randy408@protonmail.com
 
-RUN apt-get update && apt-get install -y cmake pkg-config zlib1g-dev
+RUN apt-get update && apt-get install -y cmake pkg-config zlib1g-dev liblzma-dev libbz2-dev
 
 RUN git clone --depth 1 https://github.com/nih-at/libzip.git
 


### PR DESCRIPTION
This reenables lzma support which was disabled due to a linking issue, ~~it also installs bz2.~~

edit: it can't link libbz2, but at least it can link against lzma again.