### PR TITLE
ovs: Disable debug features in fuzzing build.

### DIFF
--- a/projects/openvswitch/build.sh
+++ b/projects/openvswitch/build.sh
@@ -15,7 +15,7 @@
 #
 ################################################################################
 
-./boot.sh && ./configure && make -j$(nproc) && make oss-fuzz-targets
+./boot.sh && HAVE_UNWIND=no ./configure --enable-ndebug && make -j$(nproc) && make oss-fuzz-targets
 
 cp $SRC/openvswitch/tests/oss-fuzz/config/*.options $OUT/
 cp $SRC/openvswitch/tests/oss-fuzz/config/*.dict $OUT/


### PR DESCRIPTION
Attempt to fix build failure because fuzzing binary depended on libunwind which is no longer available in fuzzing machines.

I suspect `libunwind` is necessary for some debugging feature that this PR disables.

Depends on https://github.com/google/oss-fuzz/issues/3165