### PR TITLE
Add stan project

### DIFF
--- a/projects/stan/project.yaml
+++ b/projects/stan/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/stan-dev/stanc3"
+primary_contact: "adamhaber@gmail.com"
+language: ocaml
+auto_ccs:
+  - "rb3234@columbia.edu"
+  - "rok.cesnovar@fri.uni-lj.si"


### PR DESCRIPTION
[Stan](https://mc-stan.org) is a state-of-the-art platform for statistical modeling and high-performance statistical computation. 

Stanc3 is the new Stan compiler. The compiler itself is written in OCaml, which isn't listed as one of the supported languages, but is supported by [AFL](https://github.com/NathanReb/ocaml-afl-examples). 