### PR TITLE
[mupdf] enable dataflow config (#1632).

### DIFF
--- a/projects/mupdf/project.yaml
+++ b/projects/mupdf/project.yaml
@@ -1,8 +1,14 @@
 homepage: "https://www.mupdf.com"
 primary_contact: tor.andersson@artifex.com
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+  - dataflow
 sanitizers:
   - address
   - memory
+  - dataflow
 auto_ccs:
   - jonathan@titanous.com
   - sebastian.rasmussen@artifex.com


### PR DESCRIPTION
Tested with https://pantheon.corp.google.com/logs/viewer?resource=build%2Fbuild_id%2F9e804198-492a-4762-8551-928c66a8b4e1&project=oss-fuzz&minLogLevel=0&expandAll=false&timestamp=2020-01-21T23:45:43.424000000Z&customFacets=&limitCustomFacetWidth=true&dateRangeEnd=2020-01-21T23:43:14.050Z&interval=PT1H&dateRangeUnbound=backwardInTime&scrollTimestamp=2020-01-21T20:24:16.755968968Z