### PR TITLE
[esp-v2]: Fix broken builds by changing spawn strategy

### DIFF
--- a/projects/esp-v2/build.sh
+++ b/projects/esp-v2/build.sh
@@ -62,7 +62,7 @@ do
 done
 
 # Build driverless libraries.
-bazel build --verbose_failures --dynamic_mode=off --spawn_strategy=standalone \
+bazel build --verbose_failures --dynamic_mode=off --spawn_strategy=sandboxed \
   --genrule_strategy=standalone --strip=never \
   --copt=-fno-sanitize=vptr --linkopt=-fno-sanitize=vptr \
   --define tcmalloc=disabled --define signal_trace=disabled \


### PR DESCRIPTION
[Example failure](https://oss-fuzz-build-logs.storage.googleapis.com/log-8eabbac0-bb8f-4f90-a840-f23efe427e0e.txt)

This only occurs on the fuzzers for some reason, not on Travis CI. Error is similar to https://github.com/bazelbuild/bazel/issues/5640.

Change spawn strategy to `sandboxed` to work around this. Not sure why it was `local` to begin with (other than a slight performance improvement).

Tested locally to ensure this spawn strategy will work.

```
python infra/helper.py build_fuzzers --sanitizer address --engine libfuzzer --architecture x86_64 esp-v2
```

Signed-off-by: Teju Nareddy <nareddyt@google.com>