### PR TITLE
Fix TensorFlow build

### DIFF
--- a/projects/tensorflow/Dockerfile
+++ b/projects/tensorflow/Dockerfile
@@ -30,6 +30,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
 RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
 RUN apt-get update && apt-get install -y bazel
+RUN curl -Lo /usr/bin/bazel \
+        https://github.com/bazelbuild/bazelisk/releases/download/v1.1.0/bazelisk-linux-amd64 \
+        && \
+    chmod +x /usr/bin/bazel
 
 RUN git clone --depth 1 https://github.com/tensorflow/tensorflow tensorflow
 WORKDIR $SRC/tensorflow

--- a/projects/tensorflow/Dockerfile
+++ b/projects/tensorflow/Dockerfile
@@ -19,8 +19,8 @@ MAINTAINER mihaimaruseac@google.com
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
-        python-dev \
-        python-future \
+        python3-dev \
+        python3-future \
         rsync \
         && \
     apt-get clean && \

--- a/projects/tensorflow/Dockerfile
+++ b/projects/tensorflow/Dockerfile
@@ -19,12 +19,11 @@ MAINTAINER mihaimaruseac@google.com
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
-        python3-dev \
-        python3-future \
         rsync \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+RUN python3 -m pip install numpy
 
 # Install Bazel from apt-get to ensure dependencies are there
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list

--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -15,31 +15,6 @@
 #
 ################################################################################
 
-# First, determine the latest Bazel we can support
-BAZEL_VERSION=$(
-  grep '_TF_MAX_BAZEL_VERSION =' configure.py | \
-  cut -d\' -f2 | tr -d '[:space:]'
-)
-if [ -z ${BAZEL_VERSION} ]; then
-  echo "Couldn't find a valid bazel version in configure.py script"
-  exit 1
-fi
-
-# Then, install it
-curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh
-chmod +x ./bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh
-./bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh
-
-# Finally, check instalation before proceeding to compile
-INSTALLED_VERSION=$(
-  bazel version | grep 'Build label' | cut -d: -f2 | tr -d '[:space:]'
-)
-if [ ${INSTALLED_VERSION} != ${BAZEL_VERSION} ]; then
-  echo "Couldn't install required Bazel. "
-  echo "Want ${BAZEL_VERSION}. Got ${INSTALLED_VERSION}."
-  exit 1
-fi
-
 # Generate the list of fuzzers we have (only the base/op name).
 FUZZING_BUILD_FILE="tensorflow/core/kernels/fuzzing/BUILD"
 declare -r FUZZERS=$(

--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -25,7 +25,7 @@ declare -r FUZZERS=$(
 # Note the c++11/libc++ flags to build using the same toolchain as the one used
 # to build libFuzzingEngine.
 CFLAGS="${CFLAGS} -fno-sanitize=vptr"
-CXXFLAGS="${CXXFLAGS} -fno-sanitize=vptr -std=c++11 -stdlib=libc++"
+CXXFLAGS="${CXXFLAGS} -fno-sanitize=vptr"
 
 # Force Python3 and install required python deps
 PYTHON=python3

--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -29,6 +29,7 @@ CXXFLAGS="${CXXFLAGS} -fno-sanitize=vptr -std=c++11 -stdlib=libc++"
 
 # Force Python3 and install required python deps
 PYTHON=python3
+${PYTHON} -m pip install numpy
 
 # Make sure we run ./configure to detect when we are using a Bazel out of range
 yes "" | ${PYTHON} configure.py

--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -27,8 +27,11 @@ declare -r FUZZERS=$(
 CFLAGS="${CFLAGS} -fno-sanitize=vptr"
 CXXFLAGS="${CXXFLAGS} -fno-sanitize=vptr -std=c++11 -stdlib=libc++"
 
+# Force Python3 and install required python deps
+PYTHON=python3
+
 # Make sure we run ./configure to detect when we are using a Bazel out of range
-yes "" | ./configure
+yes "" | ${PYTHON} configure.py
 
 # See https://github.com/bazelbuild/bazel/issues/6697
 sed '/::kM..SeedBytes/d' -i tensorflow/stream_executor/rng.cc

--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -33,9 +33,6 @@ PYTHON=python3
 # Make sure we run ./configure to detect when we are using a Bazel out of range
 yes "" | ${PYTHON} configure.py
 
-# See https://github.com/bazelbuild/bazel/issues/6697
-sed '/::kM..SeedBytes/d' -i tensorflow/stream_executor/rng.cc
-
 # Due to statically linking boringssl dependency, we have to define one extra
 # flag when compiling for memory fuzzing (see the boringssl project).
 if [ "$SANITIZER" = "memory" ]

--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -29,7 +29,6 @@ CXXFLAGS="${CXXFLAGS} -fno-sanitize=vptr"
 
 # Force Python3 and install required python deps
 PYTHON=python3
-${PYTHON} -m pip install numpy
 
 # Make sure we run ./configure to detect when we are using a Bazel out of range
 yes "" | ${PYTHON} configure.py

--- a/projects/tensorflow/project.yaml
+++ b/projects/tensorflow/project.yaml
@@ -2,7 +2,6 @@ homepage: "https://www.tensorflow.org"
 language: c++
 primary_contact: "mihaimaruseac@google.com"
 auto_ccs:
- - "dga@google.com"
  - "frankchn@google.com"
 fuzzing_engines:
   - libfuzzer


### PR DESCRIPTION
Apparently as TF moved to stable Bazel releases the build became even more broken.

This PR should make TF use Bazel from `.bazelversion`, via Bazelisk. So we install Bazelisk in `Dockerfile` and then remove the workarounds for getting the Bazel binary that we had in `build.sh`. Since those were causing the [recent build failure](https://oss-fuzz-build-logs.storage.googleapis.com/log-12d36a9a-0ce0-45c8-8887-a39ecfb5f344.txt) this should fix that.

I am currently compiling in the container. First try resulted in a need to also install `numpy`.

Finally, since `dga@` left Google, remove address from cc list