### PR TITLE
[quic-go] add qpack

### DIFF
--- a/projects/quic-go/Dockerfile
+++ b/projects/quic-go/Dockerfile
@@ -16,6 +16,10 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 
+RUN go get -u -d github.com/marten-seemann/qpack/ && \
+  cd /root/go/src/github.com/marten-seemann/qpack && \
+  go build
+
 RUN go get -u -d github.com/lucas-clemente/quic-go/ && \
   cd /root/go/src/github.com/lucas-clemente/quic-go && \
   go build

--- a/projects/quic-go/build.sh
+++ b/projects/quic-go/build.sh
@@ -29,5 +29,9 @@ function compile_fuzzer {
   $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
 }
 
+# Fuzz qpack
+compile_fuzzer github.com/marten-seemann/qpack/fuzzing Fuzz qpack_fuzzer
+
+# Fuzz quic-go
 compile_fuzzer github.com/lucas-clemente/quic-go/fuzzing/frames Fuzz frame_fuzzer
 compile_fuzzer github.com/lucas-clemente/quic-go/fuzzing/header Fuzz header_fuzzer


### PR DESCRIPTION
[qpack](https://tools.ietf.org/html/draft-ietf-quic-qpack-16) is the protocol that HTTP/3 uses to compress request and response headers.

[marten-seemann/qpack](https://github.com/marten-seemann/qpack) is the library that powers qpack support in quic-go.