### PR TITLE
Try to fix the wasmtime Rust build

### DIFF
--- a/projects/wasmtime/Dockerfile
+++ b/projects/wasmtime/Dockerfile
@@ -18,8 +18,9 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER foote@fastly.com
 RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang
 
+ENV CARGO_HOME=/rust RUSTUP_HOME=/rust/rustup PATH=$PATH:/rust/bin
 RUN curl https://sh.rustup.rs | sh -s -- -y --default-toolchain=nightly
-RUN /bin/bash -c "source $HOME/.cargo/env && cargo install cargo-fuzz" 
+RUN cargo install cargo-fuzz
 
 RUN git clone --depth 1 https://github.com/bytecodealliance/wasmtime wasmtime
 WORKDIR wasmtime

--- a/projects/wasmtime/build.sh
+++ b/projects/wasmtime/build.sh
@@ -17,13 +17,11 @@
 
 # Note: This project creates Rust fuzz targets exclusively
 
-source $HOME/.cargo/env
-
 export CUSTOM_LIBFUZZER_PATH="$LIB_FUZZING_ENGINE_DEPRECATED"
 export CUSTOM_LIBFUZZER_STD_CXX=c++
 PROJECT_DIR=$SRC/wasmtime
 
-# Because Rust does not support sanitizers via CFLAGS/CXXFLAGS, the environment 
+# Because Rust does not support sanitizers via CFLAGS/CXXFLAGS, the environment
 # variables are overridden with values from base-images/base-clang only
 
 export CFLAGS="-O1 -fno-omit-frame-pointer -gline-tables-only -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"


### PR DESCRIPTION
This is an attempt to fixup the errors found on #3292. Although I'm not
certain where the error was coming from this switches the Rust
installation to being in `PATH` by default so there's no need to
`source` any scripts to get access to the Rust compiler.

cc @fitzgen, @jfoote, y'all are likely interested in this!