### PR TITLE
[unbound] add fuzzers written for OSTIF audit

### DIFF
--- a/projects/unbound/Dockerfile
+++ b/projects/unbound/Dockerfile
@@ -20,4 +20,8 @@ RUN apt-get install -y make libtool libssl-dev libexpat-dev wget
 RUN git clone --depth=1 https://github.com/NLnetLabs/unbound unbound
 WORKDIR unbound
 COPY parse_packet_fuzzer.c .
+COPY fuzz_1.c .
+COPY fuzz_2.c .
+COPY fuzz_3.c .
+COPY fuzz_4.c .
 COPY build.sh $SRC/

--- a/projects/unbound/build.sh
+++ b/projects/unbound/build.sh
@@ -22,6 +22,10 @@ CFLAGS="${CFLAGS} -DVALGRIND=1"
 make -j6 all
 
 $CC $CFLAGS -I. -DSRCDIR=. -c -o parse_packet_fuzzer.o parse_packet_fuzzer.c
+$CC $CFLAGS -I. -DSRCDIR=. -c -o fuzz_1.o fuzz_1.c
+$CC $CFLAGS -I. -DSRCDIR=. -c -o fuzz_2.o fuzz_2.c
+$CC $CFLAGS -I. -DSRCDIR=. -c -o fuzz_3.o fuzz_3.c
+$CC $CFLAGS -I. -DSRCDIR=. -c -o fuzz_4.o fuzz_4.c
 
 # get the LIBOBJS with the replaced functions needed for linking.
 LIBOBJS=`make --eval 'echolibobjs: ; @echo "$(LIBOBJS)"' echolibobjs`
@@ -46,4 +50,88 @@ $CXX $CXXFLAGS -std=c++11 \
   libworker.o context.o \
   $LIBOBJS
 
