### PR TITLE
capstone/keystone/unicorn: add to auto_ccs

### DIFF
--- a/projects/capstone/project.yaml
+++ b/projects/capstone/project.yaml
@@ -3,6 +3,7 @@ language: c++
 primary_contact: "capstone.engine@gmail.com"
 auto_ccs : 
   - "p.antoine@catenacyber.fr"
+  - "stalkr@stalkr.net"
 fuzzing_engines:
   - libfuzzer
   - afl

--- a/projects/keystone/project.yaml
+++ b/projects/keystone/project.yaml
@@ -3,7 +3,7 @@ language: c++
 primary_contact: "keystone.engine@gmail.com"
 auto_ccs :
   - "p.antoine@catenacyber.fr"
-
+  - "stalkr@stalkr.net"
 sanitizers:
   - address
   - memory

--- a/projects/unicorn/project.yaml
+++ b/projects/unicorn/project.yaml
@@ -4,6 +4,7 @@ primary_contact: "unicorn.emu@gmail.com"
 auto_ccs:
   - "p.antoine@catenacyber.fr"
   - "ch980501427@gmail.com"
+  - "stalkr@stalkr.net"
 fuzzing_engines:
   - libfuzzer
   - afl


### PR DESCRIPTION
Follow-up to #4451, I was just working on a couple reports for https://github.com/aquynh/capstone

 - https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=14912 fixed by aquynh/capstone#1684 & aquynh/capstone#1685

 - https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=22236 potential fix by aquynh/capstone#1687 & aquynh/capstone#1688

But I couldn't access the report because of permission denied:

> Detailed Report: https://oss-fuzz.com/testcase?key=5666610666012672

Adding to capstone but also related keystone/unicorn that I've been looking at.
I don't know what are the restrictions to be added to projects, so I'm trying this pull request.

Using my GSuite account (stalkr@stalkr.net), let's see if it works otherwise I also have a Gmail account (@gmail.com).

My Google CLA is up to date.

Thanks!