### PR TITLE
[stb] extend code coverage for stb_image

### DIFF
--- a/projects/stb/Dockerfile
+++ b/projects/stb/Dockerfile
@@ -23,9 +23,9 @@ MAINTAINER randy408@protonmail.com
 
 RUN git clone --depth 1 https://github.com/nothings/stb.git
 
-wget -O $SRC/stb/gif.tar.gz https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/imagetestsuite/imagetestsuite-gif-1.00.tar.gz
-wget -O $SRC/stb/jpg.tar.gz https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/imagetestsuite/imagetestsuite-jpg-1.00.tar.gz
-wget -O $SRC/stb/tests/gif.dict https://raw.githubusercontent.com/mirrorer/afl/master/dictionaries/gif.dict &> /dev/null
+RUN wget -O $SRC/stb/gif.tar.gz https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/imagetestsuite/imagetestsuite-gif-1.00.tar.gz
+RUN wget -O $SRC/stb/jpg.tar.gz https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/imagetestsuite/imagetestsuite-jpg-1.00.tar.gz
+RUN wget -O $SRC/stb/tests/gif.dict https://raw.githubusercontent.com/mirrorer/afl/master/dictionaries/gif.dict &> /dev/null
 
 WORKDIR stb
 COPY build.sh $SRC/

--- a/projects/stb/Dockerfile
+++ b/projects/stb/Dockerfile
@@ -16,6 +16,9 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 
+RUN apt-get update && \
+    apt-get install -y wget tar
+
 MAINTAINER randy408@protonmail.com
 
 RUN git clone --depth 1 https://github.com/nothings/stb.git

--- a/projects/stb/Dockerfile
+++ b/projects/stb/Dockerfile
@@ -23,5 +23,9 @@ MAINTAINER randy408@protonmail.com
 
 RUN git clone --depth 1 https://github.com/nothings/stb.git
 
+wget -O $SRC/stb/gif.tar.gz https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/imagetestsuite/imagetestsuite-gif-1.00.tar.gz
+wget -O $SRC/stb/jpg.tar.gz https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/imagetestsuite/imagetestsuite-jpg-1.00.tar.gz
+wget -O $SRC/stb/tests/gif.dict https://raw.githubusercontent.com/mirrorer/afl/master/dictionaries/gif.dict &> /dev/null
+
 WORKDIR stb
 COPY build.sh $SRC/

--- a/projects/stb/build.sh
+++ b/projects/stb/build.sh
@@ -15,11 +15,31 @@
 #
 ################################################################################
 
-$CXX $CXXFLAGS -std=c++11 -I. \
-    $SRC/stb/tests/stb_png_read_fuzzer.cpp \
+# remove this line when this change is upstreamed
+sed '2d' $SRC/stb/tests/stb_png_read_fuzzer.cpp > $SRC/stb/tests/stbi_read_fuzzer.c
+
+$CXX $CXXFLAGS -std=c++11 -I. -DSTBI_ONLY_PNG  \
+    $SRC/stb/tests/stbi_read_fuzzer.c \
     -o $OUT/stb_png_read_fuzzer $LIB_FUZZING_ENGINE
+
+$CXX $CXXFLAGS -std=c++11 -I. \
+    $SRC/stb/tests/stbi_read_fuzzer.c \
+    -o $OUT/stbi_read_fuzzer $LIB_FUZZING_ENGINE
 
 find $SRC/stb/tests/pngsuite -name "*.png" | \
      xargs zip $OUT/stb_png_read_fuzzer_seed_corpus.zip
 
 cp $SRC/stb/tests/stb_png.dict $OUT/stb_png_read_fuzzer.dict
+
+wget -O $SRC/stb/gif.tar.gz https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/imagetestsuite/imagetestsuite-gif-1.00.tar.gz
+wget -O $SRC/stb/jpg.tar.gz https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/imagetestsuite/imagetestsuite-jpg-1.00.tar.gz
+tar xvzf $SRC/stb/jpg.tar.gz --directory $SRC/stb/tests
+tar xvzf $SRC/stb/gif.tar.gz --directory $SRC/stb/tests
+
+find $SRC/stb/tests -name "*.png" -o -name "*.jpg" -o -name ".gif" | \
+     xargs zip $OUT/stbi_read_fuzzer_seed_corpus.zip
+
+wget -O $SRC/stb/tests/gif.dict https://raw.githubusercontent.com/mirrorer/afl/master/dictionaries/gif.dict &> /dev/null
+
+echo "" >> $SRC/stb/tests/gif.dict
+cat $SRC/stb/tests/gif.dict $SRC/stb/tests/stb_png.dict > $OUT/stbi_read_fuzzer.dict

--- a/projects/stb/build.sh
+++ b/projects/stb/build.sh
@@ -31,15 +31,11 @@ find $SRC/stb/tests/pngsuite -name "*.png" | \
 
 cp $SRC/stb/tests/stb_png.dict $OUT/stb_png_read_fuzzer.dict
 
-wget -O $SRC/stb/gif.tar.gz https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/imagetestsuite/imagetestsuite-gif-1.00.tar.gz
-wget -O $SRC/stb/jpg.tar.gz https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/imagetestsuite/imagetestsuite-jpg-1.00.tar.gz
 tar xvzf $SRC/stb/jpg.tar.gz --directory $SRC/stb/tests
 tar xvzf $SRC/stb/gif.tar.gz --directory $SRC/stb/tests
 
 find $SRC/stb/tests -name "*.png" -o -name "*.jpg" -o -name ".gif" | \
      xargs zip $OUT/stbi_read_fuzzer_seed_corpus.zip
-
-wget -O $SRC/stb/tests/gif.dict https://raw.githubusercontent.com/mirrorer/afl/master/dictionaries/gif.dict &> /dev/null
 
 echo "" >> $SRC/stb/tests/gif.dict
 cat $SRC/stb/tests/gif.dict $SRC/stb/tests/stb_png.dict > $OUT/stbi_read_fuzzer.dict


### PR DESCRIPTION
This PR adds a generic image read fuzzer with a gif+png dictionary and gif+png+jpg seed corpus.

I think this should be merged after https://github.com/nothings/stb/pull/960 which contains a lot of fixes, PR's are only getting merged every 4-6 months so it might take a while. Should the build script be upstreamed in this case?