### PR TITLE
Revert clang workaround for Envoy

### DIFF
--- a/projects/envoy/Dockerfile
+++ b/projects/envoy/Dockerfile
@@ -14,9 +14,8 @@
 #
 ################################################################################
 
-# TODO(https://github.com/google/oss-fuzz/issues/3093): Stop specifying the
-# image SHA once the bug is fixed.
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:276813aef0ce5972db43c0230f96162003994fa742fb1b2f4e66c67498575c65
+
+FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER htuch@google.com
 
 RUN apt-get update && apt-get -y install  \


### PR DESCRIPTION
Fixes for Envoy: https://github.com/google/oss-fuzz/issues/3157

Signed-off-by: Asra Ali <asraa@google.com>