### PR TITLE
FIX: build failure of tidb

### DIFF
--- a/projects/tidb/Dockerfile
+++ b/projects/tidb/Dockerfile
@@ -15,6 +15,6 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN go get github.com/pingcap/tidb/store
+RUN go get github.com/pingcap/tidb/tree/master/store
 COPY build.sh $SRC/
 WORKDIR $SRC/


### PR DESCRIPTION
This patch fixes build failure of `tidb`: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25010