### PR TITLE
qemu: add ninja to the build image

### DIFF
--- a/projects/qemu/Dockerfile
+++ b/projects/qemu/Dockerfile
@@ -15,7 +15,13 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev patchelf
+RUN apt-get update && apt-get install -y make autoconf automake libtool \
+    libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev patchelf wget
+# Ninja in the apt repos is too old. Get it directly from github
+RUN wget https://github.com/ninja-build/ninja/releases/latest/download/ninja-linux.zip \
+    && unzip ninja-linux.zip \
+    && rm ninja-linux.zip \
+    && mv ninja /usr/bin/ninja
 RUN git clone --depth 1 https://git.qemu.org/git/qemu.git qemu
 WORKDIR qemu
 RUN cp scripts/oss-fuzz/build.sh $SRC


### PR DESCRIPTION
QEMU builds are currently broken.

As of QEMU's 09e93326e4 ("build: replace ninjatool with ninja"), QEMU
now requires ninja instead of ninjatool for builds.