### PR TITLE
wasmtime: build fuzz targets with --all-features

### DIFF
--- a/projects/wasmtime/build.sh
+++ b/projects/wasmtime/build.sh
@@ -17,7 +17,10 @@
 
 # Note: This project creates Rust fuzz targets exclusively
 PROJECT_DIR=$SRC/wasmtime
-cd $PROJECT_DIR/fuzz && cargo fuzz build -O --debug-assertions --features binaryen
+
+# Build with all features to enable the binaryen-using fuzz targets, and
+# the peepmatic fuzz targets.
+cd $PROJECT_DIR/fuzz && cargo fuzz build -O --debug-assertions --all-features
 
 FUZZ_TARGET_OUTPUT_DIR=$PROJECT_DIR/target/x86_64-unknown-linux-gnu/release
 for f in $SRC/wasmtime/fuzz/fuzz_targets/*.rs


### PR DESCRIPTION
This enables not only the binaryen-using fuzz targets, but also the peepmatic fuzz targets (which is necessary after https://github.com/bytecodealliance/wasmtime/pull/1727).