### PR TITLE
Fix CIFuzz issue where targets assumed in OSS-Fuzz build if exists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ matrix:
         - TRAVIS_SANITIZER=dataflow
         - TRAVIS_ARCHITECTURE=x86_64
     - name: "infra-tests"
-      script: sudo pip install -r infra/travis/requirements.txt && sudo ./infra/presubmit.py infra-tests
+      script: sudo --preserve-env=HOME /bin/bash -c 'source $HOME/virtualenv/python3.6/bin/activate ./infra/presubmit.py infra-tests'
 
 script: ./infra/travis/travis_build.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ matrix:
         - TRAVIS_SANITIZER=dataflow
         - TRAVIS_ARCHITECTURE=x86_64
     - name: "infra-tests"
-      script: sudo su && pip install -r infra/travis/requirements.txt && ./infra/presubmit.py infra-tests
+      script: sudo pip install -r infra/travis/requirements.txt && sudo ./infra/presubmit.py infra-tests
 
 script: ./infra/travis/travis_build.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,9 +56,7 @@ matrix:
         - TRAVIS_SANITIZER=dataflow
         - TRAVIS_ARCHITECTURE=x86_64
     - name: "infra-tests"
-      script: sudo su && \
-      pip install -r infra/travis/requirements.txt && \
-      ./infra/presubmit.py infra-tests
+      script: sudo su && pip install -r infra/travis/requirements.txt && ./infra/presubmit.py infra-tests
 
 script: ./infra/travis/travis_build.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ matrix:
         - TRAVIS_SANITIZER=dataflow
         - TRAVIS_ARCHITECTURE=x86_64
     - name: "infra-tests"
-      script: sudo --preserve-env=HOME /bin/bash -c 'source $HOME/virtualenv/python3.6/bin/activate ./infra/presubmit.py infra-tests'
+      script: sudo --preserve-env=HOME /bin/bash -c 'source $HOME/virtualenv/python3.6/bin/activate && ./infra/presubmit.py infra-tests'
 
 script: ./infra/travis/travis_build.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ matrix:
         - TRAVIS_SANITIZER=dataflow
         - TRAVIS_ARCHITECTURE=x86_64
     - name: "infra-tests"
-      script: sudo --preserve-env=HOME /bin/bash -c 'source $HOME/virtualenv/python3.6/bin/activate && ./infra/presubmit.py infra-tests'
+      script: sudo /bin/bash -c 'source $HOME/virtualenv/python3.6/bin/activate && ./infra/presubmit.py infra-tests'
 
 script: ./infra/travis/travis_build.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,9 @@ matrix:
         - TRAVIS_SANITIZER=dataflow
         - TRAVIS_ARCHITECTURE=x86_64
     - name: "infra-tests"
-      script: sudo ./infra/presubmit.py infra-tests
+      script: sudo su && \
+      pip install -r infra/travis/requirements.txt && \
+      ./infra/presubmit.py infra-tests
 
 script: ./infra/travis/travis_build.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ install:
 matrix:
   include:
     - name: "presubmit"
-      install:
-        - pip install -r infra/dev-requirements.txt
       script: ./infra/presubmit.py
     - name: "libfuzzer address x86_64"
       env:

--- a/infra/cifuzz/cifuzz_test.py
+++ b/infra/cifuzz/cifuzz_test.py
@@ -158,8 +158,7 @@ class RunFuzzersIntegrationTest(unittest.TestCase):
     with mock.patch.object(fuzz_target.FuzzTarget,
                            'is_reproducible',
                            side_effect=[True, False]):
-      run_success = cifuzz.run_fuzzers(10, TEST_FILES_PATH,
-                                       EXAMPLE_PROJECT)
+      run_success = cifuzz.run_fuzzers(10, TEST_FILES_PATH, EXAMPLE_PROJECT)
       build_dir = os.path.join(TEST_FILES_PATH, 'out', 'oss_fuzz_latest')
       self.assertTrue(os.path.exists(build_dir))
       self.assertNotEqual(0, len(os.listdir(build_dir)))
@@ -171,8 +170,7 @@ class RunFuzzersIntegrationTest(unittest.TestCase):
     with mock.patch.object(fuzz_target.FuzzTarget,
                            'is_reproducible',
                            side_effect=[True, True]):
-      bug_found = cifuzz.run_fuzzers(10, TEST_FILES_PATH,
-                                     EXAMPLE_PROJECT)
+      bug_found = cifuzz.run_fuzzers(10, TEST_FILES_PATH, EXAMPLE_PROJECT)
       build_dir = os.path.join(TEST_FILES_PATH, 'out', 'oss_fuzz_latest')
       self.assertTrue(os.path.exists(build_dir))
       self.assertNotEqual(0, len(os.listdir(build_dir)))

--- a/infra/cifuzz/cifuzz_test.py
+++ b/infra/cifuzz/cifuzz_test.py
@@ -157,7 +157,7 @@ class RunFuzzersIntegrationTest(unittest.TestCase):
     # OSS-Fuzz build.
     with mock.patch.object(fuzz_target.FuzzTarget,
                            'is_reproducible',
-                           side_effect=[True, False]):
+                           side_effect=[(True, True), (False, True)]):
       run_success, bug_found = cifuzz.run_fuzzers(10, TEST_FILES_PATH,
                                                   EXAMPLE_PROJECT)
       build_dir = os.path.join(TEST_FILES_PATH, 'out', 'oss_fuzz_latest')
