### PR TITLE
Adding Libucl project

### DIFF
--- a/projects/libucl/Dockerfile
+++ b/projects/libucl/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER adam@adalogics.com
+RUN apt-get update && apt-get install -y make cmake autoconf pkg-config libtool
+RUN git clone https://github.com/vstakhov/libucl
+
+WORKDIR $SRC
+
+COPY build.sh $SRC/

--- a/projects/libucl/build.sh
+++ b/projects/libucl/build.sh
@@ -18,4 +18,5 @@ cd libucl
 ./autogen.sh && ./configure
 make
 
+
 $CC tests/fuzzers/ucl_add_string_fuzzer.c -DHAVE_CONFIG_H -I./src -I./include src/.libs/libucl.a -I./  $CFLAGS $LIB_FUZZING_ENGINE -o $OUT/ucl_add_string_fuzzer

--- a/projects/libucl/build.sh
+++ b/projects/libucl/build.sh
@@ -1,0 +1,21 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd libucl 
+./autogen.sh && ./configure
+make
+
+$CC tests/fuzzers/ucl_add_string_fuzzer.c -DHAVE_CONFIG_H -I./src -I./include src/.libs/libucl.a -I./  $CFLAGS $LIB_FUZZING_ENGINE -o $OUT/ucl_add_string_fuzzer

--- a/projects/libucl/build.sh
+++ b/projects/libucl/build.sh
@@ -14,9 +14,10 @@
 #
 ################################################################################
 
+export ASAN_OPTIONS=detect_leaks=0
+
 cd libucl 
 ./autogen.sh && ./configure
 make
-
 
 $CC tests/fuzzers/ucl_add_string_fuzzer.c -DHAVE_CONFIG_H -I./src -I./include src/.libs/libucl.a -I./  $CFLAGS $LIB_FUZZING_ENGINE -o $OUT/ucl_add_string_fuzzer

--- a/projects/libucl/project.yaml
+++ b/projects/libucl/project.yaml
@@ -1,3 +1,6 @@
 homepage: "https://github.com/vstakhov/libucl"
 primary_contact: "adam@adalogics.com"
 language: c
+
+fuzzing_engines:
+        - libfuzzer

--- a/projects/libucl/project.yaml
+++ b/projects/libucl/project.yaml
@@ -1,5 +1,8 @@
 homepage: "https://github.com/vstakhov/libucl"
-primary_contact: "adam@adalogics.com"
+primary_contact: "vsevolod@highsecure.ru"
+auto_ccs:
+        - "adam@adalogics.com"
+
 language: c
 
 fuzzing_engines:

--- a/projects/libucl/project.yaml
+++ b/projects/libucl/project.yaml
@@ -1,0 +1,3 @@
+homepage: "https://github.com/vstakhov/libucl"
+primary_contact: "adam@adalogics.com"
+language: c


### PR DESCRIPTION
Have talked with the maintainers of Libucl,  which is a popular universal configuration library parser, and they are happy to integrate with OSS-fuzz.

The fuzzer for this project has been committed to the upstream repository and the pull request can be found here: https://github.com/vstakhov/libucl/pull/214

Waiting for email address of the maintainers for bug reports and once I get it I will commit it.