### PR TITLE
[infra] Dump full coverage JSONs separately (#1632).

### DIFF
--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -97,16 +97,18 @@ function run_fuzz_target {
 
   shared_libraries=$(coverage_helper shared_libs -build-dir=$OUT -object=$target)
 
-  local summary_only_flag="-summary-only"
+  llvm-cov export -summary-only -instr-profile=$profdata_file -object=$target \
+      $shared_libraries $LLVM_COV_COMMON_ARGS > $FUZZER_STATS_DIR/$target.json
+
   if [ -n "${FULL_SUMMARY_PER_TARGET-}" ]; then
     # This is needed for dataflow strategy analysis, can be removed later. See
     # - https://github.com/google/oss-fuzz/pull/3306
     # - https://github.com/google/oss-fuzz/issues/1632
-    summary_only_flag=""
+    # Intentionally writing these to the logs dir in order to hide the dumps
+    # from the ClusterFuzz cron job.
+    llvm-cov export -instr-profile=$profdata_file -object=$target \
+      $shared_libraries $LLVM_COV_COMMON_ARGS > $LOGS_DIR/$target.json
   fi
-
-  llvm-cov export $summary_only_flag -instr-profile=$profdata_file -object=$target \
-      $shared_libraries $LLVM_COV_COMMON_ARGS > $FUZZER_STATS_DIR/$target.json
 }
 
 # Run each fuzz target, generate raw coverage dumps.


### PR DESCRIPTION
Apparently python is way to hungry on full JSONs (from relatively small fuzz targets) and our cron dies with `Exceeded soft memory limit of 2048 MB with 2712 MB after servicing 5 requests total. Consider setting a larger instance class in app.yaml.`.

OTOH it's just safer to leave the summary only stuff as-if, and any temporary extra stuff I need store separately.