### PR TITLE
[Go] remove "-lpthread" flag from "compile_fuzzer" and fix comments (#2714).

### DIFF
--- a/docs/getting-started/new-project-guide/go_lang.md
+++ b/docs/getting-started/new-project-guide/go_lang.md
@@ -82,11 +82,11 @@ function compile_fuzzer {
   function=$2
   fuzzer=$3
 
-   # Instrument all Go files relevant to this fuzzer
+  # Compile and instrument all Go files relevant to this fuzz target.
   go-fuzz -func $function -o $fuzzer.a $path
 
-   # Instrumented, compiled Go ($fuzzer.a) + fuzzing engine = fuzzer binary
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -lpthread -o $OUT/$fuzzer
+  # Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
 }
 
 compile_fuzzer ./pkg/compiler Fuzz compiler_fuzzer

--- a/projects/go-attestation/build.sh
+++ b/projects/go-attestation/build.sh
@@ -15,20 +15,23 @@
 #
 ################################################################################
 
-# Based on the function from oss-fuzz/projects/golang/build.sh script.
 function compile_fuzzer {
   package=$1
   function=$2
   fuzzer=$3
 
-   # Instrument all Go files relevant to this fuzzer
+  # Compile and instrument all Go files relevant to this fuzz target.
   go-fuzz -func $function -o $fuzzer.a $package
 
-   # Instrumented, compiled Go ($fuzzer.a) + fuzzing engine = fuzzer binary
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -lpthread -o $OUT/$fuzzer
+  # Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
 }
 
-compile_fuzzer github.com/google/go-attestation/attest FuzzParseEventLog parse_event_log_fuzzer
-compile_fuzzer github.com/google/go-attestation/attest FuzzParseAKPublic12 parse_ak_public12_fuzzer
-compile_fuzzer github.com/google/go-attestation/attest FuzzParseAKPublic20 parse_ak_public20_fuzzer
-compile_fuzzer github.com/google/go-attestation/attest FuzzParseEKCertificate parse_ek_certificate_fuzzer
+compile_fuzzer github.com/google/go-attestation/attest FuzzParseEventLog \
+    parse_event_log_fuzzer
+compile_fuzzer github.com/google/go-attestation/attest FuzzParseAKPublic12 \
+    parse_ak_public12_fuzzer
+compile_fuzzer github.com/google/go-attestation/attest FuzzParseAKPublic20 \
+    parse_ak_public20_fuzzer
+compile_fuzzer github.com/google/go-attestation/attest FuzzParseEKCertificate \
+    parse_ek_certificate_fuzzer

--- a/projects/go-dns/build.sh
+++ b/projects/go-dns/build.sh
@@ -28,5 +28,5 @@ function compile_fuzzer {
 }
 
 # Same as usual except for added -tags fuzz.
-compile_fuzzer /root/go/src/github.com/miekg/dns/ FuzzNewRR fuzz_newrr
-compile_fuzzer /root/go/src/github.com/miekg/dns/ Fuzz fuzz_msg_unpack
+compile_fuzzer github.com/miekg/dns FuzzNewRR fuzz_newrr
+compile_fuzzer github.com/miekg/dns Fuzz fuzz_msg_unpack

--- a/projects/go-dns/build.sh
+++ b/projects/go-dns/build.sh
@@ -15,19 +15,18 @@
 #
 ################################################################################
 
-# build target function
 function compile_fuzzer {
   path=$1
   function=$2
   fuzzer=$3
 
-   # Instrument all Go files relevant to this fuzzer
+  # Compile and instrument all Go files relevant to this fuzz target.
   go-fuzz -tags fuzz -func $function -o $fuzzer.a $path
 
-   # Instrumented, compiled Go ($fuzzer.a) + fuzzing engine = fuzzer binary
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -lpthread -o $OUT/$fuzzer
+  # Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
 }
 
-#same as usual except for added -tags fuzz
+# Same as usual except for added -tags fuzz.
 compile_fuzzer /root/go/src/github.com/miekg/dns/ FuzzNewRR fuzz_newrr
 compile_fuzzer /root/go/src/github.com/miekg/dns/ Fuzz fuzz_msg_unpack

--- a/projects/go-json-iterator/build.sh
+++ b/projects/go-json-iterator/build.sh
@@ -15,17 +15,16 @@
 #
 ################################################################################
 
-# build target function
 function compile_fuzzer {
   path=$1
   function=$2
   fuzzer=$3
 
-   # Instrument all Go files relevant to this fuzzer
+  # Compile and instrument all Go files relevant to this fuzz target.
   go-fuzz -func $function -o $fuzzer.a $path
 
-   # Instrumented, compiled Go ($fuzzer.a) + fuzzing engine = fuzzer binary
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -lpthread -o $OUT/$fuzzer
+  # Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
 }
 
 compile_fuzzer . Fuzz fuzz_json

--- a/projects/golang/build.sh
+++ b/projects/golang/build.sh
@@ -13,23 +13,23 @@
 # limitations under the License.
 
 function compile_fuzzer {
-    fuzzer=$(basename $1)
+  fuzzer=$(basename $1)
 
-    # Instrument all Go files relevant to this fuzzer, compile and store in $fuzzer.a
-    go-fuzz -o $fuzzer.a github.com/dvyukov/go-fuzz-corpus/$fuzzer
+  # Compile and instrument all Go files relevant to this fuzz target.
+  go-fuzz -o $fuzzer.a github.com/dvyukov/go-fuzz-corpus/$fuzzer
 
-    # Instrumented, compiled Go ($fuzzer.a) + libFuzzer = fuzzer binary
-    $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -lpthread -o fuzzer-$fuzzer
+  # Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o fuzzer-$fuzzer
 
-    # Copy the fuzzer binary
-    cp fuzzer-$fuzzer $OUT
+  # Copy the fuzzer binary
+  cp fuzzer-$fuzzer $OUT
 
-    # Pack the seed corpus
-    zip -r fuzzer-${fuzzer}_seed_corpus.zip \
-        $GOPATH/src/github.com/dvyukov/go-fuzz-corpus/$fuzzer/corpus
+  # Pack the seed corpus
+  zip -r fuzzer-${fuzzer}_seed_corpus.zip \
+      $GOPATH/src/github.com/dvyukov/go-fuzz-corpus/$fuzzer/corpus
 
-    # Copy the seed corpus
-    cp fuzzer-${fuzzer}_seed_corpus.zip $OUT
+  # Copy the seed corpus
+  cp fuzzer-${fuzzer}_seed_corpus.zip $OUT
 }
 
 export -f compile_fuzzer

--- a/projects/golang/build.sh
+++ b/projects/golang/build.sh
@@ -19,17 +19,11 @@ function compile_fuzzer {
   go-fuzz -o $fuzzer.a github.com/dvyukov/go-fuzz-corpus/$fuzzer
 
   # Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o fuzzer-$fuzzer
-
-  # Copy the fuzzer binary
-  cp fuzzer-$fuzzer $OUT
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/fuzzer-$fuzzer
 
   # Pack the seed corpus
-  zip -r fuzzer-${fuzzer}_seed_corpus.zip \
+  zip -r $OUT/fuzzer-${fuzzer}_seed_corpus.zip \
       $GOPATH/src/github.com/dvyukov/go-fuzz-corpus/$fuzzer/corpus
-
-  # Copy the seed corpus
-  cp fuzzer-${fuzzer}_seed_corpus.zip $OUT
 }
 
 export -f compile_fuzzer

--- a/projects/gonids/Dockerfile
+++ b/projects/gonids/Dockerfile
@@ -21,4 +21,4 @@ RUN go get github.com/google/gonids
 ADD https://rules.emergingthreats.net/open/suricata/emerging.rules.zip emerging.rules.zip
 
 COPY build.sh $SRC/
-WORKDIR $SRC/
+WORKDIR $SRC

--- a/projects/gonids/build.sh
+++ b/projects/gonids/build.sh
@@ -27,8 +27,7 @@ function compile_fuzzer {
   $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
 }
 
-compile_fuzzer /root/go/src/github.com/google/gonids/ FuzzParseRule \
-    fuzz_parserule
+compile_fuzzer github.com/google/gonids FuzzParseRule fuzz_parserule
 
 unzip emerging.rules.zip
 cd rules

--- a/projects/gonids/build.sh
+++ b/projects/gonids/build.sh
@@ -15,20 +15,20 @@
 #
 ################################################################################
 
-# build target function
 function compile_fuzzer {
   path=$1
   function=$2
   fuzzer=$3
 
-   # Instrument all Go files relevant to this fuzzer
+  # Compile and instrument all Go files relevant to this fuzz target.
   go-fuzz -func $function -o $fuzzer.a $path
 
-   # Instrumented, compiled Go ($fuzzer.a) + fuzzing engine = fuzzer binary
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -lpthread -o $OUT/$fuzzer
+  # Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
 }
 
-compile_fuzzer /root/go/src/github.com/google/gonids/ FuzzParseRule fuzz_parserule
+compile_fuzzer /root/go/src/github.com/google/gonids/ FuzzParseRule \
+    fuzz_parserule
 
 unzip emerging.rules.zip
 cd rules

--- a/projects/kubernetes/build.sh
+++ b/projects/kubernetes/build.sh
@@ -20,17 +20,16 @@ set -o pipefail
 set -o errexit
 set -x
 
-# Based on the function from oss-fuzz/projects/golang/build.sh script.
 function compile_fuzzer {
   local pkg=$1
   local function=$2
   local fuzzer="${pkg}_${function}"
 
-   # Instrument all Go files relevant to this fuzzer
+  # Compile and instrument all Go files relevant to this fuzz target.
   go-fuzz -func "${function}" -o "${fuzzer}.a" "k8s.io/kubernetes/test/fuzz/${pkg}"
 
-   # Instrumented, compiled Go ($fuzzer.a) + fuzzing engine = fuzzer binary
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE "${fuzzer}.a" -lpthread -o "${OUT}/${fuzzer}"
+  # Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE "${fuzzer}.a" -o "${OUT}/${fuzzer}"
 }
 
 compile_fuzzer "yaml" "FuzzDurationStrict"

--- a/projects/syzkaller/build.sh
+++ b/projects/syzkaller/build.sh
@@ -15,17 +15,16 @@
 #
 ################################################################################
 
-# Based on the function from oss-fuzz/projects/golang/build.sh script.
 function compile_fuzzer {
   path=$1
   function=$2
   fuzzer=$3
 
-   # Instrument all Go files relevant to this fuzzer
+  # Compile and instrument all Go files relevant to this fuzz target.
   go-fuzz -func $function -o $fuzzer.a $path
 
-   # Instrumented, compiled Go ($fuzzer.a) + fuzzing engine = fuzzer binary
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -lpthread -o $OUT/$fuzzer
+  # Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
 }
 
 compile_fuzzer ./pkg/compiler Fuzz compiler_fuzzer


### PR DESCRIPTION
Looks like it isn't needed anymore, or maybe it was never needed and I mistakenly added it in the first place.

Also fixed `gonids` and `go-dns` builds, they had import errors.

