### PR TITLE
moved code inside try/catch block

### DIFF
--- a/projects/openexr/openexr_deepscanlines_fuzzer.cc
+++ b/projects/openexr/openexr_deepscanlines_fuzzer.cc
@@ -113,8 +113,8 @@ static void readFile(T *inpart) {
 
 static void readFileSingle(IStream& is, uint64_t width, uint64_t height) {
   DeepScanLineInputFile *file = NULL;
-  Header header(width, height);
   try {
+    Header header(width, height);
     file = new DeepScanLineInputFile(header, &is, EXR_VERSION, 0);
   } catch (...) {
     return;

--- a/projects/openexr/openexr_tiles_fuzzer.cc
+++ b/projects/openexr/openexr_tiles_fuzzer.cc
@@ -142,8 +142,13 @@ void readImageRIP(TiledRgbaInputFile *in, int dwx, int dwy) {
 }  // namespace
 
 static void fuzzImage(IStream& is) {
-  Header::setMaxImageSize(10000, 10000);
-  Header::setMaxTileSize(10000, 10000);
+
+  try {
+    Header::setMaxImageSize(10000, 10000);
+    Header::setMaxTileSize(10000, 10000);
+  } catch (...) {
+    return;
+  }
 
   TiledRgbaInputFile *in;
   try {


### PR DESCRIPTION
Header::Header throws on invalid input, so it must be inside the try/catch. This should resolve:

https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=24320

Signed-off-by: Cary Phillips <cary@ilm.com>