### PR TITLE
bisector: raise exceptions when building new or old commit fails.

### DIFF
--- a/infra/bisector.py
+++ b/infra/bisector.py
@@ -123,9 +123,10 @@ def bisect(old_commit, new_commit, test_case_path, fuzz_target, build_data):  # 
     old_idx = len(commit_list) - 1
     new_idx = 0
     logging.info('Testing against new_commit (%s)', commit_list[new_idx])
-    build_specified_commit.build_fuzzers_from_commit(commit_list[new_idx],
-                                                     bisect_repo_manager,
-                                                     host_src_dir, build_data)
+    if not build_specified_commit.build_fuzzers_from_commit(
+        commit_list[new_idx], bisect_repo_manager, host_src_dir, build_data):
+      raise RuntimeError('Failed to build new_commit')
+
     expected_error_code = helper.reproduce_impl(build_data.project_name,
                                                 fuzz_target, False, [], [],
                                                 test_case_path)
@@ -133,12 +134,13 @@ def bisect(old_commit, new_commit, test_case_path, fuzz_target, build_data):  # 
     # Check if the error is persistent through the commit range
     if old_commit:
       logging.info('Testing against old_commit (%s)', commit_list[old_idx])
-      build_specified_commit.build_fuzzers_from_commit(
+      if not build_specified_commit.build_fuzzers_from_commit(
           commit_list[old_idx],
           bisect_repo_manager,
           host_src_dir,
           build_data,
-      )
+      ):
+        raise RuntimeError('Failed to build old_commit')
 
       if expected_error_code == helper.reproduce_impl(build_data.project_name,
                                                       fuzz_target, False, [],

--- a/infra/build_specified_commit.py
+++ b/infra/build_specified_commit.py
@@ -59,14 +59,15 @@ def build_fuzzers_from_commit(commit, build_repo_manager, host_src_path,
     0 on successful build or error code on failure.
   """
   build_repo_manager.checkout_commit(commit)
-  return helper.build_fuzzers_impl(project_name=build_data.project_name,
-                                   clean=True,
-                                   engine=build_data.engine,
-                                   sanitizer=build_data.sanitizer,
-                                   architecture=build_data.architecture,
-                                   env_to_add=None,
-                                   source_path=host_src_path,
-                                   mount_location=os.path.join('/src'))
+  result = helper.build_fuzzers_impl(project_name=build_data.project_name,
+                                     clean=True,
+                                     engine=build_data.engine,
+                                     sanitizer=build_data.sanitizer,
+                                     architecture=build_data.architecture,
+                                     env_to_add=None,
+                                     source_path=host_src_path,
+                                     mount_location=os.path.join('/src'))
+  return result == 0
 
 
 def detect_main_repo(project_name, repo_name=None, commit=None):


### PR DESCRIPTION
Let build failures continue during the actual bisection for now to keep
the bisection going. A future PR can improve the logic of that when it
happens.