### PR TITLE
[jbig2dec] Limit allocations to 1Gbyte.

### DIFF
--- a/projects/jbig2dec/jbig2_fuzzer.cc
+++ b/projects/jbig2dec/jbig2_fuzzer.cc
@@ -26,7 +26,7 @@
 #define ALIGNMENT 16
 #define MBYTE (1024 * 1024)
 #define GBYTE (1024 * MBYTE)
-#define MAX_ALLOCATION (3 * GBYTE)
+#define MAX_ALLOCATION (1 * GBYTE)
 
 static uint64_t total = 0;
 static uint64_t peak = 0;


### PR DESCRIPTION
Apparently the maximum memory usage is 2.5Gbyte so a limit of 3Gbyte
is to liberal. Set limit to 1Gbyte to make sure that any extra memory
used by the fuzzer is allowed. 1Gbyte ought to be enough for most real
world images decoded by jbig2dec.