### PR TITLE
docs: guard curly braces with {% raw %} .. {% endraw %}

### DIFF
--- a/docs/getting-started/continuous_integration.md
+++ b/docs/getting-started/continuous_integration.md
@@ -102,6 +102,7 @@ a [matrix](https://help.github.com/en/actions/reference/workflow-syntax-for-gith
 can be used. To use a sanitizer add it to the list of sanitizers in the matrix field below:
 
 ```yaml
+{% raw %}
 name: CIFuzz
 on: [pull_request]
 jobs:
@@ -132,6 +133,7 @@ jobs:
      with:
        name: ${{ matrix.sanitizer }}-artifacts
        path: ./out/artifacts
+{% endraw %}
 ```
 
 ## Understanding results


### PR DESCRIPTION
Just a follow-up to https://github.com/google/oss-fuzz/pull/3984 that
should address https://github.com/google/oss-fuzz/pull/3984#discussion_r440951881.
According to https://jekyllrb.com/docs/liquid/tags/#code-snippet-highlighting,
another option would be to add `render_with_liquid: false` in your front matter to
disable Liquid entirely for a particular document.