### PR TITLE
[skia] Further limit number of concurrent links.

### DIFF
--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -64,7 +64,7 @@ export LDFLAGS_ARR=`echo $LDFLAGS | sed -e "s/\s/\",\"/g"`
 $SRC/depot_tools/gn gen out/Fuzz\
     --args='cc="'$CC'"
       cxx="'$CXX'"
-      link_pool_depth=0
+      link_pool_depth=1
       is_debug=false
       extra_cflags_c=["'"$CFLAGS_ARR"'"]
       extra_cflags_cc=["'"$CXXFLAGS_ARR"'"]
@@ -83,7 +83,7 @@ $SRC/depot_tools/gn gen out/Fuzz\
 $SRC/depot_tools/gn gen out/Fuzz_mem_constraints\
     --args='cc="'$CC'"
       cxx="'$CXX'"
-      link_pool_depth=0
+      link_pool_depth=1
       is_debug=false
       extra_cflags_c=["'"$CFLAGS_ARR"'"]
       extra_cflags_cc=["'"$CXXFLAGS_ARR"'","-DIS_FUZZING"]


### PR DESCRIPTION
Reducing the number of concurrent link steps to the number of cpus does
not appear to have made much difference to the success of the Skia
project build. Limit the number of concurrent links to one in an attempt
to avoid running out of memory. If issues persist it is likely the bot
running this simply does not have enough memory to run the linker step.

This change is speculative since these builds have been working on the
CI bots and only failing on the oss-fuzz build.

Bug: oss-fuzz:23438,oss-fuzz:24345