### PR TITLE
[quic-go] add a fuzz target for QUIC transport parameters

### DIFF
--- a/projects/quic-go/build.sh
+++ b/projects/quic-go/build.sh
@@ -31,3 +31,4 @@ function compile_fuzzer {
 
 compile_fuzzer github.com/lucas-clemente/quic-go/fuzzing/frames Fuzz frame_fuzzer
 compile_fuzzer github.com/lucas-clemente/quic-go/fuzzing/header Fuzz header_fuzzer
+compile_fuzzer github.com/lucas-clemente/quic-go/fuzzing/transportparameters Fuzz transportparameter_fuzzer


### PR DESCRIPTION
https://github.com/lucas-clemente/quic-go/pull/2713 added a fuzzer for testing the parsing and the serialization of [QUIC transport parameters](https://tools.ietf.org/html/draft-ietf-quic-transport-29#section-7.4).

This PR adds the fuzz target to quic-go's build script.