### PR TITLE
[ghostscript] Make sure that all state kept in memory.

### DIFF
--- a/projects/ghostscript/gstoraster_fuzzer.cc
+++ b/projects/ghostscript/gstoraster_fuzzer.cc
@@ -58,6 +58,7 @@ static int gs_to_raster_fuzz(const unsigned char *buf, size_t size)
 		"gs",
 		"-K1048576",
 		"-r200x200",
+		"-sBandListStorage=memory",
 		"-dMaxBitmap=0",
 		"-dBufferSpace=450k",
 		"-dMediaPosition=1",


### PR DESCRIPTION
The default setting allows for state to be temporarily saved to disk.
This is likely to interfere with the fuzzer's knowledge about state of data.