### PR TITLE
Revert "[xz] Apply a harmless local patch to migrate to $LIB_FUZZING_ENGINE."

### DIFF
--- a/projects/xz/build.sh
+++ b/projects/xz/build.sh
@@ -15,8 +15,6 @@
 #
 ################################################################################
 
-sed -i 's/-lFuzzingEngine/$(LIB_FUZZING_ENGINE)/g' tests/ossfuzz/Makefile
-
 ./autogen.sh
 ./configure \
   --enable-static \


### PR DESCRIPTION
Reverts google/oss-fuzz#3252.

This should be fixed upstream now.