### PR TITLE
Fix clang updating script to actually track Chrome's

### DIFF
--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -52,8 +52,8 @@ LLVM_SRC=$SRC/llvm-project
 # For manual bumping.
 OUR_LLVM_REVISION=e84b7a5fe230e42b8e6fe451369874a773bf1867
 
-# To allow for manual downgrades. Set to 0 not to force a manual downgrade.
-# Set to 1 to force a manual downgrade.
+# To allow for manual downgrades. Set to 0 to use Chrome's clang version (i.e.
+# *not* force a manual downgrade). Set to 1 to force a manual downgrade.
 FORCE_OUR_REVISION=0
 LLVM_REVISION=$(grep -Po "CLANG_REVISION = '\K[a-f0-9]+(?=')" scripts/update.py)
 
@@ -61,12 +61,12 @@ clone_with_retries https://github.com/llvm/llvm-project.git $LLVM_SRC
 
 set +e
 git -C $LLVM_SRC merge-base --is-ancestor $OUR_LLVM_REVISION $LLVM_REVISION
-IS_OUR_REVISION_ANCESTOR=$?
+IS_OUR_REVISION_ANCESTOR_RETCODE=$?
 set -e
 
 # Use our revision if specified by FORCE_OUR_REVISION or if our revision is a
 # later revision than Chrome's (i.e. not an ancestor of Chrome's).
-if [ $IS_OUR_REVISION_ANCESTOR -ne 0 ] || [ $FORCE_OUR_REVISION -eq 1 ] ; then
+if [ $IS_OUR_REVISION_ANCESTOR_RETCODE -ne 0 ] || [ $FORCE_OUR_REVISION -eq 1 ] ; then
   LLVM_REVISION=$OUR_LLVM_REVISION
 fi
 

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -48,19 +48,25 @@ git clone https://chromium.googlesource.com/chromium/src/tools/clang
 cd clang
 
 LLVM_SRC=$SRC/llvm-project
-OUR_LLVM_REVISION=e84b7a5fe230e42b8e6fe451369874a773bf1867  # For manual bumping.
-FORCE_OUR_REVISION=0  # To allow for manual downgrades.
+
+# For manual bumping.
+OUR_LLVM_REVISION=e84b7a5fe230e42b8e6fe451369874a773bf1867
+
+# To allow for manual downgrades. Set to 0 not to force a manual downgrade.
+# Set to 1 to force a manual downgrade.
+FORCE_OUR_REVISION=0
 LLVM_REVISION=$(grep -Po "CLANG_REVISION = '\K[a-f0-9]+(?=')" scripts/update.py)
 
 clone_with_retries https://github.com/llvm/llvm-project.git $LLVM_SRC
 
 set +e
-IS_OUR_REVISION_ANCESTOR=$(git -C $LLVM_SRC merge-base --is-ancestor $OUR_LLVM_REVISION $LLVM_REVISION)
+git -C $LLVM_SRC merge-base --is-ancestor $OUR_LLVM_REVISION $LLVM_REVISION
+IS_OUR_REVISION_ANCESTOR=$?
 set -e
 
-# Use our revision if specified or if our revision is a later revision than
-# Chrome's.
-if [ ! $IS_OUR_REVISION_ANCESTOR  ] || [ $FORCE_OUR_REVISION ] ; then
+# Use our revision if specified by FORCE_OUR_REVISION or if our revision is a
+# later revision than Chrome's (i.e. not an ancestor of Chrome's).
+if [ $IS_OUR_REVISION_ANCESTOR -ne 0 ] || [ $FORCE_OUR_REVISION -eq 1 ] ; then
   LLVM_REVISION=$OUR_LLVM_REVISION
 fi
 


### PR DESCRIPTION
This commit fixes bugs so that commit OSS-Fuzz builds clang from will track
Chrome's instead of being pinned to e84b7a5fe230e42b8e6fe451369874a773bf1867.
With this commit, clang (llvm-project) will be updated from:
e84b7a5fe230e42b8e6fe451369874a773bf1867
to Chrome's current version:
99ac9ce7016d701b43b8f0c308dc3463da57d983.

This commit fixes two bad bugs:
1. Using the output of a command instead of the return code.
2. Using "!" to determine whether the command succeeded. "!" in bash
will do the same thing for 0 and 1.

These bugs were hidden by OUR_LLVM_REVISION which we traditionally
set to the last commit we rolled back to. If this were set to nothing and
the last commit stored as a comment
instead of stored as a variable that is not supposed to be used
unless FORCE_OUR_REVISION is set, this bug probably could have
been caught earlier. Instead, the code always used the value
provided by this variable.

Fixes #3805