### PR TITLE
[gnutls] disable the full test suite

### DIFF
--- a/projects/gnutls/build.sh
+++ b/projects/gnutls/build.sh
@@ -77,7 +77,8 @@ cd $SRC/gnutls
 ./bootstrap
 ASAN_OPTIONS=detect_leaks=0 LIBS="-lunistring" CXXFLAGS="$CXXFLAGS -L$DEPS_PATH/lib" \
   ./configure --enable-fuzzer-target --disable-gcc-warnings --enable-static --disable-shared --disable-doc --disable-tests \
-    --disable-tools --disable-cxx --disable-maintainer-mode --disable-libdane --without-p11-kit $GNUTLS_CONFIGURE_FLAGS
+    --disable-tools --disable-cxx --disable-maintainer-mode --disable-libdane --without-p11-kit \
+    --disable-full-test-suite $GNUTLS_CONFIGURE_FLAGS
 
 # Do not use the syscall interface for randomness in oss-fuzz, it seems
 # to confuse memory sanitizer.


### PR DESCRIPTION
The full test suite is not necessary for this build and this
disablement avoids any dependencies required by it.

Signed-off-by: Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>