### PR TITLE
Right handling for rust path for ecc-diff-fuzzer

### DIFF
--- a/projects/ecc-diff-fuzzer/Dockerfile
+++ b/projects/ecc-diff-fuzzer/Dockerfile
@@ -17,8 +17,9 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER p.antoine@catenacyber.fr
 RUN apt-get update && apt-get install -y make cmake bzip2 autoconf automake gettext libtool python nodejs npm
+ENV CARGO_HOME=/rust RUSTUP_HOME=/rust/rustup PATH=$PATH:/rust/bin
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-RUN /bin/bash -c "source $HOME/.cargo/env && rustup target add i686-unknown-linux-gnu"
+RUN rustup target add i686-unknown-linux-gnu
 RUN npm install -g browserify
 RUN npm install elliptic
 RUN git clone --depth 1 https://github.com/horhof/quickjs quickjs

--- a/projects/ecc-diff-fuzzer/Dockerfile
+++ b/projects/ecc-diff-fuzzer/Dockerfile
@@ -18,8 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER p.antoine@catenacyber.fr
 RUN apt-get update && apt-get install -y make cmake bzip2 autoconf automake gettext libtool python nodejs npm
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH="$HOME/.cargo/bin:${PATH}"
-RUN /bin/bash -c "cat $HOME/.cargo/env && echo $HOME && source $HOME/.cargo/env && rustup target add i686-unknown-linux-gnu"
+RUN /bin/bash -c "source $HOME/.cargo/env && rustup target add i686-unknown-linux-gnu"
 RUN npm install -g browserify
 RUN npm install elliptic
 RUN git clone --depth 1 https://github.com/horhof/quickjs quickjs

--- a/projects/ecc-diff-fuzzer/Dockerfile
+++ b/projects/ecc-diff-fuzzer/Dockerfile
@@ -19,7 +19,7 @@ MAINTAINER p.antoine@catenacyber.fr
 RUN apt-get update && apt-get install -y make cmake bzip2 autoconf automake gettext libtool python nodejs npm
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="$HOME/.cargo/bin:${PATH}"
-RUN rustup target add i686-unknown-linux-gnu
+RUN /bin/bash -c "cat $HOME/.cargo/env && echo $HOME && source $HOME/.cargo/env && rustup target add i686-unknown-linux-gnu"
 RUN npm install -g browserify
 RUN npm install elliptic
 RUN git clone --depth 1 https://github.com/horhof/quickjs quickjs

--- a/projects/ecc-diff-fuzzer/Dockerfile
+++ b/projects/ecc-diff-fuzzer/Dockerfile
@@ -18,7 +18,8 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER p.antoine@catenacyber.fr
 RUN apt-get update && apt-get install -y make cmake bzip2 autoconf automake gettext libtool python nodejs npm
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-RUN /bin/bash -c "source $HOME/.cargo/env && rustup target add i686-unknown-linux-gnu"
+ENV PATH="$HOME/.cargo/bin:${PATH}"
+RUN rustup target add i686-unknown-linux-gnu
 RUN npm install -g browserify
 RUN npm install elliptic
 RUN git clone --depth 1 https://github.com/horhof/quickjs quickjs

--- a/projects/ecc-diff-fuzzer/build.sh
+++ b/projects/ecc-diff-fuzzer/build.sh
@@ -127,7 +127,6 @@ mv /usr/lib/x86_64-linux-gnu/libcrypto.a /usr/lib/x86_64-linux-gnu/libcrypto_old
 mv /usr/lib/x86_64-linux-gnu/libcrypto.so /usr/lib/x86_64-linux-gnu/libcrypto_old.so
 #build fuzz target
 cd ecfuzzer
-source $HOME/.cargo/env
 if [ "$ARCHITECTURE" = 'i386' ]; then
     export GOARCH=386
 #needed explicitly because of cross compilation cf https://golang.org/cmd/cgo/

--- a/projects/ecc-diff-fuzzer/build.sh
+++ b/projects/ecc-diff-fuzzer/build.sh
@@ -127,7 +127,6 @@ mv /usr/lib/x86_64-linux-gnu/libcrypto.a /usr/lib/x86_64-linux-gnu/libcrypto_old
 mv /usr/lib/x86_64-linux-gnu/libcrypto.so /usr/lib/x86_64-linux-gnu/libcrypto_old.so
 #build fuzz target
 cd ecfuzzer
-source /root/.cargo/env
 if [ "$ARCHITECTURE" = 'i386' ]; then
     export GOARCH=386
 #needed explicitly because of cross compilation cf https://golang.org/cmd/cgo/

--- a/projects/ecc-diff-fuzzer/build.sh
+++ b/projects/ecc-diff-fuzzer/build.sh
@@ -127,6 +127,7 @@ mv /usr/lib/x86_64-linux-gnu/libcrypto.a /usr/lib/x86_64-linux-gnu/libcrypto_old
 mv /usr/lib/x86_64-linux-gnu/libcrypto.so /usr/lib/x86_64-linux-gnu/libcrypto_old.so
 #build fuzz target
 cd ecfuzzer
+source /root/.cargo/env
 if [ "$ARCHITECTURE" = 'i386' ]; then
     export GOARCH=386
 #needed explicitly because of cross compilation cf https://golang.org/cmd/cgo/


### PR DESCRIPTION
This follows #3408 

Even if the CI was green, the build on oss-fuzz does not work 

Error logs are
```
Step #4: + source /builder/home/.cargo/env
Step #4: /src/build.sh: line 130: /builder/home/.cargo/env: No such file or directory
Step #4: ********************************************************************************
Step #4: Failed to build.
Step #4: To reproduce, run:
Step #4: python infra/helper.py build_image ecc-diff-fuzzer
Step #4: python infra/helper.py build_fuzzers --sanitizer address --engine libfuzzer --architecture x86_64 ecc-diff-fuzzer
Step #4: ********************************************************************************
```

So, I guess this is because the user is not root here but builder and `/builder/home/.cargo/env` does not exist even if `/root/.cargo/env` does exist

So, I am trying this patch