### PR TITLE
[qt] Don't install build-essential

### DIFF
--- a/projects/qt/Dockerfile
+++ b/projects/qt/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER rlohningqt@gmail.com
 RUN dpkg --add-architecture i386
-RUN apt-get update && apt-get install -y build-essential libc6-dev:i386
+RUN apt-get update && apt-get install -y libc6-dev:i386
 RUN git clone --branch 5.15 --depth 1 git://code.qt.io/qt/qt5.git qt
 WORKDIR qt
 RUN git submodule update --init --depth 1 qtbase


### PR DESCRIPTION
It's in base-builder now.