### PR TITLE
[espv2] Install rsync

### DIFF
--- a/projects/esp-v2/Dockerfile
+++ b/projects/esp-v2/Dockerfile
@@ -29,7 +29,8 @@ RUN apt-get update && apt-get -y install  \
     libtool         \
     wget            \
     golang          \
-    python
+    python          \
+    rsync
 
 # Install Bazelisk
 RUN wget -O /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v0.0.8/bazelisk-linux-amd64; \


### PR DESCRIPTION
Our coverage reports started failing recently with `rsync: command not found`. Install `rsync` to solve.

Similar to #3912 