### PR TITLE
[uriparser] Fix null dereference in uri_dissect_query_malloc_fuzzer

### DIFF
--- a/projects/uriparser/uri_dissect_query_malloc_fuzzer.cc
+++ b/projects/uriparser/uri_dissect_query_malloc_fuzzer.cc
@@ -42,19 +42,20 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   if (query_list == nullptr || result != URI_SUCCESS || item_count < 0)
     return 0;
 
-  int chars_required;
+  int chars_required = 0;
   if (uriComposeQueryCharsRequiredA(query_list, &chars_required) != URI_SUCCESS)
     return 0;
 
-  if (!chars_required) return 0;
+  if (!chars_required) {
+    uriFreeQueryListA(query_list);
+    return 0;
+  }
 
   std::vector<char> buf(chars_required, 0);
   int written = -1;
-  char *dest = &buf[0];
   // Reverse the process of uriDissectQueryMallocA.
-  result = uriComposeQueryA(dest, query_list, chars_required, &written);
+  result = uriComposeQueryA(buf.data(), query_list, chars_required, &written);
 
   uriFreeQueryListA(query_list);
-
   return 0;
 }

--- a/projects/uriparser/uri_dissect_query_malloc_fuzzer.cc
+++ b/projects/uriparser/uri_dissect_query_malloc_fuzzer.cc
@@ -22,8 +22,6 @@
 #include <utility>
 #include <vector>
 
-#include <iostream>
-
 using std::string;
 #include "uriparser/include/uriparser/Uri.h"
 

--- a/projects/uriparser/uri_dissect_query_malloc_fuzzer.cc
+++ b/projects/uriparser/uri_dissect_query_malloc_fuzzer.cc
@@ -22,6 +22,8 @@
 #include <utility>
 #include <vector>
 
+#include <iostream>
+
 using std::string;
 #include "uriparser/include/uriparser/Uri.h"
 
@@ -45,7 +47,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   int chars_required;
   if (uriComposeQueryCharsRequiredA(query_list, &chars_required) != URI_SUCCESS)
     return 0;
-    
+
+  if (!chars_required) return 0;
+
   std::vector<char> buf(chars_required, 0);
   int written = -1;
   char *dest = &buf[0];


### PR DESCRIPTION
There was an issue in uri_dissect_query_malloc_fuzzer where our destination buffer has a size of 0, resulting in a [null-dereference](https://oss-fuzz.com/testcase-detail/5085315342270464). To fix this, I've included a check to ensure we only use the second half of our fuzzer if the buffer will have positive size.