### PR TITLE
envoy: pin bazel version by using bazelisk

### DIFF
--- a/projects/envoy/Dockerfile
+++ b/projects/envoy/Dockerfile
@@ -31,10 +31,9 @@ RUN apt-get update && apt-get -y install  \
     golang          \
     python
 
-# Install Bazel
-RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
-RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
-RUN apt-get update && apt-get install -y bazel
+# Install Bazelisk
+RUN wget -O /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v0.0.8/bazelisk-linux-amd64
+RUN chmod +x /usr/local/bin/bazel
 
 # Install cmake
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.14.5/cmake-3.14.5-Linux-x86_64.sh; \


### PR DESCRIPTION
Fixes Envoy build failure by pinning bazel verison to the version specified in Envoy's `.bazelversion`. 

Signed-off-by: Asra Ali <asraa@google.com>