### PR TITLE
[libtheora] Remove unused dataflow sanitizer.

### DIFF
--- a/projects/libtheora/project.yaml
+++ b/projects/libtheora/project.yaml
@@ -4,6 +4,11 @@ vendor_ccs:
  - "cdiehl@mozilla.com"
  - "daede003@umn.edu"
  - "twsmith@mozilla.com"
+fuzzing_engines:
+ - afl
+ - libfuzzer
+ - honggfuzz
+ - dataflow
 sanitizers:
  - address
  - undefined

--- a/projects/libtheora/project.yaml
+++ b/projects/libtheora/project.yaml
@@ -4,16 +4,10 @@ vendor_ccs:
  - "cdiehl@mozilla.com"
  - "daede003@umn.edu"
  - "twsmith@mozilla.com"
-fuzzing_engines:
- - afl
- - libfuzzer
- - honggfuzz
- - dataflow
 sanitizers:
  - address
  - undefined
  - memory
- - dataflow
 architectures:
  - x86_64
  - i386


### PR DESCRIPTION
Just noticed that `dataflow` sanitizer is enabled while `fuzzing_engine` is not. Let's see if it works or should be removed.