### PR TITLE
Update build.sh to fix build failure

### DIFF
--- a/projects/unbound/build.sh
+++ b/projects/unbound/build.sh
@@ -47,7 +47,7 @@ $CXX $CXXFLAGS -std=c++11 \
   val_secalgo.o val_sigcrypt.o val_utils.o dns64.o cachedb.o redis.o authzone.o \
   respip.o netevent.o listen_dnsport.o outside_network.o ub_event.o keyraw.o \
   sbuffer.o wire2str.o parse.o parseutil.o rrdef.o str2wire.o libunbound.o \
-  libworker.o context.o \
+  libworker.o context.o rpz.o \
   $LIBOBJS
 
 $CXX $CXXFLAGS -std=c++11 \
@@ -67,7 +67,7 @@ $CXX $CXXFLAGS -std=c++11 \
   val_secalgo.o val_sigcrypt.o val_utils.o dns64.o cachedb.o redis.o authzone.o \
   respip.o netevent.o listen_dnsport.o outside_network.o ub_event.o keyraw.o \
   sbuffer.o wire2str.o parse.o parseutil.o rrdef.o str2wire.o libunbound.o \
-  libworker.o context.o \
+  libworker.o context.o rpz.o \
   $LIBOBJS
 
 $CXX $CXXFLAGS -std=c++11 \
@@ -87,7 +87,7 @@ $CXX $CXXFLAGS -std=c++11 \
   val_secalgo.o val_sigcrypt.o val_utils.o dns64.o cachedb.o redis.o authzone.o \
   respip.o netevent.o listen_dnsport.o outside_network.o ub_event.o keyraw.o \
   sbuffer.o wire2str.o parse.o parseutil.o rrdef.o str2wire.o libunbound.o \
-  libworker.o context.o \
+  libworker.o context.o rpz.o \
   $LIBOBJS
 
 $CXX $CXXFLAGS -std=c++11 \
@@ -107,7 +107,7 @@ $CXX $CXXFLAGS -std=c++11 \
   val_secalgo.o val_sigcrypt.o val_utils.o dns64.o cachedb.o redis.o authzone.o \
   respip.o netevent.o listen_dnsport.o outside_network.o ub_event.o keyraw.o \
   sbuffer.o wire2str.o parse.o parseutil.o rrdef.o str2wire.o libunbound.o \
-  libworker.o context.o \
+  libworker.o context.o rpz.o \
   $LIBOBJS
 
 $CXX $CXXFLAGS -std=c++11 \
@@ -127,7 +127,7 @@ $CXX $CXXFLAGS -std=c++11 \
   val_secalgo.o val_sigcrypt.o val_utils.o dns64.o cachedb.o redis.o authzone.o \
   respip.o netevent.o listen_dnsport.o outside_network.o ub_event.o keyraw.o \
   sbuffer.o wire2str.o parse.o parseutil.o rrdef.o str2wire.o libunbound.o \
-  libworker.o context.o \
+  libworker.o context.o rpz.o \
   $LIBOBJS
 
 wget --directory-prefix $OUT https://github.com/jsha/unbound/raw/fuzzing-corpora/testdata/parse_packet_fuzzer_seed_corpus.zip


### PR DESCRIPTION
Hi oss-fuzz,
This is a proposal to fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20471
It adds rpz.o, the build failure logs shows rpz symbols missing and this file has recently been added to the source repository. So I think this is likely the cause of the issue.  The diff supposedly just adds rpz.o to the object file list.
Best regards, Wouter