### PR TITLE
fix dav1d build

### DIFF
--- a/projects/dav1d/Dockerfile
+++ b/projects/dav1d/Dockerfile
@@ -20,7 +20,7 @@ ADD nasm.list /etc/apt/sources.list.d/nasm.list
 ADD nasm_apt.pin /etc/apt/preferences
 
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y libstdc++-5-dev libstdc++-5-dev:i386 curl python3-pip python3-setuptools python3-wheel nasm && \
+    apt-get install --no-install-recommends -y curl python3-pip python3-setuptools python3-wheel nasm && \
     pip3 install meson ninja
 RUN curl --silent -O https://storage.googleapis.com/aom-test-data/fuzzer/dec_fuzzer_seed_corpus.zip
 RUN curl --silent -O https://jannau.net/dav1d_fuzzer_seed_corpus.zip

--- a/projects/dav1d/build.sh
+++ b/projects/dav1d/build.sh
@@ -46,7 +46,7 @@ cp $SRC/dec_fuzzer_seed_corpus.zip ${WORK}/tmp/seed_corpus.zip
 (cd ${WORK}/tmp && zip -q -m -r -0 ${WORK}/tmp/seed_corpus.zip testdata)
 
 # copy fuzzers and link testdata
-for fuzzer in $(find ${build} -name 'dav1d_fuzzer*'); do
+for fuzzer in $(find ${build}/tests/libfuzzer -maxdepth 1 -type f -executable -name 'dav1d_fuzzer*'); do
 	cp "${fuzzer}" $OUT/
 	cp ${WORK}/tmp/seed_corpus.zip $OUT/$(basename "$fuzzer")_seed_corpus.zip
 done


### PR DESCRIPTION
a meson change broke the build. The build directories holding the objects for the fuzzing binaries matched the patter used for copying the fuzzing binaries to the output dir.