### PR TITLE
glib: Fix build due to Meson option changing type

### DIFF
--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -90,6 +90,7 @@ class ProjectYamlChecker:
       'vendor_ccs',
       'view_restrictions',
       'language',
+      'help_url',
   ]
 
   LANGUAGES_SUPPORTED = ['c', 'cpp', 'go', 'rust', 'python']

--- a/projects/glib/build.sh
+++ b/projects/glib/build.sh
@@ -24,7 +24,7 @@ meson $BUILD \
   -Doss_fuzz=enabled \
   -Db_lundef=false \
   -Ddefault_library=static \
-  -Dlibmount=false
+  -Dlibmount=disabled
 
 ninja -C $BUILD
 

--- a/projects/glib/project.yaml
+++ b/projects/glib/project.yaml
@@ -1,4 +1,4 @@
-homepage: "https://www.gnu.org/directory/glib.html"
+homepage: "https://gitlab.gnome.org/GNOME/glib/"
 primary_contact: "bugzilla@tecnocode.co.uk"
 auto_ccs:
 - philip.withnall@gmail.com


### PR DESCRIPTION
In GLib master commit b220033c we changed the `libmount` option from a
`boolean` to a `feature`, which means it now takes
`enabled`/`disabled`/`auto` rather than `true`/`false`.

Signed-off-by: Philip Withnall <philip@tecnocode.co.uk>

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20552