### PR TITLE
Fix build status update.

### DIFF
--- a/infra/build/functions/update_build_status.py
+++ b/infra/build/functions/update_build_status.py
@@ -46,7 +46,7 @@ def get_last_build(build_ids):
   for build_id in reversed(build_ids):
     project_build = cloudbuild.projects().builds().get(projectId=image_project,
                                                        id=build_id).execute()
-    if project_build['status'] == 'WORKING':
+    if project_build['status'] not in ('SUCCESS', 'FAILURE', 'TIMEOUT'):
       continue
 
     if not builds_status.upload_log(build_id):


### PR DESCRIPTION
Check for valid statuses rather than only excluding the WORKING status.
There are other failure statuses that need to be accounted for (e.g.
EXPIRED).