### PR TITLE
[wasmtime] fix security@bytecodealliance.org alias

### DIFF
--- a/projects/wasmtime/project.yaml
+++ b/projects/wasmtime/project.yaml
@@ -1,7 +1,7 @@
 homepage: "https://wasmtime.dev/"
 primary_contact: "jonathan.foote@gmail.com"
 auto_ccs:
-  - "security@bytecodealliance.com"
+  - "security@bytecodealliance.org"
   - "fitzgen@gmail.com"
 sanitizers:
   - address


### PR DESCRIPTION
I accidentally typed the wrong TLD in the initial commit -- apologies