### PR TITLE
[presubmit] Enforce language attribute in project.yaml to be always set.

### DIFF
--- a/docs/getting-started/new_project_guide.md
+++ b/docs/getting-started/new_project_guide.md
@@ -72,6 +72,7 @@ Once the template configuration files are created, you can modify them to fit yo
 This configuration file stores project metadata. The following attributes are supported:
 
 - [homepage](#homepage)
+- [language](#language)
 - [primary_contact](#primary)
 - [auto_ccs](#primary)
 - [vendor_ccs](#vendor) (optional)
@@ -81,6 +82,13 @@ This configuration file stores project metadata. The following attributes are su
 
 ### homepage
 You project's homepage.
+
+### language
+
+Programming language the project is written in. Most often this would be `c` or
+`c++`. Other values for this attribute are documented in language specific
+documentation pages (e.g.
+[Integrating a Go project]({{ site.baseurl }}//getting-started/new-project-guide/go-lang/)).
 
 ### primary_contact, auto_ccs {#primary}
 The primary contact and list of other contacts to be CCed. Each person listed gets access to ClusterFuzz, including crash reports and fuzzer statistics, and are auto-cced on new bugs filed in the OSS-Fuzz

--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -94,7 +94,7 @@ class ProjectYamlChecker:
       'help_url',
   ]
 
-  LANGUAGES_SUPPORTED = ['c', 'cpp', 'go', 'rust', 'python']
+  LANGUAGES_SUPPORTED = ['c', 'c++', 'go', 'rust', 'python']
 
   # Note that some projects like boost only have auto-ccs. However, forgetting
   # primary contact is probably a mistake.
@@ -188,9 +188,11 @@ class ProjectYamlChecker:
         self.error(email_address + ' is an invalid email address.')
 
   def check_valid_language(self):
-    """Check that the language specified is valid."""
+    """Check that the language is specified and valid."""
     language = self.data.get('language')
-    if language not in self.LANGUAGES_SUPPORTED:
+    if not language:
+      self.error('Missing "language" attribute in project.yaml.')
+    elif language not in self.LANGUAGES_SUPPORTED:
       self.error(
           '"language: {language}" is not supported ({supported}).'.format(
               language=language, supported=self.LANGUAGES_SUPPORTED))

--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -190,12 +190,10 @@ class ProjectYamlChecker:
   def check_valid_language(self):
     """Check that the language specified is valid."""
     language = self.data.get('language')
-    if not language:
-      return
-
     if language not in self.LANGUAGES_SUPPORTED:
-      self.error('{language} is not supported ({supported}).'.format(
-          language=language, supported=self.LANGUAGES_SUPPORTED))
+      self.error(
+          '"language: {language}" is not supported ({supported}).'.format(
+              language=language, supported=self.LANGUAGES_SUPPORTED))
 
 
 def _check_one_project_yaml(project_yaml_filename):

--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -92,6 +92,8 @@ class ProjectYamlChecker:
       'view_restrictions',
       'language',
       'help_url',
+      'labels',  # For internal use only, hard to lint as it uses fuzzer names.
+      'selective_unpack',
   ]
 
   LANGUAGES_SUPPORTED = [

--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -94,7 +94,7 @@ class ProjectYamlChecker:
       'help_url',
   ]
 
-  LANGUAGES_SUPPORTED = ['c', 'c++', 'go', 'rust', 'python']
+  LANGUAGES_SUPPORTED = ['c', 'c++', 'go', 'rust',]
 
   # Note that some projects like boost only have auto-ccs. However, forgetting
   # primary contact is probably a mistake.

--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -94,7 +94,12 @@ class ProjectYamlChecker:
       'help_url',
   ]
 
-  LANGUAGES_SUPPORTED = ['c', 'c++', 'go', 'rust',]
+  LANGUAGES_SUPPORTED = [
+      'c',
+      'c++',
+      'go',
+      'rust',
+  ]
 
   # Note that some projects like boost only have auto-ccs. However, forgetting
   # primary contact is probably a mistake.

--- a/infra/templates.py
+++ b/infra/templates.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 ################################################################################
+"""Templates for OSS-Fuzz project files."""
 
 PROJECT_YAML_TEMPLATE = """\
 homepage: "<your_project_homepage>"

--- a/infra/templates.py
+++ b/infra/templates.py
@@ -16,6 +16,7 @@
 
 PROJECT_YAML_TEMPLATE = """\
 homepage: "<your_project_homepage>"
+language: <programming_language>
 primary_contact: "<primary_contact_email>"
 """
 

--- a/infra/templates.py
+++ b/infra/templates.py
@@ -17,7 +17,7 @@
 
 PROJECT_YAML_TEMPLATE = """\
 homepage: "<your_project_homepage>"
-language: <programming_language>
+language: <programming_language>  # Example values: c, c++, go, rust.
 primary_contact: "<primary_contact_email>"
 """
 

--- a/projects/arduinojson/project.yaml
+++ b/projects/arduinojson/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/bblanchon/ArduinoJson"
+language: c++
 primary_contact: "benoit.blanchon@gmail.com"
 sanitizers:
   - address

--- a/projects/arrow/project.yaml
+++ b/projects/arrow/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://arrow.apache.org/"
+language: c++
 primary_contact: "antoine@python.org"
 auto_ccs:
   - "bengilgit@gmail.com"

--- a/projects/aspell/project.yaml
+++ b/projects/aspell/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/GNUAspell/aspell"
+language: c++
 primary_contact: "kevina@gnu.org"
 auto_ccs:
   - "kevinatkn@gmail.com"

--- a/projects/augeas/project.yaml
+++ b/projects/augeas/project.yaml
@@ -1,4 +1,5 @@
 homepage: https://github.com/hercules-team/augeas
+language: c++
 primary_contact: lutter@watzmann.net
 auto_ccs:
   - hhan@redhat.com

--- a/projects/avahi/project.yaml
+++ b/projects/avahi/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://avahi.org/"
+language: c++
 primary_contact: trent@lloyd.id.au
 auto_ccs:
   - alex.gaynor@gmail.com

--- a/projects/bad_example/project.yaml
+++ b/projects/bad_example/project.yaml
@@ -1,6 +1,7 @@
-disabled: True
 homepage: "http://www.zlib.net/"
+language: c++
 sanitizers:
   - address
   - memory
   - undefined
+disabled: True

--- a/projects/bignum-fuzzer/project.yaml
+++ b/projects/bignum-fuzzer/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/guidovranken/bignum-fuzzer"
+language: c++
 primary_contact: "guidovranken@gmail.com"
 auto_ccs:
     - "martin.swende@ethereum.org"

--- a/projects/binutils/project.yaml
+++ b/projects/binutils/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.gnu.org/software/binutils/"
+language: c++
 primary_contact: "bug-binutils@gnu.org"
 auto_ccs :
   - "p.antoine@catenacyber.fr"

--- a/projects/bloaty/project.yaml
+++ b/projects/bloaty/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/google/bloaty"
+language: c++
 primary_contact: "jhaberman@gmail.com"
 architectures:
   - x86_64

--- a/projects/boost/project.yaml
+++ b/projects/boost/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://www.boost.org/"
+language: c++
 
 # TODO: add more boost maintainers here and possibly a mailing list.
 # primary_contact: "someone@boost.org"

--- a/projects/boringssl/project.yaml
+++ b/projects/boringssl/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://boringssl.googlesource.com/boringssl/"
+language: c++
 primary_contact: "agl@google.com"
 auto_ccs:
  - "davidben@google.com"

--- a/projects/botan/project.yaml
+++ b/projects/botan/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://botan.randombit.net"
+language: c++
 primary_contact: "jack.lloyd@gmail.com"
 auto_ccs:
   - "r.korthaus@sirrix.com"

--- a/projects/brotli/project.yaml
+++ b/projects/brotli/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/google/brotli"
+language: c++
 primary_contact: "eustas@chromium.org"
 vendor_ccs:
   - "jkew@mozilla.com"

--- a/projects/bzip2/project.yaml
+++ b/projects/bzip2/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://sourceware.org/bzip2/"
+language: c++
 primary_contact: "bzip2fuzzer@gmail.com"
 auto_ccs:
   - "bshas3@gmail.com"

--- a/projects/c-ares/project.yaml
+++ b/projects/c-ares/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://c-ares.haxx.se/"
+language: c++
 primary_contact: "drysdale@google.com"
 fuzzing_engines:
   - afl

--- a/projects/c-blosc/project.yaml
+++ b/projects/c-blosc/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/Blosc/c-blosc"
+language: c++
 primary_contact: "blosc.oss.fuzz@gmail.com"
 sanitizers:
   - address

--- a/projects/capstone/project.yaml
+++ b/projects/capstone/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.capstone-engine.org"
+language: c++
 primary_contact: "capstone.engine@gmail.com"
 auto_ccs : 
   - "p.antoine@catenacyber.fr"

--- a/projects/casync/project.yaml
+++ b/projects/casync/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/casync/casync"
+language: c++
 primary_contact: "lennart@poettering.net"
 sanitizers:
   - address

--- a/projects/chakra/project.yaml
+++ b/projects/chakra/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/Microsoft/ChakraCore"
+language: c++
 primary_contact: "ChakraCoreEng@microsoft.com"
 fuzzing_engines:
   - none

--- a/projects/cjson/project.yaml
+++ b/projects/cjson/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/DaveGamble/cJSON"
+language: c++
 primary_contact: "max@maxbruckner.de"
 auto_ccs:
   - "randy440088@gmail.com"

--- a/projects/clamav/project.yaml
+++ b/projects/clamav/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.clamav.net/"
+language: c++
 primary_contact: "clamav.fuzz@gmail.com"
 auto_ccs:
     - clamav-bugs@external.cisco.com

--- a/projects/cmark/project.yaml
+++ b/projects/cmark/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://commonmark.org"
+language: c++
 primary_contact: "jgm@berkeley.edu"
 auto_ccs:
   - "kivikakk@github.com"

--- a/projects/cppcheck/project.yaml
+++ b/projects/cppcheck/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://cppcheck.sourceforge.net"
+language: c++
 primary_contact: "daniel.marjamaki@gmail.com"
 auto_ccs:
   - "daniel.marjamaki@gmail.com"

--- a/projects/cpython3/project.yaml
+++ b/projects/cpython3/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://python.org/"
+language: c++
 primary_contact: "gps@google.com"
 auto_ccs:
  - "alex.gaynor@gmail.com"

--- a/projects/cras/project.yaml
+++ b/projects/cras/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.chromium.org"
+language: c++
 primary_contact: "dgreid@chromium.org"
 auto_ccs:
   - "hychao@chromium.org"

--- a/projects/cryptofuzz/project.yaml
+++ b/projects/cryptofuzz/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/guidovranken/cryptofuzz"
+language: c++
 primary_contact: "guidovranken@gmail.com"
 auto_ccs:
     - "openssl-security@openssl.org"

--- a/projects/curl/project.yaml
+++ b/projects/curl/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://curl.haxx.se/"
+language: c++
 primary_contact: "daniel@haxx.se"
 auto_ccs:
   - "daniel.haxx@gmail.com"

--- a/projects/dav1d/project.yaml
+++ b/projects/dav1d/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://code.videolan.org/videolan/dav1d"
+language: c++
 primary_contact: "janne.grunau@gmail.com"
 auto_ccs:
   - "rsbultje@gmail.com"

--- a/projects/django/project.yaml
+++ b/projects/django/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.djangoproject.com/"
+language: c++
 primary_contact: "guidovranken@gmail.com"
 auto_ccs:
  - "f.apolloner@gmail.com"

--- a/projects/dlplibs/project.yaml
+++ b/projects/dlplibs/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.documentliberation.org"
+language: c++
 primary_contact: "dtardon@redhat.com"
 sanitizers:
   - address

--- a/projects/double-conversion/project.yaml
+++ b/projects/double-conversion/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/google/double-conversion"
+language: c++
 primary_contact: "florian@loitsch.com"
 auto_ccs:
   - "sbucur@google.com"

--- a/projects/dropbear/project.yaml
+++ b/projects/dropbear/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://matt.ucc.asn.au/dropbear/dropbear.html"
+language: c++
 primary_contact: "matt@ucc.asn.au"
 sanitizers:
   - address

--- a/projects/easywsclient/project.yaml
+++ b/projects/easywsclient/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/dhbaird/easywsclient"
+language: c++
 primary_contact: "dhbaird@gmail.com"
 sanitizers:
   - address

--- a/projects/ecc-diff-fuzzer/project.yaml
+++ b/projects/ecc-diff-fuzzer/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/catenacyber/elliptic-curve-differential-fuzzer"
+language: c++
 primary_contact: "p.antoine@catenacyber.fr"
 
 architectures:

--- a/projects/eigen/project.yaml
+++ b/projects/eigen/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://eigen.tuxfamily.org/index.php?title=Main_Page"
+language: c++
 primary_contact: "eigen-core-team@lists.tuxfamily.org"
 sanitizers:
   - address

--- a/projects/envoy/project.yaml
+++ b/projects/envoy/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.envoyproxy.io/"
+language: c++
 primary_contact: "htuch@google.com"
 auto_ccs:
   - "mattklein123@gmail.com"

--- a/projects/esp-v2/project.yaml
+++ b/projects/esp-v2/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/GoogleCloudPlatform/esp-v2"
+language: c++
 primary_contact: "jilinxia@google.com"
 auto_ccs:
 - "nareddyt@google.com"

--- a/projects/example/project.yaml
+++ b/projects/example/project.yaml
@@ -1,6 +1,9 @@
 # Provide the home page for *your* project:
 homepage: "https://my-api.example.com"
 
+# Language the project is written in:
+language: c++
+
 # Provide the e-mail for the primary contact and others:
 # Un-comment the below lines to make auto-cc work.
 # primary_contact: "primary-my-api-maintainer@example.com"

--- a/projects/expat/project.yaml
+++ b/projects/expat/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/libexpat/libexpat"
+language: c++
 primary_contact: "sebastian@pipping.org"
 auto_ccs:
  - "rhodri@kynesim.co.uk"

--- a/projects/ffmpeg/project.yaml
+++ b/projects/ffmpeg/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.ffmpeg.org/"
+language: c++
 primary_contact: "ffmpeg-security@ffmpeg.org"
 auto_ccs:
  - "michaelni@gmx.at"

--- a/projects/file/project.yaml
+++ b/projects/file/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://www.darwinsys.com/file/"
+language: c++
 primary_contact: "zoulasc@gmail.com"
 sanitizers:
   - address

--- a/projects/firefox/project.yaml
+++ b/projects/firefox/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.mozilla.org/firefox/"
+language: c++
 primary_contact: "choller@mozilla.com"
 auto_ccs:
   - twsmith@mozilla.com

--- a/projects/firestore/project.yaml
+++ b/projects/firestore/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://firebase.google.com/docs/firestore/"
+language: c++
 primary_contact: "varconst@google.com"
 auto_ccs:
   - "varconst@google.com"

--- a/projects/flac/project.yaml
+++ b/projects/flac/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://xiph.org/flac/"
+language: c++
 primary_contact: "guidovranken@gmail.com"
 auto_ccs:
  - "erik.de.castro.lopo@gmail.com"

--- a/projects/freeimage/project.yaml
+++ b/projects/freeimage/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://freeimage.sourceforge.net/"
+language: c++
 primary_contact: "drolon@infonie.fr"
 
 sanitizers:

--- a/projects/freetype2/project.yaml
+++ b/projects/freetype2/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.freetype.org/"
+language: c++
 primary_contact: "lemzwerg@gmail.com"
 auto_ccs:
   - "darnold@adobe.com"

--- a/projects/fuzzing-puzzles/project.yaml
+++ b/projects/fuzzing-puzzles/project.yaml
@@ -1,4 +1,5 @@
 homepage: https://github.com/google/fuzzer-test-suite
+language: c++
 primary_contact: kcc@google.com
 auto_ccs:
   - "kevinwkt@google.com"

--- a/projects/gdal/project.yaml
+++ b/projects/gdal/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://gdal.org"
+language: c++
 primary_contact: "even.rouault@gmail.com"
 auto_ccs:
   - "schwehr@gmail.com"

--- a/projects/gfwx/project.yaml
+++ b/projects/gfwx/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://www.gfwx.org/"
+language: c++
 primary_contact: "fyffe@google.com"
 sanitizers:
  - address

--- a/projects/ghostscript/project.yaml
+++ b/projects/ghostscript/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://ghostscript.com"
+language: c++
 primary_contact: "skau@google.com"
 auto_ccs:
   - "henry.stiles@artifex.com"

--- a/projects/giflib/project.yaml
+++ b/projects/giflib/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://giflib.sourceforge.net/"
+language: c++
 primary_contact: "esr@thyrsus.com"
 auto_ccs:
   - "vincent.ulitzsch@live.de"

--- a/projects/git/project.yaml
+++ b/projects/git/project.yaml
@@ -1,2 +1,3 @@
 homepage: "https://git-scm.com"
+language: c++
 primary_contact: "steadmon@google.com"

--- a/projects/glib/project.yaml
+++ b/projects/glib/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://gitlab.gnome.org/GNOME/glib/"
+language: c++
 primary_contact: "bugzilla@tecnocode.co.uk"
 auto_ccs:
 - philip.withnall@gmail.com

--- a/projects/gnupg/project.yaml
+++ b/projects/gnupg/project.yaml
@@ -1,2 +1,3 @@
 homepage: "https://www.gnupg.org"
+language: c++
 primary_contact: "p.antoine@catenacyber.fr"

--- a/projects/gnutls/project.yaml
+++ b/projects/gnutls/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.gnutls.org"
+language: c++
 primary_contact: "n.mavrogiannopoulos@gmail.com"
 auto_ccs:
   - "daiki.ueno@gmail.com"

--- a/projects/graphicsfuzz-spirv/project.yaml
+++ b/projects/graphicsfuzz-spirv/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.graphicsfuzz.com"
+language: c++
 primary_contact: "afdx@google.com"
 auto_ccs:
   - "paulthomson@google.com"

--- a/projects/graphicsmagick/project.yaml
+++ b/projects/graphicsmagick/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://www.graphicsmagick.org/"
+language: c++
 primary_contact: "bobjfriesenhahn@gmail.com"
 auto_ccs:
     - troyjp@gmail.com

--- a/projects/grpc/project.yaml
+++ b/projects/grpc/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://www.grpc.io/"
+language: c++
 primary_contact: "nnoble@google.com"
 auto_ccs:
   - "donnadionne@google.com"

--- a/projects/gstreamer/project.yaml
+++ b/projects/gstreamer/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://gstreamer.freedesktop.org/"
+language: c++
 primary_contact: "gstreamer-security@lists.freedesktop.org"
 auto_ccs:
  - "bilboed@bilboed.com"

--- a/projects/guetzli/project.yaml
+++ b/projects/guetzli/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/google/guetzli"
+language: c++
 primary_contact: "robryk@google.com"
 auto_ccs:
   - "szabadka@google.com"

--- a/projects/h2o/project.yaml
+++ b/projects/h2o/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/h2o/h2o"
+language: c++
 primary_contact: "jonathan.foote@gmail.com"
 auto_ccs:
   - "frederik.deweerdt@gmail.com"

--- a/projects/harfbuzz/project.yaml
+++ b/projects/harfbuzz/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/harfbuzz/harfbuzz"
+language: c++
 primary_contact: "harfbuzz-admin@googlegroups.com"
 auto_ccs:
   - "behdad.esfahbod@gmail.com"

--- a/projects/hoextdown/project.yaml
+++ b/projects/hoextdown/project.yaml
@@ -1,2 +1,3 @@
 homepage: "https://github.com/kjdev/hoextdown"
+language: c++
 primary_contact: "kjclev@gmail.com"

--- a/projects/hostap/project.yaml
+++ b/projects/hostap/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://w1.fi/cvs.html"
+language: c++
 primary_contact: "j@w1.fi"
 auto_ccs:
    - "elver@google.com"

--- a/projects/htslib/project.yaml
+++ b/projects/htslib/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.htslib.org/"
+language: c++
 primary_contact: "rmd@sanger.ac.uk"
 auto_ccs:
         - "aw7@sanger.ac.uk"

--- a/projects/hunspell/project.yaml
+++ b/projects/hunspell/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://hunspell.github.io/"
+language: c++
 primary_contact: "caolanm@redhat.com"
 auto_ccs:
   - "security@documentfoundation.org"

--- a/projects/ibmswtpm2/project.yaml
+++ b/projects/ibmswtpm2/project.yaml
@@ -1,4 +1,5 @@
 homepage: https://sourceforge.net/projects/ibmswtpm2/
+language: c++
 primary_contact: kgoldman@us.ibm.com
 auto_ccs:
   - "john.s.andersen@intel.com"

--- a/projects/icu/project.yaml
+++ b/projects/icu/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://site.icu-project.org/"
+language: c++
 auto_ccs:
  - icu-security@unicode.org
  - andy.heninger@gmail.com

--- a/projects/imagemagick/project.yaml
+++ b/projects/imagemagick/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.imagemagick.org"
+language: c++
 primary_contact: "dirk@lemstra.org"
 auto_ccs:
   - paul.l.kehrer@gmail.com

--- a/projects/iroha/project.yaml
+++ b/projects/iroha/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/hyperledger/iroha"
+language: c++
 primary_contact: "boldrev@soramitsu.co.jp"
 auto_ccs:
   - "andrei@soramitsu.co.jp"

--- a/projects/irssi/project.yaml
+++ b/projects/irssi/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/irssi/irssi"
+language: c++
 primary_contact: "ahf@irssi.org"
 auto_ccs:
   - "dx@dxzone.com.ar"

--- a/projects/jansson/project.yaml
+++ b/projects/jansson/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/akheron/jansson"
+language: c++
 primary_contact: "git@cfware.com"
 auto_ccs:
   - "cmeister2@gmail.com"

--- a/projects/janus-gateway/project.yaml
+++ b/projects/janus-gateway/project.yaml
@@ -1,20 +1,5 @@
-# Copyright 2019 Google Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-################################################################################
-
 homepage: "https://github.com/meetecho/janus-gateway"
+language: c++
 primary_contact: "toppi.ale@gmail.com"
 auto_ccs:
   - "lminiero@gmail.com"

--- a/projects/jbig2dec/project.yaml
+++ b/projects/jbig2dec/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.jbig2dec.com"
+language: c++
 primary_contact: sebastian.rasmussen@artifex.com
 sanitizers:
   - address

--- a/projects/jsc/project.yaml
+++ b/projects/jsc/project.yaml
@@ -1,4 +1,5 @@
 homepage: https://webkit.org/
+language: c++
 fuzzing_engines:
   - none
 sanitizers:

--- a/projects/json-c/project.yaml
+++ b/projects/json-c/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://json-c.github.io/json-c/"
+language: c++
 primary_contact: "erh+git@nimenees.com"
 auto_ccs:
   - "chriswwolfe@gmail.com"

--- a/projects/json/project.yaml
+++ b/projects/json/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/nlohmann/json"
+language: c++
 primary_contact: "niels.lohmann@gmail.com"
 sanitizers:
  - address

--- a/projects/jsoncpp/project.yaml
+++ b/projects/jsoncpp/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/open-source-parsers/jsoncpp/"
+language: c++
 primary_contact: "cdunn2001@gmail.com"
 auto_ccs:
  - "jophba@chromium.org"

--- a/projects/jsonnet/project.yaml
+++ b/projects/jsonnet/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/google/jsonnet"
+language: c++
 primary_contact: "dcunnin@google.com"
 auto_ccs:
   - "wwweiwang@google.com"

--- a/projects/karchive/project.yaml
+++ b/projects/karchive/project.yaml
@@ -1,4 +1,5 @@
 homepage: https://cgit.kde.org/karchive.git/
+language: c++
 primary_contact: tsdgeos@gmail.com
 sanitizers:
   - address

--- a/projects/kcodecs/project.yaml
+++ b/projects/kcodecs/project.yaml
@@ -1,4 +1,5 @@
 homepage: https://cgit.kde.org/kcodecs.git/
+language: c++
 primary_contact: tsdgeos@gmail.com
 sanitizers:
   - address

--- a/projects/keystone/project.yaml
+++ b/projects/keystone/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.keystone-engine.org"
+language: c++
 primary_contact: "keystone.engine@gmail.com"
 auto_ccs : "p.antoine@catenacyber.fr"
 

--- a/projects/keystone/project.yaml
+++ b/projects/keystone/project.yaml
@@ -1,9 +1,10 @@
 homepage: "https://www.keystone-engine.org"
 language: c++
 primary_contact: "keystone.engine@gmail.com"
-auto_ccs : "p.antoine@catenacyber.fr"
+auto_ccs :
+  - "p.antoine@catenacyber.fr"
 
 sanitizers:
-- address
-- memory
-- undefined
+  - address
+  - memory
+  - undefined

--- a/projects/kimageformats/project.yaml
+++ b/projects/kimageformats/project.yaml
@@ -1,4 +1,5 @@
 homepage: https://cgit.kde.org/kimageformats.git/
+language: c++
 primary_contact: tsdgeos@gmail.com
 sanitizers:
   - address

--- a/projects/knot-dns/project.yaml
+++ b/projects/knot-dns/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.knot-dns.cz/"
+language: c++
 primary_contact: "knot.dns@gmail.com"
 auto_ccs:
   - "jonathan.foote@gmail.com"

--- a/projects/lame/project.yaml
+++ b/projects/lame/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://sourceforge.net/projects/lame/"
+language: c++
 primary_contact: "guidovranken@gmail.com"
 auto_ccs:
     - "bouvigne@gmail.com"

--- a/projects/lcms/project.yaml
+++ b/projects/lcms/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://www.littlecms.com/"
+language: c++
 primary_contact: "marti.maria.s@gmail.com"
 sanitizers:
   - address

--- a/projects/leptonica/project.yaml
+++ b/projects/leptonica/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://www.leptonica.com"
+language: c++
 primary_contact: "taking@google.com"
 auto_ccs:
   - "kusano@google.com"

--- a/projects/libaom/project.yaml
+++ b/projects/libaom/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://aomedia.org/av1-features/get-started/"
+language: c++
 primary_contact: "urvang@google.com"
 sanitizers:
 - address

--- a/projects/libarchive/project.yaml
+++ b/projects/libarchive/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/libarchive/libarchive"
+language: c++
 primary_contact: "joerg.sonnenberger@googlemail.com"
 auto_ccs:
   - "kientzle@gmail.com"

--- a/projects/libass/project.yaml
+++ b/projects/libass/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/libass/libass"
+language: c++
 primary_contact: "greg@kinoho.net"
 auto_ccs:
   - "rodger.combs@gmail.com"

--- a/projects/libavc/project.yaml
+++ b/projects/libavc/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://android.googlesource.com/platform/external/libavc/"
+language: c++
 primary_contact: "harish.mahendrakar@ittiam.com"
 sanitizers:
   - address

--- a/projects/libavif/project.yaml
+++ b/projects/libavif/project.yaml
@@ -1,2 +1,3 @@
 homepage: "https://github.com/AOMediaCodec/libavif"
+language: c++
 primary_contact: "joedrago@gmail.com"

--- a/projects/libcbor/project.yaml
+++ b/projects/libcbor/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/PJK/libcbor"
+language: c++
 primary_contact: "me@pavelkalvoda.com"
 auto_ccs:
   - alex.gaynor@gmail.com

--- a/projects/libchewing/project.yaml
+++ b/projects/libchewing/project.yaml
@@ -1,3 +1,4 @@
 homepage: "http://chewing.im/"
+language: c++
 disabled: true
 view_restrictions: none

--- a/projects/libcoap/project.yaml
+++ b/projects/libcoap/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://libcoap.net/"
+language: c++
 primary_contact: "bergmann@tzi.org"
 auto_ccs:
     - "libcoap@gmail.com"

--- a/projects/libexif/project.yaml
+++ b/projects/libexif/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://libexif.github.io"
+language: c++
 primary_contact: "dan@coneharvesters.com"
 auto_ccs:
   - paul.l.kehrer@gmail.com

--- a/projects/libfdk-aac/project.yaml
+++ b/projects/libfdk-aac/project.yaml
@@ -1,4 +1,5 @@
 homepage: https://android.googlesource.com/platform/external/aac/
+language: c++
 primary_contact: audio-fdk@iis.fraunhofer.de
 auto_ccs:
   - jmtrivi@google.com

--- a/projects/libfido2/project.yaml
+++ b/projects/libfido2/project.yaml
@@ -1,4 +1,5 @@
 homepage: https://github.com/Yubico/libfido2
+language: c++
 primary_contact: "g.kihlman@yubico.com"
 auto_ccs:
     - "pedro@ambientworks.net"

--- a/projects/libfmt/project.yaml
+++ b/projects/libfmt/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/fmtlib/fmt"
+language: c++
 primary_contact: "pauldreikossfuzz@gmail.com"
 auto_ccs:
  - "victor.zverovich@gmail.com"

--- a/projects/libgd/project.yaml
+++ b/projects/libgd/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://libgd.org"
+language: c++
 primary_contact: "security@libgd.org"
 auto_ccs:
   - vapier@gmail.com

--- a/projects/libgit2/project.yaml
+++ b/projects/libgit2/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://libgit2.github.com/"
+language: c++
 primary_contact: "ps@pks.im"
 auto_ccs:
   - "nelhage@nelhage.com"

--- a/projects/libheif/project.yaml
+++ b/projects/libheif/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/strukturag/libheif"
+language: c++
 primary_contact: "dirk.farin@gmail.com"
 auto_ccs:
   - "mail@joachim-bauch.de"

--- a/projects/libhevc/project.yaml
+++ b/projects/libhevc/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://android.googlesource.com/platform/external/libhevc/"
+language: c++
 primary_contact: "harish.mahendrakar@ittiam.com"
 sanitizers:
   - address

--- a/projects/libhtp/project.yaml
+++ b/projects/libhtp/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/OISF/libhtp"
+language: c++
 primary_contact: "vjulien@openinfosecfoundation.org"
 auto_ccs :
 - "p.antoine@catenacyber.fr"

--- a/projects/libical/project.yaml
+++ b/projects/libical/project.yaml
@@ -1,4 +1,5 @@
 homepage: https://github.com/libical/libical
+language: c++
 primary_contact: tsdgeos@gmail.com
 auto_ccs:
   - allen.d.winter@gmail.com

--- a/projects/libidn/project.yaml
+++ b/projects/libidn/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.gnu.org/software/libidn/"
+language: c++
 primary_contact: "rockdaboot@gmail.com"
 auto_ccs:
   - "tim.ruehsen@gmx.de"

--- a/projects/libidn2/project.yaml
+++ b/projects/libidn2/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://gitlab.com/libidn/libidn2"
+language: c++
 primary_contact: "rockdaboot@gmail.com"
 auto_ccs:
   - "n.mavrogiannopoulos@gmail.com"

--- a/projects/libjpeg-turbo/project.yaml
+++ b/projects/libjpeg-turbo/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/libjpeg-turbo/libjpeg-turbo"
+language: c++
 vendor_ccs:
   - "aosmond@mozilla.com"
   - "tnikkel@mozilla.com"

--- a/projects/libldac/project.yaml
+++ b/projects/libldac/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://android.googlesource.com/platform/external/libldac"
+language: c++
 primary_contact: "Chisato.Kenmochi@sony.com"
 auto_ccs:
   - twsmith@mozilla.com

--- a/projects/libmpeg2/project.yaml
+++ b/projects/libmpeg2/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://android.googlesource.com/platform/external/libmpeg2/"
+language: c++
 primary_contact: "harish.mahendrakar@ittiam.com"
 sanitizers:
   - address

--- a/projects/libpcap/project.yaml
+++ b/projects/libpcap/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.tcpdump.org"
+language: c++
 primary_contact: "security@tcpdump.org"
 auto_ccs :
   - "p.antoine@catenacyber.fr"

--- a/projects/libplist/project.yaml
+++ b/projects/libplist/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/libimobiledevice/libplist"
+language: c++
 primary_contact: "nikias.bassen@gmail.com"
 auto_ccs:
   - "nikias@gmx.li"

--- a/projects/libpng-proto/project.yaml
+++ b/projects/libpng-proto/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://www.libpng.org/pub/png/libpng.html"
+language: c++
 primary_contact: "kcc@google.com"
 sanitizers:
   - undefined

--- a/projects/libpng/project.yaml
+++ b/projects/libpng/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://www.libpng.org/pub/png/libpng.html"
+language: c++
 primary_contact: "glennrp@gmail.com"
 vendor_ccs:
   - "aosmond@mozilla.com"

--- a/projects/libprotobuf-mutator/project.yaml
+++ b/projects/libprotobuf-mutator/project.yaml
@@ -1,2 +1,4 @@
+homepage: "https://github.com/google/libprotobuf-mutator"
+language: c++
 auto_ccs:
   - "vitalybuka@chromium.org"

--- a/projects/libpsl/project.yaml
+++ b/projects/libpsl/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/rockdaboot/libpsl"
+language: c++
 primary_contact: "rockdaboot@gmail.com"
 auto_ccs:
   - "tim.ruehsen@gmx.de"

--- a/projects/librawspeed/project.yaml
+++ b/projects/librawspeed/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/darktable-org/rawspeed"
+language: c++
 primary_contact: "lebedev.ri@gmail.com"
 sanitizers:
 - address

--- a/projects/libreoffice/project.yaml
+++ b/projects/libreoffice/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.libreoffice.org/"
+language: c++
 primary_contact: "caolanm@redhat.com"
 auto_ccs:
   - "officesecurity@lists.freedesktop.org"

--- a/projects/libressl/project.yaml
+++ b/projects/libressl/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.libressl.org/"
+language: c++
 primary_contact: "busterb@gmail.com"
 auto_ccs:
  - "beck@obtuse.com"

--- a/projects/libsass/project.yaml
+++ b/projects/libsass/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://libsass.org/"
+language: c++
 primary_contact: "xzyfer@gmail.com"
 
 sanitizers:

--- a/projects/libsodium/project.yaml
+++ b/projects/libsodium/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://libsodium.org"
+language: c++
 primary_contact: "ossfuzzz+sodium@gmail.com"
 auto_ccs:
  - "chriswwolfe@gmail.com"

--- a/projects/libspectre/project.yaml
+++ b/projects/libspectre/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.freedesktop.org/wiki/Software/libspectre/"
+language: c++
 primary_contact: "tsdgeos@gmail.com"
 auto_ccs:
   - "randy440088@gmail.com"

--- a/projects/libspng/project.yaml
+++ b/projects/libspng/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://libspng.org"
+language: c++
 primary_contact: "randy408@protonmail.com"
 auto_ccs:
   - "randy440088@gmail.com"

--- a/projects/libsrtp/project.yaml
+++ b/projects/libsrtp/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/cisco/libsrtp"
+language: c++
 primary_contact: "richbarn@cisco.com"
 auto_ccs:
  - "guidovranken@gmail.com"

--- a/projects/libssh/project.yaml
+++ b/projects/libssh/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://libssh.org/"
+language: c++
 primary_contact: "asn@cryptomilk.org"
 auto_ccs:
  - "cryptomilk@gmail.com"

--- a/projects/libssh2/project.yaml
+++ b/projects/libssh2/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/libssh2/libssh2"
+language: c++
 primary_contact: "will.cosgrove@gmail.com"
 auto_ccs:
   - "cmeister2@gmail.com"

--- a/projects/libtasn1/project.yaml
+++ b/projects/libtasn1/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://gitlab.com/gnutls/libtasn1"
+language: c++
 primary_contact: "rockdaboot@gmail.com"
 auto_ccs:
   - "n.mavrogiannopoulos@gmail.com"

--- a/projects/libteken/project.yaml
+++ b/projects/libteken/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://svn.freebsd.org/base/head/sys/teken/"
+language: c++
 primary_contact: "ed@nuxi.nl"
 sanitizers:
   - address

--- a/projects/libtheora/project.yaml
+++ b/projects/libtheora/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.theora.org/"
+language: c++
 primary_contact: "guidovranken@gmail.com"
 vendor_ccs:
  - "daede003@umn.edu"

--- a/projects/libtiff/project.yaml
+++ b/projects/libtiff/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://www.libtiff.org"
+language: c++
 primary_contact: "even.rouault@gmail.com"
 auto_ccs:
   - paul.l.kehrer@gmail.com

--- a/projects/libtorrent/project.yaml
+++ b/projects/libtorrent/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/arvidn/libtorrent.git"
+language: c++
 primary_contact: "pauldreikossfuzz@gmail.com"
 auto_ccs:
  - "oss-fuzz-libtorrent@pauldreik.se"

--- a/projects/libtpms/project.yaml
+++ b/projects/libtpms/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/stefanberger/libtpms"
+language: c++
 primary_contact: "stefanb@us.ibm.com"
 auto_ccs:
   - "mlureau@redhat.com"

--- a/projects/libtsm/project.yaml
+++ b/projects/libtsm/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.freedesktop.org/wiki/Software/kmscon/libtsm/"
+language: c++
 primary_contact: "dh.herrmann@gmail.com"
 sanitizers:
   - address

--- a/projects/libvips/project.yaml
+++ b/projects/libvips/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/libvips/libvips"
+language: c++
 primary_contact: "jcupitt@gmail.com"
 auto_ccs:
   - "oscar.mira@adevinta.com"

--- a/projects/libvpx/project.yaml
+++ b/projects/libvpx/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.webmproject.org"
+language: c++
 primary_contact: "jzern@google.com"
 sanitizers:
 - address

--- a/projects/libwebp/project.yaml
+++ b/projects/libwebp/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://developers.google.com/speed/webp/"
+language: c++
 primary_contact: "jzern@google.com"
 fuzzing_engines:
   - libfuzzer

--- a/projects/libxls/project.yaml
+++ b/projects/libxls/project.yaml
@@ -1,2 +1,3 @@
 homepage: "https://github.com/libxls/libxls"
+language: c++
 primary_contact: "emmiller@gmail.com"

--- a/projects/libxml2/project.yaml
+++ b/projects/libxml2/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://www.xmlsoft.org/"
+language: c++
 primary_contact: "wellnhofer@aevum.de"
 vendor_ccs:
   - "akilsrin@apple.com"

--- a/projects/libxslt/project.yaml
+++ b/projects/libxslt/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://www.xmlsoft.org/libxslt/"
+language: c++
 primary_contact: "wellnhofer@aevum.de"
 vendor_ccs:
   - "ddkilzer@apple.com"

--- a/projects/libyaml/project.yaml
+++ b/projects/libyaml/project.yaml
@@ -1,4 +1,5 @@
 homepage: https://github.com/yaml/libyaml
+language: c++
 primary_contact: "sigmavirus24@gmail.com"
 auto_ccs:
   - "alex.gaynor@gmail.com"

--- a/projects/libzip/project.yaml
+++ b/projects/libzip/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://libzip.org/"
+language: c++
 primary_contact: "libzip@nih.at"
 auto_ccs:
   - "randy440088@gmail.com"

--- a/projects/llvm/project.yaml
+++ b/projects/llvm/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://llvm.org/"
+language: c++
 primary_contact: "kcc@google.com"
 auto_ccs:
   - "mascasa@google.com"

--- a/projects/llvm_libcxx/project.yaml
+++ b/projects/llvm_libcxx/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://libcxx.llvm.org/"
+language: c++
 primary_contact: "mclow.lists@gmail.com"
 auto_ccs:
   - "timshen91@gmail.com"

--- a/projects/llvm_libcxxabi/project.yaml
+++ b/projects/llvm_libcxxabi/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://libcxxabi.llvm.org/"
+language: c++
 primary_contact: "kcc@google.com"
 auto_ccs:
   - "Erik.Pilkington@gmail.com"

--- a/projects/lodepng/project.yaml
+++ b/projects/lodepng/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/lvandeve/lodepng"
+language: c++
 primary_contact: "lvandeve@gmail.com"
 sanitizers:
 - address

--- a/projects/lwan/project.yaml
+++ b/projects/lwan/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/lpereira/lwan"
+language: c++
 primary_contact: "leandro.pereira@gmail.com"
 sanitizers:
   - address

--- a/projects/lz4/project.yaml
+++ b/projects/lz4/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/lz4/lz4"
+language: c++
 primary_contact: "Yann.collet.73@gmail.com"
 auto_ccs:
   - "NickRTerrell@gmail.com"

--- a/projects/lzma/project.yaml
+++ b/projects/lzma/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.7-zip.org/sdk.html"
+language: c++
 primary_contact: "ipavlov@users.sourceforge.net"
 auto_ccs:
   - "mail@joachim-bauch.de"

--- a/projects/lzo/project.yaml
+++ b/projects/lzo/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://www.oberhumer.com"
+language: c++
 primary_contact: "info@oberhumer.com"
 auto_ccs:
   - "bshas3@gmail.com"

--- a/projects/matio/project.yaml
+++ b/projects/matio/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/tbeu/matio"
+language: c++
 primary_contact: "t-beu@users.sourceforge.net"
 sanitizers:
   - address

--- a/projects/mbedtls/project.yaml
+++ b/projects/mbedtls/project.yaml
@@ -1,3 +1,4 @@
 homepage: "https://tls.mbed.org"
+language: c++
 primary_contact: "support-mbedtls@arm.com"
 auto_ccs : "p.antoine@catenacyber.fr"

--- a/projects/mbedtls/project.yaml
+++ b/projects/mbedtls/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://tls.mbed.org"
 language: c++
 primary_contact: "support-mbedtls@arm.com"
-auto_ccs : "p.antoine@catenacyber.fr"
+auto_ccs :
+  - "p.antoine@catenacyber.fr"

--- a/projects/mercurial/project.yaml
+++ b/projects/mercurial/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.mercurial-scm.org/"
+language: c++
 primary_contact: "durin42@gmail.com"
 auto_ccs:
   - "gregory.szorc@gmail.com"

--- a/projects/minizinc/project.yaml
+++ b/projects/minizinc/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://www.minizinc.org/"
+language: c++
 primary_contact: "jip.dekker@monash.edu"
 auto_ccs:
   - "jip.dekker@monash.edu"

--- a/projects/minizip/project.yaml
+++ b/projects/minizip/project.yaml
@@ -1,20 +1,5 @@
-# Copyright 2018 Google Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-################################################################################
-
 homepage: "https://github.com/nmoinvaz/minizip"
+language: c++
 primary_contact: "nathan.moinvaziri@gmail.com"
 sanitizers:
   - address

--- a/projects/mpg123/project.yaml
+++ b/projects/mpg123/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.mpg123.de"
+language: c++
 primary_contact: "maintainer@mpg123.org"
 
 sanitizers:

--- a/projects/mruby/project.yaml
+++ b/projects/mruby/project.yaml
@@ -1,4 +1,5 @@
 homepage: https://www.mruby.org/
+language: c++
 primary_contact: "yukihiro@gmail.com"
 auto_ccs:
   - "bshas3@gmail.com"

--- a/projects/msgpack-c/project.yaml
+++ b/projects/msgpack-c/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://msgpack.org/"
+language: c++
 primary_contact: "redboltz@gmail.com"
 auto_ccs:
   - nobu.k.jp@gmail.com

--- a/projects/mupdf/project.yaml
+++ b/projects/mupdf/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.mupdf.com"
+language: c++
 primary_contact: tor.andersson@artifex.com
 fuzzing_engines:
   - libfuzzer

--- a/projects/myanmar-tools/project.yaml
+++ b/projects/myanmar-tools/project.yaml
@@ -1,18 +1,5 @@
-# Copyright 2019 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 homepage: "https://github.com/googlei18n/myanmar-tools/"
+language: c++
 primary_contact: "sffc@google.com"
 auto_ccs:
   - "ccornelius@google.com"

--- a/projects/mysql-server/project.yaml
+++ b/projects/mysql-server/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.mysql.com"
+language: c++
 primary_contact: "secalert_us@oracle.com"
 auto_ccs :
 - "p.antoine@catenacyber.fr"

--- a/projects/nanopb/project.yaml
+++ b/projects/nanopb/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://jpa.kapsi.fi/nanopb/"
+language: c++
 primary_contact: "jpa@npb.mail.kapsi.fi"
 sanitizers:
   - address

--- a/projects/ndpi/project.yaml
+++ b/projects/ndpi/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.ntop.org/products/deep-packet-inspection/ndpi/"
+language: c++
 primary_contact: "luca.deri@gmail.com"
 auto_ccs :
   - "p.antoine@catenacyber.fr"

--- a/projects/neomutt/project.yaml
+++ b/projects/neomutt/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://neomutt.org"
+language: c++
 primary_contact: "joseph.bisch@gmail.com"
 auto_ccs:
   - "richard.russon@gmail.com"

--- a/projects/nestegg/project.yaml
+++ b/projects/nestegg/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/kinetiknz/nestegg"
+language: c++
 primary_contact: "mgregan@mozilla.com"
 fuzzing_engines:
   - afl

--- a/projects/net-snmp/project.yaml
+++ b/projects/net-snmp/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://www.net-snmp.org/"
+language: c++
 primary_contact: "hardaker@users.sourceforge.net"
 auto_ccs:
    - "rstory@freesnmp.com"

--- a/projects/nghttp2/project.yaml
+++ b/projects/nghttp2/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://nghttp2.org/"
+language: c++
 primary_contact: "tatsuhiro.t@gmail.com"
 sanitizers:
   - address

--- a/projects/njs/project.yaml
+++ b/projects/njs/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://nginx.org/en/docs/njs/"
+language: c++
 primary_contact: "xeioex@nginx.com"
 auto_ccs:
  - "alexander.borisov@nginx.com"

--- a/projects/nss/project.yaml
+++ b/projects/nss/project.yaml
@@ -1,6 +1,6 @@
 homepage: "https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS"
 language: c++
-primary_contact: "fkiefer@mozilla.com"
+primary_contact: "jjones@mozilla.com"
 auto_ccs:
   - "bbeurdouche@mozilla.com"
   - "tvandermerwe@mozilla.com"

--- a/projects/nss/project.yaml
+++ b/projects/nss/project.yaml
@@ -1,5 +1,6 @@
 homepage: "https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS"
-primary_contact: "jjones@mozilla.com"
+language: c++
+primary_contact: "fkiefer@mozilla.com"
 auto_ccs:
   - "bbeurdouche@mozilla.com"
   - "tvandermerwe@mozilla.com"

--- a/projects/ntp/project.yaml
+++ b/projects/ntp/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://www.ntp.org"
+language: c++
 primary_contact: "security@ntp.org"
 auto_ccs:
   - "p.antoine@catenacyber.fr"

--- a/projects/oak/project.yaml
+++ b/projects/oak/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/project-oak/oak"
+language: c++
 primary_contact: "tzn@google.com"
 auto_ccs:
   - "project-oak-team@google.com"

--- a/projects/open62541/project.yaml
+++ b/projects/open62541/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://open62541.org/"
+language: c++
 primary_contact: "Stefan.Profanter@gmail.com"
 auto_ccs:
  - "julius.pfrommer@gmail.com"

--- a/projects/opencv/project.yaml
+++ b/projects/opencv/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://opencv.org/"
+language: c++
 primary_contact: "garybradski@gmail.com"
 
 auto_ccs:

--- a/projects/opendnp3/project.yaml
+++ b/projects/opendnp3/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://www.automatak.com/opendnp3/"
+language: c++
 primary_contact: "info@automatak.com"
 auto_ccs :
   - "p.antoine@catenacyber.fr"

--- a/projects/openh264/project.yaml
+++ b/projects/openh264/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.openh264.org"
+language: c++
 primary_contact: "huili2@cisco.com"
 auto_ccs:
   - "guangwwa@cisco.com"

--- a/projects/openjpeg/project.yaml
+++ b/projects/openjpeg/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://www.openjpeg.org/"
+language: c++
 primary_contact: "antonin@gmail.com"
 auto_ccs:
   - "even.rouault@gmail.com"

--- a/projects/opensc/project.yaml
+++ b/projects/opensc/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/OpenSC/OpenSC/"
+language: c++
 primary_contact: "frankmorgner@gmail.com"
 auto_ccs:
   - "martin.paljak@gmail.com"

--- a/projects/openssh/project.yaml
+++ b/projects/openssh/project.yaml
@@ -1,4 +1,5 @@
 homepage: https://www.openssh.com/
+language: c++
 primary_contact: "djm@mindrot.org"
 auto_ccs:
         - "dtucker@dtucker.net.au"

--- a/projects/openssl/project.yaml
+++ b/projects/openssl/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.openssl.org/"
+language: c++
 primary_contact: "kurt@roeckx.be"
 auto_ccs: 
  - "openssl-security@openssl.org"

--- a/projects/openthread/project.yaml
+++ b/projects/openthread/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/openthread/openthread"
+language: c++
 primary_contact: "jonhui@google.com"
 fuzzing_engines:
   - libfuzzer

--- a/projects/openvswitch/project.yaml
+++ b/projects/openvswitch/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://www.openvswitch.org"
+language: c++
 primary_contact: "blp@ovn.org"
 auto_ccs:
   - "jpettit@ovn.org"

--- a/projects/opus/project.yaml
+++ b/projects/opus/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://opus-codec.org/"
+language: c++
 primary_contact: "jmvalin@jmvalin.ca"
 auto_ccs:
   - "flim@google.com"

--- a/projects/osquery/project.yaml
+++ b/projects/osquery/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://osquery.io"
+language: c++
 primary_contact: "osquery@osquery.io"
 auto_ccs:
   - "theopolis@osquery.io"

--- a/projects/ots/project.yaml
+++ b/projects/ots/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/khaledhosny/ots"
+language: c++
 primary_contact: "dr.khaled.hosny@gmail.com"
 auto_ccs:
   - "kevin899@gmail.com"

--- a/projects/pcre2/project.yaml
+++ b/projects/pcre2/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://www.pcre.org/"
+language: c++
 primary_contact: "philip.hazel@gmail.com"
 fuzzing_engines:
   - libfuzzer

--- a/projects/perfetto/project.yaml
+++ b/projects/perfetto/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://perfetto.dev"
+language: c++
 primary_contact: "fmayer@google.com"
 auto_ccs:
   - "hjd@google.com"

--- a/projects/pffft/project.yaml
+++ b/projects/pffft/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://bitbucket.org/jpommier/pffft"
+language: c++
 primary_contact: "pommier@modartt.com"
 auto_ccs:
   - "alessiob@webrtc.org"

--- a/projects/php/project.yaml
+++ b/projects/php/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://php.net/"
+language: c++
 primary_contact: "stas@php.net"
 auto_ccs:
  - "smalyshev@gmail.com"

--- a/projects/picotls/project.yaml
+++ b/projects/picotls/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/h2o/picotls"
+language: c++
 primary_contact: "jonathan.foote@gmail.com"
 auto_ccs:
   - "frederik.deweerdt@gmail.com"

--- a/projects/piex/project.yaml
+++ b/projects/piex/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/google/piex"
+language: c++
 primary_contact: "nchusid@google.com"
 sanitizers:
  - address

--- a/projects/pillow/project.yaml
+++ b/projects/pillow/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://python-pillow.org/"
+language: c++
 primary_contact: "guidovranken@gmail.com"
 auto_ccs:
  - "security@python-pillow.org"

--- a/projects/poppler/project.yaml
+++ b/projects/poppler/project.yaml
@@ -1,4 +1,5 @@
 homepage: https://poppler.freedesktop.org/
+language: c++
 primary_contact: tsdgeos@gmail.com
 sanitizers:
   - address

--- a/projects/postgis/project.yaml
+++ b/projects/postgis/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://postgis.net/"
+language: c++
 primary_contact: "lr@pcorp.us"
 auto_ccs:
   - "even.rouault@gmail.com"

--- a/projects/powerdns/project.yaml
+++ b/projects/powerdns/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.powerdns.com/"
+language: c++
 primary_contact: "remi.gacogne@powerdns.com"
 auto_ccs:
   - "powerdnsossfuzz@gmail.com"

--- a/projects/proj4/project.yaml
+++ b/projects/proj4/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://proj.org/"
+language: c++
 primary_contact: "even.rouault@gmail.com"
 auto_ccs:
   - "hobu.inc@gmail.com"

--- a/projects/proxygen/project.yaml
+++ b/projects/proxygen/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/facebook/proxygen"
+language: c++
 primary_contact: "mhl@fb.com"
 auto_ccs:
   - "gulshan@fb.com"

--- a/projects/python3-libraries/project.yaml
+++ b/projects/python3-libraries/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://python.org/"
+language: c++
 primary_contact: "guidovranken@gmail.com"
 auto_ccs:
  - "gps@google.com"

--- a/projects/qcms/project.yaml
+++ b/projects/qcms/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://hg.mozilla.org/mozilla-central/file/tip/gfx/qcms/"
+language: c++
 primary_contact: "twsmith@mozilla.com"
 sanitizers:
 - address

--- a/projects/qpdf/project.yaml
+++ b/projects/qpdf/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://qpdf.sourceforge.net/"
+language: c++
 primary_contact: "qberkenbilt@gmail.com"
 sanitizers:
   - address

--- a/projects/qpid-proton/project.yaml
+++ b/projects/qpid-proton/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://qpid.apache.org/proton/"
+language: c++
 primary_contact: "jross@apache.org"
 auto_ccs:
  - "security@apache.org"

--- a/projects/qt/project.yaml
+++ b/projects/qt/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://qt-project.org"
+language: c++
 primary_contact: "rlohningqt@gmail.com"
 sanitizers:
  - address

--- a/projects/qubes-os/project.yaml
+++ b/projects/qubes-os/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.qubes-os.org/"
+language: c++
 primary_contact: "jpo@vt.edu"
 auto_ccs:
  - "joanna@invisiblethingslab.com"

--- a/projects/radare2/project.yaml
+++ b/projects/radare2/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/radare/radare2"
+language: c++
 primary_contact: "pancake@nopcode.org"
 auto_ccs:
   - "zlowram@gmail.com"

--- a/projects/rapidjson/project.yaml
+++ b/projects/rapidjson/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/tencent/rapidjson"
+language: c++
 primary_contact: "guidovranken@gmail.com"
 sanitizers:
  - address

--- a/projects/re2/project.yaml
+++ b/projects/re2/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://code.googlesource.com/re2"
+language: c++
 primary_contact: "junyer@google.com"
 sanitizers:
   - address

--- a/projects/readstat/project.yaml
+++ b/projects/readstat/project.yaml
@@ -1,2 +1,3 @@
 homepage: "https://github.com/WizardMac/ReadStat"
+language: c++
 primary_contact: "emmiller@gmail.com"

--- a/projects/resiprocate/project.yaml
+++ b/projects/resiprocate/project.yaml
@@ -1,2 +1,3 @@
 homepage: "https://www.resiprocate.org/"
+language: c++
 primary_contact: "gjasny@googlemail.com"

--- a/projects/s2opc/project.yaml
+++ b/projects/s2opc/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://gitlab.com/systerel/S2OPC"
+language: c++
 primary_contact: "pab.systerel@gmail.com"
 auto_ccs:
   - "mcl.systerel@gmail.com"

--- a/projects/samba/project.yaml
+++ b/projects/samba/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://samba.org"
+language: c++
 primary_contact: "douglas.bagnall@catalyst.net.nz"
 auto_ccs:
   - "abartlet+google@catalyst.net.nz"

--- a/projects/simdjson/project.yaml
+++ b/projects/simdjson/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/lemire/simdjson"
+language: c++
 primary_contact: "pauldreikossfuzz@gmail.com"
 auto_ccs:
  - "lemire@gmail.com"

--- a/projects/skcms/project.yaml
+++ b/projects/skcms/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://skia.googlesource.com/skcms/+/master"
+language: c++
 primary_contact: "kjlubick@chromium.org"
 auto_ccs:
   - "mtklein@google.com"

--- a/projects/skia/project.yaml
+++ b/projects/skia/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/google/skia"
+language: c++
 primary_contact: "kjlubick@chromium.org"
 auto_ccs:
   - "hcm@chromium.org"

--- a/projects/solidity/project.yaml
+++ b/projects/solidity/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://solidity.readthedocs.io"
+language: c++
 primary_contact: "bhargava.shastry@ethereum.org"
 auto_ccs:
   - "axic@ethereum.org"

--- a/projects/spdlog/project.yaml
+++ b/projects/spdlog/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/google/zopfli"
+language: c++
 primary_contact: "gmelman1@gmail.com"
 sanitizers:
   - address

--- a/projects/speex/project.yaml
+++ b/projects/speex/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://speex.org/"
+language: c++
 primary_contact: "tmatth@videolan.org"
 auto_ccs:
   - "twsmith@mozilla.com"

--- a/projects/spidermonkey-ufi/project.yaml
+++ b/projects/spidermonkey-ufi/project.yaml
@@ -1,4 +1,5 @@
 homepage: 'https://searchfox.org/mozilla-central/source/js/src/fuzz-tests/README'
+language: c++
 primary_contact: 'choller@mozilla.com'
 fuzzing_engines:
   - libfuzzer

--- a/projects/spidermonkey/project.yaml
+++ b/projects/spidermonkey/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey"
+language: c++
 primary_contact: "choller@mozilla.com"
 auto_ccs:
   - sledru@mozilla.com

--- a/projects/sqlite3/project.yaml
+++ b/projects/sqlite3/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://sqlite.org/"
+language: c++
 primary_contact: "drhsqlite@gmail.com"
 auto_ccs:
   - "sboydps@gmail.com"

--- a/projects/stb/project.yaml
+++ b/projects/stb/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/nothings/stb"
+language: c++
 primary_contact: "nothings.org@gmail.com"
 auto_ccs:
   - "randy440088@gmail.com"

--- a/projects/strongswan/project.yaml
+++ b/projects/strongswan/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.strongswan.org"
+language: c++
 primary_contact: "security@strongswan.org"
 auto_ccs:
   - "tobias@strongswan.org"

--- a/projects/systemd/project.yaml
+++ b/projects/systemd/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://freedesktop.org/wiki/Software/systemd/"
+language: c++
 primary_contact: "lennart@poettering.net"
 sanitizers:
   - address

--- a/projects/tensorflow/project.yaml
+++ b/projects/tensorflow/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.tensorflow.org"
+language: c++
 primary_contact: "mihaimaruseac@google.com"
 auto_ccs:
  - "dga@google.com"

--- a/projects/tesseract-ocr/project.yaml
+++ b/projects/tesseract-ocr/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/tesseract-ocr/tesseract"
+language: c++
 primary_contact: "stjoweil@googlemail.com"
 fuzzing_engines:
   - libfuzzer

--- a/projects/tidy-html5/project.yaml
+++ b/projects/tidy-html5/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://www.html-tidy.org/"
+language: c++
 primary_contact: "sbucur@google.com"
 auto_ccs:
   - "nmarrow@google.com"

--- a/projects/tinyxml2/project.yaml
+++ b/projects/tinyxml2/project.yaml
@@ -1,19 +1,5 @@
-# Copyright 2017 Google Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-################################################################################
 homepage: "www.grinninglizard.com/tinyxml2"
+language: c++
 auto_ccs:
   - "leethomason@gmail.com"
   - "pranjal.jumde@gmail.com"

--- a/projects/tor/project.yaml
+++ b/projects/tor/project.yaml
@@ -1,7 +1,8 @@
 homepage: "https://www.torproject.org"
 language: c++
 primary_contact: "nima@torproject.org"
-auto_ccs: "nick.a.mathewson@gmail.com"
+auto_ccs:
+  - "nick.a.mathewson@gmail.com"
 sanitizers:
  - address
  - memory

--- a/projects/tor/project.yaml
+++ b/projects/tor/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.torproject.org"
+language: c++
 primary_contact: "nima@torproject.org"
 auto_ccs: "nick.a.mathewson@gmail.com"
 sanitizers:

--- a/projects/tpm2-tss/project.yaml
+++ b/projects/tpm2-tss/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/tpm2-software/tpm2-tss"
+language: c++
 primary_contact: "tadeusz.struk@intel.com"
 auto_ccs:
   - "andreas.fuchs@sit.fraunhofer.de"

--- a/projects/tpm2/project.yaml
+++ b/projects/tpm2/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://chromium.googlesource.com/chromiumos/third_party/tpm2"
+language: c++
 # todo: delete Dockerfile from tpm2 repo.
 # Docker files change too much, it was moved to oss-fuzz repository.
 #

--- a/projects/tremor/project.yaml
+++ b/projects/tremor/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://xiph.org/vorbis/"
+language: c++
 primary_contact: "daede003@umn.edu"
 auto_ccs:
   - "paul.l.kehrer@gmail.com"

--- a/projects/unbound/project.yaml
+++ b/projects/unbound/project.yaml
@@ -1,2 +1,3 @@
 homepage: "https://nlnetlabs.nl/projects/unbound/about/"
+language: c++
 primary_contact: "wouter@nlnetlabs.nl"

--- a/projects/unicorn/project.yaml
+++ b/projects/unicorn/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.unicorn-engine.org"
+language: c++
 primary_contact: "unicorn.emu@gmail.com"
 auto_ccs :
 - "p.antoine@catenacyber.fr"

--- a/projects/unrar/project.yaml
+++ b/projects/unrar/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://www.rarlab.com/"
+language: c++
 primary_contact: "roshal@rarlab.com"
 auto_ccs:
   - "vakh@chromium.org"

--- a/projects/usbguard/project.yaml
+++ b/projects/usbguard/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://usbguard.github.io/"
+language: c++
 primary_contact: "dkopecek@redhat.com"
 sanitizers:
  - address

--- a/projects/usrsctp/project.yaml
+++ b/projects/usrsctp/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/sctplab/usrsctp"
+language: c++
 primary_contact: "weinrank@fh-muenster.de"
 auto_ccs:
   - "t00fcxen@googlemail.com"

--- a/projects/uwebsockets/project.yaml
+++ b/projects/uwebsockets/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/uNetworking/uWebSockets"
+language: c++
 primary_contact: "alexhultman@gmail.com"
 sanitizers:
   - address

--- a/projects/vorbis/project.yaml
+++ b/projects/vorbis/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://xiph.org/vorbis/"
+language: c++
 primary_contact: "daede003@umn.edu"
 auto_ccs:
   - paul.l.kehrer@gmail.com

--- a/projects/wabt/project.yaml
+++ b/projects/wabt/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/WebAssembly/wabt"
+language: c++
 primary_contact: "binji@chromium.org"
 sanitizers:
  - address

--- a/projects/wavpack/project.yaml
+++ b/projects/wavpack/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://www.wavpack.com" 
+language: c++
 primary_contact: "david@wavpack.com" 
 auto_ccs:
 - dvbryant@gmail.com

--- a/projects/wget/project.yaml
+++ b/projects/wget/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.gnu.org/software/wget/"
+language: c++
 primary_contact: "rockdaboot@gmail.com"
 auto_ccs:
   - "tim.ruehsen@gmx.de"

--- a/projects/wget2/project.yaml
+++ b/projects/wget2/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://gitlab.com/gnuwget/wget2"
+language: c++
 primary_contact: "rockdaboot@gmail.com"
 auto_ccs:
   - "tim.ruehsen@gmx.de"

--- a/projects/wireshark/project.yaml
+++ b/projects/wireshark/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.wireshark.org"
+language: c++
 primary_contact: "gerald@wireshark.org"
 auto_ccs:
  - "security@wireshark.org"

--- a/projects/woff2/project.yaml
+++ b/projects/woff2/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/google/woff2"
+language: c++
 primary_contact: "rsheeter@google.com"
 auto_ccs:
   - "grieger@google.com"

--- a/projects/wolfssl/project.yaml
+++ b/projects/wolfssl/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.wolfssl.com/"
+language: c++
 primary_contact: "jacob@wolfssl.com"
 auto_ccs:
   - "david@wolfssl.com"

--- a/projects/wpantund/project.yaml
+++ b/projects/wpantund/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/openthread/wpantund"
+language: c++
 primary_contact: "rquattle@google.com"
 auto_ccs:
  - "abtink@google.com"

--- a/projects/wuffs/project.yaml
+++ b/projects/wuffs/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/google/wuffs"
+language: c++
 primary_contact: "nigeltao@golang.org"
 fuzzing_engines:
   - libfuzzer

--- a/projects/wxwidgets/project.yaml
+++ b/projects/wxwidgets/project.yaml
@@ -1,2 +1,3 @@
 homepage: "https://www.wxwidgets.org/"
+language: c++
 primary_contact: "vzeitlin@gmail.com"

--- a/projects/xerces-c/project.yaml
+++ b/projects/xerces-c/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://xerces.apache.org/"
+language: c++
 primary_contact: "vincent.ulitzsch@live.de"
 auto_ccs:
   - "vincent.ulitzsch@live.de"

--- a/projects/xmlsec/project.yaml
+++ b/projects/xmlsec/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.aleksey.com/xmlsec/"
+language: c++
 primary_contact: "aleksey@aleksey.com"
 auto_ccs:
   - "alekseysanin@gmail.com"

--- a/projects/xvid/project.yaml
+++ b/projects/xvid/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.xvid.com/"
+language: c++
 primary_contact: "guidovranken@gmail.com"
 auto_ccs:
  - "mm@xvid.org"

--- a/projects/xz/project.yaml
+++ b/projects/xz/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://tukaani.org/xz/"
+language: c++
 primary_contact: "lasse.collin@tukaani.org"
 auto_ccs:
   - "bshas3@gmail.com"

--- a/projects/yajl-ruby/project.yaml
+++ b/projects/yajl-ruby/project.yaml
@@ -1,4 +1,5 @@
 homepage: https://github.com/brianmario/yajl-ruby
+language: c++
 primary_contact: seniorlopez@gmail.com
 sanitizers:
   - address

--- a/projects/yara/project.yaml
+++ b/projects/yara/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://virustotal.github.io/yara/"
+language: c++
 primary_contact: "vmalvarez@google.com"
 auto_ccs:
   - "vmalvarez@virustotal.com"

--- a/projects/zlib-ng/project.yaml
+++ b/projects/zlib-ng/project.yaml
@@ -1,20 +1,5 @@
-# Copyright 2018 Google Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-################################################################################
-
 homepage: "https://github.com/Dead2/zlib-ng"
+language: c++
 primary_contact: "zlib-ng@circlestorm.org"
 auto_ccs:
   - "sebpop@gmail.com"

--- a/projects/zlib/project.yaml
+++ b/projects/zlib/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://www.zlib.net/"
+language: c++
 primary_contact: "glennrp@gmail.com"
 auto_ccs:
   - "sebpop@gmail.com"

--- a/projects/zopfli/project.yaml
+++ b/projects/zopfli/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/google/zopfli"
+language: c++
 primary_contact: "lode@google.com"
 sanitizers:
   - address

--- a/projects/zstd/project.yaml
+++ b/projects/zstd/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://facebook.github.io/zstd/"
+language: c++
 primary_contact: "terrelln@fb.com"
 auto_ccs:
   - "NickRTerrell@gmail.com"


### PR DESCRIPTION
My original intent was to enforce this for non C/C++ projects, but I couldn't come up with a good way to do it only in such cases. Landing this change might somewhat annoy people who contribute more changes to OSS-Fuzz for already integrated C/C++ projects, but that's fine with me -- yet another reason to remind people of the ideal integration.

**UPD:** when landing this change, I'll update all existing project.yaml files and we'll enforce the attribute from now on.