### PR TITLE
Temporarily disable fuzzing for project Oak

### DIFF
--- a/projects/oak/build.sh
+++ b/projects/oak/build.sh
@@ -42,9 +42,7 @@ fi
 # Temporary hack, see https://github.com/google/oss-fuzz/issues/383
 readonly NO_VPTR='--copt=-fno-sanitize=vptr --linkopt=-fno-sanitize=vptr'
 
-readonly FUZZER_TARGETS=(
-  'oak/server:wasm_node_fuzz'
-)
+readonly FUZZER_TARGETS=()
 
 bazel build \
   --client_env=CC=${CC} \

--- a/projects/oak/project.yaml
+++ b/projects/oak/project.yaml
@@ -1,3 +1,4 @@
+disabled: True
 homepage: "https://github.com/project-oak/oak"
 language: c++
 primary_contact: "tzn@google.com"


### PR DESCRIPTION
Temporarily disable fuzzing for [project Oak](https://github.com/project-oak/oak). 

We are currently making changes to the codebase, and migrating from C++ to Rust. Until we have fuzzing for Rust the fuzzing should be disabled. 

Ref https://github.com/project-oak/oak/issues/539.