### PR TITLE
Add rnp

### DIFF
--- a/projects/rnp/Dockerfile
+++ b/projects/rnp/Dockerfile
@@ -1,0 +1,35 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update
+RUN apt-get install -y \
+    make \
+    autoconf \
+    automake \
+    libtool \
+    cmake \
+    chrpath \
+    libbz2-dev \
+    zlib1g-dev \
+    libjson-c-dev \
+    build-essential \
+    python-minimal \
+    wget
+
+RUN git clone --depth 1 https://github.com/rnpgp/rnp.git rnp
+WORKDIR rnp/..
+COPY build.sh $SRC/

--- a/projects/rnp/build.sh
+++ b/projects/rnp/build.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+wget -qO- https://botan.randombit.net/releases/Botan-2.12.1.tar.xz | tar xvJ
+cd Botan-2.12.1
+./configure.py --prefix=/usr --cc-bin=$CXX --cc-abi-flags="$CXXFLAGS" \
+               --disable-modules=locking_allocator \
+               --unsafe-fuzzer-mode --build-fuzzers=libfuzzer \
+               --with-fuzzer-lib='FuzzingEngine'
+make
+make install
+cd ..
+
+mkdir rnp-build
+cd rnp-build
+cmake \
+    -DENABLE_SANITIZERS=1 \
+    -DENABLE_FUZZING=1 \
+    -DCMAKE_C_COMPILER=$CC \
+    -DCMAKE_CXX_COMPILER=$CXX \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DBUILD_SHARED_LIBS=on \
+    -DBUILD_TESTING=off \
+    ../rnp/
+make
+
+FUZZERS="fuzz_dump fuzz_keyring"
+for f in $FUZZERS; do
+    cp src/fuzzing/$f "${OUT}/"
+    chrpath -r '$ORIGIN/lib' "${OUT}/$f"
+done
+
+mkdir -p "${OUT}/lib"
+cp src/lib/librnp-0.so.0 "${OUT}/lib/"
+cp /usr/lib/libbotan-2.so.12 "${OUT}/lib/"
+cp /lib/x86_64-linux-gnu/libjson-c.so.2 "${OUT}/lib/"

--- a/projects/rnp/project.yaml
+++ b/projects/rnp/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://www.rnpgp.com/"
+language: c++
+primary_contact: "tse@ribose.com"
+auto_ccs:
+  - "tom@ritter.vg"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer


### PR DESCRIPTION
rnp is the OpenPGP library that will be directly integrated into Thunderbird in the coming months. (See https://wiki.mozilla.org/Thunderbird:OpenPGP#Testing ) This commit adds it as a project, with two small fuzzers. More extensive fuzzers, corpus, dictionaries to come.

cc @ronaldtse