### PR TITLE
Switching detect_repo.py script into /opt

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -104,7 +104,7 @@ RUN mkdir honggfuzz && \
 COPY compile compile_afl compile_dataflow compile_libfuzzer compile_honggfuzz \
     precompile_honggfuzz srcmap write_labels.py /usr/local/bin/
 
-COPY detect_repo.py /opt
+COPY detect_repo.py /opt/cifuzz/
 
 RUN precompile_honggfuzz
 

--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -104,7 +104,7 @@ RUN mkdir honggfuzz && \
 COPY compile compile_afl compile_dataflow compile_libfuzzer compile_honggfuzz \
     precompile_honggfuzz srcmap write_labels.py /usr/local/bin/
 
-COPY detect_repo.py /src
+COPY detect_repo.py /opt
 
 RUN precompile_honggfuzz
 

--- a/infra/build_specified_commit.py
+++ b/infra/build_specified_commit.py
@@ -82,7 +82,7 @@ def detect_main_repo(project_name, repo_name=None, commit=None):
   docker_image_name = 'gcr.io/oss-fuzz/' + project_name
   command_to_run = [
       'docker', 'run', '--rm', '-t', docker_image_name, 'python3',
-      os.path.join('/src', 'detect_repo.py')
+      os.path.join('/opt', 'detect_repo.py')
   ]
   if repo_name:
     command_to_run.extend(['--repo_name', repo_name])

--- a/infra/build_specified_commit.py
+++ b/infra/build_specified_commit.py
@@ -82,7 +82,7 @@ def detect_main_repo(project_name, repo_name=None, commit=None):
   docker_image_name = 'gcr.io/oss-fuzz/' + project_name
   command_to_run = [
       'docker', 'run', '--rm', '-t', docker_image_name, 'python3',
-      os.path.join('/opt', 'detect_repo.py')
+      os.path.join('/opt', 'cifuzz', 'detect_repo.py')
   ]
   if repo_name:
     command_to_run.extend(['--repo_name', repo_name])


### PR DESCRIPTION
At @jonathanmetzman request, switching the detect_repo.py script from /src to /opt. 