### PR TITLE
Prometheus: Don't use WORKDIR $SRC

### DIFF
--- a/projects/prometheus/Dockerfile
+++ b/projects/prometheus/Dockerfile
@@ -18,4 +18,5 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER adam@adalogics.com
 RUN go get github.com/prometheus/prometheus/cmd/...
 COPY build.sh $SRC/
-WORKDIR $SRC/
+RUN mkdir $SRC/prometheus/
+WORKDIR $SRC/prometheus/


### PR DESCRIPTION
This makes build_fuzzers work with local checkouts.

Without this, it complains with 'Cannot use local checkout with "WORKDIR
/src".'

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>