@@ -170,7 +170,7 @@ class RunFuzzersIntegrationTest(unittest.TestCase):
     """Test run_fuzzers with a bug found in OSS-Fuzz before."""
     with mock.patch.object(fuzz_target.FuzzTarget,
                            'is_reproducible',
-                           side_effect=[True, True]):
+                           side_effect=[(True, True), (True, True)]):
       run_success, bug_found = cifuzz.run_fuzzers(10, TEST_FILES_PATH,
                                                   EXAMPLE_PROJECT)
       build_dir = os.path.join(TEST_FILES_PATH, 'out', 'oss_fuzz_latest')

--- a/infra/cifuzz/cifuzz_test.py
+++ b/infra/cifuzz/cifuzz_test.py
@@ -157,9 +157,9 @@ class RunFuzzersIntegrationTest(unittest.TestCase):
     # OSS-Fuzz build.
     with mock.patch.object(fuzz_target.FuzzTarget,
                            'is_reproducible',
-                           side_effect=[(True, True), (False, True)]):
-      run_success, bug_found = cifuzz.run_fuzzers(10, TEST_FILES_PATH,
-                                                  EXAMPLE_PROJECT)
+                           side_effect=[True, False]):
+      run_success = cifuzz.run_fuzzers(10, TEST_FILES_PATH,
+                                       EXAMPLE_PROJECT)
       build_dir = os.path.join(TEST_FILES_PATH, 'out', 'oss_fuzz_latest')
       self.assertTrue(os.path.exists(build_dir))
       self.assertNotEqual(0, len(os.listdir(build_dir)))
@@ -170,9 +170,9 @@ class RunFuzzersIntegrationTest(unittest.TestCase):
     """Test run_fuzzers with a bug found in OSS-Fuzz before."""
     with mock.patch.object(fuzz_target.FuzzTarget,
                            'is_reproducible',
-                           side_effect=[(True, True), (True, True)]):
-      run_success, bug_found = cifuzz.run_fuzzers(10, TEST_FILES_PATH,
-                                                  EXAMPLE_PROJECT)
+                           side_effect=[True, True]):
+      bug_found = cifuzz.run_fuzzers(10, TEST_FILES_PATH,
+                                     EXAMPLE_PROJECT)
       build_dir = os.path.join(TEST_FILES_PATH, 'out', 'oss_fuzz_latest')
       self.assertTrue(os.path.exists(build_dir))
       self.assertNotEqual(0, len(os.listdir(build_dir)))

--- a/infra/cifuzz/cifuzz_test.py
+++ b/infra/cifuzz/cifuzz_test.py
@@ -158,7 +158,8 @@ class RunFuzzersIntegrationTest(unittest.TestCase):
     with mock.patch.object(fuzz_target.FuzzTarget,
                            'is_reproducible',
                            side_effect=[True, False]):
-      run_success = cifuzz.run_fuzzers(10, TEST_FILES_PATH, EXAMPLE_PROJECT)
+      run_success, bug_found = cifuzz.run_fuzzers(10, TEST_FILES_PATH,
+                                                  EXAMPLE_PROJECT)
       build_dir = os.path.join(TEST_FILES_PATH, 'out', 'oss_fuzz_latest')
       self.assertTrue(os.path.exists(build_dir))
       self.assertNotEqual(0, len(os.listdir(build_dir)))
@@ -170,7 +171,8 @@ class RunFuzzersIntegrationTest(unittest.TestCase):
     with mock.patch.object(fuzz_target.FuzzTarget,
                            'is_reproducible',
                            side_effect=[True, True]):
-      bug_found = cifuzz.run_fuzzers(10, TEST_FILES_PATH, EXAMPLE_PROJECT)
+      run_success, bug_found = cifuzz.run_fuzzers(10, TEST_FILES_PATH,
+                                                  EXAMPLE_PROJECT)
       build_dir = os.path.join(TEST_FILES_PATH, 'out', 'oss_fuzz_latest')
       self.assertTrue(os.path.exists(build_dir))
       self.assertNotEqual(0, len(os.listdir(build_dir)))

--- a/infra/cifuzz/fuzz_target.py
+++ b/infra/cifuzz/fuzz_target.py
@@ -237,9 +237,9 @@ class FuzzTarget:
       reproducible_on_pr_build = self.is_reproducible(test_case,
                                                       self.target_path)
     except ReproduceError as error:
-      logs.error('Could not run target when checking for reproducibility.'
-                 'Please file an issue:'
-                 'https://github.com/google/oss-fuzz/issues/new.')
+      logging.error('Could not run target when checking for reproducibility.'
+                    'Please file an issue:'
+                    'https://github.com/google/oss-fuzz/issues/new.')
       raise error
 
     if not self.project_name:

--- a/infra/cifuzz/fuzz_target.py
+++ b/infra/cifuzz/fuzz_target.py
@@ -161,7 +161,7 @@ class FuzzTarget:
       Returns:
         (True, True) if crash is reproducible and we were able to run the
         binary.
-        (True, False) if we were not able to attempt reproduction. Do not rely
+        (False, False) if we were not able to attempt reproduction. Do not rely
         on the first return value in this case.
         (False, True) if we were able to attempt reproduction but the crash did
         not reproduce.
@@ -255,7 +255,7 @@ class FuzzTarget:
 
     if not ran_target:
       # This happens if the project has OSS-Fuzz builds, but the fuzz target
-      # doesn't.
+      # is not in it.
       logging.info(could_not_test_on_oss_fuzz_message)
       return True
 

