### PR TITLE
build: Project sync fixes.

### DIFF
--- a/infra/build/functions/datastore_entities.py
+++ b/infra/build/functions/datastore_entities.py
@@ -27,9 +27,10 @@ class Project(ndb.Model):
 
 
 # pylint: disable=too-few-public-methods
-class GitAuth(ndb.Model):
-  """Represents Github access token entity."""
-  access_token = ndb.StringProperty()
+class GithubCreds(ndb.Model):
+  """Represents GitHub credentials."""
+  client_id = ndb.StringProperty()
+  client_secret = ndb.StringProperty()
 
 
 # pylint: disable=too-few-public-methods

--- a/infra/build/functions/deploy.sh
+++ b/infra/build/functions/deploy.sh
@@ -1,3 +1,4 @@
+#!/bin/bash -ex
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -58,16 +59,16 @@ function deploy_scheduler {
 	if gcloud scheduler jobs describe $scheduler_name --project $project ;
 		then
 			gcloud scheduler jobs update pubsub $scheduler_name \
+			--project $project \
 			--schedule "$schedule" \
 			--topic $topic \
-			--message-body "$message" \
-			--project $project
+			--message-body "$message"
 		else
 			gcloud scheduler jobs create pubsub $scheduler_name \
+			--project $project \
 			--schedule "$schedule" \
 			--topic $topic \
-			--message-body "$message" \
-			--project $project
+			--message-body "$message"
 	fi
 }
 

--- a/infra/build/functions/project_sync_test.py
+++ b/infra/build/functions/project_sync_test.py
@@ -21,7 +21,7 @@ import unittest
 from google.cloud import ndb
 
 from datastore_entities import Project
-from project_sync import get_access_token
+from project_sync import get_github_creds
 from project_sync import get_projects
 from project_sync import ProjectMetadata
 from project_sync import sync_projects
@@ -276,10 +276,10 @@ class TestDataSync(unittest.TestCase):
 
     self.assertEqual(get_projects(repo), {})
 
-  def test_get_access_token(self):
-    """Testing get_access_token()."""
+  def test_get_github_creds(self):
+    """Testing get_github_creds()."""
     with ndb.Client().context():
-      self.assertRaises(RuntimeError, get_access_token)
+      self.assertRaises(RuntimeError, get_github_creds)
 
   @classmethod
   def tearDownClass(cls):


### PR DESCRIPTION
- Add some more logging.
- Use GitHub client ID/secret rather than personal access token.
- Fix function deploy wrt "--project" argument.