### PR TITLE
[grpc-gateway] Initial integration

### DIFF
--- a/projects/grpc-gateway/Dockerfile
+++ b/projects/grpc-gateway/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER adam@adalogics.com
+RUN go get github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
+COPY build.sh $SRC/
+WORKDIR $SRC/

--- a/projects/grpc-gateway/build.sh
+++ b/projects/grpc-gateway/build.sh
@@ -1,0 +1,27 @@
+#/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+function compile_fuzzer {
+  path=$1
+  function=$2
+  fuzzer=$3
+
+  go-fuzz -func $function -o $fuzzer.a $path
+
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
+}
+
+compile_fuzzer github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/httprule Fuzz fuzz

--- a/projects/grpc-gateway/project.yaml
+++ b/projects/grpc-gateway/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/grpc-ecosystem/grpc-gateway"
+primary_contact: "grpc-gateway-maintainers@googlegroups.com"
+auto_ccs :
+  - "adam@adalogics.com"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
This PR provides initial integration of [grpc-gateway](https://github.com/grpc-ecosystem/grpc-gateway).

Adopters include:

- [Ad Hoc](https://adhocteam.us/) uses the gRPC-Gateway to serve millions of API requests per day.
- Chef uses gRPC-Gateway to provide the user-facing API of Chef Automate. Furthermore, the generated OpenAPI data serves as the basis for its API documentation. An example can be seen [here](https://github.com/chef/automate/tree/master/vendor/github.com/grpc-ecosystem/grpc-gateway).
- [Argo](https://github.com/argoproj/argo-cd/blob/master/Gopkg.toml#L11)
- [Azure](https://github.com/Azure/open-service-broker-azure/tree/master/vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway)
- [Scaleway](https://www.scaleway.com/en/) uses the gRPC-Gateway since 2018 to serve millions of API requests per day

@johanbrandhorst is a core contributor of grpc-gateway.