### PR TITLE
[json-c] enable dataflow config (#1632).

### DIFF
--- a/projects/json-c/project.yaml
+++ b/projects/json-c/project.yaml
@@ -2,6 +2,15 @@ homepage: "https://json-c.github.io/json-c/"
 primary_contact: "erh+git@nimenees.com"
 auto_ccs:
   - "chriswwolfe@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+  - dataflow
+sanitizers:
+  - address
+  - undefined
+  - dataflow
 architectures:
   - x86_64
   - i386


### PR DESCRIPTION
Should work based on https://pantheon.corp.google.com/logs/viewer?resource=build%2Fbuild_id%2F3fc8371d-951a-4003-9ce5-97d4adaf449c&project=oss-fuzz&minLogLevel=0&expandAll=false&timestamp=2020-01-21T22:54:26.943000000Z&customFacets=&limitCustomFacetWidth=true&dateRangeEnd=2020-01-21T22:54:25.085Z&interval=PT1H&dateRangeUnbound=backwardInTime&scrollTimestamp=2020-01-21T18:50:28.370948047Z, double checking with Travis.