### PR TITLE
[h2o] Explicitly define sanitizer support

### DIFF
--- a/projects/h2o/project.yaml
+++ b/projects/h2o/project.yaml
@@ -1,6 +1,9 @@
 homepage: "https://github.com/h2o/h2o"
 language: c++
 primary_contact: "jonathan.foote@gmail.com"
+sanitizers:
+  - address
+  - undefined
 auto_ccs:
   - "frederik.deweerdt@gmail.com"
   - "kazuhooku@gmail.com"


### PR DESCRIPTION
The oss-fuzz documentation states that listing supported sanitizers in a project's yaml [is optional](https://google.github.io/oss-fuzz/getting-started/new-project-guide/#sanitizers). It appears that CIFuzz requires supported sanitizers to be included in this file ([ref](https://github.com/google/oss-fuzz/blob/26e8d7c7728096edf55a1fb6d0ecbc4b2dae6afa/infra/cifuzz/cifuzz.py#L508-L529)). I believe this causes the CIFuzz Github Action to fail for projects that have not listed support for address sanitizer explicitly in their respective project YAML.

This PR explicitly defines support for asan and ubsan with a goal of fixing h2o's CIFuzz build