### PR TITLE
[go-ethereum] Initial integration

### DIFF
--- a/projects/go-ethereum/Dockerfile
+++ b/projects/go-ethereum/Dockerfile
@@ -1,0 +1,43 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN go get github.com/ethereum/go-ethereum
+RUN go get golang.org/x/sys/cpu
+RUN go get github.com/go-stack/stack
+RUN go get github.com/deckarep/golang-set
+RUN go get github.com/golang/snappy
+RUN go get github.com/gorilla/websocket
+RUN go get github.com/hashicorp/golang-lru
+RUN go get github.com/holiman/uint256
+RUN go get github.com/olekukonko/tablewriter
+RUN go get github.com/prometheus/tsdb/fileutil
+RUN go get github.com/shirou/gopsutil/cpu
+RUN go get github.com/steakknife/bloomfilter
+RUN go get github.com/syndtr/goleveldb/leveldb
+RUN go get github.com/syndtr/goleveldb/leveldb/errors
+RUN go get github.com/syndtr/goleveldb/leveldb/filter
+RUN go get github.com/syndtr/goleveldb/leveldb/opt
+RUN go get github.com/syndtr/goleveldb/leveldb/util
+RUN go get github.com/VictoriaMetrics/fastcache
+RUN go get github.com/aristanetworks/goarista/monotime
+RUN go get github.com/pborman/uuid
+RUN go get github.com/rjeczalik/notify
+RUN go get github.com/google/gofuzz
+ 
+COPY build.sh $SRC/
+WORKDIR $SRC/

--- a/projects/go-ethereum/build.sh
+++ b/projects/go-ethereum/build.sh
@@ -1,0 +1,44 @@
+#/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+function compile_fuzzer {
+  path=$1
+  function=$2
+  fuzzer=$3
+
+  go-fuzz -func $function -o $fuzzer.a $path
+
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
+}
+
+cd $GOPATH/src/github.com/ethereum/go-ethereum
+make all
+
+cd $SRC
+
+
+compile_fuzzer github.com/ethereum/go-ethereum/common/bitutil Fuzz fuzzBitutilCompress
+compile_fuzzer github.com/ethereum/go-ethereum/crypto/bn256 FuzzAdd fuzzAdd
+compile_fuzzer github.com/ethereum/go-ethereum/crypto/bn256 FuzzMul fuzzMul
+compile_fuzzer github.com/ethereum/go-ethereum/crypto/bn256 FuzzPair fuzzPair
+compile_fuzzer github.com/ethereum/go-ethereum/core/vm/runtime Fuzz fuzzVmRuntime
+compile_fuzzer github.com/ethereum/go-ethereum/crypto/blake2b Fuzz fuzzBlake2b
+compile_fuzzer github.com/ethereum/go-ethereum/tests/fuzzers/keystore Fuzz fuzzKeystore
+compile_fuzzer github.com/ethereum/go-ethereum/tests/fuzzers/txfetcher Fuzz fuzzTxfetcher
+#compile_fuzzer github.com/ethereum/go-ethereum/tests/fuzzers/abi Fuzz fuzzAbi
+compile_fuzzer github.com/ethereum/go-ethereum/tests/fuzzers/rlp Fuzz fuzzRlp
+compile_fuzzer github.com/ethereum/go-ethereum/tests/fuzzers/trie Fuzz fuzzTrie
+

--- a/projects/go-ethereum/project.yaml
+++ b/projects/go-ethereum/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://github.com/ethereum/go-ethereum"
+primary_contact: "Adam@adalogics.com"
+auto_ccs :
+  - "adam@adalogics.com"
+  - "fjl@ethereum.org"
+  - "martin.swende@ethereum.org"
+  - "peter@ethereum.org"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
This PR adds initial integration of [go-ethereum](https://github.com/ethereum/go-ethereum), the official Golang implementation of the Ethereum protocol.

The following maintainers have been added to receive potential bug reports: @fjl @holiman @karalabe

A few notes for the go-ethereum maintainers: 
1. Upon integration, you will get access to the dashboard to monitor performance of the fuzzers. If bugs are found, you will receive emails with links to detailed bug reports.
2. I have added myself as cc for the bug reports. This means that I will have access to all reports for bugs and vulnerabilities found by the fuzzers through oss-fuzz. The reason I have added myself is to keep an eye on the performance on the fuzzers for a bit and step in if adjustments are needed. If you prefer me off the list, please let me know in a comment below. If not, I will remove my email address from the cc-list once the fuzzers are confirmed to run effectively on the platform. If you are fine with me being on the list for now, please leave a confirmation in a comment for the oss-fuzz team to see.
3. You can see in `build.sh` that the abi-fuzzer is left out for now. This is because it compiles fine but breaks immediately when running.
4. I suggest moving the build script to the upstream repository in a few weeks. It will then be easier to deal with issues like #3 above. I will be happy to do it as part of removing myself from the cc-list.