### PR TITLE
[wasmtime] update auto_ccs

### DIFF
--- a/projects/wasmtime/project.yaml
+++ b/projects/wasmtime/project.yaml
@@ -1,9 +1,9 @@
 homepage: "https://wasmtime.dev/"
 primary_contact: "jonathan.foote@gmail.com"
 auto_ccs:
-  - "security@bytecodealliance.org"
   - "fitzgen@gmail.com"
   - "alex@alexcrichton.com"
+  - "till_bytecodealliance@tillschneidereit.net"
 sanitizers:
   - address
 fuzzing_engines:


### PR DESCRIPTION
Following up on internal bytecodealliance/wasmtime discussion, this removes the security@bytecodealliance.org alias from the wasmtime notification list and adds @tschneidereit.