### PR TITLE
[zetasql] Initial onboarding of ZetaSQL

### DIFF
--- a/projects/zetasql/Dockerfile
+++ b/projects/zetasql/Dockerfile
@@ -1,0 +1,32 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER zdwho@google.com
+RUN apt-get update && apt-get install -y \
+        make autoconf automake libtool apt-transport-https \
+        libunwind-dev tzdata chrpath \
+        curl gnupg openjdk-8-jdk
+
+RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add - && \
+    echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
+
+RUN apt-get update && apt-get -y install bazel-1.0.0
+
+# RUN git clone --depth 1 <git_url> zetasql     # or use other version control
+# COPY zetasql-fuzzing zetasql
+COPY build.sh $SRC/
+WORKDIR zetasql

--- a/projects/zetasql/Dockerfile
+++ b/projects/zetasql/Dockerfile
@@ -16,9 +16,9 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER zdwho@google.com
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y \
         make autoconf automake libtool apt-transport-https \
-        libunwind-dev tzdata chrpath \
+        libunwind-dev tzdata rsync \
         curl gnupg openjdk-8-jdk
 
 RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add - && \

--- a/projects/zetasql/Dockerfile
+++ b/projects/zetasql/Dockerfile
@@ -26,7 +26,7 @@ RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add - && \
 
 RUN apt-get update && apt-get -y install bazel-1.0.0
 
-# RUN git clone --depth 1 <git_url> zetasql     # or use other version control
-# COPY zetasql-fuzzing zetasql
+RUN git clone -b simple_fuzzer --depth 1 \
+    https://github.com/googleinterns/zetasql-fuzzing.git zetasql
 COPY build.sh $SRC/
 WORKDIR zetasql

--- a/projects/zetasql/Dockerfile
+++ b/projects/zetasql/Dockerfile
@@ -26,7 +26,6 @@ RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add - && \
 
 RUN apt-get update && apt-get -y install bazel-1.0.0
 
-RUN git clone -b simple_fuzzer --depth 1 \
-    https://github.com/googleinterns/zetasql-fuzzing.git zetasql
+RUN git clone --depth 1 https://github.com/googleinterns/zetasql-fuzzing.git zetasql
 COPY build.sh $SRC/
 WORKDIR zetasql

--- a/projects/zetasql/build.sh
+++ b/projects/zetasql/build.sh
@@ -1,0 +1,83 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# This build.sh is partly modeled after that of envoyproxy:
+# https://github.com/google/oss-fuzz/blob/master/projects/envoy/build.sh
+
+export CFLAGS="$CFLAGS"
+export CXXFLAGS="$CXXFLAGS"
+
+# Copy $CFLAGS and $CXXFLAGS into Bazel command-line flags, for both
+# compilation and linking.
+#
+# Some flags, such as `-stdlib=libc++`, generate warnings if used on a C source
+# file. Since the build runs with `-Werror` this will cause it to break, so we
+# use `--conlyopt` and `--cxxopt` instead of `--copt`.
+declare -r EXTRA_BAZEL_FLAGS="$(
+for f in ${CFLAGS}; do
+  echo "--conlyopt=${f}" "--linkopt=${f}"
+done
+for f in ${CXXFLAGS}; do
+  echo "--cxxopt=${f}" "--linkopt=${f}"
+done
+
+if [ "$SANITIZER" = "undefined" ]
+then
+  # Bazel uses clang to link binary, which does not link clang_rt ubsan library for C++ automatically.
+  # See issue: https://github.com/bazelbuild/bazel/issues/8777
+  echo "--linkopt=\"$(find $(llvm-config --libdir) -name libclang_rt.ubsan_standalone_cxx-x86_64.a | head -1)\""
+fi
+)"
+
+# Temporary hack, see https://github.com/google/oss-fuzz/issues/383
+readonly NO_VPTR='--copt=-fno-sanitize=vptr --linkopt=-fno-sanitize=vptr'
+
+declare FUZZER_PATH="zetasql/fuzzing/simple_evaluator_fuzzer"
+declare FUZZ_TARGET="//zetasql/fuzzing:simple_evaluator_fuzzer"
+
+# Build fuzz target
+# see https://google.github.io/oss-fuzz/further-reading/fuzzer-environment/
+bazel-1.0.0 build -s --verbose_failures --compilation_mode=dbg \
+  --dynamic_mode=off \
+  --spawn_strategy=standalone \
+  --genrule_strategy=standalone \
+  --conlyopt=-Wno-error=c99-extensions \
+  --copt -D__OSS_FUZZ__ \
+  --copt -fno-sanitize-blacklist \
+  --linkopt=--rtlib=compiler-rt \
+  --linkopt=--unwindlib=libunwind \
+  --linkopt=-lc++ \
+  --linkopt="-rpath '\$ORIGIN\/lib'" \
+  --define LIB_FUZZING_ENGINE=${LIB_FUZZING_ENGINE} \
+  ${EXTRA_BAZEL_FLAGS} ${NO_VPTR} \
+  ${FUZZ_TARGET}
+
+# Move out dynamically linked libraries
+mkdir -p $OUT/lib
+cp /usr/lib/x86_64-linux-gnu/libunwind.so.8 $OUT/lib/
+
+# Move out tzdata
+# See also https://github.com/googleinterns/zetasql-fuzzing/pull/3
+mkdir -p $OUT/data
+cp -r /usr/share/zoneinfo $OUT/data/
+
+# Move out fuzz target
+cp bazel-bin/"${FUZZER_PATH}" "${OUT}"/
+
+# Cleanup bazel- symlinks to avoid oss-fuzz trying to copy out of the build
+# cache.
+rm -f bazel-*

