### PR TITLE
[skia] Build SwiftShader without UBSAN.

### DIFF
--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -31,7 +31,11 @@ else
   elif [ $SANITIZER == "memory" ]; then
     CMAKE_SANITIZER="SWIFTSHADER_MSAN"
   elif [ $SANITIZER == "undefined" ]; then
-    CMAKE_SANITIZER="SWIFTSHADER_UBSAN"
+    # The current SwiftShader build needs -fno-sanitize=vptr, but it cannot be
+    # specified here since -fsanitize=undefined will always come after any
+    # user specified flags passed to cmake. SwiftShader does not need to be
+    # built with the undefined sanitizer in order to fuzz Skia, so don't.
+    CMAKE_SANITIZER="SWIFTSHADER_UBSAN_DISABLED"
   else
     exit 1
   fi


### PR DESCRIPTION
By default a cmake based build puts user provided flags at the beginning
of a compiler invocation, giving them lowest priority. This makes it
quite difficult to add the required -fno-sanitize=vptr flag since it
will be placed before -fsanitize=undefined in a SWIFTSHADER_UBSAN build.
To make this work will require upstream changes to SwiftShader's build.

However, it is not necessary to build SwiftShader with the undefined
behavior sanitizer in order to fuzz Skia for issues. (This is only
required for the memory sanitizer which fortunately works.) As a result,
build SwiftShader without the sanitizer in the Skia undefined sanitizer
fuzzer build.