### PR TITLE
Run apt-get autoremove after removing honggfuzz dependencies.

### DIFF
--- a/infra/base-images/base-builder/precompile_honggfuzz
+++ b/infra/base-images/base-builder/precompile_honggfuzz
@@ -41,4 +41,5 @@ cp honggfuzz $PRECOMPILED_DIR/
 popd > /dev/null
 
 apt-get remove -y --purge ${PACKAGES[@]}
+apt-get autoremove -y
 echo " done."


### PR DESCRIPTION
Fixes #3165