### PR TITLE
optimize size and time using "--no-cache-dir"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,14 @@ before_install:
   - git fetch origin +refs/heads/$TRAVIS_BRANCH
 
 install:
-  - pip install -r infra/travis/requirements.txt
+  - pip install --no-cache-dir -r infra/travis/requirements.txt
 
 
 matrix:
   include:
     - name: "presubmit"
       install:
-        - pip install -r infra/dev-requirements.txt
+        - pip install --no-cache-dir -r infra/dev-requirements.txt
       script: ./infra/presubmit.py
     - name: "libfuzzer address x86_64"
       env:

--- a/infra/base-images/base-runner/Dockerfile
+++ b/infra/base-images/base-runner/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get install -y \
     zip
 
 RUN git clone https://chromium.googlesource.com/chromium/src/tools/code_coverage /opt/code_coverage
-RUN pip3 install -r /opt/code_coverage/requirements.txt
+RUN pip3 install --no-cache-dir -r /opt/code_coverage/requirements.txt
 
 COPY bad_build_check \
     collect_dft \

--- a/infra/gcb/jenkins_config/base_job.xml
+++ b/infra/gcb/jenkins_config/base_job.xml
@@ -51,7 +51,7 @@ set +o nounset
 set -o nounset
 
 cd $WORKSPACE/oss-fuzz/infra/gcb
-pip install -r requirements.txt
+pip install --no-cache-dir -r requirements.txt
 build_id=$(python build_project.py $WORKSPACE/oss-fuzz/$JOB_NAME)
 python wait_for_build.py $build_id
 </command>

--- a/infra/gcb/jenkins_config/coverage_job.xml
+++ b/infra/gcb/jenkins_config/coverage_job.xml
@@ -44,7 +44,7 @@ set +o nounset
 set -o nounset
 
 cd $WORKSPACE/oss-fuzz/infra/gcb
-pip install -r requirements.txt
+pip install --no-cache-dir -r requirements.txt
 project_dir=$WORKSPACE/oss-fuzz/projects/$(basename $JOB_NAME)
 build_id=$(python build_and_run_coverage.py $project_dir)
 if [[ "$build_id" == "0" ]]; then

--- a/projects/casync/Dockerfile
+++ b/projects/casync/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && \
         rsync \
         udev \
         && \
-    pip3 install meson ninja
+    pip3 install --no-cache-dir meson ninja
 RUN git clone --depth 1 https://github.com/systemd/casync casync
 WORKDIR casync
 COPY build.sh $SRC/

--- a/projects/dav1d/Dockerfile
+++ b/projects/dav1d/Dockerfile
@@ -23,7 +23,7 @@ ADD nasm_apt.pin /etc/apt/preferences
 RUN dpkg --add-architecture i386 && \
     apt-get update && \
     apt-get install --no-install-recommends -y libstdc++-5-dev libstdc++-5-dev:i386 curl python3-pip python3-setuptools python3-wheel nasm && \
-    pip3 install meson ninja
+    pip3 install --no-cache-dir meson ninja
 RUN curl --silent -O https://storage.googleapis.com/aom-test-data/fuzzer/dec_fuzzer_seed_corpus.zip
 RUN curl --silent -O https://jannau.net/dav1d_fuzzer_seed_corpus.zip
 RUN git clone --depth 1 https://code.videolan.org/videolan/dav1d.git dav1d

--- a/projects/django/build.sh
+++ b/projects/django/build.sh
@@ -61,7 +61,7 @@ cp -R $CPYTHON_INSTALL_PATH $OUT/
 
 rm -rf $OUT/django-dependencies
 mkdir $OUT/django-dependencies
-$CPYTHON_INSTALL_PATH/bin/pip3 install asgiref pytz sqlparse -t $OUT/django-dependencies
+$CPYTHON_INSTALL_PATH/bin/pip3 install --no-cache-dir asgiref pytz sqlparse -t $OUT/django-dependencies
 
 cd $SRC/django-fuzzers
 rm $CPYTHON_INSTALL_PATH/lib/python3.8/lib-dynload/_tkinter*.so

--- a/projects/glib/Dockerfile
+++ b/projects/glib/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER pdknsk@gmail.com
 RUN apt-get update && apt-get install -y python3-pip
-RUN pip3 install -U meson ninja
+RUN pip3 install --no-cache-dir -U meson ninja
 RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/glib
 WORKDIR glib
 COPY build.sh $SRC/

--- a/projects/grpc/Dockerfile
+++ b/projects/grpc/Dockerfile
@@ -38,9 +38,9 @@ RUN apt-get update && apt-get install -y \
     python-pip
 
 # Install Python packages from PyPI
-RUN pip install --upgrade pip==10.0.1
-RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install --no-cache-dir --upgrade pip==10.0.1
+RUN pip install --no-cache-dir virtualenv
+RUN pip install --no-cache-dir futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 #========================
 # Bazel installation

