### PR TITLE
[FFmpeg] Add fate samples for demuxer tests

### DIFF
--- a/projects/ffmpeg/build.sh
+++ b/projects/ffmpeg/build.sh
@@ -149,8 +149,8 @@ make -j$(nproc) install
 # TODO: implement a better way to maintain a minimized seed corpora
 # for all targets. As of 2017-05-04 now the combined size of corpora
 # is too big for ClusterFuzz (over 10Gb compressed data).
-# export TEST_SAMPLES_PATH=$SRC/ffmpeg/fate-suite/
-# make fate-rsync SAMPLES=$TEST_SAMPLES_PATH
+export TEST_SAMPLES_PATH=$SRC/ffmpeg/fate-suite/
+make fate-rsync SAMPLES=$TEST_SAMPLES_PATH
 
 # Build the fuzzers.
 cd $SRC/ffmpeg
@@ -184,6 +184,13 @@ fuzzer_name=ffmpeg_DEMUXER_fuzzer
 echo -en "[libfuzzer]\nmax_len = 1000000\n" > $OUT/${fuzzer_name}.options
 make tools/target_dem_fuzzer
 mv tools/target_dem_fuzzer $OUT/${fuzzer_name}
+
+# We do not need raw reference files for the muxer
+rm `find fate-suite -name '*.s16'`
+rm `find fate-suite -name '*.dec'`
+rm `find fate-suite -name '*.pcm'`
+
+zip -r $OUT/${fuzzer_name}_seed_corpus.zip fate-suite
 
 # Find relevant corpus in test samples and archive them for every fuzzer.
 #cd $SRC


### PR DESCRIPTION
This should add the fate samples as seeds for the libavformat test, iam not 100% sure that works as the
local docker seems not to use the seed corpus locally specified and there
are options to stop it from downloading from google cloud and specifying a local
directory, which is how it was tested.

Another problem could be docs/getting-started/new_project_guide.md which says

"Seed corpus files will be used for cross-mutations and portions of them might appear
in bug reports or be used for further security research. It is important that corpus
has an appropriate and consistent license."

Now google themselfs added the original code using this and then
disabled it because of space. But yeah i dunno if this is ok or not.