### PR TITLE
[bind9] Adjust the Dockerfile and build.sh for main branch

### DIFF
--- a/projects/bind9/Dockerfile
+++ b/projects/bind9/Dockerfile
@@ -29,6 +29,6 @@ RUN apt-get -y install		\
 	libuv1-dev		\
 	pkg-config		\
 	zip
-RUN git clone --depth 1 --branch ondrej/oss-fuzz https://gitlab.isc.org/isc-projects/bind9.git
+RUN git clone --depth 1 https://gitlab.isc.org/isc-projects/bind9.git
 WORKDIR bind9
 COPY build.sh $SRC/


### PR DESCRIPTION
This is the slight update of the bind9 fuzzing project:
* Uses main/HEAD branch (we merged the necessary changes on our side)
* Uses upstream-integrated support for ossfuzz