### PR TITLE
add project quic-go

### DIFF
--- a/projects/quic-go/project.yaml
+++ b/projects/quic-go/project.yaml
@@ -1,0 +1,7 @@
+homepage: "https://github.com/lucas-clemente/quic-go"
+primary_contact: "martenseemann@gmail.com"
+language: go
+fuzzing_engines:
+- libfuzzer
+sanitizers:
+- address


### PR DESCRIPTION
[quic-go](https://github.com/lucas-clemente/quic-go/) is an implementation of the QUIC protocol (currently support IETF QUIC [working group draft-29](https://tools.ietf.org/html/draft-ietf-quic-transport-29)), including HTTP/3.

quic-go is used as the default transport in [IPFS](https://github.com/ipfs/go-ipfs/) and it powers HTTP/3 support in the [Caddy webserver](https://caddyserver.com/).