### PR TITLE
dav1d: use nasm from ubuntu eoan since dav1d needs nasm-2.14

### DIFF
--- a/projects/dav1d/Dockerfile
+++ b/projects/dav1d/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER janne-vlc@jannau.net
 
-ADD bionic.list /etc/apt/sources.list.d/bionic.list
+ADD nasm.list /etc/apt/sources.list.d/nasm.list
 ADD nasm_apt.pin /etc/apt/preferences
 
 RUN dpkg --add-architecture i386 && \

--- a/projects/dav1d/bionic.list
+++ b/projects/dav1d/bionic.list
@@ -1,2 +1,0 @@
-# use nasm 2.13.02 from bionic
-deb http://archive.ubuntu.com/ubuntu/ bionic universe

--- a/projects/dav1d/nasm.list
+++ b/projects/dav1d/nasm.list
@@ -1,0 +1,2 @@
+# use nasm from a newer ubuntu release
+deb http://archive.ubuntu.com/ubuntu/ eoan universe

--- a/projects/dav1d/nasm_apt.pin
+++ b/projects/dav1d/nasm_apt.pin
@@ -1,7 +1,7 @@
 Package: *
-Pin: release n=bionic
+Pin: release n=eoan
 Pin-Priority: 1
 
 Package: nasm
-Pin: release n=bionic
+Pin: release n=eoan
 Pin-Priority: 555


### PR DESCRIPTION
Fixes the dav1d build locally