### PR TITLE
nanopb: Fix build error, remove anaconda dependency

### DIFF
--- a/projects/nanopb/Dockerfile
+++ b/projects/nanopb/Dockerfile
@@ -16,12 +16,10 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER jpa@npb.mail.kapsi.fi
-RUN apt-get update && apt-get install -y python3-pip git scons wget
+RUN apt-get update && apt-get install -y python3-pip git wget
 RUN python3 -m pip install --upgrade pip
+RUN pip3 install protobuf grpcio-tools scons
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 100
 RUN git clone --depth 1 https://github.com/nanopb/nanopb $SRC/nanopb
-
-RUN wget "https://repo.anaconda.com/archive/Anaconda3-2020.02-Linux-x86_64.sh"
-RUN bash "Anaconda3-2020.02-Linux-x86_64.sh" -b
-
 COPY build.sh $SRC/
 

--- a/projects/nanopb/build.sh
+++ b/projects/nanopb/build.sh
@@ -15,10 +15,6 @@
 #
 ################################################################################
 
-export PATH=~/anaconda3/bin:$PATH
-conda install protobuf -y
-pip3 install grpcio-tools
-
 cd $SRC/nanopb/tests
 
 # Build seed corpus.


### PR DESCRIPTION
This pull request fixes a python2 vs. python3 version conflict that caused nanopb build to fail. This remaps `/usr/bin/python` to python3 to make sure everything runs with the same version.

There were previous pull requests #3637 and #3693 that attempted to fix this, but there still remained some scripts that got run with Python 2. As a workaround for that Anaconda was used for protobuf installation, but now that is unnecessary also.