### PR TITLE
karchive: xz now needs po4a, install it

### DIFF
--- a/projects/karchive/Dockerfile
+++ b/projects/karchive/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER tsdgeos@gmail.com
-RUN apt-get update && apt-get install --yes cmake make autoconf automake autopoint libtool wget
+RUN apt-get update && apt-get install --yes cmake make autoconf automake autopoint libtool wget po4a
 RUN git clone --depth 1 https://github.com/madler/zlib.git
 RUN git clone --depth 1 https://github.com/nih-at/libzip.git
 RUN wget https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz


### PR DESCRIPTION
Fixes https://oss-fuzz-build-logs.storage.googleapis.com/log-8701517e-ce60-406d-93d1-a0acf29a2391.txt