### PR TITLE
[graphicsfuzz-spirv] Disable project.

### DIFF
--- a/projects/graphicsfuzz-spirv/project.yaml
+++ b/projects/graphicsfuzz-spirv/project.yaml
@@ -16,3 +16,5 @@ sanitizers:
 architectures:
   - x86_64
   - i386
+
+disabled: True


### PR DESCRIPTION
It's broken now because ClusterFuzz's blackbox fuzzer model can't
support it.