### PR TITLE
[CIFuzz] Add seed and len control to fuzzer arguments

### DIFF
--- a/infra/cifuzz/fuzz_target.py
+++ b/infra/cifuzz/fuzz_target.py
@@ -73,7 +73,7 @@ class FuzzTarget:
     command += [
         '-e', 'FUZZING_ENGINE=libfuzzer', '-e', 'SANITIZER=address', '-e',
         'RUN_FUZZER_MODE=interactive', 'gcr.io/oss-fuzz-base/base-runner',
-        'bash', '-c', 'run_fuzzer {0} {1} {2}'.format(self.target_name,
+        'bash', '-c', 'run_fuzzer {fuzz target} {seed} {len control}'.format(self.target_name,
                                                       '-seed=1337',
                                                       '-len_control=0')
     ]

--- a/infra/cifuzz/fuzz_target.py
+++ b/infra/cifuzz/fuzz_target.py
@@ -72,7 +72,7 @@ class FuzzTarget:
     command += [
         '-e', 'FUZZING_ENGINE=libfuzzer', '-e', 'SANITIZER=address', '-e',
         'RUN_FUZZER_MODE=interactive', 'gcr.io/oss-fuzz-base/base-runner',
-        'bash', '-c', 'run_fuzzer {0}'.format(self.target_name)
+        'bash', '-c', 'run_fuzzer {0} {1} {2}'.format(self.target_name, '-seed=1337', '-len_control=0')
     ]
     logging.info('Running command: %s', ' '.join(command))
     process = subprocess.Popen(command,

--- a/infra/cifuzz/fuzz_target.py
+++ b/infra/cifuzz/fuzz_target.py
@@ -73,9 +73,10 @@ class FuzzTarget:
     command += [
         '-e', 'FUZZING_ENGINE=libfuzzer', '-e', 'SANITIZER=address', '-e',
         'RUN_FUZZER_MODE=interactive', 'gcr.io/oss-fuzz-base/base-runner',
-        'bash', '-c', 'run_fuzzer {fuzz target} {seed} {len control}'.format(self.target_name,
-                                                      '-seed=1337',
-                                                      '-len_control=0')
+        'bash', '-c', 'run_fuzzer {fuzz_target} {seed} {len_control}'.format(
+            fuzz_target=self.target_name,
+            seed='-seed=1337',
+            len_control='-len_control=0')
     ]
     logging.info('Running command: %s', ' '.join(command))
     process = subprocess.Popen(command,

--- a/infra/cifuzz/fuzz_target.py
+++ b/infra/cifuzz/fuzz_target.py
@@ -28,7 +28,7 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     level=logging.DEBUG)
 
-DEFAULT_OPTIONS = '-seed=1337 -len_control=0'
+LIBFUZZER_OPTIONS = '-seed=1337 -len_control=0'
 
 
 class FuzzTarget:
@@ -76,7 +76,7 @@ class FuzzTarget:
         '-e', 'FUZZING_ENGINE=libfuzzer', '-e', 'SANITIZER=address', '-e',
         'RUN_FUZZER_MODE=interactive', 'gcr.io/oss-fuzz-base/base-runner',
         'bash', '-c', 'run_fuzzer {fuzz_target} {options}'.format(
-            fuzz_target=self.target_name, options=DEFAULT_OPTIONS)
+            fuzz_target=self.target_name, options=LIBFUZZER_OPTIONS)
     ]
     logging.info('Running command: %s', ' '.join(command))
     process = subprocess.Popen(command,

--- a/infra/cifuzz/fuzz_target.py
+++ b/infra/cifuzz/fuzz_target.py
@@ -19,6 +19,7 @@ import subprocess
 import sys
 
 # pylint: disable=wrong-import-position
+# pylint: disable=import-error
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import utils
 
@@ -72,7 +73,9 @@ class FuzzTarget:
     command += [
         '-e', 'FUZZING_ENGINE=libfuzzer', '-e', 'SANITIZER=address', '-e',
         'RUN_FUZZER_MODE=interactive', 'gcr.io/oss-fuzz-base/base-runner',
-        'bash', '-c', 'run_fuzzer {0} {1} {2}'.format(self.target_name, '-seed=1337', '-len_control=0')
+        'bash', '-c', 'run_fuzzer {0} {1} {2}'.format(self.target_name,
+                                                      '-seed=1337',
+                                                      '-len_control=0')
     ]
     logging.info('Running command: %s', ' '.join(command))
     process = subprocess.Popen(command,

--- a/infra/cifuzz/fuzz_target.py
+++ b/infra/cifuzz/fuzz_target.py
@@ -28,6 +28,7 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     level=logging.DEBUG)
 
+DEFAULT_OPTIONS = '-seed=1337 -len_control=0'
 
 class FuzzTarget:
   """A class to manage a single fuzz target.
@@ -75,8 +76,7 @@ class FuzzTarget:
         'RUN_FUZZER_MODE=interactive', 'gcr.io/oss-fuzz-base/base-runner',
         'bash', '-c', 'run_fuzzer {fuzz_target} {seed} {len_control}'.format(
             fuzz_target=self.target_name,
-            seed='-seed=1337',
-            len_control='-len_control=0')
+            options=DEFAULT_OPTIONS)
     ]
     logging.info('Running command: %s', ' '.join(command))
     process = subprocess.Popen(command,

--- a/infra/cifuzz/fuzz_target.py
+++ b/infra/cifuzz/fuzz_target.py
@@ -30,6 +30,7 @@ logging.basicConfig(
 
 DEFAULT_OPTIONS = '-seed=1337 -len_control=0'
 
+
 class FuzzTarget:
   """A class to manage a single fuzz target.
 
@@ -74,9 +75,8 @@ class FuzzTarget:
     command += [
         '-e', 'FUZZING_ENGINE=libfuzzer', '-e', 'SANITIZER=address', '-e',
         'RUN_FUZZER_MODE=interactive', 'gcr.io/oss-fuzz-base/base-runner',
-        'bash', '-c', 'run_fuzzer {fuzz_target} {seed} {len_control}'.format(
-            fuzz_target=self.target_name,
-            options=DEFAULT_OPTIONS)
+        'bash', '-c', 'run_fuzzer {fuzz_target} {options}'.format(
+            fuzz_target=self.target_name, options=DEFAULT_OPTIONS)
     ]
     logging.info('Running command: %s', ' '.join(command))
     process = subprocess.Popen(command,


### PR DESCRIPTION
Adds seed number and length control arguments when calling running a fuzz target. These two arguments are added to optimize for time constrained fuzzing.  Detailed info about the arguments can be found here: https://llvm.org/docs/LibFuzzer.html#options 