### PR TITLE
[dragonfly] initial integration

### DIFF
--- a/projects/dragonfly/Dockerfile
+++ b/projects/dragonfly/Dockerfile
@@ -1,0 +1,34 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER zj3142063@gmail.com
+RUN go get	github.com/go-openapi/swag \
+		github.com/go-openapi/validate \
+		gopkg.in/warnings.v0 \
+		github.com/gorilla/mux \
+		github.com/prometheus/client_golang/prometheus \ 
+		github.com/pkg/errors \
+		github.com/sirupsen/logrus \
+		gopkg.in/gcfg.v1 \
+		github.com/valyala/fasthttp \
+		gopkg.in/natefinch/lumberjack.v2 \
+		github.com/emirpasic/gods/maps/treemap \
+		github.com/emirpasic/gods/utils \
+		github.com/willf/bitset
+RUN git clone https://github.com/dragonflyoss/Dragonfly
+COPY build.sh $SRC/
+WORKDIR $SRC/

--- a/projects/dragonfly/build.sh
+++ b/projects/dragonfly/build.sh
@@ -23,6 +23,7 @@ function compile_fuzzer {
 
   $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
 }
+
 mkdir $GOPATH/src/github.com/dragonflyoss
 cp -r $SRC/Dragonfly $GOPATH/src/github.com/dragonflyoss/
 

--- a/projects/dragonfly/build.sh
+++ b/projects/dragonfly/build.sh
@@ -23,6 +23,8 @@ function compile_fuzzer {
 
   $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
 }
+mkdir $GOPATH/src/github.com/dragonflyoss
+cp -r $SRC/Dragonfly $GOPATH/src/github.com/dragonflyoss/
 
 compile_fuzzer github.com/dragonflyoss/Dragonfly/dfget/core/uploader FuzzParseParams uploader_fuzz
 compile_fuzzer github.com/dragonflyoss/Dragonfly/supernode/daemon/mgr/cdn Fuzz cdn_fuzz

--- a/projects/dragonfly/build.sh
+++ b/projects/dragonfly/build.sh
@@ -1,0 +1,27 @@
+#/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+function compile_fuzzer {
+  path=$1
+  function=$2
+  fuzzer=$3
+
+  go-fuzz -func $function -o $fuzzer.a $path
+
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
+}
+compile_fuzzer github.com/dragonflyoss/Dragonfly/dfget/core/uploader FuzzParseParams uploader_fuzz
+compile_fuzzer github.com/dragonflyoss/Dragonfly/supernode/daemon/mgr/cdn Fuzz cdn_fuzz

--- a/projects/dragonfly/build.sh
+++ b/projects/dragonfly/build.sh
@@ -23,7 +23,6 @@ function compile_fuzzer {
 
   $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
 }
-
 mkdir $GOPATH/src/github.com/dragonflyoss
 cp -r $SRC/Dragonfly $GOPATH/src/github.com/dragonflyoss/
 

--- a/projects/dragonfly/build.sh
+++ b/projects/dragonfly/build.sh
@@ -23,5 +23,6 @@ function compile_fuzzer {
 
   $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
 }
+
 compile_fuzzer github.com/dragonflyoss/Dragonfly/dfget/core/uploader FuzzParseParams uploader_fuzz
 compile_fuzzer github.com/dragonflyoss/Dragonfly/supernode/daemon/mgr/cdn Fuzz cdn_fuzz

--- a/projects/dragonfly/project.yaml
+++ b/projects/dragonfly/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/dragonflyoss/Dragonfly"
+primary_contact: "zj3142063@gmail.com"
+auto_ccs :
+  - "adam@adalogics.com"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
This PR provides initial integration of [Dragonfly](https://github.com/dragonflyoss/Dragonfly).

Dragonfly is part of the [Cloud Native Computing Foundation](https://landscape.cncf.io/selected=dragonfly), and a [1-year-old tweet](https://twitter.com/dragonfly_oss/status/1151852499659190272) reveals a part of their userbase.

@lowzj Is the contact person of the oss-fuzz integration, and currently we are waiting for the fuzzers to be merged upstream.