### PR TITLE
[docs] Remove link to the old builder (#3538).

### DIFF
--- a/docs/reference/useful_links.md
+++ b/docs/reference/useful_links.md
@@ -21,8 +21,6 @@ parent: Reference
 * [This page](https://oss-fuzz-build-logs.storage.googleapis.com/index.html)
   gives the latest build logs for each project.
 
-* (Internal only) [Builds dashboard](https://builder.oss-fuzz.com).
-
 ## Blog posts
 
 * 2016-12-01 - Announcing OSS-Fuzz: Continuous fuzzing for open source software


### PR DESCRIPTION
@oliverchang is this fine to remove or should it be replaced with anything else?