### PR TITLE
[knot-dns] add liblmdb dependency

### DIFF
--- a/projects/knot-dns/Dockerfile
+++ b/projects/knot-dns/Dockerfile
@@ -37,6 +37,7 @@ RUN git clone git://git.savannah.gnu.org/gnulib.git
 RUN git clone --depth=1 --recursive https://git.savannah.gnu.org/git/libunistring.git
 RUN git clone --depth=1 https://git.lysator.liu.se/nettle/nettle.git
 RUN git clone --depth=1 https://gitlab.com/gnutls/gnutls.git
+RUN git clone --depth=1 https://github.com/LMDB/lmdb.git
 RUN git clone --depth=1 https://gitlab.labs.nic.cz/knot/knot-dns
 
 WORKDIR knot-dns

--- a/projects/knot-dns/build.sh
+++ b/projects/knot-dns/build.sh
@@ -56,19 +56,21 @@ CFLAGS="$GNUTLS_CFLAGS" \
 make -j$(nproc)
 make install
 
+cd $SRC/lmdb/libraries/liblmdb
+make -j$(nproc)
+make install
 
 # Compile knot, install fuzzers to $OUT
 
 cd $SRC/knot-dns
+sed -i 's/-llmdb/-Wl,-Bstatic,-llmdb,-Bdynamic/' configure.ac
 autoreconf -if
-
-./configure --with-oss-fuzz=yes --disable-shared --enable-static --disable-daemon --disable-utilities --disable-documentation --disable-fastparser --disable-modules
-
+./configure --with-oss-fuzz=yes --disable-shared --enable-static --disable-daemon --disable-utilities --disable-documentation \
+    --disable-fastparser --disable-modules
 make -j$(nproc)
 cd $SRC/knot-dns/tests-fuzz
 make check
 /bin/bash ../libtool   --mode=install /usr/bin/install -c fuzz_packet fuzz_zscanner fuzz_dname_to_str fuzz_dname_from_str "$OUT"
-
 
 # Set up fuzzing seeds
 


### PR DESCRIPTION
Relates to https://gitlab.labs.nic.cz/knot/knot-dns/-/commit/d4ec3a3aa8b7e2ba4d196e2f7984173069e3d91b

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=22191