### PR TITLE
[bind9] Adjust the emails, so everybody on the team has access

### DIFF
--- a/projects/bind9/project.yaml
+++ b/projects/bind9/project.yaml
@@ -1,13 +1,15 @@
 homepage: "https://gitlab.isc.org/isc-projects/bind9"
 language: c
-primary_contact: "security-officer@isc.org"
+primary_contact: "bind9-dev@isc.org"
 auto_ccs:
-  - "ondrej@isc.org"
-  - "michal@isc.org"
-  - "marka@isc.org"
-  - "wpk@isc.org"
-  - "matthijs@isc.org"
   - "dfronza@isc.org"
+  - "each@isc.org"
+  - "marka@isc.org"
+  - "matthijs@isc.org"
+  - "michal@isc.org"
+  - "mnowak@isc.org"
+  - "ondrej@isc.org"
+  - "wpk@isc.org"
 sanitizers:
   - address
   - memory:


### PR DESCRIPTION
+ change the primary contact to the BIND 9 developers group alias,
instead of security-officer