### PR TITLE
sound-open-firmware: add build files

### DIFF
--- a/projects/sound-open-firmware/Dockerfile
+++ b/projects/sound-open-firmware/Dockerfile
@@ -1,0 +1,58 @@
+# Copyright 2020 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+#
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN apt-get -y update && \
+	    apt-get install -y \
+	    	autoconf \
+		bison \
+		build-essential \
+		flex \
+		gawk \
+		gettext \
+		git \
+		gperf \
+		help2man \
+		libncurses5-dev \
+		libssl-dev \
+		libtool \
+		libtool-bin \
+		pkg-config \
+		software-properties-common \
+		texinfo \
+		udev \
+		cmake \
+		libglib2.0-dev
+
+ARG CLONE_DEFAULTS="--depth 5"
+
+# Use ToT alsa utils for the latest topology patches.
+RUN cd /tmp && \
+git clone $CLONE_DEFAULTS https://github.com/thesofproject/alsa-lib.git && \
+git clone $CLONE_DEFAULTS https://github.com/thesofproject/alsa-utils.git && \
+cd /tmp/alsa-lib && ./gitcompile &&  make install && \
+cd /tmp/alsa-utils && ./gitcompile &&  make install
+
+ARG GITHUB_SOF=https://github.com/thesofproject
+
+RUN cd $SRC && git clone $CLONE_DEFAULTS $GITHUB_SOF/sof
+WORKDIR sof
+COPY build.sh $SRC/

--- a/projects/sound-open-firmware/build.sh
+++ b/projects/sound-open-firmware/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -eux
+# Copyright 2020 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+#
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC/sof/tools/oss-fuzz
+cp corpus/* $OUT/
+rm -rf build_oss_fuzz
+mkdir -p build_oss_fuzz
+cd build_oss_fuzz
+
+export VERBOSE=1
+cmake -DCMAKE_INSTALL_PREFIX=install -DCMAKE_LINKER=$CXX -DCMAKE_C_LINK_EXECUTABLE="<CMAKE_LINKER> <FLAGS> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>" ..
+make install -j $(nproc)

--- a/projects/sound-open-firmware/project.yaml
+++ b/projects/sound-open-firmware/project.yaml
@@ -3,3 +3,7 @@ primary_contact: "cujomalainey@chromium.org"
 language: c
 auto_ccs:
   - "ranjani.sridharan@intel.corp-partner.google.com"
+fuzzing_engines:
+  - libfuzzer
+  - honggfuzz
+main_repo: "https://github.com/thesofproject/sof"


### PR DESCRIPTION
Initial build files for sound open firmware fuzzer

https://github.com/thesofproject/sof/pull/3505 needs to merge first

TODO
- [x] missing seed corpus
- [x] Redirect to origin repo once PR is merged
