### PR TITLE
[c-ares] Update build script for upstream changes

### DIFF
--- a/projects/c-ares/build.sh
+++ b/projects/c-ares/build.sh
@@ -15,12 +15,6 @@
 #
 ################################################################################
 
-# Remove -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION from CFLAGS
-# as a workaround for https://github.com/google/oss-fuzz/issues/413.
-# It's unclear why the c-ares configure is that picky;
-# a better fix would probably be in the c-ares build system.
-CFLAGS=$(for f in $CFLAGS; do [ $f != "-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION" ] && echo $f; done);
-
 # Build the project.
 ./buildconf
 ./configure --enable-debug
@@ -28,16 +22,16 @@ make clean
 make -j$(nproc) V=1 all
 
 # Build the fuzzers.
-$CC $CFLAGS -I. -c $SRC/c-ares/test/ares-test-fuzz.c -o $WORK/ares-test-fuzz.o
+$CC $CFLAGS -Iinclude -Isrc/lib -c $SRC/c-ares/test/ares-test-fuzz.c -o $WORK/ares-test-fuzz.o
 $CXX $CXXFLAGS -std=c++11 $WORK/ares-test-fuzz.o \
     -o $OUT/ares_parse_reply_fuzzer \
-    $LIB_FUZZING_ENGINE $SRC/c-ares/.libs/libcares.a
+    $LIB_FUZZING_ENGINE $SRC/c-ares/src/lib/.libs/libcares.a
 
-$CC $CFLAGS -I. -c $SRC/c-ares/test/ares-test-fuzz-name.c \
+$CC $CFLAGS -Iinclude -Isrc/lib -c $SRC/c-ares/test/ares-test-fuzz-name.c \
     -o $WORK/ares-test-fuzz-name.o
 $CXX $CXXFLAGS -std=c++11 $WORK/ares-test-fuzz-name.o \
     -o $OUT/ares_create_query_fuzzer \
-    $LIB_FUZZING_ENGINE $SRC/c-ares/.libs/libcares.a
+    $LIB_FUZZING_ENGINE $SRC/c-ares/src/lib/.libs/libcares.a
 
 # Archive and copy to $OUT seed corpus if the build succeeded.
 zip -j $OUT/ares_parse_reply_fuzzer_seed_corpus.zip $SRC/c-ares/test/fuzzinput/*

--- a/projects/c-ares/project.yaml
+++ b/projects/c-ares/project.yaml
@@ -5,12 +5,10 @@ fuzzing_engines:
   - afl
   - libfuzzer
   - honggfuzz
-  - dataflow
 sanitizers:
   - address
   - memory
   - undefined
-  - dataflow
 architectures:
   - x86_64
   - i386


### PR DESCRIPTION
Upstream https://github.com/c-ares/c-ares/pull/349 re-organized the
c-ares source tree, so update build.sh to find things in their new
places.

Also remove the CFLAGS workaround, which seems to be no longer needed
(and also seems to result in a malformed test/Makefile being generated).

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25566