### PR TITLE
[libressl] Add standalone Cryptofuzz instance

### DIFF
--- a/projects/libressl/Dockerfile
+++ b/projects/libressl/Dockerfile
@@ -15,9 +15,11 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make cmake
+RUN apt-get update && apt-get install -y make cmake libboost-all-dev
 RUN git clone --depth 1 https://github.com/libressl-portable/portable.git libressl
 RUN git clone --depth 1 https://github.com/libressl-portable/fuzz.git libressl.fuzzers
+RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
+RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora
 WORKDIR libressl
 RUN ./update.sh
 COPY build.sh *.options $SRC/

--- a/projects/libressl/build.sh
+++ b/projects/libressl/build.sh
@@ -15,6 +15,10 @@
 # limitations under the License.
 #
 ################################################################################
+
+# Prevent Boost compilation error with -std=c++17
+export CXXFLAGS="$CXXFLAGS -D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR"
+
 mkdir -p $WORK/libressl
 cd $WORK/libressl
 
@@ -58,3 +62,26 @@ done
 cp $SRC/*.options $OUT/
 cp $LIBRESSL_FUZZERS/oids.txt $OUT/asn1.dict
 cp $LIBRESSL_FUZZERS/oids.txt $OUT/x509.dict
+
+# Cryptofuzz
+cd $SRC/cryptofuzz/
+if [[ $CFLAGS = *sanitize=memory* ]]
+then
+    export CXXFLAGS="$CXXFLAGS -DMSAN"
+fi
+# Generate lookup tables
+python3 gen_repository.py
+# Compile Cryptofuzz LibreSSL module
+cd $SRC/cryptofuzz/modules/openssl
+OPENSSL_INCLUDE_PATH="$SRC/libressl/include" OPENSSL_LIBCRYPTO_A_PATH="$WORK/libressl/crypto/libcrypto.a" CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_LIBRESSL" make
+# Compile Cryptofuzz
+cd $SRC/cryptofuzz/
+LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_LIBRESSL -I $SRC/libressl/include" make -j$(nproc)
+# Generate dictionary
+./generate_dict
+# Copy fuzzer
+cp $SRC/cryptofuzz/cryptofuzz $OUT/cryptofuzz
+# Copy dictionary
+cp $SRC/cryptofuzz/cryptofuzz-dict.txt $OUT/cryptofuzz.dict
+# Copy seed corpus
+cp $SRC/cryptofuzz-corpora/libressl_latest.zip $OUT/cryptofuzz_seed_corpus.zip

--- a/projects/libressl/project.yaml
+++ b/projects/libressl/project.yaml
@@ -7,6 +7,7 @@ auto_ccs:
  - "kinichiro.inoguchi@gmail.com"
  - "ted.unangst@gmail.com"
  - "miwaxe@gmail.com"
+ - "guidovranken@gmail.com"
 sanitizers:
  - address
  - undefined


### PR DESCRIPTION
The LibreSSL team and I have decided to

- Integrate a standalone version of Cryptofuzz into the OSS-Fuzz libressl project
- Add me to the CC list of this project

Reasons for this are:

- Unlike https://github.com/guidovranken/cryptofuzz , which sends a report for every bug in any library to each of the subscribers, this will only send a report if there is a bug in LibreSSL, so no "false positives"
- While https://github.com/guidovranken/cryptofuzz has to divide its CPU time between 10+ libraries, this standalone integration can focus entirely on LibreSSL, probably resulting in a more code coverage (and likelihood of finding bugs)

I will not apply to receive any integration reward for this PR or subsequent maintenance.

Can someone from LibreSSL please confirm this to the OSS-Fuzz team?