### PR TITLE
[libfido2] CIFuzz workaround, put seed corpus outside of cloned libfido2 repo

### DIFF
--- a/projects/libfido2/Dockerfile
+++ b/projects/libfido2/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get install -y cmake libudev-dev pkg-config chrpath
 RUN git clone --branch v0.5.0 https://github.com/PJK/libcbor
 RUN git clone --branch OpenSSL_1_1_1-stable https://github.com/openssl/openssl
 RUN git clone https://github.com/Yubico/libfido2
-ADD https://ambientworks.net/libfido2/corpus.tgz libfido2/fuzz/corpus.tgz
+# CIFuzz will replace the libfido directory so put the corpus outside
+ADD https://ambientworks.net/libfido2/corpus.tgz corpus.tgz
 WORKDIR libfido2
 COPY build.sh $SRC/

--- a/projects/libfido2/build.sh
+++ b/projects/libfido2/build.sh
@@ -61,7 +61,7 @@ for f in `ls fuzz/fuzz_*`; do
 done
 
  # Prepare seed corpora
-tar xzf ${SRC}/libfido2/fuzz/corpus.tgz
+tar xzf ${SRC}/corpus.tgz
 (set -e ; cd fuzz_assert/corpus  ; zip -r ${OUT}/fuzz_assert_seed_corpus.zip .)
 (set -e ; cd fuzz_bio/corpus     ; zip -r ${OUT}/fuzz_bio_seed_corpus.zip .)
 (set -e ; cd fuzz_cred/corpus    ; zip -r ${OUT}/fuzz_cred_seed_corpus.zip .)


### PR DESCRIPTION
CIFuzz was failing and not finding the downloaded corpus, looking
at the logs show:

2020-03-12T15:15:53.2454777Z Running: docker run --rm --privileged --cap-add SYS_PTRACE -e
  FUZZING_ENGINE=libfuzzer -e SANITIZER=address -e ARCHITECTURE=x86_64 -e OUT=/github/workspace/out
  --volumes-from aaad25ec2b6d gcr.io/oss-fuzz/libfido2 /bin/bash -c 'rm -rf /src/libfido2/* && cp -r
    /github/workspace/storage/libfido2 /src && compile'

Note the the rm -rf /src/libfido/* bit.