### PR TITLE
[rnp] add more fuzzers and update build script.

### DIFF
--- a/projects/rnp/Dockerfile
+++ b/projects/rnp/Dockerfile
@@ -31,5 +31,5 @@ RUN apt-get install -y \
     wget
 
 RUN git clone --depth 1 https://github.com/rnpgp/rnp.git rnp
-WORKDIR rnp/..
+WORKDIR $SRC
 COPY build.sh $SRC/

--- a/projects/rnp/build.sh
+++ b/projects/rnp/build.sh
@@ -51,10 +51,11 @@ cmake \
     $SRC/rnp
 make -j$(nproc)
 
-FUZZERS="fuzz_dump fuzz_keyring"
+FUZZERS=`find src/fuzzing -maxdepth 1 -type f -name "fuzz_*" -exec basename {} \;`
+printf "Detected fuzzers: \n$FUZZERS\n"
 for f in $FUZZERS; do
     cp src/fuzzing/$f "${OUT}/"
-    chrpath -r '$ORIGIN/lib' "${OUT}/$f"
+    chrpath -r '$ORIGIN/lib' "${OUT}/$f" || echo "chrpath failed with $?, ignoring."
     zip -j -r "${OUT}/${f}_seed_corpus.zip" $SRC/fuzzing_corpus/
 done
 

--- a/projects/rnp/build.sh
+++ b/projects/rnp/build.sh
@@ -15,7 +15,7 @@
 #
 ################################################################################
 
-ORIG_DIR=$(pwd)
+cd $SRC
 
 wget -qO- https://botan.randombit.net/releases/Botan-2.12.1.tar.xz | tar xJ
 cd Botan-2.12.1
@@ -26,17 +26,16 @@ cd Botan-2.12.1
 make -j$(nproc)
 make install
 
-cd $ORIG_DIR
+cd $SRC
 mkdir fuzzing_corpus
 
-cd rnp/src/tests/data
-find . -type f -print0 | xargs -0 -I bob -- cp bob $ORIG_DIR/fuzzing_corpus/
-
-cd $ORIG_DIR
+cd $SRC/rnp/src/tests/data
+find . -type f -print0 | xargs -0 -I bob -- cp bob $SRC/fuzzing_corpus/
 
 # -DENABLE_SANITIZERS=0 because oss-fuzz will add the sanitizer flags in CFLAGS
 # See https://github.com/google/oss-fuzz/pull/4189 to explain CMAKE_C_LINK_EXECUTABLE
 
+cd $SRC
 mkdir rnp-build
 cd rnp-build
 cmake \
@@ -49,14 +48,14 @@ cmake \
     -DBUILD_SHARED_LIBS=on \
     -DBUILD_TESTING=off \
     -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
-    ../rnp/
+    $SRC/rnp
 make -j$(nproc)
 
 FUZZERS="fuzz_dump fuzz_keyring"
 for f in $FUZZERS; do
     cp src/fuzzing/$f "${OUT}/"
     chrpath -r '$ORIGIN/lib' "${OUT}/$f"
-    zip -j -r "${OUT}/${f}_seed_corpus.zip" $ORIG_DIR/fuzzing_corpus/
+    zip -j -r "${OUT}/${f}_seed_corpus.zip" $SRC/fuzzing_corpus/
 done
 
 mkdir -p "${OUT}/lib"

--- a/projects/rnp/build.sh
+++ b/projects/rnp/build.sh
@@ -23,7 +23,7 @@ cd Botan-2.12.1
                --disable-modules=locking_allocator \
                --unsafe-fuzzer-mode --build-fuzzers=libfuzzer \
                --with-fuzzer-lib='FuzzingEngine'
-make
+make -j$(nproc)
 make install
 
 cd $ORIG_DIR
@@ -50,7 +50,7 @@ cmake \
     -DBUILD_TESTING=off \
     -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
     ../rnp/
-make
+make -j$(nproc)
 
 FUZZERS="fuzz_dump fuzz_keyring"
 for f in $FUZZERS; do

--- a/projects/rnp/build.sh
+++ b/projects/rnp/build.sh
@@ -17,7 +17,7 @@
 
 ORIG_DIR=$(pwd)
 
-wget -qO- https://botan.randombit.net/releases/Botan-2.12.1.tar.xz | tar xvJ
+wget -qO- https://botan.randombit.net/releases/Botan-2.12.1.tar.xz | tar xJ
 cd Botan-2.12.1
 ./configure.py --prefix=/usr --cc-bin=$CXX --cc-abi-flags="$CXXFLAGS" \
                --disable-modules=locking_allocator \


### PR DESCRIPTION
This PR adds support for more fuzzers, added recently to rnp codebase.

Also it updates build script with following changes:
- remove some unneeded verbosity
- disable building of some modules in Botan
- stick to the $SRC folder when running commands
- detect fuzzers automatically instead of using hardcoded list
- use all available cores during make

@tomrittervg Could you please take a look whether it's ok?
Also I removed fuzzers building from the Botan, was it really needed?