### PR TITLE
[proxygen] Install libunwind8 in Dockerfile

### DIFF
--- a/projects/proxygen/Dockerfile
+++ b/projects/proxygen/Dockerfile
@@ -148,7 +148,7 @@ RUN apt-get install -y \
     binutils-dev \
     libsodium-dev \
     libdouble-conversion-dev \
-    libunwind8
+    libunwind8-dev
 
 # Install patchelf so we can fix path to libunwind
 RUN apt-get install patchelf

--- a/projects/proxygen/Dockerfile
+++ b/projects/proxygen/Dockerfile
@@ -147,7 +147,8 @@ RUN apt-get install -y \
     zlib1g-dev \
     binutils-dev \
     libsodium-dev \
-    libdouble-conversion-dev
+    libdouble-conversion-dev \
+    libunwind8
 
 # Install patchelf so we can fix path to libunwind
 RUN apt-get install patchelf


### PR DESCRIPTION
This should fix the build since libunwind was removed from the base image in https://github.com/google/oss-fuzz/pull/3031/files and we need it in this case.

I have not tested this yet, and will wait on Travis to confirm that this works.