### PR TITLE
[infra] Travis: rely on the presence of Dockerfile to identify buildable projects.

### DIFF
--- a/infra/travis/travis_build.py
+++ b/infra/travis/travis_build.py
@@ -39,7 +39,7 @@ def get_modified_buildable_projects():
   projects_regex = '.*projects/(?P<name>.*)/.*\n'
   modified_projects = set(re.findall(projects_regex, output))
   projects_dir = os.path.join(get_oss_fuzz_root(), 'projects')
-  # Filter out projects without build.sh files since new projects and reverted
+  # Filter out projects without Dockerfile files since new projects and reverted
   # projects frequently don't have them. In these cases we don't want Travis's
   # builds to fail.
   modified_buildable_projects = []

--- a/infra/travis/travis_build.py
+++ b/infra/travis/travis_build.py
@@ -44,8 +44,8 @@ def get_modified_buildable_projects():
   # builds to fail.
   modified_buildable_projects = []
   for project in modified_projects:
-    if not os.path.exists(os.path.join(projects_dir, project, 'build.sh')):
-      print('Project {0} does not have a build.sh. skipping build.'.format(
+    if not os.path.exists(os.path.join(projects_dir, project, 'Dockerfile')):
+      print('Project {0} does not have Dockerfile. skipping build.'.format(
           project))
       continue
     modified_buildable_projects.append(project)


### PR DESCRIPTION
Projects may not have build.sh in OSS-Fuzz, but they must have Dockerfile in order to be built and fuzzed by OSS-Fuzz. This has bitten me in https://github.com/google/oss-fuzz/pull/3327