### PR TITLE
Make bad_build_check more likely to catch hardcoding /out

### DIFF
--- a/infra/base-images/base-runner/Dockerfile
+++ b/infra/base-images/base-runner/Dockerfile
@@ -49,6 +49,7 @@ COPY bad_build_check \
     run_minijail \
     targets_list \
     test_all \
+    test_one \
     /usr/local/bin/
 
 # Default environment options for various sanitizers.

--- a/infra/base-images/base-runner/bad_build_check
+++ b/infra/base-images/base-runner/bad_build_check
@@ -371,22 +371,6 @@ function check_architecture {
 
 function main {
   local FUZZER=$1
-
-  # Move the directory the fuzzer is located in to somewhere that doesn't exist
-  # on the builder to make it more likely that hardcoding /out fails here (since
-  # it will fail on ClusterFuzz).
-  FUZZER=$(realpath $FUZZER)
-  local INITIAL_FUZZER_DIR=$(dirname $FUZZER)
-
-  local FUZZER_DIR=/mnt/scratch0/clusterfuzz/bot/builds/build/revisions
-  rm -rf $FUZZER_DIR
-  # Make FUZZER_DIR's parents.
-  mkdir -p $FUZZER_DIR
-  # Move contents of INITIAL_FUZZER_DIR rather than the directory itself since
-  # usually (when it is /out) it is mounted and cannot be moved.
-  mv $INITIAL_FUZZER_DIR/* $FUZZER_DIR
-  FUZZER="$FUZZER_DIR/$(basename $FUZZER)"
-
   local checks_failed=0
   local result=0
 

--- a/infra/base-images/base-runner/bad_build_check
+++ b/infra/base-images/base-runner/bad_build_check
@@ -371,6 +371,20 @@ function check_architecture {
 
 function main {
   local FUZZER=$1
+
+  # Move the directory the fuzzer is located in to somewhere that doesn't exist
+  # on the builder to make it more likely that hardcoding /out fails here (since
+  # it will fail on ClusterFuzz).
+  FUZZER=$(realpath $FUZZER)
+  local INITIAL_FUZZER_DIR=$(dirname $FUZZER)
+
+  local FUZZER_DIR=/tmp/mnt/scratch0/clusterfuzz/bot/builds/build/revisions
+  rm -rf $FUZZER_DIR
+  # Make FUZZER_DIR's parents.
+  mkdir -p $(dirname $FUZZER_DIR)
+  mv $INITIAL_FUZZER_DIR $FUZZER_DIR
+  FUZZER="$FUZZER_DIR/$(basename $FUZZER)"
+
   local checks_failed=0
   local result=0
 

--- a/infra/base-images/base-runner/bad_build_check
+++ b/infra/base-images/base-runner/bad_build_check
@@ -378,7 +378,7 @@ function main {
   FUZZER=$(realpath $FUZZER)
   local INITIAL_FUZZER_DIR=$(dirname $FUZZER)
 
-  local FUZZER_DIR=/tmp/mnt/scratch0/clusterfuzz/bot/builds/build/revisions
+  local FUZZER_DIR=/mnt/scratch0/clusterfuzz/bot/builds/build/revisions
   rm -rf $FUZZER_DIR
   # Make FUZZER_DIR's parents.
   mkdir -p $FUZZER_DIR

--- a/infra/base-images/base-runner/bad_build_check
+++ b/infra/base-images/base-runner/bad_build_check
@@ -381,8 +381,10 @@ function main {
   local FUZZER_DIR=/tmp/mnt/scratch0/clusterfuzz/bot/builds/build/revisions
   rm -rf $FUZZER_DIR
   # Make FUZZER_DIR's parents.
-  mkdir -p $(dirname $FUZZER_DIR)
-  mv $INITIAL_FUZZER_DIR $FUZZER_DIR
+  mkdir -p $FUZZER_DIR
+  # Move contents of INITIAL_FUZZER_DIR rather than the directory itself since
+  # usually (when it is /out) it is mounted and cannot be moved.
+  mv $INITIAL_FUZZER_DIR/* $FUZZER_DIR
   FUZZER="$FUZZER_DIR/$(basename $FUZZER)"
 
   local checks_failed=0

--- a/infra/base-images/base-runner/test_all
+++ b/infra/base-images/base-runner/test_all
@@ -32,8 +32,18 @@ rm -rf $BROKEN_TARGETS_DIR
 mkdir $VALID_TARGETS_DIR
 mkdir $BROKEN_TARGETS_DIR
 
+# Move the directory the fuzzer is located in to somewhere that doesn't exist
+# on the builder to make it more likely that hardcoding /out fails here (since
+# it will fail on ClusterFuzz).
+TMP_FUZZER_DIR=/tmp/not-out
+rm -rf $TMP_FUZZER_DIR
+mkdir $TMP_FUZZER_DIR
+# Move contents of $OUT/ into $TMP_FUZZER_DIR. We can't move the directory
+# itself because it is a mount.
+mv $OUT/* $TMP_FUZZER_DIR
+
 # Main loop that iterates through all fuzz targets and runs the check.
-for FUZZER_BINARY in $(find $OUT/ -maxdepth 1 -executable -type f); do
+for FUZZER_BINARY in $(find $TMP_FUZZER_DIR -maxdepth 1 -executable -type f); do
   if file "$FUZZER_BINARY" | grep -v ELF > /dev/null 2>&1; then
     continue
   fi
@@ -72,6 +82,9 @@ done
 
 # Wait for background processes to finish.
 wait
+
+# Restore $OUT
+mv $TMP_FUZZER_DIR/* $OUT
 
 # Sanity check in case there are no fuzz targets in the $OUT/ dir.
 if [ "$TOTAL_TARGETS_COUNT" -eq "0" ]; then

--- a/infra/base-images/base-runner/test_one
+++ b/infra/base-images/base-runner/test_one
@@ -1,0 +1,44 @@
+#!/bin/bash -u
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Wrapper around bad_build_check that moves the /out directory to /not-out. This
+# is useful when bad_build_check isn't called from test_all which does the same
+# thing.
+
+function main {
+  # Move the directory the fuzzer is located in to somewhere that doesn't exist
+  # on the builder to make it more likely that hardcoding /out fails here (since
+  # it will fail on ClusterFuzz).
+  FUZZER=$1
+  FUZZER=$(realpath $FUZZER)
+  local INITIAL_FUZZER_DIR=$(dirname $FUZZER)
+
+  local TMP_FUZZER_DIR=/tmp/not-out
+  rm -rf $TMP_FUZZER_DIR
+  mkdir $TMP_FUZZER_DIR
+  # Move the contents of $INITIAL_FUZZER_DIR rather than the directory itself in
+  # case it is a mount.
+  mv $INITIAL_FUZZER_DIR/* $TMP_FUZZER_DIR
+  FUZZER="$TMP_FUZZER_DIR/$(basename $FUZZER)"
+
+  bad_build_check $1
+  returncode=$?
+
+  mv $INITIAL_FUZZER_DIR/* $TMP_FUZZER_DIR
+  exit returncode
+}
+main $1

--- a/infra/base-images/base-runner/test_one
+++ b/infra/base-images/base-runner/test_one
@@ -15,30 +15,30 @@
 #
 ################################################################################
 
-# Wrapper around bad_build_check that moves the /out directory to /not-out. This
-# is useful when bad_build_check isn't called from test_all which does the same
-# thing.
+# Wrapper around bad_build_check that moves the /out directory to /tmp/not-out.
+# This is useful when bad_build_check isn't called from test_all which does the
+# same thing.
 
 function main {
   # Move the directory the fuzzer is located in to somewhere that doesn't exist
   # on the builder to make it more likely that hardcoding /out fails here (since
   # it will fail on ClusterFuzz).
-  FUZZER=$1
-  FUZZER=$(realpath $FUZZER)
-  local INITIAL_FUZZER_DIR=$(dirname $FUZZER)
+  local fuzzer=$1
+  fuzzer=$(realpath $fuzzer)
+  local initial_fuzzer_dir=$(dirname $fuzzer)
 
-  local TMP_FUZZER_DIR=/tmp/not-out
-  rm -rf $TMP_FUZZER_DIR
-  mkdir $TMP_FUZZER_DIR
-  # Move the contents of $INITIAL_FUZZER_DIR rather than the directory itself in
+  local tmp_fuzzer_dir=/tmp/not-out
+  rm -rf $tmp_fuzzer_dir
+  mkdir $tmp_fuzzer_dir
+  # Move the contents of $initial_fuzzer_dir rather than the directory itself in
   # case it is a mount.
-  mv $INITIAL_FUZZER_DIR/* $TMP_FUZZER_DIR
-  FUZZER="$TMP_FUZZER_DIR/$(basename $FUZZER)"
+  mv $initial_fuzzer_dir/* $tmp_fuzzer_dir
+  fuzzer="$tmp_fuzzer_dir/$(basename $fuzzer)"
 
-  bad_build_check $FUZZER
+  bad_build_check $fuzzer
   returncode=$?
 
-  mv $TMP_FUZZER_DIR/* $INITIAL_FUZZER_DIR
+  mv $tmp_fuzzer_dir/* $initial_fuzzer_dir
   exit returncode
 }
 

--- a/infra/base-images/base-runner/test_one
+++ b/infra/base-images/base-runner/test_one
@@ -1,5 +1,5 @@
 #!/bin/bash -u
-# Copyright 2016 Google Inc.
+# Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,10 +35,16 @@ function main {
   mv $INITIAL_FUZZER_DIR/* $TMP_FUZZER_DIR
   FUZZER="$TMP_FUZZER_DIR/$(basename $FUZZER)"
 
-  bad_build_check $1
+  bad_build_check $FUZZER
   returncode=$?
 
-  mv $INITIAL_FUZZER_DIR/* $TMP_FUZZER_DIR
+  mv $TMP_FUZZER_DIR/* $INITIAL_FUZZER_DIR
   exit returncode
 }
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <fuzz_target_binary>"
+  exit 1
+fi
+
 main $1

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -524,7 +524,7 @@ def check_build(args):
 
   if args.fuzzer_name:
     run_args += [
-        'bad_build_check',
+        'test_one',
         os.path.join('/out', args.fuzzer_name)
     ]
   else:


### PR DESCRIPTION
Loading dynamic libraries/files or anything else from /out breaks on CF. It doesn't break in the "runner" because as we've already seen the runner is not used on CF.

Rather than hack OSS-Fuzz's fake runner to be more like ClusterFuzz's real runner I'm fixing the issue closer to where it is actually causing an issue, bad_build_check.

Long term we should get rid of the runner and replace it with CF's image rather than deal with these issues again and again.