### PR TITLE
Compatible build for Suricata with CIFuzz

### DIFF
--- a/projects/suricata/Dockerfile
+++ b/projects/suricata/Dockerfile
@@ -28,7 +28,7 @@ ADD https://rules.emergingthreats.net/open/suricata/emerging.rules.zip emerging.
 RUN cargo install --force cbindgen
 
 RUN git clone --depth 1 https://github.com/OISF/suricata.git suricata
-RUN git clone --depth 1 https://github.com/OISF/libhtp.git suricata/libhtp
+RUN git clone --depth 1 https://github.com/OISF/libhtp.git libhtp
 RUN git clone --depth 1 https://github.com/OISF/suricata-verify suricata-verify
 WORKDIR $SRC
 COPY build.sh $SRC/

--- a/projects/suricata/build.sh
+++ b/projects/suricata/build.sh
@@ -46,6 +46,8 @@ cd ..
 
 export CARGO_BUILD_TARGET="x86_64-unknown-linux-gnu"
 
+#we did not put libhtp there before so that cifuzz does not remove it
+mv libhtp suricata/
 # build project
 cd suricata
 sh autogen.sh


### PR DESCRIPTION
CIFuzz integration for Suricata failed at first cf
https://github.com/OISF/suricata/pull/5538

This is because suricata uses embedded libhtp
and cifuzz.py removes the whole suricata directory to replace it with the one from the PR cf
```
bash_command = 'rm -rf {0} && cp -r {1} {2} && compile'.format(
        os.path.join(src_in_project_builder, project_repo_name, '*'),
        os.path.join(git_workspace, project_repo_name), src_in_project_builder)
```

Workaround is to clone libhtp in another directory, and move it in suricata directory during the build