### PR TITLE
[bind9] Temporarily disable AFL fuzzing engine.

### DIFF
--- a/projects/bind9/project.yaml
+++ b/projects/bind9/project.yaml
@@ -4,6 +4,9 @@ primary_contact: "security-officer@isc.org"
 auto_ccs:
   - "ondrej@sury.org"
   - "michal@isc.org"
+fuzzing_engines:
+  - libfuzzer
+  - honggfuzz
 sanitizers:
   - address
   - memory:


### PR DESCRIPTION
//cc @oerdnj

please see the failure with AFL here: https://github.com/google/oss-fuzz/runs/977415892?check_suite_focus=true

you should be able to reproduce it locally by running:

```
Running command: python /home/runner/work/oss-fuzz/oss-fuzz/infra/helper.py build_fuzzers bind9 --engine afl --sanitizer address --architecture x86_64
Running command: python /home/runner/work/oss-fuzz/oss-fuzz/infra/helper.py check_build bind9 --engine afl --sanitizer address --architecture x86_64
```