### PR TITLE
Add the first fuzz target for Qt

### DIFF
--- a/projects/qt/Dockerfile
+++ b/projects/qt/Dockerfile
@@ -21,10 +21,6 @@ RUN git clone --depth 1 git://code.qt.io/qt/qt5.git qt
 WORKDIR qt
 RUN perl init-repository --module-subset=qtbase
 
-#temporary workaround
-WORKDIR qtbase
-RUN git checkout origin/dev
-
 WORKDIR $SRC
 RUN git clone --depth 1 git://code.qt.io/qt/qtqa.git
 COPY build.sh $SRC/

--- a/projects/qt/Dockerfile
+++ b/projects/qt/Dockerfile
@@ -1,0 +1,30 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER rlohningqt@gmail.com
+RUN apt-get update && apt-get install -y build-essential python libxcb-xinerama0-dev && apt-get install --no-install-recommends afl-doc
+RUN git clone --depth 1 git://code.qt.io/qt/qt5.git qt
+WORKDIR qt
+RUN perl init-repository --module-subset=qtbase
+
+#temporary workaround
+WORKDIR qtbase
+RUN git checkout origin/dev
+
+WORKDIR $SRC
+RUN git clone --depth 1 git://code.qt.io/qt/qtqa.git
+COPY build.sh $SRC/

--- a/projects/qt/build.sh
+++ b/projects/qt/build.sh
@@ -1,0 +1,40 @@
+#!/bin/bash -eu
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# add the flags to Qt build, gratefully borrowed from karchive
+cd $SRC/qt/qtbase/mkspecs
+sed -i -e "s/QMAKE_CXXFLAGS    += -stdlib=libc++/QMAKE_CXXFLAGS    += -stdlib=libc++  $CXXFLAGS\nQMAKE_CFLAGS += $CFLAGS/g" linux-clang-libc++/qmake.conf
+sed -i -e "s/QMAKE_LFLAGS      += -stdlib=libc++/QMAKE_LFLAGS      += -stdlib=libc++ -lpthread $CXXFLAGS/g" linux-clang-libc++/qmake.conf
+
+# set optimization to O1
+sed -i -e "s/QMAKE_CFLAGS_OPTIMIZE      = -O2/QMAKE_CFLAGS_OPTIMIZE      = -O1/g" common/gcc-base.conf
+sed -i -e "s/QMAKE_CFLAGS_OPTIMIZE_FULL = -O3/QMAKE_CFLAGS_OPTIMIZE_FULL = -O1/g" common/gcc-base.conf
+
+# build project
+cd $WORK
+MAKEFLAGS=-j$(nproc) $SRC/qt/configure -platform linux-clang-libc++ -sanitize fuzzer-no-link -opensource -confirm-license -no-opengl -no-widgets -nomake tests -nomake examples -prefix $OUT
+make -j$(nproc)
+make install
+
+# prepare corpus files
+zip -j $WORK/xml $SRC/qtqa/fuzzing/testcases/xml/* /usr/share/afl/testcases/others/xml/*
+
+# build fuzzers
+$OUT/bin/qmake $SRC/qt/qtbase/tests/libfuzzer/corelib/serialization/qxmlstream/qxmlstreamreader/readnext/readnext.pro
+make -j$(nproc)
+mv readnext $OUT
+cp $WORK/xml.zip $OUT/readnext_seed_corpus.zip

--- a/projects/qt/build.sh
+++ b/projects/qt/build.sh
@@ -26,7 +26,7 @@ sed -i -e "s/QMAKE_CFLAGS_OPTIMIZE_FULL = -O3/QMAKE_CFLAGS_OPTIMIZE_FULL = -O1/g
 
 # build project
 cd $WORK
-MAKEFLAGS=-j$(nproc) $SRC/qt/configure -platform linux-clang-libc++ -sanitize fuzzer-no-link -opensource -confirm-license -no-opengl -no-widgets -nomake tests -nomake examples -prefix $OUT
+MAKEFLAGS=-j$(nproc) $SRC/qt/configure -platform linux-clang-libc++ -opensource -confirm-license -no-opengl -no-widgets -nomake tests -nomake examples -prefix $OUT
 make -j$(nproc)
 make install
 

--- a/projects/qt/build.sh
+++ b/projects/qt/build.sh
@@ -34,7 +34,8 @@ make install
 zip -j $WORK/xml $SRC/qtqa/fuzzing/testcases/xml/* /usr/share/afl/testcases/others/xml/*
 
 # build fuzzers
-$OUT/bin/qmake $SRC/qt/qtbase/tests/libfuzzer/corelib/serialization/qxmlstream/qxmlstreamreader/readnext/readnext.pro
+sed -i -e "/LIBS/d" $SRC/qt/qtbase/tests/libfuzzer/corelib/serialization/qxmlstream/qxmlstreamreader/readnext/readnext.pro
+$OUT/bin/qmake LIBS+=$LIB_FUZZING_ENGINE $SRC/qt/qtbase/tests/libfuzzer/corelib/serialization/qxmlstream/qxmlstreamreader/readnext/readnext.pro
 make -j$(nproc)
 mv readnext $OUT
 cp $WORK/xml.zip $OUT/readnext_seed_corpus.zip

--- a/projects/qt/project.yaml
+++ b/projects/qt/project.yaml
@@ -1,2 +1,4 @@
 homepage: "http://qt-project.org"
 primary_contact: "rlohningqt@gmail.com"
+sanitizers:
+ - address


### PR DESCRIPTION
This builds Qt and a first fuzz target for it. Qt's sources contain further fuzz targets already, but I'd like to start with one to see if and how this all works. If it does, I'll add the others one by one.

Improvements I'd like to do soon, i.e. not in this change:
- further fuzz targets
- dictionaries
- add proper parameters to Qt's configure instead of editing the mkspec files in build.sh

In case I made any mistakes, please let me know and I'll happily fix them.

A healthy, happy new year to all of you. :-)