--- a/infra/cifuzz/fuzz_target.py
+++ b/infra/cifuzz/fuzz_target.py
@@ -234,13 +234,12 @@ class FuzzTarget:
       ReproduceError if we can't attempt to reproduce the crash on the PR build.
     """
     try:
-      reproducible_on_pr_build = self.is_reproducible(
-          test_case, self.target_path)
+      reproducible_on_pr_build = self.is_reproducible(test_case,
+                                                      self.target_path)
     except ReproduceError as error:
-      logs.error(
-          'Could not run target when checking for reproducibility.'
-          'Please file an issue:'
-          'https://github.com/google/oss-fuzz/issues/new.')
+      logs.error('Could not run target when checking for reproducibility.'
+                 'Please file an issue:'
+                 'https://github.com/google/oss-fuzz/issues/new.')
       raise error
 
     if not self.project_name:

--- a/infra/cifuzz/fuzz_target.py
+++ b/infra/cifuzz/fuzz_target.py
@@ -174,7 +174,7 @@ class FuzzTarget:
         binary.
 
       Raises:
-        ReproduceError if we can't reproduce attempt to reproduce the crash.
+        ReproduceError if we can't attempt to reproduce the crash.
     """
 
     if not os.path.exists(target_path):
@@ -233,7 +233,7 @@ class FuzzTarget:
       ReproduceError if we can't attempt to reproduce the crash on the PR build.
     """
     if not os.path.exists(test_case):
-      raise RuntimeError('Test case %s not found.' % test_case)
+      raise ReproduceError('Test case %s not found.' % test_case)
 
     try:
       reproducible_on_pr_build = self.is_reproducible(test_case,

--- a/infra/cifuzz/fuzz_target.py
+++ b/infra/cifuzz/fuzz_target.py
@@ -264,7 +264,7 @@ class FuzzTarget:
           test_case, oss_fuzz_target_path)
     except ReproduceError:
       # This happens if the project has OSS-Fuzz builds, but the fuzz target
-      # is not in it.
+      # is not in it (e.g. because the fuzz target is new).
       logging.info(COULD_NOT_TEST_ON_OSS_FUZZ_MESSAGE)
       return True
 

--- a/infra/cifuzz/fuzz_target.py
+++ b/infra/cifuzz/fuzz_target.py
@@ -68,7 +68,7 @@ COULD_NOT_TEST_ON_OSS_FUZZ_MESSAGE = (
     'Assuming this pull request introduced crash.')
 
 
-class ReproduceError:
+class ReproduceError(Exception):
   """Error for when we can't attempt to reproduce a crash."""
 
 
@@ -180,7 +180,7 @@ class FuzzTarget:
       raise ReproduceError('Test case %s not found.' % test_case)
 
     if not os.path.exists(target_path):
-      raise ReproduceError('Target %s not found.', % target_path)
+      raise ReproduceError('Target %s not found.' % target_path)
 
     os.chmod(target_path, stat.S_IRWXO)
 

--- a/infra/cifuzz/fuzz_target.py
+++ b/infra/cifuzz/fuzz_target.py
@@ -176,8 +176,6 @@ class FuzzTarget:
       Raises:
         ReproduceError if we can't reproduce attempt to reproduce the crash.
     """
-    if not os.path.exists(test_case):
-      raise ReproduceError('Test case %s not found.' % test_case)
 
     if not os.path.exists(target_path):
       raise ReproduceError('Target %s not found.' % target_path)
@@ -218,8 +216,9 @@ class FuzzTarget:
     return False
 
   def is_crash_reportable(self, test_case):
-    """Checks if a crash is reproducible, and if it is, whether it's a new
-    regression that cannot be reproduced with the latest OSS-Fuzz build.
+    """Returns True if a crash is reportable. This means the crash is
+    reproducible but not reproducible on a build from OSS-Fuzz (meaning the
+    crash was introduced by this PR).
 
     NOTE: If no project is specified the crash is assumed introduced
     by the pull request if it is reproducible.
@@ -233,6 +232,9 @@ class FuzzTarget:
     Raises:
       ReproduceError if we can't attempt to reproduce the crash on the PR build.
     """
+    if not os.path.exists(test_case):
+      raise RuntimeError('Test case %s not found.' % test_case)
+
     try:
       reproducible_on_pr_build = self.is_reproducible(test_case,
                                                       self.target_path)

--- a/infra/cifuzz/fuzz_target_test.py
+++ b/infra/cifuzz/fuzz_target_test.py
@@ -46,8 +46,8 @@ EXECUTE_SUCCESS_RETVAL = ('', '', 0)
 EXECUTE_FAILURE_RETVAL = ('', '', 1)
 
 
-# TODO(metzman): Use patch from clusterfuzz/src/python/tests/test_libs/
-# so that we don't need to accept this as an argument in every test method.
+# TODO(metzman): Use patch from test_libs/helpers.py in clusterfuzz so that we
+# don't need to accept this as an argument in every test method.
 @unittest.mock.patch('utils.get_container_name', return_value='container')
 class IsReproducibleUnitTest(fake_filesystem_unittest.TestCase):
   """Test is_reproducible function in the fuzz_target module."""

--- a/infra/cifuzz/fuzz_target_test.py
+++ b/infra/cifuzz/fuzz_target_test.py
@@ -50,7 +50,7 @@ EXECUTE_FAILURE_RETVAL = ('', '', 1)
 # don't need to accept this as an argument in every test method.
 @unittest.mock.patch('utils.get_container_name', return_value='container')
 class IsReproducibleUnitTest(fake_filesystem_unittest.TestCase):
