### PR TITLE
[Infra] Add git diff to repo manager class

### DIFF
--- a/infra/repo_manager.py
+++ b/infra/repo_manager.py
@@ -94,7 +94,7 @@ class RepoManager:
                                    self.repo_dir)
     return not err_code
 
-  def get_git_dif(self):
+  def get_git_diff(self):
     """Gets a list of files that have changed from the repo head.
 
     Returns:

--- a/infra/repo_manager.py
+++ b/infra/repo_manager.py
@@ -102,7 +102,7 @@ class RepoManager:
     """
     self.fetch_unshallow()
     out, err_msg, err_code = utils.execute(
-        ['git', 'diff', '--name-only', 'origin'], self.repo_dir)
+        ['git', 'diff', '--name-only', 'origin...'], self.repo_dir)
     if err_code:
       logging.error('Git diff failed with error message %s.', err_msg)
       return None

--- a/infra/repo_manager.py
+++ b/infra/repo_manager.py
@@ -107,7 +107,7 @@ class RepoManager:
       logging.error('Git diff failed with error message %s.', err_msg)
       return None
     if not out:
-      logging.info('No diff was found.')
+      logging.error('No diff was found.')
       return None
     return [line for line in out.splitlines() if line]
 

--- a/infra/repo_manager.py
+++ b/infra/repo_manager.py
@@ -101,7 +101,8 @@ class RepoManager:
       A list of changed file paths or None on Error.
     """
     self.fetch_unshallow()
-    out, err_msg, err_code = utils.execute(['git', 'diff', '--name-only', 'origin'], self.repo_dir)
+    out, err_msg, err_code = utils.execute(
+        ['git', 'diff', '--name-only', 'origin'], self.repo_dir)
     if err_code:
       logging.error('Git diff failed with error message %s.', err_msg)
       return None

--- a/infra/repo_manager.py
+++ b/infra/repo_manager.py
@@ -21,6 +21,7 @@ a python API and manage the current state of the git repo.
     r_man =  RepoManager('https://github.com/google/oss-fuzz.git')
     r_man.checkout('5668cc422c2c92d38a370545d3591039fb5bb8d4')
 """
+import logging
 import os
 import shutil
 
@@ -92,6 +93,23 @@ class RepoManager:
     _, _, err_code = utils.execute(['git', 'cat-file', '-e', commit],
                                    self.repo_dir)
     return not err_code
+
+  def get_git_dif(self):
+    """Gets a list of files that have changed from the repo head.
+
+    Returns:
+      A list of changed file paths or None on Error.
+    """
+    self.fetch_unshallow()
+    out, err_msg, err_code = utils.execute(['git', 'diff', '--name-only', 'origin'], self.repo_dir)
+    if err_code:
+      logging.error('Git diff failed with error message %s.', err_msg)
+      return None
+    if not out:
+      logging.info('No diff was found.')
+      return None
+    file_diff = list(filter(None, out.split('\n')))
+    return file_diff
 
   def get_current_commit(self):
     """Gets the current commit SHA of the repo.

--- a/infra/repo_manager.py
+++ b/infra/repo_manager.py
@@ -109,8 +109,7 @@ class RepoManager:
     if not out:
       logging.info('No diff was found.')
       return None
-    file_diff = list(filter(None, out.split('\n')))
-    return file_diff
+    return [line for line in out.splitlines() if line]
 
   def get_current_commit(self):
     """Gets the current commit SHA of the repo.

--- a/infra/repo_manager_test.py
+++ b/infra/repo_manager_test.py
@@ -159,6 +159,7 @@ class CheckoutPRIntegrationTest(unittest.TestCase):
       repo_man = repo_manager.RepoManager(OSS_FUZZ_REPO, tmp_dir)
       repo_man.checkout_pr('refs/pull/3415/merge')
       diff = repo_man.get_git_diff()
+      print(diff)
       self.assertCountEqual(diff, ['README.md'])
 
   def test_checkout_invalid_pull_request(self):

