### PR TITLE
[Prometheus] Initial integration

### DIFF
--- a/projects/prometheus/Dockerfile
+++ b/projects/prometheus/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER adam@adalogics.com
+RUN go get github.com/prometheus/prometheus/cmd/...
+COPY build.sh $SRC/
+WORKDIR $SRC/

--- a/projects/prometheus/build.sh
+++ b/projects/prometheus/build.sh
@@ -1,0 +1,29 @@
+#/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+function compile_fuzzer {
+  path=$1
+  function=$2
+  fuzzer=$3
+
+  go-fuzz -func $function -o $fuzzer.a $path
+
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
+}
+compile_fuzzer github.com/prometheus/prometheus/promql FuzzParseMetric fuzzParseMetric
+compile_fuzzer github.com/prometheus/prometheus/promql FuzzParseOpenMetric fuzzParseOpenMetric
+compile_fuzzer github.com/prometheus/prometheus/promql FuzzParseMetricSelector fuzzParseMetricSelector
+compile_fuzzer github.com/prometheus/prometheus/promql FuzzParseExpr fuzzParseExpr

--- a/projects/prometheus/project.yaml
+++ b/projects/prometheus/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/prometheus/prometheus"
+primary_contact: "prometheus-team@googlegroups.com"
+auto_ccs :
+  "adam@adalogics.com"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address

--- a/projects/prometheus/project.yaml
+++ b/projects/prometheus/project.yaml
@@ -1,7 +1,7 @@
 homepage: "https://github.com/prometheus/prometheus"
 primary_contact: "prometheus-team@googlegroups.com"
 auto_ccs :
-  "adam@adalogics.com"
+  -  "adam@adalogics.com"
 language: go
 fuzzing_engines:
   - libfuzzer


### PR DESCRIPTION
This PR adds initial integration of the Cloud Native Computing Foundation graduated project, [Prometheus](https://github.com/prometheus/prometheus). 

A selection of the projects users can be found on [the Prometheus website](https://prometheus.io/).

@juliusv is in the loop as well for this integration application.