### PR TITLE
Reland Make bad_build_check more likely to catch hardcoding /out (#3180)

### DIFF
--- a/infra/base-images/base-runner/Dockerfile
+++ b/infra/base-images/base-runner/Dockerfile
@@ -49,6 +49,7 @@ COPY bad_build_check \
     run_minijail \
     targets_list \
     test_all \
+    test_one \
     /usr/local/bin/
 
 # Default environment options for various sanitizers.

--- a/infra/base-images/base-runner/test_all
+++ b/infra/base-images/base-runner/test_all
@@ -32,8 +32,18 @@ rm -rf $BROKEN_TARGETS_DIR
 mkdir $VALID_TARGETS_DIR
 mkdir $BROKEN_TARGETS_DIR
 
+# Move the directory the fuzzer is located in to somewhere that doesn't exist
+# on the builder to make it more likely that hardcoding /out fails here (since
+# it will fail on ClusterFuzz).
+TMP_FUZZER_DIR=/tmp/not-out
+rm -rf $TMP_FUZZER_DIR
+mkdir $TMP_FUZZER_DIR
+# Move contents of $OUT/ into $TMP_FUZZER_DIR. We can't move the directory
+# itself because it is a mount.
+mv $OUT/* $TMP_FUZZER_DIR
+
 # Main loop that iterates through all fuzz targets and runs the check.
-for FUZZER_BINARY in $(find $OUT/ -maxdepth 1 -executable -type f); do
+for FUZZER_BINARY in $(find $TMP_FUZZER_DIR -maxdepth 1 -executable -type f); do
   if file "$FUZZER_BINARY" | grep -v ELF > /dev/null 2>&1; then
     continue
   fi
@@ -72,6 +82,9 @@ done
 
 # Wait for background processes to finish.
 wait
+
+# Restore $OUT
+mv $TMP_FUZZER_DIR/* $OUT
 
 # Sanity check in case there are no fuzz targets in the $OUT/ dir.
 if [ "$TOTAL_TARGETS_COUNT" -eq "0" ]; then

--- a/infra/base-images/base-runner/test_one
+++ b/infra/base-images/base-runner/test_one
@@ -1,0 +1,50 @@
+#!/bin/bash -u
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Wrapper around bad_build_check that moves the /out directory to /tmp/not-out.
+# This is useful when bad_build_check isn't called from test_all which does the
+# same thing.
+
+function main {
+  # Move the directory the fuzzer is located in to somewhere that doesn't exist
+  # on the builder to make it more likely that hardcoding /out fails here (since
+  # it will fail on ClusterFuzz).
+  local fuzzer=$1
+  fuzzer=$(realpath $fuzzer)
+  local initial_fuzzer_dir=$(dirname $fuzzer)
+
+  local tmp_fuzzer_dir=/tmp/not-out
+  rm -rf $tmp_fuzzer_dir
+  mkdir $tmp_fuzzer_dir
+  # Move the contents of $initial_fuzzer_dir rather than the directory itself in
+  # case it is a mount.
+  mv $initial_fuzzer_dir/* $tmp_fuzzer_dir
+  fuzzer="$tmp_fuzzer_dir/$(basename $fuzzer)"
+
+  bad_build_check $fuzzer
+  returncode=$?
+
+  mv $tmp_fuzzer_dir/* $initial_fuzzer_dir
+  exit returncode
+}
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <fuzz_target_binary>"
+  exit 1
+fi
+
+main $1

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -530,7 +530,7 @@ def check_build(args):
 
   if args.fuzzer_name:
     run_args += [
-        'bad_build_check',
+        'test_one',
         os.path.join('/out', args.fuzzer_name)
     ]
   else:


### PR DESCRIPTION
This reverts commit 689c3f4b65b77ca27e882de828b4e741121238fc.