### PR TITLE
[TiDB] initial integration

### DIFF
--- a/projects/tidb/Dockerfile
+++ b/projects/tidb/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER adam@adalogics.com
+RUN go get github.com/pingcap/tidb/store
+COPY build.sh $SRC/
+WORKDIR $SRC/

--- a/projects/tidb/build.sh
+++ b/projects/tidb/build.sh
@@ -1,0 +1,28 @@
+#/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+function compile_fuzzer {
+  path=$1
+  function=$2
+  fuzzer=$3
+
+  go-fuzz -func $function -o $fuzzer.a $path
+
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
+}
+compile_fuzzer github.com/pingcap/tidb/types FuzzMarshalJSON fuzzMarshalJSON
+compile_fuzzer github.com/pingcap/tidb/types FuzzNewBitLiteral fuzzNewBitLiteral
+compile_fuzzer github.com/pingcap/tidb/types FuzzNewHexLiteral fuzzNewHexLiteral

--- a/projects/tidb/project.yaml
+++ b/projects/tidb/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/pingcap/tidb"
+primary_contact: "zhouqiang@pingcap.com"
+auto_ccs :
+  - "adam@adalogics.com"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
This PR adds initial integration of [TiDB](https://github.com/pingcap/tidb).

The storage layer of TiDB, named TiKV, became a CNCF member in 2018, and many large companies rely on TiDB, including Bank of Beijing, Industrial and Commercial Bank of China, China Telecom Shanghai.

An extensive but not exhaustive list of adopters can be found [here](https://pingcap.com/docs/dev/adopters/).