### PR TITLE
[infra] Fix dataflow engine compilation for a runtime speed up (#1632).

### DIFF
--- a/infra/base-images/base-builder/compile_dataflow
+++ b/infra/base-images/base-builder/compile_dataflow
@@ -15,13 +15,18 @@
 #
 ################################################################################
 
+export LIB_FUZZING_ENGINE="/usr/lib/DataFlow*.o"
 echo -n "Compiling DataFlow to $LIB_FUZZING_ENGINE... "
 mkdir -p $WORK/libfuzzer
 pushd $WORK/libfuzzer > /dev/null
 
-$CXX $CXXFLAGS $SANITIZER_FLAGS -std=c++11 -O2 -c \
-    $SRC/libfuzzer/dataflow/*.cpp
-ar r $LIB_FUZZING_ENGINE $WORK/libfuzzer/*.o
+$CXX $CXXFLAGS -fno-sanitize=all $SANITIZER_FLAGS -std=c++11 -O2 -c \
+    $SRC/libfuzzer/dataflow/DataFlow.cpp
+$CXX $CXXFLAGS -fno-sanitize=all -fPIC -std=c++11 -O2 -c \
+    $SRC/libfuzzer/dataflow/DataFlowCallbacks.cpp
+
+cp $WORK/libfuzzer/DataFlow*.o /usr/lib/
+
 popd > /dev/null
 rm -rf $WORK/libfuzzer
 echo " done."

--- a/infra/base-images/base-runner/bad_build_check
+++ b/infra/base-images/base-runner/bad_build_check
@@ -23,6 +23,10 @@ MIN_NUMBER_OF_RUNS=4
 # Mercurial's bdiff_fuzzer has 116 PCs when built with ASan.
 THRESHOLD_FOR_NUMBER_OF_EDGES=100
 
+# A fuzz target is supposed to have at least two functions, such as
+# LLVMFuzzerTestOneInput and an API that is being called from there.
+THRESHOLD_FOR_NUMBER_OF_FUNCTIONS=2
+
 # Threshold values for different sanitizers used by instrumentation checks.
 ASAN_CALLS_THRESHOLD_FOR_ASAN_BUILD=1000
 ASAN_CALLS_THRESHOLD_FOR_NON_ASAN_BUILD=0
@@ -95,8 +99,14 @@ function check_engine {
       return 1
     fi
   elif [[ "$FUZZING_ENGINE" == dataflow ]]; then
-    # TODO(https://github.com/google/oss-fuzz/issues/1632): add check for
-    # binaries compiled with dataflow engine when the interface becomes stable.
+    $FUZZER &> $FUZZER_OUTPUT
+    local NUMBER_OF_FUNCTIONS=$(grep -Po "INFO:\s+\K[[:digit:]]+(?=\s+instrumented function.*)" $FUZZER_OUTPUT)
+    [[ -z "$NUMBER_OF_FUNCTIONS" ]] && NUMBER_OF_FUNCTIONS=0
+    if (( $NUMBER_OF_FUNCTIONS < $THRESHOLD_FOR_NUMBER_OF_FUNCTIONS )); then
+      echo "BAD BUILD: $FUZZER does not seem to be properly built in 'dataflow' config."
+      cat $FUZZER_OUTPUT
+      return 1
+    fi
     return 0
   fi
 


### PR DESCRIPTION
This was changed in https://github.com/llvm/llvm-project/commit/679669a77e5bbd7451f4c482ec1996b0649f65d0, and besides the speedup, it seems like tracing didn't work on OSS-Fuzz since then. Maybe it stopped working some time later, but it definitely doesn't work right now.

Also added a bad build check for the current existing interface.
