### PR TITLE
[CIFuzz] Support ALLOWED_BROKEN_TARGETS_PERCENTAGE

### DIFF
--- a/docs/getting-started/continuous_integration.md
+++ b/docs/getting-started/continuous_integration.md
@@ -89,6 +89,10 @@ CIFuzz will never report a failure even if it finds a crash in your project.
 This requires the user to manually check the logs for detected bugs. If dry run mode is desired,
 make sure to set the dry-run parameters in both the `Build Fuzzers` and `Run Fuzzers` action step.
 
+`allowed_broken_targets_percentage`: Can be set if you want to set a stricter
+limit for broken fuzz targets than OSS-Fuzz's check_build. Most users should
+not set this.
+
 ## Understanding results
 
 The results of CIFuzz can be found in two different places.

--- a/infra/cifuzz/actions/build_fuzzers/action.yml
+++ b/infra/cifuzz/actions/build_fuzzers/action.yml
@@ -8,9 +8,13 @@ inputs:
   dry-run:
     description: 'If set, run the action without actually reporting a failure.'
     default: false
+  allowed-broken-targets-percentage:
+    description: 'The percentage of broken targets allowed in bad_build_check.'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
   env:
     OSS_FUZZ_PROJECT_NAME: ${{ inputs.oss-fuzz-project-name }}
     DRY_RUN: ${{ inputs.dry-run}}
+    ALLOWED_BROKEN_TARGETS_PERCENTAGE: ${{ inputs.allowed-broken-targets-percentage}}

--- a/infra/cifuzz/cifuzz.py
+++ b/infra/cifuzz/cifuzz.py
@@ -253,8 +253,11 @@ def check_fuzzer_build(out_dir):
   allowed_broken_targets_percentage = os.getenv(
       'ALLOWED_BROKEN_TARGETS_PERCENTAGE')
   if allowed_broken_targets_percentage is not None:
-    command += ['-e', ('ALLOWED_BROKEN_TARGETS_PERCENTAGE=' +
-                       allowed_broken_targets_percentage)]
+    command += [
+        '-e',
+        ('ALLOWED_BROKEN_TARGETS_PERCENTAGE=' +
+         allowed_broken_targets_percentage)
+    ]
 
   container = utils.get_container_name()
   if container:

--- a/infra/cifuzz/cifuzz.py
+++ b/infra/cifuzz/cifuzz.py
@@ -253,9 +253,8 @@ def check_fuzzer_build(out_dir):
   allowed_broken_targets_percentage = os.getenv(
       'ALLOWED_BROKEN_TARGETS_PERCENTAGE')
   if allowed_broken_targets_percentage is not None:
-    set_env_var_arg = ('ALLOWED_BROKEN_TARGETS_PERCENTAGE=' +
-                       allowed_broken_targets_percentage)
-    command += ['-e', set_env_var_arg]
+    command += ['-e', ('ALLOWED_BROKEN_TARGETS_PERCENTAGE=' +
+                       allowed_broken_targets_percentage)]
 
   container = utils.get_container_name()
   if container:

--- a/infra/cifuzz/cifuzz.py
+++ b/infra/cifuzz/cifuzz.py
@@ -248,6 +248,15 @@ def check_fuzzer_build(out_dir):
       'SANITIZER=' + DEFAULT_SANITIZER, '-e',
       'ARCHITECTURE=' + DEFAULT_ARCHITECTURE
   ]
+
+  # Set ALLOWED_BROKEN_TARGETS_PERCENTAGE in docker if specified by user.
+  allowed_broken_targets_percentage = os.getenv(
+      'ALLOWED_BROKEN_TARGETS_PERCENTAGE')
+  if allowed_broken_targets_percentage is not None:
+    set_env_var_arg = ('ALLOWED_BROKEN_TARGETS_PERCENTAGE=' +
+                       allowed_broken_targets_percentage)
+    command += ['-e', set_env_var_arg]
+
   container = utils.get_container_name()
   if container:
     command += ['-e', 'OUT=' + out_dir, '--volumes-from', container]

--- a/infra/cifuzz/cifuzz_test.py
+++ b/infra/cifuzz/cifuzz_test.py
@@ -22,7 +22,7 @@ import shutil
 import sys
 import tempfile
 import unittest
-import unittest.mock
+from unittest import mock
 
 # pylint: disable=wrong-import-position
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -49,6 +49,8 @@ EXAMPLE_NOCRASH_FUZZER = 'example_nocrash_fuzzer'
 
 # A fuzzer to be built in build_fuzzers integration tests.
 EXAMPLE_BUILD_FUZZER = 'do_stuff_fuzzer'
