### PR TITLE
[rust-url] initial integration

### DIFF
--- a/projects/rust-url/Dockerfile
+++ b/projects/rust-url/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER david@adalogics.com
+
+RUN git clone --depth 1 https://github.com/servo/rust-url
+WORKDIR $SRC
+COPY build.sh $SRC/

--- a/projects/rust-url/build.sh
+++ b/projects/rust-url/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC/rust-url
+cargo fuzz build -O 
+cp fuzz/target/x86_64-unknown-linux-gnu/release/parse $OUT/

--- a/projects/rust-url/project.yaml
+++ b/projects/rust-url/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/servo/rust-url"
+primary_contact: "vgosu@mozilla.com"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+language: rust
+auto_ccs:
+  - "david@adalogics.com"
+  - "jmatthews@mozilla.com"


### PR DESCRIPTION
This adds initial integration of rust-url project.
@valenting is the primary maintainer of rust-url and is responsible for integration use of it into Firefox. Rust-url is used by Firefox in some places and the goal is to make it the primary URL parser of Firefox in the future.   

@valenting I set you as the primary contact and I also added you on the cc list @jdm 