### PR TITLE
[uwebsockets] Don't install zlib from apt

### DIFF
--- a/projects/uwebsockets/Dockerfile
+++ b/projects/uwebsockets/Dockerfile
@@ -15,7 +15,6 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y libz-dev
 RUN git clone --recursive https://github.com/uNetworking/uWebSockets.git uWebSockets
 WORKDIR uWebSockets
 COPY build.sh $SRC/


### PR DESCRIPTION
I was installing zlib from ubuntu.com and got msan false positives. Now zlib is cloned/built as part of building the fuzz targets.