### PR TITLE
[libyuv] MJPEG codec fuzzer

### DIFF
--- a/projects/libyuv/Dockerfile
+++ b/projects/libyuv/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER david@adalogics.com
+
+RUN apt-get update && apt-get install -y make cmake
+RUN git clone https://chromium.googlesource.com/libyuv/libyuv
+RUN git clone https://github.com/libjpeg-turbo/libjpeg-turbo
+
+WORKDIR $SRC
+COPY build.sh $SRC/
+COPY fuzz_jpeg.cc $SRC/

--- a/projects/libyuv/build.sh
+++ b/projects/libyuv/build.sh
@@ -17,6 +17,8 @@
 # First install libjpeg
 cd libjpeg-turbo
 mkdir build && cd build
+export CFLAGS="$CFLAGS -fPIC"
+export CXXFLAGS="$CXXFLAGS -fPIC"
 cmake ..
 make
 

--- a/projects/libyuv/build.sh
+++ b/projects/libyuv/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+# First install libjpeg
+cd libjpeg-turbo
+mkdir build && cd build
+cmake ..
+make
+
+# Set include flags and HAVE_JPEG option
+export CFLAGS="$CFLAGS -I$PWD -I$PWD/.. -DHAVE_JPEG"
+export CXXFLAGS="$CXXFLAGS -I$PWD -I$PWD/.. -DHAVE_JPEG"
+
+# Install libyuv, make sure HAVE_JPEG is set
+cd $SRC/libyuv
+make libyuv.a -f linux.mk
+
+# Compile the fuzzer
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE -I./include -I./include/libyuv ./source/*.o \
+    $SRC/fuzz_jpeg.cc $SRC/libjpeg-turbo/build/libjpeg.a -o $OUT/fuzz_jpeg_decoder

--- a/projects/libyuv/fuzz_jpeg.cc
+++ b/projects/libyuv/fuzz_jpeg.cc
@@ -1,0 +1,12 @@
+#include <stddef.h>
+#include <stdint.h>
+#include "libyuv.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+  // Fuzz the mjpeg_decoder
+  libyuv::MJpegDecoder mjpeg_decoder;
+  mjpeg_decoder.LoadFrame(data, size);
+
+  return 0;
+}

--- a/projects/libyuv/fuzz_jpeg.cc
+++ b/projects/libyuv/fuzz_jpeg.cc
@@ -1,3 +1,19 @@
+/* Copyright 2020 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
 #include <stddef.h>
 #include <stdint.h>
 #include "libyuv.h"

--- a/projects/libyuv/project.yaml
+++ b/projects/libyuv/project.yaml
@@ -4,13 +4,7 @@ primary_contact: "mikhal@webrtc.org"
 auto_ccs:
     - "fbarchard@google.com"
     - "frkoenig@google.com"
+    - "david@adalogics.com"
 vendor_ccs:
     - "ansgoel@microsoft.com"
     - "jonorman@microsoft.com"
-fuzzing_engines:
-    - libfuzzer
-    - afl
-sanitizers:
-    - address
-    - memory
-    - undefined


### PR DESCRIPTION
MJPEG codec fuzzer for Libyuv. 

Notice this conflicts with the initial integration work over here: https://github.com/google/oss-fuzz/pull/4363 and am not interested in jumping in on other peoples work, so am happy to have this merged following the merge of https://github.com/google/oss-fuzz/pull/4363