### PR TITLE
Fix samba build by including /etc/default/locale to set LANG=en_US.utf8

### DIFF
--- a/projects/samba/build.sh
+++ b/projects/samba/build.sh
@@ -15,5 +15,11 @@
 #
 ################################################################################
 
+# It is critical that this script, just as Samba's GitLab CI docker
+# has LANG set to en_US.utf8
+. /etc/default/locale
+export LANG
+export LC_ALL
+
 # The real script is maintained in the Samba repo
 exec lib/fuzzing/oss-fuzz/build_samba.sh


### PR DESCRIPTION
By invoking our build scripts under a login shell we pick up the locale we set up when we did the build_image step.

This fixes the Samba build in oss-fuzz, which seems to have been broken by a couple of untested changes on the oss-fuzz side.