### PR TITLE
[xpdf] Disable leak check

### DIFF
--- a/projects/xpdf/Dockerfile
+++ b/projects/xpdf/Dockerfile
@@ -22,3 +22,4 @@ RUN wget --no-check-certificate https://dl.xpdfreader.com/xpdf-latest.tar.gz
 WORKDIR $SRC
 COPY fuzz_*.cc $SRC/
 COPY build.sh $SRC/
+COPY fuzz_pdfload.options $SRC/fuzz_pdfload.options

--- a/projects/xpdf/build.sh
+++ b/projects/xpdf/build.sh
@@ -36,3 +36,6 @@ for fuzzer in zxdoc pdfload; do
       ./xpdf/libtestXpdfStatic.a ./fofi/libfofi.a ./goo/libgoo.a \
       -I../ -I../goo -I../fofi -I. -I../xpdf
 done
+
+# Copy over options files
+cp $SRC/fuzz_pdfload.options $OUT/

--- a/projects/xpdf/fuzz_pdfload.options
+++ b/projects/xpdf/fuzz_pdfload.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+detect_leaks=0


### PR DESCRIPTION
Due to longer release schedule of xpdf and the rather transient nature of the tool we disable leak checking as it is currently blocking the fuzzer. 