### PR TITLE
Fix overflow in binutils fuzz target

### DIFF
--- a/projects/binutils/fuzz_disassemble.c
+++ b/projects/binutils/fuzz_disassemble.c
@@ -46,7 +46,7 @@ static int objdump_sprintf (void *vf, const char *format, ...)
     va_end (args);
     f->pos += n;
     //reset to keep just one line
-    if (f->pos != 0 && f->buffer[f->pos - 1] == '\n')
+    if (f->pos != 0 && f->buffer[f->pos - 1] == '\n' && f->pos <= MAX_TEXT_SIZE)
         f->pos = 0;
     return n;
 }


### PR DESCRIPTION
Should fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20602 and such

`snprintf` returns the number of needed spaces in the buffer (not the number of printed ones)