### PR TITLE
[lz4] Disable i386 fuzzing

### DIFF
--- a/projects/lz4/project.yaml
+++ b/projects/lz4/project.yaml
@@ -21,4 +21,3 @@ sanitizers:
   - dataflow
 architectures:
   - x86_64
-  - i386


### PR DESCRIPTION
There are 3 open LZ4 i386 issues. Each claims to be reliably reproducible. We've never been able to reproduce any of them. At this point it is just causing noise. So we want to disable i386 fuzzing until these issues have been sorted out.

OSS-Fuzz claims the latest tested revision is https://github.com/lz4/lz4/commit/664427aa8f6808411a2c04f003a9b364bdebe578 from 5 days ago. Does that mean it was able to successfully reproduce then? If so, why can't I reproduce with docker locally on the same commit?