### PR TITLE
Improve OpenSC fuzzing

### DIFF
--- a/projects/opensc/build.sh
+++ b/projects/opensc/build.sh
@@ -20,9 +20,12 @@
 ./configure --disable-optimization --disable-shared --disable-pcsc --enable-ctapi --enable-fuzzing FUZZING_LIBS="$LIB_FUZZING_ENGINE"
 make -j4
 
-cp src/tests/fuzzing/fuzz_asn1_print $OUT
-cp src/tests/fuzzing/fuzz_asn1_sig_value $OUT
-cp src/tests/fuzzing/fuzz_pkcs15_decode $OUT
-cp src/tests/fuzzing/fuzz_pkcs15_reader $OUT
+fuzzerFiles=$(find $SRC/opensc/src/tests/fuzzing/ -name "fuzz_*.c")
 
-#cp src/tests/fuzzing/fuzz_pkcs15_reader.options $OUT
+for F in $fuzzerFiles; do
+    fuzzerName=$(basename $F .c)
+    cp "$SRC/opensc/src/tests/fuzzing/$fuzzerName" $OUT
+    if [ -d "$SRC/opensc/src/tests/fuzzing/corpus/${fuzzerName}" ]; then
+        zip -j $OUT/${fuzzerName}_seed_corpus.zip $SRC/opensc/src/tests/fuzzing/corpus/${fuzzerName}/*
+    fi
+done

--- a/projects/opensc/build.sh
+++ b/projects/opensc/build.sh
@@ -17,7 +17,7 @@
 
 ./bootstrap
 # FIXME FUZZING_LIBS="$LIB_FUZZING_ENGINE" fails with some missing C++ library, I don't know how to fix this
-./configure --disable-shared --disable-pcsc --enable-ctapi --enable-fuzzing FUZZING_LIBS="$LIB_FUZZING_ENGINE"
+./configure --disable-optimization --disable-shared --disable-pcsc --enable-ctapi --enable-fuzzing FUZZING_LIBS="$LIB_FUZZING_ENGINE"
 make -j4
 
 cp src/tests/fuzzing/fuzz_asn1_print $OUT


### PR DESCRIPTION
This changeset improves fuzzing of OpenSC project:

 * Disable optimization when building to get nicer traces
 * Add corpus files for first fuzzers (which is already available in repository for some time)

Please, do not merge yet. There are few bugs that need to be fixed first in OpenSC side in OpenSC/OpenSC#2012. With these changes, I am able to build fuzzers successfully:
```
$ python infra/helper.py build_fuzzers opensc ~/devel/OpenSC
$  python infra/helper.py check_build opensc
Running: docker run --rm --privileged -i -e FUZZING_ENGINE=libfuzzer -e SANITIZER=address -e ARCHITECTURE=x86_64 -v /home/jjelen/devel/oss-fuzz/build/out/opensc:/out -t gcr.io/oss-fuzz-base/base-runner test_all
INFO: performing bad build checks for /tmp/not-out/fuzz_asn1_sig_value.
INFO: performing bad build checks for /tmp/not-out/fuzz_pkcs15_reader.
INFO: performing bad build checks for /tmp/not-out/fuzz_pkcs15_decode.
INFO: performing bad build checks for /tmp/not-out/fuzz_asn1_print.
4 fuzzers total, 0 seem to be broken (0%).
Check build passed.
```