### PR TITLE
[tpm2-tss] disable swtpm tcti

### DIFF
--- a/projects/tpm2-tss/build.sh
+++ b/projects/tpm2-tss/build.sh
@@ -28,8 +28,9 @@ export GEN_FUZZ=1
   --enable-debug \
   --with-fuzzing=ossfuzz \
   --enable-tcti-fuzzing \
-  --enable-tcti-device=no \
-  --enable-tcti-mssim=no \
+  --disable-tcti-device \
+  --disable-tcti-mssim \
+  --disable-tcti-swtpm \
   --disable-doxygen-doc \
   --disable-shared \
   --disable-fapi


### PR DESCRIPTION
We need to disable all supported tctis for fuzzing.
This includes recently added swtpm.
Also switch the option from --enable-<module>=no
to preferred --disable-<module>