### PR TITLE
[fuzzing-puzzles] Disable the project for now.

### DIFF
--- a/projects/fuzzing-puzzles/project.yaml
+++ b/projects/fuzzing-puzzles/project.yaml
@@ -10,3 +10,5 @@ sanitizers:
 
 fuzzing_engines:
   - honggfuzz
+
+disabled: True


### PR DESCRIPTION
@robertswiecki looks like honggfuzz wasn't able to crack it, so this might be of interest to you

This is the target: https://github.com/llvm/llvm-project/blob/master/compiler-rt/test/fuzzer/MultipleConstraintsOnSmallInputTest.cpp

Here are some notes on how libFuzzer dealt with it: https://github.com/google/sanitizers/issues/964

libFuzzer on ClusterFuzz managed to crash it in 2-3 days. The conclusion was that corpus subset strategy did really help like a backtracking mechanism.