### PR TITLE
Silence unsigned overflow

### DIFF
--- a/projects/binutils/build.sh
+++ b/projects/binutils/build.sh
@@ -17,8 +17,8 @@
 
 # build project
 if [ "$SANITIZER" = undefined ]; then
-    export CFLAGS="$CFLAGS -fsanitize=unsigned-integer-overflow -fno-sanitize-recover=unsigned-integer-overflow"
-    export CXXFLAGS="$CXXFLAGS -fsanitize=unsigned-integer-overflow -fno-sanitize-recover=unsigned-integer-overflow"
+    export CFLAGS="$CFLAGS -fno-sanitize=unsigned-integer-overflow"
+    export CXXFLAGS="$CXXFLAGS -fno-sanitize=unsigned-integer-overflow"
 fi
 cd binutils-gdb
 ./configure --disable-gdb --enable-targets=all


### PR DESCRIPTION
Fixes #3178 which meant to silence unsigned integer overflow, not enable them.
cf https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=19993

So, there seems to be a bug with https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=19679
This was first an undefined shift which got fixed but the bug remained open as en unsigned integer overflow with the same stack trace.
Should not the bug have been closed ? And a new one with a new title created instead ?