### PR TITLE
[teleport] Initial integration

### DIFF
--- a/projects/teleport/Dockerfile
+++ b/projects/teleport/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+COPY build.sh $SRC/
+WORKDIR $SRC/

--- a/projects/teleport/build.sh
+++ b/projects/teleport/build.sh
@@ -23,6 +23,7 @@ function compile_fuzzer {
 
   $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
 }
+
 mkdir -p $GOPATH/src/github.com/gravitational
 cd $GOPATH/src/github.com/gravitational
 git clone https://github.com/gravitational/teleport.git

--- a/projects/teleport/build.sh
+++ b/projects/teleport/build.sh
@@ -1,0 +1,31 @@
+#/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+function compile_fuzzer {
+  path=$1
+  function=$2
+  fuzzer=$3
+
+  go-fuzz -func $function -o $fuzzer.a $path
+
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
+}
+mkdir -p $GOPATH/src/github.com/gravitational
+cd $GOPATH/src/github.com/gravitational
+git clone https://github.com/gravitational/teleport.git
+
+compile_fuzzer github.com/gravitational/teleport/lib/fuzz FuzzParseProxyJump utils_fuzz
+compile_fuzzer github.com/gravitational/teleport/lib/fuzz FuzzNewExpression parse_fuzz

--- a/projects/teleport/project.yaml
+++ b/projects/teleport/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/gravitational/teleport"
+primary_contact: "andrew@awly.dev"
+auto_ccs :
+  - "adam@adalogics.com"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
This PR adds initial integration of [teleport](https://github.com/gravitational/teleport).

The following maintainers have been added to receive potential bug reports: @awly. And I am just tagging @webvictim and @benarent as well to keep you in the loop.

A selection of teleports users can be found [here](https://gravitational.com/teleport#customerlist).

**A few notes for the teleport maintainers:**
1. Upon integration, you will get access to the dashboard to monitor performance of the fuzzers. If bugs are found, you will receive emails with links to detailed bug reports.

2. I have added myself as cc for the bug reports. This means that I will have access to all reports for bugs and vulnerabilities found by the fuzzers through oss-fuzz. The reason I have added myself is to keep an eye on the performance on the fuzzers for a bit and step in if adjustments are needed. If you prefer me off the list, please let me know in a comment below. If not, I will remove my email address from the cc-list once the fuzzers are confirmed to run effectively on the platform. If you are fine with me being on the list for now, please leave a confirmation in a comment for the oss-fuzz team to see.

3. I suggest moving the build script to the upstream repository in a few weeks. It will then be easier to deal with issues like # 2 above. I will be happy to do it as part of removing myself from the cc-list.

4. Please let me know if any other maintainers need to be added to the contact list. A comment in this thread will be great.

**A few notes to the oss-fuzz maintainers:**
1. We are currently waiting for the fuzzers to be merged upstream. Once they are merged, I will update til PR to allow the Travis tests to pass.
