### PR TITLE
Monero update: fix typo allowing corpus zip file creation anew, enable honggfuzz & afl

### DIFF
--- a/projects/monero/build.sh
+++ b/projects/monero/build.sh
@@ -48,7 +48,7 @@ do
   cp "$fuzzer" "$OUT"
   base=$(echo $fuzzer | sed -e s/_fuzz_tests//)
   cd "/src/monero/monero/tests/data/fuzz/$base"
-  rm -f "${OUT}/${base}_seed_corpus.zip"
+  rm -f "${OUT}/${fuzzer}_seed_corpus.zip"
   for f in *
   do
     h=$(sha1sum "$f" | awk '{print $1}')

--- a/projects/monero/build.sh
+++ b/projects/monero/build.sh
@@ -26,7 +26,8 @@ mkdir -p build
 cd build
 export CXXFLAGS="$CXXFLAGS -fPIC"
 cmake -D OSSFUZZ=ON -D STATIC=ON -D BUILD_TESTS=ON -D USE_LTO=OFF -D ARCH="default" ..
-make -C tests/fuzz \
+
+TESTS="\
   base58_fuzz_tests \
   block_fuzz_tests \
   transaction_fuzz_tests \
@@ -36,11 +37,20 @@ make -C tests/fuzz \
   http-client_fuzz_tests \
   levin_fuzz_tests \
   bulletproof_fuzz_tests \
-  signature_fuzz_tests \
-  transaction_fuzz_tests \
-  cold-outputs_fuzz_tests \
-  cold-transaction_fuzz_tests \
-  tx-extra_fuzz_tests
+  tx-extra_fuzz_tests \
+"
+
+# only libfuzzer can run the slow to start ones
+if test "x$FUZZING_ENGINE" == 'xlibfuzzer'
+then
+  TESTS="$TESTS \
+    signature_fuzz_tests \
+    cold-outputs_fuzz_tests \
+    cold-transaction_fuzz_tests \
+  "
+fi
+
+make -C tests/fuzz $TESTS
 
 cd /src/monero/monero/build/tests/fuzz
 for fuzzer in *_fuzz_tests

--- a/projects/monero/project.yaml
+++ b/projects/monero/project.yaml
@@ -9,5 +9,7 @@ sanitizers:
   - address
 fuzzing_engines:
   - libfuzzer
+  - afl
+  - honggfuzz
 architectures:
   - x86_64


### PR DESCRIPTION
Monero
 - fix typo ensuring the corpus zip file is created anew
 - enable honggfuzz and afl