### PR TITLE
[infra] Fix reproduce command invoking run_fuzzer for a single testcase (#4338).

### DIFF
--- a/infra/base-images/base-runner/reproduce
+++ b/infra/base-images/base-runner/reproduce
@@ -29,6 +29,7 @@ fi
 
 export RUN_FUZZER_MODE="interactive"
 export FUZZING_ENGINE="libfuzzer"
+export SKIP_SEED_CORPUS="1"
 export DO_NOT_USE_CORPUS="1"
 
 run_fuzzer $FUZZER $@ $TESTCASE

--- a/infra/base-images/base-runner/reproduce
+++ b/infra/base-images/base-runner/reproduce
@@ -30,6 +30,5 @@ fi
 export RUN_FUZZER_MODE="interactive"
 export FUZZING_ENGINE="libfuzzer"
 export SKIP_SEED_CORPUS="1"
-export DO_NOT_USE_CORPUS="1"
 
 run_fuzzer $FUZZER $@ $TESTCASE

--- a/infra/base-images/base-runner/reproduce
+++ b/infra/base-images/base-runner/reproduce
@@ -29,5 +29,6 @@ fi
 
 export RUN_FUZZER_MODE="interactive"
 export FUZZING_ENGINE="libfuzzer"
+export DO_NOT_USE_CORPUS="1"
 
 run_fuzzer $FUZZER $@ $TESTCASE

--- a/infra/base-images/base-runner/run_fuzzer
+++ b/infra/base-images/base-runner/run_fuzzer
@@ -67,6 +67,11 @@ rm -rf $CORPUS_DIR && mkdir $CORPUS_DIR
 rm -rf $FUZZER_OUT && mkdir $FUZZER_OUT
 
 SEED_CORPUS="${FUZZER}_seed_corpus.zip"
+
+if [ ! -z ${DO_NOT_USE_CORPUS:-} ]; then
+  SKIP_SEED_CORPUS=1
+fi
+
 if [ -f $SEED_CORPUS ] && [ -z ${SKIP_SEED_CORPUS:-} ]; then
   echo "Using seed corpus: $SEED_CORPUS"
   unzip -d ${CORPUS_DIR}/ $SEED_CORPUS > /dev/null
@@ -118,7 +123,11 @@ elif [[ "$FUZZING_ENGINE" = honggfuzz ]]; then
   # -n: number of fuzzing threads (and processes)
   CMD_LINE="$OUT/honggfuzz -n 1 --exit_upon_crash -R /tmp/${FUZZER}_honggfuzz.report -W $FUZZER_OUT -v -z -P -f \"$CORPUS_DIR\" $(get_dictionary) $* -- \"$OUT/$FUZZER\""
 else
-  CMD_LINE="$OUT/$FUZZER $FUZZER_ARGS $* $CORPUS_DIR"
+  CMD_LINE="$OUT/$FUZZER $FUZZER_ARGS $*"
+
+  if [ -z ${DO_NOT_USE_CORPUS:-} ]; then
+    CMD_LINE="$CMD_LINE $CORPUS_DIR"
+  fi
 
   if [ ! -z $CUSTOM_LIBFUZZER_OPTIONS ]; then
     CMD_LINE="$CMD_LINE $CUSTOM_LIBFUZZER_OPTIONS"

--- a/infra/base-images/base-runner/run_fuzzer
+++ b/infra/base-images/base-runner/run_fuzzer
@@ -68,10 +68,6 @@ rm -rf $FUZZER_OUT && mkdir $FUZZER_OUT
 
 SEED_CORPUS="${FUZZER}_seed_corpus.zip"
 
-if [ ! -z ${DO_NOT_USE_CORPUS:-} ]; then
-  SKIP_SEED_CORPUS=1
-fi
-
 if [ -f $SEED_CORPUS ] && [ -z ${SKIP_SEED_CORPUS:-} ]; then
   echo "Using seed corpus: $SEED_CORPUS"
   unzip -d ${CORPUS_DIR}/ $SEED_CORPUS > /dev/null

--- a/infra/base-images/base-runner/run_fuzzer
+++ b/infra/base-images/base-runner/run_fuzzer
@@ -121,7 +121,7 @@ elif [[ "$FUZZING_ENGINE" = honggfuzz ]]; then
 else
   CMD_LINE="$OUT/$FUZZER $FUZZER_ARGS $*"
 
-  if [ -z ${DO_NOT_USE_CORPUS:-} ]; then
+  if [ -z ${SKIP_SEED_CORPUS:-} ]; then
     CMD_LINE="$CMD_LINE $CORPUS_DIR"
   fi
 


### PR DESCRIPTION
```
$ python infra/helper.py reproduce lz4 decompress_fuzzer ~/Downloads/clusterfuzz-testcase-minimized-decompress_fuzzer-5720493764378624
Running: docker run --rm --privileged -i -v /usr/local/google/home/mmoroz/projects/oss-fuzz/build/out/lz4:/out -v /usr/local/google/home/mmoroz/Downloads/clusterfuzz-testcase-minimized-decompress_fuzzer-5720493764378624:/testcase -t gcr.io/oss-fuzz-base/base-runner reproduce decompress_fuzzer -runs=100

+ FUZZER=decompress_fuzzer
+ shift
+ '[' '!' -v TESTCASE ']'
+ TESTCASE=/testcase
+ '[' '!' -f /testcase ']'
+ export RUN_FUZZER_MODE=interactive
+ RUN_FUZZER_MODE=interactive
+ export FUZZING_ENGINE=libfuzzer
+ FUZZING_ENGINE=libfuzzer
+ export DO_NOT_USE_CORPUS=1
+ DO_NOT_USE_CORPUS=1
+ run_fuzzer decompress_fuzzer -runs=100 /testcase
/out/decompress_fuzzer -rss_limit_mb=2560 -timeout=25 -runs=100 /testcase < /dev/null
INFO: Seed: 1402304775
INFO: Loaded 1 modules   (5451 inline 8-bit counters): 5451 [0x8266e30, 0x826837b), 
INFO: Loaded 1 PC tables (5451 PCs): 5451 [0x821a610,0x8225068), 
/out/decompress_fuzzer: Running 1 inputs 100 time(s) each.
Running: /testcase
Executed /testcase in 1896 ms
***
*** NOTE: fuzzing was not performed, you have only
***       executed the target code on a fixed set of inputs.
***