--- a/infra/repo_manager_test.py
+++ b/infra/repo_manager_test.py
@@ -151,7 +151,7 @@ class GitDiffUnitTest(unittest.TestCase):
 
 
 class CheckoutPRIntegrationTest(unittest.TestCase):
-  """Class testing functionality of get_git_diff in the repo_manager module."""
+  """Class testing functionality of checkout_pr in the repo_manager module."""
 
   def test_pull_request_exists(self):
     """Tests that a diff is returned when a valid PR is checked out."""

--- a/infra/repo_manager_test.py
+++ b/infra/repo_manager_test.py
@@ -15,7 +15,7 @@
 
 import os
 import unittest
-import unittest.mock
+from unittest import mock
 import tempfile
 
 import repo_manager
@@ -28,7 +28,7 @@ class TestRepoManager(unittest.TestCase):
   """Class to test the functionality of the RepoManager class."""
 
 
-class RepoManagerCloneUnitTests(unittest.TestCase):
+class RepoManagerCloneUnitTest(unittest.TestCase):
   """Class to test the functionality of clone of the RepoManager class."""
 
   def test_clone_valid_repo(self):
@@ -52,7 +52,7 @@ class RepoManagerCloneUnitTests(unittest.TestCase):
                                  tmp_dir)
 
 
-class RepoManagerCheckoutUnitTests(unittest.TestCase):
+class RepoManagerCheckoutUnitTest(unittest.TestCase):
   """Class to test the functionality of checkout of the RepoManager class."""
 
   def test_checkout_valid_commit(self):
@@ -76,7 +76,7 @@ class RepoManagerCheckoutUnitTests(unittest.TestCase):
         test_repo_manager.checkout_commit('not-a-valid-commit')
 
 
-class RepoManagerGetCommitListUnitTests(unittest.TestCase):
+class RepoManagerGetCommitListUnitTest(unittest.TestCase):
   """Class to test the functionality of get commit list in the
    RepoManager class."""
 
@@ -111,7 +111,7 @@ class RepoManagerGetCommitListUnitTests(unittest.TestCase):
         test_repo_manager.get_commit_list(new_commit, old_commit)
 
 
-class RepoManagerCheckoutPullRequestUnitTests(unittest.TestCase):
+class RepoManagerCheckoutPullRequestUnitTest(unittest.TestCase):
   """Class to test the functionality of checkout_pr of the RepoManager class."""
 
   def test_checkout_valid_pull_request(self):
@@ -135,17 +135,16 @@ class RepoManagerCheckoutPullRequestUnitTests(unittest.TestCase):
         test_repo_manager.checkout_pr('not/a/valid/pr')
 
 
-class GitDiffUnitTests(unittest.TestCase):
+class GitDiffUnitTest(unittest.TestCase):
   """Class testing functionality of get_git_diff in the repo_manager module."""
 
   def test_diff_exists(self):
     """Tests that a real diff is returned when a valid repo manager exists."""
     with tempfile.TemporaryDirectory() as tmp_dir:
       repo_man = repo_manager.RepoManager(OSS_FUZZ_REPO, tmp_dir)
-      with unittest.mock.patch.object(utils,
-                                      'execute',
-                                      return_value=('test.py\ndiff.py', None,
-                                                    0)):
+      with mock.patch.object(utils,
+                             'execute',
+                             return_value=('test.py\ndiff.py', None, 0)):
         diff = repo_man.get_git_dif()
         self.assertCountEqual(diff, ['test.py', 'diff.py'])
 
@@ -153,9 +152,7 @@ class GitDiffUnitTests(unittest.TestCase):
     """Tests that None is returned when there is no difference between repos."""
     with tempfile.TemporaryDirectory() as tmp_dir:
       repo_man = repo_manager.RepoManager(OSS_FUZZ_REPO, tmp_dir)
-      with unittest.mock.patch.object(utils,
-                                      'execute',
-                                      return_value=('', None, 0)):
+      with mock.patch.object(utils, 'execute', return_value=('', None, 0)):
         diff = repo_man.get_git_dif()
         self.assertIsNone(diff)
 
