### PR TITLE
[systemd] remove my non-gmail address

### DIFF
--- a/projects/systemd/project.yaml
+++ b/projects/systemd/project.yaml
@@ -11,7 +11,6 @@ auto_ccs:
   - dimitri.ledkov@canonical.com
   - poettering@gmail.com
   - watanabe.yu@gmail.com
-  - evvers@ya.ru
   - evverx@gmail.com
   - Tixxdz@gmail.com
   - fsumsal@redhat.com


### PR DESCRIPTION
It doesn't seem to make much sense to keep non-gmail addresses there.

https://github.com/google/oss-fuzz/issues/3576
https://bugs.chromium.org/p/monorail/issues/detail?id=7461