### PR TITLE
[infra] Use 16 threads when building LLVM (#4270).

### DIFF
--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -15,7 +15,7 @@
 #
 ################################################################################
 
-NPROC=4  # TODO(#4270): remove or increase this depending on the build status.
+NPROC=16
 
 LLVM_DEP_PACKAGES="build-essential make cmake ninja-build git python2.7 g++-multilib"
 apt-get install -y $LLVM_DEP_PACKAGES

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -15,7 +15,7 @@
 #
 ################################################################################
 
-NPROC=16
+NPROC=16  # See issue #4270. The compiler crashes on GCB instance with 32 vCPUs.
 
 LLVM_DEP_PACKAGES="build-essential make cmake ninja-build git python2.7 g++-multilib"
 apt-get install -y $LLVM_DEP_PACKAGES


### PR DESCRIPTION
Since https://github.com/google/oss-fuzz/pull/4311 succeeded, now it's time to do some binary search in production!