### PR TITLE
[freetype] Remove zlib and libpng dev packages.

### DIFF
--- a/projects/freetype2/Dockerfile
+++ b/projects/freetype2/Dockerfile
@@ -20,10 +20,8 @@ RUN apt-get update &&  \
     apt-get install -y \
       autoconf         \
       cmake            \
-      libpng-dev       \
       libtool          \
       pkg-config       \
-      zlib1g-dev       \
       make
 
 # Get some files for the seed corpus


### PR DESCRIPTION
The upstream build of the fuzzer currently builds freetype --without-zlib
and --without-png so these are not needed. In addition, because of the
way these dependencies are used they must be built with the sanitizer in
order to detect interesting issues like CVE-2020-15999, where FreeType
may call into libpng incorrectly but it is libpng which actually does
the reads and writes. This has been proposed upstream at
https://github.com/freetype/freetype2-testing/pull/86 which uses
prefixes to ensure that the system symbols are never used, but it would
be beneficial to not have them available at all.