### PR TITLE
[qt] Don't clone AFL

### DIFF
--- a/projects/qt/Dockerfile
+++ b/projects/qt/Dockerfile
@@ -24,4 +24,3 @@ RUN git submodule update --init --depth 1 qtsvg
 WORKDIR $SRC
 RUN git clone --depth 1 git://code.qt.io/qt/qtqa.git
 RUN cp qtqa/fuzzing/oss-fuzz/build.sh $SRC/
-RUN git clone --depth 1 https://github.com/google/AFL.git


### PR DESCRIPTION
Now that stable caught up with master, we
can use the clone from base-builder image.