### PR TITLE
[cryptofuzz] Fix NSS coverage

### DIFF
--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -42,5 +42,6 @@ RUN git clone --depth 1 https://github.com/ARMmbed/mbed-crypto.git
 RUN hg clone https://hg.mozilla.org/projects/nspr
 RUN hg clone https://hg.mozilla.org/projects/nss
 RUN apt-get remove -y libunwind8
+RUN apt-get install -y libssl-dev
 
 COPY build.sh $SRC/

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -67,15 +67,9 @@ then
     mv $SRC/nss $SRC/nss-nspr/
     mv $SRC/nspr $SRC/nss-nspr/
     cd $SRC/nss-nspr/
-    if [[ $CFLAGS = *sanitize=address* ]]
-    then
-        CFLAGS="" CXXFLAGS="" nss/build.sh --asan --static
-    elif [[ $CFLAGS = *sanitize=memory* ]]
-    then
-        CFLAGS="" CXXFLAGS="" nss/build.sh --msan --static
-    else
-        CFLAGS="" CXXFLAGS="" nss/build.sh --ubsan --static
-    fi
+
+    CXX="$CXX -stdlib=libc++" LDFLAGS="$CFLAGS" nss/build.sh --enable-fips --static --disable-tests --fuzz=oss
+
     export NSS_NSPR_PATH=$(realpath $SRC/nss-nspr/)
     export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NSS"
     export LINK_FLAGS="$LINK_FLAGS -lsqlite3"


### PR DESCRIPTION
Currently the coverage reports don't work for NSS: https://storage.googleapis.com/oss-fuzz-coverage/cryptofuzz/reports/20200303/linux/src/nss-nspr/nss/report.html

This PR should fix that