### PR TITLE
Submit Apache Arrow for inclusion

### DIFF
--- a/projects/arrow/Dockerfile
+++ b/projects/arrow/Dockerfile
@@ -1,0 +1,29 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER dev@arrow.apache.org
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update -y -q && \
+    apt-get update -y -q && \
+    apt-get install -y -q --no-install-recommends \
+        cmake \
+        ninja-build \
+        python3
+
+RUN git clone --depth=1 https://github.com/apache/arrow.git $SRC/arrow
+COPY build.sh $SRC/

--- a/projects/arrow/build.sh
+++ b/projects/arrow/build.sh
@@ -1,0 +1,61 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+set -ex
+
+ARROW=${SRC}/arrow/cpp
+
+cd ${WORK}
+
+cmake ${ARROW} -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DARROW_DEPENDENCY_SOURCE=BUNDLED \
+    -DCMAKE_C_FLAGS="${CFLAGS}" \
+    -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
+    -DARROW_EXTRA_ERROR_CONTEXT=off \
+    -DARROW_JEMALLOC=off \
+    -DARROW_MIMALLOC=off \
+    -DARROW_FILESYSTEM=off \
+    -DARROW_PARQUET=off \
+    -DARROW_BUILD_SHARED=off \
+    -DARROW_BUILD_STATIC=on \
+    -DARROW_BUILD_TESTS=off \
+    -DARROW_BUILD_INTEGRATION=off \
+    -DARROW_BUILD_BENCHMARKS=off \
+    -DARROW_BUILD_EXAMPLES=off \
+    -DARROW_BUILD_UTILITIES=off \
+    -DARROW_TEST_LINKAGE=static \
+    -DPARQUET_BUILD_EXAMPLES=off \
+    -DPARQUET_BUILD_EXECUTABLES=off \
+    -DPARQUET_REQUIRE_ENCRYPTION=off \
+    -DARROW_WITH_BROTLI=off \
+    -DARROW_WITH_BZ2=off \
+    -DARROW_WITH_LZ4=off \
+    -DARROW_WITH_SNAPPY=off \
+    -DARROW_WITH_ZLIB=off \
+    -DARROW_WITH_ZSTD=off \
+    -DARROW_USE_GLOG=off \
+    -DARROW_USE_ASAN=off \
+    -DARROW_USE_UBSAN=off \
+    -DARROW_USE_TSAN=off \
+    -DARROW_FUZZING=on \
+
+cmake --build .
+
+cp -a release/* ${OUT}
+
+${ARROW}/build-support/fuzzing/generate_corpuses.sh ${OUT}

--- a/projects/arrow/project.yaml
+++ b/projects/arrow/project.yaml
@@ -1,3 +1,19 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
 homepage: "https://arrow.apache.org/"
 primary_contact: "antoine@python.org"
 auto_ccs:

--- a/projects/arrow/project.yaml
+++ b/projects/arrow/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://arrow.apache.org/"
+primary_contact: "antoine@python.org"
+auto_ccs:
+  - "wesmckinn@gmail.com"
+  - "private@arrow.apache.org"
+sanitizers:
+  - address
+  - undefined


### PR DESCRIPTION
Arrow is both an efficient in-memory format for tabular data, an IPC format with zero-copy capabilities, and a set of interoperable language implementations (~10 languages currently: C++, Python, Java, Rust, Go...).

This submission is for fuzzing the Arrow C++ IPC reader. If accepted, we plan to add other fuzz targets, for example for reading Parquet files.