### PR TITLE
libcacard: Add fuzzing scripts

### DIFF
--- a/projects/libcacard/Dockerfile
+++ b/projects/libcacard/Dockerfile
@@ -1,0 +1,29 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER jjelen@redhat.com
+RUN apt-get update && apt-get install -y pkg-config libglib2.0-dev gyp libsqlite3-dev mercurial python3-pip
+# Because Ubuntu has really ancient meson out there
+RUN pip3 install meson ninja
+
+#RUN git clone --depth 1 https://gitlab.freedesktop.org/spice/libcacard.git libcacard
+RUN git clone --depth 1 --single-branch --branch fuzzers https://gitlab.freedesktop.org/jjelen/libcacard.git libcacard
+RUN git clone --depth 1 https://github.com/nss-dev/nss.git nss
+RUN hg clone https://hg.mozilla.org/projects/nspr
+
+WORKDIR libcacard
+COPY build.sh $SRC/

--- a/projects/libcacard/build.sh
+++ b/projects/libcacard/build.sh
@@ -1,0 +1,63 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Compile NSS
+mkdir $SRC/nss-nspr
+mv $SRC/nss $SRC/nss-nspr/
+mv $SRC/nspr $SRC/nss-nspr/
+cd $SRC/nss-nspr/
+# We do not need NSS to be built with address sanitizer
+CFLAGS="" CXXFLAGS="" nss/build.sh --static
+
+# Create a package config for NSS
+cp dist/Debug/lib/pkgconfig/{nspr,nss}.pc
+sed -i "s/Debug//g" dist/Debug/lib/pkgconfig/nss.pc
+sed -i "s/\/lib/\/lib\/Debug/g" dist/Debug/lib/pkgconfig/nss.pc
+sed -i "s/include\/nspr/public\/nss/g" dist/Debug/lib/pkgconfig/nss.pc
+sed -i "s/NSPR/NSS/g" dist/Debug/lib/pkgconfig/nss.pc
+sed -i "s/Libs:.*/Libs: -L\${libdir} -lssl -lsmime -lnssdev -lnss_static -lpk11wrap_static -lcryptohi -lcerthi -lcertdb -lnssb -lnssutil -lnsspki -ldl -lm -lsqlite -lsoftokn_static -lfreebl_static -lgcm-aes-x86_c_lib -lhw-acc-crypto-avx -lhw-acc-crypto-avx2 /g" dist/Debug/lib/pkgconfig/nss.pc
+echo "Requires: nspr" >> dist/Debug/lib/pkgconfig/nss.pc
+
+export NSS_NSPR_PATH=$(realpath $SRC/nss-nspr/)
+export PKG_CONFIG_PATH=$NSS_NSPR_PATH/dist/Debug/lib/pkgconfig
+export LD_LIBRARY_PATH=$NSS_NSPR_PATH/dist/Debug/lib
+
+# compile libcacard
+BUILD=$WORK/meson
+rm -rf $BUILD
+mkdir $BUILD
+
+cd $SRC/libcacard
+# Drop the tests as they are not needed and require too much dependencies
+meson $BUILD -Ddefault_library=static -Ddisable_tests=true
+ninja -C $BUILD
+
+# We need nss db to work
+cp -r tests/db $OUT/
+
+echo "XXXXXXXX" > $WORK/testinput
+
+fuzzers=$(find $BUILD/fuzz/ -executable -type f)
+for f in $fuzzers; do
+	fuzzer=$(basename $f)
+	cp $f $OUT/
+	# Check if it runs at least in build image
+	$OUT/$fuzzer $WORK/testinput
+	#zip -j $OUT/${fuzzer}_seed_corpus.zip fuzz/corpora/${fuzzer}/*
+done
+
+rm $WORK/testinput

--- a/projects/libcacard/project.yaml
+++ b/projects/libcacard/project.yaml
@@ -1,9 +1,8 @@
 homepage: "https://gitlab.freedesktop.org/spice/libcacard"
+language: c
 primary_contact: "jjelen@redhat.com"
 auto_ccs:
  - "jakuje@gmail.com"
 sanitizers:
  - address
- - memory:
-    experimental: True
  - undefined


### PR DESCRIPTION
This finally (after #3019) adds the dockerfile and build.sh script to start fuzzing. It depends on merging the fuzzers into libcacard source tree so marking as WIP, but generally, the concept should be done (after fixing the URL to the upstream repository instead of my fork).

The ugly thing is a rebuild of NSS, which is needed for statically compiled fuzzer binary (as Ubuntu does not ship static nss libraries nor any pkg-config information about linking). Tested locally with helper scripts. Comments welcomed.

[1] https://gitlab.freedesktop.org/spice/libcacard/-/merge_requests/14/