### PR TITLE
[firefox] Fix libFuzzer cloning process

### DIFF
--- a/projects/firefox/build.sh
+++ b/projects/firefox/build.sh
@@ -45,6 +45,13 @@ export MOZCONFIG=$SRC/mozconfig.$SANITIZER
 export SHELL=/bin/bash
 ./mach bootstrap --no-interactive --application-choice browser
 
+# Skip patches for now
+rm tools/fuzzing/libfuzzer/patches/*.patch
+touch tools/fuzzing/libfuzzer/patches/dummy.patch
+
+# The git version used on oss-fuzz does not support --shallow-since
+sed -i -e 's/--shallow-since "[^"]*"/--depth 1/' tools/fuzzing/libfuzzer/clone_libfuzzer.sh
+
 # Update internal libFuzzer.
 (cd tools/fuzzing/libfuzzer && ./clone_libfuzzer.sh HEAD)
 

--- a/projects/firefox/build.sh
+++ b/projects/firefox/build.sh
@@ -49,9 +49,6 @@ export SHELL=/bin/bash
 rm tools/fuzzing/libfuzzer/patches/*.patch
 touch tools/fuzzing/libfuzzer/patches/dummy.patch
 
-# The git version used on oss-fuzz does not support --shallow-since
-sed -i -e 's/--shallow-since "[^"]*"/--depth 1/' tools/fuzzing/libfuzzer/clone_libfuzzer.sh
-
 # Update internal libFuzzer.
 (cd tools/fuzzing/libfuzzer && ./clone_libfuzzer.sh HEAD)
 


### PR DESCRIPTION
This fixes the problems that we're recently introduced when adding git support and patches to the libFuzzer cloning script. For now, the patches are not relevant to oss-fuzz and since only `HEAD` is built on oss-fuzz, we can use `--depth` instead of `--shallow-since` for speeding up the git clone.