### PR TITLE
[infra] Use wildcard in gsutil cp command as it lacks -T option.

### DIFF
--- a/infra/gcb/build_and_run_coverage.py
+++ b/infra/gcb/build_and_run_coverage.py
@@ -186,7 +186,7 @@ def get_build_steps(project_dir):
           '-m',
           'cp',
           '-r',
-          os.path.join(out, 'report'),
+          os.path.join(out, 'report', '*'),
           upload_report_url,
       ],
   })
@@ -202,7 +202,7 @@ def get_build_steps(project_dir):
           '-m',
           'cp',
           '-r',
-          os.path.join(out, 'fuzzer_stats'),
+          os.path.join(out, 'fuzzer_stats', '*'),
           upload_fuzzer_stats_url,
       ],
   })
@@ -215,7 +215,7 @@ def get_build_steps(project_dir):
           '-m',
           'cp',
           '-r',
-          os.path.join(out, 'logs'),
+          os.path.join(out, 'logs', '*'),
           UPLOAD_URL_FORMAT.format(project=project_name,
                                    type='logs',
                                    date=report_date),


### PR DESCRIPTION
Without this, if we re-run coverage job for a project, gsutil will create redundant subdirectory inside e.g. `logs` directory so it will look like:

```
logs/
    fuzzer1.log
    fuzzer2.log
    logs/
        fuzzer1.log
        fuzzer2.log
```

and that would confuse coverage cron that iterates through the files in `fuzzer_stats` dir, for example
