### PR TITLE
Add FeaturePolicyParser target to firefox builds

### DIFF
--- a/projects/firefox/build.sh
+++ b/projects/firefox/build.sh
@@ -24,6 +24,7 @@ FUZZ_TARGETS=(
   ContentParentIPC
   CompositorManagerParentIPC
   ContentSecurityPolicyParser
+  FeaturePolicyParser
   # Image
   ImageGIF
   ImageICO


### PR DESCRIPTION
I verified the build with these commands

> python infra/helper.py pull_images
> python infra/helper.py build_image firefox
> python infra/helper.py build_fuzzers --sanitizer address firefox
> python infra/helper.py check_build --sanitizer address --engine libfuzzer firefox FeaturePolicyParser

The last command said "Check build passed", so I think we're good here.