### PR TITLE
Catch all exceptions via (...) rather than by explicit type

### DIFF
--- a/projects/openexr/openexr_deepscanlines_fuzzer.cc
+++ b/projects/openexr/openexr_deepscanlines_fuzzer.cc
@@ -122,7 +122,7 @@ static void readFileSingle(IStream& is, uint64_t width, uint64_t height) {
 
   try {
     readFile(file);
-  } catch (std::exception &e) {
+  } catch (...) {
   }
 
   delete file;
@@ -145,7 +145,7 @@ static void readFileMulti(IStream& is) {
     }
     try {
       readFile(inpart);
-    } catch (std::exception &e) {
+    } catch (...) {
     }
     delete inpart;
   }

--- a/projects/openexr/openexr_deeptiles_fuzzer.cc
+++ b/projects/openexr/openexr_deeptiles_fuzzer.cc
@@ -126,7 +126,7 @@ static void readFileSingle(IStream& is) {
 
   try {
     readFile(file);
-  } catch (std::exception &e) {
+  } catch (...) {
   }
 
   delete file;

--- a/projects/openexr/openexr_exrenvmap_fuzzer.cc
+++ b/projects/openexr/openexr_exrenvmap_fuzzer.cc
@@ -85,10 +85,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
                  compression, mapWidth,
                  filterRadius, numSamples,
                  false);
-  } catch (IEX_NAMESPACE::InputExc& e) {
-    ;
-  } catch (IEX_NAMESPACE::ArgExc& e) {
-    ;
+  } catch (...) {
   }
 
   unlink(file);

--- a/projects/openexr/openexr_exrheader_fuzzer.cc
+++ b/projects/openexr/openexr_exrheader_fuzzer.cc
@@ -222,9 +222,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   try {
     dumpInfo(is);
-  } catch (IEX_NAMESPACE::InputExc& e) {
-    ;
-  } catch (IEX_NAMESPACE::ArgExc& e) {
+  } catch (...) {
     ;
   }
 


### PR DESCRIPTION
The purpose of the fuzzer is to very that an exception is thrown, not to validate that the correct *type* of exception is thrown. That is the responsibility of the project's traditional test suite. Therefore, the exception type is inconsequential.

Signed-off-by: Cary Phillips <seabeepea@gmail.com>