### PR TITLE
[Haproxy] Updated settings in project yaml so there are no restrictions on who can view bugs.

### DIFF
--- a/projects/haproxy/project.yaml
+++ b/projects/haproxy/project.yaml
@@ -7,3 +7,6 @@ auto_ccs:
   - "willy@1wt.eu"
 sanitizers:
   - address
+
+# Bug reports are public by default:
+view_restrictions: none


### PR DESCRIPTION
This was asked for by the maintainers here https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=23653#c5 where the reasoning for having no restrictions are also found. 