### PR TITLE
[cryptofuzz] Disable i386 build

### DIFF
--- a/projects/cryptofuzz/project.yaml
+++ b/projects/cryptofuzz/project.yaml
@@ -38,4 +38,3 @@ sanitizers:
  - memory
 architectures:
  - x86_64
- - i386


### PR DESCRIPTION
Temporarily disable the i386 build

The i386 fuzzers contain too much code now and this frequently causes false positives. Some examples:

https://oss-fuzz.com/testcase-detail/5448129780121600
https://oss-fuzz.com/testcase-detail/4775822470414336
https://oss-fuzz.com/testcase-detail/5766529993670656
https://oss-fuzz.com/testcase-detail/6016977623318528
https://oss-fuzz.com/testcase-detail/5736577529282560
https://oss-fuzz.com/testcase-detail/5638214188269568

I need to split this up into multiple binaries, but I need some time for that.

The x64 fuzzers still work fine despite the amount of code they run.