### PR TITLE
Remove SkSVGCanvas.cpp from api_svg_canvas.

### DIFF
--- a/projects/skia/BUILD.gn.diff
+++ b/projects/skia/BUILD.gn.diff
@@ -294,7 +294,6 @@ test_app("api_svg_canvas") {
     "fuzz/FuzzCanvas.cpp",
     "fuzz/FuzzCommon.cpp",
     "fuzz/oss_fuzz/FuzzAPISVGCanvas.cpp",
-    "src/svg/SkSVGCanvas.cpp",
     "tools/Resources.cpp",
     "tools/UrlDataManager.cpp",
     "tools/debugger/DebugCanvas.cpp",


### PR DESCRIPTION
This leads to multiple definitions of everything defined in
SkSVGCanvas.cpp since it will be compiled into the api_svg_canvas target
directly as well as the Skia xml target.