### PR TITLE
Support cross-compilation for AArch64

### DIFF
--- a/.github/workflows/project_tests.yml
+++ b/.github/workflows/project_tests.yml
@@ -32,6 +32,9 @@ jobs:
           - engine: dataflow
             sanitizer: dataflow
             architecture: x86_64
+          - engine: libfuzzer
+            sanitizer: undefined
+            architecture: aarch64
     env:
       ENGINE: ${{ matrix.engine }}
       SANITIZER: ${{ matrix.sanitizer }}

--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -84,8 +84,10 @@ RUN rustup component add rust-src --toolchain nightly
 # Default build flags for various sanitizers.
 ENV SANITIZER_FLAGS_address "-fsanitize=address -fsanitize-address-use-after-scope"
 
-# Set of '-fsanitize' flags matches '-fno-sanitize-recover' + 'unsigned-integer-overflow'.
 ENV SANITIZER_FLAGS_undefined "-fsanitize=array-bounds,bool,builtin,enum,float-divide-by-zero,function,integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,shift,signed-integer-overflow,unsigned-integer-overflow,unreachable,vla-bound,vptr -fno-sanitize-recover=array-bounds,bool,builtin,enum,float-divide-by-zero,function,integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,shift,signed-integer-overflow,unreachable,vla-bound,vptr"
+
+# Don't include "function" since it is unsupported on aarch64.
+ENV SANITIZER_FLAGS_undefined_aarch64 "-fsanitize=array-bounds,bool,builtin,enum,float-divide-by-zero,integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,shift,signed-integer-overflow,unsigned-integer-overflow,unreachable,vla-bound,vptr -fno-sanitize-recover=array-bounds,bool,builtin,enum,float-divide-by-zero,integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,shift,signed-integer-overflow,unreachable,vla-bound,vptr"
 
 ENV SANITIZER_FLAGS_memory "-fsanitize=memory -fsanitize-memory-track-origins"
 

--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -22,6 +22,11 @@ if [ "$SANITIZER" = "dataflow" ] && [ "$FUZZING_ENGINE" != "dataflow" ]; then
   exit 1
 fi
 
+if [[ $ARCHITECTURE == "aarch64" ]]; then
+     printf "yooo\n\n\n\yooooo"
+    export CFLAGS="$AARCH64_EXTRA_CFLAGS $CFLAGS"
+    export SANITIZER_FLAGS_undefined=$SANITIZER_FLAGS_undefined_aarch64
+fi
 if [ -z "${SANITIZER_FLAGS-}" ]; then
   FLAGS_VAR="SANITIZER_FLAGS_${SANITIZER}"
   export SANITIZER_FLAGS=${!FLAGS_VAR-}
