### PR TITLE
Adding Microsoft email to view libyuv bugs

### DIFF
--- a/projects/libyuv/project.yaml
+++ b/projects/libyuv/project.yaml
@@ -4,6 +4,9 @@ primary_contact: "mikhal@webrtc.org"
 auto_ccs:
     - "fbarchard@google.com"
     - "frkoenig@google.com"
+vendor_ccs:
+    - "ansgoel@microsoft.com"
+    - "jonorman@microsoft.com"
 fuzzing_engines:
     - libfuzzer
     - afl


### PR DESCRIPTION
Adding Microsoft email as vendor_ccs to view libyuv bugs