### PR TITLE
wavpack: add undefined behavior sanitizer

### DIFF
--- a/projects/wavpack/project.yaml
+++ b/projects/wavpack/project.yaml
@@ -6,3 +6,4 @@ auto_ccs:
 sanitizers: 
 - address 
 - memory
+- undefined


### PR DESCRIPTION
Note that we are excluding signed-integer-overflow in our build file, but everything else is good.