--- a/projects/zetasql/build.sh
+++ b/projects/zetasql/build.sh
@@ -103,9 +103,10 @@ mkdir -p $OUT/lib
 cp /usr/lib/x86_64-linux-gnu/libunwind.so.8 $OUT/lib/
 
 # Move out tzdata
-# See also https://github.com/googleinterns/zetasql-fuzzing/pull/3
 mkdir -p $OUT/data
 cp -r /usr/share/zoneinfo $OUT/data/
+# Set localtime to UTC
+ln -sf Etc/UTC $OUT/data/zoneinfo/localtime
 
 # Move out fuzz target
 cp bazel-bin/"${FUZZER_PATH}" "${OUT}"/

--- a/projects/zetasql/project.yaml
+++ b/projects/zetasql/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/google/zetasql"
+language: c++
+primary_contact: "evmaus@google.com"
+auto_ccs:
+ - "zdwho@google.com"
+ - "shumway@google.com"

--- a/projects/zetasql/project.yaml
+++ b/projects/zetasql/project.yaml
@@ -4,3 +4,6 @@ primary_contact: "evmaus@google.com"
 auto_ccs:
  - "zdwho@google.com"
  - "shumway@google.com"
+sanitizers:
+ - address
+ - memory


### PR DESCRIPTION
This PR includes basic files required for Fuzzing integration (Dockerfile, build.sh, and project.yaml). Current pipeline only contains a primitive fuzz target that tries to evaluate raw fuzzing input as a SQL expression. See pull request of the fuzz target [here](https://github.com/googleinterns/zetasql-fuzzing/pull/3)

This PR is subject to following changes before merging:

- [x] Since the pull request of the fuzz target hasn't been merged in, cloning zetasql repo from github is not viable at the moment. To test, clone the repository and switch to `zetasql` branch manually,  copy the repo to `oss-fuzz/projects/zetasql` and uncomment `COPY` command in the Dockerfile.
- [ ] In build.sh, `--copt -fno-sanitize-blacklist` is temporarily specified globally in `bazel build` to resolve issue [10510](https://github.com/bazelbuild/bazel/issues/10510). It would be idea to specify this option locally at build target level. Suggestions are welcome on improving this temporary fix.
- [x] `bazel build` specifies `-s` for verbose logging for debugging purpose, which will be turned off before merging.