### PR TITLE
[IPFS] Initial fuzzing of datastore consistency

### DIFF
--- a/projects/ipfs/Dockerfile
+++ b/projects/ipfs/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER willscott@protocol.io
+RUN go get -t github.com/ipfs/go-datastore
+
+COPY build.sh $SRC/
+WORKDIR $SRC/

--- a/projects/ipfs/build.sh
+++ b/projects/ipfs/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $GOPATH/src/github.com/ipfs/go-datastore/fuzz
+DS_PROVIDERS="github.com/ipfs/go-ds-badger,github.com/ipfs/go-ds-badger2" go generate
+
+# vendor dependencies since go-fuzz doesn't play nicely with go mod.
+go mod vendor
+mkdir .gopath
+cd .gopath
+ln -s ../vendor src
+cd ..
+
+fuzzer="ipfs_ds_fuzzer"
+# Compile and instrument all Go files relevant to this fuzz target.
+GO111MODULE=off GOPATH=$PWD/.gopath go-fuzz -o $fuzzer.a .
+
+# Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer

--- a/projects/ipfs/build.sh
+++ b/projects/ipfs/build.sh
@@ -16,18 +16,31 @@
 ################################################################################
 
 cd $GOPATH/src/github.com/ipfs/go-datastore/fuzz
-DS_PROVIDERS="github.com/ipfs/go-ds-badger,github.com/ipfs/go-ds-badger2" go generate
 
-# vendor dependencies since go-fuzz doesn't play nicely with go mod.
-go mod vendor
-mkdir .gopath
-cd .gopath
-ln -s ../vendor src
-cd ..
+function compile_ds_fuzzer {
+  fuzzer=$1
 
-fuzzer="ipfs_ds_fuzzer"
-# Compile and instrument all Go files relevant to this fuzz target.
-GO111MODULE=off GOPATH=$PWD/.gopath go-fuzz -o $fuzzer.a .
+  if [ $# == 2 ]; then
+    rm provider* || true
+    DS_PROVIDERS="$2" go generate
+  fi
 
-# Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
-$CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
+  # vendor dependencies since go-fuzz doesn't play nicely with go mod.
+  rm -rf vendor .gopath || true
+  go mod vendor
+  mkdir .gopath
+  cd .gopath
+  ln -s ../vendor src
+  cd ..
+
+  # Compile and instrument all Go files relevant to this fuzz target.
+  GO111MODULE=off GOPATH=$PWD/.gopath go-fuzz -o $fuzzer.a .
+
+  # Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
+}
+
+compile_ds_fuzzer ipfs_ds_flatfs
+compile_ds_fuzzer ipfs_ds_badger "github.com/ipfs/go-ds-badger"
+compile_ds_fuzzer ipfs_ds_badger2 "github.com/ipfs/go-ds-badger2"
+

--- a/projects/ipfs/project.yaml
+++ b/projects/ipfs/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/ipfs/go-datastore"
+primary_contact: "willscott@protocol.ai"
+auto_ccs :
+- "stebalien@protocol.ai"
+language: go
+fuzzing_engines:
+- libfuzzer
+sanitizers:
+- address


### PR DESCRIPTION
Submitting [IPFS](http://github.com/ipfs/go-ipfs) for initial integration.

This initial fuzz testing validates the interface of the multiple
[datastores](http://github.com/ipfs/go-datastore) backing of IPFS. A fuzzer for the protocol between nodes will follow.