### PR TITLE
Fixing Dockerfile for fuzzers that use LPM

### DIFF
--- a/projects/giflib/Dockerfile
+++ b/projects/giflib/Dockerfile
@@ -20,7 +20,6 @@ RUN apt-get update -y && \
   apt-get install -y make autoconf automake libtool wget zlib1g-dev \
   protobuf-compiler libprotobuf-dev binutils cmake \
   ninja-build liblzma-dev libz-dev pkg-config
-
 RUN git clone --depth=1 https://git.code.sf.net/p/giflib/code $SRC/giflib-code
 RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
 RUN (mkdir LPM && cd LPM && cmake ../libprotobuf-mutator -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release && ninja)

--- a/projects/giflib/Dockerfile
+++ b/projects/giflib/Dockerfile
@@ -16,9 +16,11 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER esr@thyrsus.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool wget zlib1g-dev
-RUN apt-get update && \
-apt-get install -y  libtool ninja-build cmake
+RUN apt-get update -y && \
+  apt-get install -y make autoconf automake libtool wget zlib1g-dev \
+  protobuf-compiler libprotobuf-dev binutils cmake \
+  ninja-build liblzma-dev libz-dev pkg-config
+
 RUN git clone --depth=1 https://git.code.sf.net/p/giflib/code $SRC/giflib-code
 RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
 RUN (mkdir LPM && cd LPM && cmake ../libprotobuf-mutator -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release && ninja)

--- a/projects/giflib/Dockerfile
+++ b/projects/giflib/Dockerfile
@@ -17,9 +17,8 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER esr@thyrsus.com
 RUN apt-get update -y && \
-  apt-get install -y make autoconf automake libtool wget zlib1g-dev \
-  protobuf-compiler libprotobuf-dev binutils cmake \
-  ninja-build liblzma-dev libz-dev pkg-config
+    apt-get install -y make autoconf automake libtool wget zlib1g-dev \
+    binutils cmake ninja-build liblzma-dev libz-dev pkg-config
 RUN git clone --depth=1 https://git.code.sf.net/p/giflib/code $SRC/giflib-code
 RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
 RUN (mkdir LPM && cd LPM && cmake ../libprotobuf-mutator -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release && ninja)

--- a/projects/libpng-proto/Dockerfile
+++ b/projects/libpng-proto/Dockerfile
@@ -20,7 +20,6 @@ RUN apt-get update -y && \
   apt-get install -y make autoconf automake libtool zlib1g-dev \
   protobuf-compiler libprotobuf-dev binutils cmake \
   ninja-build liblzma-dev libz-dev pkg-config
-
 RUN git clone --depth 1 https://github.com/glennrp/libpng.git
 RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
 RUN git clone --depth 1 https://github.com/google/fuzzer-test-suite

--- a/projects/libpng-proto/Dockerfile
+++ b/projects/libpng-proto/Dockerfile
@@ -17,9 +17,8 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER kcc@google.com
 RUN apt-get update -y && \
-  apt-get install -y make autoconf automake libtool zlib1g-dev \
-  protobuf-compiler libprotobuf-dev binutils cmake \
-  ninja-build liblzma-dev libz-dev pkg-config
+    apt-get install -y make autoconf automake libtool zlib1g-dev \
+    binutils cmake ninja-build liblzma-dev libz-dev pkg-config
 RUN git clone --depth 1 https://github.com/glennrp/libpng.git
 RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
 RUN git clone --depth 1 https://github.com/google/fuzzer-test-suite

--- a/projects/libpng-proto/Dockerfile
+++ b/projects/libpng-proto/Dockerfile
@@ -16,8 +16,10 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER kcc@google.com
-RUN apt-get update && \
-    apt-get install -y make autoconf automake libtool zlib1g-dev ninja-build cmake
+RUN apt-get update -y && \
+  apt-get install -y make autoconf automake libtool zlib1g-dev \
+  protobuf-compiler libprotobuf-dev binutils cmake \
+  ninja-build liblzma-dev libz-dev pkg-config
 
 RUN git clone --depth 1 https://github.com/glennrp/libpng.git
 RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git

--- a/projects/xerces-c/Dockerfile
+++ b/projects/xerces-c/Dockerfile
@@ -14,7 +14,10 @@
 ################################################################################
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER vincent.ulitzsch@live.de
-RUN apt-get update && apt-get install -y make autoconf automake libtool wget zlib1g-dev libtool ninja-build cmake subversion
+RUN apt-get update -y && \
+  apt-get install -y make autoconf automake libtool wget zlib1g-dev \
+  protobuf-compiler libprotobuf-dev binutils cmake subversion \
+  ninja-build liblzma-dev libz-dev pkg-config
 RUN svn co https://svn.apache.org/repos/asf/xerces/c/trunk $SRC/xerces-c
 RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
 RUN (mkdir LPM && cd LPM && cmake ../libprotobuf-mutator -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release && ninja)

--- a/projects/xerces-c/Dockerfile
+++ b/projects/xerces-c/Dockerfile
@@ -15,9 +15,8 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER vincent.ulitzsch@live.de
 RUN apt-get update -y && \
-  apt-get install -y make autoconf automake libtool wget zlib1g-dev \
-  protobuf-compiler libprotobuf-dev binutils cmake subversion \
-  ninja-build liblzma-dev libz-dev pkg-config
+    apt-get install -y make autoconf automake libtool wget zlib1g-dev \
+    binutils cmake subversion ninja-build liblzma-dev libz-dev pkg-config
 RUN svn co https://svn.apache.org/repos/asf/xerces/c/trunk $SRC/xerces-c
 RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
 RUN (mkdir LPM && cd LPM && cmake ../libprotobuf-mutator -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release && ninja)


### PR DESCRIPTION
### Issue
Building the Docker image failed for the projects that use LPM. This is because the Dockerfile for those projects (libpng-proto, xerces-c, and giflib) do not grab the correct prereqs to compile LPM (such as liblzma-dev), so compiling LPM was failing.
### Fix
I used the [LPM guide](https://github.com/google/libprotobuf-mutator) to find and add the appropriate prereqs. Building and fuzzing for those projects are now working again.

PTAL @sleevi @Dor1s 