### PR TITLE
cifuzz: s/allowed_broken_targets_percentage/allowed-broken-targets-pe…

### DIFF
--- a/docs/getting-started/continuous_integration.md
+++ b/docs/getting-started/continuous_integration.md
@@ -90,7 +90,7 @@ CIFuzz will never report a failure even if it finds a crash in your project.
 This requires the user to manually check the logs for detected bugs. If dry run mode is desired,
 make sure to set the dry-run parameters in both the `Build Fuzzers` and `Run Fuzzers` action step.
 
-`allowed_broken_targets_percentage`: Can be set if you want to set a stricter
+`allowed-broken-targets-percentage`: Can be set if you want to set a stricter
 limit for broken fuzz targets than OSS-Fuzz's check_build. Most users should
 not set this.
 


### PR DESCRIPTION
…rcentage/

I understand that most users shouldn't use it but this typo kind of took it to a whole new level :-)

I'd wait for https://github.com/systemd/systemd/runs/672205972?check_suite_focus=true to fail to make sure it's really called "allowed-broken-targets-percentage"