### PR TITLE
[php] Add execute fuzzer

### DIFF
--- a/projects/php/build.sh
+++ b/projects/php/build.sh
@@ -32,6 +32,7 @@ export CXXFLAGS="$CXXFLAGS -fno-sanitize=object-size"
 ./buildconf
 ./configure \
     --disable-all \
+    --enable-debug-assertions \
     --enable-option-checking=fatal \
     --enable-fuzzer \
     --enable-exif \
@@ -55,7 +56,8 @@ php-fuzz-exif
 php-fuzz-mbstring
 php-fuzz-unserialize
 php-fuzz-unserializehash
-php-fuzz-parser"
+php-fuzz-parser
+php-fuzz-execute"
 for fuzzerName in $FUZZERS; do
 	cp sapi/fuzzer/$fuzzerName $OUT/
 done


### PR DESCRIPTION
This adds an end-to-end fuzzer that executes arbitrary PHP code on a step-limited VM. I hope I don't drown in the number of issues this finds...

I'm also enabling debug assertions for the fuzzing builds. The execute fuzzer needs this because PHP may intentionally "leak" in non-assert builds. I think having the assertions would also be useful in general.