### PR TITLE
[espv2] Fix build failures due to OOM

### DIFF
--- a/projects/esp-v2/build.sh
+++ b/projects/esp-v2/build.sh
@@ -74,7 +74,6 @@ bazel build --verbose_failures --dynamic_mode=off --spawn_strategy=standalone \
   --copt=-fno-sanitize=vptr --linkopt=-fno-sanitize=vptr \
   --define tcmalloc=disabled --define signal_trace=disabled \
   --define ENVOY_CONFIG_ASAN=1 \
-  --copt -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS \
   --define force_libcpp=enabled --build_tag_filters=-no_asan \
   --linkopt=-lc++ --linkopt=-pthread ${EXTRA_BAZEL_FLAGS} \
   ${BAZEL_BUILD_TARGETS[*]} ${BAZEL_CORPUS_TARGETS[*]}

--- a/projects/esp-v2/build.sh
+++ b/projects/esp-v2/build.sh
@@ -15,7 +15,7 @@
 #
 ################################################################################
 
-## Copied from esp-v2
+## Copied from envoy
 
 export CFLAGS="$CFLAGS"
 export CXXFLAGS="$CXXFLAGS"
@@ -37,6 +37,7 @@ done
 for f in ${CXXFLAGS}; do
   echo "--cxxopt=${f}" "--linkopt=${f}"
 done
+
 if [ "$SANITIZER" = "undefined" ]
 then
   # Bazel uses clang to link binary, which does not link clang_rt ubsan library for C++ automatically.
@@ -67,12 +68,13 @@ done
 # Build driverless libraries.
 # Benchmark about 3 GB per CPU (10 threads for 28.8 GB RAM)
 # TODO(nareddyt): Remove deprecation warnings when Envoy and deps moves to C++17
-bazel build --verbose_failures --dynamic_mode=off --spawn_strategy=sandboxed \
+bazel build --verbose_failures --dynamic_mode=off --spawn_strategy=standalone \
   --local_cpu_resources=HOST_CPUS*0.32 \
   --genrule_strategy=standalone --strip=never \
   --copt=-fno-sanitize=vptr --linkopt=-fno-sanitize=vptr \
   --define tcmalloc=disabled --define signal_trace=disabled \
-  --define ENVOY_CONFIG_ASAN=1 --copt -D__SANITIZE_ADDRESS__ \
+  --define ENVOY_CONFIG_ASAN=1 \
+  --copt -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS \
   --define force_libcpp=enabled --build_tag_filters=-no_asan \
   --linkopt=-lc++ --linkopt=-pthread ${EXTRA_BAZEL_FLAGS} \
   ${BAZEL_BUILD_TARGETS[*]} ${BAZEL_CORPUS_TARGETS[*]}

--- a/projects/esp-v2/build.sh
+++ b/projects/esp-v2/build.sh
@@ -68,7 +68,7 @@ done
 # Build driverless libraries.
 # Benchmark about 3 GB per CPU (10 threads for 28.8 GB RAM)
 # TODO(nareddyt): Remove deprecation warnings when Envoy and deps moves to C++17
-bazel build --verbose_failures --dynamic_mode=off --spawn_strategy=standalone \
+bazel build --verbose_failures --dynamic_mode=off --spawn_strategy=sandboxed \
   --local_cpu_resources=HOST_CPUS*0.32 \
   --genrule_strategy=standalone --strip=never \
   --copt=-fno-sanitize=vptr --linkopt=-fno-sanitize=vptr \

--- a/projects/esp-v2/project.yaml
+++ b/projects/esp-v2/project.yaml
@@ -1,8 +1,7 @@
 homepage: "https://github.com/GoogleCloudPlatform/esp-v2"
 language: c++
-primary_contact: "jilinxia@google.com"
+primary_contact: "nareddyt@google.com"
 auto_ccs:
-- "nareddyt@google.com"
 - "taoxuy@google.com"
 - "qiwzhang@google.com"
 sanitizers:


### PR DESCRIPTION
- ESPv2 builds have been failing with OOM since we updated our envoy dependency. Example error is below. Copy relevant portions from Envoy's build script to workaround this issue.
- Fix ubsan and coverage build by moving a `--copt` to only be defined in address builds.
- Update primary contact for the project due to a change in team members.

```
Step #13: (11:02:55) [3,248 / 3,318] Compiling external/envoy/test/mocks/router/mocks.cc; 2034s linux-sandbox ... (32 actions running)
Step #13: 
Step #13: Server terminated abruptly (error code: 14, error message: 'Socket closed', log file: '/builder/home/.cache/bazel/_bazel_root/28d323c1ffc0c0ec503bc89d22bdf549/server/jvm.out')
Step #13: 
Step #13: rules_foreign_cc: Cleaning temp directoriesrules_foreign_cc: Cleaning temp directoriesrules_foreign_cc: Cleaning temp directoriesrules_foreign_cc: Cleaning temp directories********************************************************************************
Step #13: Failed to build.
Step #13: To reproduce, run:
Step #13: python infra/helper.py build_image esp-v2
Step #13: python infra/helper.py build_fuzzers --sanitizer undefined --engine libfuzzer --architecture x86_64 esp-v2
Step #13: ********************************************************************************
Finished Step #13
ERROR
ERROR: build step 13 "gcr.io/oss-fuzz/esp-v2" failed: step exited with non-zero status: 1
```

Signed-off-by: Teju Nareddy <nareddyt@google.com>