### PR TITLE
Revert "[Envoy][Oak] Use older builder image with older clang to build

### DIFF
--- a/projects/envoy/Dockerfile
+++ b/projects/envoy/Dockerfile
@@ -14,9 +14,7 @@
 #
 ################################################################################
 
-# TODO(https://github.com/google/oss-fuzz/issues/3093): Stop specifying the
-# image SHA once the bug is fixed.
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:276813aef0ce5972db43c0230f96162003994fa742fb1b2f4e66c67498575c65
+FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER htuch@google.com
 
 RUN apt-get update && apt-get -y install  \

--- a/projects/oak/Dockerfile
+++ b/projects/oak/Dockerfile
@@ -14,9 +14,7 @@
 #
 ################################################################################
 
-# TODO(https://github.com/google/oss-fuzz/issues/3093): Stop specifying the
-# image SHA once the bug is fixed.
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:276813aef0ce5972db43c0230f96162003994fa742fb1b2f4e66c67498575c65
+FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER tzn@google.com
 
 # Use a fixed Bazel version.


### PR DESCRIPTION
Related to #3157

This reverts commit 0a5cd93182be0ca8724346da9613bedc4bee1955.