### PR TITLE
[libass] Build with HarfBuzz

### DIFF
--- a/projects/libass/Dockerfile
+++ b/projects/libass/Dockerfile
@@ -15,9 +15,11 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config libfreetype6-dev libfontconfig1-dev
+RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config libfreetype6-dev libfontconfig1-dev python3-pip && \
+    pip3 install meson==0.53.0 ninja
 
 RUN git clone --depth 1 https://github.com/libass/libass.git
 RUN git clone --depth 1 https://github.com/behdad/fribidi.git
+RUN git clone --depth 1 https://github.com/harfbuzz/harfbuzz.git
 
 COPY build.sh libass_fuzzer.cc *.dict *.options $SRC/


### PR DESCRIPTION
libass made HarfBuzz a required dependency the other day, which broke its OSS-Fuzz build. This fixes it.

Building libass with HarfBuzz also ensures more libass code is covered with the fuzzing.

The system package of HarfBuzz cannot be used as it’s too old on Ubuntu 16.04, which OSS-Fuzz [seems to use](https://github.com/google/oss-fuzz/blob/master@{2020-10-22}/infra/base-images/base-image/Dockerfile#L19). The HarfBuzz build code is based on the OSS-Fuzz module for HarfBuzz itself. I have no idea why that module defines `HB_NO_VISIBILITY`, but I figured it might be safer to omit it when building it as a library dependency for another library.