### PR TITLE
Partially revert "[infra] Fix dataflow engine compilation for a speed up (#1632). (#3219)"

### DIFF
--- a/infra/base-images/base-builder/compile_dataflow
+++ b/infra/base-images/base-builder/compile_dataflow
@@ -15,7 +15,6 @@
 #
 ################################################################################
 
-export LIB_FUZZING_ENGINE="/usr/lib/DataFlow*.o"
 echo -n "Compiling DataFlow to $LIB_FUZZING_ENGINE... "
 mkdir -p $WORK/libfuzzer
 pushd $WORK/libfuzzer > /dev/null
@@ -25,7 +24,7 @@ $CXX $CXXFLAGS -fno-sanitize=all $SANITIZER_FLAGS -std=c++11 -O2 -c \
 $CXX $CXXFLAGS -fno-sanitize=all -fPIC -std=c++11 -O2 -c \
     $SRC/libfuzzer/dataflow/DataFlowCallbacks.cpp
 
-cp $WORK/libfuzzer/DataFlow*.o /usr/lib/
+ar r $LIB_FUZZING_ENGINE $WORK/libfuzzer/DataFlow*.o
 
 popd > /dev/null
 rm -rf $WORK/libfuzzer


### PR DESCRIPTION
CC @Dor1s

Relying on the fact that `LIB_FUZZING_ENGINE` will not be escaped and will
be interpreted as a glob by the build system seems counter-intuitive,
and actively prevents RawSpeed dataflow config from (just?) working.

NOTE that i haven't really tested this, i'm not familiar enough with this infra to understand
what i need to do to actually make infra use this updated script.
I believe it's within base image.

This partially reverts commit cbdc65515e579f769fd2570f234e95189cc315fd.