### PR TITLE
[google-cloud-go] Initial integration

### DIFF
--- a/projects/google-cloud-go/Dockerfile
+++ b/projects/google-cloud-go/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER adam@adalogics.com
+COPY build.sh fuzz.go $SRC/
+WORKDIR $SRC/

--- a/projects/google-cloud-go/build.sh
+++ b/projects/google-cloud-go/build.sh
@@ -1,0 +1,33 @@
+#/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+function compile_fuzzer {
+  path=$1
+  function=$2
+  fuzzer=$3
+
+  go-fuzz -func $function -o $fuzzer.a $path
+
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
+}
+
+mkdir sample_cloud_project && cd sample_cloud_project
+echo -e 'import "cloud.google.com/go/spanner"'>>sample.go
+go get cloud.google.com/go/spanner
+
+mkdir $GOPATH/src/cloud.google.com/go/spanner/fuzz
+cp $SRC/fuzz.go $GOPATH/src/cloud.google.com/go/spanner/fuzz/
+compile_fuzzer cloud.google.com/go/spanner/fuzz Fuzz fuzz

--- a/projects/google-cloud-go/fuzz.go
+++ b/projects/google-cloud-go/fuzz.go
@@ -1,0 +1,25 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fuzz
+
+import "cloud.google.com/go/spanner/spansql"
+
+func Fuzz(data []byte) int {
+	_, err := spansql.ParseQuery(string(data))
+	if err != nil {
+		return 0
+	}
+	return 1
+}

--- a/projects/google-cloud-go/project.yaml
+++ b/projects/google-cloud-go/project.yaml
@@ -1,0 +1,7 @@
+homepage: "https://github.com/googleapis/google-cloud-go"
+primary_contact: "adam@adalogics.com"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
This PR adds initial integration of [the Google Cloud Client Libraries for Go](https://github.com/googleapis/google-cloud-go).

I add the fuzzer here, since no contributions are accepted at https://github.com/googleapis/google-cloud-go. However, I have opened an issue upstream about [this crash](https://github.com/googleapis/google-cloud-go/issues/2196) that the fuzzer finds in accordance with [the contribution-guidelines of google-cloud-go](https://github.com/googleapis/google-cloud-go/blob/master/CONTRIBUTING.md).

I have solely added my own email in the project.yaml, and I will ask upstream about email addresses to add.