### PR TITLE
[ESPv2] Attempt to fix coverage build

### DIFF
--- a/projects/esp-v2/build.sh
+++ b/projects/esp-v2/build.sh
@@ -94,7 +94,9 @@ then
     "*.hpp" "--include" "*.cpp" "--include" "*.c" "--include" "*/" "--exclude" "*")
   rsync -avLk "${RSYNC_FILTER_ARGS[@]}" "${SRC}"/esp-v2/bazel-out "${REMAP_PATH}"
   rsync -avLkR "${RSYNC_FILTER_ARGS[@]}" "${HOME}" "${OUT}"
-  rsync -avLkR "${RSYNC_FILTER_ARGS[@]}" /tmp "${OUT}"
+  # Some low-level libraries are built located /tmp.
+  # But ESPv2 engineeers don't really look at them.
+  # rsync -avLkR "${RSYNC_FILTER_ARGS[@]}" /tmp "${OUT}"
 fi
 
 # Copy out test driverless binaries from bazel-bin/.


### PR DESCRIPTION
Currently, coverage builds fail on step 3 with:
```
Step #3: + rsync -avLkR --include '*.h' --include '*.cc' --include '*.hpp' --include '*.cpp' --include '*.c' --include '*/' --exclude '*' /tmp /workspace/out/coverage
Step #3: sending incremental file list
Step #3: symlink has no referent: "/tmp/tmp.BOH6TAB62E/ares/include/ares_build.h"
Step #3: symlink has no referent: "/tmp/tmp.BOH6TAB62E/ares/include/ares_dns.h"
Step #3: symlink has no referent: "/tmp/tmp.BOH6TAB62E/ares/include/ares.h"
Step #3: symlink has no referent: "/tmp/tmp.BOH6TAB62E/ares/include/ares_rules.h"
Step #3: symlink has no referent: "/tmp/tmp.BOH6TAB62E/ares/include/ares_version.h"
Step #3: symlink has no referent: "/tmp/tmp.BOH6TAB62E/include/sha1.c"
Step #3: symlink has no referent: "/tmp/tmp.BOH6TAB62E/include/gcm_nohw.c"
Step #3: symlink has no referent: "/tmp/tmp.BOH6TAB62E/include/digests.c"
...
```

Just exclude these files. Doubt they matter to us.

Ref: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=23621&q=esp-v2&can=2
Signed-off-by: Teju Nareddy <nareddyt@google.com>