### PR TITLE
Qt: Test on branch 5.15 instead of dev

### DIFF
--- a/projects/qt/Dockerfile
+++ b/projects/qt/Dockerfile
@@ -17,9 +17,9 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER rlohningqt@gmail.com
 RUN apt-get update && apt-get install -y build-essential python libxcb-xinerama0-dev && apt-get install --no-install-recommends afl-doc
-RUN git clone --depth 1 git://code.qt.io/qt/qt5.git qt
+RUN git clone --branch 5.15 --depth 1 git://code.qt.io/qt/qt5.git qt
 WORKDIR qt
-RUN perl init-repository --module-subset=qtbase
+RUN perl init-repository --module-subset=qtbase --no-update && git submodule update --depth 1 --recursive
 
 WORKDIR $SRC
 RUN git clone --depth 1 git://code.qt.io/qt/qtqa.git

--- a/projects/qt/build.sh
+++ b/projects/qt/build.sh
@@ -34,8 +34,7 @@ make install
 zip -j $WORK/xml $SRC/qtqa/fuzzing/testcases/xml/* /usr/share/afl/testcases/others/xml/*
 
 # build fuzzers
-sed -i -e "/LIBS/d" $SRC/qt/qtbase/tests/libfuzzer/corelib/serialization/qxmlstream/qxmlstreamreader/readnext/readnext.pro
-$OUT/bin/qmake LIBS+=$LIB_FUZZING_ENGINE $SRC/qt/qtbase/tests/libfuzzer/corelib/serialization/qxmlstream/qxmlstreamreader/readnext/readnext.pro
+$OUT/bin/qmake $SRC/qt/qtbase/tests/libfuzzer/corelib/serialization/qxmlstream/qxmlstreamreader/readnext/readnext.pro
 make -j$(nproc)
 mv readnext $OUT
 cp $WORK/xml.zip $OUT/readnext_seed_corpus.zip


### PR DESCRIPTION
- dev will change the build system to cmake. When I stay on 5.15,
  I can choose when to port the fuzzing.

- Submodules are currently outdated in dev. On 5.15, changes in
  stable branch will be tested earlier and additions for fuzzing
  can be used earlier.