### PR TITLE
libcacard: Reference upstream repository with merged fuzzers

### DIFF
--- a/projects/libcacard/Dockerfile
+++ b/projects/libcacard/Dockerfile
@@ -20,8 +20,7 @@ RUN apt-get update && apt-get install -y pkg-config libglib2.0-dev gyp libsqlite
 # Because Ubuntu has really ancient meson out there
 RUN pip3 install meson ninja
 
-#RUN git clone --depth 1 https://gitlab.freedesktop.org/spice/libcacard.git libcacard
-RUN git clone --depth 1 --single-branch --branch fuzzers https://gitlab.freedesktop.org/jjelen/libcacard.git libcacard
+RUN git clone --depth 1 --single-branch --branch master https://gitlab.freedesktop.org/spice/libcacard.git libcacard
 RUN git clone --depth 1 https://github.com/nss-dev/nss.git nss
 RUN hg clone https://hg.mozilla.org/projects/nspr
 


### PR DESCRIPTION
Fuzzers are already merged in the upstream project [1] so this updates the link to the correct repository.

Tested locally with `check_build`:

```
$ python infra/helper.py check_build libcacard
Running: docker run --rm --privileged -i -e FUZZING_ENGINE=libfuzzer -e SANITIZER=address -e ARCHITECTURE=x86_64 -v /home/jjelen/devel/oss-fuzz/build/out/libcacard:/out -t gcr.io/oss-fuzz-base/base-runner test_all
INFO: performing bad build checks for /tmp/not-out/fuzz_xfer.
1 fuzzers total, 0 seem to be broken (0%).
Check build passed.
```

[1] https://gitlab.freedesktop.org/spice/libcacard/-/merge_requests/14