### PR TITLE
libplist: Update for new release

### DIFF
--- a/projects/libplist/build.sh
+++ b/projects/libplist/build.sh
@@ -23,7 +23,7 @@ make -j$(nproc) all
 for fuzzer in bplist_fuzzer xplist_fuzzer; do
   $CXX $CXXFLAGS -std=c++11 -Iinclude/ \
       fuzz/$fuzzer.cc -o $OUT/$fuzzer \
-      $LIB_FUZZING_ENGINE src/.libs/libplist.a
+      $LIB_FUZZING_ENGINE src/.libs/libplist-2.0.a
 done
 
 zip -j $OUT/bplist_fuzzer_seed_corpus.zip test/data/*.bplist


### PR DESCRIPTION
The latest release of libplist has a library rename (added API version). This PR will make it work with the latest codebase. Please merge.