### PR TITLE
[inchi] Initial Integration

### DIFF
--- a/projects/inchi/Dockerfile
+++ b/projects/inchi/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y wget make unzip git
+RUN wget http://www.inchi-trust.org/download/105/INCHI-1-SRC.zip
+RUN unzip INCHI-1-SRC.zip
+WORKDIR INCHI-1-SRC
+COPY build.sh *_fuzzer.cc $SRC/

--- a/projects/inchi/Dockerfile
+++ b/projects/inchi/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get update && apt-get install -y wget make unzip git
 RUN wget http://www.inchi-trust.org/download/105/INCHI-1-SRC.zip
 RUN unzip INCHI-1-SRC.zip
 WORKDIR INCHI-1-SRC
-COPY build.sh *_fuzzer.cc $SRC/
+COPY build.sh *_fuzzer.c $SRC/

--- a/projects/inchi/Dockerfile
+++ b/projects/inchi/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y wget make unzip git
-RUN wget http://www.inchi-trust.org/download/105/INCHI-1-SRC.zip
+RUN wget https://www.inchi-trust.org/download/106PR3/INCHI-1-SRC.zip
 RUN unzip INCHI-1-SRC.zip
 WORKDIR INCHI-1-SRC
 COPY build.sh *_fuzzer.c $SRC/

