### PR TITLE
[hostap] Add missing libssl-dev dependency

### DIFF
--- a/projects/hostap/Dockerfile
+++ b/projects/hostap/Dockerfile
@@ -16,7 +16,10 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER elver@google.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool g++
+RUN dpkg --add-architecture i386 && \
+    apt-get update && \
+    apt-get install -y make autoconf automake libtool g++ libssl-dev \
+                       libssl-dev:i386
 RUN git clone --depth 1 git://w1.fi/srv/git/hostap.git hostap
 WORKDIR hostap
 COPY build.sh $SRC/


### PR DESCRIPTION
Recent builds have started failing due to libssl-dev missing --
presumably the base image no longer includes this. Fix this by
installing libssl-dev.