### PR TITLE
[infra] Print additional information for build/coverage failures on GCB (#3104).

### DIFF
--- a/infra/gcb/build_and_run_coverage.py
+++ b/infra/gcb/build_and_run_coverage.py
@@ -176,7 +176,14 @@ def get_build_steps(project_dir):
           'args': [
               'bash',
               '-c',
-              'for f in /corpus/*.zip; do unzip -q $f -d ${f%%.*}; done && coverage',
+              ('for f in /corpus/*.zip; do unzip -q $f -d ${f%%.*} || '
+               'echo "Failed to unpack the corpus for ${f%%.*}. This usually '
+               'means that corpus backup for a particular fuzz target does not '
+               'exist. If a fuzz target was added in the last 24 hours, please '
+               'wait one more day. Otherwise, something is wrong with the fuzz '
+               'target or the infrastructure, and corpus pruning task does not '
+               'finish successfully." && false; '
+               'done && coverage')
           ],
           'volumes': [{'name': 'corpus', 'path': '/corpus'}],
       }

--- a/infra/gcb/build_and_run_coverage.py
+++ b/infra/gcb/build_and_run_coverage.py
@@ -182,7 +182,7 @@ def get_build_steps(project_dir):
                'target does not exist. If a fuzz target was added in the last '
                '24 hours, please wait one more day. Otherwise, something is '
                'wrong with the fuzz target or the infrastructure, and corpus '
-               'pruning task does not finish successfully. && exit"; '
+               'pruning task does not finish successfully. && exit 1"; '
                'done && coverage')
           ],
           'volumes': [{'name': 'corpus', 'path': '/corpus'}],

--- a/infra/gcb/build_and_run_coverage.py
+++ b/infra/gcb/build_and_run_coverage.py
@@ -177,12 +177,12 @@ def get_build_steps(project_dir):
               'bash',
               '-c',
               ('for f in /corpus/*.zip; do unzip -q $f -d ${f%%.*} || '
-               'echo "Failed to unpack the corpus for ${f%%.*}. This usually '
-               'means that corpus backup for a particular fuzz target does not '
-               'exist. If a fuzz target was added in the last 24 hours, please '
-               'wait one more day. Otherwise, something is wrong with the fuzz '
-               'target or the infrastructure, and corpus pruning task does not '
-               'finish successfully." && false; '
+               'echo "Failed to unpack the corpus for $(basename ${f%%.*}). '
+               'This usually means that corpus backup for a particular fuzz '
+               'target does not exist. If a fuzz target was added in the last '
+               '24 hours, please wait one more day. Otherwise, something is '
+               'wrong with the fuzz target or the infrastructure, and corpus '
+               'pruning task does not finish successfully. && exit"; '
                'done && coverage')
           ],
           'volumes': [{'name': 'corpus', 'path': '/corpus'}],

--- a/infra/gcb/build_and_run_coverage.py
+++ b/infra/gcb/build_and_run_coverage.py
@@ -182,7 +182,7 @@ def get_build_steps(project_dir):
                'target does not exist. If a fuzz target was added in the last '
                '24 hours, please wait one more day. Otherwise, something is '
                'wrong with the fuzz target or the infrastructure, and corpus '
-               'pruning task does not finish successfully. && exit 1"; '
+               'pruning task does not finish successfully." && exit 1; '
                'done && coverage')
           ],
           'volumes': [{'name': 'corpus', 'path': '/corpus'}],

--- a/infra/gcb/build_project.py
+++ b/infra/gcb/build_project.py
@@ -236,6 +236,8 @@ def get_build_steps(project_dir):
         if not workdir:
           workdir = '/src'
 
+        failure_msg = ('FAILED IN THE FOLLOWING CONFIG: --sanitizer {0} '
+                       '--engine {1}').format(sanitizer, fuzzing_engine)
         build_steps.append(
             # compile
             {
@@ -251,8 +253,9 @@ def get_build_steps(project_dir):
                     # `cd /src && cd {workdir}` (where {workdir} is parsed from
                     # the Dockerfile). Container Builder overrides our workdir
                     # so we need to add this step to set it back.
-                    'rm -r /out && cd /src && cd {1} && mkdir -p {0} && compile'
-                    .format(out, workdir),
+                    ('rm -r /out && cd /src && cd {1} && mkdir -p {0} && '
+                     'compile || echo "build_fuzzers {2}"')
+                    .format(out, workdir, failure_msg),
                 ],
             })
 
@@ -276,7 +279,10 @@ def get_build_steps(project_dir):
               {
                   'name': 'gcr.io/oss-fuzz-base/base-runner',
                   'env': env,
-                  'args': ['bash', '-c', 'test_all'],
+                  'args': [
+                      'bash',
+                      '-c',
+                      'test_all || echo "check_build %s"' % failure_msg],
               })
 
         if project_yaml['labels']:

--- a/infra/gcb/build_project.py
+++ b/infra/gcb/build_project.py
@@ -282,7 +282,8 @@ def get_build_steps(project_dir):
                   'args': [
                       'bash',
                       '-c',
-                      'test_all || echo "check_build %s" && false' % failure_msg
+                      'test_all || echo "check_build {0}" && false'.format(
+                          failure_msg)
                   ],
               })
 

--- a/infra/gcb/build_project.py
+++ b/infra/gcb/build_project.py
@@ -254,7 +254,7 @@ def get_build_steps(project_dir):
                     # the Dockerfile). Container Builder overrides our workdir
                     # so we need to add this step to set it back.
                     ('rm -r /out && cd /src && cd {1} && mkdir -p {0} && '
-                     'compile || echo "build_fuzzers {2}"')
+                     'compile || echo "build_fuzzers {2}" && false')
                     .format(out, workdir, failure_msg),
                 ],
             })
@@ -282,7 +282,8 @@ def get_build_steps(project_dir):
                   'args': [
                       'bash',
                       '-c',
-                      'test_all || echo "check_build %s"' % failure_msg],
+                      'test_all || echo "check_build %s" && false' % failure_msg
+                  ],
               })
 
         if project_yaml['labels']:


### PR DESCRIPTION
Haven't tested yet, will do before landing.

Inspired by https://github.com/GoogleCloudPlatform/cloud-builders/issues/253, as it seems like there doesn't exist a better mechanism for this.