--- a/projects/inchi/build.sh
+++ b/projects/inchi/build.sh
@@ -19,12 +19,16 @@ $CC $CFLAGS -Wno-everything -DTARGET_API_LIB -DCOMPILE_ANSI_ONLY -ansi -c \
     INCHI_BASE/src/*.c INCHI_API/libinchi/src/*.c INCHI_API/libinchi/src/ixa/*.c
 ar rcs $WORK/libinchi.a *.o
 
-for fuzzer in $SRC/*_fuzzer.cc; do
-  fuzzer_basename=$(basename -s .cc $fuzzer)
-  $CXX $CXXFLAGS \
+for fuzzer in $SRC/*_fuzzer.c; do
+  fuzzer_basename=$(basename -s .c $fuzzer)
+
+  $CC $CFLAGS \
       -I INCHI_BASE/src/ \
       -I INCHI_API/libinchi/src/ \
       -I INCHI_API/libinchi/src/ixa/ \
-      $fuzzer $LIB_FUZZING_ENGINE $WORK/libinchi.a \
-      -o $OUT/$fuzzer_basename
+      $fuzzer -c -o ${fuzzer_basename}.o
+
+  $CXX $CXXFLAGS \
+      ${fuzzer_basename}.o -o $OUT/$fuzzer_basename \
+      $LIB_FUZZING_ENGINE $WORK/libinchi.a
 done

--- a/projects/inchi/build.sh
+++ b/projects/inchi/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+$CC $CFLAGS -Wno-everything -DTARGET_API_LIB -DCOMPILE_ANSI_ONLY -ansi -c \
+    INCHI_BASE/src/*.c INCHI_API/libinchi/src/*.c INCHI_API/libinchi/src/ixa/*.c
+ar rcs $WORK/libinchi.a *.o
+
+for fuzzer in $SRC/*_fuzzer.cc; do
+  fuzzer_basename=$(basename -s .cc $fuzzer)
+  $CXX $CXXFLAGS \
+      -I INCHI_BASE/src/ \
+      -I INCHI_API/libinchi/src/ \
+      -I INCHI_API/libinchi/src/ixa/ \
+      $fuzzer $LIB_FUZZING_ENGINE $WORK/libinchi.a \
+      -o $OUT/$fuzzer_basename
+done

--- a/projects/inchi/inchi_input_fuzzer.c
+++ b/projects/inchi/inchi_input_fuzzer.c
@@ -12,18 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <limits>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <string>
 
 #include "inchi_api.h"
 
-static constexpr size_t kSizeMax = std::numeric_limits<size_t>::max();
+// Define the maximum value for size_t. We return if the fuzzing input is equal
+// to kSizeMax because appending the null-terminator to the InChI buffer would
+// cause wraparound, thereby initializing the buffer to size 0.
+static const size_t kSizeMax = (size_t)-1;
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   if (size == kSizeMax)
     return 0;
@@ -38,7 +39,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   GetINCHIKeyFromINCHI(szINCHISource, 0, 0, szINCHIKey, szXtra1, szXtra2);
 
   inchi_InputINCHI inpInChI;
-  inpInChI.szInChI = const_cast<char *>(szINCHISource);
+  inpInChI.szInChI = szINCHISource;
 
   inchi_Output out;
   GetINCHIfromINCHI(&inpInChI, &out);

--- a/projects/inchi/inchi_input_fuzzer.c
+++ b/projects/inchi/inchi_input_fuzzer.c
@@ -29,13 +29,13 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   if (size == kSizeMax)
     return 0;
 
-  char szINCHISource[size + 1];
+  char *szINCHISource = malloc(sizeof(char) * (size + 1));
   memcpy(szINCHISource, data, size);
   szINCHISource[size] = '\0'; // InChI string must be null-terminated
 
   // Buffer lengths taken from InChI API reference, located at
   // https://www.inchi-trust.org/download/104/InChI_API_Reference.pdf, page 24
-  char szINCHIKey[29], szXtra1[65], szXtra2[65];
+  char szINCHIKey[28], szXtra1[65], szXtra2[65];
   GetINCHIKeyFromINCHI(szINCHISource, 0, 0, szINCHIKey, szXtra1, szXtra2);
 
   inchi_InputINCHI inpInChI;
@@ -47,6 +47,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   inchi_OutputStruct outStruct;
   GetStructFromINCHI(&inpInChI, &outStruct);
 
+  free(szINCHISource);
   FreeINCHI(&out);
   FreeStructFromINCHI(&outStruct);
 

--- a/projects/inchi/inchi_input_fuzzer.cc
+++ b/projects/inchi/inchi_input_fuzzer.cc
@@ -1,0 +1,53 @@
+// Copyright 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <limits>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <string>
+
+#include "inchi_api.h"
+
+static constexpr size_t kSizeMax = std::numeric_limits<size_t>::max();
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+
+  if (size == kSizeMax)
+    return 0;
+
+  char szINCHISource[size + 1];
+  memcpy(szINCHISource, data, size);
+  szINCHISource[size] = '\0'; // InChI string must be null-terminated
+
+  // Buffer lengths taken from InChI API reference, located at
+  // https://www.inchi-trust.org/download/104/InChI_API_Reference.pdf, page 24
+  char szINCHIKey[29], szXtra1[65], szXtra2[65];
+  GetINCHIKeyFromINCHI(szINCHISource, 0, 0, szINCHIKey, szXtra1, szXtra2);
+
+  inchi_InputINCHI inpInChI;
+  inpInChI.szInChI = const_cast<char *>(szINCHISource);
+
+  inchi_Output out;
+  GetINCHIfromINCHI(&inpInChI, &out);
+
+  inchi_OutputStruct outStruct;
+  GetStructFromINCHI(&inpInChI, &outStruct);
+
+  FreeINCHI(&out);
+  FreeStructFromINCHI(&outStruct);
+
+  return 0;
+}

--- a/projects/inchi/project.yaml
+++ b/projects/inchi/project.yaml
@@ -1,0 +1,3 @@
+homepage: "https://www.inchi-trust.org/"
+language: c
+primary_contact: "" # TODO(rjotwani): Find primary contact email address

--- a/projects/inchi/project.yaml
+++ b/projects/inchi/project.yaml
@@ -1,3 +1,5 @@
 homepage: "https://www.inchi-trust.org/"
 language: c
-primary_contact: "" # TODO(rjotwani): Find primary contact email address
+primary_contact: "" # TODO(mtjz): Find primary contact email address
+sanitizers:
+  - address

--- a/projects/inchi/project.yaml
+++ b/projects/inchi/project.yaml
@@ -1,5 +1,5 @@
 homepage: "https://www.inchi-trust.org/"
 language: c
-primary_contact: "" # TODO(mtjz): Find primary contact email address
+primary_contact: "member-info@inchi-trust.org"
 sanitizers:
   - address


### PR DESCRIPTION
Initial integration for [InChI](https://www.inchi-trust.org/), using [this](https://github.com/google/security-research-pocs/blob/master/autofuzz/inchi_fuzzer.cc) fuzzer.

@inferno-chromium any idea who we can add as the primary contact? I couldn't find contact information for the InChI development team online.

@alsophian @spq requesting review.