### PR TITLE
[gnostic] Initial integration

### DIFF
--- a/projects/gnostic/Dockerfile
+++ b/projects/gnostic/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER adam@adalogics.com
+RUN go get github.com/googleapis/gnostic
+COPY build.sh fuzz.go $SRC/
+WORKDIR $SRC/

--- a/projects/gnostic/build.sh
+++ b/projects/gnostic/build.sh
@@ -1,0 +1,29 @@
+#/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+function compile_fuzzer {
+  path=$1
+  function=$2
+  fuzzer=$3
+
+  go-fuzz -func $function -o $fuzzer.a $path
+
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
+}
+
+mkdir $GOPATH/src/github.com/googleapis/gnostic/fuzz
+cp $SRC/fuzz.go $GOPATH/src/github.com/googleapis/gnostic/fuzz/
+compile_fuzzer github.com/googleapis/gnostic/fuzz Fuzz fuzz

--- a/projects/gnostic/fuzz.go
+++ b/projects/gnostic/fuzz.go
@@ -1,0 +1,34 @@
+/*
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+*/
+
+package fuzz
+
+import(
+	"github.com/googleapis/gnostic/lib"
+	"strings"
+)
+
+func Fuzz(data []byte) int {
+	payload := strings.Fields(string(data))
+	g := lib.NewGnostic(payload)
+	err := g.Main()
+	if err != nil {
+		return 0
+	}
+	return 1
+}

--- a/projects/gnostic/project.yaml
+++ b/projects/gnostic/project.yaml
@@ -1,0 +1,7 @@
+homepage: "https://github.com/googleapis/gnostic"
+primary_contact: "adam@adalogics.com"
+language: go
+fuzzing_engines:
+- libfuzzer
+sanitizers:
+- address


### PR DESCRIPTION
This PR adds initial integration of Googles [gnostic](https://github.com/googleapis/gnostic).

Gnostic is used by [Prometheus](https://github.com/prometheus/prometheus/blob/master/go.mod#L31), [Kubernetes](https://github.com/kubernetes/client-go/blob/master/go.mod#L20) and [Jenkins X](https://github.com/jenkins-x/jx/blob/master/go.sum#L331) to name a few.

A small notice on this PR: This project.yaml does not contain any email addresses for any maintainers or contributors of gnostic. I have setup [a PR](https://github.com/googleapis/gnostic/pull/171) on the gnostic repository with the fuzzer. This should allow maintainers to chime in. The fuzzer is added in this PR as a reference to demonstrate a working build.