### PR TITLE
SOF: add project yaml

### DIFF
--- a/projects/sound-open-firmware/project.yaml
+++ b/projects/sound-open-firmware/project.yaml
@@ -1,0 +1,5 @@
+homepage: "https://thesofproject.github.io"
+primary_contact: "cujomalainey@chromium.org"
+language: c
+auto_ccs:
+  - "ranjani.sridharan@intel.corp-partner.google.com"


### PR DESCRIPTION
Sound open firmware is audio firmware for Intel and NXP systems and
therefore is safety critical for systems everywhere

Fixes https://github.com/thesofproject/sof/issues/3388