### PR TITLE
[yhirose/cpp-httplib] Add email ids to get build visibility. 

### DIFF
--- a/projects/cpp-httplib/project.yaml
+++ b/projects/cpp-httplib/project.yaml
@@ -3,6 +3,8 @@ language: c++
 primary_contact: "yuji.hirose.bug@gmail.com"
 auto_ccs :
   - "cpp-httplib-oss-fuzz@googlegroups.com"
+  - "omkarjadhav@google.com"
+  - "sungsk@google.com"
 sanitizers:
   - address
   - dataflow


### PR DESCRIPTION
Hey, @inferno-chromium  @yhirose 
Added two email ids to gain access to oss-fuzz build interface. 