### PR TITLE
[binutils] Add new fuzzer

### DIFF
--- a/projects/binutils/Dockerfile
+++ b/projects/binutils/Dockerfile
@@ -16,11 +16,9 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 #TODO change
-RUN apt-get update && apt-get install -y make
-RUN apt-get install -y flex bison
+RUN apt-get update && apt-get install -y make flex bison
 RUN git clone --recursive --depth 1 git://sourceware.org/git/binutils-gdb.git binutils-gdb
 WORKDIR $SRC
 COPY build.sh $SRC/
-COPY fuzz_*.c $SRC/
+COPY fuzz_*.c *.options $SRC/
 COPY fuzz_readelf_seed_corpus $SRC/fuzz_readelf_seed_corpus
-COPY fuzz_readelf.options $SRC/fuzz_readelf.options

--- a/projects/binutils/build.sh
+++ b/projects/binutils/build.sh
@@ -37,7 +37,7 @@ mkdir fuzz
 cp ../fuzz_*.c fuzz/
 cd fuzz
 
-for i in fuzz_disassemble fuzz_bfd; do
+for i in fuzz_disassemble fuzz_bfd fuzz_demangle; do
     $CC $CFLAGS -I ../include -I ../bfd -I ../opcodes -c $i.c -o $i.o
     $CXX $CXXFLAGS $i.o -o $OUT/$i $LIB_FUZZING_ENGINE ../opcodes/libopcodes.a ../bfd/libbfd.a ../libiberty/libiberty.a ../zlib/libz.a
 done
@@ -59,12 +59,12 @@ done
 
 # Link the files
 ## Readelf
-$CXX $CXXFLAGS $LIB_FUZZING_ENGINE -W -Wall -I./../zlib -o fuzz_readelf fuzz_readelf.o version.o unwind-ia64.o dwarf.o elfcomm.o ../libctf/.libs/libctf-nobfd.a -L/src/binutils-gdb/zlib -lz ../libiberty/libiberty.a 
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE -W -Wall -I./../zlib -o fuzz_readelf fuzz_readelf.o version.o unwind-ia64.o dwarf.o elfcomm.o ../libctf/.libs/libctf-nobfd.a -L/src/binutils-gdb/zlib -lz ../libiberty/libiberty.a
 mv fuzz_readelf $OUT/fuzz_readelf
 
-### Set up seed corpus for readelf in the form of a single ELF file. 
+### Set up seed corpus for readelf in the form of a single ELF file.
 zip fuzz_readelf_seed_corpus.zip /src/fuzz_readelf_seed_corpus/simple_elf
-mv fuzz_readelf_seed_corpus.zip $OUT/ 
+mv fuzz_readelf_seed_corpus.zip $OUT/
 
 ## Copy over the options file
 cp $SRC/fuzz_readelf.options $OUT/fuzz_readelf.options

--- a/projects/binutils/fuzz_demangle.c
+++ b/projects/binutils/fuzz_demangle.c
@@ -1,0 +1,15 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "demangle.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  char *name = malloc(sizeof(char) * (size + 1));
+  memcpy(name, data, size);
+  name[size] = '\0';  // NUL-terminate
+  char *demangled = cplus_demangle(name, DMGL_AUTO);
+  if (demangled) free(demangled);
+  free(name);
+  return 0;
+}

--- a/projects/binutils/fuzz_demangle.c
+++ b/projects/binutils/fuzz_demangle.c
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Adding the binutils fuzzer from [security-research-pocs](https://github.com/google/security-research-pocs/blob/master/autofuzz/demangle_fuzzer.cc). Converted the fuzzer to C for the purposes of this project, as that is what the build file currently supports.