### PR TITLE
Fix builds_status cron exception.

### DIFF
--- a/infra/gcb/builds_status.py
+++ b/infra/gcb/builds_status.py
@@ -96,10 +96,13 @@ def find_last_build(builds, project, build_tag_suffix):
           build_project.GCB_LOGS_BUCKET)
       log_name = 'log-{0}.txt'.format(build['id'])
       log = gcb_bucket.blob(log_name)
-      dest_log = status_bucket.blob(log_name)
+      if not log.exists():
+        print >> sys.stderr, 'Failed to find build log', log_name
+        continue
 
       with tempfile.NamedTemporaryFile() as f:
         log.download_to_filename(f.name)
+        dest_log = status_bucket.blob(log_name)
         dest_log.upload_from_filename(f.name, content_type='text/plain')
 
       return build


### PR DESCRIPTION
When build log is not found, skip it and avoid 404.
Fixes exception
```
Traceback (most recent call last):
  File "oss-fuzz/infra/gcb/builds_status.py", line 243, in <module>
    main()
  File "oss-fuzz/infra/gcb/builds_status.py", line 228, in main
    status_filename='status.json')
  File "oss-fuzz/infra/gcb/builds_status.py", line 159, in update_build_status
    last_build = find_last_build(builds, project, build_tag_suffix)
  File "oss-fuzz/infra/gcb/builds_status.py", line 102, in find_last_build
    log.download_to_filename(f.name)
  File "/var/jenkins_home/workspace/infra/builds_status/ENV/local/lib/python2.7/site-packages/google/cloud/storage/blob.py", line 565, in download_to_filename
    file_obj, client=client, start=start, end=end)
  File "/var/jenkins_home/workspace/infra/builds_status/ENV/local/lib/python2.7/site-packages/google/cloud/storage/blob.py", line 537, in download_to_file
    _raise_from_invalid_response(exc)
  File "/var/jenkins_home/workspace/infra/builds_status/ENV/local/lib/python2.7/site-packages/google/cloud/storage/blob.py", line 1873, in _raise_from_invalid_response
    raise exceptions.from_http_response(error.response)
google.api_core.exceptions.NotFound: 404 GET https://www.googleapis.com/download/storage/v1/b/oss-fuzz-gcb-logs/o/log-9fca5dab-72bf-4970-9557-86b93ede51e0.txt?alt=media: No such object: oss-fuzz-gcb-logs/log-9fca5dab-72bf-4970-9557-86b93ede51e0.txt
Build step 'Execute shell' marked build as failure
Finished: FAILURE
```