### PR TITLE
[arrow] Enable Parquet build

### DIFF
--- a/projects/arrow/Dockerfile
+++ b/projects/arrow/Dockerfile
@@ -21,9 +21,14 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update -y -q && \
     apt-get update -y -q && \
     apt-get install -y -q --no-install-recommends \
+        bison \
+        build-essential \
         cmake \
+        flex \
+        libboost-all-dev \
         ninja-build \
         python3
 
 RUN git clone --depth=1 https://github.com/apache/arrow.git $SRC/arrow
+
 COPY build.sh $SRC/

--- a/projects/arrow/build.sh
+++ b/projects/arrow/build.sh
@@ -21,16 +21,21 @@ ARROW=${SRC}/arrow/cpp
 
 cd ${WORK}
 
+# The CMake build setup compiles and runs the Thrift compiler, but ASAN
+# would report leaks and error out.
+export ASAN_OPTIONS="detect_leaks=0"
+
 cmake ${ARROW} -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
     -DARROW_DEPENDENCY_SOURCE=BUNDLED \
+    -DBOOST_SOURCE=SYSTEM \
     -DCMAKE_C_FLAGS="${CFLAGS}" \
     -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
     -DARROW_EXTRA_ERROR_CONTEXT=off \
     -DARROW_JEMALLOC=off \
     -DARROW_MIMALLOC=off \
     -DARROW_FILESYSTEM=off \
-    -DARROW_PARQUET=off \
+    -DARROW_PARQUET=on \
     -DARROW_BUILD_SHARED=off \
     -DARROW_BUILD_STATIC=on \
     -DARROW_BUILD_TESTS=off \


### PR DESCRIPTION
The Parquet C++ reader is part of the Arrow project but needs to be enabled
explicitly.  This is required so that we can add a fuzz target for Parquet files.