### PR TITLE
[qt] Don't try to shallow-copy submodules

### DIFF
--- a/projects/qt/Dockerfile
+++ b/projects/qt/Dockerfile
@@ -19,7 +19,7 @@ MAINTAINER rlohningqt@gmail.com
 RUN apt-get update && apt-get install -y build-essential python libxcb-xinerama0-dev && apt-get install --no-install-recommends afl-doc
 RUN git clone --branch 5.15 --depth 1 git://code.qt.io/qt/qt5.git qt
 WORKDIR qt
-RUN perl init-repository --module-subset=qtbase --no-update && git submodule update --depth 1 --recursive
+RUN perl init-repository --module-subset=qtbase
 
 WORKDIR $SRC
 RUN git clone --depth 1 git://code.qt.io/qt/qtqa.git


### PR DESCRIPTION
This was meant to create a shallow copy of the submodules but "perl init-repository --no-update" already does a deep copy.