### PR TITLE
[muparser] set open_mp not required

### DIFF
--- a/projects/muparser/build.sh
+++ b/projects/muparser/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 # build project
-cmake . -DBUILD_SHARED_LIBS=OFF
+cmake . -DBUILD_SHARED_LIBS=OFF  -DENABLE_OPENMP=OFF
 make -j$(nproc)
 
 # install


### PR DESCRIPTION
Fix [this build failure](https://oss-fuzz-build-logs.storage.googleapis.com/index.html#muparser).
Related to https://github.com/google/oss-fuzz/pull/3814
@inferno-chromium 