### PR TITLE
Improves binutils fuzz target

### DIFF
--- a/projects/binutils/fuzz_disassemble.c
+++ b/projects/binutils/fuzz_disassemble.c
@@ -42,8 +42,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     SFILE s;
     bfd abfd;
 
-    if (Size < 10) {
+    if (Size < 10 || Size > 16394) {
         // 10 bytes for options
+        // 16394 limit code to prevent timeouts
         return 0;
     }
 
@@ -68,7 +69,16 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         disassembler_ftype disasfunc = disassembler(disasm_info.arch, 0, disasm_info.mach, NULL);
         if (disasfunc != NULL) {
             disassemble_init_for_target(&disasm_info);
-            disasfunc(0x1000, &disasm_info);
+            while (1) {
+                int octets = disasfunc(0x1000, &disasm_info);
+                if (octets < 0)
+                    break;
+                if (disasm_info.buffer_length <= (size_t) octets)
+                    break;
+                disasm_info.buffer += octets;
+                disasm_info.buffer_vma += octets / disasm_info.octets_per_byte;
+                disasm_info.buffer_length -= octets;
+            }
             disassemble_free_target(&disasm_info);
         }
     }


### PR DESCRIPTION
Support disassembly of testcases containing more than one instruction

cc @amodra