### PR TITLE
FIX: build failure of eigen

### DIFF
--- a/projects/eigen/Dockerfile
+++ b/projects/eigen/Dockerfile
@@ -16,6 +16,6 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install --yes cmake mercurial
-RUN hg clone https://GOOGLE-AUTOFUZZ@bitbucket.org/eigen/eigen
+RUN git clone https://GOOGLE-AUTOFUZZ@bitbucket.org/eigen/eigen
 WORKDIR eigen
 COPY build.sh *.cc $SRC/


### PR DESCRIPTION
This patch fixes build failure of `eigen`: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25063