+$CXX $CXXFLAGS -std=c++11 \
+  $LIB_FUZZING_ENGINE \
+  -lssl -lcrypto -pthread \
+  -o $OUT/fuzz_1_fuzzer \
+  fuzz_1.o \
+  dns.o infra.o rrset.o dname.o \
+  msgencode.o as112.o msgparse.o msgreply.o packed_rrset.o iterator.o \
+  iter_delegpt.o iter_donotq.o iter_fwd.o iter_hints.o iter_priv.o \
+  iter_resptype.o iter_scrub.o iter_utils.o localzone.o mesh.o modstack.o view.o \
+  outbound_list.o alloc.o config_file.o configlexer.o configparser.o \
+  fptr_wlist.o edns.o locks.o log.o mini_event.o module.o net_help.o random.o \
+  rbtree.o regional.o rtt.o dnstree.o lookup3.o lruhash.o slabhash.o \
+  tcp_conn_limit.o timehist.o tube.o winsock_event.o autotrust.o val_anchor.o \
+  validator.o val_kcache.o val_kentry.o val_neg.o val_nsec3.o val_nsec.o \
+  val_secalgo.o val_sigcrypt.o val_utils.o dns64.o cachedb.o redis.o authzone.o \
+  respip.o netevent.o listen_dnsport.o outside_network.o ub_event.o keyraw.o \
+  sbuffer.o wire2str.o parse.o parseutil.o rrdef.o str2wire.o libunbound.o \
+  libworker.o context.o \
+  $LIBOBJS
+
+$CXX $CXXFLAGS -std=c++11 \
+  $LIB_FUZZING_ENGINE \
+  -lssl -lcrypto -pthread \
+  -o $OUT/fuzz_2_fuzzer \
+  fuzz_2.o \
+  dns.o infra.o rrset.o dname.o \
+  msgencode.o as112.o msgparse.o msgreply.o packed_rrset.o iterator.o \
+  iter_delegpt.o iter_donotq.o iter_fwd.o iter_hints.o iter_priv.o \
+  iter_resptype.o iter_scrub.o iter_utils.o localzone.o mesh.o modstack.o view.o \
+  outbound_list.o alloc.o config_file.o configlexer.o configparser.o \
+  fptr_wlist.o edns.o locks.o log.o mini_event.o module.o net_help.o random.o \
+  rbtree.o regional.o rtt.o dnstree.o lookup3.o lruhash.o slabhash.o \
+  tcp_conn_limit.o timehist.o tube.o winsock_event.o autotrust.o val_anchor.o \
+  validator.o val_kcache.o val_kentry.o val_neg.o val_nsec3.o val_nsec.o \
+  val_secalgo.o val_sigcrypt.o val_utils.o dns64.o cachedb.o redis.o authzone.o \
+  respip.o netevent.o listen_dnsport.o outside_network.o ub_event.o keyraw.o \
+  sbuffer.o wire2str.o parse.o parseutil.o rrdef.o str2wire.o libunbound.o \
+  libworker.o context.o \
+  $LIBOBJS
+
+$CXX $CXXFLAGS -std=c++11 \
+  $LIB_FUZZING_ENGINE \
+  -lssl -lcrypto -pthread \
+  -o $OUT/fuzz_3_fuzzer \
+  fuzz_3.o \
+  dns.o infra.o rrset.o dname.o \
+  msgencode.o as112.o msgparse.o msgreply.o packed_rrset.o iterator.o \
+  iter_delegpt.o iter_donotq.o iter_fwd.o iter_hints.o iter_priv.o \
+  iter_resptype.o iter_scrub.o iter_utils.o localzone.o mesh.o modstack.o view.o \
+  outbound_list.o alloc.o config_file.o configlexer.o configparser.o \
+  fptr_wlist.o edns.o locks.o log.o mini_event.o module.o net_help.o random.o \
+  rbtree.o regional.o rtt.o dnstree.o lookup3.o lruhash.o slabhash.o \
+  tcp_conn_limit.o timehist.o tube.o winsock_event.o autotrust.o val_anchor.o \
+  validator.o val_kcache.o val_kentry.o val_neg.o val_nsec3.o val_nsec.o \
+  val_secalgo.o val_sigcrypt.o val_utils.o dns64.o cachedb.o redis.o authzone.o \
+  respip.o netevent.o listen_dnsport.o outside_network.o ub_event.o keyraw.o \
+  sbuffer.o wire2str.o parse.o parseutil.o rrdef.o str2wire.o libunbound.o \
+  libworker.o context.o \
+  $LIBOBJS
+
+$CXX $CXXFLAGS -std=c++11 \
+  $LIB_FUZZING_ENGINE \
+  -lssl -lcrypto -pthread \
+  -o $OUT/fuzz_4_fuzzer \
+  fuzz_4.o \
+  dns.o infra.o rrset.o dname.o \
+  msgencode.o as112.o msgparse.o msgreply.o packed_rrset.o iterator.o \
+  iter_delegpt.o iter_donotq.o iter_fwd.o iter_hints.o iter_priv.o \
+  iter_resptype.o iter_scrub.o iter_utils.o localzone.o mesh.o modstack.o view.o \
+  outbound_list.o alloc.o config_file.o configlexer.o configparser.o \
+  fptr_wlist.o edns.o locks.o log.o mini_event.o module.o net_help.o random.o \
+  rbtree.o regional.o rtt.o dnstree.o lookup3.o lruhash.o slabhash.o \
+  tcp_conn_limit.o timehist.o tube.o winsock_event.o autotrust.o val_anchor.o \
+  validator.o val_kcache.o val_kentry.o val_neg.o val_nsec3.o val_nsec.o \
+  val_secalgo.o val_sigcrypt.o val_utils.o dns64.o cachedb.o redis.o authzone.o \
+  respip.o netevent.o listen_dnsport.o outside_network.o ub_event.o keyraw.o \
+  sbuffer.o wire2str.o parse.o parseutil.o rrdef.o str2wire.o libunbound.o \
+  libworker.o context.o \
+  $LIBOBJS
+
 wget --directory-prefix $OUT https://github.com/jsha/unbound/raw/fuzzing-corpora/testdata/parse_packet_fuzzer_seed_corpus.zip
