### PR TITLE
Fix builds status requirements.txt

### DIFF
--- a/infra/gcb/requirements.txt
+++ b/infra/gcb/requirements.txt
@@ -2,6 +2,7 @@ cachetools==2.1.0
 certifi==2018.4.16
 chardet==3.0.4
 enum34==1.1.6
+future==0.18.2
 futures==3.2.0
 google-api-core==1.2.0
 google-api-python-client==1.7.0


### PR DESCRIPTION
New builds status not ready to be migrated to yet, as that depends on all the builds being migrated first.