### PR TITLE
[wasmtime] correct auto_ccs

### DIFF
--- a/projects/wasmtime/project.yaml
+++ b/projects/wasmtime/project.yaml
@@ -3,7 +3,7 @@ primary_contact: "jonathan.foote@gmail.com"
 auto_ccs:
   - "fitzgen@gmail.com"
   - "alex@alexcrichton.com"
-  - "till_bytecodealliance@tillschneidereit.net"
+  - "till@tillschneidereit.net"
 sanitizers:
   - address
 fuzzing_engines:


### PR DESCRIPTION
I had used a site-specific alias for @tschneidereit in my last commit; he is unable to login to monorail with it. This corrects to an alias that should work. Apologies for the oversight.