### PR TITLE
[infra] Loose the limits for dataflow traces collection (#1632).

### DIFF
--- a/infra/base-images/base-runner/collect_dft
+++ b/infra/base-images/base-runner/collect_dft
@@ -23,7 +23,9 @@ else
 fi
 
 # Timeout for running a single fuzz target.
-TIMEOUT=1h
+if [ -z "$COLLECT_DFT_TIMEOUT"]; then
+  COLLECT_DFT_TIMEOUT=1h
+fi
 
 # Number of CPUs available, this is needed for running targets in parallel.
 NPROC=$(nproc)
@@ -38,7 +40,7 @@ function run_one_target {
 
   rm -rf $traces && mkdir -p $traces
 
-  timeout $TIMEOUT dataflow_tracer.py $OUT/$target $corpus $traces &> $log
+  timeout $COLLECT_DFT_TIMEOUT dataflow_tracer.py $OUT/$target $corpus $traces &> $log
   if (( $? != 0 )); then
     echo "Error occured while collecting data flow traces for $target:"
     cat $log

--- a/infra/gcb/build_project.py
+++ b/infra/gcb/build_project.py
@@ -356,13 +356,15 @@ def dataflow_post_build_steps(project_name, env):
     return None
 
   steps.append({
-      'name': 'gcr.io/oss-fuzz-base/base-runner',
-      'env': env + [
-          'COLLECT_DFT_TIMEOUT=2h',
-          'DFT_FILE_SIZE_LIMIT=65535',
-          'DFT_MIN_TIMEOUT=2.0',
-          'DFT_TIMEOUT_RANGE=6.0',
-      ],
+      'name':
+          'gcr.io/oss-fuzz-base/base-runner',
+      'env':
+          env + [
+              'COLLECT_DFT_TIMEOUT=2h',
+              'DFT_FILE_SIZE_LIMIT=65535',
+              'DFT_MIN_TIMEOUT=2.0',
+              'DFT_TIMEOUT_RANGE=6.0',
+          ],
       'args': [
           'bash', '-c',
           ('for f in /corpus/*.zip; do unzip -q $f -d ${f%%.*}; done && '

--- a/infra/gcb/build_project.py
+++ b/infra/gcb/build_project.py
@@ -357,7 +357,12 @@ def dataflow_post_build_steps(project_name, env):
 
   steps.append({
       'name': 'gcr.io/oss-fuzz-base/base-runner',
-      'env': env,
+      'env': env + [
+          'COLLECT_DFT_TIMEOUT=2h',
+          'DFT_FILE_SIZE_LIMIT=65535',
+          'DFT_MIN_TIMEOUT=2.0',
+          'DFT_TIMEOUT_RANGE=6.0',
+      ],
       'args': [
           'bash', '-c',
           ('for f in /corpus/*.zip; do unzip -q $f -d ${f%%.*}; done && '


### PR DESCRIPTION
All 30 projects that have dataflow enabled have green builds (except xz, there is an unrelated breakage). However, over the past 5-6 days the average performance of dataflow strategy looks worse than it looked before. Trying to loose the restrictions for the traces collection (increasing everything by ~2x) in order to collect even more traces.