### PR TITLE
[envoy] fix envoy coverage

### DIFF
--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -66,10 +66,10 @@ do
 done
 
 # Build driverless libraries.
-# Benchmark about 2 GB per CPU (14 threads for 28.8 GB RAM)
+# Benchmark about 3 GB per CPU (10 threads for 28.8 GB RAM)
 # TODO(asraa): Remove deprecation warnings when Envoy and deps moves to C++17
 bazel build --verbose_failures --dynamic_mode=off --spawn_strategy=standalone \
-  --local_cpu_resources=HOST_CPUS*0.45 \
+  --local_cpu_resources=HOST_CPUS*0.32 \
   --genrule_strategy=standalone --strip=never \
   --copt=-fno-sanitize=vptr --linkopt=-fno-sanitize=vptr \
   --define tcmalloc=disabled --define signal_trace=disabled \

--- a/projects/envoy/project.yaml
+++ b/projects/envoy/project.yaml
@@ -13,12 +13,7 @@ auto_ccs:
   - "asraa@google.com"
   - "adip@google.com"
   - "avd@google.com"
-  - "akonradi@google.com"
-  - "liebchen@google.com"
-  - "samflattery@google.com"
-  - "jianwendong@google.com"
   - "skerner@google.com"
-  - "arthuryan@google.com"
   - "rdsmith@google.com"
   - "zasweq@google.com"
 coverage_extra_args: -ignore-filename-regex=.*\.cache.*envoy_deps_cache.*


### PR DESCRIPTION
Envoy's coverage works locally for me (pull_images, build --sanitizer coverage), but fails upstream. Provision more memory as a fix.

Also remove interns/old hosts

Signed-off-by: Asra Ali <asraa@google.com>