### PR TITLE
Update build.sh

### DIFF
--- a/projects/muparser/build.sh
+++ b/projects/muparser/build.sh
@@ -15,6 +15,9 @@
 #
 ################################################################################
 
+CFLAGS="${CFLAGS} -fno-sanitize=integer-divide-by-zero,float-divide-by-zero"
+CXXFLAGS="${CXXFLAGS} -fno-sanitize=integer-divide-by-zero,float-divide-by-zero"
+
 # build project
 cmake . -DBUILD_SHARED_LIBS=OFF  -DENABLE_OPENMP=OFF
 make -j$(nproc)


### PR DESCRIPTION
Disabled divide by zero sanitation for muparser as discussed here https://github.com/google/oss-fuzz/issues/3968#issuecomment-643373346

Please review the modifications. I cannot test this properly.