### PR TITLE
Lint Python code for syntax errors and undefined names

### DIFF
--- a/.github/workflows/project_tests.yml
+++ b/.github/workflows/project_tests.yml
@@ -61,5 +61,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r infra/ci/requirements.txt
 
+      - name: Lint Python code for syntax errors and undefined names
+        run: |
+          python -m pip install --upgrade flake8
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+
       - name: Run project tests
         run: python infra/ci/build.py


### PR DESCRIPTION
`xrange()` was removed from Python on 1/1/2020.

Numeric literals starting with 0 are syntax errors in Python since 1/1/2020.

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.