### PR TITLE
[wolfssl] Add more wolfSSL and wolfSSH fuzzers

### DIFF
--- a/projects/wolfssl/Dockerfile
+++ b/projects/wolfssl/Dockerfile
@@ -18,6 +18,9 @@ FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN apt-get update && apt-get install -y make autoconf automake libtool zip
 RUN git clone https://github.com/wolfssl/wolfssl --depth 1 $SRC/wolfssl
+RUN git clone --depth 1 https://github.com/wolfSSL/wolfssh.git
+RUN git clone --depth 1 https://github.com/guidovranken/fuzzing-headers.git
+RUN git clone --depth 1 https://github.com/guidovranken/wolf-ssl-ssh-fuzzers
 RUN git clone https://github.com/wolfssl/oss-fuzz-targets --depth 1 $SRC/fuzz-targets
 
 WORKDIR wolfssl

--- a/projects/wolfssl/build.sh
+++ b/projects/wolfssl/build.sh
@@ -15,6 +15,12 @@
 #
 ################################################################################
 
+NEW_SRC=$SRC/wolf-ssl-ssh-fuzzers/oss-fuzz/projects/wolf-ssl-ssh/
+cp -R $SRC/wolfssl/ $NEW_SRC
+cp -R $SRC/wolfssh/ $NEW_SRC
+cp -R $SRC/fuzzing-headers/ $NEW_SRC
+OSS_FUZZ_BUILD=1 SRC="$NEW_SRC" $NEW_SRC/build.sh
+
 # target_dir determined by Dockerfile
 target_dir="$SRC/fuzz-targets"
 

--- a/projects/wolfssl/build.sh
+++ b/projects/wolfssl/build.sh
@@ -15,11 +15,14 @@
 #
 ################################################################################
 
-NEW_SRC=$SRC/wolf-ssl-ssh-fuzzers/oss-fuzz/projects/wolf-ssl-ssh/
-cp -R $SRC/wolfssl/ $NEW_SRC
-cp -R $SRC/wolfssh/ $NEW_SRC
-cp -R $SRC/fuzzing-headers/ $NEW_SRC
-OSS_FUZZ_BUILD=1 SRC="$NEW_SRC" $NEW_SRC/build.sh
+if [[ $CFLAGS != *sanitize=dataflow* ]]
+then
+    NEW_SRC=$SRC/wolf-ssl-ssh-fuzzers/oss-fuzz/projects/wolf-ssl-ssh/
+    cp -R $SRC/wolfssl/ $NEW_SRC
+    cp -R $SRC/wolfssh/ $NEW_SRC
+    cp -R $SRC/fuzzing-headers/ $NEW_SRC
+    OSS_FUZZ_BUILD=1 SRC="$NEW_SRC" $NEW_SRC/build.sh
+fi
 
 # target_dir determined by Dockerfile
 target_dir="$SRC/fuzz-targets"

--- a/projects/wolfssl/project.yaml
+++ b/projects/wolfssl/project.yaml
@@ -7,6 +7,7 @@ auto_ccs:
   - "kaleb.himes@gmail.com"
   - "levi@wolfssl.com"
   - "testing@wolfssl.com"
+  - "guidovranken@gmail.com"
 fuzzing_engines:
   - libfuzzer
   - afl


### PR DESCRIPTION
This adds the targets residing in https://github.com/guidovranken/wolf-ssl-ssh-fuzzers

The following targets are built:

```
fuzzer-wolfssh-client
fuzzer-wolfssh-client-randomize
fuzzer-wolfssh-server
fuzzer-wolfssh-server-randomize
fuzzer-wolfssl-client
fuzzer-wolfssl-client-randomize
fuzzer-wolfssl-crl
fuzzer-wolfssl-misc
fuzzer-wolfssl-ocsp
fuzzer-wolfssl-rsa
fuzzer-wolfssl-server
fuzzer-wolfssl-server-randomize
fuzzer-wolfssl-srp
fuzzer-wolfssl-x509
```

The `*-randomize` client/server targets emulate allocation and IO failures, whereas those without `*-randomize` do not. This is a trade-off between rate of code coverage increase and catching corner cases. Both have their merits, hence two targets for each client and server.

These scripts will be fetched and executed during the build:

https://github.com/guidovranken/wolf-ssl-ssh-fuzzers/blob/master/oss-fuzz/projects/wolf-ssl-ssh/build.sh
https://github.com/guidovranken/wolf-ssl-ssh-fuzzers/blob/master/oss-fuzz/projects/wolf-ssl-ssh/build_wolfssl_fuzzers.sh
https://github.com/guidovranken/wolf-ssl-ssh-fuzzers/blob/master/oss-fuzz/projects/wolf-ssl-ssh/build_wolfssh_fuzzers.sh

I am consulting for wolfSSL and this integration was approved by @toddouska of wolfSSL.

@JacobBarthelmeh or @toddouska can you please confirm this to OSS-Fuzz?

