### PR TITLE
[infra] Print exact reproduction commands in build failures (#3104).

### DIFF
--- a/infra/gcb/build_and_run_coverage.py
+++ b/infra/gcb/build_and_run_coverage.py
@@ -120,7 +120,7 @@ def get_build_steps(project_dir):
     workdir = '/src'
 
   failure_msg = ('*' * 80 + '\nCoverage build failed.\nTo reproduce, run:\n'
-                 'python infra/helper.py build_project {0}\n'
+                 'python infra/helper.py build_image {0}\n'
                  'python infra/helper.py build_fuzzers --sanitizer coverage {0}'
                  '\n' + '*' * 80).format(name)
 
@@ -171,7 +171,7 @@ def get_build_steps(project_dir):
 
   failure_msg = ('*' * 80 + '\nCode coverage report generation failed.\n'
                  'To reproduce, run:\n'
-                 'python infra/helper.py build_project {0}\n'
+                 'python infra/helper.py build_image {0}\n'
                  'python infra/helper.py build_fuzzers --sanitizer coverage {0}'
                  '\npython infra/helper.py coverage {0}\n' +
                  '*' * 80).format(name)

--- a/infra/gcb/build_and_run_coverage.py
+++ b/infra/gcb/build_and_run_coverage.py
@@ -139,7 +139,7 @@ def get_build_steps(project_dir):
           # to add this step to set it back.
           ('rm -r /out && cd /src && cd {workdir} && mkdir -p {out} && '
            'compile || (echo "{failure_msg}" && false)'
-           ).format(workdir=workdir, out=out, failure_msg=failure_msg),
+          ).format(workdir=workdir, out=out, failure_msg=failure_msg),
       ],
   })
 

--- a/infra/gcb/build_and_run_coverage.py
+++ b/infra/gcb/build_and_run_coverage.py
@@ -173,7 +173,7 @@ def get_build_steps(project_dir):
                  'To reproduce, run:\n'
                  'python infra/helper.py build_project {0} &&\n'
                  'python infra/helper.py build_fuzzers --sanitizer coverage {0}'
-                 '\npython infra/helper.py coverage {0}\n'
+                 '\npython infra/helper.py coverage {0}\n' +
                  '*' * 80).format(name)
 
   # Unpack the corpus and run coverage script.
@@ -195,7 +195,7 @@ def get_build_steps(project_dir):
            '24 hours, please wait one more day. Otherwise, something is '
            'wrong with the fuzz target or the infrastructure, and corpus '
            'pruning task does not finish successfully." && exit 1'
-           '); done && coverage || (echo "{0}" && false)').format(failure_msg)
+           '); done && coverage || (echo "' + failure_msg + '" && false)')
       ],
       'volumes': [{
           'name': 'corpus',

--- a/infra/gcb/build_and_run_coverage.py
+++ b/infra/gcb/build_and_run_coverage.py
@@ -120,9 +120,9 @@ def get_build_steps(project_dir):
     workdir = '/src'
 
   failure_msg = ('*' * 80 + '\nCoverage build failed.\nTo reproduce, run:\n'
-                 'python infra/helper.py build_image {0}\n'
-                 'python infra/helper.py build_fuzzers --sanitizer coverage {0}'
-                 '\n' + '*' * 80).format(name)
+                 'python infra/helper.py build_image {name}\n'
+                 'python infra/helper.py build_fuzzers --sanitizer coverage '
+                 '{name}\n' + '*' * 80).format(name=name)
 
   # Compilation step.
   build_steps.append({
@@ -137,8 +137,9 @@ def get_build_steps(project_dir):
           # `cd /src && cd {workdir}` (where {workdir} is parsed from the
           # Dockerfile). Container Builder overrides our workdir so we need
           # to add this step to set it back.
-          'rm -r /out && cd /src && cd {1} && mkdir -p {0} && compile || (echo "{2}" && false)'
-          .format(out, workdir, failure_msg),
+          ('rm -r /out && cd /src && cd {workdir} && mkdir -p {out} && '
+           'compile || (echo "{failure_msg}" && false)'
+           ).format(workdir=workdir, out=out, failure_msg=failure_msg),
       ],
   })
 
