### PR TITLE
[capstone] enable dataflow config (#1632).

### DIFF
--- a/projects/capstone/project.yaml
+++ b/projects/capstone/project.yaml
@@ -1,15 +1,13 @@
 homepage: "https://www.capstone-engine.org"
 primary_contact: "capstone.engine@gmail.com"
 auto_ccs : "p.antoine@catenacyber.fr"
-
 fuzzing_engines:
-- libfuzzer
-- afl
-- honggfuzz
-- dataflow
-
+  - libfuzzer
+  - afl
+  - honggfuzz
+  - dataflow
 sanitizers:
-- address
-- memory
-- undefined
-- dataflow
+  - address
+  - memory
+  - undefined
+  - dataflow

--- a/projects/capstone/project.yaml
+++ b/projects/capstone/project.yaml
@@ -2,7 +2,14 @@ homepage: "https://www.capstone-engine.org"
 primary_contact: "capstone.engine@gmail.com"
 auto_ccs : "p.antoine@catenacyber.fr"
 
+fuzzing_engines:
+- libfuzzer
+- afl
+- honggfuzz
+- dataflow
+
 sanitizers:
 - address
 - memory
 - undefined
+- dataflow

--- a/projects/capstone/project.yaml
+++ b/projects/capstone/project.yaml
@@ -1,6 +1,7 @@
 homepage: "https://www.capstone-engine.org"
 primary_contact: "capstone.engine@gmail.com"
-auto_ccs : "p.antoine@catenacyber.fr"
+auto_ccs : 
+  - "p.antoine@catenacyber.fr"
 fuzzing_engines:
   - libfuzzer
   - afl


### PR DESCRIPTION
Should work based on https://pantheon.corp.google.com/logs/viewer?resource=build%2Fbuild_id%2Fb106a717-7725-44c6-81a5-e196300b9401&project=oss-fuzz&minLogLevel=0&expandAll=false&timestamp=2020-01-21T22:41:43.490000000Z&customFacets=&limitCustomFacetWidth=true&dateRangeEnd=2020-01-21T22:41:40.447Z&interval=PT1H&dateRangeUnbound=backwardInTime&scrollTimestamp=2020-01-21T19:58:48.579291555Z, but uploading as an explicit PR to let Travis double check me.