### PR TITLE
Revert "[qt] Add pdf to image corpus (#3926)"

### DIFF
--- a/projects/qt/build.sh
+++ b/projects/qt/build.sh
@@ -35,7 +35,7 @@ make -j$(nproc) > /dev/null
 # prepare corpus files
 zip -j $WORK/cbor $SRC/qtqa/fuzzing/testcases/cbor/*
 zip -j $WORK/html $SRC/qtqa/fuzzing/testcases/html/*
-zip -j $WORK/images $SRC/qtqa/fuzzing/testcases/svg/* $SRC/AFL/testcases/images/*/* $SRC/AFL/testcases/others/pdf/*
+zip -j $WORK/images $SRC/qtqa/fuzzing/testcases/svg/* $SRC/AFL/testcases/images/*/*
 zip -j $WORK/markdown $SRC/qtqa/fuzzing/testcases/markdown/*
 zip -j $WORK/qml $SRC/qtqa/fuzzing/testcases/qml/*
 zip -j $WORK/ssl.pem.zip $SRC/qtqa/fuzzing/testcases/ssl.pem/*


### PR DESCRIPTION
To handle PDFs, QImage requires qtwebengine
which doesn't build statically.

This reverts commit 934c770abb932629da5c53af594bbe785964c7fb.