+wget --directory-prefix $OUT https://github.com/luisx41/fuzzing-corpus/raw/master/projects/unbound/fuzz_1_fuzzer_seed_corpus.zip
+wget --directory-prefix $OUT https://github.com/luisx41/fuzzing-corpus/raw/master/projects/unbound/fuzz_2_fuzzer_seed_corpus.zip
+wget --directory-prefix $OUT https://github.com/luisx41/fuzzing-corpus/raw/master/projects/unbound/fuzz_3_fuzzer_seed_corpus.zip
+wget --directory-prefix $OUT https://github.com/luisx41/fuzzing-corpus/raw/master/projects/unbound/fuzz_4_fuzzer_seed_corpus.zip

--- a/projects/unbound/fuzz_1.c
+++ b/projects/unbound/fuzz_1.c
@@ -1,0 +1,59 @@
+/*
+ * unbound-fuzzme.c - parse a packet provided on stdin (for fuzzing).
+ *
+ */
+#include "config.h"
+#include "util/regional.h"
+#include "util/module.h"
+#include "util/config_file.h"
+#include "iterator/iterator.h"
+#include "iterator/iter_priv.h"
+#include "iterator/iter_scrub.h"
+#include "util/log.h"
+#include "sldns/sbuffer.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len) {
+  log_init("/tmp/foo", 0, NULL);
+  char *bin = buf;
+  struct regional* reg;
+
+  struct sldns_buffer *pkt = sldns_buffer_new(1);
+  sldns_buffer_new_frm_data(pkt, bin, len);
+
+  reg = regional_create();
+
+  struct msg_parse msg;
+  struct edns_data edns;
+  memset(&msg, 0, sizeof(struct msg_parse));
+  memset(&edns, 0, sizeof(edns));
+  if (parse_packet(pkt, &msg, reg) != LDNS_RCODE_NOERROR) {    
+    goto out;
+  }
+  if (parse_extract_edns(&msg, &edns, reg) != LDNS_RCODE_NOERROR) {
+    goto out;
+  }
+
+
+  struct query_info qinfo_out;
+  memset(&qinfo_out, 0, sizeof(struct query_info));
+  qinfo_out.qname = (unsigned char *) "\03nic\02de";
+  uint8_t *peter = (unsigned char *) "\02de";   // zonename  
+  struct module_env env;
+  memset(&env, 0, sizeof(struct module_env));
+  struct config_file cfg;
+  memset(&cfg, 0, sizeof(struct config_file));
+  cfg.harden_glue = 1;    // crashes now, want to remove that later
+  env.cfg = &cfg;
+
+  struct iter_env ie;
+  memset(&ie, 0, sizeof(struct iter_env));
+
+  struct iter_priv priv;
+  memset(&priv, 0, sizeof(struct iter_priv));
+  ie.priv = &priv;
+  scrub_message(pkt, &msg, &qinfo_out, peter, reg, &env, &ie);   
+out:
+  regional_destroy(reg);
+  sldns_buffer_free(pkt);
+  return 0;
+}

