### PR TITLE
[ghostscript] Add place holder program name.

### DIFF
--- a/projects/ghostscript/gstoraster_fuzzer.cc
+++ b/projects/ghostscript/gstoraster_fuzzer.cc
@@ -41,6 +41,7 @@ static int gs_to_raster_fuzz(const unsigned char *buf, size_t size)
 
 	/* Mostly stolen from cups-filters gstoraster. */
 	char *args[] = {
+		"gs",
 		"-K1048576",
 		"-r200x200",
 		"-dMediaPosition=1",


### PR DESCRIPTION
The first element in the argument array to gsapi_new_instance()
is ignored since it normally is the program name. This means that
the commit introducing the "-K" argument to limit memory usage did
not have its intended effect since the "-K" argument was ignored.
Moreover, prior to that the resolution argument "-r200x200" was
being unintentionally ignored. By introducing a place holder program
name all arguments are taken into account and the reader is reminded
that the first argument is the program name.

I'm hoping this will improve the situation with ghostscript oss-fuzz issue #15650.