### PR TITLE
[PROJ4] Build libtiff from source to create a static archive

### DIFF
--- a/projects/proj4/Dockerfile
+++ b/projects/proj4/Dockerfile
@@ -24,6 +24,8 @@ RUN git clone --depth 1 https://github.com/OSGeo/proj proj
 
 RUN git clone --depth 1 https://github.com/curl/curl.git proj/curl
 
+RUN git clone --depth 1 https://gitlab.com/libtiff/libtiff.git proj/libtiff
+
 WORKDIR proj
 
 RUN cp test/fuzzers/build.sh $SRC/


### PR DESCRIPTION
Previously we linked against the dynamic libtiff library, but this
didn't work when running the fuzzers.
This time, actually tested by launching
python infra/helper.py run_fuzzer $PROJECT_NAME proj_crs_to_crs_fuzzer