### PR TITLE
Lwan: Enable `memory` and `undefined` sanitizers

### DIFF
--- a/projects/lwan/project.yaml
+++ b/projects/lwan/project.yaml
@@ -3,3 +3,5 @@ language: c++
 primary_contact: "leandro.pereira@gmail.com"
 sanitizers:
   - address
+  - memory
+  - undefined


### PR DESCRIPTION
Until now, Lwan was only tested with AddressSanitizer.  This enables MemorySanitizer and UndefinedSanitizer.