### PR TITLE
[ghostscript] Build using the bundled tiff and jpeg libraries.

### DIFF
--- a/projects/ghostscript/Dockerfile
+++ b/projects/ghostscript/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER skau@google.com
 
-RUN apt-get update && apt-get install -y autoconf zlibc libtool liblcms2-dev libpng-dev libtiff-dev
+RUN apt-get update && apt-get install -y autoconf zlibc libtool liblcms2-dev libpng-dev
 RUN git clone --branch branch-2.2 --single-branch --depth 1 https://github.com/apple/cups.git cups
 RUN git clone --branch VER-2-10-1 --single-branch --depth 1 https://git.savannah.nongnu.org/git/freetype/freetype2.git freetype
 RUN git clone --single-branch --depth 1 git://git.ghostscript.com/ghostpdl.git ghostpdl

--- a/projects/ghostscript/build.sh
+++ b/projects/ghostscript/build.sh
@@ -33,7 +33,6 @@ cd ghostpdl
 rm -rf cups/libs || die
 rm -rf freetype || die
 rm -rf libpng || die
-rm -rf tiff || die
 rm -rf zlib || die
 
 mv ../freetype freetype


### PR DESCRIPTION
The previous configuration tried to use the system tiff library with
the bundled jpeg library. That configuration is not supported by
Ghostscript.