### PR TITLE
[wasmtime] Try fixing delivery of SIGILL/SIGSEGV to JIT

### DIFF
--- a/projects/wasmtime/Dockerfile
+++ b/projects/wasmtime/Dockerfile
@@ -28,4 +28,4 @@ RUN git submodule update --init --recursive
 
 RUN git clone --depth 1 https://github.com/bytecodealliance/wasmtime-libfuzzer-corpus wasmtime-libfuzzer-corpus
 
-COPY build.sh $SRC/
+COPY build.sh default.options $SRC/

--- a/projects/wasmtime/build.sh
+++ b/projects/wasmtime/build.sh
@@ -37,4 +37,5 @@ do
     FUZZ_TARGET_NAME=$(basename ${f%.*})
     cp $FUZZ_TARGET_OUTPUT_DIR/$FUZZ_TARGET_NAME $OUT/
     zip -jr $OUT/${FUZZ_TARGET_NAME}_seed_corpus.zip $PROJECT_DIR/wasmtime-libfuzzer-corpus/$FUZZ_TARGET_NAME/
+    cp $SRC/default.options $OUT/$FUZZ_TARGET_NAME.options
 done

--- a/projects/wasmtime/default.options
+++ b/projects/wasmtime/default.options
@@ -1,0 +1,3 @@
+[asan]
+allow_user_segv_handler=0
+handle_sigill=1


### PR DESCRIPTION
This is an attempt to apply the suggestions from #3316 to the fuzzing
infrastructure for the `wasmtime` target. This will hopefully allow the
delivery of SIGSEGV and SIGILL signals to the `wasmtime` program itself.
These are expected signals when executing wasm code so we don't want the
fuzzer to treat all forms of the signal as a fatal error.

Unfortunately I'm not entirely sure how to test this locally, using the reproduction workflow this doesn't seem to have any effect, but it looks like this `*.options` file may not be picked up during the `reproduce` workflow? I figure a shot in the dark could hopefully help here and I'm trusting @Dor1s as well :)