### PR TITLE
[ESPv2] Use latest base-builder image

### DIFF
--- a/projects/esp-v2/Dockerfile
+++ b/projects/esp-v2/Dockerfile
@@ -16,9 +16,7 @@
 
 ## This file was copied from envoy (with minor changes).
 
-# TODO(https://github.com/google/oss-fuzz/issues/3093): Stop specifying the
-# image SHA once the bug is fixed.
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:276813aef0ce5972db43c0230f96162003994fa742fb1b2f4e66c67498575c65
+FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER nareddyt@google.com
 
 RUN apt-get update && apt-get -y install  \


### PR DESCRIPTION
No need for workaround since ESPv2 was updated to Bazel 3.0.0

Ref: #3093
Signed-off-by: Teju Nareddy <nareddyt@google.com>