### PR TITLE
[infra] Generate full coverage JSONs for dataflow enabled targets (#1632).

### DIFF
--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -96,7 +96,16 @@ function run_fuzz_target {
   rm $profraw_file_mask
 
   shared_libraries=$(coverage_helper shared_libs -build-dir=$OUT -object=$target)
-  llvm-cov export -summary-only -instr-profile=$profdata_file -object=$target \
+
+  local summary_only_flag="-summary-only"
+  if [ -n "${FULL_SUMMARY_PER_TARGET-}" ]; then
+    # This is needed for dataflow strategy analysis, can be removed later. See
+    # - https://github.com/google/oss-fuzz/pull/3306
+    # - https://github.com/google/oss-fuzz/issues/1632
+    summary_only_flag=""
+  fi
+
+  llvm-cov export $summary_only_flag -instr-profile=$profdata_file -object=$target \
       $shared_libraries $LLVM_COV_COMMON_ARGS > $FUZZER_STATS_DIR/$target.json
 }
 

--- a/infra/gcb/build_and_run_coverage.py
+++ b/infra/gcb/build_and_run_coverage.py
@@ -147,15 +147,16 @@ def get_build_steps(project_dir):
                  '*' * 80).format(name=name)
 
   # Unpack the corpus and run coverage script.
+  coverage_env = env + [
+      'HTTP_PORT=',
+      'COVERAGE_EXTRA_ARGS=%s' % project_yaml['coverage_extra_args'].strip(),
+  ]
+  if 'dataflow' in project_yaml['fuzzing_engines']:
+    coverage_env.append('FULL_SUMMARY_PER_TARGET=1')
+
   build_steps.append({
-      'name':
-          'gcr.io/oss-fuzz-base/base-runner',
-      'env':
-          env + [
-              'HTTP_PORT=',
-              'COVERAGE_EXTRA_ARGS=%s' %
-              project_yaml['coverage_extra_args'].strip()
-          ],
+      'name': 'gcr.io/oss-fuzz-base/base-runner',
+      'env': coverage_env,
       'args': [
           'bash', '-c',
           ('for f in /corpus/*.zip; do unzip -q $f -d ${f%%.*} || ('


### PR DESCRIPTION
Needed for https://github.com/google/oss-fuzz/pull/3306 and better analysis automation. When there is a coverage improvement reported in BigQuery stats, I'm pulling up coverage reports and try to compare them. Full JSONs would make it more advanced, as right now the best I can get is something like:

```
filename: abc.cc, coverage diff: +5 regions
```

and then I have to manually diff HTML reports for that file, which doesn't scale.

With full JSONs, coverage diff will be more granular without any manual work.

This will make coverage job slower for the affected projects, but I don't expect anything to go out of hand on the dataflow enabled projects.