### PR TITLE
Don't traverse symlinks in patch_build.py

### DIFF
--- a/infra/base-images/base-msan-builder/patch_build.py
+++ b/infra/base-images/base-msan-builder/patch_build.py
@@ -120,6 +120,10 @@ def PatchBuild(output_directory):
   for root_dir, _, filenames in os.walk(output_directory):
     for filename in filenames:
       file_path = os.path.join(root_dir, filename)
+
+      if os.path.islink(file_path):
+        continue
+
       if not IsElf(file_path):
         continue
 


### PR DESCRIPTION
open() should not be called on symlinks.

Should fix https://github.com/google/oss-fuzz/issues/4003