### PR TITLE
[nanopb] Split fuzztest to separate test cases.

### DIFF
--- a/projects/nanopb/build.sh
+++ b/projects/nanopb/build.sh
@@ -32,15 +32,21 @@ for f in fuzztest_seed_corpus/*; do
 done
 zip -r "$OUT/fuzztest_seed_corpus.zip" fuzztest_seed_corpus
 
-# Build the fuzz testing stub with instrumentation
+# Build the fuzz testing stubs with instrumentation
 rm -rf build
+
+FUZZERS="build/fuzztest/fuzztest_proto2_static
+         build/fuzztest/fuzztest_proto2_pointer
+         build/fuzztest/fuzztest_proto3_static
+         build/fuzztest/fuzztest_proto3_pointer
+         build/fuzztest/fuzztest_io_errors"
+
 scons CC="$CC" CXX="$CXX" LINK="$CXX" \
       CCFLAGS="-Wall -Wextra -g -DLLVMFUZZER $CFLAGS" \
       CXXFLAGS="-Wall -Wextra -g -DLLVMFUZZER $CXXFLAGS" \
       NODEFARGS="1" \
       LINKFLAGS="-std=c++11 $CXXFLAGS" \
-      LINKLIBS="$LIB_FUZZING_ENGINE" build/fuzztest/fuzztest
+      LINKLIBS="$LIB_FUZZING_ENGINE" $FUZZERS
 
-cp build/fuzztest/fuzztest "$OUT/fuzztest"
-
+cp $FUZZERS "$OUT"
 


### PR DESCRIPTION
This should improve fuzzing performance.