### PR TITLE
[wolfssl] enable dataflow config (#1632).

### DIFF
--- a/projects/wolfssl/project.yaml
+++ b/projects/wolfssl/project.yaml
@@ -15,3 +15,4 @@ sanitizers:
  - memory:
     experimental: True
  - undefined
+ - dataflow

--- a/projects/wolfssl/project.yaml
+++ b/projects/wolfssl/project.yaml
@@ -5,6 +5,11 @@ auto_ccs:
  - "kaleb@wolfssl.com"
  - "levi@wolfssl.com"
  - "testing@wolfssl.com"
+fuzzing_engines:
+- libfuzzer
+- afl
+- honggfuzz
+- dataflow
 sanitizers:
  - address
  - memory:

--- a/projects/wolfssl/project.yaml
+++ b/projects/wolfssl/project.yaml
@@ -6,10 +6,10 @@ auto_ccs:
  - "levi@wolfssl.com"
  - "testing@wolfssl.com"
 fuzzing_engines:
-- libfuzzer
-- afl
-- honggfuzz
-- dataflow
+ - libfuzzer
+ - afl
+ - honggfuzz
+ - dataflow
 sanitizers:
  - address
  - memory:


### PR DESCRIPTION
Tested with https://pantheon.corp.google.com/logs/viewer?resource=build%2Fbuild_id%2Fe577cd61-fcc2-42bd-90ec-b199371d2682&project=oss-fuzz&minLogLevel=0&expandAll=false&timestamp=2020-01-21T23:46:39.985000000Z&customFacets=&limitCustomFacetWidth=true&dateRangeEnd=2020-01-21T23:43:32.057Z&interval=PT1H&dateRangeUnbound=backwardInTime&scrollTimestamp=2020-01-21T19:05:52.366118139Z