### PR TITLE
wasmtime: Try enabling memory sanitizer

### DIFF
--- a/projects/wasmtime/project.yaml
+++ b/projects/wasmtime/project.yaml
@@ -7,6 +7,7 @@ auto_ccs:
   - "ydelendik@mozilla.com"
 sanitizers:
   - address
+  - memory
 fuzzing_engines:
   - libfuzzer
 language: rust


### PR DESCRIPTION
This commit attempts to address the last comments on #3978 and see if we
can enable the memory sanitizer for Rust projects. If this goes through
well then we can update the documentation to list this as well!