### PR TITLE
Update email addresses for Prometheus

### DIFF
--- a/projects/prometheus/project.yaml
+++ b/projects/prometheus/project.yaml
@@ -1,7 +1,10 @@
 homepage: "https://github.com/prometheus/prometheus"
 primary_contact: "prometheus-team@googlegroups.com"
 auto_ccs :
-  -  "adam@adalogics.com"
+  - "julius.volz@gmail.com"
+  - "brian.brazil@robustperception.io"
+  - "roidelapluie@prometheus.io"
+  - "richih@richih.org"
 language: go
 fuzzing_engines:
   - libfuzzer


### PR DESCRIPTION
All of these people are active Prometheus Team members (though it's only a subset of team members).

Signed-off-by: Julius Volz <julius.volz@gmail.com>