### PR TITLE
ecc-diff-fuzzer buils nettle without openssl

### DIFF
--- a/projects/ecc-diff-fuzzer/build.sh
+++ b/projects/ecc-diff-fuzzer/build.sh
@@ -28,7 +28,7 @@ make -j$(nproc)
 make install
 cd ..
 autoreconf
-./configure --disable-shared
+./configure --disable-shared --disable-openssl
 make -j$(nproc)
 make install
 )


### PR DESCRIPTION
Should fix build failure 
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=22819