-  """Test is_reproducible function in the fuzz_target module."""
+  """Test is_reproducible method in the fuzz_target.FuzzTarget class."""
 
   def setUp(self):
     """Sets up dummy fuzz target to test is_reproducible method."""
@@ -60,8 +60,8 @@ class IsReproducibleUnitTest(fake_filesystem_unittest.TestCase):
                                               '/example/outdir')
 
   def test_reproducible(self, _):
-    """Tests that is_reproducible will return True, True if crash is
-    detected and that the command used to reproduce is correct."""
+    """Tests that is_reproducible will return True if crash is detected and that
+    the command used to reproduce is correct."""
     self._set_up_fakefs()
     all_repro = [EXECUTE_FAILURE_RETVAL] * fuzz_target.REPRODUCE_ATTEMPTS
     with unittest.mock.patch('utils.execute',
@@ -85,8 +85,8 @@ class IsReproducibleUnitTest(fake_filesystem_unittest.TestCase):
     self.fs.add_real_directory(TEST_FILES_PATH)
 
   def test_flaky(self, _):
-    """Tests that is_reproducible will return True, True if crash is
-    detected on the last attempt."""
+    """Tests that is_reproducible returns True if crash is detected on the last
+    attempt."""
     self._set_up_fakefs()
     last_time_repro = [EXECUTE_SUCCESS_RETVAL] * 9 + [EXECUTE_FAILURE_RETVAL]
     with unittest.mock.patch('utils.execute',
@@ -112,15 +112,6 @@ class IsReproducibleUnitTest(fake_filesystem_unittest.TestCase):
       result = self.test_target.is_reproducible(TEST_FILES_PATH,
                                                 self.fuzz_target_bin)
       self.assertFalse(result)
-
-  def test_non_existent_testcase(self, _):
-    """Tests that method reports it did not attempt reproduction if testcase
-    doesn't exist."""
-    self._set_up_fakefs()
-
-    with self.assertRaises(fuzz_target.ReproduceError):
-      self.test_target.is_reproducible('/non-existent-path',
-                                       self.fuzz_target_bin)
 
 
 class GetTestCaseUnitTest(unittest.TestCase):

--- a/infra/cifuzz/fuzz_target_test.py
+++ b/infra/cifuzz/fuzz_target_test.py
@@ -18,15 +18,15 @@ import sys
 import tempfile
 import unittest
 import unittest.mock
-import urllib
+
+import parameterized
+from pyfakefs import fake_filesystem_unittest
 
 # Pylint has issue importing utils which is why error suppression is required.
 # pylint: disable=wrong-import-position
 # pylint: disable=import-error
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import fuzz_target
-
-import utils
 
 # NOTE: This integration test relies on
 # https://github.com/google/oss-fuzz/tree/master/projects/example project.
@@ -39,41 +39,91 @@ EXAMPLE_FUZZER = 'example_crash_fuzzer'
 TEST_FILES_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                'test_files')
 
+# The return value of a successful call to utils.execute.
+EXECUTE_SUCCESS_RETVAL = ('', '', 0)
 
-class IsReproducibleUnitTest(unittest.TestCase):
+# The return value of a failed call to utils.execute.
+EXECUTE_FAILURE_RETVAL = ('', '', 1)
+
+
+# TODO(metzman): Use patch from clusterfuzz/src/python/tests/test_libs/
+# so that we don't need to accept this as an argument in every test method.
+@unittest.mock.patch('utils.get_container_name', return_value='container')
+class IsReproducibleUnitTest(fake_filesystem_unittest.TestCase):
   """Test is_reproducible function in the fuzz_target module."""
 
   def setUp(self):
     """Sets up dummy fuzz target to test is_reproducible method."""
-    self.test_target = fuzz_target.FuzzTarget('/example/path', 10,
+    self.fuzz_target_bin = '/example/path'
+    self.test_target = fuzz_target.FuzzTarget(self.fuzz_target_bin,
+                                              fuzz_target.REPRODUCE_ATTEMPTS,
                                               '/example/outdir')
 
-  def test_with_reproducible(self):
-    """Tests that a is_reproducible will return true if crash is detected."""
-    test_all_success = [(0, 0, 1)] * 10
-    with unittest.mock.patch.object(utils,
-                                    'execute',
-                                    side_effect=test_all_success) as patch:
-      self.assertTrue(
-          self.test_target.is_reproducible(TEST_FILES_PATH, '/not/exist'))
-      self.assertEqual(1, patch.call_count)
+  def test_reproducible(self, _):
+    """Tests that is_reproducible will return True, True if crash is
+    detected and that the command used to reproduce is correct."""
+    self._set_up_fakefs()
+    all_repro = [EXECUTE_FAILURE_RETVAL] * fuzz_target.REPRODUCE_ATTEMPTS
+    with unittest.mock.patch('utils.execute',
+                             side_effect=all_repro) as mocked_execute:
+      result = self.test_target.is_reproducible(TEST_FILES_PATH,
+                                                self.fuzz_target_bin)
+      mocked_execute.assert_called_once_with([
+          'docker', 'run', '--rm', '--privileged', '--volumes-from',
+          'container', '-e', 'OUT=/example', '-e',
+          'TESTCASE=' + TEST_FILES_PATH, '-t',
+          'gcr.io/oss-fuzz-base/base-runner', 'reproduce', 'path', '-runs=100'
+      ])
+      self.assertEqual(result, (True, True))
+      self.assertEqual(1, mocked_execute.call_count)
 
-    test_one_success = [(0, 0, 0)] * 9 + [(0, 0, 1)]
-    with unittest.mock.patch.object(utils,
-                                    'execute',
-                                    side_effect=test_one_success) as patch:
-      self.assertTrue(
-          self.test_target.is_reproducible(TEST_FILES_PATH, '/not/exist'))
-      self.assertEqual(10, patch.call_count)
+  def _set_up_fakefs(self):
+    """Helper to setup pyfakefs and add important files to the fake
+    filesystem."""
+    self.setUpPyfakefs()
+    self.fs.create_file(self.fuzz_target_bin)
+    self.fs.add_real_directory(TEST_FILES_PATH)
 
-  def test_with_not_reproducible(self):
-    """Tests that a is_reproducible will return False if crash not detected."""
-    test_all_fail = [(0, 0, 0)] * 10
-    with unittest.mock.patch.object(utils, 'execute',
-                                    side_effect=test_all_fail) as patch:
-      self.assertFalse(
-          self.test_target.is_reproducible(TEST_FILES_PATH, '/not/exist'))
-      self.assertEqual(10, patch.call_count)
+  def test_flaky(self, _):
+    """Tests that is_reproducible will return True, True if crash is
+    detected on the last attempt."""
+    self._set_up_fakefs()
+    last_time_repro = [EXECUTE_SUCCESS_RETVAL] * 9 + [EXECUTE_FAILURE_RETVAL]
+    with unittest.mock.patch('utils.execute',
+                             side_effect=last_time_repro) as mocked_execute:
+      self.assertTrue(
+          self.test_target.is_reproducible(TEST_FILES_PATH,
+                                           self.fuzz_target_bin))
+      self.assertEqual(fuzz_target.REPRODUCE_ATTEMPTS,
+                       mocked_execute.call_count)
+
+  def test_non_existent_fuzzer(self, _):
+    """Tests that is_reproducible will report that it could not attempt
+    reproduction if the fuzzer does not exist."""
+    result = self.test_target.is_reproducible(TEST_FILES_PATH,
+                                              '/non-existent-path')
+    expected_result = (False, False)
+    self.assertEqual(result, expected_result)
+
+  def test_unreproducible(self, _):
+    """Tests that is_reproducible returns (True, True) for a crash that cannot
+    be reproduced."""
+    all_unrepro = [EXECUTE_SUCCESS_RETVAL] * fuzz_target.REPRODUCE_ATTEMPTS
+    self._set_up_fakefs()
+    with unittest.mock.patch('utils.execute', side_effect=all_unrepro):
+      result = self.test_target.is_reproducible(TEST_FILES_PATH,
+                                                self.fuzz_target_bin)
+      expected_result = (False, True)
+      self.assertEqual(result, expected_result)
+
+  def test_non_existent_testcase(self, _):
+    """Tests that method reports it did not attempt reproduction if testcase
+    doesn't exist."""
+    self._set_up_fakefs()
+    result = self.test_target.is_reproducible('/non-existent-path',
+                                              self.fuzz_target_bin)
+    expected_result = (False, False)
+    self.assertEqual(result, expected_result)
 
 
 class GetTestCaseUnitTest(unittest.TestCase):
@@ -84,7 +134,7 @@ class GetTestCaseUnitTest(unittest.TestCase):
     self.test_target = fuzz_target.FuzzTarget('/example/path', 10,
                                               '/example/outdir')
 
-  def test_with_valid_error_string(self):
+  def test_valid_error_string(self):
     """Tests that get_test_case returns the correct test case give an error."""
     test_case_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                   'test_files',
@@ -95,7 +145,7 @@ class GetTestCaseUnitTest(unittest.TestCase):
         parsed_test_case,
         '/example/outdir/crash-ad6700613693ef977ff3a8c8f4dae239c3dde6f5')
 
-  def test_with_invalid_error_string(self):
+  def test_invalid_error_string(self):
     """Tests that get_test_case will return None with a bad error string."""
     self.assertIsNone(self.test_target.get_test_case(''))
     self.assertIsNone(self.test_target.get_test_case(' Example crash string.'))
@@ -111,17 +161,15 @@ class DownloadLatestCorpusUnitTest(unittest.TestCase):
       test_target.project_name = EXAMPLE_PROJECT
       test_target.target_name = EXAMPLE_FUZZER
       test_target.out_dir = tmp_dir
-      with unittest.mock.patch.object(fuzz_target,
-                                      'download_and_unpack_zip',
-                                      return_value=tmp_dir) as mock:
+      with unittest.mock.patch(
+          'fuzz_target.download_and_unpack_zip',
+          return_value=tmp_dir) as mocked_download_and_unpack_zip:
         test_target.download_latest_corpus()
-        (url, out_dir), _ = mock.call_args
+        (url, out_dir), _ = mocked_download_and_unpack_zip.call_args
         self.assertEqual(
-            url,
-            'https://storage.googleapis.com/example-backup.' \
-            'clusterfuzz-external.appspot.com/corpus/libFuzzer/' \
-            'example_crash_fuzzer/public.zip'
-        )
+            url, 'https://storage.googleapis.com/example-backup.'
+            'clusterfuzz-external.appspot.com/corpus/libFuzzer/'
+            'example_crash_fuzzer/public.zip')
         self.assertEqual(out_dir,
                          os.path.join(tmp_dir, 'backup_corpus', EXAMPLE_FUZZER))
 
