### PR TITLE
[bignum-fuzzer] Mbed TLS no longer has an mbed-crypto submodule

### DIFF
--- a/projects/bignum-fuzzer/Dockerfile
+++ b/projects/bignum-fuzzer/Dockerfile
@@ -26,5 +26,5 @@ RUN git clone --depth 1 https://github.com/guidovranken/bignum-fuzzer
 RUN git clone --depth 1 https://github.com/openssl/openssl
 RUN hg clone https://gmplib.org/repo/gmp/ libgmp/
 RUN git clone https://boringssl.googlesource.com/boringssl
-RUN git clone --recursive --depth 1 https://github.com/ARMmbed/mbedtls
+RUN git clone --depth 1 https://github.com/ARMmbed/mbedtls
 COPY build.sh $SRC/

--- a/projects/bignum-fuzzer/build.sh
+++ b/projects/bignum-fuzzer/build.sh
@@ -98,7 +98,7 @@ LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" make
 cp $SRC/bignum-fuzzer/fuzzer $OUT/fuzzer_openssl_libgmp_num_len_1200_all_operations_num_loops_1
 
 # Build mbedtls
-cd $SRC/mbedtls/crypto
+cd $SRC/mbedtls
 make lib -j$(nproc)
 
 # Build BoringSSL
@@ -115,7 +115,7 @@ CFLAGS="$CFLAGS -DBIGNUM_FUZZER_BORINGSSL" OPENSSL_INCLUDE_PATH=$SRC/boringssl/i
 
 # Build mbedtls module
 cd $SRC/bignum-fuzzer/modules/mbedtls
-MBEDTLS_LIBMBEDCRYPTO_A_PATH=$SRC/mbedtls/crypto/library/libmbedcrypto.a MBEDTLS_INCLUDE_PATH=$SRC/mbedtls/crypto/include make
+MBEDTLS_LIBMBEDCRYPTO_A_PATH=$SRC/mbedtls/library/libmbedcrypto.a MBEDTLS_INCLUDE_PATH=$SRC/mbedtls/include make
 
 # Build BoringSSL/mbedtls fuzzer
 cd $SRC/bignum-fuzzer


### PR DESCRIPTION
Mbed TLS has gone back to being self-contained, without a separate
submodule for the cryptography part of the library. Revert the
bignum-fuzzer build scripts accordingly.

This reverts commit 54733ddc84ec73e3c21d6fffc446dbd0fa7a2c5e.