### PR TITLE
syzkaller: update go get invocation

### DIFF
--- a/projects/syzkaller/Dockerfile
+++ b/projects/syzkaller/Dockerfile
@@ -17,11 +17,11 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mmoroz@chromium.org
 
-RUN go get -u -d github.com/google/syzkaller/...
+RUN go get -u -d github.com/google/syzkaller/prog
 
 # Dependency for one of the fuzz targets.
+# Note: this should not be necessary because this package is in syzkaller/vendor.
 RUN go get github.com/ianlancetaylor/demangle
 
-RUN git clone --depth 1 https://github.com/google/syzkaller.git
-WORKDIR syzkaller
+WORKDIR /root/go/src/github.com/google/syzkaller
 COPY build.sh $SRC/

--- a/projects/syzkaller/build.sh
+++ b/projects/syzkaller/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/bash -eux
 # Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,7 @@ function compile_fuzzer {
   $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
 }
 
+make descriptions
 compile_fuzzer ./pkg/compiler Fuzz compiler_fuzzer
 compile_fuzzer ./prog/test FuzzDeserialize prog_deserialize_fuzzer
 compile_fuzzer ./prog/test FuzzParseLog prog_parselog_fuzzer

--- a/projects/syzkaller/build.sh
+++ b/projects/syzkaller/build.sh
@@ -28,10 +28,10 @@ function compile_fuzzer {
 }
 
 make descriptions
-compile_fuzzer ./pkg/compiler Fuzz compiler_fuzzer
-compile_fuzzer ./prog/test FuzzDeserialize prog_deserialize_fuzzer
-compile_fuzzer ./prog/test FuzzParseLog prog_parselog_fuzzer
-compile_fuzzer ./pkg/report Fuzz report_fuzzer
+compile_fuzzer github.com/google/syzkaller/pkg/compiler Fuzz compiler_fuzzer
+compile_fuzzer github.com/google/syzkaller/prog/test FuzzDeserialize prog_deserialize_fuzzer
+compile_fuzzer github.com/google/syzkaller/prog/test FuzzParseLog prog_parselog_fuzzer
+compile_fuzzer github.com/google/syzkaller/pkg/report Fuzz report_fuzzer
 
 # This target is way too spammy and OOMs very quickly.
 # compile_fuzzer ./tools/syz-trace2syz/proggen Fuzz trace2syz_fuzzer


### PR DESCRIPTION
The way to checkout the repo has changed.
Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=21994