### PR TITLE
[tmux] Initial integration

### DIFF
--- a/projects/tmux/Dockerfile
+++ b/projects/tmux/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y autoconf automake bison pkg-config \
     libevent-dev ncurses-dev
 
-RUN git clone --depth 1 https://github.com/tmux/tmux.git
+RUN git clone --depth 1 https://github.com/snizovtsev/tmux.git
 RUN git clone --depth 1 https://github.com/snizovtsev/tmux-fuzzing-corpus.git
 WORKDIR tmux
 COPY build.sh $SRC/

--- a/projects/tmux/Dockerfile
+++ b/projects/tmux/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y autoconf automake bison pkg-config \
+    libevent-dev ncurses-dev
+
+RUN git clone --depth 1 https://github.com/tmux/tmux.git
+RUN git clone --depth 1 https://github.com/snizovtsev/tmux-fuzzing-corpus.git
+WORKDIR tmux
+COPY build.sh $SRC/

--- a/projects/tmux/build.sh
+++ b/projects/tmux/build.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -eu
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+./autogen.sh
+./configure \
+    --enable-fuzzing \
+    FUZZING_LIBS="${LIB_FUZZING_ENGINE} -lc++" \
+    LIBEVENT_LIBS="-Wl,-Bstatic -levent -Wl,-Bdynamic" \
+    LIBTINFO_LIBS="-Wl,-Bstatic -ltinfo -Wl,-Bdynamic"
+
+make -j"$(nproc)" check
+find "${SRC}/tmux/fuzz/" -name '*-fuzzer' -exec cp -v '{}' "${OUT}"/ \;
+find "${SRC}/tmux/fuzz/" -name '*-fuzzer.options' -exec cp -v '{}' "${OUT}"/ \;
+find "${SRC}/tmux/fuzz/" -name '*-fuzzer.dict' -exec cp -v '{}' "${OUT}"/ \;
+
+MAXLEN=$(grep -Po 'max_len\s+=\s+\K\d+' "${OUT}/input-fuzzer.options")
+mkdir "${WORK}/fuzzing_corpus"
+cd "${WORK}/fuzzing_corpus"
+bash "${SRC}/tmux/tools/24-bit-color.sh" | \
+    split -a4 -db$MAXLEN - 24-bit-color.out.
+perl "${SRC}/tmux/tools/256colors.pl" | \
+    split -a4 -db$MAXLEN - 256colors.out.
+cat "${SRC}/tmux/tools/UTF-8-demo.txt" | \
+    split -a4 -db$MAXLEN - UTF-8-demo.txt.
+cat "${SRC}/tmux-fuzzing-corpus/alacritty"/* | \
+    split -a4 -db$MAXLEN - alacritty.
+cat "${SRC}/tmux-fuzzing-corpus/esctest"/* | \
+    split -a4 -db$MAXLEN - esctest.
+cat "${SRC}/tmux-fuzzing-corpus/iterm2"/* | \
+    split -a5 -db$MAXLEN - iterm2.
+zip -q -j -r "${OUT}/input-fuzzer_seed_corpus.zip" \
+    "${WORK}/fuzzing_corpus/"

--- a/projects/tmux/project.yaml
+++ b/projects/tmux/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://tmux.github.io/"
+language: c
+primary_contact: nicholas.marriott@gmail.com
+auto_ccs:
+  - security@openbsd.org
+sanitizers:
+  - address
+  - undefined


### PR DESCRIPTION
Depends on: tmux/tmux#2448.

tmux is a terminal multiplexer widely used by engineers. It ranked as [2602](https://qa.debian.org/popcon.php?package=tmux) across all debian packages by number of installs. It is even [used](https://cloud.google.com/shell/docs/configuring-cloud-shell#tmux_support) in Google Cloud Shell by default.

The essential part of tmux is escape sequence parser. It accepts input from arbitrary sources, like remote ssh stream or docker sandbox, and converts them into formatted symbol grid. This could be dangerous since the same process handles user interaction and so it has full capabilities.

The work on this fuzzer has already helped to uncover [CVE-2020-27347](https://seclists.org/oss-sec/2020/q4/100) ([OpenBSD 6.8 errata 003](https://marc.info/?l=openbsd-announce&m=160399126725142)). 

