### PR TITLE
Add myself as auto CC for HarfBuzz

### DIFF
--- a/projects/harfbuzz/project.yaml
+++ b/projects/harfbuzz/project.yaml
@@ -14,6 +14,7 @@ auto_ccs:
   - "ariza@typekit.com"
   - "qxliu@google.com"
   - "ckitagawa@google.com"
+  - "drott@google.com"
 vendor_ccs:
   - "jmuizelaar@mozilla.com"
   - "lsalzman@mozilla.com"


### PR DESCRIPTION
I am responsible for rolling HarfBuzz into Chromium. I would like
to stay on top of oss-fuzz issues for HarfBuzz as they are reported.