### PR TITLE
Revert "[wavpack] Enabe dataflow build config."

### DIFF
--- a/projects/wavpack/project.yaml
+++ b/projects/wavpack/project.yaml
@@ -3,13 +3,7 @@ primary_contact: "david@wavpack.com"
 auto_ccs:
 - dvbryant@gmail.com
 - thuanpv.nus@gmail.com
-fuzzing_engines:
-- afl
-- libfuzzer
-- honggfuzz
-- dataflow
 sanitizers: 
 - address 
 - memory
 - undefined
-- dataflow


### PR DESCRIPTION
Reverts google/oss-fuzz#3324

That was a mistake, Travis tricked me, it actually skipped the project because it follows ideal integration guidelines and doesn't even have build.sh in OSS-Fuzz repo.