### PR TITLE
Add a blackbox field to project.yaml

### DIFF
--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -82,6 +82,7 @@ class ProjectYamlChecker:
   VALID_SECTION_NAMES = [
       'architectures',
       'auto_ccs',
+      'blackbox',
       'builds_per_day',
       'coverage_extra_args',
       'disabled',

--- a/projects/graphicsfuzz-spirv/project.yaml
+++ b/projects/graphicsfuzz-spirv/project.yaml
@@ -18,3 +18,4 @@ architectures:
   - i386
 
 disabled: True
+blackbox: true

--- a/projects/jsc/project.yaml
+++ b/projects/jsc/project.yaml
@@ -11,3 +11,4 @@ auto_ccs:
   - "jfb@chromium.org"
   - "sbarati@apple.com"
   - "ysuzuki@apple.com"
+blackbox: true

--- a/projects/quickjs/project.yaml
+++ b/projects/quickjs/project.yaml
@@ -6,3 +6,5 @@ auto_ccs :
 
 sanitizers:
 - address
+
+blackbox: true  # also use a blackbox fuzzer for this project.

--- a/projects/spidermonkey/project.yaml
+++ b/projects/spidermonkey/project.yaml
@@ -8,3 +8,4 @@ fuzzing_engines:
   - none
 sanitizers:
   - address
+blackbox: true


### PR DESCRIPTION
This is needed for CF to determine whether or not to allocate the
project on a higher end bot to run the blackbox fuzzer.

Previously this was keyed on the "none" entry under fuzzing_engines,
which wasn't very descriptive. This change also lets us do both blackbox
and greybox fuzzing in the same project using the engine (i.e. libFuzzer)
build, which wasn't possible before as the "none" engine does not link with
any engines.

The "none" entries and any other dependencies can be removed in a future PR,
to avoid complications with migration.