--- a/projects/gstreamer/Dockerfile
+++ b/projects/gstreamer/Dockerfile
@@ -25,7 +25,7 @@ RUN sed -i '/^#\sdeb-src /s/^#//' "/etc/apt/sources.list" && \
    apt-get install -y build-essential pkg-config bison flex gettext \
     libffi-dev liblzma-dev libvorbis-dev libtheora-dev libogg-dev zlib1g-dev \
     ninja-build python3-pip && \
-   pip3 install meson==0.53.2
+   pip3 install --no-cache-dir meson==0.53.2
 
 ADD https://ftp.gnome.org/pub/gnome/sources/glib/2.64/glib-2.64.2.tar.xz $SRC
 

--- a/projects/irssi/Dockerfile
+++ b/projects/irssi/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER joseph.bisch@gmail.com
 RUN apt-get update && apt-get install -y pkg-config libncurses5-dev libssl-dev python3-pip
-RUN pip3 install -U meson ninja
+RUN pip3 install --no-cache-dir -U meson ninja
 RUN git clone https://github.com/irssi/irssi
 
 WORKDIR irssi

--- a/projects/libavif/Dockerfile
+++ b/projects/libavif/Dockerfile
@@ -22,7 +22,7 @@ ADD nasm_apt.pin /etc/apt/preferences
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y curl python3-pip python3-setuptools python3-wheel cmake git && \
-    pip3 install meson ninja
+    pip3 install --no-cache-dir meson ninja
 
 RUN git clone --depth 1 https://github.com/AOMediaCodec/libavif.git libavif
 WORKDIR libavif

--- a/projects/libcacard/Dockerfile
+++ b/projects/libcacard/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER jjelen@redhat.com
 RUN apt-get update && apt-get install -y pkg-config libglib2.0-dev gyp libsqlite3-dev mercurial python3-pip
 # Because Ubuntu has really ancient meson out there
-RUN pip3 install meson ninja
+RUN pip3 install --no-cache-dir meson ninja
 
 RUN git clone --depth 1 --single-branch --branch master https://gitlab.freedesktop.org/spice/libcacard.git libcacard
 RUN git clone --depth 1 https://github.com/nss-dev/nss.git nss

--- a/projects/nanopb/Dockerfile
+++ b/projects/nanopb/Dockerfile
@@ -17,8 +17,8 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER jpa@npb.mail.kapsi.fi
 RUN apt-get update && apt-get install -y python3-pip git wget
-RUN python3 -m pip install --upgrade pip
-RUN pip3 install protobuf grpcio-tools scons
+RUN python3 -m pip install --no-cache-dir --upgrade pip
+RUN pip3 install --no-cache-dir protobuf grpcio-tools scons
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 100
 RUN git clone --depth 1 https://github.com/nanopb/nanopb $SRC/nanopb
 COPY build.sh $SRC/

--- a/projects/openvswitch/Dockerfile
+++ b/projects/openvswitch/Dockerfile
@@ -19,7 +19,7 @@ MAINTAINER blp@ovn.org
 RUN apt-get update && apt-get install -y make autoconf automake \
     libtool python python3-pip \
     libz-dev libssl-dev libssl1.0.0 wget
-RUN pip3 install six
+RUN pip3 install --no-cache-dir six
 RUN git clone --depth 1 https://github.com/openvswitch/ovs.git openvswitch
 RUN git clone --depth 1 https://github.com/openvswitch/ovs-fuzzing-corpus.git \
     ovs-fuzzing-corpus

--- a/projects/ots/Dockerfile
+++ b/projects/ots/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mmoroz@chromium.org
 RUN apt-get update && apt-get install -y python3-pip pkg-config zlib1g-dev && \
-    pip3 install meson==0.52.0 ninja
+    pip3 install --no-cache-dir meson==0.52.0 ninja
 RUN git clone --depth 1 https://github.com/khaledhosny/ots.git
 WORKDIR ots
 RUN git submodule update --init --recursive

--- a/projects/systemd/Dockerfile
+++ b/projects/systemd/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update &&\
     apt-get install -y gperf m4 gettext python3-pip \
         libcap-dev libmount-dev libkmod-dev \
         pkg-config wget &&\
-    pip3 install meson ninja
+    pip3 install --no-cache-dir meson ninja
 RUN git clone --depth 1 https://github.com/systemd/systemd systemd
 WORKDIR systemd
 COPY build.sh $SRC/

--- a/projects/tpm2-tss/Dockerfile
+++ b/projects/tpm2-tss/Dockerfile
@@ -52,7 +52,7 @@ RUN apt-get update && \
     python-cryptography \
     python3-cryptography
 
-RUN pip3 install cpp-coveralls
+RUN pip3 install --no-cache-dir cpp-coveralls
 
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 100
 RUN update-alternatives --install /usr/bin/scan-build scan-build /usr/bin/scan-build-6.0 100


### PR DESCRIPTION
Using "--no-cache-dir" flag in pip install ,make sure dowloaded packages
by pip don't cached on system . This is a best practise which make sure
to fetch ftom repo instead of using local cached one . Further , in case
of Docker Containers , by restricing caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6