### PR TITLE
excludes builds artifacts from ndpi project

### DIFF
--- a/projects/ndpi/build.sh
+++ b/projects/ndpi/build.sh
@@ -28,4 +28,4 @@ cd ndpi
 sh autogen.sh
 ./configure --enable-fuzztargets
 make
-ls fuzz/fuzz* | grep -v "\." | while read i; do cp $i $OUT/; done
+ls fuzz/fuzz* | grep -v "\." | grep -v "with_main" | while read i; do cp $i $OUT/; done


### PR DESCRIPTION
cc @lucaderi @lnslbrty

Should fix oss-fuzz ndpi build failure
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=23752

Problem arises because there is now a binary `fuzz_ndpi_reader_with_main` which does not use the libFuzzer driver...