### PR TITLE
[infra] GCB: ignore failing "gsutil rm -rf" step.

### DIFF
--- a/infra/gcb/build_lib.py
+++ b/infra/gcb/build_lib.py
@@ -158,11 +158,10 @@ def gsutil_rm_rf_step(url):
   """Returns a GCB step to recursively delete the object with given GCS url."""
   step = {
       'name': 'gcr.io/cloud-builders/gsutil',
+      'entrypoint': 'sh',
       'args': [
-          '-m',
-          'rm',
-          '-rf',
-          url,
+          '-c',
+          'gsutil -m rm -rf %s || exit 0' % url,
       ],
   }
   return step


### PR DESCRIPTION
Workaround for yet another specific behavior by gsutil. Apparently, it reports an error even with `-f` flag (e.g. deleting a non existent object).

Not sure if this works, testing on GCB right now.