### PR TITLE
[libspng] extract zlib to separate directory

### DIFF
--- a/projects/libspng/Dockerfile
+++ b/projects/libspng/Dockerfile
@@ -25,8 +25,8 @@ RUN git clone --depth 1 https://github.com/randy408/libspng.git
 RUN git clone --depth 1 https://github.com/google/fuzzer-test-suite
 
 RUN wget -O $WORK/zlib.tar.gz http://www.zlib.net/zlib-1.2.11.tar.gz
-RUN tar xzvf $WORK/zlib.tar.gz --directory $SRC/libspng/
-RUN mv $SRC/libspng/zlib-1.2.11 $SRC/libspng/zlib
+RUN tar xzvf $WORK/zlib.tar.gz --directory $SRC/
+RUN mv $SRC/zlib-1.2.11 $SRC/zlib
 
 WORKDIR libspng
 COPY build.sh $SRC/


### PR DESCRIPTION
CIFuzz is overwriting $SRC/libspng after executing the Dockerfile before running build.sh which means $SRC/libspng/zlib is lost:
https://github.com/randy408/libspng/runs/830380355#step:4:549