### PR TITLE
[envoy] lower CPU more

### DIFF
--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -73,7 +73,8 @@ done
 # Build driverless libraries.
 bazel build --verbose_failures --dynamic_mode=off --spawn_strategy=standalone \
   --discard_analysis_cache --notrack_incremental_state --nokeep_state_after_build \
-  --local_cpu_resources=HOST_CPUS*0.75 \
+  # Use 8, since we know this to work with n1-standard-8 with 30 GB RAM.
+  --local_cpu_resources=8 \
   --genrule_strategy=standalone --strip=never \
   --copt=-fno-sanitize=vptr --linkopt=-fno-sanitize=vptr \
   --define tcmalloc=disabled --define signal_trace=disabled \

--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -73,8 +73,8 @@ done
 # Build driverless libraries.
 bazel build --verbose_failures --dynamic_mode=off --spawn_strategy=standalone \
   --discard_analysis_cache --notrack_incremental_state --nokeep_state_after_build \
-  # Use 8, since we know this to work with n1-standard-8 with 30 GB RAM.
-  --local_cpu_resources=8 \
+  # Benchmark about 1.5-2 GB per CPU
+  --local_cpu_resources=16 \
   --genrule_strategy=standalone --strip=never \
   --copt=-fno-sanitize=vptr --linkopt=-fno-sanitize=vptr \
   --define tcmalloc=disabled --define signal_trace=disabled \

--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -71,9 +71,9 @@ do
 done
 
 # Build driverless libraries.
+# Benchmark about 1.5-2 GB per CPU
 bazel build --verbose_failures --dynamic_mode=off --spawn_strategy=standalone \
   --discard_analysis_cache --notrack_incremental_state --nokeep_state_after_build \
-  # Benchmark about 1.5-2 GB per CPU
   --local_cpu_resources=16 \
   --genrule_strategy=standalone --strip=never \
   --copt=-fno-sanitize=vptr --linkopt=-fno-sanitize=vptr \

--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -74,7 +74,7 @@ done
 # Benchmark about 1.5-2 GB per CPU
 bazel build --verbose_failures --dynamic_mode=off --spawn_strategy=standalone \
   --discard_analysis_cache --notrack_incremental_state --nokeep_state_after_build \
-  --local_cpu_resources=16 \
+  --local_cpu_resources=HOST_CPUS*0.5 \
   --genrule_strategy=standalone --strip=never \
   --copt=-fno-sanitize=vptr --linkopt=-fno-sanitize=vptr \
   --define tcmalloc=disabled --define signal_trace=disabled \


### PR DESCRIPTION
n1-highcpu-32 has 28.8 GB RAM. Choosing 16  per a thread on envoy slack:

> mklein  5:04 PM
I think it takes around 2GB per CPU to not OOM is my guess in the worst case
yeah I think you would have to limit jobs to around 2GB per CPU
for now
is my guess
maybe 1.5

There's also a Bazel option to estimate memory here: https://docs.bazel.build/versions/master/command-line-reference.html#flag--experimental_local_memory_estimate that I could use an alternative, but I'm not sure if that works well.