--- a/projects/unbound/fuzz_2.c
+++ b/projects/unbound/fuzz_2.c
@@ -1,0 +1,51 @@
+#include "config.h"
+#include "sldns/sbuffer.h"
+#include "sldns/wire2str.h"
+#include "util/data/dname.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *bin, size_t nr) {
+  char *bout;
+  uint8_t *a;
+  char *b;
+  size_t bl;
+  size_t al;
+  size_t len;
+
+  if (nr > 2) {
+    len = bin[0] & 0xff;  // want random sized output buf
+    bout = malloc(len);
+    nr--;
+    bin++;
+    b = bout; bl = len; sldns_wire2str_edns_subnet_print(&b, &bl, bin, nr);
+    b = bout; bl = len; sldns_wire2str_edns_n3u_print(&b, &bl, bin, nr);
+    b = bout; bl = len; sldns_wire2str_edns_dhu_print(&b, &bl, bin, nr);
+    b = bout; bl = len; sldns_wire2str_edns_dau_print(&b, &bl, bin, nr);
+    b = bout; bl = len; sldns_wire2str_edns_nsid_print(&b, &bl, bin, nr);
+    b = bout; bl = len; sldns_wire2str_edns_ul_print(&b, &bl, bin, nr);
+    b = bout; bl = len; sldns_wire2str_edns_llq_print(&b, &bl, bin, nr); 
+  
+    a = bin; al = nr; b = bout; bl = len; sldns_wire2str_tsigerror_scan(&a, &al, &b, &bl);
+    a = bin; al = nr; b = bout; bl = len; sldns_wire2str_long_str_scan(&a, &al, &b, &bl);
+    a = bin; al = nr; b = bout; bl = len; sldns_wire2str_tag_scan(&a, &al, &b, &bl);
+    a = bin; al = nr; b = bout; bl = len; sldns_wire2str_eui64_scan(&a, &al, &b, &bl);
+    a = bin; al = nr; b = bout; bl = len; sldns_wire2str_int16_data_scan(&a, &al, &b, &bl);
+    a = bin; al = nr; b = bout; bl = len; sldns_wire2str_hip_scan(&a, &al, &b, &bl);
+    a = bin; al = nr; b = bout; bl = len; sldns_wire2str_wks_scan(&a, &al, &b, &bl);
+    a = bin; al = nr; b = bout; bl = len; sldns_wire2str_loc_scan(&a, &al, &b, &bl);
+    a = bin; al = nr; b = bout; bl = len; sldns_wire2str_cert_alg_scan(&a, &al, &b, &bl);
+    a = bin; al = nr; b = bout; bl = len; sldns_wire2str_nsec3_salt_scan(&a, &al, &b, &bl);
+    a = bin; al = nr; b = bout; bl = len; sldns_wire2str_nsec_scan(&a, &al, &b, &bl);
+    a = bin; al = nr; b = bout; bl = len; sldns_wire2str_b32_ext_scan(&a, &al, &b, &bl);
+    a = bin; al = nr; b = bout; bl = len; sldns_wire2str_apl_scan(&a, &al, &b, &bl);
+    a = bin; al = nr; b = bout; bl = len; sldns_wire2str_str_scan(&a, &al, &b, &bl);
+    a = bin; al = nr; b = bout; bl = len; sldns_wire2str_rdata_unknown_scan(&a, &al, &b, &bl);
+    a = bin; al = nr; b = bout; bl = len; sldns_wire2str_header_scan(&a, &al, &b, &bl);
+    a = bin; al = nr; b = bout; bl = len; sldns_wire2str_pkt_scan(&a, &al, &b, &bl);
+
+    bin--;
+    free(bout);
+  }
+
+out:
+  return 0;
+}

--- a/projects/unbound/fuzz_3.c
+++ b/projects/unbound/fuzz_3.c
@@ -1,0 +1,67 @@
+#include "config.h"
+#include "sldns/sbuffer.h"
+#include "sldns/wire2str.h"
+#include "sldns/str2wire.h"
+#include "util/data/dname.h"
+
+#define SZ 1000
+#define SZ2 100
+
+
+int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t nr) {
+  char *bin = malloc(nr);
+  uint8_t *bout;
+  size_t len, len2;
+
+  memset(bin, 0, nr);
+  memcpy(bin, buf, nr);
+
+  if (nr > 2) {
+    bin[nr-1] = 0x00;  // null terminate
+    len = bin[0] & 0xff;  // want random sized output buf
+    bout = malloc(len);
+    nr--;
+    bin++;
+  
+    // call the targets  
+    len2 = len; sldns_str2wire_dname_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_int8_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_int16_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_int32_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_a_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_aaaa_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_str_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_apl_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_b64_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_b32_ext_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_hex_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_nsec_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_type_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_class_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_cert_alg_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_alg_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_tsigerror_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_time_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_tsigtime_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_period_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_loc_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_wks_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_nsap_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_atma_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_ipseckey_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_nsec3_salt_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_ilnp64_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_eui48_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_eui64_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_tag_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_long_str_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_hip_buf(bin, bout, &len2);
+    len2 = len; sldns_str2wire_int16_data_buf(bin, bout, &len2);
+
+    bin--;
+    free(bout);
+  }
+
+out:
+  free(bin);
+}

