### PR TITLE
disable logging support in libtorrent, to avoid clang 10 ICE

### DIFF
--- a/projects/libtorrent/Dockerfile
+++ b/projects/libtorrent/Dockerfile
@@ -18,8 +18,8 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER arvid@libtorrent.org
 RUN apt-get update && apt-get install -y wget libssl-dev
 
-RUN wget --no-verbose https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz
-RUN tar xzf boost_1_69_0.tar.gz
+RUN git clone --depth 1 --single-branch --branch boost-1.72.0 --recurse-submodules https://github.com/boostorg/boost.git
+
 
 RUN git clone --depth 1 --single-branch --branch RC_1_2 --recurse-submodules https://github.com/arvidn/libtorrent.git
 WORKDIR libtorrent

--- a/projects/libtorrent/build.sh
+++ b/projects/libtorrent/build.sh
@@ -27,7 +27,7 @@ echo "CXXFLAGS=$CXXFLAGS"
 echo "using clang : ossfuzz : $CXX : <compileflags>\"$CXXFLAGS\" <linkflags>\"$CXXFLAGS\" <linkflags>\"${LIB_FUZZING_ENGINE}\" ;" >project-config.jam
 cat project-config.jam
 cd fuzzers
-b2 clang-ossfuzz -j$(nproc) crypto=openssl fuzz=external sanitize=off stage-large
+b2 clang-ossfuzz -j$(nproc) crypto=openssl fuzz=external sanitize=off stage-large logging=off
 cp fuzzers/* $OUT
 
 wget --no-verbose https://github.com/arvidn/libtorrent/releases/download/libtorrent-1_2_1/corpus.zip

--- a/projects/libtorrent/build.sh
+++ b/projects/libtorrent/build.sh
@@ -15,11 +15,12 @@
 #
 ################################################################################
 
-export PATH=${PATH}:${PWD}/../boost_1_69_0/tools/build/src/engine/bin.linuxx86_64
-export BOOST_ROOT=${PWD}/../boost_1_69_0
-export BOOST_BUILD_PATH=${PWD}/../boost_1_69_0/tools/build
-
-(cd ${PWD}/../boost_1_69_0 && ./bootstrap.sh)
+export PATH=${PATH}:${PWD}/../boost
+export BOOST_ROOT=${PWD}/../boost
+export BOOST_BUILD_PATH=${PWD}/../boost/tools/build
+# when building b2, we don't want sanitizers enabled
+ASAN_OPTIONS=detect_leaks=0
+(cd ${PWD}/../boost && ./bootstrap.sh && ./b2 headers)
 
 echo "CXX=$CXX"
 echo "CXXFLAGS=$CXXFLAGS"
@@ -27,7 +28,8 @@ echo "CXXFLAGS=$CXXFLAGS"
 echo "using clang : ossfuzz : $CXX : <compileflags>\"$CXXFLAGS\" <linkflags>\"$CXXFLAGS\" <linkflags>\"${LIB_FUZZING_ENGINE}\" ;" >project-config.jam
 cat project-config.jam
 cd fuzzers
-b2 clang-ossfuzz -j$(nproc) crypto=openssl fuzz=external sanitize=off stage-large logging=off
+# we don't want sanitizers enabled on b2 itself
+ASAN_OPTIONS=detect_leaks=0 b2 clang-ossfuzz -j$(nproc) crypto=openssl fuzz=external sanitize=off stage-large logging=off
 cp fuzzers/* $OUT
 
 wget --no-verbose https://github.com/arvidn/libtorrent/releases/download/libtorrent-1_2_1/corpus.zip


### PR DESCRIPTION
This disables code in libtorrent that causes clang 10 to ICE, specifically [this issue](https://bugs.llvm.org/show_bug.cgi?id=43814). Hopefully restoring fuzzing.