### PR TITLE
Build AFL++ in AFL builds and include in /out

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -133,8 +133,8 @@ RUN mkdir $PRECOMPILED_DIR
 WORKDIR $SRC
 
 RUN git clone -b stable https://github.com/google/AFL.git afl
-RUN git clone https://github.com/AFLplusplus/AFLplusplus.git && \
-    cd AFLplusplus && \
+RUN git clone https://github.com/AFLplusplus/AFLplusplus.git aflplusplus && \
+    cd aflplusplus && \
     git checkout 4a51cb71fb8785325dedac693cdea4648f6e5279
 
 ADD https://github.com/google/honggfuzz/archive/oss-fuzz.tar.gz $SRC/

--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -133,6 +133,9 @@ RUN mkdir $PRECOMPILED_DIR
 WORKDIR $SRC
 
 RUN git clone -b stable https://github.com/google/AFL.git afl
+RUN git clone https://github.com/AFLplusplus/AFLplusplus.git && \
+    cd AFLplusplus && \
+    git checkout 4a51cb71fb8785325dedac693cdea4648f6e5279
 
 ADD https://github.com/google/honggfuzz/archive/oss-fuzz.tar.gz $SRC/
 RUN mkdir honggfuzz && \

--- a/infra/base-images/base-builder/compile_afl
+++ b/infra/base-images/base-builder/compile_afl
@@ -20,6 +20,7 @@ echo -n "Compiling afl to $LIB_FUZZING_ENGINE ..."
 # afl needs its special coverage flags
 export COVERAGE_FLAGS="-fsanitize-coverage=trace-pc-guard"
 
+# Prepare AFL build.
 mkdir -p $WORK/afl
 pushd $WORK/afl > /dev/null
 # Add -Wno-pointer-sign to silence warning (AFL is compiled this way).
@@ -29,20 +30,27 @@ ar r $LIB_FUZZING_ENGINE $WORK/afl/*.o
 popd > /dev/null
 rm -rf $WORK/afl
 
-# Build and copy afl tools necessary for fuzzing.
-pushd $SRC/afl > /dev/null
-
 # Unset CFLAGS and CXXFLAGS while building AFL since we don't want to slow it
 # down with sanitizers.
 INITIAL_CXXFLAGS=$CXXFLAGS
 INITIAL_CFLAGS=$CFLAGS
 unset CXXFLAGS
 unset CFLAGS
-make clean && AFL_NO_X86=1 make
-CFLAGS=$INITIAL_CFLAGS
-CXXFLAGS=$INITIAL_CXXFLAGS
 
+# Build and copy afl tools necessary for fuzzing.
+pushd $SRC/afl > /dev/null
+make clean && AFL_NO_X86=1 make
 find . -name 'afl-*' -executable -type f | xargs cp -t $OUT
 popd > /dev/null
+
+pushd $SRC/aflplusplus > /dev/null
+make clean && AFL_NO_X86=1 make
+mkdir -p $OUT/aflplusplus
+find . -name 'afl-*' -executable -type f | xargs cp -t $OUT/aflplusplus
+popd > /dev/null
+
+
+CFLAGS=$INITIAL_CFLAGS
+CXXFLAGS=$INITIAL_CXXFLAGS
 
 echo " done."


### PR DESCRIPTION
This will allow us to use AFL++ in OSS-Fuzz alongside AFL.
This model may be used for other AFL variants in the future.
It does not make any changes to the build process. Everything should "just work".
However, since many of the benefits of AFL++ come from buildtime changes, we may want to change this.
Some of the buildtime changes, like laf-intel, should work with AFL.
Others, such as shared memory for mutated inputs, will not.
Related: #4280 