### PR TITLE
[jsoncons] All work in building fuzzers has been moved to upstream.

### DIFF
--- a/projects/jsoncons/build.sh
+++ b/projects/jsoncons/build.sh
@@ -14,22 +14,8 @@
 # limitations under the License.
 #
 ################################################################################
+cd jsoncons/fuzzers
 
-cd jsoncons
-$CXX ./fuzzers/fuzz_parse.cpp -I./include $CXXFLAGS $LIB_FUZZING_ENGINE -o $OUT/fuzz_parse
-$CXX ./fuzzers/fuzz_csv.cpp -I./include $CXXFLAGS $LIB_FUZZING_ENGINE -o $OUT/fuzz_csv
-
-# With third party
-$CXX ./fuzzers/fuzz_cbor.cpp -I./include -I./third_party $CXXFLAGS $LIB_FUZZING_ENGINE -o $OUT/fuzz_cbor
-$CXX ./fuzzers/fuzz_bson.cpp -I./include -I./third_party $CXXFLAGS $LIB_FUZZING_ENGINE -o $OUT/fuzz_bson
-$CXX ./fuzzers/fuzz_msgpack.cpp -I./include -I./third_party $CXXFLAGS $LIB_FUZZING_ENGINE -o $OUT/fuzz_msgpack
-$CXX ./fuzzers/fuzz_ubjson.cpp -I./include -I./third_party $CXXFLAGS $LIB_FUZZING_ENGINE -o $OUT/fuzz_ubjson
-
-
-# Fuzzers with encoders
-$CXX ./fuzzers/fuzz_bson_encoder.cpp -I./include -I./third_party $CXXFLAGS $LIB_FUZZING_ENGINE -o $OUT/fuzz_bson_encoder
-$CXX ./fuzzers/fuzz_cbor_encoder.cpp -I./include -I./third_party $CXXFLAGS $LIB_FUZZING_ENGINE -o $OUT/fuzz_cbor_encoder
-$CXX ./fuzzers/fuzz_csv_encoder.cpp -I./include -I./third_party $CXXFLAGS $LIB_FUZZING_ENGINE -o $OUT/fuzz_csv_encoder
-$CXX ./fuzzers/fuzz_json_encoder.cpp -I./include -I./third_party $CXXFLAGS $LIB_FUZZING_ENGINE -o $OUT/fuzz_json_encoder
-$CXX ./fuzzers/fuzz_msgpack_encoder.cpp -I./include -I./third_party $CXXFLAGS $LIB_FUZZING_ENGINE -o $OUT/fuzz_msgpack_encoder
-$CXX ./fuzzers/fuzz_ubjson_encoder.cpp -I./include -I./third_party $CXXFLAGS $LIB_FUZZING_ENGINE -o $OUT/fuzz_ubjson_encoder
+# Ensure script is executable
+chmod +x ./build_fuzzers.sh
+./build_fuzzers.sh


### PR DESCRIPTION
To simplify things from an OSS-Fuzz point of view we have moved all work related to building fuzzers in Jsoncons to upstream. 