### PR TITLE
[honggfuzz] Enable honggfuzz for 19 more projects (fixes #3591).

### DIFF
--- a/projects/brotli/project.yaml
+++ b/projects/brotli/project.yaml
@@ -7,6 +7,7 @@ vendor_ccs:
 fuzzing_engines:
   - libfuzzer
   - afl
+  - honggfuzz
   - dataflow
 sanitizers:
   - address

--- a/projects/bzip2/project.yaml
+++ b/projects/bzip2/project.yaml
@@ -8,6 +8,7 @@ vendor_ccs:
 fuzzing_engines:
   - libfuzzer
   - afl
+  - honggfuzz
   - dataflow
 sanitizers:
   - address

--- a/projects/django/project.yaml
+++ b/projects/django/project.yaml
@@ -7,5 +7,6 @@ auto_ccs:
  - "jammamarkus@gmail.com"
 fuzzing_engines:
   - libfuzzer
+  - honggfuzz
 sanitizers:
  - undefined

--- a/projects/dropbear/project.yaml
+++ b/projects/dropbear/project.yaml
@@ -6,4 +6,5 @@ sanitizers:
   - undefined
   - memory
 fuzzing_engines:
-   - libfuzzer
+  - libfuzzer
+  - honggfuzz

--- a/projects/firefox/project.yaml
+++ b/projects/firefox/project.yaml
@@ -6,6 +6,7 @@ auto_ccs:
   - sledru@mozilla.com
 fuzzing_engines:
   - libfuzzer
+  - honggfuzz
 sanitizers:
   - address
   - undefined

--- a/projects/fuzzing-puzzles/build.sh
+++ b/projects/fuzzing-puzzles/build.sh
@@ -16,5 +16,5 @@
 ################################################################################
 
 $CXX $CXXFLAGS $SRC/fuzzing-puzzles/MultipleConstraintsOnSmallInputTest.cpp \
-    -o $OUT/multiple_constraints_on_small_input_afl_fuzzer \
+    -o $OUT/multiple_constraints_on_small_input_honggfuzz_fuzzer \
     $LIB_FUZZING_ENGINE

--- a/projects/fuzzing-puzzles/project.yaml
+++ b/projects/fuzzing-puzzles/project.yaml
@@ -2,8 +2,6 @@ homepage: https://github.com/google/fuzzer-test-suite
 language: c++
 primary_contact: kcc@google.com
 auto_ccs:
-  - "kevinwkt@google.com"
-  - "kodewilliams@google.com"
   - "metzman@google.com"
   - "mmoroz@google.com"
 
@@ -11,6 +9,4 @@ sanitizers:
   - address
 
 fuzzing_engines:
-  - afl
-
-disabled: True
+  - honggfuzz

--- a/projects/libexif/project.yaml
+++ b/projects/libexif/project.yaml
@@ -7,6 +7,7 @@ auto_ccs:
 fuzzing_engines:
   - libfuzzer
   - afl
+  - honggfuzz
   - dataflow
 sanitizers:
   - address

--- a/projects/libucl/project.yaml
+++ b/projects/libucl/project.yaml
@@ -1,9 +1,8 @@
 homepage: "https://github.com/vstakhov/libucl"
 primary_contact: "vsevolod@highsecure.ru"
 auto_ccs:
-        - "adam@adalogics.com"
-
+  - "adam@adalogics.com"
 language: c
-
 fuzzing_engines:
-        - libfuzzer
+  - libfuzzer
+  - honggfuzz

--- a/projects/libyaml/project.yaml
+++ b/projects/libyaml/project.yaml
@@ -6,6 +6,7 @@ auto_ccs:
 fuzzing_engines:
   - libfuzzer
   - afl
+  - honggfuzz
   - dataflow
 sanitizers:
   - address

--- a/projects/llvm/project.yaml
+++ b/projects/llvm/project.yaml
@@ -20,9 +20,9 @@ sanitizers:
   - address
   - memory
 
-# The LLVM build currently supports only libFuzzer
 fuzzing_engines:
-    - libfuzzer
+  - libfuzzer
+  - honggfuzz
 
 # Bug reports are public by default:
 view_restrictions: none

--- a/projects/mysql-server/project.yaml
+++ b/projects/mysql-server/project.yaml
@@ -1,15 +1,15 @@
 homepage: "https://www.mysql.com"
 language: c++
 primary_contact: "secalert_us@oracle.com"
-auto_ccs :
-- "p.antoine@catenacyber.fr"
-- "christopher.alves@telecomnancy.net"
-- "zouhair.janati-idrissi@telecomnancy.net"
-- "julien.zhan@telecomnancy.net"
+auto_ccs:
+  - "p.antoine@catenacyber.fr"
+  - "christopher.alves@telecomnancy.net"
+  - "zouhair.janati-idrissi@telecomnancy.net"
+  - "julien.zhan@telecomnancy.net"
 
 fuzzing_engines:
-- libfuzzer
+  - libfuzzer
+  - honggfuzz
 sanitizers:
-- address
-  # - memory
-- undefined
+  - address
+  - undefined

--- a/projects/nss/project.yaml
+++ b/projects/nss/project.yaml
@@ -6,6 +6,3 @@ auto_ccs:
   - "tvandermerwe@mozilla.com"
   - "sledru@mozilla.com"
   - "kjacobs@mozilla.com"
-fuzzing_engines:
-  - libfuzzer
-  - afl

--- a/projects/openjpeg/project.yaml
+++ b/projects/openjpeg/project.yaml
@@ -6,8 +6,10 @@ auto_ccs:
 fuzzing_engines:
   - libfuzzer
   - afl
+  - honggfuzz
   - dataflow
 sanitizers:
   - address
+  - memory
   - dataflow
   - undefined

--- a/projects/perfetto/project.yaml
+++ b/projects/perfetto/project.yaml
@@ -16,5 +16,6 @@ vendor_ccs:
   - mikelogan@google.com
 fuzzing_engines:
   - libfuzzer
+  - honggfuzz
 sanitizers:
   - address

--- a/projects/pffft/project.yaml
+++ b/projects/pffft/project.yaml
@@ -7,6 +7,7 @@ auto_ccs:
 fuzzing_engines:
   - libfuzzer
   - afl
+  - honggfuzz
   - dataflow
 sanitizers:
   - address

--- a/projects/pillow/project.yaml
+++ b/projects/pillow/project.yaml
@@ -10,3 +10,4 @@ architectures:
  - x86_64
 fuzzing_engines:
   - libfuzzer
+  - honggfuzz

--- a/projects/python3-libraries/project.yaml
+++ b/projects/python3-libraries/project.yaml
@@ -7,6 +7,7 @@ auto_ccs:
  - "ammar@ammaraskar.com"
 fuzzing_engines:
   - libfuzzer
+  - honggfuzz
 sanitizers:
  - address
  - undefined

--- a/projects/samba/project.yaml
+++ b/projects/samba/project.yaml
@@ -10,6 +10,7 @@ auto_ccs:
   - "gdeschner@gmail.com"
 fuzzing_engines:
   - libfuzzer
+  - honggfuzz
 sanitizers:
   - address
   - undefined

--- a/projects/tesseract-ocr/project.yaml
+++ b/projects/tesseract-ocr/project.yaml
@@ -3,3 +3,4 @@ language: c++
 primary_contact: "stjoweil@googlemail.com"
 fuzzing_engines:
   - libfuzzer
+  - honggfuzz

--- a/projects/xz/project.yaml
+++ b/projects/xz/project.yaml
@@ -6,6 +6,7 @@ auto_ccs:
 fuzzing_engines:
   - libfuzzer
   - afl
+  - honggfuzz
   - dataflow
 sanitizers:
   - address


### PR DESCRIPTION
Also enabled msan for openjpeg and re-enabled fuzzing-puzzles project to see if honggfuzz could crack it. I may need to remove the existing corpora though.

Travis will likely time out so I'll just TBR this later today.

I've built all these projects on GCB and they have at least one build archived now.