@@ -171,10 +172,11 @@ def get_build_steps(project_dir):
 
   failure_msg = ('*' * 80 + '\nCode coverage report generation failed.\n'
                  'To reproduce, run:\n'
-                 'python infra/helper.py build_image {0}\n'
-                 'python infra/helper.py build_fuzzers --sanitizer coverage {0}'
-                 '\npython infra/helper.py coverage {0}\n' +
-                 '*' * 80).format(name)
+                 'python infra/helper.py build_image {name}\n'
+                 'python infra/helper.py build_fuzzers --sanitizer coverage '
+                 '{name}\n'
+                 'python infra/helper.py coverage {name}\n' +
+                 '*' * 80).format(name=name)
 
   # Unpack the corpus and run coverage script.
   build_steps.append({

--- a/infra/gcb/build_and_run_coverage.py
+++ b/infra/gcb/build_and_run_coverage.py
@@ -33,13 +33,12 @@ GCS_URL_BASENAME = 'https://storage.googleapis.com/'
 COVERAGE_BUCKET_NAME = 'oss-fuzz-coverage'
 
 # Link to the code coverage report in HTML format.
-HTML_REPORT_URL_FORMAT = (
-    GCS_URL_BASENAME + COVERAGE_BUCKET_NAME +
-    '/{project}/reports/{date}/{platform}/index.html')
+HTML_REPORT_URL_FORMAT = (GCS_URL_BASENAME + COVERAGE_BUCKET_NAME +
+                          '/{project}/reports/{date}/{platform}/index.html')
 
 # This is needed for ClusterFuzz to pick up the most recent reports data.
-LATEST_REPORT_INFO_URL = (
-    '/' + COVERAGE_BUCKET_NAME + '/latest_report_info/{project}.json')
+LATEST_REPORT_INFO_URL = ('/' + COVERAGE_BUCKET_NAME +
+                          '/latest_report_info/{project}.json')
 
 # Link where to upload code coverage report files to.
 UPLOAD_URL_FORMAT = 'gs://' + COVERAGE_BUCKET_NAME + '/{project}/{type}/{date}'
@@ -58,8 +57,7 @@ def skip_build(message):
 
 
 def usage():
-  sys.stderr.write(
-    "Usage: " + sys.argv[0] + " <project_dir>\n")
+  sys.stderr.write("Usage: " + sys.argv[0] + " <project_dir>\n")
   exit(1)
 
 
@@ -88,7 +86,8 @@ def get_build_steps(project_dir):
   build_steps = [
       {
           'args': [
-              'clone', 'https://github.com/google/oss-fuzz.git',
+              'clone',
+              'https://github.com/google/oss-fuzz.git',
           ],
           'name': 'gcr.io/cloud-builders/git',
       },
@@ -103,8 +102,7 @@ def get_build_steps(project_dir):
           'dir': 'oss-fuzz/projects/' + name,
       },
       {
-          'name':
-              image,
+          'name': image,
           'args': [
               'bash', '-c',
               'srcmap > /workspace/srcmap.json && cat /workspace/srcmap.json'
@@ -121,172 +119,197 @@ def get_build_steps(project_dir):
   if not workdir:
     workdir = '/src'
 
+  failure_msg = ('*' * 80 + '\nCoverage build failed.\nTo reproduce, run:\n'
+                 'python infra/helper.py build_project {0} &&\n'
+                 'python infra/helper.py build_fuzzers --sanitizer coverage {0}'
+                 '\n' + '*' * 80).format(name)
+
   # Compilation step.
-  build_steps.append(
-      {
-          'name': image,
-          'env': env,
-          'args': [
-              'bash',
-              '-c',
-               # Remove /out to make sure there are non instrumented binaries.
-               # `cd /src && cd {workdir}` (where {workdir} is parsed from the
-               # Dockerfile). Container Builder overrides our workdir so we need
-               # to add this step to set it back.
-               'rm -r /out && cd /src && cd {1} && mkdir -p {0} && compile'.format(out, workdir),
-          ],
-      }
-  )
+  build_steps.append({
+      'name':
+          image,
+      'env':
+          env,
+      'args': [
+          'bash',
+          '-c',
+          # Remove /out to make sure there are non instrumented binaries.
+          # `cd /src && cd {workdir}` (where {workdir} is parsed from the
+          # Dockerfile). Container Builder overrides our workdir so we need
+          # to add this step to set it back.
+          'rm -r /out && cd /src && cd {1} && mkdir -p {0} && compile || (echo "{2}" && false)'
+          .format(out, workdir, failure_msg),
+      ],
+  })
 
   # Split fuzz targets into batches of CORPUS_DOWNLOAD_BATCH_SIZE.
-  for i in xrange(0,  len(fuzz_targets), CORPUS_DOWNLOAD_BATCH_SIZE):
+  for i in xrange(0, len(fuzz_targets), CORPUS_DOWNLOAD_BATCH_SIZE):
     download_corpus_args = []
-    for binary_name in fuzz_targets[i : i+CORPUS_DOWNLOAD_BATCH_SIZE]:
+    for binary_name in fuzz_targets[i:i + CORPUS_DOWNLOAD_BATCH_SIZE]:
       qualified_name = binary_name
       qualified_name_prefix = '%s_' % project_name
       if not binary_name.startswith(qualified_name_prefix):
         qualified_name = qualified_name_prefix + binary_name
 
-      url = build_project.get_signed_url(
-          CORPUS_BACKUP_URL.format(
-              project=project_name, fuzzer=qualified_name),
-          method='GET')
+      url = build_project.get_signed_url(CORPUS_BACKUP_URL.format(
+          project=project_name, fuzzer=qualified_name),
+                                         method='GET')
 
       corpus_archive_path = os.path.join('/corpus', binary_name + '.zip')
       download_corpus_args.append('%s %s' % (corpus_archive_path, url))
 
     # Download corpus.
-    build_steps.append(
-        {
-            'name': 'gcr.io/oss-fuzz-base/base-runner',
-            'entrypoint': 'download_corpus',
-            'args': download_corpus_args,
-            'volumes': [{'name': 'corpus', 'path': '/corpus'}],
-        }
-    )
+    build_steps.append({
+        'name': 'gcr.io/oss-fuzz-base/base-runner',
+        'entrypoint': 'download_corpus',
+        'args': download_corpus_args,
+        'volumes': [{
+            'name': 'corpus',
+            'path': '/corpus'
+        }],
+    })
+
+  failure_msg = ('*' * 80 + '\nCode coverage report generation failed.\n'
+                 'To reproduce, run:\n'
+                 'python infra/helper.py build_project {0} &&\n'
+                 'python infra/helper.py build_fuzzers --sanitizer coverage {0}'
+                 '\npython infra/helper.py coverage {0}\n'
+                 '*' * 80).format(name)
 
   # Unpack the corpus and run coverage script.
-  build_steps.append(
-      {
-          'name': 'gcr.io/oss-fuzz-base/base-runner',
-          'env': env + [
+  build_steps.append({
+      'name':
+          'gcr.io/oss-fuzz-base/base-runner',
+      'env':
+          env + [
               'HTTP_PORT=',
-              'COVERAGE_EXTRA_ARGS=%s' % project_yaml['coverage_extra_args'].strip()
+              'COVERAGE_EXTRA_ARGS=%s' %
+              project_yaml['coverage_extra_args'].strip()
           ],
-          'args': [
-              'bash',
-              '-c',
-              ('for f in /corpus/*.zip; do unzip -q $f -d ${f%%.*} || ('
-               'echo "Failed to unpack the corpus for $(basename ${f%%.*}). '
-               'This usually means that corpus backup for a particular fuzz '
-               'target does not exist. If a fuzz target was added in the last '
-               '24 hours, please wait one more day. Otherwise, something is '
-               'wrong with the fuzz target or the infrastructure, and corpus '
-               'pruning task does not finish successfully." && exit 1'
-               '); done && coverage')
-          ],
-          'volumes': [{'name': 'corpus', 'path': '/corpus'}],
-      }
-  )
+      'args': [
+          'bash', '-c',
+          ('for f in /corpus/*.zip; do unzip -q $f -d ${f%%.*} || ('
+           'echo "Failed to unpack the corpus for $(basename ${f%%.*}). '
+           'This usually means that corpus backup for a particular fuzz '
+           'target does not exist. If a fuzz target was added in the last '
+           '24 hours, please wait one more day. Otherwise, something is '
+           'wrong with the fuzz target or the infrastructure, and corpus '
+           'pruning task does not finish successfully." && exit 1'
+           '); done && coverage || (echo "{0}" && false)').format(failure_msg)
+      ],
+      'volumes': [{
+          'name': 'corpus',
+          'path': '/corpus'
+      }],
+  })
 
   # Upload the report.
-  upload_report_url = UPLOAD_URL_FORMAT.format(
-      project=project_name, type='reports', date=report_date)
-  build_steps.append(
-      {
-          'name': 'gcr.io/cloud-builders/gsutil',
-          'args': [
-              '-m', 'cp', '-r',
-              os.path.join(out, 'report'),
-              upload_report_url,
-          ],
-      }
-  )
+  upload_report_url = UPLOAD_URL_FORMAT.format(project=project_name,
+                                               type='reports',
+                                               date=report_date)
+  build_steps.append({
+      'name':
+          'gcr.io/cloud-builders/gsutil',
+      'args': [
+          '-m',
+          'cp',
+          '-r',
+          os.path.join(out, 'report'),
+          upload_report_url,
+      ],
+  })
 
   # Upload the fuzzer stats.
-  upload_fuzzer_stats_url = UPLOAD_URL_FORMAT.format(
-      project=project_name, type='fuzzer_stats', date=report_date)
-  build_steps.append(
-      {
-          'name': 'gcr.io/cloud-builders/gsutil',
-          'args': [
-              '-m', 'cp', '-r',
-              os.path.join(out, 'fuzzer_stats'),
-              upload_fuzzer_stats_url,
-          ],
-      }
-  )
+  upload_fuzzer_stats_url = UPLOAD_URL_FORMAT.format(project=project_name,
+                                                     type='fuzzer_stats',
+                                                     date=report_date)
+  build_steps.append({
+      'name':
+          'gcr.io/cloud-builders/gsutil',
+      'args': [
+          '-m',
+          'cp',
+          '-r',
+          os.path.join(out, 'fuzzer_stats'),
+          upload_fuzzer_stats_url,
+      ],
+  })
 
   # Upload the fuzzer logs.
-  build_steps.append(
-      {
-          'name': 'gcr.io/cloud-builders/gsutil',
-          'args': [
-              '-m', 'cp', '-r',
-              os.path.join(out, 'logs'),
-              UPLOAD_URL_FORMAT.format(
-                  project=project_name, type='logs', date=report_date),
-          ],
-      }
-  )
+  build_steps.append({
+      'name':
+          'gcr.io/cloud-builders/gsutil',
+      'args': [
+          '-m',
+          'cp',
+          '-r',
+          os.path.join(out, 'logs'),
+          UPLOAD_URL_FORMAT.format(project=project_name,
+                                   type='logs',
+                                   date=report_date),
+      ],
+  })
 
   # Upload srcmap.
-  srcmap_upload_url = UPLOAD_URL_FORMAT.format(
-      project=project_name, type='srcmap', date=report_date)
+  srcmap_upload_url = UPLOAD_URL_FORMAT.format(project=project_name,
+                                               type='srcmap',
+                                               date=report_date)
   srcmap_upload_url = srcmap_upload_url.rstrip('/') + '.json'
-  build_steps.append(
-      {
-          'name': 'gcr.io/cloud-builders/gsutil',
-          'args': [
-              'cp',
-              '/workspace/srcmap.json',
-              srcmap_upload_url,
-          ],
-      }
-  )
+  build_steps.append({
+      'name': 'gcr.io/cloud-builders/gsutil',
+      'args': [
+          'cp',
+          '/workspace/srcmap.json',
+          srcmap_upload_url,
+      ],
+  })
 
   # Update the latest report information file for ClusterFuzz.
   latest_report_info_url = build_project.get_signed_url(
       LATEST_REPORT_INFO_URL.format(project=project_name),
       method='PUT',
       content_type='application/json')
-  latest_report_info_body = json.dumps(
-      {
-          'fuzzer_stats_dir': upload_fuzzer_stats_url,
-          'html_report_url': HTML_REPORT_URL_FORMAT.format(
-              project=project_name, date=report_date, platform=PLATFORM),
-          'report_date': report_date,
-          'report_summary_path': os.path.join(
-              upload_report_url, PLATFORM, 'summary.json'),
-      }
-  )
+  latest_report_info_body = json.dumps({
+      'fuzzer_stats_dir':
+          upload_fuzzer_stats_url,
+      'html_report_url':
+          HTML_REPORT_URL_FORMAT.format(project=project_name,
+                                        date=report_date,
+                                        platform=PLATFORM),
+      'report_date':
+          report_date,
+      'report_summary_path':
+          os.path.join(upload_report_url, PLATFORM, 'summary.json'),
+  })
 
-  build_steps.append(
-      {
-          'name': 'gcr.io/cloud-builders/curl',
-          'args': [
-              '-H', 'Content-Type: application/json',
-              '-X', 'PUT',
-              '-d', latest_report_info_body,
-              latest_report_info_url,
-          ],
-      }
-  )
+  build_steps.append({
+      'name':
+          'gcr.io/cloud-builders/curl',
+      'args': [
+          '-H',
+          'Content-Type: application/json',
+          '-X',
+          'PUT',
+          '-d',
+          latest_report_info_body,
+          latest_report_info_url,
+      ],
+  })
   return build_steps
 
 
 def get_targets_list(project_name):
   # libFuzzer ASan is the default configuration, get list of targets from it.
   url = build_project.get_targets_list_url(
-      build_project.ENGINE_INFO['libfuzzer'].upload_bucket,
-      project_name,
+      build_project.ENGINE_INFO['libfuzzer'].upload_bucket, project_name,
       'address')
 
-  url = urlparse.urljoin(GCS_URL_BASENAME , url)
+  url = urlparse.urljoin(GCS_URL_BASENAME, url)
   r = requests.get(url)
   if not r.status_code == 200:
     sys.stderr.write('Failed to get list of targets from "%s".\n' % url)
-    sys.stderr.write('Status code: %d \t\tText:\n%s\n' % (r.status_code, r.text))
+    sys.stderr.write('Status code: %d \t\tText:\n%s\n' %
+                     (r.status_code, r.text))
     return None
 
   return r.text.split()

--- a/infra/gcb/build_and_run_coverage.py
+++ b/infra/gcb/build_and_run_coverage.py
@@ -120,7 +120,7 @@ def get_build_steps(project_dir):
     workdir = '/src'
 
   failure_msg = ('*' * 80 + '\nCoverage build failed.\nTo reproduce, run:\n'
-                 'python infra/helper.py build_project {0} &&\n'
+                 'python infra/helper.py build_project {0}\n'
                  'python infra/helper.py build_fuzzers --sanitizer coverage {0}'
                  '\n' + '*' * 80).format(name)
 
@@ -171,7 +171,7 @@ def get_build_steps(project_dir):
 
   failure_msg = ('*' * 80 + '\nCode coverage report generation failed.\n'
                  'To reproduce, run:\n'
-                 'python infra/helper.py build_project {0} &&\n'
+                 'python infra/helper.py build_project {0}\n'
                  'python infra/helper.py build_fuzzers --sanitizer coverage {0}'
                  '\npython infra/helper.py coverage {0}\n' +
                  '*' * 80).format(name)

--- a/infra/gcb/build_project.py
+++ b/infra/gcb/build_project.py
@@ -237,9 +237,11 @@ def get_build_steps(project_dir):
                        'python infra/helper.py build_image {name}\n'
                        'python infra/helper.py build_fuzzers --sanitizer '
                        '{sanitizer} --engine {engine} --architecture '
-                       '{architecture} {name}\n' + '*' * 80
-                       ).format(name=name, sanitizer=sanitizer,
-                                engine=fuzzing_engine, architecture=architecture)
+                       '{architecture} {name}\n' + '*' * 80).format(
+                           name=name,
+                           sanitizer=sanitizer,
+                           engine=fuzzing_engine,
+                           architecture=architecture)
 
         build_steps.append(
             # compile
@@ -285,9 +287,11 @@ def get_build_steps(project_dir):
                          '{architecture} {name}\n'
                          'python infra/helper.py check_build --sanitizer '
                          '{sanitizer} --engine {engine} --architecture '
-                         '{architecture} {name}\n' + '*' * 80
-                         ).format(name=name, sanitizer=sanitizer,
-                                  engine=fuzzing_engine, architecture=architecture)
+                         '{architecture} {name}\n' + '*' * 80).format(
+                             name=name,
+                             sanitizer=sanitizer,
+                             engine=fuzzing_engine,
+                             architecture=architecture)
 
           build_steps.append(
               # test binaries

--- a/infra/gcb/build_project.py
+++ b/infra/gcb/build_project.py
@@ -234,7 +234,7 @@ def get_build_steps(project_dir):
           workdir = '/src'
 
         failure_msg = ('*' * 80 + '\nFailed to build.\nTo reproduce, run:\n'
-                       'python infra/helper.py build_project {0}\n'
+                       'python infra/helper.py build_image {0}\n'
                        'python infra/helper.py build_fuzzers --sanitizer {1} '
                        '--engine {2} --architecture {3} {0}\n' +
                        '*' * 80).format(name, sanitizer, fuzzing_engine,
@@ -278,7 +278,7 @@ def get_build_steps(project_dir):
         if run_tests:
           failure_msg = ('*' * 80 + '\nBuild checks failed.\n'
                          'To reproduce, run:\n'
-                         'python infra/helper.py build_project {0}\n'
+                         'python infra/helper.py build_image {0}\n'
                          'python infra/helper.py build_fuzzers --sanitizer {1} '
                          '--engine {2} --architecture {3} {0}\n'
                          'python infra/helper.py check_build --sanitizer {1} '

--- a/infra/gcb/build_project.py
+++ b/infra/gcb/build_project.py
@@ -234,11 +234,12 @@ def get_build_steps(project_dir):
           workdir = '/src'
 
         failure_msg = ('*' * 80 + '\nFailed to build.\nTo reproduce, run:\n'
-                       'python infra/helper.py build_image {0}\n'
-                       'python infra/helper.py build_fuzzers --sanitizer {1} '
-                       '--engine {2} --architecture {3} {0}\n' +
-                       '*' * 80).format(name, sanitizer, fuzzing_engine,
-                                        architecture)
+                       'python infra/helper.py build_image {name}\n'
+                       'python infra/helper.py build_fuzzers --sanitizer '
+                       '{sanitizer} --engine {engine} --architecture '
+                       '{architecture} {name}\n' + '*' * 80
+                       ).format(name=name, sanitizer=sanitizer,
+                                engine=fuzzing_engine, architecture=architecture)
 
         build_steps.append(
             # compile
@@ -255,9 +256,9 @@ def get_build_steps(project_dir):
                     # `cd /src && cd {workdir}` (where {workdir} is parsed from
                     # the Dockerfile). Container Builder overrides our workdir
                     # so we need to add this step to set it back.
-                    ('rm -r /out && cd /src && cd {1} && mkdir -p {0} && '
-                     'compile || (echo "{2}" && false)'
-                    ).format(out, workdir, failure_msg),
+                    ('rm -r /out && cd /src && cd {workdir} && mkdir -p {out} && '
+                     'compile || (echo "{failure_msg}" && false)'
+                    ).format(workdir=workdir, out=out, failure_msg=failure_msg),
                 ],
             })
 
@@ -278,13 +279,15 @@ def get_build_steps(project_dir):
         if run_tests:
           failure_msg = ('*' * 80 + '\nBuild checks failed.\n'
                          'To reproduce, run:\n'
-                         'python infra/helper.py build_image {0}\n'
-                         'python infra/helper.py build_fuzzers --sanitizer {1} '
-                         '--engine {2} --architecture {3} {0}\n'
-                         'python infra/helper.py check_build --sanitizer {1} '
-                         '--engine {2} --architecture {3} {0}\n' +
-                         '*' * 80).format(name, sanitizer, fuzzing_engine,
-                                          architecture)
+                         'python infra/helper.py build_image {name}\n'
+                         'python infra/helper.py build_fuzzers --sanitizer '
+                         '{sanitizer} --engine {engine} --architecture '
+                         '{architecture} {name}\n'
+                         'python infra/helper.py check_build --sanitizer '
+                         '{sanitizer} --engine {engine} --architecture '
+                         '{architecture} {name}\n' + '*' * 80
+                         ).format(name=name, sanitizer=sanitizer,
+                                  engine=fuzzing_engine, architecture=architecture)
 
           build_steps.append(
               # test binaries
@@ -333,7 +336,8 @@ def get_build_steps(project_dir):
                     image,
                 'args': [
                     'bash', '-c',
-                    'cd {0} && zip -r {1} *'.format(out, zip_file)
+                    'cd {out} && zip -r {zip_file} *'.format(out=out,
+                                                             zip_file=zip_file)
                 ],
             },
             # upload srcmap

--- a/infra/gcb/build_project.py
+++ b/infra/gcb/build_project.py
@@ -234,7 +234,7 @@ def get_build_steps(project_dir):
           workdir = '/src'
 
         failure_msg = ('*' * 80 + '\nFailed to build.\nTo reproduce, run:\n'
-                       'python infra/helper.py build_project {0} &&\n'
+                       'python infra/helper.py build_project {0}\n'
                        'python infra/helper.py build_fuzzers --sanitizer {1} '
                        '--engine {2} --architecture {3} {0}\n' +
                        '*' * 80).format(name, sanitizer, fuzzing_engine,
@@ -278,11 +278,11 @@ def get_build_steps(project_dir):
         if run_tests:
           failure_msg = ('*' * 80 + '\nBuild checks failed.\n'
                          'To reproduce, run:\n'
-                         'python infra/helper.py build_project {0} &&\n'
+                         'python infra/helper.py build_project {0}\n'
                          'python infra/helper.py build_fuzzers --sanitizer {1} '
-                         '--engine {2} --architecture {3} {0} &&\n'
+                         '--engine {2} --architecture {3} {0}\n'
                          'python infra/helper.py check_build --sanitizer {1} '
-                         '--engine {2} --architecture {3} {0} &&\n' +
+                         '--engine {2} --architecture {3} {0}\n' +
                          '*' * 80).format(name, sanitizer, fuzzing_engine,
                                           architecture)
 


### PR DESCRIPTION
This also includes some formatting changes. Sorry I didn't realize that these scripts were not formatted. I can separate formatting and the actual change, but that would have to be done manually, as I don't have a non-formatted commit even locally.