### PR TITLE
[php] Remove --enable-json

### DIFF
--- a/projects/php/build.sh
+++ b/projects/php/build.sh
@@ -34,7 +34,6 @@ export CXXFLAGS="$CXXFLAGS -fno-sanitize=object-size"
     --disable-all \
     --enable-option-checking=fatal \
     --enable-fuzzer \
-    --enable-json \
     --enable-exif \
     --enable-mbstring \
     --without-pcre-jit \


### PR DESCRIPTION
This fixes the build failure. The `--enable-json` option no longer exists, and is promoted to an error due to `--enable-option-checking=fatal`.