### PR TITLE
Add check to ensure Dockerfiles don't use more than one WORKDIR

### DIFF
--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -394,7 +394,8 @@ def main():
   # Get program arguments.
   parser = argparse.ArgumentParser(description='Presubmit script for oss-fuzz.')
   parser.add_argument('command',
-                      choices=['format', 'lint', 'license', 'infra-tests'],
+                      choices=['format', 'lint', 'license', 'infra-tests',
+                               'check_dockerfile'],
                       nargs='?')
 
   parser.add_argument('--all-files',
@@ -425,6 +426,10 @@ def main():
 
   if args.command == 'infra-tests':
     return bool_to_returncode(run_tests())
+
+  if args.command == 'check_dockerfile':
+    success = check_dockerfile(relevant_files)
+    return bool_to_returncode(success)
 
   # Do all the checks (but no tests).
   success = do_checks(relevant_files)

--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -393,10 +393,10 @@ def main():
   """Check changes on a branch for common issues before submitting."""
   # Get program arguments.
   parser = argparse.ArgumentParser(description='Presubmit script for oss-fuzz.')
-  parser.add_argument('command',
-                      choices=['format', 'lint', 'license', 'infra-tests',
-                               'check_dockerfile'],
-                      nargs='?')
+  parser.add_argument(
+      'command',
+      choices=['format', 'lint', 'license', 'infra-tests', 'check_dockerfile'],
+      nargs='?')
 
   parser.add_argument('--all-files',
                       '-a',


### PR DESCRIPTION
This is needed to ensure that builds on GCB work.

Also: add option to run presubmit on all files.

This intended to prevent issues like these https://github.com/google/oss-fuzz/pull/3818