### PR TITLE
[hunspell] Add project to oss-fuzz

### DIFF
--- a/projects/hunspell/Dockerfile
+++ b/projects/hunspell/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER twsmith@mozilla.com
+RUN dpkg --add-architecture i386 && \
+    apt-get update && \
+    apt-get install -y autoconf automake autopoint libtool
+RUN git clone --depth 1 https://github.com/hunspell/hunspell.git hunspell
+WORKDIR hunspell
+COPY build.sh $SRC/

--- a/projects/hunspell/build.sh
+++ b/projects/hunspell/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+mv -f ./tests/*.aff $OUT/
+mv -f ./tests/*.dic $OUT/
+
+autoreconf -vfi
+./configure --disable-shared --enable-static
+make clean
+make -j$(nproc) 
+$CXX $CXXFLAGS -o $OUT/fuzzer -I./src/ $LIB_FUZZING_ENGINE ./src/tools/fuzzer.cxx ./src/hunspell/.libs/libhunspell-1.7.a

--- a/projects/hunspell/project.yaml
+++ b/projects/hunspell/project.yaml
@@ -1,0 +1,11 @@
+homepage: "https://hunspell.github.io/"
+primary_contact: ""
+vendor_ccs:
+  - "twsmith@mozilla.com"
+sanitizers:
+  - address
+  - memory
+  - undefined
+architectures:
+ - i386
+ - x86_64


### PR DESCRIPTION
I would like to add Hunspell (hunspell.github.io) to oss-fuzz