### PR TITLE
[infra] Perform "gsutil rm -rf" if we need to overwrite coverage data.

### DIFF
--- a/infra/gcb/build_and_run_coverage.py
+++ b/infra/gcb/build_and_run_coverage.py
@@ -179,6 +179,10 @@ def get_build_steps(project_dir):
   upload_report_url = UPLOAD_URL_FORMAT.format(project=project_name,
                                                type='reports',
                                                date=report_date)
+
+  # Delete the existing report as gsutil cannot overwrite it in a sane way due
+  # to the lack of `-T` option (it creates a subdir in the destination dir).
+  build_steps.append(build_lib.gsutil_rm_rf_step(upload_report_url))
   build_steps.append({
       'name':
           'gcr.io/cloud-builders/gsutil',
@@ -186,15 +190,16 @@ def get_build_steps(project_dir):
           '-m',
           'cp',
           '-r',
-          os.path.join(out, 'report', '*'),
+          os.path.join(out, 'report'),
           upload_report_url,
       ],
   })
 
-  # Upload the fuzzer stats.
+  # Upload the fuzzer stats. Delete the old ones just in case.
   upload_fuzzer_stats_url = UPLOAD_URL_FORMAT.format(project=project_name,
                                                      type='fuzzer_stats',
                                                      date=report_date)
+  build_steps.append(build_lib.gsutil_rm_rf_step(upload_fuzzer_stats_url))
   build_steps.append({
       'name':
           'gcr.io/cloud-builders/gsutil',
@@ -202,12 +207,16 @@ def get_build_steps(project_dir):
           '-m',
           'cp',
           '-r',
-          os.path.join(out, 'fuzzer_stats', '*'),
+          os.path.join(out, 'fuzzer_stats'),
           upload_fuzzer_stats_url,
       ],
   })
 
-  # Upload the fuzzer logs.
+  # Upload the fuzzer logs. Delete the old ones just in case
+  upload_fuzzer_logs_url = UPLOAD_URL_FORMAT.format(project=project_name,
+                                                    type='logs',
+                                                    date=report_date),
+  build_steps.append(build_lib.gsutil_rm_rf_step(upload_fuzzer_logs_url))
   build_steps.append({
       'name':
           'gcr.io/cloud-builders/gsutil',
@@ -215,10 +224,8 @@ def get_build_steps(project_dir):
           '-m',
           'cp',
           '-r',
-          os.path.join(out, 'logs', '*'),
-          UPLOAD_URL_FORMAT.format(project=project_name,
-                                   type='logs',
-                                   date=report_date),
+          os.path.join(out, 'logs'),
+          upload_fuzzer_logs_url,
       ],
   })
 

--- a/infra/gcb/build_lib.py
+++ b/infra/gcb/build_lib.py
@@ -157,8 +157,7 @@ def http_upload_step(data, signed_url, content_type):
 def gsutil_rm_rf_step(url):
   """Returns a GCB step to recursively delete the object with given GCS url."""
   step = {
-      'name':
-          'gcr.io/cloud-builders/gsutil',
+      'name': 'gcr.io/cloud-builders/gsutil',
       'args': [
           '-m',
           'rm',

--- a/infra/gcb/build_lib.py
+++ b/infra/gcb/build_lib.py
@@ -152,3 +152,18 @@ def http_upload_step(data, signed_url, content_type):
       ],
   }
   return step
+
+
+def gsutil_rm_rf_step(url):
+  """Returns a GCB step to recursively delete the object with given GCS url."""
+  step = {
+      'name':
+          'gcr.io/cloud-builders/gsutil',
+      'args': [
+          '-m',
+          'rm',
+          '-rf',
+          url,
+      ],
+  }
+  return step


### PR DESCRIPTION
The workaround in https://github.com/google/oss-fuzz/pull/3396 worked for the logs and stats dirs, but didn't quite work for the HTML report dir (as it has subdirs and gsutil exhibits yet another weird behavior there).

https://console.cloud.google.com/errors/CI_aqYOjjdDauQE?time=P30D&project=clusterfuzz-external should go away after this.