### PR TITLE
Compile + install LLVMgold.so so -flto works

### DIFF
--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -17,7 +17,7 @@
 
 NPROC=16  # See issue #4270. The compiler crashes on GCB instance with 32 vCPUs.
 
-LLVM_DEP_PACKAGES="build-essential make cmake ninja-build git python2.7 g++-multilib"
+LLVM_DEP_PACKAGES="build-essential make cmake ninja-build git python2.7 g++-multilib binutils-dev"
 apt-get install -y $LLVM_DEP_PACKAGES
 
 # Checkout
@@ -52,6 +52,7 @@ function cmake_llvm {
       -DCMAKE_BUILD_TYPE=Release \
       -DLLVM_TARGETS_TO_BUILD="$TARGET_TO_BUILD" \
       -DLLVM_ENABLE_PROJECTS="$PROJECTS_TO_BUILD" \
+      -DLLVM_BINUTILS_INCDIR="/usr/include/" \
       $extra_args \
       $LLVM_SRC/llvm
 }
@@ -109,6 +110,8 @@ case $(uname -m) in
 esac
 
 PROJECTS_TO_BUILD="libcxx;libcxxabi;compiler-rt;clang;lld"
+clang-tools-extra;libclc;libunwind;lld
+
 cmake_llvm
 ninja -j $NPROC
 

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -110,7 +110,6 @@ case $(uname -m) in
 esac
 
 PROJECTS_TO_BUILD="libcxx;libcxxabi;compiler-rt;clang;lld"
-clang-tools-extra;libclc;libunwind;lld
 
 cmake_llvm
 ninja -j $NPROC


### PR DESCRIPTION
As discussed in https://github.com/google/fuzzbench/issues/646

LLVMgold.so is already built by default with the clang target, however the binutil includes must be installed.
This requirement is well hidden in the LLVM documenation ...