### PR TITLE
Fix issue running AFL targets with run_fuzzer

### DIFF
--- a/infra/base-images/base-runner/run_fuzzer
+++ b/infra/base-images/base-runner/run_fuzzer
@@ -106,12 +106,7 @@ fi
 echo $CMD_LINE
 
 # Unset OUT so the fuzz target can't rely on it.
-INITIAL_OUT=$OUT
 unset OUT
+
 bash -c "$CMD_LINE"
-RETURNCODE=$?
 
-# Restore OUT
-OUT=$INITIAL_OUT
-
-exit $RETURNCODE

--- a/infra/base-images/base-runner/run_fuzzer
+++ b/infra/base-images/base-runner/run_fuzzer
@@ -104,4 +104,14 @@ else
 fi
 
 echo $CMD_LINE
+
+# Unset OUT so the fuzz target can't rely on it.
+INITIAL_OUT=$OUT
+unset OUT
 bash -c "$CMD_LINE"
+RETURNCODE=$?
+
+# Restore OUT
+OUT=$INITIAL_OUT
+
+exit $RETURNCODE

--- a/infra/base-images/base-runner/test_all
+++ b/infra/base-images/base-runner/test_all
@@ -41,6 +41,9 @@ mkdir $TMP_FUZZER_DIR
 # Move contents of $OUT/ into $TMP_FUZZER_DIR. We can't move the directory
 # itself because it is a mount.
 mv $OUT/* $TMP_FUZZER_DIR
+INITIAL_OUT=$OUT
+OUT=$TMP_FUZZER_DIR
+
 
 # Main loop that iterates through all fuzz targets and runs the check.
 for FUZZER_BINARY in $(find $TMP_FUZZER_DIR -maxdepth 1 -executable -type f); do
@@ -83,7 +86,8 @@ done
 # Wait for background processes to finish.
 wait
 
-# Restore $OUT
+# Restore OUT
+OUT=$INITIAL_OUT
 mv $TMP_FUZZER_DIR/* $OUT
 
 # Sanity check in case there are no fuzz targets in the $OUT/ dir.

--- a/infra/base-images/base-runner/test_all
+++ b/infra/base-images/base-runner/test_all
@@ -42,7 +42,7 @@ mkdir $TMP_FUZZER_DIR
 # itself because it is a mount.
 mv $OUT/* $TMP_FUZZER_DIR
 INITIAL_OUT=$OUT
-OUT=$TMP_FUZZER_DIR
+export OUT=$TMP_FUZZER_DIR
 
 
 # Main loop that iterates through all fuzz targets and runs the check.
@@ -87,7 +87,7 @@ done
 wait
 
 # Restore OUT
-OUT=$INITIAL_OUT
+export OUT=$INITIAL_OUT
 mv $TMP_FUZZER_DIR/* $OUT
 
 # Sanity check in case there are no fuzz targets in the $OUT/ dir.

--- a/infra/base-images/base-runner/test_one
+++ b/infra/base-images/base-runner/test_one
@@ -35,11 +35,18 @@ function main {
   mv $initial_fuzzer_dir/* $tmp_fuzzer_dir
   fuzzer="$tmp_fuzzer_dir/$(basename $fuzzer)"
 
+  # Change OUT to the temporary fuzzer dir.
+  local initial_out=$OUT
+  OUT=$tmp_fuzzer_dir
+
   bad_build_check $fuzzer
   returncode=$?
 
+  # Restore OUT and $initial_fuzzer_dir
+  OUT=$initial_out
   mv $tmp_fuzzer_dir/* $initial_fuzzer_dir
-  exit returncode
+
+  return $returncode
 }
 
 if [ $# -ne 1 ]; then
@@ -48,3 +55,4 @@ if [ $# -ne 1 ]; then
 fi
 
 main $1
+exit $?

--- a/infra/base-images/base-runner/test_one
+++ b/infra/base-images/base-runner/test_one
@@ -37,13 +37,13 @@ function main {
 
   # Change OUT to the temporary fuzzer dir.
   local initial_out=$OUT
-  OUT=$tmp_fuzzer_dir
+  export OUT=$tmp_fuzzer_dir
 
   bad_build_check $fuzzer
   returncode=$?
 
   # Restore OUT and $initial_fuzzer_dir
-  OUT=$initial_out
+  export OUT=$initial_out
   mv $tmp_fuzzer_dir/* $initial_fuzzer_dir
 
   return $returncode


### PR DESCRIPTION
Set `$OUT` to the `not-out` directory before running `run_fuzzer` so that `afl-fuzz` and `honggfuzz` can be used by `run_fuzzer`.

Also unset the `$OUT` environment variable in `run_fuzzer` just in case any fuzz targets use it at run time.

Fixes #3194