### PR TITLE
[dropbear] Unset fuzzing_engines so AFL will run

### DIFF
--- a/projects/dropbear/project.yaml
+++ b/projects/dropbear/project.yaml
@@ -5,6 +5,3 @@ sanitizers:
   - address
   - undefined
   - memory
-fuzzing_engines:
-  - libfuzzer
-  - honggfuzz


### PR DESCRIPTION
Hopefully the timeout [1] is now fixed by running initialisation
in a constructor function
https://github.com/mkj/dropbear/commit/b8352f81642ef4e0bd3c256e091f70a6723bdb24

[1] https://github.com/google/oss-fuzz/pull/2474