@@ -163,14 +160,14 @@ class GitDiffUnitTests(unittest.TestCase):
     """Tests that None is returned when the command errors out."""
     with tempfile.TemporaryDirectory() as tmp_dir:
       repo_man = repo_manager.RepoManager(OSS_FUZZ_REPO, tmp_dir)
-      with unittest.mock.patch.object(utils,
-                                      'execute',
-                                      return_value=('', 'Test error.', 1)):
+      with mock.patch.object(utils,
+                             'execute',
+                             return_value=('', 'Test error.', 1)):
         diff = repo_man.get_git_dif()
         self.assertIsNone(diff)
 
 
-class GitDiffIntegrationTests(unittest.TestCase):
+class GitDiffIntegrationTest(unittest.TestCase):
   """Class testing functionality of get_git_diff in the repo_manager module."""
 
   def test_diff_exists(self):

--- a/infra/repo_manager_test.py
+++ b/infra/repo_manager_test.py
@@ -111,30 +111,6 @@ class RepoManagerGetCommitListUnitTest(unittest.TestCase):
         test_repo_manager.get_commit_list(new_commit, old_commit)
 
 
-class RepoManagerCheckoutPullRequestUnitTest(unittest.TestCase):
-  """Class to test the functionality of checkout_pr of the RepoManager class."""
-
-  def test_checkout_valid_pull_request(self):
-    """Tests that the git checkout pull request works."""
-    with tempfile.TemporaryDirectory() as tmp_dir:
-      test_repo_manager = repo_manager.RepoManager(OSS_FUZZ_REPO, tmp_dir)
-      test_repo_manager.checkout_pr('refs/pull/3415/merge')
-      self.assertEqual(test_repo_manager.get_current_commit(),
-                       '2d9759999071e2c0843c63129d8426282a1a7669')
-
-  def test_checkout_invalid_pull_request(self):
-    """Tests that the git checkout invalid pull request fails."""
-    with tempfile.TemporaryDirectory() as tmp_dir:
-      test_repo_manager = repo_manager.RepoManager(OSS_FUZZ_REPO, tmp_dir)
-      with self.assertRaises(RuntimeError):
-        test_repo_manager.checkout_pr(' ')
-      with self.assertRaises(RuntimeError):
-        test_repo_manager.checkout_pr(
-            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
-      with self.assertRaises(RuntimeError):
-        test_repo_manager.checkout_pr('not/a/valid/pr')
-
-
 class GitDiffUnitTest(unittest.TestCase):
   """Class testing functionality of get_git_diff in the repo_manager module."""
 
@@ -166,24 +142,38 @@ class GitDiffUnitTest(unittest.TestCase):
         diff = repo_man.get_git_diff()
         self.assertIsNone(diff)
 
-
-class GitDiffIntegrationTest(unittest.TestCase):
-  """Class testing functionality of get_git_diff in the repo_manager module."""
-
-  def test_diff_exists(self):
-    """Tests that a real diff is returned when a valid repo manager exists."""
-    with tempfile.TemporaryDirectory() as tmp_dir:
-      repo_man = repo_manager.RepoManager(OSS_FUZZ_REPO, tmp_dir)
-      repo_man.checkout_pr('refs/pull/3415/merge')
-      diff = repo_man.get_git_diff()
-      self.assertCountEqual(diff, ['README.md'])
-
   def test_diff_empty(self):
     """Tests that None is returned when there is no difference between repos."""
     with tempfile.TemporaryDirectory() as tmp_dir:
       repo_man = repo_manager.RepoManager(OSS_FUZZ_REPO, tmp_dir)
       diff = repo_man.get_git_diff()
       self.assertIsNone(diff)
+
+
+class CheckoutPRIntegrationTest(unittest.TestCase):
+  """Class testing functionality of get_git_diff in the repo_manager module."""
+
+  def test_PR_exists(self):
+    """Tests that a diff is returned when a valid PR is checked out."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      repo_man = repo_manager.RepoManager(OSS_FUZZ_REPO, tmp_dir)
+      repo_man.checkout_pr('refs/pull/3415/merge')
+      diff = repo_man.get_git_diff()
+      self.assertCountEqual(diff, ['README.md'])
+
+  def test_checkout_invalid_pull_request(self):
+    """Tests that the git checkout invalid pull request fails."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      test_repo_manager = repo_manager.RepoManager(OSS_FUZZ_REPO, tmp_dir)
+      with self.assertRaises(RuntimeError):
+        test_repo_manager.checkout_pr(' ')
+      with self.assertRaises(RuntimeError):
+        test_repo_manager.checkout_pr(
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+      with self.assertRaises(RuntimeError):
+        test_repo_manager.checkout_pr('not/a/valid/pr')
+
+
 
 
 if __name__ == '__main__':

--- a/infra/repo_manager_test.py
+++ b/infra/repo_manager_test.py
@@ -145,7 +145,7 @@ class GitDiffUnitTest(unittest.TestCase):
       with mock.patch.object(utils,
                              'execute',
                              return_value=('test.py\ndiff.py', None, 0)):
-        diff = repo_man.get_git_dif()
+        diff = repo_man.get_git_diff()
         self.assertCountEqual(diff, ['test.py', 'diff.py'])
 
   def test_diff_empty(self):
@@ -153,7 +153,7 @@ class GitDiffUnitTest(unittest.TestCase):
     with tempfile.TemporaryDirectory() as tmp_dir:
       repo_man = repo_manager.RepoManager(OSS_FUZZ_REPO, tmp_dir)
       with mock.patch.object(utils, 'execute', return_value=('', None, 0)):
-        diff = repo_man.get_git_dif()
+        diff = repo_man.get_git_diff()
         self.assertIsNone(diff)
 
   def test_error_on_command(self):
@@ -163,7 +163,7 @@ class GitDiffUnitTest(unittest.TestCase):
       with mock.patch.object(utils,
                              'execute',
                              return_value=('', 'Test error.', 1)):
-        diff = repo_man.get_git_dif()
+        diff = repo_man.get_git_diff()
         self.assertIsNone(diff)
 
 
@@ -175,14 +175,14 @@ class GitDiffIntegrationTest(unittest.TestCase):
     with tempfile.TemporaryDirectory() as tmp_dir:
       repo_man = repo_manager.RepoManager(OSS_FUZZ_REPO, tmp_dir)
       repo_man.checkout_pr('refs/pull/3415/merge')
-      diff = repo_man.get_git_dif()
+      diff = repo_man.get_git_diff()
       self.assertCountEqual(diff, ['README.md'])
 
   def test_diff_empty(self):
     """Tests that None is returned when there is no difference between repos."""
     with tempfile.TemporaryDirectory() as tmp_dir:
       repo_man = repo_manager.RepoManager(OSS_FUZZ_REPO, tmp_dir)
-      diff = repo_man.get_git_dif()
+      diff = repo_man.get_git_diff()
       self.assertIsNone(diff)
 
 

--- a/infra/repo_manager_test.py
+++ b/infra/repo_manager_test.py
@@ -141,25 +141,32 @@ class GitDiffUnitTests(unittest.TestCase):
   def test_diff_exists(self):
     """Tests that a real diff is returned when a valid repo manager exists."""
     with tempfile.TemporaryDirectory() as tmp_dir:
-      self.repo_man = repo_manager.RepoManager(OSS_FUZZ_REPO, tmp_dir)
-      with unittest.mock.patch.object(utils, 'execute', return_value=('test.py\ndiff.py',None,0)):
-        diff = self.repo_man.get_git_dif()
+      repo_man = repo_manager.RepoManager(OSS_FUZZ_REPO, tmp_dir)
+      with unittest.mock.patch.object(utils,
+                                      'execute',
+                                      return_value=('test.py\ndiff.py', None,
+                                                    0)):
+        diff = repo_man.get_git_dif()
         self.assertCountEqual(diff, ['test.py', 'diff.py'])
 
   def test_diff_empty(self):
     """Tests that None is returned when there is no difference between repos."""
     with tempfile.TemporaryDirectory() as tmp_dir:
-      self.repo_man = repo_manager.RepoManager(OSS_FUZZ_REPO, tmp_dir)
-      with unittest.mock.patch.object(utils, 'execute', return_value=('',None,0)):
-        diff = self.repo_man.get_git_dif()
+      repo_man = repo_manager.RepoManager(OSS_FUZZ_REPO, tmp_dir)
+      with unittest.mock.patch.object(utils,
+                                      'execute',
+                                      return_value=('', None, 0)):
+        diff = repo_man.get_git_dif()
         self.assertIsNone(diff)
 
   def test_error_on_command(self):
     """Tests that None is returned when the command errors out."""
     with tempfile.TemporaryDirectory() as tmp_dir:
-      self.repo_man = repo_manager.RepoManager(OSS_FUZZ_REPO, tmp_dir)
-      with unittest.mock.patch.object(utils, 'execute', return_value=('','Test error.',1)):
-        diff = self.repo_man.get_git_dif()
+      repo_man = repo_manager.RepoManager(OSS_FUZZ_REPO, tmp_dir)
+      with unittest.mock.patch.object(utils,
+                                      'execute',
+                                      return_value=('', 'Test error.', 1)):
+        diff = repo_man.get_git_dif()
         self.assertIsNone(diff)
 
 
@@ -169,18 +176,17 @@ class GitDiffIntegrationTests(unittest.TestCase):
   def test_diff_exists(self):
     """Tests that a real diff is returned when a valid repo manager exists."""
     with tempfile.TemporaryDirectory() as tmp_dir:
-      self.repo_man = repo_manager.RepoManager(OSS_FUZZ_REPO, tmp_dir)
-      self.repo_man.checkout_pr('refs/pull/3415/merge')
-      diff = self.repo_man.get_git_dif()
+      repo_man = repo_manager.RepoManager(OSS_FUZZ_REPO, tmp_dir)
+      repo_man.checkout_pr('refs/pull/3415/merge')
+      diff = repo_man.get_git_dif()
       self.assertCountEqual(diff, ['README.md'])
 
   def test_diff_empty(self):
     """Tests that None is returned when there is no difference between repos."""
     with tempfile.TemporaryDirectory() as tmp_dir:
-      self.repo_man = repo_manager.RepoManager(OSS_FUZZ_REPO, tmp_dir)
-      diff = self.repo_man.get_git_dif()
+      repo_man = repo_manager.RepoManager(OSS_FUZZ_REPO, tmp_dir)
+      diff = repo_man.get_git_dif()
       self.assertIsNone(diff)
-
 
 
 if __name__ == '__main__':

--- a/infra/repo_manager_test.py
+++ b/infra/repo_manager_test.py
@@ -142,7 +142,7 @@ class GitDiffUnitTest(unittest.TestCase):
         diff = repo_man.get_git_diff()
         self.assertIsNone(diff)
 
-  def test_diff_empty(self):
+  def test_diff_no_change(self):
     """Tests that None is returned when there is no difference between repos."""
     with tempfile.TemporaryDirectory() as tmp_dir:
       repo_man = repo_manager.RepoManager(OSS_FUZZ_REPO, tmp_dir)
@@ -153,7 +153,7 @@ class GitDiffUnitTest(unittest.TestCase):
 class CheckoutPRIntegrationTest(unittest.TestCase):
   """Class testing functionality of get_git_diff in the repo_manager module."""
 
-  def test_PR_exists(self):
+  def test_pull_request_exists(self):
     """Tests that a diff is returned when a valid PR is checked out."""
     with tempfile.TemporaryDirectory() as tmp_dir:
       repo_man = repo_manager.RepoManager(OSS_FUZZ_REPO, tmp_dir)
@@ -172,8 +172,6 @@ class CheckoutPRIntegrationTest(unittest.TestCase):
             'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
       with self.assertRaises(RuntimeError):
         test_repo_manager.checkout_pr('not/a/valid/pr')
-
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds the functionality of git diff --name-only to the repo manager module. This functionality will be used for the affected fuzzer feature of CIFuzz. Associated tests have also been added.