### PR TITLE
bisector: Preserve file metadata when copying /src to host.

### DIFF
--- a/infra/build_specified_commit.py
+++ b/infra/build_specified_commit.py
@@ -39,6 +39,7 @@ def copy_src_from_docker(project_name, host_dir):
       image_name,
       'cp',
       '-r',
+      '-p',
       '/src',
       '/out',
   ]


### PR DESCRIPTION
Otherwise changed timestamps may cause build issues.