### PR TITLE
Enable more fuzzing for TensorFlow

### DIFF
--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -27,17 +27,13 @@ yes "" | ${PYTHON} configure.py
 # Note: Make sure that by this line `$CFLAGS` and `$CXXFLAGS` are properly set
 # up as further changes to them won't be visible to Bazel.
 #
-# Note: We remove the `-stdlib=libc++` flag as Bazel produces linker errors if
-# it is present.
 declare -r EXTRA_FLAGS="\
 $(
 for f in ${CFLAGS}; do
   echo "--conlyopt=${f}" "--linkopt=${f}"
 done
 for f in ${CXXFLAGS}; do
-  if [[ "$f" != "-stdlib=libc++" ]]; then
     echo "--cxxopt=${f}" "--linkopt=${f}"
-  fi
 done
 )"
 
@@ -46,12 +42,14 @@ done
 declare -r FUZZERS=$(bazel query 'tests(//tensorflow/security/fuzzing/...)' | grep -v identity)
 
 # Build the fuzzer targets.
+# Pass in `--config=libc++` to link against libc++.
 # Pass in `--verbose_failures` so it is easy to debug compile crashes.
 # Pass in `--strip=never` to ensure coverage support.
 # Pass in `$LIB_FUZZING_ENGINE` to `--copt` and `--linkopt` to ensure we have a
 # `main` symbol defined (all these fuzzers build without a `main` and by default
 # `$CFLAGS` and `CXXFLAGS` compile with `-fsanitize=fuzzer-no-link`).
 bazel build \
+  --config=libc++ \
   ${EXTRA_FLAGS} \
   --verbose_failures \
   --strip=never \

--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -78,7 +78,7 @@ done
 # paths. We also need to resolve all symlinks that Bazel creates.
 if [ "$SANITIZER" = "coverage" ]
 then
-  declare -r RSYNC_CMD="rsync -avLkR"
+  declare -r RSYNC_CMD="rsync -aLkR"
   declare -r REMAP_PATH=${OUT}/proc/self/cwd/
   mkdir -p ${REMAP_PATH}
 

--- a/projects/tensorflow/project.yaml
+++ b/projects/tensorflow/project.yaml
@@ -7,3 +7,5 @@ fuzzing_engines:
   - libfuzzer
 sanitizers:
   - address
+  - undefined
+  - memory

--- a/projects/tensorflow/project.yaml
+++ b/projects/tensorflow/project.yaml
@@ -3,8 +3,6 @@ language: c++
 primary_contact: "mihaimaruseac@google.com"
 auto_ccs:
  - "frankchn@google.com"
-fuzzing_engines:
-  - libfuzzer
 sanitizers:
   - address
   - undefined


### PR DESCRIPTION
This should enable fuzzing with `ubsan` and `msan` as well as supporting all fuzzing engines.

This is possible after https://github.com/tensorflow/tensorflow/commit/950cffcd8deb881dcbfdf92f22c37eaa36f61e04 since now TensorFlow's `.bazelrc` has a config option to link against `libc++`.

While doing this PR, I'm also cleaning up the log by removing verbosity from the `rsync` command used to copy the files needed for coverage build.