### PR TITLE
Upgrade lcamtuf.coredump.cx requests to use HTTPS, fixes builds for guetzli, libjpeg-turbo, libtiff, libvips

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ OSS-Fuzz aims to make common open source software more secure and stable by
 combining modern fuzzing techniques with scalable,
 distributed execution.
 
-We support the [libFuzzer](http://llvm.org/docs/LibFuzzer.html) and [AFL](http://lcamtuf.coredump.cx/afl/) fuzzing engines
+We support the [libFuzzer](http://llvm.org/docs/LibFuzzer.html) and [AFL](https://lcamtuf.coredump.cx/afl/) fuzzing engines
 in combination with [Sanitizers](https://github.com/google/sanitizers), as well as
 [ClusterFuzz](https://github.com/google/clusterfuzz),
 a distributed fuzzer execution environment and reporting tool. 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -163,7 +163,7 @@ restore it to the new GCS location later (instruction to find the
 new location [here]({{ site.baseurl }}/advanced-topics/corpora/#viewing-the-corpus-for-a-fuzz-target)).
 
 ## Does OSS-Fuzz support AFL or honggfuzz?
-OSS-Fuzz *uses* both [AFL](http://lcamtuf.coredump.cx/afl/) and
+OSS-Fuzz *uses* both [AFL](https://lcamtuf.coredump.cx/afl/) and
 [honggfuzz](https://github.com/google/honggfuzz)
 [fuzzing engines]({{ site.baseurl }}/reference/glossary/#fuzzing-engine).
 Follow the

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ OSS-Fuzz aims to make common open source software more secure and stable by
 combining modern fuzzing techniques with scalable,
 distributed execution.
 
-We support the [libFuzzer](http://llvm.org/docs/LibFuzzer.html) and [AFL](http://lcamtuf.coredump.cx/afl/) fuzzing engines
+We support the [libFuzzer](http://llvm.org/docs/LibFuzzer.html) and [AFL](https://lcamtuf.coredump.cx/afl/) fuzzing engines
 in combination with [Sanitizers](https://github.com/google/sanitizers), as well as
 [ClusterFuzz](https://github.com/google/clusterfuzz),
 a distributed fuzzer execution environment and reporting tool. 

--- a/projects/guetzli/Dockerfile
+++ b/projects/guetzli/Dockerfile
@@ -19,7 +19,7 @@ MAINTAINER robryk@google.com
 RUN apt-get update && apt-get install -y make autoconf automake libtool libpng-dev pkg-config curl
 
 RUN mkdir afl-testcases
-RUN cd afl-testcases/ && curl http://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz | tar -xz
+RUN cd afl-testcases/ && curl https://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz | tar -xz
 RUN zip guetzli_fuzzer_seed_corpus.zip afl-testcases/jpeg/full/images/* afl-testcases/jpeg_turbo/full/images/* $SRC/libjpeg-turbo/testimages/
 
 RUN git clone --depth=1 https://github.com/google/guetzli guetzli

--- a/projects/imagemagick/Dockerfile
+++ b/projects/imagemagick/Dockerfile
@@ -34,6 +34,6 @@ RUN git clone --depth 1 https://github.com/pnggroup/libpng
 RUN git clone --depth 1 https://github.com/mm2/Little-CMS
 RUN svn export https://github.com/mozillasecurity/fuzzdata.git/trunk/samples/heic heic_corpus
 RUN git clone --depth 1 https://gitlab.com/federicomenaquintero/bzip2.git
-ADD http://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz afl_testcases.tgz
+ADD https://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz afl_testcases.tgz
 WORKDIR imagemagick
 COPY build.sh $SRC/

--- a/projects/libgd/Dockerfile
+++ b/projects/libgd/Dockerfile
@@ -19,6 +19,6 @@ MAINTAINER ossfuzz@tds.xyz
 RUN apt-get update && \
     apt-get install -y make autoconf automake libtool pkg-config libz-dev
 RUN git clone --depth 1 https://github.com/libgd/libgd
-ADD http://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz $SRC/afl_testcases.tgz
+ADD https://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz $SRC/afl_testcases.tgz
 WORKDIR libgd
 COPY build.sh parser_target.cc $SRC/

--- a/projects/libjpeg-turbo/Dockerfile
+++ b/projects/libjpeg-turbo/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool nasm cur
 RUN git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo
 
 RUN mkdir afl-testcases
-RUN cd afl-testcases/ && curl http://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz | tar -xz
+RUN cd afl-testcases/ && curl https://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz | tar -xz
 RUN zip libjpeg_turbo_fuzzer_seed_corpus.zip afl-testcases/jpeg/full/images/* afl-testcases/jpeg_turbo/full/images/* $SRC/libjpeg-turbo/testimages/*
 
 WORKDIR libjpeg-turbo

--- a/projects/libreoffice/Dockerfile
+++ b/projects/libreoffice/Dockerfile
@@ -118,7 +118,7 @@ ADD https://raw.githubusercontent.com/rc0r/afl-fuzz/master/dictionaries/gif.dict
     https://raw.githubusercontent.com/rc0r/afl-fuzz/master/dictionaries/xml.dict \
     https://raw.githubusercontent.com/rc0r/afl-fuzz/master/dictionaries/html_tags.dict $SRC/
 #fuzzing corpuses
-ADD http://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz $SRC/
+ADD https://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz $SRC/
 RUN mkdir afl-testcases && cd afl-testcases/ && tar xf $SRC/afl_testcases.tgz && cd .. && \
     zip -q $SRC/jpgfuzzer_seed_corpus.zip afl-testcases/jpeg*/full/images/* && \
     zip -q $SRC/giffuzzer_seed_corpus.zip afl-testcases/gif*/full/images/* && \

--- a/projects/libtiff/Dockerfile
+++ b/projects/libtiff/Dockerfile
@@ -21,7 +21,7 @@ RUN git clone --depth 1 https://gitlab.com/libtiff/libtiff
 RUN git clone --depth 1 https://github.com/madler/zlib
 RUN git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo
 RUN git clone https://www.cl.cam.ac.uk/~mgk25/git/jbigkit
-ADD http://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz afl_testcases.tgz
+ADD https://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz afl_testcases.tgz
 ADD https://raw.githubusercontent.com/google/AFL/debe27037b9444bbf090a0ffbd5d24889bb887ae/dictionaries/tiff.dict tiff.dict
 WORKDIR libtiff
 COPY build.sh $SRC/

--- a/projects/libvips/Dockerfile
+++ b/projects/libvips/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y \
   libffi-dev \
   glib2.0-dev
 RUN mkdir afl-testcases
-RUN curl http://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz | tar xzC afl-testcases
+RUN curl https://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz | tar xzC afl-testcases
 RUN git clone --depth 1 https://github.com/libvips/libvips
 RUN git clone --depth 1 https://github.com/madler/zlib.git
 RUN git clone --depth 1 https://github.com/libexif/libexif


### PR DESCRIPTION
The lcamtuf.coredump.cx hostname has been accepting HTTPS connections only since around the 13th or 14th March.

This fix will allow the builds for the affected projects to succeed again as they will have been failing for the last week.