### PR TITLE
[cascadia] initial integration

### DIFF
--- a/projects/cascadia/Dockerfile
+++ b/projects/cascadia/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER cascadia@balholm.com
+RUN go get github.com/andybalholm/cascadia
+
+COPY build.sh $SRC/
+WORKDIR $SRC/

--- a/projects/cascadia/build.sh
+++ b/projects/cascadia/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+function compile_fuzzer {
+  path=$1
+  function=$2
+  fuzzer=$3
+
+  go-fuzz -func $function -o $fuzzer.a $path
+
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
+}
+
+compile_fuzzer github.com/andybalholm/cascadia/fuzz Fuzz fuzz

--- a/projects/cascadia/project.yaml
+++ b/projects/cascadia/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/andybalholm/cascadia"
+primary_contact: "cascadia@balholm.com"
+auto_ccs :
+  - "adam@adalogics.com"
+language: go
+fuzzing_engines:
+- libfuzzer
+sanitizers:
+- address


### PR DESCRIPTION
This PR adds [cascadia](https://github.com/andybalholm/cascadia) to oss-fuzz. 

cascadia is used by [goquery](https://github.com/PuerkitoBio/goquery) of which there is an example [here](https://github.com/PuerkitoBio/goquery/blob/master/type.go#L9).