### PR TITLE
Enhancement debian package manager tweaks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ Use the following instructions to make documentation changes locally.
 
 ## Prerequisites
 ```bash
-$ sudo apt install ruby bundler
+$ sudo apt-get --no-install-recommends  install -y apt-utils ca-certificates ruby bundler
 $ bundle install --path vendor/bundle
 ```
 

--- a/docs/getting-started/new_project_guide.md
+++ b/docs/getting-started/new_project_guide.md
@@ -163,7 +163,7 @@ For most projects, the image is simple:
 ```docker
 FROM gcr.io/oss-fuzz-base/base-builder       # base image with clang toolchain
 MAINTAINER YOUR_EMAIL                        # maintainer for this file
-RUN apt-get update && apt-get install -y ... # install required packages to build your project
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates ... # install required packages to build your project
 RUN go get ...                               # install dependencies to build your Go project
 RUN git clone <git_url> <checkout_dir>       # checkout all sources needed to build your project
 WORKDIR <checkout_dir>                       # current directory for the build script

--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-clang
-RUN apt-get install -y git \
+RUN apt-get --no-install-recommends  install -y apt-utils ca-certificates git \
     subversion \
     jq \
     python3 \

--- a/infra/base-images/base-builder/precompile_honggfuzz
+++ b/infra/base-images/base-builder/precompile_honggfuzz
@@ -26,7 +26,7 @@ PACKAGES=(
     zlib1g-dev
     pkg-config)
 
-apt-get install -y ${PACKAGES[@]}
+apt-get --no-install-recommends  install -y apt-utils ca-certificates ${PACKAGES[@]}
 
 pushd $SRC/honggfuzz > /dev/null
 make clean

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 LLVM_DEP_PACKAGES="build-essential make cmake ninja-build git python2.7 g++-multilib"
-apt-get install -y $LLVM_DEP_PACKAGES
+apt-get --no-install-recommends  install -y apt-utils ca-certificates $LLVM_DEP_PACKAGES
 
 # Checkout
 CHECKOUT_RETRIES=10

--- a/infra/base-images/base-image-debian-testing/Dockerfile
+++ b/infra/base-images/base-image-debian-testing/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN echo 'deb-src http://deb.debian.org/debian testing main' >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y libc6-dev binutils libgcc-7-dev && \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates libc6-dev binutils libgcc-7-dev && \
     apt-get autoremove -y
 
 

--- a/infra/base-images/base-image/Dockerfile
+++ b/infra/base-images/base-image/Dockerfile
@@ -20,7 +20,7 @@ FROM ubuntu:16.04
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y libc6-dev binutils libgcc-5-dev && \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates libc6-dev binutils libgcc-5-dev && \
     apt-get autoremove -y
 
 ENV OUT=/out

--- a/infra/base-images/base-msan-builder/Dockerfile
+++ b/infra/base-images/base-msan-builder/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-clang
 RUN sed -i -r 's/#\s*deb-src/deb-src/g' /etc/apt/sources.list
-RUN apt-get update && apt-get install -y python dpkg-dev patchelf python-apt zip
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates python dpkg-dev patchelf python-apt zip
 
 # Take all libraries from lib/msan
 RUN cp -R /usr/msan/lib/* /usr/lib/

--- a/infra/base-images/base-runner-debug/Dockerfile
+++ b/infra/base-images/base-runner-debug/Dockerfile
@@ -15,4 +15,4 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-runner
-RUN apt-get install -y gdb valgrind zip
+RUN apt-get --no-install-recommends  install -y apt-utils ca-certificates gdb valgrind zip

--- a/infra/base-images/base-runner/Dockerfile
+++ b/infra/base-images/base-runner/Dockerfile
@@ -24,7 +24,7 @@ COPY --from=base-clang /usr/local/bin/llvm-cov /usr/local/bin/
 COPY --from=base-clang /usr/local/bin/llvm-profdata /usr/local/bin/
 COPY --from=base-clang /usr/local/bin/llvm-symbolizer /usr/local/bin/
 
-RUN apt-get install -y \
+RUN apt-get --no-install-recommends  install -y apt-utils ca-certificates \
     binutils \
     file \
     fonts-dejavu \

--- a/infra/cifuzz/cifuzz-base/Dockerfile
+++ b/infra/cifuzz/cifuzz-base/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get install -y git \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates git \
     apt-transport-https \
     ca-certificates \
     curl \
@@ -31,7 +31,7 @@ RUN add-apt-repository \
    xenial \
    stable"
 
-RUN apt-get update && apt-get install docker-ce docker-ce-cli containerd.io -y
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates docker-ce docker-ce-cli containerd.io -y
 
 ENV OSS_FUZZ_ROOT=/opt/oss-fuzz
 RUN git clone https://github.com/google/oss-fuzz.git ${OSS_FUZZ_ROOT}

--- a/infra/dev-requirements.txt
+++ b/infra/dev-requirements.txt
@@ -2,4 +2,4 @@
 pylint==2.4.4
 yapf==0.28.0
 PyYAML==5.1
-
+docstring

--- a/infra/dev-requirements.txt
+++ b/infra/dev-requirements.txt
@@ -1,6 +1,6 @@
 # Requirements for submitting code changes to infra/ (needed by presubmit.py).
+utils
 pylint==2.4.4
 yapf==0.28.0
 PyYAML==5.1
 docstring
-utils

--- a/infra/dev-requirements.txt
+++ b/infra/dev-requirements.txt
@@ -3,3 +3,4 @@ pylint==2.4.4
 yapf==0.28.0
 PyYAML==5.1
 docstring
+utils

--- a/infra/templates.py
+++ b/infra/templates.py
@@ -38,7 +38,7 @@ DOCKER_TEMPLATE = """\
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER your@email.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool
 RUN git clone --depth 1 <git_url> %(project_name)s     # or use other version control
 WORKDIR %(project_name)s
 COPY build.sh $SRC/

--- a/infra/templates.py
+++ b/infra/templates.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 ################################################################################
+import docstring
 
 PROJECT_YAML_TEMPLATE = """\
 homepage: "<your_project_homepage>"

--- a/infra/uploader/Dockerfile
+++ b/infra/uploader/Dockerfile
@@ -1,7 +1,7 @@
 from ubuntu:16.04
 
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y curl
+RUN apt-get --no-install-recommends  install -y apt-utils ca-certificates curl
 
 ENTRYPOINT ["curl", "--retry", "5", "-X", "PUT", "-T"]
 

--- a/projects/arduinojson/Dockerfile
+++ b/projects/arduinojson/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER oss-fuzz@benoitblanchon.fr
-RUN apt-get update && apt-get install -y make zip git
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make zip git
 RUN git clone --depth 1 https://github.com/bblanchon/ArduinoJson.git arduinojson
 WORKDIR arduinojson
 COPY build.sh $SRC/

--- a/projects/arrow/Dockerfile
+++ b/projects/arrow/Dockerfile
@@ -20,7 +20,7 @@ MAINTAINER dev@arrow.apache.org
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update -y -q && \
     apt-get update -y -q && \
-    apt-get install -y -q --no-install-recommends \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates -q \
         bison \
         build-essential \
         cmake \

--- a/projects/augeas/Dockerfile
+++ b/projects/augeas/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER hhan@redhat.com
-RUN apt-get update && apt-get install -y libreadline-dev libselinux1-dev \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates libreadline-dev libselinux1-dev \
     libxml2-dev make autoconf automake libtool pkg-config bison flex
 
 RUN git clone --depth 1 https://github.com/hercules-team/augeas

--- a/projects/avahi/Dockerfile
+++ b/projects/avahi/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER alex.gaynor@gmail.com
 RUN dpkg --add-architecture i386 && \
     apt-get update && \
-    apt-get install -y autoconf gettext libtool m4 automake pkg-config libexpat-dev libexpat-dev:i386
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates autoconf gettext libtool m4 automake pkg-config libexpat-dev libexpat-dev:i386
 RUN git clone --depth 1 https://github.com/lathiat/avahi
 WORKDIR avahi
 COPY build.sh avahi_packet_consume_record_fuzzer.cc avahi_packet_consume_key_fuzzer.cc $SRC/

--- a/projects/bad_example/Dockerfile
+++ b/projects/bad_example/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mmoroz@chromium.org
-RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool
 
 # Using a real zlib project, but with broken build script and/or fuzz target.
 

--- a/projects/bignum-fuzzer/Dockerfile
+++ b/projects/bignum-fuzzer/Dockerfile
@@ -16,8 +16,8 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER guidovranken@gmail.com
-RUN apt-get update && apt-get install -y software-properties-common python-software-properties wget curl sudo mercurial autoconf bison texinfo libboost-all-dev cmake
-RUN add-apt-repository -y ppa:gophers/archive && apt-get update && apt-get install -y golang-1.9-go
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates software-properties-common python-software-properties wget curl sudo mercurial autoconf bison texinfo libboost-all-dev cmake
+RUN add-apt-repository -y ppa:gophers/archive && apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates golang-1.9-go
 RUN ln -s /usr/lib/go-1.9/bin/go /usr/bin/go
 
 RUN wget https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.4.2.tar.gz

--- a/projects/binutils/Dockerfile
+++ b/projects/binutils/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 #TODO change
 MAINTAINER bug-binutils@gnu.org
-RUN apt-get update && apt-get install -y make
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make
 RUN git clone --recursive --depth 1 git://sourceware.org/git/binutils-gdb.git binutils-gdb
 WORKDIR $SRC
 COPY build.sh $SRC/

--- a/projects/bloaty/Dockerfile
+++ b/projects/bloaty/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER jhaberman@gmail.com
-RUN apt-get update && apt-get install -y cmake ninja-build g++
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates cmake ninja-build g++
 RUN git clone --depth 1 https://github.com/google/bloaty.git bloaty
 WORKDIR bloaty
 COPY build.sh $SRC/

--- a/projects/boost/Dockerfile
+++ b/projects/boost/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y g++
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates g++
 
 RUN git clone --recursive https://github.com/boostorg/boost.git
 WORKDIR boost

--- a/projects/boringssl/Dockerfile
+++ b/projects/boringssl/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mike.aizatsky@gmail.com
-RUN apt-get update && apt-get install -y cmake ninja-build golang
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates cmake ninja-build golang
 
 RUN git clone --depth 1 https://boringssl.googlesource.com/boringssl
 COPY build.sh $SRC/

--- a/projects/botan/Dockerfile
+++ b/projects/botan/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER jack@randombit.net
-RUN apt-get update && apt-get install -y make python
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make python
 RUN git clone --depth 1 https://github.com/randombit/botan.git botan
 RUN git clone --depth 1 https://github.com/randombit/crypto-corpus.git fuzzer_corpus
 WORKDIR botan

--- a/projects/brotli/Dockerfile
+++ b/projects/brotli/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER eustas@chromium.org
-RUN apt-get update && apt-get install -y cmake libtool make
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates cmake libtool make
 
 RUN git clone --depth 1 https://github.com/google/brotli.git
 WORKDIR brotli

--- a/projects/bzip2/Dockerfile
+++ b/projects/bzip2/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER bshas3@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool wget
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool wget
 RUN git clone git://sourceware.org/git/bzip2.git
 RUN git clone git://sourceware.org/git/bzip2-tests.git
 COPY build.sh *.c $SRC/

--- a/projects/c-ares/Dockerfile
+++ b/projects/c-ares/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mmoroz@chromium.org
-RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/c-ares/c-ares.git
 WORKDIR c-ares
 COPY build.sh $SRC/

--- a/projects/c-blosc/Dockerfile
+++ b/projects/c-blosc/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER blosc.oss.fuzz@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool cmake
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool cmake
 RUN git clone --depth 1 https://github.com/Blosc/c-blosc.git c-blosc
 WORKDIR c-blosc
 COPY build.sh blosc_fuzzer.cc $SRC/

--- a/projects/capstone/Dockerfile
+++ b/projects/capstone/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER capstone.engine@gmail.com
-RUN apt-get update && apt-get install -y make cmake python python-setuptools
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make cmake python python-setuptools
 RUN git clone --depth 1 --branch v4 https://github.com/aquynh/capstone.git capstonev4
 RUN git clone --depth 1 --branch next https://github.com/aquynh/capstone.git capstonenext
 WORKDIR $SRC

--- a/projects/casync/Dockerfile
+++ b/projects/casync/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER zbyszek@in.waw.pl
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates \
         python3-pip pkg-config wget \
         liblzma-dev \
         libzstd-dev \

--- a/projects/chakra/Dockerfile
+++ b/projects/chakra/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER ochang@google.com
-RUN apt-get update && apt-get install -y build-essential cmake libicu-dev python
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates build-essential cmake libicu-dev python
 RUN git clone --depth 1 https://github.com/Microsoft/ChakraCore.git chakra
 WORKDIR chakra
 COPY build.sh $SRC/

--- a/projects/cjson/Dockerfile
+++ b/projects/cjson/Dockerfile
@@ -19,7 +19,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 
 MAINTAINER randy408@protonmail.com
 
-RUN apt-get update && apt-get install -y cmake
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates cmake
 
 RUN git clone --depth 1 https://github.com/DaveGamble/cJSON.git cjson
 

--- a/projects/clamav/Dockerfile
+++ b/projects/clamav/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER clamav.fuzz@gmail.com
-RUN apt-get update && apt-get install -y libssl-dev libcurl4-openssl-dev
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates libssl-dev libcurl4-openssl-dev
 RUN git clone --depth 1 https://github.com/Cisco-Talos/clamav-devel.git
 RUN git clone --depth 1 https://github.com/Cisco-Talos/clamav-fuzz-corpus.git
 

--- a/projects/cmark/Dockerfile
+++ b/projects/cmark/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER philipturnbull@github.com
-RUN apt-get update && apt-get install -y make cmake
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make cmake
 RUN git clone --depth 1 https://github.com/commonmark/cmark.git cmark
 WORKDIR cmark
 COPY build.sh *.dict *.options $SRC/

--- a/projects/cpython3/Dockerfile
+++ b/projects/cpython3/Dockerfile
@@ -2,7 +2,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 LABEL maintainer="aaskar@google.com; ammar@ammaraskar.com"
 
 RUN apt-get update
-RUN apt-get install -y build-essential libncursesw5-dev \
+RUN apt-get --no-install-recommends  install -y apt-utils ca-certificates build-essential libncursesw5-dev \
 	libreadline-dev libssl-dev libgdbm-dev \
 	libc6-dev libsqlite3-dev tk-dev libbz2-dev \
 	zlib1g-dev libffi-dev

--- a/projects/cras/Dockerfile
+++ b/projects/cras/Dockerfile
@@ -8,7 +8,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER dgreid@chromium.org
 
 RUN apt-get -y update && \
-      apt-get install -y \
+      apt-get --no-install-recommends  install -y apt-utils ca-certificates \
       automake \
       build-essential \
       cargo \

--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -17,10 +17,10 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER guidovranken@gmail.com
 
-RUN apt-get update && apt-get install -y software-properties-common python-software-properties make autoconf automake libtool build-essential cmake libboost-all-dev wget mercurial gyp ninja-build zlib1g-dev libsqlite3-dev
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates software-properties-common python-software-properties make autoconf automake libtool build-essential cmake libboost-all-dev wget mercurial gyp ninja-build zlib1g-dev libsqlite3-dev
 
 # BoringSSL needs Go to build
-RUN add-apt-repository -y ppa:gophers/archive && apt-get update && apt-get install -y golang-1.9-go
+RUN add-apt-repository -y ppa:gophers/archive && apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates golang-1.9-go
 RUN ln -s /usr/lib/go-1.9/bin/go /usr/bin/go
 
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
@@ -42,6 +42,6 @@ RUN git clone --depth 1 https://github.com/ARMmbed/mbed-crypto.git
 RUN hg clone https://hg.mozilla.org/projects/nspr
 RUN hg clone https://hg.mozilla.org/projects/nss
 RUN apt-get remove -y libunwind8
-RUN apt-get install -y libssl-dev
+RUN apt-get --no-install-recommends  install -y apt-utils ca-certificates libssl-dev
 
 COPY build.sh $SRC/

--- a/projects/django/Dockerfile
+++ b/projects/django/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER guidovranken@gmail.com
-RUN apt-get install -y build-essential libncursesw5-dev libreadline-dev libssl-dev libgdbm-dev libc6-dev libsqlite3-dev tk-dev libbz2-dev zlib1g-dev libffi-dev wget
+RUN apt-get --no-install-recommends  install -y apt-utils ca-certificates build-essential libncursesw5-dev libreadline-dev libssl-dev libgdbm-dev libc6-dev libsqlite3-dev tk-dev libbz2-dev zlib1g-dev libffi-dev wget
 RUN wget -q https://github.com/python/cpython/archive/v3.8.0b2.tar.gz
 RUN git clone --depth 1 https://github.com/guidovranken/django-fuzzers.git
 RUN git clone --depth 1 https://github.com/django/django.git

--- a/projects/dlplibs/Dockerfile
+++ b/projects/dlplibs/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER dtardon@redhat.com
 # install build requirements
 RUN apt-get update && \
-    apt-get install -y wget xz-utils autoconf automake libtool pkg-config \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates wget xz-utils autoconf automake libtool pkg-config \
         gperf libglm-dev patch
 ADD https://dev-www.libreoffice.org/src/lcms2-2.8.tar.gz \
     https://dev-www.libreoffice.org/src/zlib-1.2.11.tar.xz \

--- a/projects/double-conversion/Dockerfile
+++ b/projects/double-conversion/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER sbucur@google.com
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates \
         cmake ninja-build && \
     apt-get clean
 

--- a/projects/dropbear/Dockerfile
+++ b/projects/dropbear/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER matt@ucc.asn.au
-RUN apt-get update && apt-get install -y libz-dev autoconf mercurial
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates libz-dev autoconf mercurial
 RUN hg clone https://secure.ucc.asn.au/hg/dropbear dropbear
 RUN hg clone https://secure.ucc.asn.au/hg/dropbear-fuzzcorpus dropbear/corpus
 WORKDIR dropbear

--- a/projects/easywsclient/Dockerfile
+++ b/projects/easywsclient/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER dhbaird@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/dhbaird/easywsclient easywsclient
 WORKDIR easywsclient
 COPY build.sh *.cpp $SRC/

--- a/projects/ecc-diff-fuzzer/Dockerfile
+++ b/projects/ecc-diff-fuzzer/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER p.antoine@catenacyber.fr
-RUN apt-get update && apt-get install -y make cmake bzip2 autoconf automake gettext libtool python nodejs npm
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make cmake bzip2 autoconf automake gettext libtool python nodejs npm
 ENV CARGO_HOME=/rust RUSTUP_HOME=/rust/rustup PATH=$PATH:/rust/bin
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN rustup target add i686-unknown-linux-gnu

--- a/projects/eigen/Dockerfile
+++ b/projects/eigen/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER eigen-core-team@lists.tuxfamily.org
-RUN apt-get update && apt-get install --yes cmake mercurial
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates cmake mercurial
 RUN hg clone https://GOOGLE-AUTOFUZZ@bitbucket.org/eigen/eigen
 WORKDIR eigen
 COPY build.sh solver_fuzzer.cc $SRC/

--- a/projects/example/Dockerfile
+++ b/projects/example/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make
 
 # Get *your* source code here.
 RUN git clone https://github.com/google/oss-fuzz.git my-git-repo

--- a/projects/expat/Dockerfile
+++ b/projects/expat/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mike.aizatsky@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool docbook2x cmake
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool docbook2x cmake
 
 RUN git clone --depth 1 https://github.com/libexpat/libexpat expat
 WORKDIR expat

--- a/projects/ffmpeg/Dockerfile
+++ b/projects/ffmpeg/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mmoroz@chromium.org
 ADD bionic.list /etc/apt/sources.list.d/bionic.list
 ADD nasm_apt.pin /etc/apt/preferences
-RUN apt-get update && apt-get install -y make autoconf automake libtool build-essential \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool build-essential \
     libass-dev libfreetype6-dev libsdl1.2-dev \
     libvdpau-dev libxcb1-dev libxcb-shm0-dev \
     pkg-config texinfo libbz2-dev zlib1g-dev yasm cmake mercurial wget \

--- a/projects/file/Dockerfile
+++ b/projects/file/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mike.aizatsky@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool shtool
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool shtool
 RUN git clone --depth 1 https://github.com/file/file.git
 WORKDIR file
 COPY build.sh magic_fuzzer.cc $SRC/

--- a/projects/firefox/Dockerfile
+++ b/projects/firefox/Dockerfile
@@ -16,12 +16,12 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER pdknsk@gmail.com
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
   python \
   gawk \
   software-properties-common
 RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
   libstdc++6
 RUN git clone --depth 1 https://github.com/mozilla/gecko-dev mozilla-central
 RUN git clone --depth 1 https://github.com/mozillasecurity/fuzzdata

--- a/projects/firestore/Dockerfile
+++ b/projects/firestore/Dockerfile
@@ -16,6 +16,6 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER varconst@google.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool wget golang python python-protobuf python-six
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool wget golang python python-protobuf python-six
 RUN git clone --depth 1 https://github.com/firebase/firebase-ios-sdk.git
 COPY build.sh $SRC/

--- a/projects/flac/Dockerfile
+++ b/projects/flac/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool libtool-bin pkg-config gettext sudo
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool libtool-bin pkg-config gettext sudo
 RUN git clone --depth 1 https://github.com/xiph/flac.git
 RUN git clone --depth 1 https://github.com/xiph/ogg.git
 RUN git clone --depth 1 https://github.com/guidovranken/fuzzing-headers.git

--- a/projects/freeimage/Dockerfile
+++ b/projects/freeimage/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool wget
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool wget
 # This downloads the latest version at the time of writing. There does not
 # appear to be a head version of FreeImage.
 RUN wget https://downloads.sourceforge.net/freeimage/FreeImage3180.zip

--- a/projects/freetype2/Dockerfile
+++ b/projects/freetype2/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER prince.cherusker@gmail.com
 
 RUN apt-get update &&  \
-    apt-get install -y \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates \
       autoconf         \
       cmake            \
       libpng-dev       \

--- a/projects/fuzzing-puzzles/Dockerfile
+++ b/projects/fuzzing-puzzles/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mmoroz@chromium.org
-RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool
 ADD https://raw.githubusercontent.com/llvm-mirror/compiler-rt/master/test/fuzzer/MultipleConstraintsOnSmallInputTest.cpp \
     $SRC/fuzzing-puzzles/
 WORKDIR fuzzing-puzzles

--- a/projects/gdal/Dockerfile
+++ b/projects/gdal/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER even.rouault@spatialys.com
 RUN dpkg --add-architecture i386 && \
     apt-get update && \
-    apt-get install -y make autoconf automake libtool g++ curl cmake sqlite3 pkg-config
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool g++ curl cmake sqlite3 pkg-config
 
 RUN git clone --depth 1 https://github.com/OSGeo/gdal gdal
 

--- a/projects/gfwx/Dockerfile
+++ b/projects/gfwx/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER fyffe@google.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/guidovranken/gfwx-fuzzers.git gfwx-fuzzers
 WORKDIR gfwx-fuzzers
 COPY build.sh $SRC/

--- a/projects/ghostscript/Dockerfile
+++ b/projects/ghostscript/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER skau@google.com
 
-RUN apt-get update && apt-get install -y autoconf zlibc libtool liblcms2-dev libpng-dev libtiff-dev
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates autoconf zlibc libtool liblcms2-dev libpng-dev libtiff-dev
 RUN git clone --branch branch-2.2 --single-branch --depth 1 https://github.com/apple/cups.git cups
 RUN git clone --branch VER-2-10-1 --single-branch --depth 1 https://git.savannah.nongnu.org/git/freetype/freetype2.git freetype
 RUN git clone --single-branch --depth 1 git://git.ghostscript.com/ghostpdl.git ghostpdl

--- a/projects/giflib/Dockerfile
+++ b/projects/giflib/Dockerfile
@@ -16,9 +16,9 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER esr@thyrsus.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool wget zlib1g-dev
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool wget zlib1g-dev
 RUN apt-get update && \
-apt-get install -y  libtool ninja-build cmake
+apt-get --no-install-recommends  install -y apt-utils ca-certificates  libtool ninja-build cmake
 RUN git clone --depth=1 https://git.code.sf.net/p/giflib/code $SRC/giflib-code
 RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
 RUN (mkdir LPM && cd LPM && cmake ../libprotobuf-mutator -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release && ninja)

--- a/projects/git/Dockerfile
+++ b/projects/git/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER steadmon@google.com
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates \
         cvs cvsps gettext libcgi-pm-perl libcurl4-gnutls-dev \
         libdbd-sqlite3-perl liberror-perl libexpat1-dev libhttp-date-perl \
         libio-pty-perl libmailtools-perl libpcre2-dev libpcre3-dev libsvn-perl \

--- a/projects/glib/Dockerfile
+++ b/projects/glib/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER pdknsk@gmail.com
-RUN apt-get update && apt-get install -y python3-pip
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates python3-pip
 RUN pip3 install -U meson ninja
 RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/glib
 WORKDIR glib

--- a/projects/gnupg/Dockerfile
+++ b/projects/gnupg/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER p.antoine@catenacyber.fr
-RUN apt-get update && apt-get install -y make autoconf automake libtool gettext bzip2 gnupg bison flex
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool gettext bzip2 gnupg bison flex
 
 RUN git clone --depth 1 git://git.gnupg.org/libgpg-error.git libgpg-error
 RUN git clone --depth 1 git://git.gnupg.org/libgcrypt.git libgcrypt

--- a/projects/gnutls/Dockerfile
+++ b/projects/gnutls/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER alex.gaynor@gmail.com
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
  make \
  pkg-config \
  autoconf \

--- a/projects/graphicsfuzz-spirv/Dockerfile
+++ b/projects/graphicsfuzz-spirv/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y cmake ninja-build
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates cmake ninja-build
 
 RUN mkdir -p graphicsfuzz-spirv
 

--- a/projects/graphicsmagick/Dockerfile
+++ b/projects/graphicsmagick/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER alex.gaynor@gmail.com
-RUN apt-get update && apt-get install -y mercurial automake autopoint cmake libtool nasm pkg-config
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates mercurial automake autopoint cmake libtool nasm pkg-config
 RUN hg clone --time -b default http://hg.code.sf.net/p/graphicsmagick/code graphicsmagick || \
     hg clone --time -b default http://hg.code.sf.net/p/graphicsmagick/code graphicsmagick || \
     hg clone --time -b default http://hg.code.sf.net/p/graphicsmagick/code graphicsmagick

--- a/projects/grpc/Dockerfile
+++ b/projects/grpc/Dockerfile
@@ -19,7 +19,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder@sha256:276813aef0ce5972db43c0230f96162003994fa742fb1b2f4e66c67498575c65
 MAINTAINER yangg@google.com
 
-RUN apt-get update && apt-get install -y software-properties-common python-software-properties
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates software-properties-common python-software-properties
 RUN add-apt-repository ppa:webupd8team/java
 RUN apt-get update && apt-get -y install  \
 	vim             \
@@ -32,7 +32,7 @@ RUN apt-get update && apt-get -y install  \
 
 # Install dependencies
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
     python-all-dev \
     python3-all-dev \
     python-pip

--- a/projects/gstreamer/Dockerfile
+++ b/projects/gstreamer/Dockerfile
@@ -22,7 +22,7 @@ MAINTAINER bilboed@bilboed.com
 
 RUN sed -i '/^#\sdeb-src /s/^#//' "/etc/apt/sources.list" && \
    apt-get update && \
-   apt-get install -y make autoconf automake libtool build-essential \
+   apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool build-essential \
     autopoint pkg-config bison flex gettext libffi-dev liblzma-dev \
     libvorbis-dev libtheora-dev libogg-dev zlib1g-dev
 

--- a/projects/guetzli/Dockerfile
+++ b/projects/guetzli/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER robryk@google.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool libpng-dev pkg-config curl
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool libpng-dev pkg-config curl
 
 RUN mkdir afl-testcases
 RUN cd afl-testcases/ && curl http://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz | tar -xz

--- a/projects/h2o/Dockerfile
+++ b/projects/h2o/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER jonathan.foote@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool cmake zlib1g-dev pkg-config libssl-dev
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool cmake zlib1g-dev pkg-config libssl-dev
 RUN git clone https://github.com/h2o/h2o
 WORKDIR h2o
 COPY build.sh $SRC/

--- a/projects/harfbuzz/Dockerfile
+++ b/projects/harfbuzz/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mmoroz@chromium.org
-RUN apt-get update && apt-get install -y make autoconf automake libtool ragel pkg-config
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool ragel pkg-config
 
 RUN git clone --depth 1 https://github.com/harfbuzz/harfbuzz.git
 WORKDIR harfbuzz

--- a/projects/hoextdown/Dockerfile
+++ b/projects/hoextdown/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER kjclev@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/kjdev/hoextdown.git hoextdown
 WORKDIR hoextdown
 COPY build.sh *.options *.dict $SRC/

--- a/projects/hostap/Dockerfile
+++ b/projects/hostap/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER elver@google.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool g++
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool g++
 RUN git clone --depth 1 git://w1.fi/srv/git/hostap.git hostap
 WORKDIR hostap
 COPY build.sh $SRC/

--- a/projects/htslib/Dockerfile
+++ b/projects/htslib/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER rmd@sanger.ac.uk
-RUN apt-get update && apt-get install -y make autoconf automake zlib1g-dev libbz2-dev liblzma-dev libcurl4-gnutls-dev libssl-dev
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake zlib1g-dev libbz2-dev liblzma-dev libcurl4-gnutls-dev libssl-dev
 RUN git clone --depth 1 https://github.com/samtools/htslib.git htslib
 WORKDIR htslib
 COPY build.sh $SRC/

--- a/projects/hunspell/Dockerfile
+++ b/projects/hunspell/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER twsmith@mozilla.com
 RUN dpkg --add-architecture i386 && \
     apt-get update && \
-    apt-get install -y autoconf automake autopoint libtool
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates autoconf automake autopoint libtool
 RUN git clone --depth 1 https://github.com/hunspell/hunspell.git hunspell
 WORKDIR hunspell
 COPY build.sh $SRC/

--- a/projects/ibmswtpm2/Dockerfile
+++ b/projects/ibmswtpm2/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER john.s.andersen@intel.com
 ARG SIM_DL_URL=https://downloads.sourceforge.net/project/ibmswtpm2/ibmtpm1332.tar.gz
-RUN apt-get update && apt-get install -y make autoconf automake libtool libssl-dev curl tar g++
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool libssl-dev curl tar g++
 RUN mkdir ibmswtpm2 && \
   cd ibmswtpm2 && \
   curl -sSL "${SIM_DL_URL}" | tar xvz

--- a/projects/icu/Dockerfile
+++ b/projects/icu/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mike.aizatsky@gmail.com
-RUN apt-get update && apt-get install -y make
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make
 
 RUN git clone --depth 1 https://github.com/unicode-org/icu.git icu
 COPY build.sh $SRC/

--- a/projects/imagemagick/Dockerfile
+++ b/projects/imagemagick/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER paul.l.kehrer@gmail.com
 RUN dpkg --add-architecture i386 && \
     apt-get update && \
-    apt-get install -y make autoconf automake libtool pkg-config cmake nasm autopoint libc6:i386 libc6-dev:i386
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool pkg-config cmake nasm autopoint libc6:i386 libc6-dev:i386
 RUN git clone --depth 1 https://github.com/imagemagick/imagemagick
 RUN git clone --depth 1 https://gitlab.com/libtiff/libtiff
 RUN git clone --depth 1 https://github.com/strukturag/libde265

--- a/projects/irssi/Dockerfile
+++ b/projects/irssi/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER joseph.bisch@gmail.com
-RUN apt-get update && apt-get install -y pkg-config libncurses5-dev libssl-dev python3-pip
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates pkg-config libncurses5-dev libssl-dev python3-pip
 RUN pip3 install -U meson ninja
 RUN git clone https://github.com/irssi/irssi
 

--- a/projects/janus-gateway/Dockerfile
+++ b/projects/janus-gateway/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER toppi.ale@gmail.com
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
 	autoconf autoconf-archive \
 	automake \
 	gengetopt \

--- a/projects/jbig2dec/Dockerfile
+++ b/projects/jbig2dec/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER sebastian.rasmussen@artifex.com
-RUN apt-get update && apt-get install -y make libtool pkg-config vim libreadline-dev wget autoconf
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make libtool pkg-config vim libreadline-dev wget autoconf
 RUN git clone --recursive --depth 1 git://git.ghostscript.com/jbig2dec.git jbig2dec
 RUN mkdir tests
 RUN cp $SRC/jbig2dec/annex-h.jbig2 tests/annex-h.jb2

--- a/projects/jsc/Dockerfile
+++ b/projects/jsc/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER ochang@google.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool python ruby ninja-build bison flex gperf wget
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool python ruby ninja-build bison flex gperf wget
 # Requires newer CMake than available in Ubuntu 16.04
 RUN wget -q -O - https://github.com/Kitware/CMake/releases/download/v3.14.4/cmake-3.14.4-Linux-x86_64.sh > /tmp/install_cmake.sh && \
     cd /usr && bash /tmp/install_cmake.sh -- --skip-license && \

--- a/projects/json-c/Dockerfile
+++ b/projects/json-c/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER chriswwolfe@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/json-c/json-c.git json-c
 WORKDIR json-c
 COPY build.sh *.cc *.dict $SRC/

--- a/projects/json/Dockerfile
+++ b/projects/json/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER vitalybuka@chromium.org
-RUN apt-get update && apt-get install -y binutils make
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates binutils make
 
 RUN git clone --depth 1 -b develop https://github.com/nlohmann/json.git
 WORKDIR json/

--- a/projects/jsoncpp/Dockerfile
+++ b/projects/jsoncpp/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y build-essential make curl wget
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates build-essential make curl wget
 
 # Install latest cmake.
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.14.5/cmake-3.14.5-Linux-x86_64.sh; \

--- a/projects/jsonnet/Dockerfile
+++ b/projects/jsonnet/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y build-essential cmake
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates build-essential cmake
 RUN git clone --depth 1 https://github.com/google/jsonnet.git jsonnet
 WORKDIR $SRC/
 

--- a/projects/karchive/Dockerfile
+++ b/projects/karchive/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER tsdgeos@gmail.com
-RUN apt-get update && apt-get install --yes cmake make autoconf automake autopoint libtool wget po4a
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates cmake make autoconf automake autopoint libtool wget po4a
 RUN git clone --depth 1 https://github.com/madler/zlib.git
 RUN git clone --depth 1 https://github.com/nih-at/libzip.git
 RUN wget https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz

--- a/projects/kcodecs/Dockerfile
+++ b/projects/kcodecs/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER tsdgeos@gmail.com
-RUN apt-get install --yes cmake gperf
+RUN apt-get --no-install-recommends  install -y apt-utils ca-certificates cmake gperf
 RUN git clone --depth 1 --branch=5.15 git://code.qt.io/qt/qtbase.git
 RUN git clone --depth 1 git://anongit.kde.org/kcodecs
 RUN git clone --depth 1 git://anongit.kde.org/extra-cmake-modules

--- a/projects/keystone/Dockerfile
+++ b/projects/keystone/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER keystone.engine@gmail.com
-RUN apt-get update && apt-get install -y make cmake
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make cmake
 RUN git clone --depth 1 https://github.com/keystone-engine/keystone.git
 WORKDIR $SRC
 COPY build.sh $SRC/

--- a/projects/kimageformats/Dockerfile
+++ b/projects/kimageformats/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER tsdgeos@gmail.com
-RUN apt-get install --yes cmake
+RUN apt-get --no-install-recommends  install -y apt-utils ca-certificates cmake
 RUN git clone --depth 1 https://github.com/madler/zlib.git
 RUN git clone --depth 1 https://github.com/nih-at/libzip.git
 RUN git clone --depth 1 git://anongit.kde.org/extra-cmake-modules

--- a/projects/knot-dns/Dockerfile
+++ b/projects/knot-dns/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER jonathan.foote@gmail.com
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
  autoconf \
  autogen \
  automake \

--- a/projects/lame/Dockerfile
+++ b/projects/lame/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER guidovranken@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool subversion
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool subversion
 RUN git clone --depth 1 https://github.com/guidovranken/LAME-fuzzers
 RUN svn checkout https://svn.code.sf.net/p/lame/svn/trunk/lame $SRC/lame
 COPY build.sh $SRC/

--- a/projects/lcms/Dockerfile
+++ b/projects/lcms/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER kcwu@google.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/mm2/Little-CMS.git lcms
 WORKDIR lcms
 COPY build.sh cmsIT8_load_fuzzer.* cms_transform_fuzzer.* icc.dict $SRC/

--- a/projects/leptonica/Dockerfile
+++ b/projects/leptonica/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER taking@google.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool \
   pkg-config cmake nasm
 RUN git clone --depth 1 https://github.com/DanBloomberg/leptonica.git leptonica
 RUN git clone --depth 1 https://github.com/madler/zlib.git zlib

--- a/projects/libaom/Dockerfile
+++ b/projects/libaom/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER urvang@google.com
-RUN apt-get update && apt-get install -y cmake yasm wget
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates cmake yasm wget
 RUN git clone https://aomedia.googlesource.com/aom
 ADD https://storage.googleapis.com/aom-test-data/fuzzer/dec_fuzzer_seed_corpus.zip $SRC/
 COPY build.sh av1_dec_fuzzer.dict $SRC/

--- a/projects/libarchive/Dockerfile
+++ b/projects/libarchive/Dockerfile
@@ -19,7 +19,7 @@ MAINTAINER kcwu@google.com
 
 # Installing optional libraries can utilize more code path and/or improve
 # performance (avoid calling external programs).
-RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool pkg-config \
         libbz2-dev liblzo2-dev liblzma-dev liblz4-dev libz-dev \
         libxml2-dev libssl-dev libacl1-dev libattr1-dev
 RUN git clone --depth 1 https://github.com/libarchive/libarchive.git

--- a/projects/libass/Dockerfile
+++ b/projects/libass/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER eugeni.stepanov@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config libfreetype6-dev libfontconfig1-dev
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool pkg-config libfreetype6-dev libfontconfig1-dev
 
 RUN git clone --depth 1 https://github.com/libass/libass.git
 RUN git clone --depth 1 https://github.com/behdad/fribidi.git

--- a/projects/libavc/Dockerfile
+++ b/projects/libavc/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER harish.mahendrakar@ittiam.com
-RUN apt-get update && apt-get install -y wget cmake
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates wget cmake
 RUN git clone https://android.googlesource.com/platform/external/libavc
 ADD https://storage.googleapis.com/android_media/external/libavc/fuzzer/avc_dec_fuzzer_seed_corpus.zip $SRC/
 COPY build.sh $SRC/

--- a/projects/libavif/Dockerfile
+++ b/projects/libavif/Dockerfile
@@ -21,7 +21,7 @@ ADD bionic.list /etc/apt/sources.list.d/bionic.list
 ADD nasm_apt.pin /etc/apt/preferences
 
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y curl python3-pip python3-setuptools python3-wheel cmake nasm git && \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates curl python3-pip python3-setuptools python3-wheel cmake nasm git && \
     pip3 install meson ninja
 
 RUN git clone --depth 1 https://github.com/AOMediaCodec/libavif.git libavif

--- a/projects/libcbor/Dockerfile
+++ b/projects/libcbor/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER alex.gaynor@gmail.com
-RUN apt-get update && apt-get install -y make cmake
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make cmake
 RUN git clone --depth 1 https://github.com/PJK/libcbor
 WORKDIR libcbor
 COPY build.sh $SRC/

--- a/projects/libchewing/Dockerfile
+++ b/projects/libchewing/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER kcwu@csie.org
-RUN apt-get update && apt-get install -y make autoconf automake libtool texinfo
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool texinfo
 
 RUN git clone --depth 1 https://github.com/chewing/libchewing.git
 WORKDIR libchewing

--- a/projects/libcoap/Dockerfile
+++ b/projects/libcoap/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER bergmann@tzi.org
-RUN apt-get update && apt-get install -y make autoconf automake libtool \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool \
     pkg-config
 RUN git clone --depth 1 https://github.com/obgm/libcoap.git libcoap
 WORKDIR libcoap

--- a/projects/libexif/Dockerfile
+++ b/projects/libexif/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER paul.l.kehrer@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool gettext autopoint
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool gettext autopoint
 RUN git clone --depth 1 https://github.com/libexif/libexif
 RUN git clone --depth 1 https://github.com/ianare/exif-samples
 WORKDIR libexif

--- a/projects/libfido2/Dockerfile
+++ b/projects/libfido2/Dockerfile
@@ -16,8 +16,8 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER g.kihlman@yubico.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool
-RUN apt-get install -y cmake libudev-dev pkg-config chrpath
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool
+RUN apt-get --no-install-recommends  install -y apt-utils ca-certificates cmake libudev-dev pkg-config chrpath
 RUN git clone --branch v0.5.0 https://github.com/PJK/libcbor
 RUN git clone --branch OpenSSL_1_1_1-stable https://github.com/openssl/openssl
 RUN git clone https://github.com/Yubico/libfido2

--- a/projects/libfmt/Dockerfile
+++ b/projects/libfmt/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER pauldreikossfuzz@gmail.com
 RUN echo "CXX=$CXX"
 RUN echo "CXXFLAGS=$CXXFLAGS"
-RUN apt-get update && apt-get install -y cmake ninja-build
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates cmake ninja-build
 
 RUN git clone --depth 1 --branch master \
   https://github.com/fmtlib/fmt.git

--- a/projects/libgd/Dockerfile
+++ b/projects/libgd/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER ossfuzz@tds.xyz
 RUN apt-get update && \
-    apt-get install -y make autoconf automake libtool pkg-config libz-dev
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool pkg-config libz-dev
 RUN git clone --depth 1 https://github.com/libgd/libgd
 ADD http://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz $SRC/afl_testcases.tgz
 WORKDIR libgd

--- a/projects/libgit2/Dockerfile
+++ b/projects/libgit2/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER Nelson Elhage <nelhage@nelhage.com>
-RUN apt-get update && apt-get install -y make autoconf automake libtool cmake
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool cmake
 RUN git clone --depth 1 https://github.com/libgit2/libgit2 libgit2
 WORKDIR libgit2
 

--- a/projects/libheif/Dockerfile
+++ b/projects/libheif/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 
 MAINTAINER mail@joachim-bauch.de
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
     autoconf \
     automake \
     build-essential \

--- a/projects/libhevc/Dockerfile
+++ b/projects/libhevc/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER harish.mahendrakar@ittiam.com
-RUN apt-get update && apt-get install -y wget cmake
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates wget cmake
 RUN git clone https://android.googlesource.com/platform/external/libhevc
 ADD https://storage.googleapis.com/android_media/external/libhevc/fuzzer/hevc_dec_fuzzer_seed_corpus.zip $SRC/
 COPY build.sh $SRC/

--- a/projects/libhtp/Dockerfile
+++ b/projects/libhtp/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER victor@inliniac.net
-RUN apt-get update && apt-get install -y make autoconf automake libtool zlib1g-dev liblzma-dev
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool zlib1g-dev liblzma-dev
 RUN git clone --depth 1 https://github.com/OISF/libhtp.git libhtp
 WORKDIR $SRC
 COPY build.sh $SRC/

--- a/projects/libical/Dockerfile
+++ b/projects/libical/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER tsdgeos@gmail.com
-RUN apt-get update && apt-get install --yes cmake
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates cmake
 
 # libical requires cmake 3.11 whereas Ubuntu 16.04 only has 3.5.1
 ADD https://github.com/Kitware/CMake/releases/download/v3.14.3/cmake-3.14.3-Linux-x86_64.tar.gz $WORK

--- a/projects/libidn/Dockerfile
+++ b/projects/libidn/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER rockdaboot@gmail.com
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
  pkg-config \
  autopoint \
  autoconf \

--- a/projects/libidn2/Dockerfile
+++ b/projects/libidn2/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER rockdaboot@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake gettext libtool autopoint pkg-config gengetopt curl gperf
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake gettext libtool autopoint pkg-config gengetopt curl gperf
 
 RUN git clone --depth=1 --recursive https://gitlab.com/libidn/libidn2.git
 

--- a/projects/libjpeg-turbo/Dockerfile
+++ b/projects/libjpeg-turbo/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER alex.gaynor@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool nasm curl cmake
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool nasm curl cmake
 RUN git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo
 
 RUN mkdir afl-testcases

--- a/projects/libldac/Dockerfile
+++ b/projects/libldac/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER cdiehl@mozilla.com
 
-RUN apt-get update && apt-get install -y automake libtool
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates automake libtool
 RUN git clone --depth 1 -b master https://android.googlesource.com/platform/external/libldac
 RUN svn export https://github.com/mozillasecurity/fuzzdata.git/trunk/samples/wav corpora
 

--- a/projects/libmpeg2/Dockerfile
+++ b/projects/libmpeg2/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER harish.mahendrakar@ittiam.com
-RUN apt-get update && apt-get install -y wget cmake
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates wget cmake
 RUN git clone https://android.googlesource.com/platform/external/libmpeg2
 ADD https://storage.googleapis.com/android_media/external/libmpeg2/fuzzer/mpeg2_dec_fuzzer_seed_corpus.zip $SRC/
 COPY build.sh $SRC/

--- a/projects/libpcap/Dockerfile
+++ b/projects/libpcap/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER security@tcpdump.org
-RUN apt-get update && apt-get install -y make cmake flex bison
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make cmake flex bison
 RUN git clone --depth 1 https://github.com/the-tcpdump-group/libpcap.git libpcap
 # for corpus as wireshark
 RUN git clone --depth=1 https://github.com/the-tcpdump-group/tcpdump.git tcpdump

--- a/projects/libplist/Dockerfile
+++ b/projects/libplist/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER nikias@gmx.li
-RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool pkg-config
 
 RUN git clone --depth 1 https://github.com/libimobiledevice/libplist
 WORKDIR libplist

--- a/projects/libpng-proto/Dockerfile
+++ b/projects/libpng-proto/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER kcc@google.com
 RUN apt-get update && \
-    apt-get install -y make autoconf automake libtool zlib1g-dev ninja-build cmake
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool zlib1g-dev ninja-build cmake
 
 RUN git clone --depth 1 https://github.com/glennrp/libpng.git
 RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git

--- a/projects/libpng/Dockerfile
+++ b/projects/libpng/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER glennrp@gmail.com
 RUN apt-get update && \
-    apt-get install -y make autoconf automake libtool zlib1g-dev
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool zlib1g-dev
 
 RUN git clone --depth 1 https://github.com/madler/zlib.git
 RUN git clone --depth 1 https://github.com/glennrp/libpng.git

--- a/projects/libprotobuf-mutator/Dockerfile
+++ b/projects/libprotobuf-mutator/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER vitalybuka@chromium.org
-RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config cmake \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool pkg-config cmake \
     ninja-build liblzma-dev libz-dev docbook2x
 
 RUN git clone --depth 1  https://github.com/google/libprotobuf-mutator.git

--- a/projects/libpsl/Dockerfile
+++ b/projects/libpsl/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER rockdaboot@gmail.com
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
  make \
  pkg-config \
  autogen \

--- a/projects/libra/Dockerfile
+++ b/projects/libra/Dockerfile
@@ -19,7 +19,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER davidwg@fb.com
 
 # install other tools we might need
-RUN apt-get update && apt-get install -y cmake curl
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates cmake curl
 
 # install rust and cargo-fuzz
 ENV CARGO_HOME=/rust RUSTUP_HOME=/rust/rustup PATH=$PATH:/rust/bin

--- a/projects/librawspeed/Dockerfile
+++ b/projects/librawspeed/Dockerfile
@@ -17,10 +17,10 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER lebedev.ri@gmail.com
 RUN apt-get update && \
-    apt-get install -y apt-transport-https ca-certificates gnupg software-properties-common wget && \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates apt-transport-https ca-certificates gnupg software-properties-common wget && \
     wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add - && \
     apt-add-repository 'deb https://apt.kitware.com/ubuntu/ xenial main' && \
-    apt-get update && apt-get install -y cmake make
+    apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates cmake make
 RUN git clone --depth 1 https://github.com/darktable-org/rawspeed.git librawspeed
 WORKDIR librawspeed
 COPY build.sh $SRC/

--- a/projects/libreoffice/Dockerfile
+++ b/projects/libreoffice/Dockerfile
@@ -20,10 +20,10 @@ MAINTAINER officesecurity@lists.freedesktop.org
 RUN sed -i -e '/^#\s*deb-src.*\smain\s\+restricted/s/^#//' /etc/apt/sources.list
 #build requirements
 RUN apt-get update && apt-get build-dep -y libreoffice
-RUN apt-get install -y wget yasm locales && locale-gen en_US.UTF-8
+RUN apt-get --no-install-recommends  install -y apt-utils ca-certificates wget yasm locales && locale-gen en_US.UTF-8
 #xenial gperf too old
 RUN sed -i -e 's/xenial/bionic/g' /etc/apt/sources.list
-RUN apt-get update && apt-get install gperf
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates gperf
 
 #cache build dependencies
 ADD https://dev-www.libreoffice.org/src/c74b7223abe75949b4af367942d96c7a-crosextrafonts-carlito-20130920.tar.gz \

--- a/projects/libressl/Dockerfile
+++ b/projects/libressl/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER ab@pompel.me
-RUN apt-get update && apt-get install -y make cmake
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make cmake
 RUN git clone --depth 1 https://github.com/libressl-portable/portable.git libressl
 RUN git clone --depth 1 https://github.com/libressl-portable/fuzz.git libressl.fuzzers
 WORKDIR libressl

--- a/projects/libsass/Dockerfile
+++ b/projects/libsass/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/sass/libsass.git libsass
 WORKDIR $SRC
 COPY build.sh $SRC/

--- a/projects/libsodium/Dockerfile
+++ b/projects/libsodium/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER chriswwolfe@gmail.com
-RUN apt-get update && apt-get install -y make
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make
 RUN git clone --depth 1 https://github.com/jedisct1/libsodium.git --branch stable libsodium
 WORKDIR libsodium
 COPY build.sh *.cc *.h $SRC/

--- a/projects/libspectre/Dockerfile
+++ b/projects/libspectre/Dockerfile
@@ -19,7 +19,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER randy408@protonmail.com
 
 RUN apt-get update && \
-    apt-get install -y pkg-config make automake libtool wget
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates pkg-config make automake libtool wget
 
 RUN git clone --depth 1 https://gitlab.freedesktop.org/libspectre/libspectre.git
 

--- a/projects/libspng/Dockerfile
+++ b/projects/libspng/Dockerfile
@@ -19,7 +19,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER randy408@protonmail.com
 
 RUN apt-get update && \
-    apt-get install -y wget tar cmake
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates wget tar cmake
 
 RUN git clone --depth 1 https://github.com/randy408/libspng.git
 RUN git clone --depth 1 https://github.com/google/fuzzer-test-suite

--- a/projects/libsrtp/Dockerfile
+++ b/projects/libsrtp/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER guidovranken@gmail.com
-RUN apt-get update && apt-get install -y sudo autoconf build-essential libssl-dev pkg-config
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates sudo autoconf build-essential libssl-dev pkg-config
 
 RUN git clone --depth 1 https://github.com/cisco/libsrtp
 COPY build.sh $SRC/

--- a/projects/libssh/Dockerfile
+++ b/projects/libssh/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER alex.gaynor@gmail.com
-RUN apt-get update && apt-get install -y cmake zlib1g-dev libssl-dev
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates cmake zlib1g-dev libssl-dev
 
 RUN git clone --depth=1 https://git.libssh.org/projects/libssh.git
 

--- a/projects/libtasn1/Dockerfile
+++ b/projects/libtasn1/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER rockdaboot@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool bison
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool bison
 
 RUN git clone git://git.savannah.gnu.org/gnulib.git
 ENV GNULIB_TOOL=$SRC/gnulib/gnulib-tool

--- a/projects/libteken/Dockerfile
+++ b/projects/libteken/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER kcwu@csie.org
-RUN apt-get update && apt-get install -y pmake
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates pmake
 RUN svn co https://svn.freebsd.org/base/head/sys/teken libteken
 WORKDIR libteken
 COPY build.sh libteken_fuzzer.c $SRC/

--- a/projects/libtheora/Dockerfile
+++ b/projects/libtheora/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER guidovranken@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/xiph/ogg.git
 RUN git clone --depth 1 git://git.xiph.org/theora.git libtheora
 RUN git clone --depth 1 https://github.com/guidovranken/oss-fuzz-fuzzers.git

--- a/projects/libtiff/Dockerfile
+++ b/projects/libtiff/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER paul.l.kehrer@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool cmake nasm
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool cmake nasm
 RUN git clone --depth 1 https://gitlab.com/libtiff/libtiff
 RUN git clone --depth 1 https://github.com/madler/zlib
 RUN git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo

--- a/projects/libtorrent/Dockerfile
+++ b/projects/libtorrent/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER arvid@libtorrent.org
-RUN apt-get update && apt-get install -y wget libssl-dev
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates wget libssl-dev
 
 RUN git clone --depth 1 --single-branch --branch boost-1.72.0 --recurse-submodules https://github.com/boostorg/boost.git
 

--- a/projects/libtpms/Dockerfile
+++ b/projects/libtpms/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER marcandre.lureau@redhat.com
 RUN \
         apt-get update && \
-        apt-get install -y \
+        apt-get --no-install-recommends  install -y apt-utils ca-certificates \
         make autoconf automake libtool \
         libstdc++-5-dev \
         libssl-dev libseccomp-dev

--- a/projects/libtsm/Dockerfile
+++ b/projects/libtsm/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER kcwu@csie.org
-RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool pkg-config
 
 RUN git clone --depth 1 git://people.freedesktop.org/~dvdhrm/libtsm
 WORKDIR libtsm

--- a/projects/libvips/Dockerfile
+++ b/projects/libvips/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER oscar.mira@adevinta.com
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
   curl \
   automake \
   cmake \

--- a/projects/libvpx/Dockerfile
+++ b/projects/libvpx/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER jzern@google.com
-RUN apt-get update && apt-get install -y yasm wget gcc
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates yasm wget gcc
 RUN git clone https://chromium.googlesource.com/webm/libvpx
 ADD https://storage.googleapis.com/downloads.webmproject.org/test_data/fuzzer/vpx_fuzzer_seed_corpus.zip $SRC/
 COPY build.sh vpx_dec_fuzzer.dict $SRC/

--- a/projects/libwebp/Dockerfile
+++ b/projects/libwebp/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER yguyon@google.com
-RUN apt-get update && apt-get install -y autoconf make libtool zip
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates autoconf make libtool zip
 RUN git clone https://chromium.googlesource.com/webm/libwebp
 RUN git clone https://chromium.googlesource.com/webm/libwebp-test-data
 ADD https://storage.googleapis.com/downloads.webmproject.org/webp/testdata/fuzzer/fuzz_seed_corpus.zip $SRC/

--- a/projects/libxls/Dockerfile
+++ b/projects/libxls/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER emmiller@gmail.com
-RUN apt-get update && apt-get install -y make autoconf autoconf-archive automake gettext libtool
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf autoconf-archive automake gettext libtool
 
 RUN git clone --depth 1 https://github.com/libxls/libxls libxls
 WORKDIR libxls

--- a/projects/libxml2/Dockerfile
+++ b/projects/libxml2/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER ochang@chromium.org
-RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool pkg-config
 
 RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/libxml2.git
 WORKDIR libxml2

--- a/projects/libxslt/Dockerfile
+++ b/projects/libxslt/Dockerfile
@@ -19,7 +19,7 @@ MAINTAINER wellnhofer@aevum.de
 
 # Note that we don't use the system libxml2 but a custom instrumented build.
 # libgcrypt is required for the crypto extensions of libexslt.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates --no-install-recommends \
     make autoconf automake libtool pkg-config \
     libgcrypt-dev
 RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/libxml2.git

--- a/projects/libyaml/Dockerfile
+++ b/projects/libyaml/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER alex.gaynor@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool
 
 RUN git clone --depth=1 https://github.com/yaml/libyaml
 RUN zip libyaml_fuzzer_seed_corpus.zip libyaml/examples/*

--- a/projects/libzip/Dockerfile
+++ b/projects/libzip/Dockerfile
@@ -19,7 +19,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 
 MAINTAINER randy408@protonmail.com
 
-RUN apt-get update && apt-get install -y cmake pkg-config zlib1g-dev liblzma-dev
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates cmake pkg-config zlib1g-dev liblzma-dev
 
 RUN git clone --depth 1 https://github.com/nih-at/libzip.git
 

--- a/projects/llvm/Dockerfile
+++ b/projects/llvm/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER kcc@google.com
 RUN apt-get update -y
-RUN apt-get install -y autoconf automake libtool curl make g++ unzip wget git \
+RUN apt-get --no-install-recommends  install -y apt-utils ca-certificates autoconf automake libtool curl make g++ unzip wget git \
     binutils liblzma-dev libz-dev python-all cmake ninja-build subversion \
     pkg-config
 

--- a/projects/llvm_libcxxabi/Dockerfile
+++ b/projects/llvm_libcxxabi/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER kcc@google.com
-RUN apt-get update && apt-get install -y subversion
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates subversion
 
 RUN git clone --depth 1 https://github.com/llvm/llvm-project.git
 WORKDIR llvm-project/libcxxabi

--- a/projects/lodepng/Dockerfile
+++ b/projects/lodepng/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER lvandeve@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/lvandeve/lodepng.git lodepng     # or use other version control
 WORKDIR lodepng
 COPY build.sh $SRC/

--- a/projects/lwan/Dockerfile
+++ b/projects/lwan/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER leandro.pereira@gmail.com
 RUN apt-get update
-RUN apt-get install -y build-essential cmake git ninja-build zlib1g-dev
+RUN apt-get --no-install-recommends  install -y apt-utils ca-certificates build-essential cmake git ninja-build zlib1g-dev
 
 RUN git clone --depth 1 git://github.com/lpereira/lwan
 WORKDIR lwan

--- a/projects/lzma/Dockerfile
+++ b/projects/lzma/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 
 MAINTAINER mail@joachim-bauch.de
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
 	autoconf \
 	automake \
 	libtool \

--- a/projects/lzo/Dockerfile
+++ b/projects/lzo/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER info@oberhumer.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool wget
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool wget
 RUN wget -O lzo.tar.gz \
     http://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz
 COPY *.c *.cc *.options build.sh $SRC/

--- a/projects/matio/Dockerfile
+++ b/projects/matio/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER t-beu@users.sourceforge.net
-RUN apt-get update && apt-get install -y make autoconf automake libhdf5-dev libtool zlib1g-dev
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libhdf5-dev libtool zlib1g-dev
 ENV HDF5_DIR /usr/lib/x86_64-linux-gnu/hdf5/serial
 RUN git clone --depth 1 git://git.code.sf.net/p/matio/matio matio
 WORKDIR matio

--- a/projects/mbedtls/Dockerfile
+++ b/projects/mbedtls/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 #TODO change
 MAINTAINER support-mbedtls@arm.com
-RUN apt-get update && apt-get install -y make cmake
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make cmake
 RUN git clone --recursive --depth 1 https://github.com/ARMmbed/mbedtls.git mbedtls
 RUN git clone --depth 1 https://github.com/google/boringssl.git boringssl
 RUN git clone --depth 1 https://github.com/openssl/openssl.git openssl

--- a/projects/mercurial/Dockerfile
+++ b/projects/mercurial/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER security@mercurial-scm.org
-RUN apt-get update && apt-get install -y make autoconf automake libtool \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool \
   python-dev mercurial curl
 RUN cd $SRC && curl https://www.python.org/ftp/python/2.7.15/Python-2.7.15.tgz | tar xzf -
 RUN hg clone https://www.mercurial-scm.org/repo/hg mercurial

--- a/projects/minizinc/Dockerfile
+++ b/projects/minizinc/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER Harsil S. Patel <harsil.patel@monash.edu>
-RUN apt-get update && apt-get install -y make autoconf automake libtool cmake git build-essential curl
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool cmake git build-essential curl
 RUN curl -L https://gitlab.com/minizinc/minizinc-afl-seed-corpus/-/archive/master/minizinc-afl-seed-corpus-master.zip -o $SRC/minizinc_fuzzer_seed_corpus.zip
 RUN git clone --depth 1 --branch develop https://github.com/MiniZinc/libminizinc.git minizinc
 COPY minizinc_fuzzer.cpp minizinc/

--- a/projects/minizip/Dockerfile
+++ b/projects/minizip/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER nathan.moinvaziri@gmail.com
-RUN apt-get update && apt-get install -y make cmake pkg-config
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make cmake pkg-config
 
 RUN git clone -b dev https://github.com/nmoinvaz/minizip
 WORKDIR minizip

--- a/projects/mp4parse-rust/Dockerfile
+++ b/projects/mp4parse-rust/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mgregan@mozilla.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang
 
 ENV CARGO_HOME=/rust RUSTUP_HOME=/rust/rustup PATH=$PATH:/rust/bin
 RUN curl https://sh.rustup.rs | sh -s -- -y --default-toolchain=nightly

--- a/projects/mpg123/Dockerfile
+++ b/projects/mpg123/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool wget \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool wget \
   bzip2
 RUN wget https://www.mpg123.de/snapshot
 RUN tar -xvf snapshot

--- a/projects/mruby/Dockerfile
+++ b/projects/mruby/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y build-essential ruby bison ninja-build \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates build-essential ruby bison ninja-build \
     cmake zlib1g-dev libbz2-dev
 RUN git clone --depth 1 https://github.com/mruby/mruby mruby
 RUN git clone --depth 1 https://github.com/bshastry/mruby_seeds.git mruby_seeds

--- a/projects/msgpack-c/Dockerfile
+++ b/projects/msgpack-c/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER chriswwolfe@gmail.com
-RUN apt-get update && apt-get install -y cmake
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates cmake
 RUN git clone --depth 1 https://github.com/msgpack/msgpack-c.git msgpack-c
 WORKDIR msgpack-c
 COPY build.sh $SRC/

--- a/projects/mupdf/Dockerfile
+++ b/projects/mupdf/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER jonathan@titanous.com
-RUN apt-get update && apt-get install -y make libtool pkg-config
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make libtool pkg-config
 RUN git clone --recursive --depth 1 git://git.ghostscript.com/mupdf.git mupdf
 RUN git clone --depth 1 https://github.com/mozilla/pdf.js pdf.js && \
     zip -q $SRC/pdf_fuzzer_seed_corpus.zip pdf.js/test/pdfs/*.pdf && \

--- a/projects/mysql-server/Dockerfile
+++ b/projects/mysql-server/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER secalert_us@oracle.com
 RUN apt-get update
-RUN apt-get install -y build-essential libssl-dev libncurses5-dev libncursesw5-dev make cmake perl bison pkg-config
+RUN apt-get --no-install-recommends  install -y apt-utils ca-certificates build-essential libssl-dev libncurses5-dev libncursesw5-dev make cmake perl bison pkg-config
 RUN git clone --depth 1 https://github.com/mysql/mysql-server
 WORKDIR $SRC
 COPY build.sh $SRC/

--- a/projects/nanopb/Dockerfile
+++ b/projects/nanopb/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER jpa@npb.mail.kapsi.fi
-RUN apt-get update && apt-get install -y python-pip git scons
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates python-pip git scons
 RUN pip install protobuf grpcio-tools
 RUN git clone --depth 1 https://github.com/nanopb/nanopb $SRC/nanopb
 COPY build.sh $SRC/

--- a/projects/ndpi/Dockerfile
+++ b/projects/ndpi/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER deri@ntop.org
-RUN apt-get update && apt-get install -y make autoconf automake autogen pkg-config libtool flex bison
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake autogen pkg-config libtool flex bison
 RUN git clone --depth 1 https://github.com/ntop/nDPI.git ndpi
 ADD https://www.tcpdump.org/release/libpcap-1.9.1.tar.gz libpcap-1.9.1.tar.gz
 COPY build.sh $SRC/

--- a/projects/neomutt/Dockerfile
+++ b/projects/neomutt/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER joseph.bisch@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool xsltproc libncursesw5-dev libtinfo5 libxml2-dev libxml2-utils libidn11-dev
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool xsltproc libncursesw5-dev libtinfo5 libxml2-dev libxml2-utils libidn11-dev
 RUN git clone https://github.com/neomutt/neomutt neomutt
 WORKDIR neomutt
 COPY build.sh $SRC/

--- a/projects/nestegg/Dockerfile
+++ b/projects/nestegg/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER kinetik@flim.org
-RUN apt-get update && apt-get install -y subversion wget
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates subversion wget
 RUN git clone https://github.com/kinetiknz/nestegg.git
 
 # collect corpus

--- a/projects/net-snmp/Dockerfile
+++ b/projects/net-snmp/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER fenner@gmail.com
-RUN apt-get update && apt-get install -y make autoconf libtool libssl-dev
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf libtool libssl-dev
 RUN git clone --depth 1 git://git.code.sf.net/p/net-snmp/code net-snmp
 WORKDIR net-snmp
 COPY build.sh $SRC/

--- a/projects/nghttp2/Dockerfile
+++ b/projects/nghttp2/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER tatsuhiro.t@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool pkg-config
 RUN git clone --depth 1 https://github.com/nghttp2/nghttp2.git
 WORKDIR nghttp2
 COPY build.sh *.options $SRC/

--- a/projects/njs/Dockerfile
+++ b/projects/njs/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mmoroz@chromium.org
-RUN apt-get update && apt-get install -y make autoconf automake libtool \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool \
     mercurial libpcre3-dev subversion
 RUN hg clone http://hg.nginx.org/njs
 RUN svn co svn://vcs.exim.org/pcre/code/trunk pcre

--- a/projects/nss/Dockerfile
+++ b/projects/nss/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mmoroz@chromium.org
-RUN apt-get update && apt-get install -y make mercurial zlib1g-dev gyp ninja-build libssl-dev
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make mercurial zlib1g-dev gyp ninja-build libssl-dev
 
 RUN hg clone https://hg.mozilla.org/projects/nspr nspr
 RUN hg clone https://hg.mozilla.org/projects/nss nss

--- a/projects/ntp/Dockerfile
+++ b/projects/ntp/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER security@ntp.org
-RUN apt-get update && apt-get install -y make autoconf automake libtool bison flex rsync lynx
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool bison flex rsync lynx
 ADD https://www.bitkeeper.org/downloads/7.3.3/bk-7.3.3-x86_64-glibc213-linux.bin bk-7.3.3-x86_64-glibc213-linux.bin
 RUN chmod +x bk-7.3.3-x86_64-glibc213-linux.bin
 RUN ./bk-7.3.3-x86_64-glibc213-linux.bin /usr/local/bitkeeper

--- a/projects/oak/Dockerfile
+++ b/projects/oak/Dockerfile
@@ -27,11 +27,11 @@ ARG bazel_url=https://storage.googleapis.com/bazel-apt/pool/jdk1.8/b/bazel/bazel
 
 # Install Bazel.
 RUN apt-get update && \
-    apt-get install -y wget && \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates wget && \
     wget "${bazel_url}" -nv -o- -O bazel.deb && \
     echo "${bazel_sha}  bazel.deb" > bazel.sha256 && \
     sha256sum --check bazel.sha256 && \
-    apt-get install -y ./bazel.deb && \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates ./bazel.deb && \
     rm bazel.deb bazel.sha256 && \
     apt-get clean
 

--- a/projects/open62541/Dockerfile
+++ b/projects/open62541/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER git@s.profanter.me
-RUN apt-get update && apt-get install -y make cmake python-six wget
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make cmake python-six wget
 # We need libmbedtls > 2.5.1 otherwise it does not include the lib for static linking
 RUN wget https://open62541.org/libmbedtls/libmbedtls-dev_2.6.0-1_amd64.deb && \
     wget https://open62541.org/libmbedtls/libmbedcrypto0_2.6.0-1_amd64.deb && \

--- a/projects/opencv/Dockerfile
+++ b/projects/opencv/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y build-essential cmake pkg-config
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates build-essential cmake pkg-config
 RUN git clone --depth 1 https://github.com/opencv/opencv.git opencv
 WORKDIR opencv/
 

--- a/projects/opendnp3/Dockerfile
+++ b/projects/opendnp3/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER info@automatak.com
-RUN apt-get update && apt-get install -y make wget tshark
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make wget tshark
 # The CMake version that is available on Ubuntu 16.04 is 3.5.1. OpenDNP3
 # needs CMake 3.8 or higher, because of the C# bindings. Therefore, we
 # manually install a modern CMake until the OSS Fuzz environment updates

--- a/projects/openh264/Dockerfile
+++ b/projects/openh264/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER twsmith@mozilla.com
 RUN dpkg --add-architecture i386 && \
     apt-get update && \
-    apt-get install -y libstdc++-5-dev libstdc++-5-dev:i386 nasm subversion
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates libstdc++-5-dev libstdc++-5-dev:i386 nasm subversion
 RUN git clone --depth 1 https://github.com/cisco/openh264.git openh264
 WORKDIR openh264
 COPY build.sh decoder_fuzzer.cpp $SRC/

--- a/projects/openjpeg/Dockerfile
+++ b/projects/openjpeg/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER antonin@gmail.com
-RUN apt-get update && apt-get install -y make cmake g++
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make cmake g++
 RUN git clone --depth 1 https://github.com/uclouvain/openjpeg openjpeg
 # openjpeg-data is used to create a seed corpus
 RUN git clone --depth 1 https://github.com/uclouvain/openjpeg-data openjpeg/data

--- a/projects/opensc/Dockerfile
+++ b/projects/opensc/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER frankmorgner@gmail.com
-RUN apt-get update && apt-get install -y pcscd libccid libpcsclite-dev libssl-dev libreadline-dev autoconf automake build-essential docbook-xsl xsltproc libtool pkg-config zlib1g-dev
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates pcscd libccid libpcsclite-dev libssl-dev libreadline-dev autoconf automake build-essential docbook-xsl xsltproc libtool pkg-config zlib1g-dev
 RUN git clone --depth 1 --single-branch --branch master https://github.com/OpenSC/OpenSC opensc
 WORKDIR opensc
 COPY build.sh $SRC/

--- a/projects/openssh/Dockerfile
+++ b/projects/openssh/Dockerfile
@@ -16,8 +16,8 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER djm@mindrot.org
-RUN apt-get update && apt-get install -y make autoconf automake libtool
-RUN apt-get install -y libz-dev libssl1.0.0 libssl-dev libedit-dev zip
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool
+RUN apt-get --no-install-recommends  install -y apt-utils ca-certificates libz-dev libssl1.0.0 libssl-dev libedit-dev zip
 RUN git clone --depth 1 https://github.com/openssh/openssh-portable openssh
 RUN git clone --depth 1 https://github.com/djmdjm/openssh-fuzz-cases
 WORKDIR openssh

--- a/projects/openssl/Dockerfile
+++ b/projects/openssl/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER kurt@roeckx.be
-RUN apt-get update && apt-get install -y make
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make
 RUN git clone --depth 1 https://github.com/openssl/openssl.git
 WORKDIR openssl
 COPY build.sh *.options $SRC/

--- a/projects/openthread/Dockerfile
+++ b/projects/openthread/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER jonhui@nestlabs.com
 
-RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/openthread/openthread
 
 WORKDIR openthread

--- a/projects/openvswitch/Dockerfile
+++ b/projects/openvswitch/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER blp@ovn.org
-RUN apt-get update && apt-get install -y make autoconf automake \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake \
     libtool python python3-pip \
     libz-dev libssl-dev libssl1.0.0 wget
 RUN pip3 install six

--- a/projects/opus/Dockerfile
+++ b/projects/opus/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER flim@google.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool wget
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool wget
 
 RUN git clone https://git.xiph.org/opus.git
 RUN wget https://opus-codec.org/static/testvectors/opus_testvectors.tar.gz

--- a/projects/osquery/Dockerfile
+++ b/projects/osquery/Dockerfile
@@ -17,11 +17,11 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER theopolis@osquery.io
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends python python3 bison flex make wget xz-utils libunwind-dev
+RUN apt-get --no-install-recommends  install -y apt-utils ca-certificates python python3 bison flex make wget xz-utils libunwind-dev
 
 # Install specific git version.
 RUN export GIT_VER=2.21.0 \
- && apt-get install -y libz-dev gettext nano libssl-dev autoconf libcurl4-openssl-dev \
+ && apt-get --no-install-recommends  install -y apt-utils ca-certificates libz-dev gettext nano libssl-dev autoconf libcurl4-openssl-dev \
  && wget https://github.com/git/git/archive/v$GIT_VER.tar.gz \
  && tar xf v$GIT_VER.tar.gz \
  && cd git-$GIT_VER/ \

--- a/projects/ots/Dockerfile
+++ b/projects/ots/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mmoroz@chromium.org
-RUN apt-get update && apt-get install -y python3-pip pkg-config zlib1g-dev && \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates python3-pip pkg-config zlib1g-dev && \
     pip3 install meson==0.52.0 ninja
 RUN git clone --depth 1 https://github.com/khaledhosny/ots.git
 WORKDIR ots

--- a/projects/pcre2/Dockerfile
+++ b/projects/pcre2/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER kcc@google.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool subversion
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool subversion
 
 RUN svn co svn://vcs.exim.org/pcre2/code/trunk pcre2
 WORKDIR pcre2

--- a/projects/pffft/Dockerfile
+++ b/projects/pffft/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER alessiob@webrtc.org
-RUN apt-get update && apt-get install -y mercurial python-numpy
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates mercurial python-numpy
 RUN hg clone https://bitbucket.org/jpommier/pffft $SRC/pffft
 WORKDIR pffft
 COPY build.sh $SRC

--- a/projects/php/Dockerfile
+++ b/projects/php/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER stas@php.net
 RUN apt-get update && \
-    apt-get install -y autoconf automake libtool bison re2c pkg-config
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates autoconf automake libtool bison re2c pkg-config
 RUN git clone --depth 1 --branch master https://github.com/php/php-src.git php-src
 RUN git clone https://github.com/kkos/oniguruma.git php-src/oniguruma
 WORKDIR php-src

--- a/projects/picotls/Dockerfile
+++ b/projects/picotls/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER jonathan.foote@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool cmake pkg-config libssl-dev
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool cmake pkg-config libssl-dev
 RUN git clone https://github.com/h2o/picotls
 WORKDIR picotls
 RUN git submodule init

--- a/projects/piex/Dockerfile
+++ b/projects/piex/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER guidovranken@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool
 RUN git clone https://github.com/guidovranken/piex.git piex
 WORKDIR piex
 COPY build.sh $SRC/

--- a/projects/pillow/Dockerfile
+++ b/projects/pillow/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER guidovranken@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake build-essential libbz2-dev libc6-dev libffi-dev libfreetype6-dev libgdbm-dev libjpeg-turbo8-dev liblcms2-dev libncursesw5-dev libreadline-dev libsqlite3-dev libssl-dev libtiff5-dev libtool libwebp-dev make python python-dev python-setuptools tk-dev wget zlib1g-dev libwebp-dev
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake build-essential libbz2-dev libc6-dev libffi-dev libfreetype6-dev libgdbm-dev libjpeg-turbo8-dev liblcms2-dev libncursesw5-dev libreadline-dev libsqlite3-dev libssl-dev libtiff5-dev libtool libwebp-dev make python python-dev python-setuptools tk-dev wget zlib1g-dev libwebp-dev
 RUN wget https://github.com/python/cpython/archive/v3.8.1.tar.gz
 RUN git clone --depth 1 https://github.com/python-pillow/Pillow.git pillow
 RUN git clone --depth 1 https://github.com/guidovranken/oss-fuzz-fuzzers

--- a/projects/poppler/Dockerfile
+++ b/projects/poppler/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER jonathan@titanous.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config cmake
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool pkg-config cmake
 RUN git clone --depth 1 https://anongit.freedesktop.org/git/poppler/poppler.git
 RUN git clone --depth 1 git://git.sv.nongnu.org/freetype/freetype2.git
 RUN git clone --depth 1 https://github.com/mozilla/pdf.js pdf.js && \

--- a/projects/postgis/Dockerfile
+++ b/projects/postgis/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER lr@pcorp.us
 RUN echo deb http://archive.ubuntu.com/ubuntu/ bionic main restricted universe multiverse >> /etc/apt/sources.list
-RUN apt-get update && apt-get install -y make autoconf automake libtool g++ postgresql-server-dev-10 libgeos-dev libproj-dev libxml2-dev pkg-config libjson-c-dev
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool g++ postgresql-server-dev-10 libgeos-dev libproj-dev libxml2-dev pkg-config libjson-c-dev
 RUN git clone --depth 1 https://git.osgeo.org/gitea/postgis/postgis.git postgis
 WORKDIR postgis
 COPY build.sh $SRC/

--- a/projects/powerdns/Dockerfile
+++ b/projects/powerdns/Dockerfile
@@ -21,7 +21,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER remi.gacogne@powerdns.com
 
 # install required packages to build your project
-RUN apt-get update && apt-get install -y autoconf automake bison dh-autoreconf flex libboost-all-dev libluajit-5.1-dev libedit-dev libprotobuf-dev libssl-dev libtool make pkg-config protobuf-compiler ragel
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates autoconf automake bison dh-autoreconf flex libboost-all-dev libluajit-5.1-dev libedit-dev libprotobuf-dev libssl-dev libtool make pkg-config protobuf-compiler ragel
 
 # checkout all sources needed to build your project
 RUN git clone https://github.com/PowerDNS/pdns.git pdns

--- a/projects/proj4/Dockerfile
+++ b/projects/proj4/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER even.rouault@spatialys.com
 RUN dpkg --add-architecture i386 && \
     apt-get update && \
-    apt-get install -y make autoconf automake libtool g++ sqlite3 pkg-config
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool g++ sqlite3 pkg-config
 
 RUN git clone --depth 1 https://github.com/OSGeo/proj proj
 

--- a/projects/proxygen/Dockerfile
+++ b/projects/proxygen/Dockerfile
@@ -19,7 +19,7 @@ MAINTAINER mhl@fb.com
 
 # Install packages we need to build dependencies
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates \
     make \
     autoconf \
     automake \
@@ -127,7 +127,7 @@ RUN wget https://github.com/fmtlib/fmt/archive/6.0.0.tar.gz && \
     rm -rf fmt-6.0.0
 
 # Replicate `install-dependencies` from the proxygen `build.sh` script
-RUN apt-get install -y \
+RUN apt-get --no-install-recommends  install -y apt-utils ca-certificates \
     git \
     flex \
     bison \
@@ -151,7 +151,7 @@ RUN apt-get install -y \
     libunwind8-dev
 
 # Install patchelf so we can fix path to libunwind
-RUN apt-get install patchelf
+RUN apt-get --no-install-recommends  install -y apt-utils ca-certificates patchelf
 
 # Fetch source and copy over files
 RUN git clone --depth 1 https://github.com/facebook/proxygen.git proxygen

--- a/projects/python3-libraries/Dockerfile
+++ b/projects/python3-libraries/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER guidovranken@gmail.com
-RUN apt-get install -y build-essential libncursesw5-dev libreadline-dev libssl-dev libgdbm-dev libc6-dev libsqlite3-dev tk-dev libbz2-dev zlib1g-dev libffi-dev
+RUN apt-get --no-install-recommends  install -y apt-utils ca-certificates build-essential libncursesw5-dev libreadline-dev libssl-dev libgdbm-dev libc6-dev libsqlite3-dev tk-dev libbz2-dev zlib1g-dev libffi-dev
 RUN git clone https://github.com/python/cpython.git cpython
 RUN git clone --depth 1 https://github.com/guidovranken/python-library-fuzzers.git
 COPY build.sh $SRC/

--- a/projects/qcms/Dockerfile
+++ b/projects/qcms/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER pdknsk@gmail.com
-RUN apt-get update && apt-get install -y mercurial
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates mercurial
 RUN hg clone --uncompressed https://hg.mozilla.org/mozilla-central/
 COPY build.sh $SRC/
 WORKDIR mozilla-central/gfx/qcms

--- a/projects/qpdf/Dockerfile
+++ b/projects/qpdf/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER ejb@ql.org
-RUN apt-get update && apt-get install -y make autoconf automake libtool cmake nasm
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool cmake nasm
 RUN git clone --depth 1 https://github.com/qpdf/qpdf.git qpdf
 RUN git clone --depth 1 https://github.com/madler/zlib.git zlib
 RUN git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo libjpeg-turbo

--- a/projects/qpid-proton/Dockerfile
+++ b/projects/qpid-proton/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER jdanek@redhat.com
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates \
         cmake
 
 RUN git clone https://github.com/apache/qpid-proton.git

--- a/projects/qt/Dockerfile
+++ b/projects/qt/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER rlohningqt@gmail.com
-RUN apt-get update && apt-get install -y build-essential python libxcb-xinerama0-dev && apt-get install --no-install-recommends afl-doc
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates build-essential python libxcb-xinerama0-dev afl-doc
 RUN git clone --branch 5.15 --depth 1 git://code.qt.io/qt/qt5.git qt
 WORKDIR qt
 RUN perl init-repository --module-subset=qtbase

--- a/projects/rapidjson/Dockerfile
+++ b/projects/rapidjson/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER guidovranken@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool cmake
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool cmake
 RUN git clone --depth 1 https://github.com/Tencent/rapidjson.git rapidjson
 RUN git clone --depth 1 https://github.com/guidovranken/rapidjson-fuzzers.git rapidjson-fuzzers
 RUN git clone --depth 1 https://github.com/guidovranken/fuzzing-headers.git

--- a/projects/re2/Dockerfile
+++ b/projects/re2/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER wrengr@chromium.org
-RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool
 
 RUN git clone --depth 1 https://code.googlesource.com/re2
 WORKDIR re2

--- a/projects/readstat/Dockerfile
+++ b/projects/readstat/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER emmiller@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake gettext libtool zip zlib1g-dev
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake gettext libtool zip zlib1g-dev
 
 RUN git clone --depth 1 https://github.com/WizardMac/ReadStat readstat
 WORKDIR readstat

--- a/projects/resiprocate/Dockerfile
+++ b/projects/resiprocate/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER gjasny@googlemail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool pkg-config
 RUN git clone --depth 1 https://github.com/resiprocate/resiprocate.git resiprocate
 WORKDIR resiprocate
 COPY build.sh $SRC/

--- a/projects/s2opc/Dockerfile
+++ b/projects/s2opc/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER pab.systerel@gmail.com
-RUN apt-get update && apt-get install -y make cmake git curl
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make cmake git curl
 
 # Sources and dependencies
 RUN git clone --depth 1 https://gitlab.com/systerel/S2OPC

--- a/projects/simdjson/Dockerfile
+++ b/projects/simdjson/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER pauldreikossfuzz@gmail.com
 
-RUN apt-get update && apt-get install -y ninja-build wget
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates ninja-build wget
 
 # We need a modern cmake
 ENV CMAKEVER 3.15.4

--- a/projects/skcms/Dockerfile
+++ b/projects/skcms/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER kjlubick@chromium.org
 
-RUN apt-get update && apt-get install -y wget
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates wget
 
 # checkout all sources needed to build your project
 RUN git clone https://skia.googlesource.com/skcms.git

--- a/projects/skia/Dockerfile
+++ b/projects/skia/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER kjlubick@chromium.org
 
 # Mesa needed to build swiftshader
-RUN apt-get update && apt-get install -y python wget libglu1-mesa-dev cmake
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates python wget libglu1-mesa-dev cmake
 
 RUN git clone 'https://chromium.googlesource.com/chromium/tools/depot_tools.git' --depth 1
 ENV PATH="${SRC}/depot_tools:${PATH}"

--- a/projects/solidity/Dockerfile
+++ b/projects/solidity/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool \
     build-essential libbz2-dev ninja-build zlib1g-dev wget python python-dev
 # Install cmake 3.14 (minimum requirement is cmake 3.10)
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.14.5/cmake-3.14.5-Linux-x86_64.sh; \

--- a/projects/spdlog/Dockerfile
+++ b/projects/spdlog/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER gmelman1@gmail.com
 
-RUN apt-get update && apt-get install --yes cmake
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates cmake
 
 RUN git clone --depth 1 https://github.com/gabime/spdlog.git
 WORKDIR spdlog

--- a/projects/speex/Dockerfile
+++ b/projects/speex/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER tmatth@videolan.org
-RUN apt-get update && apt-get install -y make autoconf libtool pkg-config wget
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf libtool pkg-config wget
 RUN git clone https://git.xiph.org/ogg.git
 RUN git clone https://git.xiph.org/speex.git speex
 WORKDIR speex

--- a/projects/spidermonkey-ufi/Dockerfile
+++ b/projects/spidermonkey-ufi/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER cdiehl@mozilla.com
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
     autoconf2.13 \
     python \
     libc++1 \

--- a/projects/spidermonkey/Dockerfile
+++ b/projects/spidermonkey/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER alex.gaynor@gmail.com
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
   autoconf2.13 \
   yasm \
   python

--- a/projects/sqlite3/Dockerfile
+++ b/projects/sqlite3/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER tanin@google.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool curl tcl zlib1g-dev
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool curl tcl zlib1g-dev
 
 # We won't be able to poll fossil for changes, so this will build
 # only once a day.

--- a/projects/strongswan/Dockerfile
+++ b/projects/strongswan/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER tobias@strongswan.org
-RUN apt-get update && apt-get install -y automake autoconf libtool pkg-config gettext perl python flex bison gperf lcov libgmp3-dev
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates automake autoconf libtool pkg-config gettext perl python flex bison gperf lcov libgmp3-dev
 RUN git clone --depth 1 https://github.com/strongswan/strongswan.git strongswan
 RUN git clone --depth 1 https://github.com/strongswan/fuzzing-corpora.git strongswan/fuzzing-corpora
 WORKDIR strongswan

--- a/projects/systemd/Dockerfile
+++ b/projects/systemd/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER jonathan@titanous.com
 RUN apt-get update &&\
-    apt-get install -y gperf m4 gettext python3-pip \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates gperf m4 gettext python3-pip \
         libcap-dev libmount-dev libkmod-dev \
         pkg-config wget &&\
     pip3 install meson ninja

--- a/projects/tensorflow/Dockerfile
+++ b/projects/tensorflow/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mihaimaruseac@google.com
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
         curl \
         python-dev \
         python-future \
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install Bazel from apt-get to ensure dependencies are there
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
 RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
-RUN apt-get update && apt-get install -y bazel
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates bazel
 
 RUN git clone --depth 1 https://github.com/tensorflow/tensorflow tensorflow
 WORKDIR $SRC/tensorflow

--- a/projects/tesseract-ocr/Dockerfile
+++ b/projects/tesseract-ocr/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER guidovranken@gmail.com
-RUN apt-get update && apt-get install -y autoconf automake libtool pkg-config libpng-dev libjpeg8-dev libtiff5-dev zlib1g-dev
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates autoconf automake libtool pkg-config libpng-dev libjpeg8-dev libtiff5-dev zlib1g-dev
 RUN git clone --depth 1 https://github.com/danbloomberg/leptonica
 RUN git clone --depth 1 https://github.com/tesseract-ocr/tesseract
 RUN git clone --depth 1 https://github.com/tesseract-ocr/tessdata

--- a/projects/tidy-html5/Dockerfile
+++ b/projects/tidy-html5/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER sbucur@google.com
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates \
         cmake ninja-build && \
     apt-get clean
 

--- a/projects/tinyxml2/Dockerfile
+++ b/projects/tinyxml2/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool pkg-config
 
 RUN git clone --depth 1 https://github.com/leethomason/tinyxml2
 WORKDIR tinyxml2

--- a/projects/tor/Dockerfile
+++ b/projects/tor/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER nickm@torproject.org
-RUN apt-get update && apt-get install -y autoconf automake make libtool
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates autoconf automake make libtool
 RUN git clone --depth 1 https://git.torproject.org/tor.git
 RUN git clone --depth 1 https://git.torproject.org/fuzzing-corpora.git tor-fuzz-corpora
 RUN git clone --depth 1 https://github.com/madler/zlib.git

--- a/projects/tpm2-tss/Dockerfile
+++ b/projects/tpm2-tss/Dockerfile
@@ -16,7 +16,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates \
     autoconf-archive \
     curl \
     libcmocka0 \

--- a/projects/tpm2/Dockerfile
+++ b/projects/tpm2/Dockerfile
@@ -5,7 +5,7 @@
 # Defines a docker image that can build fuzzers.
 #
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make libssl-dev binutils libgcc-5-dev
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make libssl-dev binutils libgcc-5-dev
 RUN git clone --depth 1 https://chromium.googlesource.com/chromiumos/third_party/tpm2
 WORKDIR tpm2
 RUN cp /src/tpm2/fuzz/build.sh /src/

--- a/projects/tremor/Dockerfile
+++ b/projects/tremor/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER twsmith@mozilla.com
-RUN apt-get update && apt-get install -y make autoconf automake libogg-dev libtool pkg-config wget
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libogg-dev libtool pkg-config wget
 RUN git clone https://git.xiph.org/ogg.git
 RUN git clone https://git.xiph.org/tremor.git
 RUN svn export https://github.com/mozillasecurity/fuzzdata.git/trunk/samples/vorbis decode_corpus

--- a/projects/unbound/Dockerfile
+++ b/projects/unbound/Dockerfile
@@ -16,7 +16,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER jsha@letsencrypt.org
 RUN apt-get update
-RUN apt-get install -y make libtool libssl-dev libexpat-dev wget
+RUN apt-get --no-install-recommends  install -y apt-utils ca-certificates make libtool libssl-dev libexpat-dev wget
 RUN git clone --depth=1 https://github.com/NLnetLabs/unbound unbound
 WORKDIR unbound
 COPY parse_packet_fuzzer.c .

--- a/projects/unicorn/Dockerfile
+++ b/projects/unicorn/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER unicorn.emu@gmail.com
-RUN apt-get update && apt-get install -y make python
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make python
 RUN git clone --depth 1 https://github.com/unicorn-engine/unicorn.git
 WORKDIR $SRC
 COPY build.sh $SRC/

--- a/projects/unrar/Dockerfile
+++ b/projects/unrar/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER vakh@chromium.org
-RUN apt-get update && apt-get install -y make build-essential
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make build-essential
 
 RUN git clone -b oss_fuzz --depth 1 https://github.com/aawc/unrar.git
 WORKDIR unrar

--- a/projects/usbguard/Dockerfile
+++ b/projects/usbguard/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER allenwebb@google.com
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
   make \
   autoconf \
   automake \

--- a/projects/usrsctp/Dockerfile
+++ b/projects/usrsctp/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER weinrank@fh-muenster.de
-RUN apt-get update && apt-get install -y make cmake
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make cmake
 RUN git clone --depth 1 --branch oss-fuzz https://github.com/weinrank/usrsctp usrsctp
 WORKDIR usrsctp
 COPY build.sh $SRC/

--- a/projects/uwebsockets/Dockerfile
+++ b/projects/uwebsockets/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER alexhultman@gmail.com
-RUN apt-get update && apt-get install -y libz-dev
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates libz-dev
 RUN git clone --recursive https://github.com/uNetworking/uWebSockets.git uWebSockets
 WORKDIR uWebSockets
 COPY build.sh $SRC/

--- a/projects/vorbis/Dockerfile
+++ b/projects/vorbis/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER paul.l.kehrer@mail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config wget
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool pkg-config wget
 RUN git clone https://git.xiph.org/ogg.git
 RUN git clone https://git.xiph.org/vorbis.git
 RUN svn export https://github.com/mozillasecurity/fuzzdata.git/trunk/samples/ogg decode_corpus

--- a/projects/wabt/Dockerfile
+++ b/projects/wabt/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER binji@chromium.org
-RUN apt-get update && apt-get install -y cmake libtool make python
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates cmake libtool make python
 RUN git clone --recursive https://github.com/WebAssembly/wabt
 WORKDIR wabt
 RUN git submodule init

--- a/projects/wasmtime/Dockerfile
+++ b/projects/wasmtime/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER foote@fastly.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang
 
 ENV CARGO_HOME=/rust RUSTUP_HOME=/rust/rustup PATH=$PATH:/rust/bin
 RUN curl https://sh.rustup.rs | sh -s -- -y --default-toolchain=nightly

--- a/projects/wavpack/Dockerfile
+++ b/projects/wavpack/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER david@wavpack.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/dbry/WavPack.git wavpack
 RUN cp wavpack/fuzzing/build.sh $SRC
 WORKDIR wavpack

--- a/projects/wget/Dockerfile
+++ b/projects/wget/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER rockdaboot@gmail.com
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
  make \
  pkg-config \
  gettext \

--- a/projects/wget2/Dockerfile
+++ b/projects/wget2/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER rockdaboot@gmail.com
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
  make \
  pkg-config \
  gettext \

--- a/projects/wireshark/Dockerfile
+++ b/projects/wireshark/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER Jakub Zawadzki <darkjames-ws@darkjames.pl>
 
-RUN apt-get update && apt-get install -y ninja-build cmake \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates ninja-build cmake \
                        flex bison libc-ares-dev \
                        libglib2.0-dev libgcrypt20-dev
 

--- a/projects/woff2/Dockerfile
+++ b/projects/woff2/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mmoroz@chromium.org
-RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool
 
 RUN git clone --depth 1 --recursive https://github.com/google/woff2
 WORKDIR woff2

--- a/projects/wolfssl/Dockerfile
+++ b/projects/wolfssl/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER levi@wolfssl.com
 
-RUN apt-get update && apt-get install -y make autoconf automake libtool zip
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool zip
 RUN git clone https://github.com/wolfssl/wolfssl --depth 1 $SRC/wolfssl
 RUN git clone https://github.com/wolfssl/oss-fuzz-targets --depth 1 $SRC/fuzz-targets
 

--- a/projects/wpantund/Dockerfile
+++ b/projects/wpantund/Dockerfile
@@ -19,7 +19,7 @@ MAINTAINER rquattle@google.com
 
 RUN apt-get -y update \
 	&& DEBIAN_FRONTEND=noninteractive \
-			apt-get install -y -q --no-install-recommends \
+			apt-get --no-install-recommends  install -y apt-utils ca-certificates -q \
 				gdb \
 				libdbus-1-dev \
 				libboost-dev \

--- a/projects/wuffs/Dockerfile
+++ b/projects/wuffs/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER nigeltao@golang.org
-RUN apt-get update && apt-get install -y wget
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates wget
 
 # Get Wuffs' first-party code.
 

--- a/projects/wxwidgets/Dockerfile
+++ b/projects/wxwidgets/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER vadim@wxwidgets.org
-RUN apt-get update && apt-get install -y make
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make
 RUN git clone --recurse-submodules --depth 1 https://github.com/wxWidgets/wxWidgets.git wxwidgets
 WORKDIR wxwidgets
 COPY build.sh $SRC/

--- a/projects/xerces-c/Dockerfile
+++ b/projects/xerces-c/Dockerfile
@@ -14,7 +14,7 @@
 ################################################################################
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER vincent.ulitzsch@live.de
-RUN apt-get update && apt-get install -y make autoconf automake libtool wget zlib1g-dev libtool ninja-build cmake subversion
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool wget zlib1g-dev libtool ninja-build cmake subversion
 RUN svn co https://svn.apache.org/repos/asf/xerces/c/trunk $SRC/xerces-c
 RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
 RUN (mkdir LPM && cd LPM && cmake ../libprotobuf-mutator -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release && ninja)

--- a/projects/xmlsec/Dockerfile
+++ b/projects/xmlsec/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config \
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool pkg-config \
     libssl-dev libxslt-dev wget
 
 RUN git clone --depth 1 https://github.com/lsh123/xmlsec

--- a/projects/xvid/Dockerfile
+++ b/projects/xvid/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER guidovranken@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool subversion
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool subversion
 RUN svn checkout http://svn.xvid.org/trunk --username anonymous --password "" --non-interactive --no-auth-cache
 RUN git clone --depth 1 https://github.com/guidovranken/fuzzing-headers.git
 RUN git clone --depth 1 https://github.com/guidovranken/oss-fuzz-fuzzers.git

--- a/projects/xz/Dockerfile
+++ b/projects/xz/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER bshas3@email.com
-RUN apt-get update && apt-get install -y make autoconf autopoint libtool zip
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf autopoint libtool zip
 RUN git clone https://git.tukaani.org/xz.git
 COPY build.sh $SRC/
 WORKDIR xz

--- a/projects/yara/Dockerfile
+++ b/projects/yara/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER vmalvarez@google.com
 RUN \
-  apt-get update && apt-get install -y \
+  apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates \
   automake \
   autoconf \
   make \

--- a/projects/zlib-ng/Dockerfile
+++ b/projects/zlib-ng/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER sebpop@gmail.com
-RUN apt-get update && apt-get install -y make
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make
 
 RUN git clone --depth 1 -b develop https://github.com/zlib-ng/zlib-ng.git
 WORKDIR zlib-ng

--- a/projects/zlib/Dockerfile
+++ b/projects/zlib/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER inferno@chromium.org
-RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool
 RUN git clone --depth 1 -b develop https://github.com/madler/zlib.git
 WORKDIR zlib
 COPY build.sh *_fuzzer.c* $SRC/

--- a/projects/zopfli/Dockerfile
+++ b/projects/zopfli/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER lode@google.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/google/zopfli
 WORKDIR zopfli
 COPY build.sh zopfli_compress_fuzzer.cc $SRC/

--- a/projects/zstd/Dockerfile
+++ b/projects/zstd/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER nickrterrell@gmail.com
-RUN apt-get update && apt-get install -y make python wget
+RUN apt-get update && apt-get --no-install-recommends  install -y apt-utils ca-certificates make python wget
 # Clone source
 RUN git clone --depth 1 https://github.com/facebook/zstd
 WORKDIR zstd


### PR DESCRIPTION
Major Changes No 1 : debian package manager tweaks

By default, Ubuntu or Debian based "apt" or "apt-get"
system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended
packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at
[Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Major Changes No 2 : added packages apt-utils ca-certificates

Because build is

1.  Slow  because "apt-utils" not installed

2. to avoid build to exits with error without having
certificate in wget,curl or even git clone

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>