### PR TITLE
Update flags and enable new sanitizer

### DIFF
--- a/projects/ghostscript/gstoraster_fuzzer.cc
+++ b/projects/ghostscript/gstoraster_fuzzer.cc
@@ -58,6 +58,8 @@ static int gs_to_raster_fuzz(const unsigned char *buf, size_t size)
 		"gs",
 		"-K1048576",
 		"-r200x200",
+		"-dMaxBitmap=0",
+		"-dBufferSpace=450k",
 		"-dMediaPosition=1",
 		"-dcupsColorSpace=1", /* RGB */
 		"-dQUIET",

--- a/projects/ghostscript/gstoraster_fuzzer.cc
+++ b/projects/ghostscript/gstoraster_fuzzer.cc
@@ -61,7 +61,7 @@ static int gs_to_raster_fuzz(const unsigned char *buf, size_t size)
 		"-dMediaPosition=1",
 		"-dcupsColorSpace=1", /* RGB */
 		"-dQUIET",
-		"-dPARANOIDSAFER",
+		"-dSAFER",
 		"-dNOPAUSE",
 		"-dBATCH",
 		"-dNOINTERPOLATE",

--- a/projects/ghostscript/project.yaml
+++ b/projects/ghostscript/project.yaml
@@ -8,3 +8,4 @@ auto_ccs:
   - "julians.artifex@gmail.com"
 sanitizers:
   - address
+  - memory


### PR DESCRIPTION
Several flags for Ghostscript should be updated, and we also want to enable the memory sanitizer to see what falls out.