### PR TITLE
Add project oniguruma

### DIFF
--- a/projects/oniguruma/.gitignore
+++ b/projects/oniguruma/.gitignore
@@ -1,3 +1,2 @@
-*~
 /oniguruma
 /fuzzer.options.*

--- a/projects/oniguruma/.gitignore
+++ b/projects/oniguruma/.gitignore
@@ -1,0 +1,3 @@
+*~
+/oniguruma
+/fuzzer.options.*

--- a/projects/oniguruma/Dockerfile
+++ b/projects/oniguruma/Dockerfile
@@ -17,5 +17,9 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER kkosako0@gmail.com
 
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN git clone --depth 1 https://github.com/kkos/oniguruma.git oniguruma
+
 WORKDIR oniguruma
+COPY build.sh $SRC/
 COPY fuzzer.options $SRC/oniguruma/harnesses

--- a/projects/oniguruma/Dockerfile
+++ b/projects/oniguruma/Dockerfile
@@ -1,0 +1,29 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER kkosako0@gmail.com
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+
+RUN git clone --depth 1 https://github.com/kkos/oniguruma.git oniguruma
+#COPY oniguruma $SRC/oniguruma
+
+WORKDIR oniguruma
+COPY build.sh $SRC/
+
+# for develop in local env
+#COPY base.c $SRC/oniguruma/harnesses
+COPY fuzzer.options $SRC/oniguruma/harnesses

--- a/projects/oniguruma/Dockerfile
+++ b/projects/oniguruma/Dockerfile
@@ -16,14 +16,6 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER kkosako0@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool
-
-RUN git clone --depth 1 https://github.com/kkos/oniguruma.git oniguruma
-#COPY oniguruma $SRC/oniguruma
 
 WORKDIR oniguruma
-COPY build.sh $SRC/
-
-# for develop in local env
-#COPY base.c $SRC/oniguruma/harnesses
 COPY fuzzer.options $SRC/oniguruma/harnesses

--- a/projects/oniguruma/build.sh
+++ b/projects/oniguruma/build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# build project
+./autogen.sh
+./configure
+make clean
+make -j$(nproc)
+
+FUZZ_SRCDIR=harnesses
+FUZZ_TARGET=fuzzer
+
+# build fuzzer
+$CC $CFLAGS -o $FUZZ_SRCDIR/fuzzer_syntax.o -I src -c -DSYNTAX_TEST $FUZZ_SRCDIR/base.c
+$CXX $CXXFLAGS -o $OUT/$FUZZ_TARGET $FUZZ_SRCDIR/fuzzer_syntax.o $LIB_FUZZING_ENGINE src/.libs/libonig.a
+
+# setup files
+cp $FUZZ_SRCDIR/$FUZZ_TARGET.options $FUZZ_SRCDIR/ascii_compatible.dict $OUT/

--- a/projects/oniguruma/build.sh
+++ b/projects/oniguruma/build.sh
@@ -29,4 +29,5 @@ $CC $CFLAGS -o $FUZZ_SRCDIR/fuzzer_syntax.o -I src -c -DSYNTAX_TEST $FUZZ_SRCDIR
 $CXX $CXXFLAGS -o $OUT/$FUZZ_TARGET $FUZZ_SRCDIR/fuzzer_syntax.o $LIB_FUZZING_ENGINE src/.libs/libonig.a
 
 # setup files
-cp $FUZZ_SRCDIR/$FUZZ_TARGET.options $FUZZ_SRCDIR/ascii_compatible.dict $OUT/
+cp $FUZZ_SRCDIR/$FUZZ_TARGET.options $OUT/
+cp $FUZZ_SRCDIR/ascii_compatible.dict $OUT/$FUZZ_TARGET.dict

--- a/projects/oniguruma/fuzzer.options
+++ b/projects/oniguruma/fuzzer.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+dict = ascii_compatible.dict

--- a/projects/oniguruma/fuzzer.options
+++ b/projects/oniguruma/fuzzer.options
@@ -1,2 +1,0 @@
-[libfuzzer]
-dict = ascii_compatible.dict

--- a/projects/oniguruma/project.yaml
+++ b/projects/oniguruma/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/kkos/oniguruma"
+primary_contact: "kkosako0@gmail.com"
+sanitizers:
+  - address
+  - undefined
+  - memory

--- a/projects/oniguruma/project.yaml
+++ b/projects/oniguruma/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/kkos/oniguruma"
+language: c
 primary_contact: "kkosako0@gmail.com"
 sanitizers:
   - address


### PR DESCRIPTION
This adds the project.yaml, Dockerfile and build.sh for Oniguruma.
Oniguruma is a regular expressions library under the BSD license.
I don't know how much of it is used, but it was bundled with PHP before, so there are a lot of bugs in the CVE list. (Fixed)

