### PR TITLE
Add Grok JPEG 2000 toolkit to oss-fuzz

### DIFF
--- a/projects/grok/Dockerfile
+++ b/projects/grok/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER boxerab@gmail.com
+RUN apt-get update && apt-get install -y make cmake
+RUN git clone --depth 1 https://github.com/GrokImageCompression/grok.git grok
+RUN git clone --depth 1 https://github.com/GrokImageCompression/grok-test-data.git grok/data
+WORKDIR grok
+COPY build.sh $SRC/

--- a/projects/grok/build.sh
+++ b/projects/grok/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+mkdir build
+cd build
+cmake ..
+make clean -s
+make -j$(nproc) -s
+cd ..
+
+./tests/fuzzers/build_google_oss_fuzzers.sh
+./tests/fuzzers/build_seed_corpus.sh

--- a/projects/grok/project.yaml
+++ b/projects/grok/project.yaml
@@ -1,0 +1,2 @@
+homepage: "https://github.com/GrokImageCompression/grok"
+primary_contact: "boxerab@gmail.com"


### PR DESCRIPTION
grok is a jpeg 2000 codec, one of only two actively-developed OSS jpeg 2000 toolkits, the other one being OpenJPEG. 