### PR TITLE
Fixed broken build of nanopb and switched to pip3

### DIFF
--- a/projects/nanopb/Dockerfile
+++ b/projects/nanopb/Dockerfile
@@ -16,8 +16,8 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER jpa@npb.mail.kapsi.fi
-RUN apt-get update && apt-get install -y python-pip git scons
-RUN pip install protobuf grpcio-tools
+RUN apt-get update && apt-get install -y python3-pip git scons wget
+RUN python3 -m pip install --upgrade pip
 RUN git clone --depth 1 https://github.com/nanopb/nanopb $SRC/nanopb
 COPY build.sh $SRC/
 

--- a/projects/nanopb/build.sh
+++ b/projects/nanopb/build.sh
@@ -15,6 +15,12 @@
 #
 ################################################################################
 
+wget "https://repo.anaconda.com/archive/Anaconda3-2020.02-Linux-x86_64.sh"
+bash "Anaconda3-2020.02-Linux-x86_64.sh" -b
+export PATH=~/anaconda3/bin:$PATH
+conda install protobuf -y
+pip3 install grpcio-tools
+
 cd $SRC/nanopb/tests
 
 # Build seed corpus.


### PR DESCRIPTION
This PR fixes the docker image which wasn't building.
Switched to pip3 in the process.