### PR TITLE
nettle.py: SyntaxError leading zeros in decimal integer literals

### DIFF
--- a/infra/base-images/base-sanitizer-libs-builder/packages/nettle.py
+++ b/infra/base-images/base-sanitizer-libs-builder/packages/nettle.py
@@ -21,14 +21,14 @@ import shutil
 import package
 
 
-def AddNoAsmArg(config_path):
+def add_no_asm_arg(config_path):
   """Add --disable-assembler to config scripts."""
   shutil.move(config_path, config_path + '.real')
-  with open(config_path, 'w') as f:
-    f.write(
+  with open(config_path, 'w') as out_file:
+    out_file.write(
         '#!/bin/sh\n'
         '%s.real --disable-assembler "$@"\n' % config_path)
-  os.chmod(config_path, 0755)
+  os.chmod(config_path, 0o755)
 
 
 class Package(package.Package):
@@ -37,5 +37,6 @@ class Package(package.Package):
   def __init__(self, apt_version):
     super(Package, self).__init__('nettle', apt_version)
 
-  def PreBuild(self, source_directory, env, custom_bin_dir):
-    AddNoAsmArg(os.path.join(source_directory, 'configure'))
+  def pre_build(self, source_directory, env, custom_bin_dir):
+    """ pre_build() """
+    add_no_asm_arg(os.path.join(source_directory, 'configure'))

--- a/infra/base-images/base-sanitizer-libs-builder/packages/nettle.py
+++ b/infra/base-images/base-sanitizer-libs-builder/packages/nettle.py
@@ -14,7 +14,9 @@
 # limitations under the License.
 #
 ################################################################################
-
+"""
+nettle.py
+"""
 import os
 import shutil
 
@@ -25,18 +27,18 @@ def add_no_asm_arg(config_path):
   """Add --disable-assembler to config scripts."""
   shutil.move(config_path, config_path + '.real')
   with open(config_path, 'w') as out_file:
-    out_file.write(
-        '#!/bin/sh\n'
-        '%s.real --disable-assembler "$@"\n' % config_path)
+    out_file.write('#!/bin/sh\n'
+                   '%s.real --disable-assembler "$@"\n' % config_path)
   os.chmod(config_path, 0o755)
 
 
-class Package(package.Package):
+class Package(package.Package):  # pylint: disable=too-few-public-methods
   """nettle package."""
 
   def __init__(self, apt_version):
     super(Package, self).__init__('nettle', apt_version)
 
+  # pylint: disable=no-self-use,unused-argument
   def pre_build(self, source_directory, env, custom_bin_dir):
     """ pre_build() """
     add_no_asm_arg(os.path.join(source_directory, 'configure'))


### PR DESCRIPTION
Python 3 SyntaxError: leading zeros in decimal integer literals are not permitted; use an 0o prefix for octal integers.

This PR required an alarming number of changes just to add a single `o` from `0755` --> `0o755`.