### PR TITLE
[pcre2] enable dataflow config (#1632).

### DIFF
--- a/projects/pcre2/project.yaml
+++ b/projects/pcre2/project.yaml
@@ -9,6 +9,7 @@ sanitizers:
   - address
   - memory
   - undefined
+  - dataflow
 architectures:
   - x86_64
   - i386

--- a/projects/pcre2/project.yaml
+++ b/projects/pcre2/project.yaml
@@ -1,5 +1,10 @@
 homepage: "http://www.pcre.org/"
 primary_contact: "philip.hazel@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+  - dataflow
 sanitizers:
   - address
   - memory


### PR DESCRIPTION
Tested with https://pantheon.corp.google.com/logs/viewer?resource=build%2Fbuild_id%2F9ca139cf-c469-4916-b304-d17859ebc392&project=oss-fuzz&minLogLevel=0&expandAll=false&timestamp=2020-01-21T23:36:36.516000000Z&customFacets=&limitCustomFacetWidth=true&dateRangeEnd=2020-01-21T22:57:17.770Z&interval=PT1H&dateRangeUnbound=backwardInTime&scrollTimestamp=2020-01-21T19:09:03.422310359Z, but letting Travis to verify.