### PR TITLE
[cryptofuzz] Move libtomcrypt to NSS-based binary

### DIFF
--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -289,12 +289,15 @@ then
     LINK_FLAGS=${LINK_FLAGS//"-lsqlite3"/}
 fi
 
-# libtomcrypt can only be compiled with NSS, because OpenSSL, LibreSSL and
-# BoringSSL have symbol collisions with libtomcrypt.
-#
-# So, now that NSS-based Cryptofuzz has been compiled, remove libtomcrypt
-export CXXFLAGS=${CXXFLAGS/-DCRYPTOFUZZ_LIBTOMCRYPT/}
-rm -rf "$LIBTOMCRYPT_A_PATH"
+if [[ $CFLAGS != *sanitize=memory* ]]
+then
+    # libtomcrypt can only be compiled with NSS, because OpenSSL, LibreSSL and
+    # BoringSSL have symbol collisions with libtomcrypt.
+    #
+    # So, now that NSS-based Cryptofuzz has been compiled, remove libtomcrypt
+    export CXXFLAGS=${CXXFLAGS/-DCRYPTOFUZZ_LIBTOMCRYPT/}
+    rm -rf "$LIBTOMCRYPT_A_PATH"
+fi
 
 ##############################################################################
 # Compile wolfCrypt

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -289,6 +289,13 @@ then
     LINK_FLAGS=${LINK_FLAGS//"-lsqlite3"/}
 fi
 
+# libtomcrypt can only be compiled with NSS, because OpenSSL, LibreSSL and
+# BoringSSL have symbol collisions with libtomcrypt.
+#
+# So, now that NSS-based Cryptofuzz has been compiled, remove libtomcrypt
+export CXXFLAGS=${CXXFLAGS/-DCRYPTOFUZZ_LIBTOMCRYPT/}
+rm -rf "$LIBTOMCRYPT_A_PATH"
+
 ##############################################################################
 # Compile wolfCrypt
 cd $SRC/wolfssl


### PR DESCRIPTION
I recently merged libtomcrypt into the project, but it turns out it has symbol collisions with OpenSSL/LibreSSL/BoringSSL, leading to false positive bugs like https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=21898.

This patch builds libtomcrypt together only with NSS, with which it should have no symbol collisions.