### PR TITLE
fix the dependency of tidb

### DIFF
--- a/projects/tidb/Dockerfile
+++ b/projects/tidb/Dockerfile
@@ -15,6 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN go get github.com/pingcap/tidb/store
+ENV GO111MODULE=on
+RUN go get github.com/pingcap/tidb/store@master
 COPY build.sh $SRC/
 WORKDIR $SRC/


### PR DESCRIPTION
`Tidb` uses Go modules to manage dependency now, which means a `go.mod` file is used to declare module path and dependencies.
This patch fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25010