### PR TITLE
Acceptance for wasmtime project and Rust fuzz targets

### DIFF
--- a/projects/wasmtime/project.yaml
+++ b/projects/wasmtime/project.yaml
@@ -1,0 +1,5 @@
+homepage: "https://wasmtime.dev/"
+primary_contact: "jonathan.foote@gmail.com"
+auto_ccs:
+  - "security@bytecodealliance.com"
+  - "fitzgen@gmail.com"


### PR DESCRIPTION
Hello,

[Bytecode Alliance](https://bytecodealliance.org/) projects are developed in the open, largely in Rust. As part of designing continuous fuzzing for Bytecode Alliance projects we are evaluating how we might integrate Rust fuzz targets with oss-fuzz. (some background: [Bytecode Alliance discussion issue](https://github.com/bytecodealliance/wasmtime/issues/611), [oss-fuzz PR for an unrelated Rust fuzz target from last year](https://github.com/google/oss-fuzz/pull/2533)).

This PR is for project acceptance for Rust fuzzing targets for [wasmtime](https://github.com/bytecodealliance/wasmtime). @fitzgen and I did some analysis and made a few modifications to Rust's [libfuzzer wrapper](http://github.com/rust-fuzz/libfuzzer) and [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz) to towards an integration with oss-fuzz. It works, but it isn't perfect yet. Here are some highlights:

- cargo-fuzz targets can now link the oss-fuzz build environment's libfuzzer (`libFuzzingEngine`)
    - because `-fsanitizer=fuzzer` is not supported directly, we use the default flags used by cargo fuzz and link with `LIB_FUZZING_ENGINE_DEPRECATED`
    - cargo-fuzz supports only libfuzzer at this time
- cargo-fuzz can build statically linked fuzz targets (without also running them)
- cargo-fuzz builds support address sanitizer, but not other oss-fuzz-supported sanitizers
    - as of this writing, cargo-fuzz supports [address, memory, leak, and thread sanitizers](https://github.com/rust-fuzz/cargo-fuzz/blob/cb6d07edaaa4c2b887aa56a83461508017cfd053/src/options.rs#L15-L21)
    - while memory sanitizer is supported by both cargo-fuzz and oss-fuzz, building Rust fuzz targets with memory sanitizer and `libFuzzingEngine.a` produces a linker error. I suspect an incompatibility in the instrumenting/linking used in `libFuzzingEngine.a` and what rustc/libfuzzer are using, but I did not dive in.
    - ubsan is not supported by the Rust toolchain at this time AFAICT
    - The `fsanitize*` flags are not supported, so they must be stripped. As a workaround I hard-coded the [CFLAGS/CXXFLAGS from `infra/base-images/base-clang`](https://github.com/google/oss-fuzz/blob/66e0e379395d3a3ee741b08f4d306e1ed71c4003/infra/base-images/base-clang/Dockerfile#L35-L37) into this project's `build.sh` since this seems to be what is used in the oss-fuzz build container today once you remove the sanitizer flags, but this is not a good long-term solution.
- Rust does not support [clang source-based coverage](https://clang.llvm.org/docs/SourceBasedCodeCoverage.html)
    - there is [discussion](https://github.com/rust-lang/rust/issues/34701) of supporting an analogous feature in Rust, with some recent activity, but no commitment/timeline AFAICT

We have a draft oss-fuzz wasmtime integration staged [here](https://github.com/jfoote/oss-fuzz/commit/c1ae8eafb4e6067b7d9660cd200e7a2b44b6657c).

We wanted to get your thoughts on integrating with Rust projects: Do you feel this is a viable path forward for long-term integration with Rust targets? If so, what else do you think would need to be done before we can start using oss-fuzz for Bytecode Alliance projects in the short-term?

Thanks,
Jon