### PR TITLE
[rdkit] Re-enable memory and i386 architecture

### DIFF
--- a/projects/rdkit/Dockerfile
+++ b/projects/rdkit/Dockerfile
@@ -16,27 +16,13 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER greg.landrum@gmail.com
-RUN apt-get update && apt-get install -y make wget cmake \
-  libeigen3-dev python3 libpython3-all-dev \
-  zlib1g-dev \
-  libbz2-dev
+RUN dpkg --add-architecture i386 && \
+  apt-get update && apt-get install -y make wget cmake
 
 # Install latest cmake
 RUN wget --quiet https://github.com/Kitware/CMake/releases/download/v3.14.5/cmake-3.14.5-Linux-x86_64.sh; \
     chmod +x cmake-3.14.5-Linux-x86_64.sh; \
     ./cmake-3.14.5-Linux-x86_64.sh --skip-license --prefix="/usr/local"
-
-# We're building `rdkit` using clang, but the boost package is built using gcc.
-# For whatever reason, linking would fail.
-# (Mismatch between libstdc++ and libc++ maybe?)
-# It works if we build `rdkit` using gcc or build boost using clang instead.
-# We've opted for building boost using clang.
-RUN cd $SRC && \
-    wget --quiet https://sourceforge.net/projects/boost/files/boost/1.69.0/boost_1_69_0.tar.bz2 && \
-    tar xjf boost_1_69_0.tar.bz2 && \
-    cd $SRC/boost_1_69_0 && \
-    ./bootstrap.sh --with-toolset=clang --with-libraries=serialization,system,iostreams,regex && \
-    ./b2 -q -j2 toolset=clang cxxflags="-fPIC $CXXFLAGS $CXXFLAGS_EXTRA" link=static install
 
 RUN git clone --depth 1 https://github.com/rdkit/rdkit.git $SRC/rdkit
 WORKDIR $SRC/rdkit

--- a/projects/rdkit/Dockerfile
+++ b/projects/rdkit/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER greg.landrum@gmail.com
 RUN dpkg --add-architecture i386 && \
-  apt-get update && apt-get install -y make wget cmake
+  apt-get update && apt-get install -y make wget cmake libeigen3-dev
 
 # Install latest cmake
 RUN wget --quiet https://github.com/Kitware/CMake/releases/download/v3.14.5/cmake-3.14.5-Linux-x86_64.sh; \

--- a/projects/rdkit/project.yaml
+++ b/projects/rdkit/project.yaml
@@ -4,5 +4,7 @@ primary_contact: "greg.landrum@gmail.com"
 sanitizers:
   - address
   - undefined
+  - memory
 architectures:
   - x86_64
+  - i386


### PR DESCRIPTION
Re-enable memory sanitizer.
Re-enable i386 architecture.
Fix copyright notice year.
Build boost in `build.sh` instead of Dockerfile.