### PR TITLE
golang-protobuf: use build script in protobuf repo

### DIFF
--- a/projects/golang-protobuf/build.sh
+++ b/projects/golang-protobuf/build.sh
@@ -1,19 +1,14 @@
-function compile_fuzzer {
-  path=$1
-  function=$2
-  fuzzer=$3
-
-   # Instrument all Go files relevant to this fuzzer
-  go-fuzz-build -libfuzzer -func $function -o $fuzzer.a $path
-
-   # Instrumented, compiled Go ($fuzzer.a) + fuzzing engine = fuzzer binary
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -lpthread -o $OUT/$fuzzer
-}
-
-for x in internal/fuzz/*; do
-  if [ -d $x/corpus ]; then
-    name=$(basename $x)
-    compile_fuzzer ./$x Fuzz $name
-    zip -jr $OUT/${name}_seed_corpus.zip $x/corpus
-  fi
-done
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+. internal/fuzz/oss-fuzz-build.sh


### PR DESCRIPTION
Move the core of the build script into the fuzzed repo, where it's easier
for us to manage.