### PR TITLE
[boringssl] Fix BoringSSL build break

### DIFF
--- a/projects/boringssl/build.sh
+++ b/projects/boringssl/build.sh
@@ -62,7 +62,7 @@ if [[ $CFLAGS != *sanitize=memory* ]]; then
     echo "Building fuzzer $fuzzerName"
     $CXX $CXXFLAGS -I genfiles -I . -I $SRC/libprotobuf-mutator/ -I $SRC/LPM/external.protobuf/include -I include $LIB_FUZZING_ENGINE \
         -I $SRC/boringssl/include \
-        $F genfiles/asn1_pdu.pb.cc $SRC/asn1_pdu_to_der.cc \
+        $F genfiles/asn1_pdu.pb.cc $SRC/asn1_pdu_to_der.cc $SRC/common.cc \
         ./ssl/libssl.a ./crypto/libcrypto.a \
         $SRC/LPM/src/libfuzzer/libprotobuf-mutator-libfuzzer.a \
         $SRC/LPM/src/libprotobuf-mutator.a \


### PR DESCRIPTION
The upstream LPM-based fuzzer changed its layout, so update the build
files to reflect this. This may make sense as a separate .a file in
the future to avoid these breaks.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=24776