### PR TITLE
[infra] Prioritize short files when collecting dataflow traces (#1632).

### DIFF
--- a/infra/base-images/base-runner/dataflow_tracer.py
+++ b/infra/base-images/base-runner/dataflow_tracer.py
@@ -85,6 +85,7 @@ def collect_traces(binary, corpus_dir, dft_dir):
       'failed': 0,
   }
 
+  files_to_trace = {}
   for f in _list_dir(corpus_dir):
     stats['total'] += 1
     size = os.path.getsize(f)
@@ -92,7 +93,10 @@ def collect_traces(binary, corpus_dir, dft_dir):
       stats['long'] += 1
       print('Skipping large file ({size}b): {path}'.format(size=size, path=f))
       continue
+    files_to_trace[f] = size
 
+  for f in sorted(files_to_trace, key=files_to_trace.get):
+    print(f, files_to_trace[f])
     output_path = os.path.join(dft_dir, _sha1(f))
     try:
       result = _run([binary, f, output_path], timeout=_timeout(size))

--- a/infra/base-images/base-runner/dataflow_tracer.py
+++ b/infra/base-images/base-runner/dataflow_tracer.py
@@ -96,7 +96,6 @@ def collect_traces(binary, corpus_dir, dft_dir):
     files_to_trace[f] = size
 
   for f in sorted(files_to_trace, key=files_to_trace.get):
-    print(f, files_to_trace[f])
     output_path = os.path.join(dft_dir, _sha1(f))
     try:
       result = _run([binary, f, output_path], timeout=_timeout(size))

--- a/infra/base-images/base-runner/dataflow_tracer.py
+++ b/infra/base-images/base-runner/dataflow_tracer.py
@@ -85,7 +85,7 @@ def collect_traces(binary, corpus_dir, dft_dir):
       'failed': 0,
   }
 
-  files_to_trace = {}
+  files_and_sizes = {}
   for f in _list_dir(corpus_dir):
     stats['total'] += 1
     size = os.path.getsize(f)
@@ -93,9 +93,9 @@ def collect_traces(binary, corpus_dir, dft_dir):
       stats['long'] += 1
       print('Skipping large file ({size}b): {path}'.format(size=size, path=f))
       continue
-    files_to_trace[f] = size
+    files_and_sizes[f] = size
 
-  for f in sorted(files_to_trace, key=files_to_trace.get):
+  for f in sorted(files_and_sizes, key=files_and_sizes.get):
     output_path = os.path.join(dft_dir, _sha1(f))
     try:
       result = _run([binary, f, output_path], timeout=_timeout(size))


### PR DESCRIPTION
Some targets may not process all the corpus in the given time. Prioritizing shorter inputs lets us maximize the number of inputs traced.