### PR TITLE
[libavif] add bidirectional RGB conversion paths to the fuzzer

### DIFF
--- a/projects/libavif/avif_decode_fuzzer.cc
+++ b/projects/libavif/avif_decode_fuzzer.cc
@@ -17,47 +17,73 @@
 #include "avif/avif.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+  static avifRGBFormat rgbFormats[] = {
+      AVIF_RGB_FORMAT_RGB, AVIF_RGB_FORMAT_RGBA, AVIF_RGB_FORMAT_ARGB,
+      AVIF_RGB_FORMAT_BGR, AVIF_RGB_FORMAT_BGRA, AVIF_RGB_FORMAT_ABGR};
+  static size_t rgbFormatsCount = sizeof(rgbFormats) / sizeof(rgbFormats[0]);
+
+  static avifChromaUpsampling upsamplings[] = {AVIF_CHROMA_UPSAMPLING_BILINEAR,
+                                               AVIF_CHROMA_UPSAMPLING_NEAREST};
+  static size_t upsamplingsCount = sizeof(upsamplings) / sizeof(upsamplings[0]);
+
+  static uint32_t rgbDepths[] = {8, 10, 12, 16};
+  static size_t rgbDepthsCount = sizeof(rgbDepths) / sizeof(rgbDepths[0]);
+
+  static uint32_t yuvDepths[] = {8, 10, 12};
+  static size_t yuvDepthsCount = sizeof(yuvDepths) / sizeof(yuvDepths[0]);
+
   avifROData raw;
   raw.data = Data;
   raw.size = Size;
 
   avifDecoder *decoder = avifDecoderCreate();
-  // avifDecoderSetSource(decoder, AVIF_DECODER_SOURCE_PRIMARY_ITEM);
   avifResult result = avifDecoderParse(decoder, &raw);
   if (result == AVIF_RESULT_OK) {
-    // printf("AVIF container reports dimensions: %ux%u (@ %u bpc)\n",
-    //        decoder->containerWidth, decoder->containerHeight,
-    //        decoder->containerDepth);
     for (int loop = 0; loop < 2; ++loop) {
-      // printf("Image decoded: %s\n", inputFilename);
-      // printf(" * %2.2f seconds, %d images\n", decoder->duration,
-      //        decoder->imageCount);
-      int frameIndex = 0;
       while (avifDecoderNextImage(decoder) == AVIF_RESULT_OK) {
-        // printf("  * Decoded frame [%d] [pts %2.2f] [duration %2.2f] "
-        //        "[keyframe:%s nearest:%u]: %dx%d\n",
-        //        frameIndex, decoder->imageTiming.pts,
-        //        decoder->imageTiming.duration,
-        //        avifDecoderIsKeyframe(decoder, frameIndex) ? "true" : "false",
-        //        avifDecoderNearestKeyframe(decoder, frameIndex),
-        //        decoder->image->width, decoder->image->height);
-        ++frameIndex;
+        avifRGBImage rgb;
+        avifRGBImageSetDefaults(&rgb, decoder->image);
+
+        for (size_t rgbFormatsIndex = 0; rgbFormatsIndex < rgbFormatsCount;
+             ++rgbFormatsIndex) {
+          for (size_t upsamplingsIndex = 0; upsamplingsIndex < upsamplingsCount;
+               ++upsamplingsIndex) {
+            for (size_t rgbDepthsIndex = 0; rgbDepthsIndex < rgbDepthsCount;
+                 ++rgbDepthsIndex) {
+              // Convert to RGB
+              rgb.format = rgbFormats[rgbFormatsIndex];
+              rgb.depth = rgbDepths[rgbDepthsIndex];
+              rgb.chromaUpsampling = upsamplings[upsamplingsIndex];
+              avifRGBImageAllocatePixels(&rgb);
+              avifResult rgbResult = avifImageYUVToRGB(decoder->image, &rgb);
+              if (rgbResult == AVIF_RESULT_OK) {
+                for (size_t yuvDepthsIndex = 0; yuvDepthsIndex < yuvDepthsCount;
+                     ++yuvDepthsIndex) {
+                  // ... and back to YUV
+                  avifImage *tempImage = avifImageCreate(
+                      decoder->image->width, decoder->image->height,
+                      yuvDepths[yuvDepthsIndex], decoder->image->yuvFormat);
+                  avifResult yuvResult = avifImageRGBToYUV(tempImage, &rgb);
+                  if (yuvResult != AVIF_RESULT_OK) {
+                  }
+                  avifImageDestroy(tempImage);
+                }
+              }
+
+              avifRGBImageFreePixels(&rgb);
+            }
+          }
+        }
       }
 
       if (loop != 1) {
         result = avifDecoderReset(decoder);
         if (result == AVIF_RESULT_OK) {
-          // printf("Decoder reset! Decoding one more time.\n");
         } else {
-          // printf("ERROR: Failed to reset decode: %s\n",
-          //        avifResultToString(result));
           break;
         }
       }
     }
-  } else {
-    // printf("ERROR: Failed to decode image: %s\n",
-    // avifResultToString(result));
   }
 
   avifDecoderDestroy(decoder);


### PR DESCRIPTION
This is to add some coverage for the code in libavif's reformat.c.

Context: https://bugs.chromium.org/p/chromium/issues/detail?id=1113226