### PR TITLE
[skia] Fix MSAN build and remove link limit for CIFuzz

### DIFF
--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -27,6 +27,9 @@ if [ $SANITIZER == "address" ]; then
   CMAKE_SANITIZER="SWIFTSHADER_ASAN"
 elif [ $SANITIZER == "memory" ]; then
   CMAKE_SANITIZER="SWIFTSHADER_MSAN"
+  # oss-fuzz will patch the rpath for this after compilation and linking,
+  # so we only need to set this to appease the Swiftshader build rules check.
+  export SWIFTSHADER_MSAN_INSTRUMENTED_LIBCXX_PATH="/does/not/matter"
 elif [ $SANITIZER == "undefined" ]; then
   # The current SwiftShader build needs -fno-sanitize=vptr, but it cannot be
   # specified here since -fsanitize=undefined will always come after any
@@ -60,12 +63,18 @@ export LDFLAGS_ARR=`echo $LDFLAGS | sed -e "s/\s/\",\"/g"`
 
 $SRC/skia/bin/fetch-gn
 
+LIMITED_LINK_POOL="link_pool_depth=1"
+if [ "$CIFUZZ" = "true" ]; then
+  echo "Not restricting linking because on CIFuzz"
+  LIMITED_LINK_POOL=""
+fi
+
 # Even though GPU is "enabled" for all these builds, none really
 # uses the gpu except for api_mock_gpu_canvas
 $SRC/skia/bin/gn gen out/Fuzz\
     --args='cc="'$CC'"
       cxx="'$CXX'"
-      link_pool_depth=1
+      '$LIMITED_LINK_POOL'
       is_debug=false
       extra_cflags_c=["'"$CFLAGS_ARR"'"]
       extra_cflags_cc=["'"$CXXFLAGS_ARR"'"]

--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -63,11 +63,13 @@ export LDFLAGS_ARR=`echo $LDFLAGS | sed -e "s/\s/\",\"/g"`
 
 $SRC/skia/bin/fetch-gn
 
+set +u
 LIMITED_LINK_POOL="link_pool_depth=1"
 if [ "$CIFUZZ" = "true" ]; then
   echo "Not restricting linking because on CIFuzz"
   LIMITED_LINK_POOL=""
 fi
+set -u
 
 # Even though GPU is "enabled" for all these builds, none really
 # uses the gpu except for api_mock_gpu_canvas


### PR DESCRIPTION
This should fix the build errors and make CI fuzz work faster because we use beefier machines than those that GitHub checks uses.