### PR TITLE
[libsndfile] Add libsndfile support

### DIFF
--- a/projects/libsndfile/Dockerfile
+++ b/projects/libsndfile/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN git clone --depth 1 https://github.com/erikd/libsndfile.git /src/libsndfile
+
+WORKDIR $SRC/libsndfile
+COPY build.sh $SRC/

--- a/projects/libsndfile/build.sh
+++ b/projects/libsndfile/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Run the OSS-Fuzz script in the project.
+./ossfuzz/ossfuzz.sh

--- a/projects/libsndfile/project.yaml
+++ b/projects/libsndfile/project.yaml
@@ -6,5 +6,4 @@ auto_ccs:
 sanitizers:
   - address
   - undefined
-  - memory:
-      experimental: true
+  - memory

--- a/projects/libsndfile/project.yaml
+++ b/projects/libsndfile/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/erikd/libsndfile"
+primary_contact: "evpobr@gmail.com"
+language: c
+auto_ccs:
+  - "cmeister2@gmail.com"
+sanitizers:
+  - address
+  - undefined
+  - memory:
+      experimental: true


### PR DESCRIPTION
This adds libsndfile support to ossfuzz.

libsndfile is a C library for reading and writing sound files containing sampled audio data. OSS-Fuzz support was requested in https://github.com/erikd/libsndfile/issues/476.