### PR TITLE
[openvswitch] Add William Tu and Ilya Maximets to autoccs list.

### DIFF
--- a/projects/openvswitch/project.yaml
+++ b/projects/openvswitch/project.yaml
@@ -7,6 +7,8 @@ auto_ccs:
   - "pkusunyifeng@gmail.com"
   - "bshas3@gmail.com"
   - "cpp.code.lv@gmail.com"
+  - "u9012063@gmail.com"
+  - "ilya.maximets@gmail.com"
 sanitizers:
   - address
   - memory


### PR DESCRIPTION
William and Ilya are both upstream maintainers of Open vSwitch, as one
can see from:
https://github.com/openvswitch/ovs/blob/master/MAINTAINERS.rst
They have both expressed interest in getting early access to allow
them to fix problems before public release.