@@ -30,11 +35,6 @@ fi
 if [[ $ARCHITECTURE == "i386" ]]; then
     export CFLAGS="-m32 $CFLAGS"
     cp -R /usr/i386/lib/* /usr/lib
-fi
-if [[ $ARCHITECTURE == "aarch64" ]]; then
-    export CFLAGS="$AARCH64_EXTRA_CFLAGS $CFLAGS"
-    export CXXFLAGS_EXTRA="$AARCH64_EXTRA_CFLAGS $CXXFLAGS_EXTRA"
-    export SANITIZER_FLAGS_undefined=$SANITIZER_FLAGS_undefined_aarch64
 fi
 if [[ $FUZZING_ENGINE != "none" ]]; then
   # compile script might override environment, use . to call it.

--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -31,6 +31,11 @@ if [[ $ARCHITECTURE == "i386" ]]; then
     export CFLAGS="-m32 $CFLAGS"
     cp -R /usr/i386/lib/* /usr/lib
 fi
+if [[ $ARCHITECTURE == "aarch64" ]]; then
+    export CFLAGS="$AARCH64_EXTRA_CFLAGS $CFLAGS"
+    export CXXFLAGS_EXTRA="$AARCH64_EXTRA_CFLAGS $CXXFLAGS_EXTRA"
+    export SANITIZER_FLAGS_undefined=$SANITIZER_FLAGS_undefined_aarch64
+fi
 if [[ $FUZZING_ENGINE != "none" ]]; then
   # compile script might override environment, use . to call it.
   . compile_${FUZZING_ENGINE}

--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -23,7 +23,6 @@ if [ "$SANITIZER" = "dataflow" ] && [ "$FUZZING_ENGINE" != "dataflow" ]; then
 fi
 
 if [[ $ARCHITECTURE == "aarch64" ]]; then
-     printf "yooo\n\n\n\yooooo"
     export CFLAGS="$AARCH64_EXTRA_CFLAGS $CFLAGS"
     export SANITIZER_FLAGS_undefined=$SANITIZER_FLAGS_undefined_aarch64
 fi

--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -29,19 +29,6 @@ RUN apt-get update && apt-get install -y wget sudo && \
 
 # Steps for ARM cross-compilation
 
-RUN apt-get install qemu-user wget xz-utils -y && \
-    cd /opt && \
-    wget https://releases.linaro.org/components/toolchain/binaries/7.5-2019.12/aarch64-linux-gnu/gcc-linaro-7.5.0-2019.12-x86_64_aarch64-linux-gnu.tar.xz && \
-    tar xJvf gcc-linaro-7.5.0-2019.12-x86_64_aarch64-linux-gnu.tar.xz && \
-    rm gcc-linaro-7.5.0-2019.12-x86_64_aarch64-linux-gnu.tar.xz && \
-    apt-get remove --purge -y wget xz-utils
-
-ENV AARCH64_TOOLCHAIN /opt/gcc-linaro-7.5.0-2019.12-x86_64_aarch64-linux-gnu
-ENV AARCH64_SYSROOT="$AARCH64_TOOLCHAIN/aarch64-linux-gnu/libc"
-ENV QEMU_LD_PREFIX=$AARCH64_SYSROOT
-ENV AARCH64_EXTRA_CFLAGS="--target=aarch64-linux-gnu --gcc-toolchain=$AARCH64_TOOLCHAIN --sysroot=$AARCH64_SYSROOT"
-ENV AARCH64_TARGET_TRIPLE="aarch64-linux-gnu"
-
 COPY checkout_build_install_llvm.sh /root/
 # Keep all steps in the same script to decrease the number of intermediate
 # layes in docker file.

--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -27,6 +27,21 @@ RUN apt-get update && apt-get install -y wget sudo && \
     rm cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
     SUDO_FORCE_REMOVE=yes apt-get remove --purge -y wget sudo
 
+# Steps for ARM cross-compilation
+
+RUN apt-get install qemu-user wget xz-utils -y && \
+    cd /opt && \
+    wget https://releases.linaro.org/components/toolchain/binaries/7.5-2019.12/aarch64-linux-gnu/gcc-linaro-7.5.0-2019.12-x86_64_aarch64-linux-gnu.tar.xz && \
+    tar xJvf gcc-linaro-7.5.0-2019.12-x86_64_aarch64-linux-gnu.tar.xz && \
+    rm gcc-linaro-7.5.0-2019.12-x86_64_aarch64-linux-gnu.tar.xz && \
+    apt-get remove --purge -y wget xz-utils
+
+ENV AARCH64_TOOLCHAIN /opt/gcc-linaro-7.5.0-2019.12-x86_64_aarch64-linux-gnu
+ENV AARCH64_SYSROOT="$AARCH64_TOOLCHAIN/aarch64-linux-gnu/libc"
+ENV QEMU_LD_PREFIX=$AARCH64_SYSROOT
+ENV AARCH64_EXTRA_CFLAGS="--target=aarch64-linux-gnu --gcc-toolchain=$AARCH64_TOOLCHAIN --sysroot=$AARCH64_SYSROOT"
+ENV AARCH64_TARGET_TRIPLE="aarch64-linux-gnu"
+
 COPY checkout_build_install_llvm.sh /root/
 # Keep all steps in the same script to decrease the number of intermediate
 # layes in docker file.

--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -27,8 +27,6 @@ RUN apt-get update && apt-get install -y wget sudo && \
     rm cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
     SUDO_FORCE_REMOVE=yes apt-get remove --purge -y wget sudo
 
-# Steps for ARM cross-compilation
-
 COPY checkout_build_install_llvm.sh /root/
 # Keep all steps in the same script to decrease the number of intermediate
 # layes in docker file.

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -99,7 +99,7 @@ PROJECTS_TO_BUILD="libcxx;libcxxabi;compiler-rt;clang;lld"
 
 export TARGET_TO_BUILD="X86;ARM;AArch64"
 cmake_llvm
-ninja
+ninja -j $NPROC
 
 cd $WORK/llvm-stage2
 export CC=$WORK/llvm-stage1/bin/clang
@@ -109,7 +109,7 @@ export CXX=$WORK/llvm-stage1/bin/clang++
 cmake_llvm
 ninja -j $NPROC
 ninja install
-# rm -rf $WORK/llvm-stage1 $WORK/llvm-stage2
+rm -rf $WORK/llvm-stage1 $WORK/llvm-stage2
 
 # Use the clang we just built from now on.
 CMAKE_EXTRA_ARGS="-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
@@ -124,7 +124,7 @@ cmake_llvm $CMAKE_EXTRA_ARGS \
 
 ninja -j $NPROC cxx
 ninja install-cxx
-# rm -rf $WORK/i386
+rm -rf $WORK/i386
 
 # MemorySanitizer instrumented libraries.
 mkdir -p $WORK/msan
@@ -142,7 +142,7 @@ cmake_llvm $CMAKE_EXTRA_ARGS \
 
 ninja cxx
 ninja -j $NPROC install-cxx
-# rm -rf $WORK/msan
+rm -rf $WORK/msan
 
 # DataFlowSanitizer instrumented libraries.
 mkdir -p $WORK/dfsan
@@ -153,7 +153,7 @@ cmake_llvm $CMAKE_EXTRA_ARGS \
     -DCMAKE_INSTALL_PREFIX=/usr/dfsan/
 
 ninja -j $NPROC install-cxx install-cxxabi
-# rm -rf $WORK/dfsan
+rm -rf $WORK/dfsan
 
 
 # AARCH64

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -17,8 +17,8 @@
 
 NPROC=16  # See issue #4270. The compiler crashes on GCB instance with 32 vCPUs.
 
-LLVM_DEP_PACKAGES="build-essential make cmake ninja-build git python2.7 g++-multilib binutils-dev"
-apt-get install -y $LLVM_DEP_PACKAGES
+LLVM_DEP_PACKAGES="build-essential make ninja-build git python2.7 g++-multilib binutils-dev"
+#apt-get install -y $LLVM_DEP_PACKAGES
 
 # Checkout
 CHECKOUT_RETRIES=10
@@ -95,77 +95,80 @@ echo "Using LLVM revision: $LLVM_REVISION"
 mkdir -p $WORK/llvm-stage2 $WORK/llvm-stage1
 cd $WORK/llvm-stage1
 
-TARGET_TO_BUILD=
-case $(uname -m) in
-    x86_64)
-        TARGET_TO_BUILD=X86
-        ;;
-    aarch64)
-        TARGET_TO_BUILD=AArch64
-        ;;
-    *)
-        echo "Error: unsupported target $(uname -m)"
-        exit 1
-        ;;
-esac
+# # TARGET_TO_BUILD=
+# # case $(uname -m) in
+# #     x86_64)
+# #         TARGET_TO_BUILD=X86
+# #         ;;
+# #     aarch64)
+# #         TARGET_TO_BUILD=AArch64
+# #         ;;
+# #     *)
+# #         echo "Error: unsupported target $(uname -m)"
+# #         exit 1
+# #         ;;
+# # esac
 
 PROJECTS_TO_BUILD="libcxx;libcxxabi;compiler-rt;clang;lld"
 
+export TARGET_TO_BUILD="X86;ARM;AArch64"
 cmake_llvm
-ninja -j $NPROC
+ninja -j
 
-cd $WORK/llvm-stage2
-export CC=$WORK/llvm-stage1/bin/clang
-export CXX=$WORK/llvm-stage1/bin/clang++
-cmake_llvm
-ninja -j $NPROC
+# cd $WORK/llvm-stage2
+# export CC=$WORK/llvm-stage1/bin/clang
+# export CXX=$WORK/llvm-stage1/bin/clang++
+
+
+# cmake_llvm
+# ninja -j
 ninja install
-rm -rf $WORK/llvm-stage1 $WORK/llvm-stage2
+rm -rf $WORK/llvm-stage1
 
 # Use the clang we just built from now on.
 CMAKE_EXTRA_ARGS="-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
 
-# 32-bit libraries.
-mkdir -p $WORK/i386
-cd $WORK/i386
-cmake_llvm $CMAKE_EXTRA_ARGS \
-    -DCMAKE_INSTALL_PREFIX=/usr/i386/ \
-    -DCMAKE_C_FLAGS="-m32" \
-    -DCMAKE_CXX_FLAGS="-m32"
+# # 32-bit libraries.
+# mkdir -p $WORK/i386
+# cd $WORK/i386
+# cmake_llvm $CMAKE_EXTRA_ARGS \
+#     -DCMAKE_INSTALL_PREFIX=/usr/i386/ \
+#     -DCMAKE_C_FLAGS="-m32" \
+#     -DCMAKE_CXX_FLAGS="-m32"
 
-ninja -j $NPROC cxx
-ninja install-cxx
-rm -rf $WORK/i386
+# ninja -j cxx
+# ninja install-cxx
+# rm -rf $WORK/i386
 
 # MemorySanitizer instrumented libraries.
-mkdir -p $WORK/msan
-cd $WORK/msan
+# mkdir -p $WORK/msan
+# cd $WORK/msan
 
 # https://github.com/google/oss-fuzz/issues/1099
 cat <<EOF > $WORK/msan/blacklist.txt
 fun:__gxx_personality_*
 EOF
 
-cmake_llvm $CMAKE_EXTRA_ARGS \
-    -DLLVM_USE_SANITIZER=Memory \
-    -DCMAKE_INSTALL_PREFIX=/usr/msan/ \
-    -DCMAKE_CXX_FLAGS="-fsanitize-blacklist=$WORK/msan/blacklist.txt"
+# cmake_llvm $CMAKE_EXTRA_ARGS \
+#     -DLLVM_USE_SANITIZER=Memory \
+#     -DCMAKE_INSTALL_PREFIX=/usr/msan/ \
+#     -DCMAKE_CXX_FLAGS="-fsanitize-blacklist=$WORK/msan/blacklist.txt"
 
-ninja -j $NPROC cxx
-ninja install-cxx
-rm -rf $WORK/msan
+# ninja -j cxx
+# ninja install-cxx
+# rm -rf $WORK/msan
 
-# DataFlowSanitizer instrumented libraries.
-mkdir -p $WORK/dfsan
-cd $WORK/dfsan
+# # DataFlowSanitizer instrumented libraries.
+# mkdir -p $WORK/dfsan
+# cd $WORK/dfsan
 
-cmake_llvm $CMAKE_EXTRA_ARGS \
-    -DLLVM_USE_SANITIZER=DataFlow \
-    -DCMAKE_INSTALL_PREFIX=/usr/dfsan/
+# cmake_llvm $CMAKE_EXTRA_ARGS \
+#     -DLLVM_USE_SANITIZER=DataFlow \
+#     -DCMAKE_INSTALL_PREFIX=/usr/dfsan/
 
-ninja -j $NPROC cxx cxxabi
-ninja install-cxx install-cxxabi
-rm -rf $WORK/dfsan
+# ninja -j $NPROC cxx cxxabi
+# ninja install-cxx install-cxxabi
+# rm -rf $WORK/dfsan
 
 # libFuzzer sources.
 cp -r $LLVM_SRC/compiler-rt/lib/fuzzer $SRC/libfuzzer

--- a/infra/base-images/base-image/Dockerfile
+++ b/infra/base-images/base-image/Dockerfile
@@ -29,3 +29,17 @@ ENV WORK=/work
 ENV PATH="$PATH:/out"
 
 RUN mkdir -p $OUT $SRC $WORK && chmod a+rwx $OUT $SRC $WORK
+
+# Steps for ARM cross-compilation
+RUN apt-get install qemu-user wget xz-utils -y && \
+    cd /opt && \
+    wget https://releases.linaro.org/components/toolchain/binaries/7.5-2019.12/aarch64-linux-gnu/gcc-linaro-7.5.0-2019.12-x86_64_aarch64-linux-gnu.tar.xz && \
+    tar xJvf gcc-linaro-7.5.0-2019.12-x86_64_aarch64-linux-gnu.tar.xz && \
+    rm gcc-linaro-7.5.0-2019.12-x86_64_aarch64-linux-gnu.tar.xz && \
+    apt-get remove --purge -y wget xz-utils
+
+ENV AARCH64_TOOLCHAIN /opt/gcc-linaro-7.5.0-2019.12-x86_64_aarch64-linux-gnu
+ENV AARCH64_SYSROOT="$AARCH64_TOOLCHAIN/aarch64-linux-gnu/libc"
+ENV QEMU_LD_PREFIX=$AARCH64_SYSROOT
+ENV AARCH64_EXTRA_CFLAGS="--target=aarch64-linux-gnu --gcc-toolchain=$AARCH64_TOOLCHAIN --sysroot=$AARCH64_SYSROOT"
+ENV AARCH64_TARGET_TRIPLE="aarch64-linux-gnu"

--- a/infra/base-images/base-runner/Dockerfile
+++ b/infra/base-images/base-runner/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get install -y \
     git \
     libc6-dev-i386 \
     libcap2 \
+    binutils-aarch64-linux-gnu \
     python3 \
     python3-pip \
     wget \

--- a/infra/base-images/base-runner/bad_build_check
+++ b/infra/base-images/base-runner/bad_build_check
@@ -298,27 +298,26 @@ function check_mixed_sanitizers {
   local FUZZER=$1
   local result=0
   local CALL_INSN=
-  if [[ $ARCHITECTURE == 'i386' ]]
+  if [[ $ARCHITECTURE == "x86_64" ]]
+  then
+    CALL_INSN="callq\s+[0-9a-f]+\s+<"
+    OBJDUMP="objdump"
+  elif [[ $ARCHITECTURE == "i386" ]]
   then
     CALL_INSN="call\s+[0-9a-f]+\s+<"
+    OBJDUMP="objdump"
+  elif [[ $ARCHITECTURE == "aarch64" ]]
+  then
+    CALL_INSN="bl\s+[0-9a-f]+\s+<"
+    OBJDUMP="aarch64-linux-gnu-objdump"
   else
-    case $(uname -m) in
-      x86_64)
-        CALL_INSN="callq\s+[0-9a-f]+\s+<"
-        ;;
-      aarch64)
-        CALL_INSN="bl\s+[0-9a-f]+\s+<"
-        ;;
-      *)
-        echo "Error: unsupported machine hardware $(uname -m)"
-        exit 1
-        ;;
-    esac
+    echo "UNSUPPORTED ARCHITECTURE"
+    exit 1
   fi
-  local ASAN_CALLS=$(objdump -dC $FUZZER | egrep "${CALL_INSN}__asan" -c)
-  local DFSAN_CALLS=$(objdump -dC $FUZZER | egrep "${CALL_INSN}__dfsan" -c)
-  local MSAN_CALLS=$(objdump -dC $FUZZER | egrep "${CALL_INSN}__msan" -c)
-  local UBSAN_CALLS=$(objdump -dC $FUZZER | egrep "${CALL_INSN}__ubsan" -c)
+  local ASAN_CALLS=$($OBJDUMP -dC $FUZZER | egrep "${CALL_INSN}__asan" -c)
+  local DFSAN_CALLS=$($OBJDUMP -dC $FUZZER | egrep "${CALL_INSN}__dfsan" -c)
+  local MSAN_CALLS=$($OBJDUMP -dC $FUZZER | egrep "${CALL_INSN}__msan" -c)
+  local UBSAN_CALLS=$($OBJDUMP -dC $FUZZER | egrep "${CALL_INSN}__ubsan" -c)
 
   if [[ "$SANITIZER" = address ]]; then
     check_asan_build $FUZZER $ASAN_CALLS $DFSAN_CALLS $MSAN_CALLS $UBSAN_CALLS
@@ -374,6 +373,9 @@ function check_architecture {
   elif [[ $ARCHITECTURE == "i386" ]]
   then
     echo $FILE_OUTPUT | grep "80386" > /dev/null
+  elif [[ $ARCHITECTURE == "aarch64" ]]
+  then
+    echo $FILE_OUTPUT | grep "aarch64" > /dev/null
   else
     echo "UNSUPPORTED ARCHITECTURE"
     return 1

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -305,7 +305,7 @@ def _get_project_language(project_name):
   return None
 
 
-def _add_architecture_args(parser, choices=('x86_64', 'i386')):
+def _add_architecture_args(parser, choices=('x86_64', 'i386', 'aarch64')):
   """Add common architecture args."""
   parser.add_argument('--architecture', default='x86_64', choices=choices)
 

--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -74,7 +74,7 @@ class ProjectYamlChecker:
   # to have.
   SECTIONS_AND_CONSTANTS = {
       'sanitizers': {'address', 'none', 'memory', 'undefined', 'dataflow'},
-      'architectures': {'i386', 'x86_64'},
+      'architectures': {'i386', 'x86_64', 'aarch64'},
       'fuzzing_engines': {'afl', 'libfuzzer', 'honggfuzz', 'dataflow', 'none'},
   }
 


### PR DESCRIPTION
Support cross-compiling targets with UBSAN for AArch64.
We don't support ASAN because QEMU is incompatible with ASAN.
It is awkward to support cross-compilation if qemu doesn't work for a few reasons, one being that some build systems try to run binaries they produce to test for features.
We can use this to support fuzzing using QEMU on ClusterFuzz, or to support fuzzing using CIFuzz since github actions supports ARM.
I have confirmed this works for simple projects like zlib and skcms.
I haven't tried it with any project that needs to install static libraries via apt