### PR TITLE
Update primary contact for Servo

### DIFF
--- a/projects/servo/project.yaml
+++ b/projects/servo/project.yaml
@@ -1,5 +1,5 @@
 homepage: "https://github.com/servo"
-primary_contact: "servo-ops@mozilla.com"
+primary_contact: "oss-fuzz@servo.org"
 sanitizers:
   - address
 fuzzing_engines:


### PR DESCRIPTION
Similar to https://github.com/google/oss-fuzz/pull/4501, we’re also moving that email alias out of `mozilla.com`.