### PR TITLE
[Libarchive] Removed creation of corpus from build script

### DIFF
--- a/projects/libarchive/build.sh
+++ b/projects/libarchive/build.sh
@@ -21,20 +21,8 @@
 make -j$(nproc) all
 
 # build seed
-SD=seed
-echo "Mary had a little lamb,
-Its fleece was white as snow;
-And everywhere that Mary went
-The lamb was sure to go." >> $SD
-bzip2 -k $SD && gzip -k $SD && lrzip $SD && lz4 -k $SD \
-	&& lzop $SD && xz -k $SD && zstd -k $SD \
-	&& genisoimage -o $SD.iso $SD && lcab $SD $SD.cab \
-	&& lha c $SD.lzh $SD && rar a $SD.rar $SD \
-	&& tar -czvf $SD.tar.gz $SD && jar -cvf $SD $SD \
-	&& zip $SD $SD
-
-zip corpus.zip $SD.* && mv corpus.zip /out/libarchive_fuzzer_seed_corpus.zip
-rm $SD.*
+cp $SRC/libarchive/contrib/oss-fuzz/corpus.zip\
+       	$OUT/libarchive_fuzzer_seed_corpus.zip
 
 # build fuzzer(s)
 $CXX $CXXFLAGS -Ilibarchive \


### PR DESCRIPTION
The recently added seed corpus [has been uploaded](https://github.com/libarchive/libarchive/pull/1365) to the upstream repository.

I am updating the build script accordingly by removing the creation of the seed corpus and using the .zip file in Libarchives own repository.