@@ -137,53 +185,90 @@ class DownloadLatestCorpusUnitTest(unittest.TestCase):
       self.assertIsNone(corpus_path)
 
 
-class CheckReproducibilityAndRegressionUnitTest(unittest.TestCase):
-  """Test check_reproducibility_and_regression function fuzz_target module."""
+class IsCrashReportableUnitTest(fake_filesystem_unittest.TestCase):
+  """Test is_crash_reportable method of fuzz_target.FuzzTarget."""
 
   def setUp(self):
-    """Sets up dummy fuzz target to test is_reproducible method."""
-    self.test_target = fuzz_target.FuzzTarget('/example/do_stuff_fuzzer', 100,
+    """Sets up dummy fuzz target to test is_crash_reportable method."""
+    self.fuzz_target_bin = '/example/do_stuff_fuzzer'
+    self.test_target = fuzz_target.FuzzTarget(self.fuzz_target_bin, 100,
                                               '/example/outdir', 'example')
+    self.oss_fuzz_build_path = '/oss-fuzz-build'
+    self.setUpPyfakefs()
+    self.fs.create_file(self.fuzz_target_bin)
+    self.oss_fuzz_target_path = os.path.join(
+        self.oss_fuzz_build_path, os.path.basename(self.fuzz_target_bin))
+    self.fs.create_file(self.oss_fuzz_target_path)
+    self.fs.add_real_directory(TEST_FILES_PATH)
 
-  def test_with_valid_crash(self):
-    """Checks to make sure a valid crash returns true."""
-    with unittest.mock.patch.object(
-        fuzz_target.FuzzTarget, 'is_reproducible',
-        side_effect=[True, False]), tempfile.TemporaryDirectory() as tmp_dir:
-      self.test_target.out_dir = tmp_dir
-      self.assertTrue(
-          self.test_target.check_reproducibility_and_regression(
-              '/example/crash/testcase'))
+  @unittest.mock.patch('logging.info')
+  def test_new_reproducible_crash(self, mocked_info):
+    """Tests that a new reproducible crash returns True."""
+    with unittest.mock.patch('fuzz_target.FuzzTarget.is_reproducible',
+                             side_effect=[(True, True), (False, True)]):
+      with tempfile.TemporaryDirectory() as tmp_dir:
+        self.test_target.out_dir = tmp_dir
+        self.assertTrue(
+            self.test_target.is_crash_reportable('/example/crash/testcase'))
+    mocked_info.assert_called_with(
+        'The crash is reproducible. The crash doesn\'t reproduce '
+        'on old builds. This pull request probably introduced the '
+        'crash.')
 
-  def test_with_invalid_crash(self):
-    """Checks to make sure an invalid crash returns false."""
-    with unittest.mock.patch.object(fuzz_target.FuzzTarget,
-                                    'is_reproducible',
-                                    side_effect=[True, True]):
-      self.assertFalse(
-          self.test_target.check_reproducibility_and_regression(
-              '/example/crash/testcase'))
+  # yapf: disable
+  @parameterized.parameterized.expand([
+      # Reproducible on PR build, but also reproducible on OSS-Fuzz.
+      ([(True, True), (True, True)],),
 
-    with unittest.mock.patch.object(fuzz_target.FuzzTarget,
-                                    'is_reproducible',
-                                    side_effect=[False, True]):
-      self.assertFalse(
-          self.test_target.check_reproducibility_and_regression(
-              '/example/crash/testcase'))
+      # Not reproducible on PR build, but somehow reproducible on OSS-Fuzz.
+      # Unlikely to happen in real world except if test is flaky.
+      ([(False, True), (True, False)],),
 
-    with unittest.mock.patch.object(fuzz_target.FuzzTarget,
-                                    'is_reproducible',
-                                    side_effect=[False, False]):
-      self.assertFalse(
-          self.test_target.check_reproducibility_and_regression(
-              '/example/crash/testcase'))
+      # Not reproducible on PR build, and not reproducible on OSS-Fuzz.
+      ([(False, True), (False, True)],),
+  ])
+  # yapf: enable
+  def test_invalid_crash(self, is_reproducible_retvals):
+    """Tests that an reportable crash causes the method to return False."""
+    self.setUpPyfakefs()
+    self.fs.create_file(self.fuzz_target_bin)
+    self.fs.add_real_directory(TEST_FILES_PATH)
+    with unittest.mock.patch('fuzz_target.FuzzTarget.is_reproducible',
+                             side_effect=is_reproducible_retvals):
+
+      with unittest.mock.patch('fuzz_target.FuzzTarget.download_oss_fuzz_build',
+                               return_value=self.oss_fuzz_build_path):
+        self.assertFalse(
+            self.test_target.is_crash_reportable('/example/crash/testcase'))
+
+  @unittest.mock.patch('logging.info')
+  @unittest.mock.patch('fuzz_target.FuzzTarget.is_reproducible',
+                       return_value=(True, True))
+  def test_reproducible_no_oss_fuzz_target(self, _, mocked_info):
+    """Tests that is_crash_reportable returns True when a crash repros on the
+    PR build but the target is not in the OSS-Fuzz build (usually because it
+    is new)."""
+    os.remove(self.oss_fuzz_target_path)
+    with unittest.mock.patch('fuzz_target.FuzzTarget.is_reproducible',
+                             side_effect=[(True, True), (True, False)
+                                         ]) as mocked_is_reproducible:
+      with unittest.mock.patch('fuzz_target.FuzzTarget.download_oss_fuzz_build',
+                               return_value=self.oss_fuzz_build_path):
+        self.assertTrue(
+            self.test_target.is_crash_reportable('/example/crash/testcase'))
+    mocked_is_reproducible.assert_any_call('/example/crash/testcase',
+                                           self.oss_fuzz_target_path)
+    mocked_info.assert_called_with(
+        'Crash is reproducible. Could not run OSS-Fuzz build of '
+        'target to determine if this pull request introduced crash. '
+        'Assuming this pull request introduced crash.')
 
 
 class GetLatestBuildVersionUnitTest(unittest.TestCase):
   """Test the get_latest_build_version function in the fuzz_target module."""
 
   def test_get_valid_project(self):
-    """Checks the latest build can be retrieved from gcs."""
+    """Tests that the latest build can be retrieved from GCS."""
     test_target = fuzz_target.FuzzTarget('/example/path', 10, '/example/outdir',
                                          'example')
     latest_build = test_target.get_lastest_build_version()
@@ -192,7 +277,8 @@ class GetLatestBuildVersionUnitTest(unittest.TestCase):
     self.assertTrue('address' in latest_build)
 
   def test_get_invalid_project(self):
-    """Checks the latest build will return None when project doesn't exist."""
+    """Tests that the latest build will return None when project doesn't
+    exist."""
     test_target = fuzz_target.FuzzTarget('/example/path', 10, '/example/outdir',
                                          'not-a-proj')
     self.assertIsNone(test_target.get_lastest_build_version())
@@ -204,23 +290,22 @@ class DownloadOSSFuzzBuildDirIntegrationTests(unittest.TestCase):
   """Test the download_oss_fuzz_build in function in the fuzz_target module."""
 
   def test_single_download(self):
-    """Checks that the build directory was only downloaded once."""
+    """Tests that the build directory was only downloaded once."""
     with tempfile.TemporaryDirectory() as tmp_dir:
       test_target = fuzz_target.FuzzTarget('/example/do_stuff_fuzzer', 10,
                                            tmp_dir, 'example')
       latest_version = test_target.get_lastest_build_version()
-      with unittest.mock.patch.object(
-          fuzz_target.FuzzTarget,
-          'get_lastest_build_version',
-          return_value=latest_version) as mock_build_version:
+      with unittest.mock.patch(
+          'fuzz_target.FuzzTarget.get_lastest_build_version',
+          return_value=latest_version) as mocked_get_latest_build_version:
         for _ in range(5):
           oss_fuzz_build_path = test_target.download_oss_fuzz_build()
-        self.assertEqual(1, mock_build_version.call_count)
+        self.assertEqual(1, mocked_get_latest_build_version.call_count)
         self.assertIsNotNone(oss_fuzz_build_path)
         self.assertTrue(os.listdir(oss_fuzz_build_path))
 
   def test_get_valid_project(self):
-    """Checks the latest build can be retrieved from gcs."""
+    """Tests the latest build can be retrieved from GCS."""
     with tempfile.TemporaryDirectory() as tmp_dir:
       test_target = fuzz_target.FuzzTarget('/example/do_stuff_fuzzer', 10,
                                            tmp_dir, 'example')
@@ -229,7 +314,7 @@ class DownloadOSSFuzzBuildDirIntegrationTests(unittest.TestCase):
       self.assertTrue(os.listdir(oss_fuzz_build_path))
 
   def test_get_invalid_project(self):
-    """Checks the latest build will return None when project doesn't exist."""
+    """Tests the latest build will return None when project doesn't exist."""
     with tempfile.TemporaryDirectory() as tmp_dir:
       test_target = fuzz_target.FuzzTarget('/example/do_stuff_fuzzer', 10,
                                            tmp_dir)
@@ -239,7 +324,7 @@ class DownloadOSSFuzzBuildDirIntegrationTests(unittest.TestCase):
       self.assertIsNone(test_target.download_oss_fuzz_build())
 
   def test_invalid_build_dir(self):
-    """Checks the download will return None when out_dir doesn't exist."""
+    """Tests the download will return None when out_dir doesn't exist."""
     test_target = fuzz_target.FuzzTarget('/example/do_stuff_fuzzer', 10,
                                          'not/a/dir', 'example')
     self.assertIsNone(test_target.download_oss_fuzz_build())
@@ -250,8 +335,8 @@ class DownloadAndUnpackZipUnitTests(unittest.TestCase):
 
   def test_bad_zip_download(self):
     """Tests download_and_unpack_zip returns none when a bad zip is passed."""
-    with tempfile.TemporaryDirectory() as tmp_dir, unittest.mock.patch.object(
-        urllib.request, 'urlretrieve', return_value=True):
+    with tempfile.TemporaryDirectory() as tmp_dir, unittest.mock.patch(
+        'urllib.request.urlretrieve', return_value=True):
       file_handle = open(os.path.join(tmp_dir, 'url_tmp.zip'), 'w')
       file_handle.write('Test file.')
       file_handle.close()

--- a/infra/cifuzz/fuzz_target_test.py
+++ b/infra/cifuzz/fuzz_target_test.py
@@ -101,8 +101,7 @@ class IsReproducibleUnitTest(fake_filesystem_unittest.TestCase):
     """Tests that is_reproducible will raise an error if it could not attempt
     reproduction when the fuzzer does not exist."""
     with self.assertRaises(fuzz_target.ReproduceError):
-      self.test_target.is_reproducible(TEST_FILES_PATH,
-                                       '/non-existent-path')
+      self.test_target.is_reproducible(TEST_FILES_PATH, '/non-existent-path')
 
   def test_unreproducible(self, _):
     """Tests that is_reproducible returns False for a crash that cannot
@@ -121,7 +120,7 @@ class IsReproducibleUnitTest(fake_filesystem_unittest.TestCase):
 
     with self.assertRaises(fuzz_target.ReproduceError):
       self.test_target.is_reproducible('/non-existent-path',
-                                              self.fuzz_target_bin)
+                                       self.fuzz_target_bin)
 
 
 class GetTestCaseUnitTest(unittest.TestCase):
@@ -248,6 +247,7 @@ class IsCrashReportableUnitTest(fake_filesystem_unittest.TestCase):
     PR build but the target is not in the OSS-Fuzz build (usually because it
     is new)."""
     os.remove(self.oss_fuzz_target_path)
+
     def is_reproducible_side_effect(_, target_path):
       if os.path.dirname(target_path) == self.oss_fuzz_build_path:
         raise fuzz_target.ReproduceError()

--- a/infra/cifuzz/fuzz_target_test.py
+++ b/infra/cifuzz/fuzz_target_test.py
@@ -195,8 +195,8 @@ class IsCrashReportableUnitTest(fake_filesystem_unittest.TestCase):
                              side_effect=[True, False]):
       with tempfile.TemporaryDirectory() as tmp_dir:
         self.test_target.out_dir = tmp_dir
