### PR TITLE
[nanopb] Use $(which python3) instead of hardcoding /usr/bin/python3

### DIFF
--- a/projects/nanopb/Dockerfile
+++ b/projects/nanopb/Dockerfile
@@ -19,7 +19,7 @@ MAINTAINER jpa@npb.mail.kapsi.fi
 RUN apt-get update && apt-get install -y python3-pip git wget
 RUN python3 -m pip install --upgrade pip
 RUN pip3 install protobuf grpcio-tools scons
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 100
+RUN update-alternatives --install /usr/bin/python python $(which python3) 100
 RUN git clone --depth 1 https://github.com/nanopb/nanopb $SRC/nanopb
 COPY build.sh $SRC/
 


### PR DESCRIPTION
After the addition of Python 3.8 in #3874, the default python3 is
now /usr/local/bin/python3. The nanopb Dockerfile hardcoded a path
of /usr/bin/python3, causing again problems of Python packages being
installed for different version than attempting to run with.