### PR TITLE
Fix SM builds and use -gline-tables-only for building

### DIFF
--- a/projects/spidermonkey-ufi/build.sh
+++ b/projects/spidermonkey-ufi/build.sh
@@ -38,8 +38,8 @@ mkdir -p build_OPT.OBJ
 cd build_OPT.OBJ
 
 ../configure \
-    --enable-optimize \
-    --disable-shared-js \
+    --enable-debug \
+    --enable-optimize="-O2 -gline-tables-only" \
     --disable-jemalloc \
     --enable-tests \
     --enable-fuzzing \

--- a/projects/spidermonkey/build.sh
+++ b/projects/spidermonkey/build.sh
@@ -30,8 +30,7 @@ cd build_DBG.OBJ
 # Temporarily disable cranelift (see bug 1497570)
 ../configure \
     --enable-debug \
-    --enable-optimize \
-    --disable-shared-js \
+    --enable-optimize="-O2 -gline-tables-only" \
     --disable-jemalloc \
     --disable-tests \
     --enable-address-sanitizer \


### PR DESCRIPTION
This PR changes the following things about Spidermonkey builds:

1) Don't use `--disable-shared-js` as it's currently broken and unsupported.

2) Use `-gline-tables-only` when building to save some disk space

3) Use `--enable-debug` also in the ufi build, so we have assertions enabled.


With these changes, all local builds succeed.