### PR TITLE
[cryptofuzz] Add crypto-js

### DIFF
--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -54,6 +54,7 @@ RUN wget https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.5.0.ta
 RUN git clone --depth 1 https://github.com/indutny/bn.js.git
 RUN git clone --depth 1 https://github.com/MikeMcl/bignumber.js.git
 RUN git clone --depth 1 https://github.com/guidovranken/libfuzzer-js.git
+RUN git clone --depth 1 https://github.com/brix/crypto-js.git
 RUN apt-get remove -y libunwind8
 RUN apt-get install -y libssl-dev
 

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -83,6 +83,11 @@ then
     export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_BIGNUMBER_JS"
     cd $SRC/cryptofuzz/modules/bignumber.js/
     make
+
+    export CRYPTO_JS_PATH="$SRC/crypto-js/"
+    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_CRYPTO_JS"
+    cd $SRC/cryptofuzz/modules/crypto-js/
+    make
 fi
 
 # Compile NSS


### PR DESCRIPTION
[crypto-js](https://github.com/brix/crypto-js) is a widely used (10K+ GH stars, 4K+ first-grade reverse NPM dependencies) JavaScript cryptographic library.