### PR TITLE
[openexr] add support for integrated openexr_exrcheck_fuzzer

### DIFF
--- a/projects/openexr/build.sh
+++ b/projects/openexr/build.sh
@@ -33,6 +33,7 @@ ar -qc $WORK/OpenEXR/libOpenexrUtils.a $(find $WORK/ -name "*.o")
 INCLUDES=(
   "-I $SRC"
   "-I $SRC/openexr/OpenEXR/IlmImf"
+  "-I $SRC/openexr/OpenEXR/IlmImfUtil"
   "-I $SRC/openexr/OpenEXR/exrenvmap"
   "-I $SRC/openexr/IlmBase/Imath"
   "-I $SRC/openexr/IlmBase/Iex"
@@ -50,7 +51,7 @@ LIBS=(
   "$WORK/OpenEXR/libOpenexrUtils.a"
 )
 
-for fuzzer in $SRC/*_fuzzer.cc; do
+for fuzzer in $SRC/*_fuzzer.cc $SRC/openexr/OpenEXR/IlmImfFuzzTest/oss-fuzz/*_fuzzer.cc; do
   fuzzer_basename=$(basename -s .cc $fuzzer)
   $CXX $CXXFLAGS -std=c++11 -pthread ${INCLUDES[@]} $fuzzer $LIB_FUZZING_ENGINE ${LIBS[@]} -lz \
     -o $OUT/$fuzzer_basename


### PR DESCRIPTION
OpenEXR master now has its own integrated tester, [openexr_exrcheck_fuzzer.cc](https://github.com/AcademySoftwareFoundation/openexr/tree/master/OpenEXR/IlmImfFuzzTest/oss-fuzz). It also compiles a binary, [exrcheck](https://github.com/AcademySoftwareFoundation/openexr/tree/master/OpenEXR/exrcheck), that should help to debug issues without needing the oss-fuzz framework.
This changes build.sh to build that the integrated tester as well the existing ones. As exrcheck is intended to be a fairly complete single test, so in theory the other tests could be removed

Signed-off-by: Peter Hillman <peter@pedro.kiwi>