### PR TITLE
Set rust flags always in compile step.

### DIFF
--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -63,30 +63,28 @@ if [ $FUZZING_ENGINE = "none" ]; then
   export COVERAGE_FLAGS=
 fi
 
-if [[ $FUZZING_LANGUAGE == "rust" ]]; then
-  # Rust does not support sanitizers and coverage flags via CFLAGS/CXXFLAGS.
-  # Instead, use RUSTFLAGS.
-  # FIXME: Support code coverage once support is in.
-  # See https://github.com/rust-lang/rust/issues/34701.
-  export RUSTFLAGS="--cfg fuzzing -Zsanitizer=${SANITIZER} -Cdebuginfo=1 -Cforce-frame-pointers"
+# Rust does not support sanitizers and coverage flags via CFLAGS/CXXFLAGS, so
+# use RUSTFLAGS.
+# FIXME: Support code coverage once support is in.
+# See https://github.com/rust-lang/rust/issues/34701.
+export RUSTFLAGS="--cfg fuzzing -Zsanitizer=${SANITIZER} -Cdebuginfo=1 -Cforce-frame-pointers"
 
-  # Add Rust libfuzzer flags.
-  # See https://github.com/rust-fuzz/libfuzzer/blob/master/build.rs#L12.
-  export CUSTOM_LIBFUZZER_PATH="$LIB_FUZZING_ENGINE_DEPRECATED"
-  export CUSTOM_LIBFUZZER_STD_CXX=c++
+# Add Rust libfuzzer flags.
+# See https://github.com/rust-fuzz/libfuzzer/blob/master/build.rs#L12.
+export CUSTOM_LIBFUZZER_PATH="$LIB_FUZZING_ENGINE_DEPRECATED"
+export CUSTOM_LIBFUZZER_STD_CXX=c++
 
-  # Set RUSTC_BOOTSTRAP to get nightly features like sanitizers.
-  export RUSTC_BOOTSTRAP=1
-else
-  export CFLAGS="$CFLAGS $SANITIZER_FLAGS $COVERAGE_FLAGS"
-  export CXXFLAGS="$CFLAGS $CXXFLAGS_EXTRA"
-fi
+# Set RUSTC_BOOTSTRAP to get nightly features like sanitizers.
+export RUSTC_BOOTSTRAP=1
 
+export CFLAGS="$CFLAGS $SANITIZER_FLAGS $COVERAGE_FLAGS"
+export CXXFLAGS="$CFLAGS $CXXFLAGS_EXTRA"
+
+echo "---------------------------------------------------------------"
 echo "CC=$CC"
 echo "CXX=$CXX"
 echo "CFLAGS=$CFLAGS"
 echo "CXXFLAGS=$CXXFLAGS"
-
 echo "---------------------------------------------------------------"
 
 BUILD_CMD="bash -eux $SRC/build.sh"


### PR DESCRIPTION
This is needed for projects that mix both rust and c/c++.