### PR TITLE
[cryptofuzz] Add Microsoft SymCrypt

### DIFF
--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -17,7 +17,12 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER guidovranken@gmail.com
 
-RUN apt-get update && apt-get install -y software-properties-common python-software-properties make autoconf automake libtool build-essential cmake libboost-all-dev wget mercurial gyp ninja-build zlib1g-dev libsqlite3-dev
+RUN apt-get update && \
+    apt-get install -y apt-transport-https ca-certificates gnupg software-properties-common wget && \
+    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add - && \
+    apt-add-repository 'deb https://apt.kitware.com/ubuntu/ xenial main' && \
+    apt-get update && \
+    apt-get install -y software-properties-common python-software-properties make autoconf automake libtool build-essential cmake libboost-all-dev mercurial gyp ninja-build zlib1g-dev libsqlite3-dev
 
 # BoringSSL needs Go to build
 RUN add-apt-repository -y ppa:gophers/archive && apt-get update && apt-get install -y golang-1.9-go
@@ -43,6 +48,7 @@ RUN hg clone https://hg.mozilla.org/projects/nspr
 RUN hg clone https://hg.mozilla.org/projects/nss
 RUN git clone --depth 1 https://github.com/jedisct1/libsodium.git
 RUN git clone --depth 1 https://github.com/libtom/libtomcrypt.git
+RUN git clone --depth 1 https://github.com/microsoft/SymCrypt.git
 RUN apt-get remove -y libunwind8
 RUN apt-get install -y libssl-dev
 

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -94,6 +94,28 @@ then
     make -B
 fi
 
+# Compile SymCrypt
+cd $SRC/SymCrypt/
+if [[ $CFLAGS != *sanitize=undefined* ]]
+then
+    # Unittests don't build with clang and are not needed anyway
+    sed -i "s/^add_subdirectory(unittest)$//g" CMakeLists.txt
+
+    mkdir b/
+    cd b/
+    cmake ../
+    make -j$(nproc)
+
+    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_SYMCRYPT"
+    export SYMCRYPT_INCLUDE_PATH=$(realpath ../inc/)
+    export LIBSYMCRYPT_COMMON_A_PATH=$(realpath lib/x86_64/Generic/libsymcrypt_common.a)
+    export SYMCRYPT_GENERIC_A_PATH=$(realpath lib/x86_64/Generic/symcrypt_generic.a)
+
+    # Compile Cryptofuzz SymCrypt module
+    cd $SRC/cryptofuzz/modules/symcrypt
+    make -B
+fi
+
 # Compile Cityhash
 cd $SRC/cityhash
 if [[ $CFLAGS != *-m32* ]]


### PR DESCRIPTION
Microsoft Symcrypt: https://github.com/microsoft/SymCrypt

This also fetches a recent CMake because SymCrypt requires that. Based on https://github.com/google/oss-fuzz/commit/06cd6f44311cdf3e114463bfd670b5e1ca30fbd8.

Currently not including SymCrypt in UBSAN builds to prevent a deluge of alerts for bugs already reported: https://github.com/microsoft/SymCrypt/issues/8
