### PR TITLE
[hugo] initial integration

### DIFF
--- a/projects/hugo/Dockerfile
+++ b/projects/hugo/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+ENV GO111MODULE on
+RUN git clone https://github.com/gohugoio/hugo
+COPY build.sh $SRC/
+WORKDIR $SRC/

--- a/projects/hugo/build.sh
+++ b/projects/hugo/build.sh
@@ -1,0 +1,30 @@
+#/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+function compile_fuzzer {
+  path=$1
+  function=$2
+  fuzzer=$3
+
+  go-fuzz -func $function -o $fuzzer.a $path
+
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
+}
+
+mkdir $GOPATH/src/github.com/gohugoio
+mv $SRC/hugo $GOPATH/src/github.com/gohugoio/
+
+compile_fuzzer $GOPATH/src/github.com/gohugoio/hugo/tpl/transform FuzzMarkdownify fuzzmarkdownify

--- a/projects/hugo/build.sh
+++ b/projects/hugo/build.sh
@@ -19,4 +19,4 @@ mkdir $GOPATH/src/github.com/gohugoio
 mv $SRC/hugo $GOPATH/src/github.com/gohugoio/
 cd $GOPATH/src/github.com/gohugoio/hugo
 
-compile_go_fuzzer $GOPATH/src/github.com/gohugoio/hugo/tpl/transform FuzzMarkdownify fuzzmarkdownify
+compile_go_fuzzer github.com/gohugoio/hugo/tpl/transform FuzzMarkdownify fuzzmarkdownify

--- a/projects/hugo/build.sh
+++ b/projects/hugo/build.sh
@@ -26,5 +26,6 @@ function compile_fuzzer {
 
 mkdir $GOPATH/src/github.com/gohugoio
 mv $SRC/hugo $GOPATH/src/github.com/gohugoio/
+cd $GOPATH/src/github.com/gohugoio/hugo
 
 compile_fuzzer $GOPATH/src/github.com/gohugoio/hugo/tpl/transform FuzzMarkdownify fuzzmarkdownify

--- a/projects/hugo/build.sh
+++ b/projects/hugo/build.sh
@@ -14,18 +14,9 @@
 # limitations under the License.
 #
 ################################################################################
-function compile_fuzzer {
-  path=$1
-  function=$2
-  fuzzer=$3
-
-  go-fuzz -func $function -o $fuzzer.a $path
-
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
-}
 
 mkdir $GOPATH/src/github.com/gohugoio
 mv $SRC/hugo $GOPATH/src/github.com/gohugoio/
 cd $GOPATH/src/github.com/gohugoio/hugo
 
-compile_fuzzer $GOPATH/src/github.com/gohugoio/hugo/tpl/transform FuzzMarkdownify fuzzmarkdownify
+compile_go_fuzzer $GOPATH/src/github.com/gohugoio/hugo/tpl/transform FuzzMarkdownify fuzzmarkdownify

--- a/projects/hugo/project.yaml
+++ b/projects/hugo/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/gohugoio/hugo"
+primary_contact: ""
+auto_ccs :
+  - "adam@adalogics.com"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address

--- a/projects/hugo/project.yaml
+++ b/projects/hugo/project.yaml
@@ -1,5 +1,5 @@
 homepage: "https://github.com/gohugoio/hugo"
-primary_contact: ""
+primary_contact: "bjorn.erik.pedersen@gmail.com"
 auto_ccs :
   - "adam@adalogics.com"
 language: go


### PR DESCRIPTION
This PR adds [Hugo](https://github.com/gohugoio/hugo) to oss-fuzz.

**Message for Hugo maintainers:**

@bep

I assume you are one maintainer to receive potential bug reports. I have not added your email address to `project.yaml`, but if you would like to be added, please let me know. I have also added myself to receive reports about the integration failing. This means that I can view all bug reports including potential security vulnerabilities. If you prefer that I am not on this list, please let me know in this thread and I will remove my email address.

Any number of maintainers can be added to the list. All email addresses are public and the list can be changed at any time.

**Message for oss-fuzz maintainers:**

The fuzzer has currently not been merged upstream.