### PR TITLE
[ghostscript] Relicense target fuzzer under Apache 2.0 license.

### DIFF
--- a/projects/ghostscript/gstoraster_fuzzer.cc
+++ b/projects/ghostscript/gstoraster_fuzzer.cc
@@ -1,6 +1,20 @@
-// Copyright 2019 The Chromium OS Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+/*
+# Copyright 2019 The Chromium OS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+*/
 
 #include <base/gserrors.h>
 #include <psi/iapi.h>


### PR DESCRIPTION
When contributed to OSS-fuzz the Ghostscript target fuzzer was
licensed under a "BSD-style" license, referring to a LICENSE file
that actually contained an Apache 2.0 license! Recently the OSS-fuzz
project has added a presubmit check that validates the license of
each project's target fuzzer, causing the Ghostscript target fuzzer
to now fail the test. The Ghostscript target fuzzer therefore needs
to be relicensed under Apache 2.0.

This commit relicenses the existing target fuzzer code under
Apache 2.0 so that the Ghostscript target fuzzer code will pass
OSS-fuzz's presubmit checks allowing for further development.