-        self.assertTrue(
-            self.test_target.is_crash_reportable(self.testcase_path))
+        self.assertTrue(self.test_target.is_crash_reportable(
+            self.testcase_path))
     mocked_info.assert_called_with(
         'The crash is reproducible. The crash doesn\'t reproduce '
         'on old builds. This pull request probably introduced the '
@@ -244,8 +244,8 @@ class IsCrashReportableUnitTest(fake_filesystem_unittest.TestCase):
         side_effect=is_reproducible_side_effect) as mocked_is_reproducible:
       with unittest.mock.patch('fuzz_target.FuzzTarget.download_oss_fuzz_build',
                                return_value=self.oss_fuzz_build_path):
-        self.assertTrue(
-            self.test_target.is_crash_reportable(self.testcase_path))
+        self.assertTrue(self.test_target.is_crash_reportable(
+            self.testcase_path))
     mocked_is_reproducible.assert_any_call(self.testcase_path,
                                            self.oss_fuzz_target_path)
     mocked_info.assert_called_with(

--- a/infra/dev-requirements.txt
+++ b/infra/dev-requirements.txt
@@ -1,6 +1,0 @@
-# Requirements for submitting code changes to infra/ (needed by presubmit.py).
-pylint==2.4.4
-yapf==0.28.0
-PyYAML==5.1
-pyfakefs==3.7.1
-parameterized==0.7.4

--- a/infra/dev-requirements.txt
+++ b/infra/dev-requirements.txt
@@ -2,4 +2,5 @@
 pylint==2.4.4
 yapf==0.28.0
 PyYAML==5.1
-
+pyfakefs==3.7.1
+parameterized==0.7.4

--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -337,6 +337,12 @@ def run_tests():
   # TODO(metzman): This approach for running tests is flawed since tests can
   # fail even if their directory isn't changed. Figure out if it is needed (to
   # save time) and remove it if it isn't.
+  suite_list = []
+  for change_dir in changed_dirs:
+    suite_list.append(unittest.TestLoader().discover(change_dir,
+                                                     pattern='*_test.py'))
+  full_suite = unittest.TestSuite([])
+  result = unittest.TextTestRunner().run(full_suite)
   return not result.failures and not result.errors
 
 

--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -341,8 +341,8 @@ def run_tests():
   for change_dir in changed_dirs:
     suite_list.append(unittest.TestLoader().discover(change_dir,
                                                      pattern='*_test.py'))
-  full_suite = unittest.TestSuite([])
-  result = unittest.TextTestRunner().run(full_suite)
+  suite = unittest.TestSuite(suite_list)
+  result = unittest.TextTestRunner().run(suite)
   return not result.failures and not result.errors
 
 

--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -334,16 +334,10 @@ def run_tests():
   for file in get_changed_files():
     changed_dirs.add(os.path.dirname(file))
 
-  # TODO(metzman): This approach for running tests is probably flawed since
-  # tests can fail even if their directory isn't changed. Figure out if it is
-  # needed (to save time) and remove it if it isn't.
-  suite_list = []
-  for change_dir in changed_dirs:
-    suite_list.append(unittest.TestLoader().discover(change_dir,
-                                                     pattern='*_test.py'))
-  full_suite = unittest.TestSuite(suite_list)
-  result = unittest.TextTestRunner().run(full_suite)
-  return not result.failures
+  # TODO(metzman): This approach for running tests is flawed since tests can
+  # fail even if their directory isn't changed. Figure out if it is needed (to
+  # save time) and remove it if it isn't.
+  return not result.failures and not result.errors
 
 
 def main():

--- a/infra/travis/requirements.txt
+++ b/infra/travis/requirements.txt
@@ -1,1 +1,6 @@
+# Requirements for submitting code changes to infra/ (needed by presubmit.py).
+pylint==2.4.4
+yapf==0.28.0
 PyYAML==5.1
+pyfakefs==3.7.1
+parameterized==0.7.4


### PR DESCRIPTION
This breaks when a new fuzz target is added to a project.
Intstead, always report the crash unless we can run the OSS-Fuzz build of the target and
repro the crash.

Also, make some other changes:
1. Refactor fuzz_target.py and fuzz_target_test.py
2. Introduce pyfakefs and parameterized as dependencies and use them
in tests.

Fixes https://github.com/google/oss-fuzz/issues/3813.