### PR TITLE
syzkaller: update go get invocation

### DIFF
--- a/projects/syzkaller/Dockerfile
+++ b/projects/syzkaller/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mmoroz@chromium.org
 
-RUN go get -u -d github.com/google/syzkaller/...
+RUN go get -u -d github.com/google/syzkaller/prog
 
 # Dependency for one of the fuzz targets.
 RUN go get github.com/ianlancetaylor/demangle


### PR DESCRIPTION
The way to checkout the repo has changed.
Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=21994