+
+# pylint: disable=no-self-use
 
 
 class BuildFuzzersIntegrationTest(unittest.TestCase):
@@ -153,7 +155,7 @@ class RunFuzzersIntegrationTest(unittest.TestCase):
     # Set the first return value to True, then the second to False to
     # emulate a bug existing in the current PR but not on the downloaded
     # OSS-Fuzz build.
-    with unittest.mock.patch.object(fuzz_target.FuzzTarget,
+    with mock.patch.object(fuzz_target.FuzzTarget,
                                     'is_reproducible',
                                     side_effect=[True, False]):
       run_success, bug_found = cifuzz.run_fuzzers(10, TEST_FILES_PATH,
@@ -166,7 +168,7 @@ class RunFuzzersIntegrationTest(unittest.TestCase):
 
   def test_old_bug_found(self):
     """Test run_fuzzers with a bug found in OSS-Fuzz before."""
-    with unittest.mock.patch.object(fuzz_target.FuzzTarget,
+    with mock.patch.object(fuzz_target.FuzzTarget,
                                     'is_reproducible',
                                     side_effect=[True, True]):
       run_success, bug_found = cifuzz.run_fuzzers(10, TEST_FILES_PATH,
@@ -247,6 +249,17 @@ class CheckFuzzerBuildUnitTest(unittest.TestCase):
     """Checks a directory that exists but does not have fuzzers is False."""
     self.assertFalse(cifuzz.check_fuzzer_build(TEST_FILES_PATH))
 
+  @mock.patch.dict(os.environ, {'ALLOWED_BROKEN_TARGETS_PERCENTAGE': '0'})
+  @mock.patch('helper.docker_run')
+  def test_allow_broken_fuzz_targets_percentage(self, mocked_docker_run):
+    """Tests that ALLOWED_BROKEN_TARGETS_PERCENTAGE is set when running
+    docker if it is set in the environment."""
+    test_fuzzer_dir = os.path.join(TEST_FILES_PATH, 'out')
+    mocked_docker_run.return_value = 0
+    cifuzz.check_fuzzer_build(test_fuzzer_dir)
+    self.assertIn('-e ALLOWED_BROKEN_TARGETS_PERCENTAGE=0',
+                  ' '.join(mocked_docker_run.call_args[0][0]))
+
 
 class GetFilesCoveredByTargetUnitTest(unittest.TestCase):
   """Test to get the files covered by a fuzz target in the cifuzz module."""
@@ -267,7 +280,7 @@ class GetFilesCoveredByTargetUnitTest(unittest.TestCase):
   def test_valid_target(self):
     """Tests that covered files can be retrieved from a coverage report."""
 
-    with unittest.mock.patch.object(
+    with mock.patch.object(
         cifuzz,
         'get_target_coverage_report',
         return_value=self.fuzzer_cov_report_example):
@@ -311,7 +324,7 @@ class GetTargetCoverageReporUnitTest(unittest.TestCase):
 
   def test_valid_target(self):
     """Test a target's coverage report can be downloaded and parsed."""
-    with unittest.mock.patch.object(cifuzz,
+    with mock.patch.object(cifuzz,
                                     'get_json_from_url',
                                     return_value='{}') as mock_get_json:
       cifuzz.get_target_coverage_report(self.cov_exmp, self.example_fuzzer)
@@ -345,7 +358,7 @@ class GetLatestCoverageReportUnitTest(unittest.TestCase):
     NOTE: This test relies on the test_project repo's coverage report.
     Example was not used because it has no coverage reports.
     """
-    with unittest.mock.patch.object(cifuzz,
+    with mock.patch.object(cifuzz,
                                     'get_json_from_url',
                                     return_value='{}') as mock_fun:
 
@@ -370,11 +383,11 @@ class KeepAffectedFuzzersUnitTest(unittest.TestCase):
 
   def test_keeping_fuzzer_w_no_coverage(self):
     """Tests that a specific fuzzer is kept if it is deemed affected."""
-    with tempfile.TemporaryDirectory() as tmp_dir, unittest.mock.patch.object(
+    with tempfile.TemporaryDirectory() as tmp_dir, mock.patch.object(
         cifuzz, 'get_latest_cov_report_info', return_value=1):
       shutil.copy(self.test_fuzzer_1, tmp_dir)
       shutil.copy(self.test_fuzzer_2, tmp_dir)
-      with unittest.mock.patch.object(cifuzz,
+      with mock.patch.object(cifuzz,
                                       'get_files_covered_by_target',
                                       side_effect=[[self.example_file_changed],
                                                    None]):
@@ -384,11 +397,11 @@ class KeepAffectedFuzzersUnitTest(unittest.TestCase):
 
   def test_keeping_specific_fuzzer(self):
     """Tests that a specific fuzzer is kept if it is deemed affected."""
-    with tempfile.TemporaryDirectory() as tmp_dir, unittest.mock.patch.object(
+    with tempfile.TemporaryDirectory() as tmp_dir, mock.patch.object(
         cifuzz, 'get_latest_cov_report_info', return_value=1):
       shutil.copy(self.test_fuzzer_1, tmp_dir)
       shutil.copy(self.test_fuzzer_2, tmp_dir)
-      with unittest.mock.patch.object(cifuzz,
+      with mock.patch.object(cifuzz,
                                       'get_files_covered_by_target',
                                       side_effect=[[self.example_file_changed],
                                                    ['not/a/real/file']]):
@@ -398,11 +411,11 @@ class KeepAffectedFuzzersUnitTest(unittest.TestCase):
 
   def test_no_fuzzers_kept_fuzzer(self):
     """Tests that if there is no affected then all fuzzers are kept."""
-    with tempfile.TemporaryDirectory() as tmp_dir, unittest.mock.patch.object(
+    with tempfile.TemporaryDirectory() as tmp_dir, mock.patch.object(
         cifuzz, 'get_latest_cov_report_info', return_value=1):
       shutil.copy(self.test_fuzzer_1, tmp_dir)
       shutil.copy(self.test_fuzzer_2, tmp_dir)
-      with unittest.mock.patch.object(cifuzz,
+      with mock.patch.object(cifuzz,
                                       'get_files_covered_by_target',
                                       side_effect=[None, None]):
         cifuzz.remove_unaffected_fuzzers(EXAMPLE_PROJECT, tmp_dir,
@@ -411,11 +424,11 @@ class KeepAffectedFuzzersUnitTest(unittest.TestCase):
 
   def test_both_fuzzers_kept_fuzzer(self):
     """Tests that if both fuzzers are affected then both fuzzers are kept."""
-    with tempfile.TemporaryDirectory() as tmp_dir, unittest.mock.patch.object(
+    with tempfile.TemporaryDirectory() as tmp_dir, mock.patch.object(
         cifuzz, 'get_latest_cov_report_info', return_value=1):
       shutil.copy(self.test_fuzzer_1, tmp_dir)
       shutil.copy(self.test_fuzzer_2, tmp_dir)
-      with unittest.mock.patch.object(
+      with mock.patch.object(
           cifuzz,
           'get_files_covered_by_target',
           side_effect=[self.example_file_changed, self.example_file_changed]):

--- a/infra/cifuzz/cifuzz_test.py
+++ b/infra/cifuzz/cifuzz_test.py
@@ -156,8 +156,8 @@ class RunFuzzersIntegrationTest(unittest.TestCase):
     # emulate a bug existing in the current PR but not on the downloaded
     # OSS-Fuzz build.
     with mock.patch.object(fuzz_target.FuzzTarget,
-                                    'is_reproducible',
-                                    side_effect=[True, False]):
+                           'is_reproducible',
+                           side_effect=[True, False]):
       run_success, bug_found = cifuzz.run_fuzzers(10, TEST_FILES_PATH,
                                                   EXAMPLE_PROJECT)
       build_dir = os.path.join(TEST_FILES_PATH, 'out', 'oss_fuzz_latest')
@@ -169,8 +169,8 @@ class RunFuzzersIntegrationTest(unittest.TestCase):
   def test_old_bug_found(self):
     """Test run_fuzzers with a bug found in OSS-Fuzz before."""
     with mock.patch.object(fuzz_target.FuzzTarget,
-                                    'is_reproducible',
-                                    side_effect=[True, True]):
+                           'is_reproducible',
+                           side_effect=[True, True]):
       run_success, bug_found = cifuzz.run_fuzzers(10, TEST_FILES_PATH,
                                                   EXAMPLE_PROJECT)
       build_dir = os.path.join(TEST_FILES_PATH, 'out', 'oss_fuzz_latest')
@@ -280,10 +280,9 @@ class GetFilesCoveredByTargetUnitTest(unittest.TestCase):
   def test_valid_target(self):
     """Tests that covered files can be retrieved from a coverage report."""
 
-    with mock.patch.object(
-        cifuzz,
-        'get_target_coverage_report',
-        return_value=self.fuzzer_cov_report_example):
+    with mock.patch.object(cifuzz,
+                           'get_target_coverage_report',
+                           return_value=self.fuzzer_cov_report_example):
       file_list = cifuzz.get_files_covered_by_target(
           self.proj_cov_report_example, self.example_fuzzer, '/src/curl')
 
@@ -324,9 +323,8 @@ class GetTargetCoverageReporUnitTest(unittest.TestCase):
 
   def test_valid_target(self):
     """Test a target's coverage report can be downloaded and parsed."""
-    with mock.patch.object(cifuzz,
-                                    'get_json_from_url',
-                                    return_value='{}') as mock_get_json:
+    with mock.patch.object(cifuzz, 'get_json_from_url',
+                           return_value='{}') as mock_get_json:
       cifuzz.get_target_coverage_report(self.cov_exmp, self.example_fuzzer)
       (url,), _ = mock_get_json.call_args
       self.assertEqual(
@@ -358,9 +356,8 @@ class GetLatestCoverageReportUnitTest(unittest.TestCase):
     NOTE: This test relies on the test_project repo's coverage report.
     Example was not used because it has no coverage reports.
     """
-    with mock.patch.object(cifuzz,
-                                    'get_json_from_url',
-                                    return_value='{}') as mock_fun:
+    with mock.patch.object(cifuzz, 'get_json_from_url',
+                           return_value='{}') as mock_fun:
 
       cifuzz.get_latest_cov_report_info(self.test_project)
       (url,), _ = mock_fun.call_args
@@ -388,9 +385,8 @@ class KeepAffectedFuzzersUnitTest(unittest.TestCase):
       shutil.copy(self.test_fuzzer_1, tmp_dir)
       shutil.copy(self.test_fuzzer_2, tmp_dir)
       with mock.patch.object(cifuzz,
-                                      'get_files_covered_by_target',
-                                      side_effect=[[self.example_file_changed],
-                                                   None]):
+                             'get_files_covered_by_target',
+                             side_effect=[[self.example_file_changed], None]):
         cifuzz.remove_unaffected_fuzzers(EXAMPLE_PROJECT, tmp_dir,
                                          [self.example_file_changed], '')
         self.assertEqual(2, len(os.listdir(tmp_dir)))
@@ -402,9 +398,9 @@ class KeepAffectedFuzzersUnitTest(unittest.TestCase):
       shutil.copy(self.test_fuzzer_1, tmp_dir)
       shutil.copy(self.test_fuzzer_2, tmp_dir)
       with mock.patch.object(cifuzz,
-                                      'get_files_covered_by_target',
-                                      side_effect=[[self.example_file_changed],
-                                                   ['not/a/real/file']]):
+                             'get_files_covered_by_target',
+                             side_effect=[[self.example_file_changed],
+                                          ['not/a/real/file']]):
         cifuzz.remove_unaffected_fuzzers(EXAMPLE_PROJECT, tmp_dir,
                                          [self.example_file_changed], '')
         self.assertEqual(1, len(os.listdir(tmp_dir)))
@@ -416,8 +412,8 @@ class KeepAffectedFuzzersUnitTest(unittest.TestCase):
       shutil.copy(self.test_fuzzer_1, tmp_dir)
       shutil.copy(self.test_fuzzer_2, tmp_dir)
       with mock.patch.object(cifuzz,
-                                      'get_files_covered_by_target',
-                                      side_effect=[None, None]):
+                             'get_files_covered_by_target',
+                             side_effect=[None, None]):
         cifuzz.remove_unaffected_fuzzers(EXAMPLE_PROJECT, tmp_dir,
                                          [self.example_file_changed], '')
         self.assertEqual(2, len(os.listdir(tmp_dir)))

--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -334,6 +334,9 @@ def run_tests():
   for file in get_changed_files():
     changed_dirs.add(os.path.dirname(file))
 
+  # TODO(metzman): This approach for running tests is probably flawed since
+  # tests can fail even if their directory isn't changed. Figure out if it is
+  # needed (to save time) and remove it if it isn't.
   suite_list = []
   for change_dir in changed_dirs:
     suite_list.append(unittest.TestLoader().discover(change_dir,


### PR DESCRIPTION
Allow users to set this value in the config files and then use it
during check_build.
    
Fixes https://github.com/google/oss-fuzz/issues/3429