### PR TITLE
[ghostscript] Avoid printing raster output to stdout.

### DIFF
--- a/projects/ghostscript/gstoraster_fuzzer.cc
+++ b/projects/ghostscript/gstoraster_fuzzer.cc
@@ -67,7 +67,7 @@ static int gs_to_raster_fuzz(const unsigned char *buf, size_t size)
 		"-dNOINTERPOLATE",
 		"-dNOMEDIAATTRS",
 		"-sstdout=%stderr",
-		"-sOutputFile=%stdout",
+		"-sOutputFile=/dev/null",
 		"-sDEVICE=cups",
 		"-_",
 	};


### PR DESCRIPTION
Previously raster output data was printed on stdout. While this
is similar to how Ghostscript is run by CUPS's gstoraster filter it
unnecessarily prolongs execution time for many files.

Changing the output file still means that CUPS will be sent the
rasterized page and will be asked to convert it to a PWG raster which
it then dutifully writes to /dev/null. Thus no major difference is
expected in what code is executed in Ghostscript (or CUPS).

When run locally on a testcase found among the problematic files here:
gs://ghostscript-corpus.clusterfuzz-external.appspot.com/libFuzzer/
fuzzer target reported a timeout after 120 seconds before this commit.
After this commit the fuzzer target succeeded after about 3 seconds.