### PR TITLE
[ghostscript] Enable flag also used in valgrind builds.

### DIFF
--- a/projects/ghostscript/build.sh
+++ b/projects/ghostscript/build.sh
@@ -43,7 +43,7 @@ CUPS_LDFLAGS=$($CUPSCONFIG --ldflags)
 CUPS_LIBS=$($CUPSCONFIG --image --libs)
 export CXXFLAGS="$CXXFLAGS $CUPS_CFLAGS"
 
-CPPFLAGS="${CPPFLAGS:-} $CUPS_CFLAGS" ./autogen.sh \
+CPPFLAGS="${CPPFLAGS:-} $CUPS_CFLAGS -DPACIFY_VALGRIND" ./autogen.sh \
   CUPSCONFIG=$CUPSCONFIG \
   --enable-freetype --enable-fontconfig \
   --enable-cups --with-ijs --with-jbig2dec \


### PR DESCRIPTION
Valgrind may complain when software reads out partially uninitialized data
and stores it elsewhere, but only reads the initialized parts from this
latter location. The flag enables code that initializes all the data to
avoid valgrind reporting false positives. Presumably MSAN suffers from
similar issues so, try enabling this flag.