--- a/projects/unbound/fuzz_4.c
+++ b/projects/unbound/fuzz_4.c
@@ -1,0 +1,81 @@
+/*
+ * unbound-fuzzme.c - parse a packet provided on stdin (for fuzzing).
+ *
+ */
+#include "config.h"
+#include "util/regional.h"
+#include "util/module.h"
+#include "util/config_file.h"
+#include "iterator/iterator.h"
+#include "iterator/iter_priv.h"
+#include "iterator/iter_scrub.h"
+#include "util/log.h"
+#include "util/netevent.h"
+#include "util/alloc.h"
+#include "sldns/sbuffer.h"
+#include "services/cache/rrset.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t nr) {
+  log_init("/tmp/foo", 0, NULL);
+  struct regional* reg;
+
+  struct sldns_buffer *pkt = sldns_buffer_new(1);
+  sldns_buffer_new_frm_data(pkt, buf, nr);
+
+  reg = regional_create();
+
+  struct msg_parse msg;
+  struct edns_data edns;
+  memset(&msg, 0, sizeof(struct msg_parse));
+  memset(&edns, 0, sizeof(edns));
+
+  struct query_info qinfo_out;
+  memset(&qinfo_out, 0, sizeof(struct query_info));
+  qinfo_out.qname = (unsigned char *) "\03nic\02de";
+  uint8_t *peter = (unsigned char *) "\02de";   // zonename  
+  struct module_env env;
+  memset(&env, 0, sizeof(struct module_env));
+  struct config_file cfg;
+  memset(&cfg, 0, sizeof(struct config_file));
+
+  cfg.harden_glue = 0;    // crashes now, want to remove that later
+  env.cfg = &cfg;
+  cfg.rrset_cache_slabs = HASH_DEFAULT_SLABS;
+  cfg.rrset_cache_size = HASH_DEFAULT_MAXMEM;
+
+  struct comm_base* base = comm_base_create(0);
+  comm_base_timept(base, &env.now, &env.now_tv);
+
+  env.alloc = malloc(sizeof(struct alloc_cache));
+  alloc_init(env.alloc, NULL, 0);
+
+  env.rrset_cache = rrset_cache_create(env.cfg, env.alloc);
+  
+
+  struct iter_env ie;
+  memset(&ie, 0, sizeof(struct iter_env));
+
+  struct iter_priv priv;
+  memset(&priv, 0, sizeof(struct iter_priv));
+  ie.priv = &priv;
+
+
+  if (parse_packet(pkt, &msg, reg) != LDNS_RCODE_NOERROR) {    
+    goto out;
+  }
+  if (parse_extract_edns(&msg, &edns, reg) != LDNS_RCODE_NOERROR) {
+    goto out;
+  }
+
+
+  scrub_message(pkt, &msg, &qinfo_out, peter, reg, &env, &ie);   
+
+out:
+  rrset_cache_delete(env.rrset_cache);
+  alloc_clear(env.alloc);
+  free(env.alloc);
+  comm_base_delete(base);
+  regional_destroy(reg);
+  sldns_buffer_free(pkt);
+  return 0;
+}


### PR DESCRIPTION
We at X41 D-Sec published several fuzzers as part of the OSTIF-sponsored audit of Unbound (see https://ostif.org/our-audit-of-unbound-dns-by-x41-d-sec-full-results/).

This PR includes the published fuzzers in oss-fuzz.

Comments?