### PR TITLE
[orbit] Initial integration

### DIFF
--- a/projects/orbit/project.yaml
+++ b/projects/orbit/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/google/orbit"
+language: c++
+primary_contact: "hebecker@google.com"
+auto_ccs :
+  - "orbitprofiler-eng+fuzztests@google.com"
+
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
Adding basic `project.yaml` file to request project acceptance.

Orbit (https://github.com/google/orbit) is an open-source CPU profiler
with special integration for the Stadia platform.