### PR TITLE
[uwebsockets] Use only libFuzzer for now

### DIFF
--- a/projects/uwebsockets/project.yaml
+++ b/projects/uwebsockets/project.yaml
@@ -6,3 +6,5 @@ sanitizers:
   - address
   - memory
   - undefined
+fuzzing_engines:
+   - libfuzzer


### PR DESCRIPTION
I'm getting 70% timeouts with AFL and I'm not impressed with its process spawning behavior. I much rather rely on libFuzzer which runs stable and well.