### PR TITLE
libvpx,build.sh: enable vp9 high-bitdepth

### DIFF
--- a/projects/libvpx/build.sh
+++ b/projects/libvpx/build.sh
@@ -31,6 +31,7 @@ else
 fi
 
 LDFLAGS="$CXXFLAGS" LD=$CXX $SRC/libvpx/configure \
+    --enable-vp9-highbitdepth \
     --disable-unit-tests \
     --disable-examples \
     --size-limit=12288x12288 \


### PR DESCRIPTION
This adds coverage for 10/12-bit paths.