### PR TITLE
Revert "Don't create empty corpus archive as it wont unpack."

### DIFF
--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -63,7 +63,6 @@ function run_fuzz_target {
   local profraw_file_mask="$DUMPS_DIR/$target.*.profraw"
   local profdata_file="$DUMPS_DIR/$target.profdata"
   local corpus_real="/corpus/${target}"
-  mkdir -p $corpus_real
 
   # -merge=1 requires an output directory, create a dummy dir for that.
   local corpus_dummy="$OUT/dummy_corpus_dir_for_${target}"

--- a/infra/base-images/base-runner/download_corpus
+++ b/infra/base-images/base-runner/download_corpus
@@ -22,7 +22,7 @@ fi
 
 for pair in "$@"; do
   read path url <<< "$pair"
-  wget -q -O $path $url || rm $path
+  wget -q -O $path $url
 done
 
 # Always exit with 0 as we do not track wget return codes and should not rely


### PR DESCRIPTION
Reverts google/oss-fuzz#3903

This masks other failures e.g. if a fuzz target is so broken that it doesn't have a corpus backup available.

See more reasoning in https://github.com/google/oss-fuzz/issues/4039#issuecomment-651418789

The proposed solution to the original issue (#3902) is https://github.com/google/oss-fuzz/issues/4046

