### PR TITLE
[Chrono] added integration of rust date and time parsing library 

### DIFF
--- a/projects/chrono/Dockerfile
+++ b/projects/chrono/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN git clone --depth 1 https://github.com/chronotope/chrono
+
+WORKDIR $SRC
+COPY build.sh $SRC/

--- a/projects/chrono/build.sh
+++ b/projects/chrono/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC/chrono
+cargo fuzz build -O 
+cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_reader $OUT/

--- a/projects/chrono/project.yaml
+++ b/projects/chrono/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/chronotope/chrono"
+primary_contact: "quodlibetor@gmail.com"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+language: rust
+auto_ccs:
+  - "david@adalogics.com"


### PR DESCRIPTION
Integration of date and time parsing library in Rust. Chrono has more than 13 million downloads on crates.io [here](https://crates.io/crates/chrono) and is used by roughly 2500 crates in Rust [here](https://crates.io/crates/chrono/reverse_dependencies)

Cross-referencing: https://github.com/chronotope/chrono/pull/463

The fuzzers are merged upstream.