### PR TITLE
[iroha] fix build after vcpkg migration

### DIFF
--- a/projects/iroha/Dockerfile
+++ b/projects/iroha/Dockerfile
@@ -27,29 +27,12 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.14.4/cmake-3.14.4
   
   
 # Get *your* source code here.
-RUN git clone --depth 1 https://github.com/hyperledger/iroha.git
+RUN git clone --depth 1 --single-branch --branch master https://github.com/hyperledger/iroha.git
 
 WORKDIR iroha
 
-RUN cp -R $SRC/iroha/vcpkg_old /tmp/vcpkg-vars
+RUN cp -R $SRC/iroha/vcpkg /tmp/vcpkg-vars
 
-RUN set -e; \
-    git clone https://github.com/microsoft/vcpkg /tmp/vcpkg; \
-    (cd /tmp/vcpkg ; git checkout $(cat /tmp/vcpkg-vars/VCPKG_COMMIT_SHA)); \
-    for i in /tmp/vcpkg-vars/patches/*.patch; do git -C /tmp/vcpkg apply $i; done; \
-    for i in /tmp/vcpkg-vars/patches/oss/*.patch; do git -C /tmp/vcpkg apply $i; done; \
-    sh /tmp/vcpkg/bootstrap-vcpkg.sh; \
-    /tmp/vcpkg/vcpkg install $(cat /tmp/vcpkg-vars/VCPKG_BOOST_LOCALE_DEPS_LIST | cut -d':' -f1 | tr '\n' ' '); \
-    (cd /tmp/vcpkg ; git checkout -- scripts/toolchains/linux.cmake); \
-    (cd /tmp/vcpkg ; git apply /tmp/vcpkg-vars/patches/oss/0002-vcpkg-dependencies-flags.patch); \
-    /tmp/vcpkg/vcpkg install boost-locale; \
-    (cd /tmp/vcpkg ; git apply /tmp/vcpkg-vars/patches/oss/0003-vcpkg-dependencies-sanitizer.patch); \
-    /tmp/vcpkg/vcpkg install $(sed 's/grpc://' /tmp/vcpkg-vars/VCPKG_DEPS_LIST | cut -d':' -f1 | tr '\n' ' '); \
-    bash -c 'function bumper { while sleep 1; do echo bump; done; }; function run_with_bumper { bumper & p=$!; $@; kill $p; }; ASAN_OPTIONS=detect_leaks=0 run_with_bumper /tmp/vcpkg/vcpkg install grpc'; \ 
-    /tmp/vcpkg/vcpkg install --head $(cat /tmp/vcpkg-vars/VCPKG_HEAD_DEPS_LIST | cut -d':' -f1 | tr '\n' ' '); \
-    /tmp/vcpkg/vcpkg export $(/tmp/vcpkg/vcpkg list | cut -d':' -f1 | tr '\n' ' ') --raw --output=dependencies; \
-    mv /tmp/vcpkg/dependencies /opt/dependencies; \
-    chmod +x /opt/dependencies/installed/x64-linux/tools/protobuf/protoc*; \
-    rm -rf /tmp/vcpkg*
+RUN ["bash", "/tmp/vcpkg-vars/oss/build_deps.sh"]
 
 COPY build.sh $SRC/


### PR DESCRIPTION
this change fixes the build after vcpkg version bump and completes the migration started in #2986