### PR TITLE
[ghostscript] Use official git server URL.

### DIFF
--- a/projects/ghostscript/Dockerfile
+++ b/projects/ghostscript/Dockerfile
@@ -19,7 +19,7 @@ MAINTAINER skau@google.com
 
 RUN apt-get update && apt-get install -y autoconf zlibc libtool liblcms2-dev libpng-dev libtiff-dev
 RUN git clone --branch branch-2.2 --single-branch --depth 1 https://github.com/apple/cups.git cups
-RUN git clone --branch VER-2-10-1 --single-branch --depth 1 https://git.savannah.nongnu.org/git/freetype/freetype2.git freetype
+RUN git clone --branch VER-2-10-1 --single-branch --depth 1 https://git.sv.nongnu.org/r/freetype/freetype2.git freetype
 RUN git clone --single-branch --depth 1 git://git.ghostscript.com/ghostpdl.git ghostpdl
 
 RUN mkdir ghostpdl/fuzz


### PR DESCRIPTION
This is the correct URL according to https://www.freetype.org/developer.html

This resolves the HTTP 502 error from the git server.