### PR TITLE
Fix SM libFuzzer instrumentation by disabling the new pass manager

### DIFF
--- a/projects/spidermonkey-ufi/build.sh
+++ b/projects/spidermonkey-ufi/build.sh
@@ -37,9 +37,13 @@ autoconf2.13
 mkdir -p build_OPT.OBJ
 cd build_OPT.OBJ
 
+# See https://bugzilla.mozilla.org/show_bug.cgi?id=1625268
+# for information about `--disable-new-pass-manager` below.
+
 ../configure \
     --enable-debug \
-    --enable-optimize="-O2 -gline-tables-only" \
+    --disable-new-pass-manager \
+    --enable-optimize \
     --disable-jemalloc \
     --enable-tests \
     --enable-fuzzing \


### PR DESCRIPTION
Apparently, our use of `-fexperimental-new-pass-manager` breaks libFuzzer in certain situations. I have not figured out yet when or why this happens exactly because our own builds are still functional. But disabling this feature made the oss-fuzz builds work locally. Let's see what CI has to say about it.