### PR TITLE
Adds locally installed includes for coverage build

### DIFF
--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -77,7 +77,7 @@ BUILD_CMD="bash -eux $SRC/build.sh"
 
 # We need to preserve source code files for generating a code coverage report.
 # We need exact files that were compiled, so copy both $SRC and $WORK dirs.
-COPY_SOURCES_CMD="cp -rL --parents $SRC $WORK /usr/include $OUT"
+COPY_SOURCES_CMD="cp -rL --parents $SRC $WORK /usr/include /usr/local/include $OUT"
 
 if [ "${BUILD_UID-0}" -ne "0" ]; then
   adduser -u $BUILD_UID --disabled-password --gecos '' builder


### PR DESCRIPTION
Plan is to fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20755
I am not sure this is the best way, but this should work.

ecc differential fuzzer now compiles and installs the different crypto libraries.
Before, it used to compile them, but not install them.
This is meant to have a simpler compilation scheme...

But then, it looks like the coverage build cannot find the installed header files for the coverage report :
```
Step #5: [0m[0;31merror: /workspace/out/coverage/usr/local/include/botan-2/botan/ec_group.h: No such file or directory
Step #5: [0m[0;31mwarning: The file '/usr/local/include/botan-2/botan/ec_group.h' isn't covered.
...
Step #5: Traceback (most recent call last):
Step #5:   File "/opt/code_coverage/coverage_utils.py", line 825, in <module>
Step #5:     sys.exit(Main())
Step #5:   File "/opt/code_coverage/coverage_utils.py", line 819, in Main
Step #5:     return _CmdPostProcess(args)
Step #5:   File "/opt/code_coverage/coverage_utils.py", line 776, in _CmdPostProcess
Step #5:     processor.PrepareHtmlReport()
Step #5:   File "/opt/code_coverage/coverage_utils.py", line 574, in PrepareHtmlReport
Step #5:     self.file_view_path)
Step #5:   File "/opt/code_coverage/coverage_utils.py", line 446, in GenerateFileViewHtmlIndexFile
Step #5:     self.GetCoverageHtmlReportPathForFile(file_path),
Step #5:   File "/opt/code_coverage/coverage_utils.py", line 426, in GetCoverageHtmlReportPathForFile
Step #5:     self._MapToLocal(file_path)), '"%s" is not a file.' % file_path
Step #5: AssertionError: "/usr/local/include/botan-2/botan/curve_gfp.h" is not a file.
Step #5: ********************************************************************************
Step #5: Code coverage report generation failed.
Step #5: To reproduce, run:
Step #5: python infra/helper.py build_image ecc-diff-fuzzer
Step #5: python infra/helper.py build_fuzzers --sanitizer coverage ecc-diff-fuzzer
Step #5: python infra/helper.py coverage ecc-diff-fuzzer
Step #5: ********************************************************************************
```

So, we can copy them 