### PR TITLE
[Tor] Build libevent with --disable-openssl

### DIFF
--- a/projects/tor/build.sh
+++ b/projects/tor/build.sh
@@ -79,6 +79,8 @@ for fuzzer in src/test/fuzz/*.a; do
 
     corpus_dir="${SRC}/tor-fuzz-corpora/${output#oss-fuzz-}"
     if [ -d "${corpus_dir}" ]; then
-      zip -j ${OUT}/${output}_seed_corpus.zip ${corpus_dir}/*
+      set +x
+      zip -q -j ${OUT}/${output}_seed_corpus.zip ${corpus_dir}/*
+      set -x
     fi
 done

--- a/projects/tor/build.sh
+++ b/projects/tor/build.sh
@@ -22,7 +22,7 @@ mkdir -p $TOR_DEPS
 # Build libevent with proper instrumentation.
 cd ${SRC}/libevent
 sh autogen.sh
-./configure --prefix=${TOR_DEPS}
+./configure --prefix=${TOR_DEPS} --disable-openssl
 make -j$(nproc) clean
 make -j$(nproc) all
 make install


### PR DESCRIPTION
Libevent's build is failing because it can't find openssl.  We could
try to fix this, but instead let's disable it: Tor doesn't actually
use Libvent's openssl support.