### PR TITLE
[FFmpeg] projects/ffmpeg/build: disable demuxers only used for network protocols

### DIFF
--- a/projects/ffmpeg/build.sh
+++ b/projects/ffmpeg/build.sh
@@ -139,6 +139,7 @@ PKG_CONFIG_PATH="$FFMPEG_DEPS_PATH/lib/pkgconfig" ./configure \
     --enable-nonfree \
     --disable-muxers \
     --disable-protocols \
+    --disable-demuxer=rtp,rtsp,sdp \
     --disable-devices \
     --disable-shared
 make clean


### PR DESCRIPTION
Network protocols are disabled during build so it makes no sense to
enable these

Signed-off-by: Michael Niedermayer <michaelni@gmx.at>