### PR TITLE
Added the rust-lang regex project.

### DIFF
--- a/projects/rust-regex/Dockerfile
+++ b/projects/rust-regex/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER david@adalogics.com
+RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang
+
+ENV CARGO_HOME=/rust RUSTUP_HOME=/rust/rustup PATH=$PATH:/rust/bin
+RUN curl https://sh.rustup.rs | sh -s -- -y --default-toolchain=nightly
+RUN cargo install cargo-fuzz
+
+RUN git clone --depth 1 https://github.com/rust-lang/regex regex
+WORKDIR $SRC
+
+COPY build.sh $SRC/

--- a/projects/rust-regex/Dockerfile
+++ b/projects/rust-regex/Dockerfile
@@ -14,7 +14,6 @@
 #
 ################################################################################
 FROM gcr.io/oss-fuzz-base/base-builder
-MAINTAINER david@adalogics.com
 
 RUN git clone --depth 1 https://github.com/rust-lang/regex regex
 WORKDIR $SRC

--- a/projects/rust-regex/Dockerfile
+++ b/projects/rust-regex/Dockerfile
@@ -15,11 +15,7 @@
 ################################################################################
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER david@adalogics.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang
-
-ENV CARGO_HOME=/rust RUSTUP_HOME=/rust/rustup PATH=$PATH:/rust/bin
-RUN curl https://sh.rustup.rs | sh -s -- -y --default-toolchain=nightly
-RUN cargo install cargo-fuzz
+RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python 
 
 RUN git clone --depth 1 https://github.com/rust-lang/regex regex
 WORKDIR $SRC

--- a/projects/rust-regex/Dockerfile
+++ b/projects/rust-regex/Dockerfile
@@ -15,7 +15,6 @@
 ################################################################################
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER david@adalogics.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python 
 
 RUN git clone --depth 1 https://github.com/rust-lang/regex regex
 WORKDIR $SRC

--- a/projects/rust-regex/build.sh
+++ b/projects/rust-regex/build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Note: This project creates Rust fuzz targets exclusively
+export CUSTOM_LIBFUZZER_PATH="$LIB_FUZZING_ENGINE_DEPRECATED"
+export CUSTOM_LIBFUZZER_STD_CXX=c++
+
+# Because Rust does not support sanitizers via CFLAGS/CXXFLAGS, the environment
+# variables are overridden with values from base-images/base-clang only
+export CFLAGS="-O1 -fno-omit-frame-pointer -gline-tables-only -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"
+export CXXFLAGS_EXTRA="-stdlib=libc++"
+export CXXFLAGS="$CFLAGS $CXXFLAGS_EXTRA"
+export RUSTFLAGS="-Cdebuginfo=1 -Cforce-frame-pointers"
+
+cd $SRC/regex
+cargo fuzz build -O 
+cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_regex_match $OUT/

--- a/projects/rust-regex/build.sh
+++ b/projects/rust-regex/build.sh
@@ -15,17 +15,6 @@
 #
 ################################################################################
 
-# Note: This project creates Rust fuzz targets exclusively
-export CUSTOM_LIBFUZZER_PATH="$LIB_FUZZING_ENGINE_DEPRECATED"
-export CUSTOM_LIBFUZZER_STD_CXX=c++
-
-# Because Rust does not support sanitizers via CFLAGS/CXXFLAGS, the environment
-# variables are overridden with values from base-images/base-clang only
-export CFLAGS="-O1 -fno-omit-frame-pointer -gline-tables-only -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"
-export CXXFLAGS_EXTRA="-stdlib=libc++"
-export CXXFLAGS="$CFLAGS $CXXFLAGS_EXTRA"
-export RUSTFLAGS="-Cdebuginfo=1 -Cforce-frame-pointers"
-
 cd $SRC/regex
 cargo fuzz build -O 
 cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_regex_match $OUT/

--- a/projects/rust-regex/build.sh
+++ b/projects/rust-regex/build.sh
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 ################################################################################
-
 cd $SRC/regex
 cargo fuzz build -O 
 cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_regex_match $OUT/

--- a/projects/rust-regex/project.yaml
+++ b/projects/rust-regex/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/rust-lang/regex"
+primary_contact: "jamslam@gmail.com"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+language: rust
+auto_ccs:
+  - "david@adalogics.com"


### PR DESCRIPTION
Cross-referencing [PR](https://github.com/rust-lang/regex/pull/679) 

@BurntSushi is one of the maintainers of rust-lang Regex and his email is in the project.yaml. 

The repository has more than 19 million downloads [here](https://crates.io/crates/regex) and more than 2000 projects depend on it shown [here](https://crates.io/crates/regex/reverse_dependencies)  

The library is in the top 15 most downloaded Rust projects [here](https://crates.io/crates?sort=downloads) 

Waiting for the merge upstream. 