### PR TITLE
[ClamAV] Disable mempool at compile time

### DIFF
--- a/projects/clamav/build.sh
+++ b/projects/clamav/build.sh
@@ -21,7 +21,7 @@
 rm -rf ${WORK}/build
 mkdir -p ${WORK}/build
 cd ${WORK}/build
-${SRC}/clamav-devel/configure --enable-fuzz=yes --with-libjson=no --with-pcre=no --enable-static=yes --enable-shared=no --disable-llvm --host=x86_64-unknown-linux-gnu
+ac_cv_c_mmap_anonymous=no ${SRC}/clamav-devel/configure --disable-mempool --enable-fuzz=yes --with-libjson=no --with-pcre=no --enable-static=yes --enable-shared=no --disable-llvm --host=x86_64-unknown-linux-gnu
 make clean
 make -j"$(nproc)"
 


### PR DESCRIPTION
ClamAV's mempool feature uses mmap to improve performance for some
memory allocations. As currently implemented, on systems that support
mmap's MAP_ANONYMOUS flag, fmaps are backed by mmap'd memory.
Valgrind and ASan can't track mmap-backed memory, though, so it's more
difficult to track down fmap-related memory errors.

The changes in this commit to clamav's build script should disable mmap
usage, and hopefully allow oss-fuzz to catch more bugs.