### PR TITLE
[rnp] Use patchelf instead of chrpath to add/change RPATH for fuzzers.

### DIFF
--- a/projects/rnp/Dockerfile
+++ b/projects/rnp/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get install -y \
     automake \
     libtool \
     cmake \
-    chrpath \
+    patchelf \
     libbz2-dev \
     zlib1g-dev \
     libjson-c-dev \

--- a/projects/rnp/build.sh
+++ b/projects/rnp/build.sh
@@ -55,7 +55,7 @@ FUZZERS=`find src/fuzzing -maxdepth 1 -type f -name "fuzz_*" -exec basename {} \
 printf "Detected fuzzers: \n$FUZZERS\n"
 for f in $FUZZERS; do
     cp src/fuzzing/$f "${OUT}/"
-    chrpath -r '$ORIGIN/lib' "${OUT}/$f" || echo "chrpath failed with $?, ignoring."
+    patchelf --set-rpath '$ORIGIN/lib' "${OUT}/$f" || echo "patchelf failed with $?, ignoring."
     zip -j -r "${OUT}/${f}_seed_corpus.zip" $SRC/fuzzing_corpus/
 done
 


### PR DESCRIPTION
C++ fuzzers are linked without rpath, so chrpath wasn't able to change it, while patchelf does.