### PR TITLE
[openexr] rewind streams between readSingle and readMulti

### DIFF
--- a/projects/openexr/openexr_deepscanlines_fuzzer.cc
+++ b/projects/openexr/openexr_deepscanlines_fuzzer.cc
@@ -164,10 +164,16 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   std::vector<char> buffer = stream.ConsumeRemainingBytes<char>();
 
   const std::string s(buffer.data(), buffer.size());
-  StdISStream is;
-  is.str(s);
 
-  readFileSingle(is, width, height);
-  readFileMulti(is);
+  {
+    StdISStream is;
+    is.str(s);
+    readFileSingle(is, width, height);
+  }
+  {
+    StdISStream is;
+    is.str(s);
+    readFileMulti(is);
+  }
   return 0;
 }

--- a/projects/openexr/openexr_deeptiles_fuzzer.cc
+++ b/projects/openexr/openexr_deeptiles_fuzzer.cc
@@ -165,12 +165,16 @@ static void readFileMulti(IStream& is) {
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   const std::string s(reinterpret_cast<const char*>(data), size);
-  StdISStream is;
-  is.str(s);
-
   Header::setMaxImageSize(10000, 10000);
-  readFileSingle(is);
-  readFileMulti(is);
-
+  {
+    StdISStream is;
+    is.str(s);
+    readFileSingle(is);
+  }
+  {
+    StdISStream is;
+    is.str(s);
+    readFileMulti(is);
+  }
   return 0;
 }

--- a/projects/openexr/openexr_scanlines_fuzzer.cc
+++ b/projects/openexr/openexr_scanlines_fuzzer.cc
@@ -97,10 +97,15 @@ static void readMulti(IStream& is) {
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   const std::string s(reinterpret_cast<const char*>(data), size);
-  StdISStream is;
-  is.str(s);
-
-  readSingle(is);
-  readMulti(is);
+  {
+    StdISStream is;
+    is.str(s);
+    readSingle(is);
+  }
+  {  
+    StdISStream is;
+    is.str(s);
+    readMulti(is);
+  }
   return 0;
 }


### PR DESCRIPTION
Some tests for OpenEXR have a 'readSingle' followed by a 'readMulti', but the stream pointer is not reset between reads, so readMulti tries to read  OpenEXR data directly after the data read by readSingle. Presumably the intention is that the stream only contains a single OpenEXR file, which should be read by readSingle, then again by readMulti. Re-initializing the input stream between calls should achieve that.

Signed-off-by: Peter Hillman <peter@pedro.kiwi>