### PR TITLE
wrapper_utils.py: SyntaxError leading zeros in decimal integer literals

### DIFF
--- a/.github/workflows/infra_tests.yml
+++ b/.github/workflows/infra_tests.yml
@@ -14,16 +14,11 @@ jobs:
           git fetch origin master --depth 1
           git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master
 
-      - name: Setup python environment
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r infra/ci/requirements.txt
-          pip install -r infra/build/functions/requirements.txt
+          python3 -m pip install --upgrade pip setuptools
+          python3 -m pip install -r infra/ci/requirements.txt
+          python3 -m pip install -r infra/build/functions/requirements.txt
 
       - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
@@ -33,6 +28,4 @@ jobs:
           gcloud info
 
       - name: Run infra tests
-        run: python infra/presubmit.py infra-tests
-
-
+        run: python3 infra/presubmit.py infra-tests

--- a/.github/workflows/infra_tests.yml
+++ b/.github/workflows/infra_tests.yml
@@ -14,11 +14,16 @@ jobs:
           git fetch origin master --depth 1
           git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master
 
+      - name: Setup python environment
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
       - name: Install dependencies
         run: |
-          python3 -m pip install --upgrade pip setuptools
-          python3 -m pip install -r infra/ci/requirements.txt
-          python3 -m pip install -r infra/build/functions/requirements.txt
+          python -m pip install --upgrade pip
+          pip install -r infra/ci/requirements.txt
+          pip install -r infra/build/functions/requirements.txt
 
       - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
@@ -28,4 +33,6 @@ jobs:
           gcloud info
 
       - name: Run infra tests
-        run: python3 infra/presubmit.py infra-tests
+        run: python infra/presubmit.py infra-tests
+
+

--- a/infra/base-images/base-sanitizer-libs-builder/wrapper_utils.py
+++ b/infra/base-images/base-sanitizer-libs-builder/wrapper_utils.py
@@ -14,33 +14,34 @@
 # limitations under the License.
 #
 ################################################################################
-
+"""
+wrapper_utils.py: Utilities for wrapping
+"""
 from __future__ import print_function
 
-import contextlib
 import os
 import subprocess
 
 
-def DpkgHostArchitecture():
+def dpkg_host_architecture():
   """Return the host architecture."""
-  return subprocess.check_output(
-      ['dpkg-architecture', '-qDEB_HOST_GNU_TYPE']).strip()
+  return subprocess.check_output(['dpkg-architecture',
+                                  '-qDEB_HOST_GNU_TYPE']).strip()
 
 
-def InstallWrapper(bin_dir, name, contents, extra_names=None):
+def install_wrapper(bin_dir, name, contents, extra_names=None):
   """Install a custom wrapper script into |bin_dir|."""
   path = os.path.join(bin_dir, name)
-  with open(path, 'w') as f:
-    f.write(contents)
+  with open(path, 'w') as out_file:
+    out_file.write(contents)
 
-  os.chmod(path, 0755)
+  os.chmod(path, 0o755)
 
   if extra_names:
-    CreateSymlinks(path, bin_dir, extra_names)
+    create_symlinks(path, bin_dir, extra_names)
 
 
-def CreateSymlinks(original_path, bin_dir, extra_names):
+def create_symlinks(original_path, bin_dir, extra_names):
   """Create symlinks."""
   for extra_name in extra_names:
     extra_path = os.path.join(bin_dir, extra_name)


### PR DESCRIPTION
Python 3 SyntaxError: leading zeros in decimal integer literals are not permitted; use an 0o prefix for octal integers.

This PR required an alarming number of changes just to add a single `o` from `0755` --> `0o755`.

The failing test (`import apt`) is fixed in #4520