### PR TITLE
[fasthttp] Initial integration

### DIFF
--- a/projects/fasthttp/Dockerfile
+++ b/projects/fasthttp/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER adam@adalogics.com
+RUN go get github.com/valyala/fasthttp
+
+COPY build.sh $SRC/
+WORKDIR $SRC/

--- a/projects/fasthttp/build.sh
+++ b/projects/fasthttp/build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+function compile_fuzzer {
+  path=$1
+  function=$2
+  fuzzer=$3
+
+  go-fuzz -func $function -o $fuzzer.a $path
+
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
+}
+
+
+ls $GOPATH/src/github.com/valyala/fasthttp/fuzzit | while read target
+do
+    compile_fuzzer github.com/valyala/fasthttp/fuzzit/$target Fuzz fuzz_$target
+done

--- a/projects/fasthttp/project.yaml
+++ b/projects/fasthttp/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/valyala/fasthttp"
+primary_contact: "erik@dubbelboer.com"
+auto_ccs :
+  - "adam@adalogics.com"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
This PR adds initial integration of [fasthttp](https://github.com/valyala/fasthttp), an http implementation up to 10 times faster than [net/http](https://golang.org/pkg/net/http/). 

The library is widely adopted in both open source software and closed source software that serve hundreds of thousands of rps in production.

[According to a contributor](https://github.com/valyala/fasthttp/issues/777#issuecomment-615973513), fasthttp is used by one of the largest media companies in the world for critical services.

It is used by [VertaMedia](https://adtelligent.com/) to handle 200k rps in production.

Below are some examples of open source libraries that have adopted fasthttp:

[Dragonfly](https://github.com/dragonflyoss/Dragonfly/blob/master/pkg/httputils/http_util.go#L40)
[Go-elastisearch](https://github.com/elastic/go-elasticsearch/blob/master/_examples/fasthttp/fasthttp.go#L12)
[Baton](https://github.com/americanexpress/baton/blob/master/worker.go#L20) by American Express
[Sentrys go-client](https://github.com/getsentry/sentry-go/blob/master/fasthttp/sentryfasthttp.go#L13)
[dapr](https://github.com/dapr/dapr/blob/master/pkg/http/server.go#L19)
[mosn](https://github.com/mosn/mosn/blob/master/pkg/stream/http/stream.go#L32)
[nuclio](https://github.com/nuclio/nuclio/blob/development/pkg/processor/trigger/http/cors/cors.go#L25)
[Fiber](https://github.com/gofiber/fiber/blob/master/ctx.go#L28)
