### PR TITLE
[cryptofuzz] Subscribe mbed-tls-security

### DIFF
--- a/projects/cryptofuzz/project.yaml
+++ b/projects/cryptofuzz/project.yaml
@@ -31,6 +31,7 @@ auto_ccs:
     - "matthias.st.pierre@gmail.com"
     - "kaleb.himes@gmail.com"
     - "polubelovam@gmail.com"
+    - "mbed-tls-security@lists.trustedfirmware.org"
 sanitizers:
  - address
  - undefined


### PR DESCRIPTION
Subscribe Mbed TLS maintainers to cryptofuzz reports [at the invitation of Guido Vranken](https://github.com/ARMmbed/mbedtls/issues/3665#issuecomment-691302875-).
