### PR TITLE
Add gopacket

### DIFF
--- a/projects/gopacket/Dockerfile
+++ b/projects/gopacket/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER tomfitzhenry@google.com
+RUN go get -t github.com/google/gopacket
+
+COPY build.sh $SRC/layers
+WORKDIR $SRC/layers

--- a/projects/gopacket/build.sh
+++ b/projects/gopacket/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+function compile_fuzzer {
+  package=$1
+  function=$2
+  fuzzer=$3
+
+  # Compile and instrument all Go files relevant to this fuzz target.
+  go-fuzz -func $function -o $fuzzer.a $package
+
+  # Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
+}
+
+compile_fuzzer github.com/google/gopacket/layers FuzzEAPDecoder eap_decoder_fuzzer

--- a/projects/gopacket/project.yaml
+++ b/projects/gopacket/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://github.com/google/gopacket"
+primary_contact: "tomfitzhenry@google.com"
+auto_ccs :
+language: go
+fuzzing_engines:
+- libfuzzer
+sanitizers:
+- address


### PR DESCRIPTION
https://github.com/google/gopacket provides packet processing capabilities for Go, and thus is a good target for fuzzing.

The first fuzz target is being added in https://github.com/google/gopacket/pull/782