### PR TITLE
[CRAS] Fix build error and build new fuzzer

### DIFF
--- a/projects/cras/Dockerfile
+++ b/projects/cras/Dockerfile
@@ -2,6 +2,21 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 #
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
 # Defines a docker image that can build cras fuzzers.
 #
 FROM gcr.io/oss-fuzz-base/base-builder

--- a/projects/cras/Dockerfile
+++ b/projects/cras/Dockerfile
@@ -74,6 +74,3 @@ RUN mkdir -p /tmp/alsa-build && cd /tmp/alsa-build && \
 RUN cd $SRC && git clone https://chromium.googlesource.com/chromiumos/third_party/adhd
 WORKDIR adhd/cras
 COPY build.sh $SRC/
-
-# Copy dsp.ini.sample to /etc/cras for the fuzzer
-RUN mkdir -p /etc/cras && cp /src/adhd/cras-config/dsp.ini.sample /etc/cras

--- a/projects/cras/Dockerfile
+++ b/projects/cras/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get -y update && \
       libsbc-dev \
       libsndfile-dev \
       libspeexdsp-dev \
+      libsystemd-dev \
       libtool \
       libudev-dev \
       wget \
@@ -34,11 +35,14 @@ RUN cd /tmp && git clone https://github.com/ndevilla/iniparser.git && \
       chmod 644 /usr/local/include/dictionary.h /usr/local/include/iniparser.h && \
       chmod 644 /usr/local/lib/libiniparser.a && \
       chmod 755 /usr/local/lib/libiniparser.so.*
-RUN cd /usr/src/gtest && \
-      cmake . && \
-      make && \
-      chmod 644 *.a && \
-      cp *.a /usr/local/lib
+
+RUN cd /tmp && git clone https://github.com/google/googletest.git -b v1.8.x && \
+      cd googletest && \
+      mkdir build && cd build && \
+      cmake .. -DBUILD_SHARED_LIBS=ON \
+         -DINSTALL_GTEST=ON \
+         -DCMAKE_INSTALL_PREFIX:PATH=/usr && \
+      make && make install
 
 # Need to build and install alsa so there is a static lib.
 RUN mkdir -p /tmp/alsa-build && cd /tmp/alsa-build && \
@@ -55,3 +59,6 @@ RUN mkdir -p /tmp/alsa-build && cd /tmp/alsa-build && \
 RUN cd $SRC && git clone https://chromium.googlesource.com/chromiumos/third_party/adhd
 WORKDIR adhd/cras
 COPY build.sh $SRC/
+
+# Copy dsp.ini.sample to /etc/cras for the fuzzer
+RUN mkdir -p /etc/cras && cp /src/adhd/cras-config/dsp.ini.sample /etc/cras

--- a/projects/cras/build.sh
+++ b/projects/cras/build.sh
@@ -3,6 +3,21 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 #
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
 # Builds fuzzers from within a container into /out/ directory.
 # Expects /src/cras to contain a cras checkout.
 

--- a/projects/cras/build.sh
+++ b/projects/cras/build.sh
@@ -8,17 +8,24 @@
 
 cd ${SRC}/adhd/cras
 ./git_prepare.sh
-./configure --disable-dbus --disable-webrtc-apm
-cargo build --release --manifest-path $SRC/adhd/cras/src/server/rust/Cargo.toml && \
-  cp $SRC/adhd/cras/src/server/rust/target/release/libcras_rust.a /usr/local/lib
+./configure
 make -j$(nproc)
+cp ${SRC}/adhd/cras/src/server/rust/target/release/libcras_rust.a /usr/local/lib
 
+CRAS_FUZZERS="rclient_message cras_hfp_slc"
+
+for fuzzer in ${CRAS_FUZZERS};
+do
 $CXX $CXXFLAGS $FUZZER_LDFLAGS \
-  ${SRC}/adhd/cras/src/fuzz/rclient_message.cc -o ${OUT}/rclient_message \
+  ${SRC}/adhd/cras/src/fuzz/${fuzzer}.cc -o ${OUT}/${fuzzer} \
   -I ${SRC}/adhd/cras/src/server \
   -I ${SRC}/adhd/cras/src/common \
+  $(pkg-config --cflags dbus-1) \
   ${SRC}/adhd/cras/src/.libs/libcrasserver.a \
-  -lcras_rust -lpthread -lrt -ludev -ldl -lm \
+  -lcras_rust -lpthread -lrt -ludev -ldl -lm -lsystemd \
   $LIB_FUZZING_ENGINE \
-  -Wl,-Bstatic -liniparser -lasound -lspeexdsp -Wl,-Bdynamic
+  -Wl,-Bstatic -liniparser -lasound -lspeexdsp -ldbus-1 -lsbc -Wl,-Bdynamic
+done
+
 zip -j ${OUT}/rclient_message_corpus.zip ${SRC}/adhd/cras/src/fuzz/corpus/*
+cp "${SRC}/adhd/cras/src/fuzz/cras_hfp_slc.dict" "${OUT}/cras_hfp_slc.dict"


### PR DESCRIPTION
- Fix build error by installing 1.8.x gtest and using `make install` to
  install gtest pc file for pkg-config
- Build and add new fuzzer `cras_hfp_slc`

BUG=oss-fuzz:24744