### PR TITLE
[spidermonkey-ufi] Copy additional dependency libraries

### DIFF
--- a/projects/spidermonkey-ufi/build.sh
+++ b/projects/spidermonkey-ufi/build.sh
@@ -61,4 +61,6 @@ done
 mkdir -p $OUT/lib
 cp -L /usr/lib/x86_64-linux-gnu/libc++.so.1 $OUT/lib
 cp -L /usr/lib/x86_64-linux-gnu/libc++abi.so.1 $OUT/lib
-
+cp -L dist/bin/libnspr4.so $OUT/lib
+cp -L dist/bin/libplc4.so $OUT/lib
+cp -L dist/bin/libplds4.so $OUT/lib


### PR DESCRIPTION
This copies all required dependencies for the `js` and `fuzz-tests` binaries. Note that we can't just copy `*.so` because the build also produces a `libjs` that we don't need.