### PR TITLE
Add Thyla and Ben to NSS OSS-Fuzz results

### DIFF
--- a/projects/cryptofuzz/project.yaml
+++ b/projects/cryptofuzz/project.yaml
@@ -26,6 +26,8 @@ auto_ccs:
     - "jjones@mozilla.com"
     - "sledru@mozilla.com"
     - "kjacobs@mozilla.com"
+    - "bbeurdouche@mozilla.com"
+    - "tvandermerwe@mozilla.com"
     - "matthias.st.pierre@gmail.com"
     - "kaleb.himes@gmail.com"
 sanitizers:


### PR DESCRIPTION
Thyla and Ben also need access to the NSS-side of OSS fuzz for their work.