### PR TITLE
[nodejs] Simplify build process as most work is now upstreamed.

### DIFF
--- a/projects/nodejs/Dockerfile
+++ b/projects/nodejs/Dockerfile
@@ -20,5 +20,3 @@ RUN apt-get install -y flex bison build-essential
 RUN git clone --recursive --depth 1 https://github.com/nodejs/node
 WORKDIR $SRC
 COPY build.sh $SRC/
-
-COPY fuzz_url.cc $SRC/

--- a/projects/nodejs/build.sh
+++ b/projects/nodejs/build.sh
@@ -22,4 +22,5 @@ export LD="$CXX"
 ./configure --experimental-quic --with-ossfuzz
 make -j$(nproc)
 
-cp /src/node/out/Release/fuzz_url ${OUT}/
+# Copy all fuzzers to OUT folder 
+cp out/Release/fuzz_* ${OUT}/

--- a/projects/nodejs/build.sh
+++ b/projects/nodejs/build.sh
@@ -19,28 +19,7 @@ cd $SRC/node
 # Build node
 export LDFLAGS="$CXXFLAGS"
 export LD="$CXX"
-./configure --without-intl --without-node-code-cache --without-dtrace --without-snapshot --without-ssl
+./configure --experimental-quic --with-ossfuzz
 make -j$(nproc)
 
-# Gather static libraries
-cd $SRC/node/out
-rm -rf ./library_files && mkdir library_files
-find . -name "*.a" -exec cp {} ./library_files/ \;
-
-# Build the fuzzers
-CMDS="-D__STDC_FORMAT_MACROS -D__POSIX__ -DNODE_HAVE_I18N_SUPPORT=1 \
- -DNODE_ARCH=\"x64\" -DNODE_PLATFORM=\"linux\" -DNODE_WANT_INTERNALS=1"
-INCLUDES="-I../src -I../deps/v8/include -I../deps/uv/include"
-
-# Compilation
-$CXX -o fuzz_url.o $SRC/fuzz_url.cc $CXXFLAGS $CMDS $INCLUDES \
-        -pthread -fno-omit-frame-pointer -fno-rtti -fno-exceptions -std=gnu++1y -MMD -c
-
-# Linking
-$CXX -o $OUT/fuzz_url $LIB_FUZZING_ENGINE $CXXFLAGS \
-  -rdynamic -Wl,-z,noexecstack,-z,relro,-z,now \
-  -pthread -Wl,--start-group \
-  ./Release/obj.target/cctest/src/node_snapshot_stub.o \
-  ./Release/obj.target/cctest/src/node_code_cache_stub.o \
-  fuzz_url.o ./library_files/*.a \
-  -latomic -lm -ldl -Wl,--end-group
+cp /src/node/out/Release/fuzz_url ${OUT}/

--- a/projects/nodejs/project.yaml
+++ b/projects/nodejs/project.yaml
@@ -1,6 +1,8 @@
 homepage: "https://nodejs.org"
 primary_contact: "security@nodejs.org"
 language: c++
+fuzzing_engines:
+  - libfuzzer
 sanitizers:
   - address
 auto_ccs:


### PR DESCRIPTION
The building process of nodejs fuzzers has been upstream (CR https://github.com/nodejs/node/pull/34761), in particular we now have a `--with-ossfuzz` configuration in Nodejs. 

This PR adjusts the oss-fuzz build for that.