### PR TITLE
[cryptofuzz] Enable libsodium again

### DIFF
--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -41,6 +41,7 @@ RUN git clone --depth 1 https://github.com/wolfSSL/wolfssl.git
 RUN git clone --depth 1 https://github.com/ARMmbed/mbed-crypto.git
 RUN hg clone https://hg.mozilla.org/projects/nspr
 RUN hg clone https://hg.mozilla.org/projects/nss
+RUN git clone --depth 1 https://github.com/jedisct1/libsodium.git
 RUN apt-get remove -y libunwind8
 RUN apt-get install -y libssl-dev
 

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -185,28 +185,22 @@ then
     make -B
 fi
 
-##############################################################################
-# libsodium is currently disabled due to crashes whose cause
-# is not entirely clear.
-# It will be enabled again once the problem has been resolved.
-# See also: https://github.com/jedisct1/libsodium/issues/859
-#
-#if [[ $CFLAGS != *sanitize=memory* ]]
-#then
-#    # Compile libsodium (with assembly)
-#    cd $SRC/libsodium
-#    autoreconf -ivf
-#    ./configure
-#    make -j$(nproc) >/dev/null 2>&1
-#
-#    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_LIBSODIUM"
-#    export LIBSODIUM_A_PATH="$SRC/libsodium/src/libsodium/.libs/libsodium.a"
-#    export LIBSODIUM_INCLUDE_PATH="$SRC/libsodium/src/libsodium/include"
-#
-#    # Compile Cryptofuzz libsodium (with assembly) module
-#    cd $SRC/cryptofuzz/modules/libsodium
-#    make -B
-#fi
+if [[ $CFLAGS != *sanitize=memory* ]]
+then
+    # Compile libsodium (with assembly)
+    cd $SRC/libsodium
+    autoreconf -ivf
+    ./configure
+    make -j$(nproc) >/dev/null 2>&1
+
+    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_LIBSODIUM"
+    export LIBSODIUM_A_PATH="$SRC/libsodium/src/libsodium/.libs/libsodium.a"
+    export LIBSODIUM_INCLUDE_PATH="$SRC/libsodium/src/libsodium/include"
+
+    # Compile Cryptofuzz libsodium (with assembly) module
+    cd $SRC/cryptofuzz/modules/libsodium
+    make -B
+fi
 
 if [[ $CFLAGS != *sanitize=memory* && $CFLAGS != *-m32* ]]
 then


### PR DESCRIPTION
This was broken previously but it should work now: https://github.com/google/oss-fuzz/issues/2836#issuecomment-538480084