### PR TITLE
switch to cmake, find new headers

### DIFF
--- a/projects/json-c/Dockerfile
+++ b/projects/json-c/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER chriswwolfe@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get install -y make cmake
 RUN git clone --depth 1 https://github.com/json-c/json-c.git json-c
 WORKDIR json-c
 COPY build.sh *.cc *.dict $SRC/

--- a/projects/json-c/build.sh
+++ b/projects/json-c/build.sh
@@ -14,17 +14,17 @@
 # limitations under the License.
 #
 ################################################################################
-
-./autogen.sh
-./configure --enable-static --disable-shared
-make -j$(nproc) all
-ar rc json_c.a *.o
+mkdir json-c-build
+cd json-c-build
+cmake -DBUILD_SHARED_LIBS=OFF ..
+make -j$(nproc)
+cd ..
 
 cp $SRC/*.dict $OUT/
 
 for f in $SRC/*_fuzzer.cc; do
     fuzzer=$(basename "$f" _fuzzer.cc)
-    $CXX $CXXFLAGS -std=c++11 -I$SRC/json-c \
+    $CXX $CXXFLAGS -std=c++11 -I$SRC/json-c -I$SRC/json-c/json-c-build\
          $SRC/${fuzzer}_fuzzer.cc -o $OUT/${fuzzer}_fuzzer \
-         $LIB_FUZZING_ENGINE $SRC/json-c/json_c.a
+         $LIB_FUZZING_ENGINE $SRC/json-c/json-c-build/libjson-c.a
 done


### PR DESCRIPTION
This fixes a recent build failure. Upstream has moved to using cmake and the fuzzers in oss-fuzz were still using the autogen.sh build. 