### PR TITLE
[hermes] Fix coverage build

### DIFF
--- a/projects/hermes/build.sh
+++ b/projects/hermes/build.sh
@@ -21,6 +21,8 @@ then
 elif [ "${SANITIZER}" = undefined ]
 then
     CONFIGURE_FLAGS="--enable-ubsan"
+else
+    CONFIGURE_FLAGS=""
 fi
 
 ./utils/build/configure.py "${OUT}/build" --build-system "Ninja" ${CONFIGURE_FLAGS} \


### PR DESCRIPTION
Coverage builds are failing because `CONFIGURE_FLAGS` is not set to anything.