### PR TITLE
[h2o] Install libbrotri-dev before building

### DIFF
--- a/projects/h2o/Dockerfile
+++ b/projects/h2o/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool cmake zlib1g-dev pkg-config libssl-dev
+RUN apt-get update && apt-get install -y make autoconf automake libtool cmake zlib1g-dev pkg-config libssl-dev libbrotli-dev
 RUN git clone https://github.com/h2o/h2o
 WORKDIR h2o
 COPY build.sh $SRC/


### PR DESCRIPTION
Recent change in h2o made it dependent on libbrotri
(https://github.com/h2o/h2o/pull/2326), causing the CIFuzz build
to fail.

This patch adds libbrotri-dev into preinstalled package list.