### PR TITLE
[infra] Add parens to ensure correct execution order (#3104).

### DIFF
--- a/infra/gcb/build_and_run_coverage.py
+++ b/infra/gcb/build_and_run_coverage.py
@@ -176,14 +176,14 @@ def get_build_steps(project_dir):
           'args': [
               'bash',
               '-c',
-              ('for f in /corpus/*.zip; do unzip -q $f -d ${f%%.*} || '
+              ('for f in /corpus/*.zip; do unzip -q $f -d ${f%%.*} || ('
                'echo "Failed to unpack the corpus for $(basename ${f%%.*}). '
                'This usually means that corpus backup for a particular fuzz '
                'target does not exist. If a fuzz target was added in the last '
                '24 hours, please wait one more day. Otherwise, something is '
                'wrong with the fuzz target or the infrastructure, and corpus '
-               'pruning task does not finish successfully." && exit 1; '
-               'done && coverage')
+               'pruning task does not finish successfully." && exit 1'
+               '); done && coverage')
           ],
           'volumes': [{'name': 'corpus', 'path': '/corpus'}],
       }

--- a/infra/gcb/build_project.py
+++ b/infra/gcb/build_project.py
@@ -254,7 +254,7 @@ def get_build_steps(project_dir):
                     # the Dockerfile). Container Builder overrides our workdir
                     # so we need to add this step to set it back.
                     ('rm -r /out && cd /src && cd {1} && mkdir -p {0} && '
-                     'compile || echo "build_fuzzers {2}" && false')
+                     'compile || (echo "build_fuzzers {2}" && false)')
                     .format(out, workdir, failure_msg),
                 ],
             })
@@ -282,7 +282,7 @@ def get_build_steps(project_dir):
                   'args': [
                       'bash',
                       '-c',
-                      'test_all || echo "check_build {0}" && false'.format(
+                      'test_all || (echo "check_build {0}" && false)'.format(
                           failure_msg)
                   ],
               })


### PR DESCRIPTION
Minor fixes to ensure the faulting command (`false` or `exit 1`) does not execute in a successful build.