### PR TITLE
Added initial integration of serde-yaml.

### DIFF
--- a/projects/serde-yaml/Dockerfile
+++ b/projects/serde-yaml/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER david@adalogics.com
+RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang
+
+ENV CARGO_HOME=/rust RUSTUP_HOME=/rust/rustup PATH=$PATH:/rust/bin
+RUN curl https://sh.rustup.rs | sh -s -- -y --default-toolchain=nightly
+RUN cargo install cargo-fuzz
+
+RUN git clone --depth 1 https://github.com/dtolnay/serde-yaml serde-yaml
+WORKDIR $SRC
+
+COPY build.sh $SRC/

--- a/projects/serde-yaml/Dockerfile
+++ b/projects/serde-yaml/Dockerfile
@@ -15,11 +15,6 @@
 ################################################################################
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER david@adalogics.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang
-
-ENV CARGO_HOME=/rust RUSTUP_HOME=/rust/rustup PATH=$PATH:/rust/bin
-RUN curl https://sh.rustup.rs | sh -s -- -y --default-toolchain=nightly
-RUN cargo install cargo-fuzz
 
 RUN git clone --depth 1 https://github.com/dtolnay/serde-yaml serde-yaml
 WORKDIR $SRC

--- a/projects/serde-yaml/build.sh
+++ b/projects/serde-yaml/build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Note: This project creates Rust fuzz targets exclusively
+export CUSTOM_LIBFUZZER_PATH="$LIB_FUZZING_ENGINE_DEPRECATED"
+export CUSTOM_LIBFUZZER_STD_CXX=c++
+
+# Because Rust does not support sanitizers via CFLAGS/CXXFLAGS, the environment
+# variables are overridden with values from base-images/base-clang only
+export CFLAGS="-O1 -fno-omit-frame-pointer -gline-tables-only -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"
+export CXXFLAGS_EXTRA="-stdlib=libc++"
+export CXXFLAGS="$CFLAGS $CXXFLAGS_EXTRA"
+export RUSTFLAGS="-Cdebuginfo=1 -Cforce-frame-pointers"
+
+cd $SRC/serde-yaml
+cargo fuzz build -O 
+cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_from_slice $OUT/

--- a/projects/serde-yaml/build.sh
+++ b/projects/serde-yaml/build.sh
@@ -15,17 +15,6 @@
 #
 ################################################################################
 
-# Note: This project creates Rust fuzz targets exclusively
-export CUSTOM_LIBFUZZER_PATH="$LIB_FUZZING_ENGINE_DEPRECATED"
-export CUSTOM_LIBFUZZER_STD_CXX=c++
-
-# Because Rust does not support sanitizers via CFLAGS/CXXFLAGS, the environment
-# variables are overridden with values from base-images/base-clang only
-export CFLAGS="-O1 -fno-omit-frame-pointer -gline-tables-only -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"
-export CXXFLAGS_EXTRA="-stdlib=libc++"
-export CXXFLAGS="$CFLAGS $CXXFLAGS_EXTRA"
-export RUSTFLAGS="-Cdebuginfo=1 -Cforce-frame-pointers"
-
 cd $SRC/serde-yaml
 cargo fuzz build -O 
 cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_from_slice $OUT/

--- a/projects/serde-yaml/project.yaml
+++ b/projects/serde-yaml/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/dtolnay/serde-yaml"
+primary_contact: "dtolnay@gmail.com"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+language: rust
+auto_ccs:
+  - "david@adalogics.com"


### PR DESCRIPTION
Integrated another Rust project similar to serde-json that was integrated [here](https://github.com/google/oss-fuzz/pull/3785) but now for yaml. 

The project has been downloaded 3 million times [here](https://crates.io/crates/serde_yaml) and more than 400 projects depend on it as show [here](https://crates.io/crates/serde_yaml/reverse_dependencies) 

The fuzzers are merged upstream and maintainer is @dtolnay 