### PR TITLE
[Binutils] Avoid detecting memory leaks in readelf fuzzer 

### DIFF
--- a/projects/binutils/Dockerfile
+++ b/projects/binutils/Dockerfile
@@ -24,3 +24,4 @@ WORKDIR $SRC
 COPY build.sh $SRC/
 COPY fuzz_*.c $SRC/
 COPY fuzz_readelf_seed_corpus $SRC/fuzz_readelf_seed_corpus
+COPY fuzz_readelf.options $SRC/fuzz_readelf.options

--- a/projects/binutils/build.sh
+++ b/projects/binutils/build.sh
@@ -58,10 +58,6 @@ for i in readelf; do
 done
 
 # Link the files
-# In these cases we dont want to detect leaks as the applications are thought of as "one-time-use".
-# Leaving a link to maintainers discussing this: https://github.com/google/oss-fuzz/pull/2617
-export ASAN_OPTIONS=detect_leaks=0
-
 ## Readelf
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE -W -Wall -I./../zlib -o fuzz_readelf fuzz_readelf.o version.o unwind-ia64.o dwarf.o elfcomm.o ../libctf/.libs/libctf-nobfd.a -L/src/binutils-gdb/zlib -lz ../libiberty/libiberty.a 
 mv fuzz_readelf $OUT/fuzz_readelf
@@ -69,3 +65,6 @@ mv fuzz_readelf $OUT/fuzz_readelf
 ### Set up seed corpus for readelf in the form of a single ELF file. 
 zip fuzz_readelf_seed_corpus.zip /src/fuzz_readelf_seed_corpus/simple_elf
 mv fuzz_readelf_seed_corpus.zip $OUT/ 
+
+## Copy over the options file
+cp $SRC/fuzz_readelf.options $OUT/fuzz_readelf.options

--- a/projects/binutils/build.sh
+++ b/projects/binutils/build.sh
@@ -58,6 +58,10 @@ for i in readelf; do
 done
 
 # Link the files
+# In these cases we dont want to detect leaks as the applications are thought of as "one-time-use".
+# Leaving a link to maintainers discussing this: https://github.com/google/oss-fuzz/pull/2617
+export ASAN_OPTIONS=detect_leaks=0
+
 ## Readelf
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE -W -Wall -I./../zlib -o fuzz_readelf fuzz_readelf.o version.o unwind-ia64.o dwarf.o elfcomm.o ../libctf/.libs/libctf-nobfd.a -L/src/binutils-gdb/zlib -lz ../libiberty/libiberty.a 
 mv fuzz_readelf $OUT/fuzz_readelf

--- a/projects/binutils/fuzz_readelf.options
+++ b/projects/binutils/fuzz_readelf.options
@@ -1,2 +1,2 @@
 [libfuzzer]
-detect_leaks = 0
+detect_leaks=0


### PR DESCRIPTION
Per https://github.com/google/oss-fuzz/pull/2617 the maintainers of binutils are not interested in memory leaks from the binutils tools, e.g. Readelf. These applications are transient in that they run and terminate without staying alive for long. Therefore, forcing Readelf fuzzer to avoid leak detection. 