### PR TITLE
[FFmpeg] update git link to libva

### DIFF
--- a/projects/ffmpeg/Dockerfile
+++ b/projects/ffmpeg/Dockerfile
@@ -29,7 +29,7 @@ RUN wget https://www.alsa-project.org/files/pub/lib/alsa-lib-1.1.0.tar.bz2
 RUN git clone --depth 1 https://github.com/mstorsjo/fdk-aac.git
 RUN git clone --depth 1 git://anongit.freedesktop.org/xorg/lib/libXext
 RUN git clone --depth 1 git://anongit.freedesktop.org/git/xorg/lib/libXfixes
-RUN git clone --depth 1 https://github.com/01org/libva
+RUN git clone --depth 1 https://github.com/intel/libva
 RUN git clone --depth 1 -b libvdpau-1.2 git://people.freedesktop.org/~aplattner/libvdpau
 RUN git clone --depth 1 https://chromium.googlesource.com/webm/libvpx
 RUN git clone --depth 1 https://gitlab.xiph.org/xiph/ogg.git


### PR DESCRIPTION
Fixes build failure after github.com/01org/libva disappeared/moved

Signed-off-by: Michael Niedermayer <michaelni@gmx.at>