### PR TITLE
xmlsec: Install and link xmlsec against it

### DIFF
--- a/projects/xmlsec/Dockerfile
+++ b/projects/xmlsec/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config \
-    libssl-dev libxslt-dev wget
+    libssl-dev libxslt-dev wget liblzma-dev
 
 RUN git clone --depth 1 https://github.com/lsh123/xmlsec
 RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/libxml2.git

--- a/projects/xmlsec/build.sh
+++ b/projects/xmlsec/build.sh
@@ -45,7 +45,7 @@ for file in $SRC/xmlsec/tests/oss-fuzz/*_target.c; do
     $CXX $CXXFLAGS $OUT/${b}_target.o ./src/.libs/libxmlsec1.a \
     ./src/openssl/.libs/libxmlsec1-openssl.a $LIB_FUZZING_ENGINE \
     "$XMLSEC_DEPS_PATH"/lib/libxslt.a "$XMLSEC_DEPS_PATH"/lib/libxml2.a \
-    -lz -o $OUT/${b}_fuzzer
+    -lz -llzma -o $OUT/${b}_fuzzer
 done
 cp $SRC/xmlsec/tests/oss-fuzz/config/*.options $OUT/
 wget -O $OUT/xml.dict https://raw.githubusercontent.com/mirrorer/afl/master/dictionaries/xml.dict


### PR DESCRIPTION
Fixes xmlsec build failure flagged in https://github.com/google/oss-fuzz/issues/3479#issue-577288248

Turns out xmlsec now depends on liblzma.