### PR TITLE
[envoy] fixup coverage build

### DIFF
--- a/projects/envoy/Dockerfile
+++ b/projects/envoy/Dockerfile
@@ -28,7 +28,8 @@ RUN apt-get update && apt-get -y install  \
     libtool         \
     wget            \
     golang          \
-    python
+    python	    \
+    rsync
 
 # Install Bazelisk
 RUN wget -O /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v0.0.8/bazelisk-linux-amd64

--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -71,10 +71,10 @@ do
 done
 
 # Build driverless libraries.
-# Benchmark about 1.5-2 GB per CPU
+# Benchmark about 2 GB per CPU (14 threads for 28.8 GB RAM)
 bazel build --verbose_failures --dynamic_mode=off --spawn_strategy=standalone \
   --discard_analysis_cache --notrack_incremental_state --nokeep_state_after_build \
-  --local_cpu_resources=HOST_CPUS*0.5 \
+  --local_cpu_resources=HOST_CPUS*0.45 \
   --genrule_strategy=standalone --strip=never \
   --copt=-fno-sanitize=vptr --linkopt=-fno-sanitize=vptr \
   --define tcmalloc=disabled --define signal_trace=disabled \


### PR DESCRIPTION
Another iteration. 
Normal builds look good!
Coverage builds still OOM, so increasing per thread memory to 2 GB.

Testing that out revealed missing rsync, local coverage build now work for me all the way through.

Signed-off-by: Asra Ali <asraa@google.com>