### PR TITLE
Remove dataflow for ndpi project

### DIFF
--- a/projects/ndpi/project.yaml
+++ b/projects/ndpi/project.yaml
@@ -7,9 +7,7 @@ fuzzing_engines:
   - libfuzzer
   - afl
   - honggfuzz
-  - dataflow
 sanitizers:
   - address
   - undefined
   - memory
-  - dataflow


### PR DESCRIPTION
This seems to be the reason for build failure https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25879
`python infra/helper.py build_fuzzers ndpi` works locally for me
Any more hints on this ?