### PR TITLE
Fix ecc-diff-fuzzer build

### DIFF
--- a/projects/ecc-diff-fuzzer/Dockerfile
+++ b/projects/ecc-diff-fuzzer/Dockerfile
@@ -15,8 +15,12 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make cmake bzip2 autoconf automake gettext libtool python nodejs npm
+RUN apt-get update && apt-get install -y make cmake bzip2 autoconf automake gettext libtool python curl
 RUN rustup target add i686-unknown-linux-gnu
+#use different package sources for recent npm
+RUN curl -sL https://deb.nodesource.com/setup_10.x -o nodesource_setup.sh
+RUN bash nodesource_setup.sh
+RUN apt install -y nodejs
 RUN npm install -g browserify
 RUN npm install elliptic
 RUN git clone --depth 1 https://github.com/horhof/quickjs quickjs

--- a/projects/ecc-diff-fuzzer/build.sh
+++ b/projects/ecc-diff-fuzzer/build.sh
@@ -122,8 +122,6 @@ cp quickjs*.h /usr/local/include/
 cp libquickjs.a /usr/local/lib/
 )
 
-mv /usr/lib/x86_64-linux-gnu/libcrypto.a /usr/lib/x86_64-linux-gnu/libcrypto_old.a
-mv /usr/lib/x86_64-linux-gnu/libcrypto.so /usr/lib/x86_64-linux-gnu/libcrypto_old.so
 #build fuzz target
 cd ecfuzzer
 if [ "$ARCHITECTURE" = 'i386' ]; then
@@ -150,5 +148,3 @@ fi
 cmake -DDISABLE_CRYPTOPP=ON -DDISABLE_JS=ON ..
 make -j$(nproc)
 cp ecfuzzer $OUT/fuzz_ec_noblocker
-mv /usr/lib/x86_64-linux-gnu/libcrypto_old.a /usr/lib/x86_64-linux-gnu/libcrypto.a
-mv /usr/lib/x86_64-linux-gnu/libcrypto_old.so /usr/lib/x86_64-linux-gnu/libcrypto.so

--- a/projects/ecc-diff-fuzzer/build.sh
+++ b/projects/ecc-diff-fuzzer/build.sh
@@ -122,7 +122,6 @@ cp quickjs*.h /usr/local/include/
 cp libquickjs.a /usr/local/lib/
 )
 
-ln -s /usr/bin/nodejs /usr/bin/node
 mv /usr/lib/x86_64-linux-gnu/libcrypto.a /usr/lib/x86_64-linux-gnu/libcrypto_old.a
 mv /usr/lib/x86_64-linux-gnu/libcrypto.so /usr/lib/x86_64-linux-gnu/libcrypto_old.so
 #build fuzz target


### PR DESCRIPTION
by using a more recent npm version

This should fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=26286

With this patch, I get `npm -v 6.14.8` when before I had `npm  v3.5.2`
