### PR TITLE
[cmark] Enable dataflow config (#1632).

### DIFF
--- a/projects/cmark/project.yaml
+++ b/projects/cmark/project.yaml
@@ -2,10 +2,16 @@ homepage: "http://commonmark.org"
 primary_contact: "jgm@berkeley.edu"
 auto_ccs:
   - "kivikakk@github.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+  - dataflow
 sanitizers:
   - address
   - memory
   - undefined
+  - dataflow
 architectures:
   - x86_64
   - i386


### PR DESCRIPTION
Should work based on https://pantheon.corp.google.com/logs/viewer?resource=build%2Fbuild_id%2Ffd035ed9-bbd9-4371-98ec-20d651567cee&project=oss-fuzz&minLogLevel=0&expandAll=false&timestamp=2020-01-21T22:47:00.300000000Z&customFacets=&limitCustomFacetWidth=true&dateRangeEnd=2020-01-21T22:46:58.339Z&interval=PT1H&dateRangeUnbound=backwardInTime&scrollTimestamp=2020-01-21T19:28:33.870235967Z, but letting Travins double check.