### PR TITLE
[openexr] fix memleak in scanlinefuzzer with wide images

### DIFF
--- a/projects/openexr/openexr_scanlines_fuzzer.cc
+++ b/projects/openexr/openexr_scanlines_fuzzer.cc
@@ -77,8 +77,10 @@ static void readMulti(IStream& is) {
       int w = dw.max.x - dw.min.x + 1;
       int dx = dw.min.x;
 
-      if (w > (1 << 24)) return;
-
+      if (w > (1 << 24))
+      {
+	      throw std::logic_error("ignoring - very wide datawindow\n");
+      }
       Array<Rgba> pixels(w);
       FrameBuffer i;
       i.insert("R", Slice(HALF, (char *)&(pixels[-dx].r), sizeof(Rgba), 0));


### PR DESCRIPTION
`return` was exiting `readMulti` without cleaning up, causing a memory leak (e.g. https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25148)
 