### PR TITLE
[clamav] Add flex, bison to Dockerfile

### DIFF
--- a/projects/clamav/Dockerfile
+++ b/projects/clamav/Dockerfile
@@ -16,7 +16,10 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER clamav.fuzz@gmail.com
-RUN apt-get update && apt-get install -y libssl-dev libcurl4-openssl-dev
+RUN apt-get update && apt-get install -y \
+    flex bison \
+    libssl-dev \
+    libcurl4-openssl-dev
 RUN git clone --depth 1 https://github.com/Cisco-Talos/clamav-devel.git
 RUN git clone --depth 1 https://github.com/Cisco-Talos/clamav-fuzz-corpus.git
 

--- a/projects/clamav/build.sh
+++ b/projects/clamav/build.sh
@@ -15,13 +15,30 @@
 #
 ################################################################################
 
+set -ex
+
 #
 # Build the library.
 #
 rm -rf ${WORK}/build
 mkdir -p ${WORK}/build
 cd ${WORK}/build
-ac_cv_c_mmap_anonymous=no ${SRC}/clamav-devel/configure --disable-mempool --enable-fuzz=yes --with-libjson=no --with-pcre=no --enable-static=yes --enable-shared=no --disable-llvm --host=x86_64-unknown-linux-gnu
+
+#
+# Run ./configure
+#
+ac_cv_c_mmap_anonymous=no \
+    ${SRC}/clamav-devel/configure \
+        --disable-mempool \
+        --enable-fuzz=yes \
+        --with-libjson=no \
+        --with-pcre=no \
+        --enable-static=yes \
+        --enable-shared=no \
+        --disable-llvm \
+        --host=x86_64-unknown-linux-gnu
+
+# Build libclamav
 make clean
 make -j"$(nproc)"
 
@@ -40,16 +57,16 @@ cp ./fuzz/clamav_* ${OUT}/.
 mkdir ${WORK}/all-scantype-seeds
 
 for type in ARCHIVE MAIL OLE2 PDF HTML PE ELF SWF XMLDOCS HWP3; do
-	# Prepare seed corpus for the type-specific fuzz targets.
-	zip ${OUT}/clamav_scanfile_${type}_fuzzer_seed_corpus.zip ${SRC}/clamav-fuzz-corpus/scantype/${type}/*
-	zip ${OUT}/clamav_scanmap_${type}_fuzzer_seed_corpus.zip ${SRC}/clamav-fuzz-corpus/scantype/${type}/*
+    # Prepare seed corpus for the type-specific fuzz targets.
+    zip ${OUT}/clamav_scanfile_${type}_fuzzer_seed_corpus.zip ${SRC}/clamav-fuzz-corpus/scantype/${type}/*
+    zip ${OUT}/clamav_scanmap_${type}_fuzzer_seed_corpus.zip ${SRC}/clamav-fuzz-corpus/scantype/${type}/*
 
-	# Prepare dictionary for the type-specific fuzz targets (may not exist for all types).
-	cp ${SRC}/clamav-fuzz-corpus/scantype/${type}.dict ${OUT}/clamav_scanfile_${type}_fuzzer.dict 2>/dev/null || :
-	cp ${SRC}/clamav-fuzz-corpus/scantype/${type}.dict ${OUT}/clamav_scanmap_${type}_fuzzer.dict 2>/dev/null || :
+    # Prepare dictionary for the type-specific fuzz targets (may not exist for all types).
+    cp ${SRC}/clamav-fuzz-corpus/scantype/${type}.dict ${OUT}/clamav_scanfile_${type}_fuzzer.dict 2>/dev/null || :
+    cp ${SRC}/clamav-fuzz-corpus/scantype/${type}.dict ${OUT}/clamav_scanmap_${type}_fuzzer.dict 2>/dev/null || :
 
-	# Copy seeds for the generic fuzz target.
-	cp ${SRC}/clamav-fuzz-corpus/scantype/${type}/* ${WORK}/all-scantype-seeds/
+    # Copy seeds for the generic fuzz target.
+    cp ${SRC}/clamav-fuzz-corpus/scantype/${type}/* ${WORK}/all-scantype-seeds/
 done
 
 # Prepare seed corpus for the generic fuzz target.
@@ -61,9 +78,9 @@ rm -r ${WORK}/all-scantype-seeds
 # `dbload`
 # --------
 for type in CDB CFG CRB FP FTM HDB HSB IDB IGN IGN2 LDB MDB MSB NDB PDB WDB YARA; do
-	# Prepare seed corpus for the type-specific fuzz targets.
-	zip ${OUT}/clamav_dbload_${type}_fuzzer_seed_corpus.zip ${SRC}/clamav-fuzz-corpus/database/${type}/*
+    # Prepare seed corpus for the type-specific fuzz targets.
+    zip ${OUT}/clamav_dbload_${type}_fuzzer_seed_corpus.zip ${SRC}/clamav-fuzz-corpus/database/${type}/*
 
-	# Prepare dictionary for the type-specific fuzz targets (may not exist for all types).
-	cp ${SRC}/clamav-fuzz-corpus/database/${type}.dict ${OUT}/clamav_dbload_${type}_fuzzer.dict 2>/dev/null || :
+    # Prepare dictionary for the type-specific fuzz targets (may not exist for all types).
+    cp ${SRC}/clamav-fuzz-corpus/database/${type}.dict ${OUT}/clamav_dbload_${type}_fuzzer.dict 2>/dev/null || :
 done


### PR DESCRIPTION
Flex & Bison are needed to generate source files for yara syntax
support. While the generated source are currently in the clamav-devel
repo, the build system sometimes thinks the files must be regenerated.

In the future, these and the autotools generated files will be removed
from the clamav-devel repo and will need to be generated for every
build.

We're also planning to add CMake tooling (still a work in progress).

Once the generated files are removed, we'll either have ot build the
fuzz targets with CMake or bring in autoconf, automake, m4, libtool, and
pkg-config to generate the files in build.sh. At that time, we should
also update build.sh to build the dependencies statically, many of which
are missing at present meaning we're not getting great code coverage.
We'll also want to load a small signature set to improve code coverage
for the fuzz targets.