### PR TITLE
[infra] Build LLD inside base-clang image.

### DIFF
--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -87,7 +87,7 @@ case $(uname -m) in
         ;;
 esac
 
-PROJECTS_TO_BUILD="libcxx;libcxxabi;compiler-rt;clang"
+PROJECTS_TO_BUILD="libcxx;libcxxabi;compiler-rt;clang;lld"
 cmake -G "Ninja" \
       -DLIBCXX_ENABLE_SHARED=OFF -DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON -DLIBCXXABI_ENABLE_SHARED=OFF \
       -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD="$TARGET_TO_BUILD" \


### PR DESCRIPTION
Some project may prefer using LLD. I'm not sure this is 100% safe, but should be fine to try on per project basis.

We did try it a while ago but ended up reverting: https://github.com/google/oss-fuzz/issues/295

I suspect that things should've changed by now, as Chromium is using LLD.

@kcc @morehouse do you anticipate any issues?