### PR TITLE
[CIFuzz] Change 'bug_report' directory to 'artifacts'.

### DIFF
--- a/infra/cifuzz/actions/run_fuzzers/run_fuzzers_entrypoint.py
+++ b/infra/cifuzz/actions/run_fuzzers/run_fuzzers_entrypoint.py
@@ -63,7 +63,7 @@ def main():
     # If the file does not exist, the action will crash attempting to upload it.
     # The dry run needs this file because it is set to upload a test case both
     # on successful runs and on failures.
-    out_dir = os.path.join(workspace, 'out', 'bug_report')
+    out_dir = os.path.join(workspace, 'out', 'artifacts')
     os.makedirs(out_dir, exist_ok=True)
 
     # Sets the default return code on error to success.

--- a/infra/cifuzz/cifuzz.py
+++ b/infra/cifuzz/cifuzz.py
@@ -170,8 +170,8 @@ def run_fuzzers(fuzz_seconds, workspace):
     logging.error('Invalid workspace: %s.', workspace)
     return False, False
   out_dir = os.path.join(workspace, 'out')
-  bug_report_dir = os.path.join(out_dir, 'bug_report')
-  os.makedirs(bug_report_dir, exist_ok=True)
+  artifacts_dir = os.path.join(out_dir, 'artifacts')
+  os.makedirs(artifacts_dir, exist_ok=True)
   if not fuzz_seconds or fuzz_seconds < 1:
     logging.error('Fuzz_seconds argument must be greater than 1, but was: %s.',
                   format(fuzz_seconds))
@@ -195,8 +195,8 @@ def run_fuzzers(fuzz_seconds, workspace):
     else:
       logging.info('Fuzzer %s, detected error: %s.', target.target_name,
                    stack_trace)
-      shutil.move(test_case, os.path.join(bug_report_dir, 'test_case'))
-      parse_fuzzer_output(stack_trace, bug_report_dir)
+      shutil.move(test_case, os.path.join(artifacts_dir, 'test_case'))
+      parse_fuzzer_output(stack_trace, artifacts_dir)
       return True, True
   return True, False
 

--- a/infra/cifuzz/example_main.yml
+++ b/infra/cifuzz/example_main.yml
@@ -1,12 +1,8 @@
 name: CIFuzz
-
-on: [push]
-
+on: [pull_request]
 jobs:
   Fuzzing:
-
     runs-on: ubuntu-latest
-
     steps:
     - name: Build Fuzzers
       uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
@@ -22,5 +18,5 @@ jobs:
       uses: actions/upload-artifact@v1
       if: failure()
       with:
-        name: fuzzer_testcase
-        path: ./out/testcase
+        name: bug_report
+        path: ./out/bug_report

--- a/infra/cifuzz/example_main.yml
+++ b/infra/cifuzz/example_main.yml
@@ -18,5 +18,5 @@ jobs:
       uses: actions/upload-artifact@v1
       if: failure()
       with:
-        name: bug_report
-        path: ./out/bug_report
+        name: artifacts
+        path: ./out/artifacts


### PR DESCRIPTION
example_main.yml is outdated. This will make example_main.yml in sync with the current CIFuzz actions on master.