### PR TITLE
[tpm2-tss] disable building the Feature API (FAPI)

### DIFF
--- a/projects/tpm2-tss/build.sh
+++ b/projects/tpm2-tss/build.sh
@@ -31,7 +31,8 @@ export GEN_FUZZ=1
   --enable-tcti-device=no \
   --enable-tcti-mssim=no \
   --disable-doxygen-doc \
-  --disable-shared
+  --disable-shared \
+  --disable-fapi
 
 sed -i 's/@DX_RULES@/# @DX_RULES@/g' Makefile
 make -j $(nproc) fuzz-targets


### PR DESCRIPTION
The new API introduced in https://github.com/tpm2-software/tpm2-tss/commit/6da95b04b4f22284d5b40cc03fa19e6dc514339f pulls in additional build dependencies like json-c and is currently not part of the fuzz testing, so disable it.

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=19639