### PR TITLE
[harfbuzz] enable dataflow config (#1632).

### DIFF
--- a/projects/harfbuzz/project.yaml
+++ b/projects/harfbuzz/project.yaml
@@ -17,10 +17,16 @@ vendor_ccs:
   - "jmuizelaar@mozilla.com"
   - "lsalzman@mozilla.com"
   - "twsmith@mozilla.com"
+fuzzing_engines:
+ - libfuzzer
+ - afl
+ - honggfuzz
+ - dataflow
 sanitizers:
  - address
  - undefined
  - memory
+ - dataflow
 architectures:
   - x86_64
   - i386


### PR DESCRIPTION
Should work based on https://pantheon.corp.google.com/logs/viewer?resource=build%2Fbuild_id%2F3312be9f-7e2e-45c4-9544-eb432eba8c2e&project=oss-fuzz&minLogLevel=0&expandAll=false&timestamp=2020-01-21T22:51:43.343000000Z&customFacets=&limitCustomFacetWidth=true&dateRangeEnd=2020-01-21T22:51:41.725Z&interval=PT1H&dateRangeUnbound=backwardInTime&scrollTimestamp=2020-01-21T21:13:26.578865217Z, but double checking with Travis.