### PR TITLE
[cifuzz] Temporary fix for sanitizer validation.

### DIFF
--- a/infra/cifuzz/cifuzz.py
+++ b/infra/cifuzz/cifuzz.py
@@ -531,6 +531,7 @@ def is_project_sanitizer(sanitizer, oss_fuzz_project_name):
     logging.info('No sanitizers defined in project.yaml. '
                  'Only allowing address and undefined')
     return sanitizer in {'address', 'undefined'}
-  if sanitizer + '\n' in file_data:
+
+  if sanitizer in file_data:
     return True
   return False

--- a/infra/cifuzz/cifuzz.py
+++ b/infra/cifuzz/cifuzz.py
@@ -109,7 +109,6 @@ def build_fuzzers(project_name,
 
   # Check that sanitizer is valid.
   if not is_project_sanitizer(sanitizer, project_name):
-    logging.info("%s is not a project sanitizer.", sanitizer)
     raise ValueError("{0} is not a valid sanitizer for project {1}".format(
         sanitizer, project_name))
 
@@ -203,7 +202,6 @@ def run_fuzzers(fuzz_seconds, workspace, project_name, sanitizer='address'):
 
   # Check that sanitizer is valid.
   if not is_project_sanitizer(sanitizer, project_name):
-    logging.info("%s is not a project sanitizer.", sanitizer)
     raise ValueError("{0} is not a valid sanitizer for project {1}".format(
         sanitizer, project_name))
   logging.info("Using %s as sanitizer.", sanitizer)
@@ -526,14 +524,12 @@ def is_project_sanitizer(sanitizer, oss_fuzz_project_name):
     file_data = file_handle.read()
 
   # TODO(metzman): Replace this with proper handling of project.yaml files.
-  if 'sanitizers:\n' not in file_data:
+  if 'sanitizers:' not in file_data:
     logging.info('No sanitizers defined in project.yaml. '
                  'Only allowing address and undefined')
 
     # List is from:
     # https://google.github.io/oss-fuzz/getting-started/new-project-guide/#sanitizers
-    return sanitizer in {'address', 'undefined'}
+    return sanitizer in ('address', 'undefined')
 
-  if sanitizer in file_data:
-    return True
-  return False
+  return sanitizer in file_data

--- a/infra/cifuzz/cifuzz.py
+++ b/infra/cifuzz/cifuzz.py
@@ -524,6 +524,13 @@ def is_project_sanitizer(sanitizer, oss_fuzz_project_name):
 
   # Simple parse to prevent adding pyYAML dependency.
   with open(project_yaml, 'r') as file_handle:
-    if sanitizer + '\n' in file_handle.read():
-      return True
+    file_data = file_handle.read()
+
+  # TODO(metzman): Replace this with proper handling of project.yaml files.
+  if 'sanitizers:\n' not in file_data:
+    logging.info('No sanitizers defined in project.yaml, assuming %s is valid.',
+                 sanitizer)
+    return True
+  if sanitizer + '\n' in file_data:
+    return True
   return False

--- a/infra/cifuzz/cifuzz.py
+++ b/infra/cifuzz/cifuzz.py
@@ -528,9 +528,9 @@ def is_project_sanitizer(sanitizer, oss_fuzz_project_name):
 
   # TODO(metzman): Replace this with proper handling of project.yaml files.
   if 'sanitizers:\n' not in file_data:
-    logging.info('No sanitizers defined in project.yaml, assuming %s is valid.',
+    logging.info('No sanitizers defined in project.yaml.',
                  sanitizer)
-    return True
+    return sanitizer in {'address', 'undefined'}
   if sanitizer + '\n' in file_data:
     return True
   return False

--- a/infra/cifuzz/cifuzz.py
+++ b/infra/cifuzz/cifuzz.py
@@ -528,8 +528,8 @@ def is_project_sanitizer(sanitizer, oss_fuzz_project_name):
 
   # TODO(metzman): Replace this with proper handling of project.yaml files.
   if 'sanitizers:\n' not in file_data:
-    logging.info('No sanitizers defined in project.yaml.',
-                 sanitizer)
+    logging.info('No sanitizers defined in project.yaml. '
+                 'Only allowing address and undefined')
     return sanitizer in {'address', 'undefined'}
   if sanitizer + '\n' in file_data:
     return True

--- a/infra/cifuzz/cifuzz.py
+++ b/infra/cifuzz/cifuzz.py
@@ -109,10 +109,9 @@ def build_fuzzers(project_name,
 
   # Check that sanitizer is valid.
   if not is_project_sanitizer(sanitizer, project_name):
-    logging.info("%s is not a project sanitizer, defaulting to address.",
-                 sanitizer)
-    sanitizer = 'address'
-  logging.info("Using %s as sanitizer.", sanitizer)
+    logging.info("%s is not a project sanitizer.", sanitizer)
+    raise ValueError("{0} is not a valid sanitizer for project {1}".format(
+        sanitizer, project_name))
 
   git_workspace = os.path.join(workspace, 'storage')
   os.makedirs(git_workspace, exist_ok=True)
@@ -530,6 +529,9 @@ def is_project_sanitizer(sanitizer, oss_fuzz_project_name):
   if 'sanitizers:\n' not in file_data:
     logging.info('No sanitizers defined in project.yaml. '
                  'Only allowing address and undefined')
+
+    # List is from:
+    # https://google.github.io/oss-fuzz/getting-started/new-project-guide/#sanitizers
     return sanitizer in {'address', 'undefined'}
 
   if sanitizer in file_data:

--- a/infra/cifuzz/cifuzz_test.py
+++ b/infra/cifuzz/cifuzz_test.py
@@ -530,8 +530,8 @@ class IsProjectSanitizerUnitTest(fake_filesystem_unittest.TestCase):
     """Test if sanitizers can be detected from project.yaml"""
     self.fs.add_real_directory(OSS_FUZZ_DIR)
     self.assertFalse(cifuzz.is_project_sanitizer('memory', 'example'))
-    self.assertFalse(cifuzz.is_project_sanitizer('address', 'example'))
-    self.assertFalse(cifuzz.is_project_sanitizer('undefined', 'example'))
+    self.assertTrue(cifuzz.is_project_sanitizer('address', 'example'))
+    self.assertTrue(cifuzz.is_project_sanitizer('undefined', 'example'))
     self.assertFalse(cifuzz.is_project_sanitizer('not-a-san', 'example'))
 
   def test_invalid_project(self):

--- a/infra/cifuzz/cifuzz_test.py
+++ b/infra/cifuzz/cifuzz_test.py
@@ -108,13 +108,13 @@ class BuildFuzzersIntegrationTest(unittest.TestCase):
 
   def test_invalid_project_name(self):
     """Test building fuzzers with invalid project name."""
-    with tempfile.TemporaryDirectory() as tmp_dir:
-      self.assertFalse(
-          cifuzz.build_fuzzers(
-              'not_a_valid_project',
-              'oss-fuzz',
-              tmp_dir,
-              commit_sha='0b95fe1039ed7c38fea1f97078316bfc1030c523'))
+    with tempfile.TemporaryDirectory() as tmp_dir, self.assertRaises(
+        ValueError):
+      cifuzz.build_fuzzers(
+          'not_a_valid_project',
+          'oss-fuzz',
+          tmp_dir,
+          commit_sha='0b95fe1039ed7c38fea1f97078316bfc1030c523')
 
   def test_invalid_repo_name(self):
     """Test building fuzzers with invalid repo name."""

--- a/infra/cifuzz/cifuzz_test.py
+++ b/infra/cifuzz/cifuzz_test.py
@@ -546,7 +546,10 @@ class IsProjectSanitizerUnitTest(fake_filesystem_unittest.TestCase):
                                 'project.yaml')
     contents = 'homepage: "https://my-api.example.com'
     self.fs.create_file(project_yaml, contents=contents)
-    self.assertTrue(cifuzz.is_project_sanitizer('memory', fake_project))
+    self.assertTrue(cifuzz.is_project_sanitizer('address', fake_project))
+    self.assertTrue(cifuzz.is_project_sanitizer('undefined', fake_project))
+    self.assertFalse(cifuzz.is_project_sanitizer('memory', fake_project))
+    self.assertFalse(cifuzz.is_project_sanitizer('fake', fake_project))
 
 
 @unittest.skip('Test is too long to be run with presubmit.')

--- a/infra/cifuzz/cifuzz_test.py
+++ b/infra/cifuzz/cifuzz_test.py
@@ -514,6 +514,9 @@ class IsProjectSanitizerUnitTest(fake_filesystem_unittest.TestCase):
 
   def setUp(self):
     self.setUpPyfakefs()
+    self.fake_project = 'fake_project'
+    self.project_yaml = os.path.join(OSS_FUZZ_DIR, 'projects',
+                                     self.fake_project, 'project.yaml')
 
   def test_valid_project_curl(self):
     """Test if sanitizers can be detected from project.yaml"""
@@ -541,15 +544,25 @@ class IsProjectSanitizerUnitTest(fake_filesystem_unittest.TestCase):
   def test_no_specified_sanitizers(self):
     """Tests is_project_sanitizer returns True for any fuzzer if non are
     specified."""
-    fake_project = 'fake_project'
-    project_yaml = os.path.join(OSS_FUZZ_DIR, 'projects', fake_project,
-                                'project.yaml')
     contents = 'homepage: "https://my-api.example.com'
-    self.fs.create_file(project_yaml, contents=contents)
-    self.assertTrue(cifuzz.is_project_sanitizer('address', fake_project))
-    self.assertTrue(cifuzz.is_project_sanitizer('undefined', fake_project))
-    self.assertFalse(cifuzz.is_project_sanitizer('memory', fake_project))
-    self.assertFalse(cifuzz.is_project_sanitizer('fake', fake_project))
+    self.fs.create_file(self.project_yaml, contents=contents)
+    self.assertTrue(cifuzz.is_project_sanitizer('address', self.fake_project))
+    self.assertTrue(cifuzz.is_project_sanitizer('undefined', self.fake_project))
+    self.assertFalse(cifuzz.is_project_sanitizer('memory', self.fake_project))
+    self.assertFalse(cifuzz.is_project_sanitizer('fake', self.fake_project))
+
+  def test_experimental_sanitizer(self):
+    """Tests that experimental sanitizers are handled properly."""
+    contents = ('homepage: "https://my-api.example.com\n'
+                'sanitizers:\n'
+                'memory:\n'
+                'experimental: True\n'
+                '- address')
+    self.fs.create_file(self.project_yaml, contents=contents)
+    self.assertTrue(cifuzz.is_project_sanitizer('address', self.fake_project))
+    self.assertFalse(cifuzz.is_project_sanitizer('undefined',
+                                                 self.fake_project))
+    self.assertTrue(cifuzz.is_project_sanitizer('memory', self.fake_project))
 
 
 @unittest.skip('Test is too long to be run with presubmit.')


### PR DESCRIPTION
Our sanitizer validation is hacky and isn't using pyyaml to actually
parse the project.yaml file. Temporarily work around #3996 by not
validating sanitizers if no sanitizers are specified in project.yaml.