### PR TITLE
Removing no-longer valid email and updating sanitizer definitions

### DIFF
--- a/projects/spanner_emulator/project.yaml
+++ b/projects/spanner_emulator/project.yaml
@@ -3,10 +3,8 @@ language: c++
 primary_contact: "evmaus@google.com"
 auto_ccs:
   - "snehashah@google.com"
-  - "volfson@google.com"
 fuzzing_engines:
   - libfuzzer
   - honggfuzz
 sanitizers:
   - address
-  - memory

--- a/projects/spanner_emulator/project.yaml
+++ b/projects/spanner_emulator/project.yaml
@@ -2,7 +2,7 @@ homepage: "https://github.com/googleinterns/cloud-spanner-emulator-fuzzing"
 language: c++
 primary_contact: "evmaus@google.com"
 auto_ccs:
-  - "snehashah@google.com"
+  - "cloud-spanner-emulator-dev+fuzztests@google.com"
 fuzzing_engines:
   - libfuzzer
   - honggfuzz


### PR DESCRIPTION
Two changes:
- Removing an email that no longer points to an active user.
- Removing MSAN as it is failing due to the MSAN + LPM incompatability (see issue 864)
