### PR TITLE
Revert "[usrsctp] Switch to main sctplab repository."

### DIFF
--- a/projects/usrsctp/Dockerfile
+++ b/projects/usrsctp/Dockerfile
@@ -16,6 +16,6 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make cmake
-RUN git clone --depth 1 https://github.com/sctplab/usrsctp usrsctp
+RUN git clone --depth 1 --branch oss-fuzz https://github.com/weinrank/usrsctp usrsctp
 WORKDIR usrsctp
 COPY build.sh $SRC/


### PR DESCRIPTION
This reverts commit 5a37b6c8bfabe5de60c1c57916c5312226025b21.

Build is failing due to <sys/random.h> include in user_environment.c;
will fix upstream before attempting to reland.