### PR TITLE
[libphonenumber] Initial integration

### DIFF
--- a/projects/libphonenumber/Dockerfile
+++ b/projects/libphonenumber/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y autoconf automake libtool g++ cmake-curses-gui libgtest-dev libre2-dev libicu-dev libboost-dev libboost-thread-dev libboost-system-dev binutils ninja-build liblzma-dev libz-dev pkg-config wget
+
+WORKDIR $SRC/
+RUN git clone https://github.com/google/libphonenumber
+
+RUN wget https://github.com/unicode-org/icu/releases/download/release-55-2/icu4c-55_2-src.tgz && tar xzvf icu4c-55_2-src.tgz
+
+COPY build.sh $SRC/
+COPY phonefuzz.cc $SRC/

--- a/projects/libphonenumber/Dockerfile
+++ b/projects/libphonenumber/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y autoconf automake libtool g++ cmake-curses-gui libgtest-dev libre2-dev libicu-dev libboost-dev libboost-thread-dev libboost-system-dev binutils ninja-build liblzma-dev libz-dev pkg-config wget
+RUN apt-get update && apt-get install -y autoconf automake libtool g++ cmake-curses-gui libgtest-dev libre2-dev libicu-dev libboost-dev libboost-thread-dev libboost-system-dev binutils ninja-build liblzma-dev libz-dev pkg-config wget openjdk-8-jdk
 
 WORKDIR $SRC/
 RUN git clone https://github.com/google/libphonenumber

--- a/projects/libphonenumber/build.sh
+++ b/projects/libphonenumber/build.sh
@@ -1,0 +1,70 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Build Protobuf
+git clone https://github.com/google/protobuf.git
+cd protobuf
+git submodule update --init --recursive
+./autogen.sh
+./configure
+make -j$(nproc)
+make install
+ldconfig
+
+
+# Build icu
+export DEPS_PATH=/src/deps/
+mkdir $DEPS_PATH
+
+# build ICU for linking statically.
+cd $SRC/icu/source
+./configure --disable-shared --enable-static --disable-layoutex \
+  --disable-tests --disable-samples --with-data-packaging=static --prefix=$DEPS_PATH
+make install -j$(nproc)
+
+# Ugly ugly hack to get static linking to work for icu.
+cd $DEPS_PATH/lib
+ls *.a | xargs -n1 ar x
+rm *.a
+ar r libicu.a *.{ao,o}
+ln -s libicu.a libicudata.a
+ln -s libicu.a libicuuc.a
+ln -s libicu.a libicui18n.a
+
+# Build libphonenumber
+cd $SRC/libphonenumber/cpp
+sed -i 's/set (BUILD_SHARED_LIB true)/set (BUILD_SHARED_LIB false)/g' CMakeLists.txt
+sed -i 's/list (APPEND CMAKE_C_FLAGS "-pthread")/string (APPEND CMAKE_C_FLAGS " -pthread")/g' CMakeLists.txt
+
+mkdir build && cd build
+cmake -DUSE_BOOST=OFF -DBUILD_GEOCODER=OFF -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+      -DICU_UC_INCLUDE_DIR=/src/icu/source/comon \
+      -DICU_UC_LIB=/src/deps/lib/libicuuc.a \
+      -DICU_I18N_INCLUDE_DIR=/src/icu/source/i18n/ \
+      -DICU_I18N_LIB=/src/deps/lib/libicui18n.a  ../
+make
+cd ../
+
+# Build our fuzzer
+cp $SRC/*fuzz.cc .
+$CXX -I/src/libphonenumber/cpp/src $CXXFLAGS -o phonefuzz.o -c phonefuzz.cc
+
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE phonefuzz.o -o phonefuzz \
+     build/libphonenumber.a $SRC/protobuf/src/.libs/libprotobuf.a \
+     $DEPS_PATH/lib/libicu.a -lpthread
+
+cp phonefuzz $OUT/

--- a/projects/libphonenumber/phonefuzz.cc
+++ b/projects/libphonenumber/phonefuzz.cc
@@ -1,0 +1,48 @@
+/* Copyright 2020 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "phonenumbers/phonenumbermatcher.h"
+#include <string>
+#include <vector>
+
+#include <unicode/unistr.h>
+
+#include "phonenumbers/base/basictypes.h"
+#include "phonenumbers/base/memory/scoped_ptr.h"
+#include "phonenumbers/base/memory/singleton.h"
+#include "phonenumbers/default_logger.h"
+#include "phonenumbers/phonenumber.h"
+#include "phonenumbers/phonenumber.pb.h"
+#include "phonenumbers/phonenumbermatch.h"
+#include "phonenumbers/phonenumberutil.h"
+#include "phonenumbers/stringutil.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    if (size < 75)
+        return 0;
+
+    std::string input(reinterpret_cast<const char*>(data), 60);
+    data += 60;
+    size -= 60;
+    std::string input2(reinterpret_cast<const char*>(data), size);
+
+    i18n::phonenumbers::PhoneNumberUtil *phone_util = i18n::phonenumbers::PhoneNumberUtil::GetInstance();
+    i18n::phonenumbers::PhoneNumber parsed;
+    phone_util->Parse(input, input2, &parsed);
+    phone_util->IsValidNumber(parsed);
+    phone_util->GetCountryCodeForRegion(input);
+
+    return 0;
+}

--- a/projects/libphonenumber/project.yaml
+++ b/projects/libphonenumber/project.yaml
@@ -1,0 +1,5 @@
+homepage: "https://github.com/google/libphonenumber/"
+primary_contact: "david@adalogics.com"
+language: c++
+auto_ccs:
+  - "david@adalogics.com"

--- a/projects/libphonenumber/project.yaml
+++ b/projects/libphonenumber/project.yaml
@@ -3,3 +3,9 @@ primary_contact: "david@adalogics.com"
 language: c++
 auto_ccs:
   - "david@adalogics.com"
+fuzzing_engines:
+  - libfuzzer
+  - honggfuzz
+sanitizers:
+  - address
+  - memory

--- a/projects/libphonenumber/project.yaml
+++ b/projects/libphonenumber/project.yaml
@@ -8,4 +8,3 @@ fuzzing_engines:
   - honggfuzz
 sanitizers:
   - address
-  - memory


### PR DESCRIPTION
URL to upstream project: https://github.com/google/libphonenumber/

@penmetsaa or @lararennie Could you take a look at this? I believe libphonenumber is important to Google and it would be nice to have it fuzzed. OSS-Fuzz is a service run by Google that performs continuous fuzzing of a given project. It would be nice to merge the fuzzer of this PR as well as some additional build changes to the upstream libphonenumber later on. If you are happy to have the project fuzzed, could you provide me with an email that will received updates, e.g. bug-reports, about the fuzzing. I will also take care of the failures in the CI. 