### PR TITLE
Monero: fix corpus zip file creation anew; enable honggfuzz&afl

### DIFF
--- a/projects/monero/project.yaml
+++ b/projects/monero/project.yaml
@@ -9,5 +9,7 @@ sanitizers:
   - address
 fuzzing_engines:
   - libfuzzer
+  - afl
+  - honggfuzz
 architectures:
   - x86_64


### PR DESCRIPTION
Monero
- fix typo ensuring the corpus zip file is created anew
- enable honggfuzz and afl
