### PR TITLE
[wasmtime] Fix default asan options

### DIFF
--- a/projects/wasmtime/default.options
+++ b/projects/wasmtime/default.options
@@ -1,3 +1,3 @@
 [asan]
-allow_user_segv_handler=0
-handle_sigill=1
+allow_user_segv_handler=1
+handle_sigill=0


### PR DESCRIPTION
This fixes typo mistakes from #3335 where we actually want the opposite
of the current defaults, not the current set of defaults!