### PR TITLE
[libspectre] Fetch ghostscript before building

### DIFF
--- a/projects/libspectre/Dockerfile
+++ b/projects/libspectre/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2019 Google Inc.
+# Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,5 +23,8 @@ RUN apt-get update && \
 
 RUN git clone --depth 1 https://gitlab.freedesktop.org/libspectre/libspectre.git
 
-WORKDIR libspectre
+RUN wget -O $SRC/libspectre/ghostscript-9.50.tar.gz https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs950/ghostscript-9.50.tar.gz
+RUN tar xvzf $SRC/libspectre/ghostscript-9.50.tar.gz --directory $SRC/libspectre/
+
+WORKDIR $SRC/libspectre/
 COPY build.sh $SRC/


### PR DESCRIPTION
libspectre's fuzz target takes a long time to rebuild over a slow connection, moving these lines from the build script to the Dockerfile will cache the download + extraction step. The upstream build script has already been modified.