### PR TITLE
wasmtime: Create an empty corpus for newly-defined fuzz targets

### DIFF
--- a/projects/wasmtime/build.sh
+++ b/projects/wasmtime/build.sh
@@ -27,6 +27,12 @@ for f in $SRC/wasmtime/fuzz/fuzz_targets/*.rs
 do
     FUZZ_TARGET_NAME=$(basename ${f%.*})
     cp $FUZZ_TARGET_OUTPUT_DIR/$FUZZ_TARGET_NAME $OUT/
-    zip -jr $OUT/${FUZZ_TARGET_NAME}_seed_corpus.zip $PROJECT_DIR/wasmtime-libfuzzer-corpus/$FUZZ_TARGET_NAME/
+
+    if [[ -d $PROJECT_DIR/wasmtime-libfuzzer-corpus/$FUZZ_TARGET_NAME/ ]]; then
+        zip -jr \
+            $OUT/${FUZZ_TARGET_NAME}_seed_corpus.zip \
+            $PROJECT_DIR/wasmtime-libfuzzer-corpus/$FUZZ_TARGET_NAME/
+    fi
+
     cp $SRC/default.options $OUT/$FUZZ_TARGET_NAME.options
 done


### PR DESCRIPTION
This will prevent build failures like
https://oss-fuzz-build-logs.storage.googleapis.com/log-5a0b58fe-4a35-46d5-b4d2-221905e7d208.txt
in the future.