### PR TITLE
Revert "[systemd] remove my non-gmail address"

### DIFF
--- a/projects/systemd/project.yaml
+++ b/projects/systemd/project.yaml
@@ -11,6 +11,7 @@ auto_ccs:
   - dimitri.ledkov@canonical.com
   - poettering@gmail.com
   - watanabe.yu@gmail.com
+  - evvers@ya.ru
   - evverx@gmail.com
   - Tixxdz@gmail.com
   - fsumsal@redhat.com


### PR DESCRIPTION
Reverts google/oss-fuzz#3606

Looks like it was addressed in https://bugs.chromium.org/p/monorail/issues/detail?id=7461