### PR TITLE
project/go-ethereum: use canon address instead of vanity-alias

### DIFF
--- a/projects/go-ethereum/project.yaml
+++ b/projects/go-ethereum/project.yaml
@@ -3,7 +3,7 @@ primary_contact: "peter@ethereum.org"
 auto_ccs :
   - "fjl@ethereum.org"
   - "martin.swende@ethereum.org"
-  - "mariusvdw@ethereum.org"
+  - "marius.vanderwijden@ethereum.org"
 language: go
 fuzzing_engines:
   - libfuzzer


### PR DESCRIPTION
The email address for one of our maintainers was an alias, which doesn't seem to work for signing in to oss-fuzz. 