### PR TITLE
[envoy] fix envoy build

### DIFF
--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -64,9 +64,8 @@ done
 
 # Build driverless libraries.
 # Benchmark about 2 GB per CPU (14 threads for 28.8 GB RAM)
-# TODO(asraa): Remove deprecation warnings when Envoy moves to C++17
+# TODO(asraa): Remove deprecation warnings when Envoy and deps moves to C++17
 bazel build --verbose_failures --dynamic_mode=off --spawn_strategy=standalone \
-  --discard_analysis_cache --notrack_incremental_state --nokeep_state_after_build \
   --local_cpu_resources=HOST_CPUS*0.45 \
   --genrule_strategy=standalone --strip=never \
   --copt=-fno-sanitize=vptr --linkopt=-fno-sanitize=vptr \
@@ -74,7 +73,8 @@ bazel build --verbose_failures --dynamic_mode=off --spawn_strategy=standalone \
   --define ENVOY_CONFIG_ASAN=1 --copt -D__SANITIZE_ADDRESS__ \
   --copt -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS \
   --define force_libcpp=enabled --build_tag_filters=-no_asan \
-  --linkopt=-lc++ --linkopt=-pthread ${EXTRA_BAZEL_FLAGS} \
+  --cxxopt=-std=c++17 --linkopt=-lc++ \
+  --linkopt=-pthread ${EXTRA_BAZEL_FLAGS} \
   ${BAZEL_BUILD_TARGETS[*]} ${BAZEL_CORPUS_TARGETS[*]}
 
 # Profiling with coverage requires that we resolve+copy all Bazel symlinks and

--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -51,7 +51,7 @@ then
   # Bazel uses clang to link binary, which does not link clang_rt ubsan library for C++ automatically.
   # See issue: https://github.com/bazelbuild/bazel/issues/8777
   echo "--linkopt=\"$(find $(llvm-config --libdir) -name libclang_rt.ubsan_standalone_cxx-x86_64.a | head -1)\""
-else [ "$SANITIZER" = "address" ]
+else 
   echo "--copt -D__SANITIZE_ADDRESS__" "--copt -DADDRESS_SANITIZER=1"
 fi
 )"

--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -75,8 +75,7 @@ bazel build --verbose_failures --dynamic_mode=off --spawn_strategy=standalone \
   --define ENVOY_CONFIG_ASAN=1  \
   --copt -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS \
   --define force_libcpp=enabled --build_tag_filters=-no_asan \
-  --cxxopt=-std=c++17 --linkopt=-lc++ \
-  --linkopt=-pthread ${EXTRA_BAZEL_FLAGS} \
+  --linkopt=-lc++ --linkopt=-pthread ${EXTRA_BAZEL_FLAGS} \
   ${BAZEL_BUILD_TARGETS[*]} ${BAZEL_CORPUS_TARGETS[*]}
 
 # Profiling with coverage requires that we resolve+copy all Bazel symlinks and

--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -51,6 +51,8 @@ then
   # Bazel uses clang to link binary, which does not link clang_rt ubsan library for C++ automatically.
   # See issue: https://github.com/bazelbuild/bazel/issues/8777
   echo "--linkopt=\"$(find $(llvm-config --libdir) -name libclang_rt.ubsan_standalone_cxx-x86_64.a | head -1)\""
+else [ "$SANITIZER" = "address" ]
+  echo "--copt -D__SANITIZE_ADDRESS__" "--copt -DADDRESS_SANITIZER=1"
 fi
 )"
 
@@ -70,7 +72,7 @@ bazel build --verbose_failures --dynamic_mode=off --spawn_strategy=standalone \
   --genrule_strategy=standalone --strip=never \
   --copt=-fno-sanitize=vptr --linkopt=-fno-sanitize=vptr \
   --define tcmalloc=disabled --define signal_trace=disabled \
-  --define ENVOY_CONFIG_ASAN=1 --copt -D__SANITIZE_ADDRESS__ \
+  --define ENVOY_CONFIG_ASAN=1  \
   --copt -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS \
   --define force_libcpp=enabled --build_tag_filters=-no_asan \
   --cxxopt=-std=c++17 --linkopt=-lc++ \

--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -51,7 +51,8 @@ then
   # Bazel uses clang to link binary, which does not link clang_rt ubsan library for C++ automatically.
   # See issue: https://github.com/bazelbuild/bazel/issues/8777
   echo "--linkopt=\"$(find $(llvm-config --libdir) -name libclang_rt.ubsan_standalone_cxx-x86_64.a | head -1)\""
-else 
+elif [ "$SANITIZER" = "address" ]
+then
   echo "--copt -D__SANITIZE_ADDRESS__" "--copt -DADDRESS_SANITIZER=1"
 fi
 )"


### PR DESCRIPTION
Fix envoy build. A recent bump in our absl library along with changing to C++17 caused a build failure.

Tested this locally with undefined sanitizer, hoping to wait for address/undefined to pass on CI.

Signed-off-by: Asra Ali <asraa@google.com>