### PR TITLE
[knot-dns] add libev4 dep for gnutls

### DIFF
--- a/projects/knot-dns/Dockerfile
+++ b/projects/knot-dns/Dockerfile
@@ -28,7 +28,9 @@ RUN apt-get update && apt-get install -y \
  make \
  pkg-config \
  texinfo \
- wget
+ wget \
+ libev4 \
+ libev-dev
 
 ENV GNULIB_TOOL $SRC/gnulib/gnulib-tool
 RUN git clone git://git.savannah.gnu.org/gnulib.git


### PR DESCRIPTION
The knot-dns fuzz target build is broken due to gnutls (a dependency) requiring libev4. This adds the associated packages to the Dockerfile.

/cc @salzmdan 