### PR TITLE
Add wasm-tools repository to wasmtime project

### DIFF
--- a/projects/wasmtime/Dockerfile
+++ b/projects/wasmtime/Dockerfile
@@ -17,6 +17,8 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang
 
+RUN git clone --depth 1 https://github.com/bytecodealliance/wasm-tools wasm-tools
+
 RUN git clone --depth 1 https://github.com/bytecodealliance/wasmtime wasmtime
 WORKDIR wasmtime
 RUN git submodule update --init --recursive

--- a/projects/wasmtime/build.sh
+++ b/projects/wasmtime/build.sh
@@ -16,24 +16,36 @@
 ################################################################################
 
 # Note: This project creates Rust fuzz targets exclusively
-PROJECT_DIR=$SRC/wasmtime
+
+build() {
+  project=$1
+  shift
+  fuzzer_prefix=$1
+  shift
+  PROJECT_DIR=$SRC/$project
+
+  cd $PROJECT_DIR/fuzz && cargo fuzz build -O --debug-assertions "$@"
+
+  FUZZ_TARGET_OUTPUT_DIR=$PROJECT_DIR/target/x86_64-unknown-linux-gnu/release
+
+  for f in $PROJECT_DIR/fuzz/fuzz_targets/*.rs
+  do
+      src_name=$(basename ${f%.*})
+      dst_name=$fuzzer_prefix$src_name
+      cp $FUZZ_TARGET_OUTPUT_DIR/$src_name $OUT/$dst_name
+
+      if [[ -d $PROJECT_DIR/$project-libfuzzer-corpus/$src_name/ ]]; then
+          zip -jr \
+              $OUT/${dst_name}_seed_corpus.zip \
+              $PROJECT_DIR/$project-libfuzzer-corpus/$src_name/
+      fi
+
+      cp $SRC/default.options $OUT/$dst_name.options
+  done
+}
 
 # Build with all features to enable the binaryen-using fuzz targets, and
 # the peepmatic fuzz targets.
-cd $PROJECT_DIR/fuzz && cargo fuzz build -O --debug-assertions --all-features
+build wasmtime "" --all-features
 
-FUZZ_TARGET_OUTPUT_DIR=$PROJECT_DIR/target/x86_64-unknown-linux-gnu/release
-
-for f in $SRC/wasmtime/fuzz/fuzz_targets/*.rs
-do
-    FUZZ_TARGET_NAME=$(basename ${f%.*})
-    cp $FUZZ_TARGET_OUTPUT_DIR/$FUZZ_TARGET_NAME $OUT/
-
-    if [[ -d $PROJECT_DIR/wasmtime-libfuzzer-corpus/$FUZZ_TARGET_NAME/ ]]; then
-        zip -jr \
-            $OUT/${FUZZ_TARGET_NAME}_seed_corpus.zip \
-            $PROJECT_DIR/wasmtime-libfuzzer-corpus/$FUZZ_TARGET_NAME/
-    fi
-
-    cp $SRC/default.options $OUT/$FUZZ_TARGET_NAME.options
-done
+build wasm-tools wasm-tools-

--- a/projects/wasmtime/build.sh
+++ b/projects/wasmtime/build.sh
@@ -34,10 +34,10 @@ build() {
       dst_name=$fuzzer_prefix$src_name
       cp $FUZZ_TARGET_OUTPUT_DIR/$src_name $OUT/$dst_name
 
-      if [[ -d $PROJECT_DIR/$project-libfuzzer-corpus/$src_name/ ]]; then
+      if [[ -d $SRC/wasmtime/wasmtime-libfuzzer-corpus/$dst_name/ ]]; then
           zip -jr \
               $OUT/${dst_name}_seed_corpus.zip \
-              $PROJECT_DIR/$project-libfuzzer-corpus/$src_name/
+              $SRC/wasmtime/wasmtime-libfuzzer-corpus/$dst_name/
       fi
 
       cp $SRC/default.options $OUT/$dst_name.options


### PR DESCRIPTION
This commit expands the fuzzers run under the Wasmtime project to
include those in the https://github.com/bytecodealliance/wasm-tools
repository. This includes various parsing for utilities used by Wasmtime
itself but also generally useful for other Rust projects! The
maintainers of the wasm-tools repository are also all currently all on
the notification list for Wasmtime fuzz bugs as well.