### PR TITLE
[envoy] fix coverage and c++ 17 issues

### DIFF
--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -72,6 +72,7 @@ done
 
 # Build driverless libraries.
 # Benchmark about 2 GB per CPU (14 threads for 28.8 GB RAM)
+# TODO(asraa): Remove deprecation warnings when Envoy moves to C++17
 bazel build --verbose_failures --dynamic_mode=off --spawn_strategy=standalone \
   --discard_analysis_cache --notrack_incremental_state --nokeep_state_after_build \
   --local_cpu_resources=HOST_CPUS*0.45 \
@@ -79,6 +80,7 @@ bazel build --verbose_failures --dynamic_mode=off --spawn_strategy=standalone \
   --copt=-fno-sanitize=vptr --linkopt=-fno-sanitize=vptr \
   --define tcmalloc=disabled --define signal_trace=disabled \
   --define ENVOY_CONFIG_ASAN=1 --copt -D__SANITIZE_ADDRESS__ \
+  --copt -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS \
   --define force_libcpp=enabled --build_tag_filters=-no_asan \
   --linkopt=-lc++ --linkopt=-pthread ${EXTRA_BAZEL_FLAGS} \
   ${BAZEL_BUILD_TARGETS[*]} ${BAZEL_CORPUS_TARGETS[*]}
@@ -94,6 +96,7 @@ then
   mkdir -p "${REMAP_PATH}"
   # For .cc, we only really care about source/ today.
   rsync -av "${SRC}"/envoy/source "${REMAP_PATH}"
+  rsync -av "${SRC}"/envoy/third_party "${REMAP_PATH}"
   rsync -av "${SRC}"/envoy/test "${REMAP_PATH}"
   # Remove filesystem loop manually.
   rm -rf "${SRC}"/envoy/bazel-envoy/external/envoy


### PR DESCRIPTION
Build complains about deprecated warnings for C++17 when using inlined vector from absl
```
external/com_google_absl/absl/container/inlined_vector.h:246:3: note: in instantiation of member function 'absl::inlined_vector_internal::Storage<Envoy::Buffer::RawSlice, 16, 
[...]
Step #4: #  define _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_DEPRECATED
```
Coverage also needs to map third_party/ code (which contains a copy of absl::StatusOr before release)

Tested with:
```
python infra/helper.py pull_images
python infra/helper.py build_fuzzers --sanitizer=coverage --clean envoy
```

Signed-off-by: Asra Ali <asraa@google.com>