### PR TITLE
[envoy] add libc++

### DIFF
--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -73,7 +73,7 @@ bazel build --verbose_failures --dynamic_mode=off --spawn_strategy=standalone \
   --genrule_strategy=standalone --strip=never \
   --copt=-fno-sanitize=vptr --linkopt=-fno-sanitize=vptr \
   --define tcmalloc=disabled --define signal_trace=disabled \
-  --define ENVOY_CONFIG_ASAN=1  \
+  --define ENVOY_CONFIG_ASAN=1  --config libc++ \
   --copt -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS \
   --define force_libcpp=enabled --build_tag_filters=-no_asan \
   --linkopt=-lc++ --linkopt=-pthread ${EXTRA_BAZEL_FLAGS} \


### PR DESCRIPTION
Envoy builds have failed for two reasons. 
(1) libc++ linkage here and 
(2) an upstream change compiling WASM with clang at head required a change to ignore a compiler error (https://github.com/envoyproxy/envoy/pull/13765).

They are orthogonal, so builds won't succeed until both these PRs are merged.

Signed-off-by: Asra Ali <asraa@google.com>