### PR TITLE
[ESPv2] Fix coverage build

### DIFF
--- a/projects/esp-v2/project.yaml
+++ b/projects/esp-v2/project.yaml
@@ -8,4 +8,4 @@ auto_ccs:
 sanitizers:
 - address
 - undefined
-coverage_extra_args: -ignore-filename-regex=.*\.cache.*esp-v2_deps_cache.*
+coverage_extra_args: -ignore-filename-regex=.*\.cache.* -ignore-filename-regex=.*bazel-out.*


### PR DESCRIPTION
Coverage reports previously included external dependencies. But some bazel directories have symlinks that cause lcov to check invalid directories.

Remove reports for external files. We only want reports for the files in our repository.

Verified with the following command:

```
python infra/helper.py coverage esp-v2 -- -ignore-filename-regex='.*\.cache.*' -ignore-filename-regex='.*bazel-out.*'
```