### PR TITLE
wasmtime: Enable debuginfo/frame pointers

### DIFF
--- a/projects/wasmtime/build.sh
+++ b/projects/wasmtime/build.sh
@@ -27,6 +27,7 @@ PROJECT_DIR=$SRC/wasmtime
 export CFLAGS="-O1 -fno-omit-frame-pointer -gline-tables-only -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"
 export CXXFLAGS_EXTRA="-stdlib=libc++"
 export CXXFLAGS="$CFLAGS $CXXFLAGS_EXTRA"
+export RUSTFLAGS="-Cdebuginfo=1 -Cforce-frame-pointers"
 
 cd $PROJECT_DIR/fuzz && cargo fuzz build -O --debug-assertions
 


### PR DESCRIPTION
This commit does for Rust code what the `CFLAGS` are configured to do
for C++ code, which is to enable debuginfo (but line tables only) as
well as forcing frame pointer generation to all assist in generating
stack traces.