### PR TITLE
[Radon] Added project

### DIFF
--- a/projects/radon/Dockerfile
+++ b/projects/radon/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN go get github.com/radondb/radon/src/fuzz/sqlparser
+COPY build.sh $SRC/
+WORKDIR $SRC/

--- a/projects/radon/build.sh
+++ b/projects/radon/build.sh
@@ -1,0 +1,27 @@
+#/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+function compile_fuzzer {
+  path=$1
+  function=$2
+  fuzzer=$3
+
+  go-fuzz -func $function -o $fuzzer.a $path
+
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
+}
+
+compile_fuzzer github.com/radondb/radon/src/fuzz/sqlparser Fuzz fuzz

--- a/projects/radon/project.yaml
+++ b/projects/radon/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/radondb/radon"
+primary_contact: "overred.shuttler@gmail.com"
+auto_ccs :
+  - "adam@adalogics.com"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
This PR adds [RadonDB](https://github.com/radondb/radon), an open source, Cloud-native MySQL database for unlimited scalability and performance.

According to its maintainers, RadonDB is used by Qingcloud to provide production-ready distributed database-products to their customers. More info on this can be found [here](https://www.qingcloud.com/products/radondb/).

Qingcloud is a cloud computing provider in China with [~50 million USD (CNY 377 million) in sales in 2019](https://equalocean.com/analysis/2020041313880#:~:text=When%20QingCloud%20grew%20its%20sales,98%25%20increase%20compared%20with%202017.) and customers from [industries like finance, healthcare, manufacturing, government and energy](https://www.prnewswire.com/news-releases/cloud-computing-technology-leader-qingcloud-expands-into-global-markets-with-first-stop-in-southeast-asia-300979237.html).

@BohuTANG who is a [maintainer of RadonDB](https://github.com/radondb/radon/graphs/contributors) is added as the primary contact. 