### PR TITLE
[qt] Move beginLayout to the new naming scheme

### DIFF
--- a/projects/qt/build.sh
+++ b/projects/qt/build.sh
@@ -56,8 +56,6 @@ build_fuzzer() {
     local lowercaseExeName=$exeName
     if [ "$exeName" == "setmarkdown" ]; then
         exeName=setMarkdown
-    elif [ "$exeName" == "beginlayout" ]; then
-        exeName=beginLayout
     fi
     if [ "$lowercaseExeName" != "$exeName" ]; then
         mv $lowercaseExeName $exeName
@@ -81,4 +79,4 @@ build_fuzzer "new" "qtbase" "corelib/serialization/qcborvalue/fromcbor/fromcbor.
 build_fuzzer "old" "qtbase" "corelib/serialization/qxmlstream/qxmlstreamreader/readnext/readnext.pro" "xml" "/usr/share/afl/testcases/_extras/xml.dict"
 # build_fuzzer "new" "qtbase" "gui/text/qtextdocument/sethtml/sethtml.pro" "html" "/usr/share/afl/testcases/_extras/html_tags.dict"
 build_fuzzer "old" "qtbase" "gui/text/qtextdocument/setmarkdown/setmarkdown.pro" "markdown"
-build_fuzzer "old" "qtbase" "gui/text/qtextlayout/beginlayout/beginlayout.pro" "text"
+build_fuzzer "new" "qtbase" "gui/text/qtextlayout/beginlayout/beginlayout.pro" "text"


### PR DESCRIPTION
There are no open bugs for this fuzzer.

I'm aware that I will lose corpus and statistics for it.