### PR TITLE
[needs info] Argon2: add project - password hash based on Blake2

### DIFF
--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -45,5 +45,6 @@ RUN git clone --depth 1 https://github.com/jedisct1/libsodium.git
 RUN git clone --depth 1 https://github.com/libtom/libtomcrypt.git
 RUN apt-get remove -y libunwind8
 RUN apt-get install -y libssl-dev
+RUN git clone --depth 1 https://github.com/P-H-C/phc-winner-argon2.git
 
 COPY build.sh $SRC/

--- a/projects/cryptofuzz/project.yaml
+++ b/projects/cryptofuzz/project.yaml
@@ -28,6 +28,8 @@ auto_ccs:
     - "kjacobs@mozilla.com"
     - "matthias.st.pierre@gmail.com"
     - "kaleb.himes@gmail.com"
+    - "jeanphilippe.aumasson@gmail.com"
+    - "khovratovich@gmail.com"
 sanitizers:
  - address
  - undefined


### PR DESCRIPTION
Hello,

I found that in cryptofuzz there is already fuzzed Blake3, but many project out there are using Argon2, Password Hashing Competition Winner based on Blake2.

That is likely to be hard to fuzz, as well hard to bruteforce. I also never integrated any project with cryptofuzz.

My idea is to integrate project because it seems to be alive:
- is already found in the wild as dependency,
- is updated,
- have high number of stars&forks.
Besides that, project could be added as reference for another implementations in competitive libraries.

Share any thoughts. Many that should go to cryptofuzz repo instead.
Thanks in advance.

EDIT: ...and, last but not least - the project was not listed as wanted in #402 so I asking if you want any work to be done with that.