### PR TITLE
[envoy] fix build

### DIFF
--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -31,6 +31,14 @@ FUZZER_DICTIONARIES="\
 # file. Since the build runs with `-Werror` this will cause it to break, so we
 # use `--conlyopt` and `--cxxopt` instead of `--copt`.
 #
+# NOTE: We ignore -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION. All envoy fuzz
+# targets link this flag through their build target rule. Passing this in via CLI
+# will pass this to genrules that build unit tests that rely on production
+# behavior. Ignore this flag so these unit tests don't fail by using a modified
+# RE2 library.
+# TODO(asraa): Figure out how to work around this better.
+CFLAGS=${CFLAGS//"-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"/}
+CXXFLAGS=${CXXFLAGS//"-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"/}
 declare -r EXTRA_BAZEL_FLAGS="$(
 for f in ${CFLAGS}; do
   echo "--conlyopt=${f}" "--linkopt=${f}"


### PR DESCRIPTION
We had a build issue where CLI bazel flags override the copts set by the bazel build targets. We had unit tests running as a precursor to one fuzz test (that updates the corpus on the fly), and the test fails because a library RE2 modifies it's behavior in fuzz build mode.

This prevents CLI passing of `FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION`, leaving it to the build targets.

Ideally this is not what we should do, and find some way to wrap / ignore this option when building the dependency.

Testing: Ran build locally with updated script.

Signed-off-by: Asra Ali <asraa@google.com>