### PR TITLE
[skia] Limit concurrent link steps.

### DIFF
--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -64,6 +64,7 @@ export LDFLAGS_ARR=`echo $LDFLAGS | sed -e "s/\s/\",\"/g"`
 $SRC/depot_tools/gn gen out/Fuzz\
     --args='cc="'$CC'"
       cxx="'$CXX'"
+      link_pool_depth=0
       is_debug=false
       extra_cflags_c=["'"$CFLAGS_ARR"'"]
       extra_cflags_cc=["'"$CXXFLAGS_ARR"'"]
@@ -82,6 +83,7 @@ $SRC/depot_tools/gn gen out/Fuzz\
 $SRC/depot_tools/gn gen out/Fuzz_mem_constraints\
     --args='cc="'$CC'"
       cxx="'$CXX'"
+      link_pool_depth=0
       is_debug=false
       extra_cflags_c=["'"$CFLAGS_ARR"'"]
       extra_cflags_cc=["'"$CXXFLAGS_ARR"'","-DIS_FUZZING"]


### PR DESCRIPTION
The number of link build steps in the Skia build is currently not
limited and may be leading to the current failures where the linker is
killed with a signal. This changes that to limit the number of
concurrent linker steps to the number of cpus available. If there
continue to be issues it may be necessary to implement a hard limit.

Bug: oss-fuzz:23438,oss-fuzz:24345