### PR TITLE
projects/ghostscript: add contributor

### DIFF
--- a/projects/ghostscript/project.yaml
+++ b/projects/ghostscript/project.yaml
@@ -7,6 +7,7 @@ auto_ccs:
   - "sebastian.rasmussen@artifex.com"
   - "julians.artifex@gmail.com"
   - "chris.liddell@artifex.com"
+  - "kdlee@chromium.org"
 sanitizers:
   - address
   - memory


### PR DESCRIPTION
This change adds me (Kalvin) to the list of contributors allowed
to view Ghostscript issues on OSS-Fuzz.