### PR TITLE
[clamav] Add optional autogen.sh step; fix build

### DIFF
--- a/projects/clamav/Dockerfile
+++ b/projects/clamav/Dockerfile
@@ -17,6 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y \
     flex bison \
+    automake autoconf pkg-config m4 libtool \
     libssl-dev \
     libcurl4-openssl-dev
 RUN git clone --depth 1 https://github.com/Cisco-Talos/clamav-devel.git

--- a/projects/clamav/build.sh
+++ b/projects/clamav/build.sh
@@ -24,6 +24,15 @@ rm -rf ${WORK}/build
 mkdir -p ${WORK}/build
 cd ${WORK}/build
 
+if [ -f "${SRC}/clamav-devel/autogen.sh" ]
+then
+    /bin/chmod +x ${SRC}/clamav-devel/autogen.sh
+    ${SRC}/clamav-devel/autogen.sh
+fi
+
+# Remove ltdl so clamav build doesn't detect it and add it as a dependency.
+apt remove -y libtool libltdl-dev libltdl7
+
 #
 # Run ./configure
 #


### PR DESCRIPTION
ClamAV recently removed autotools generated materials (configure,
Makefile.in, etc) from the git repo. This commit adds tools and calls
necessary to generate those files if autogen.sh is present.