### PR TITLE
[NATS] initial integration

### DIFF
--- a/projects/nats/Dockerfile
+++ b/projects/nats/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN go get github.com/nats-io/nats-server
+COPY build.sh $SRC/
+WORKDIR $SRC/

--- a/projects/nats/build.sh
+++ b/projects/nats/build.sh
@@ -1,0 +1,28 @@
+#/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+function compile_fuzzer {
+  path=$1
+  function=$2
+  fuzzer=$3
+
+  go-fuzz -func $function -o $fuzzer.a $path
+
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
+}
+
+compile_fuzzer github.com/nats-io/nats-server/conf Fuzz fuzz_conf
+compile_fuzzer github.com/nats-io/nats-server/server FuzzClient fuzz_client

--- a/projects/nats/build.sh
+++ b/projects/nats/build.sh
@@ -26,3 +26,4 @@ function compile_fuzzer {
 
 compile_fuzzer github.com/nats-io/nats-server/conf Fuzz fuzz_conf
 compile_fuzzer github.com/nats-io/nats-server/server FuzzClient fuzz_client
+

--- a/projects/nats/build.sh
+++ b/projects/nats/build.sh
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 ################################################################################
+
 function compile_fuzzer {
   path=$1
   function=$2

--- a/projects/nats/project.yaml
+++ b/projects/nats/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/nats-io/nats-server"
+primary_contact: ""
+auto_ccs :
+  - "adam@adalogics.com"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address

--- a/projects/nats/project.yaml
+++ b/projects/nats/project.yaml
@@ -1,5 +1,5 @@
 homepage: "https://github.com/nats-io/nats-server"
-primary_contact: ""
+primary_contact: "security@nats.io"
 auto_ccs :
   - "adam@adalogics.com"
 language: go


### PR DESCRIPTION
This PR adds initial integration of NATS, an incubating CNCF project.

For oss-fuzz maintainers: Please await fuzzers to be merged upstream as well as NATS maintainers to add their email addresses in this PR. 

The name of the directory is nats and not nats-server, as I intend to integrate the nats-client into this directory as well.

For NATS maintainers:
@matthiashanel and @derekcollison

I have taken the liberty to add an integration application of NATS. When the fuzzers are merged in upstream, I will finish the build so it works. The fuzzers will then run continuously and all maintainers on the contact list will receive email notifications with links to bug reports, should a bug be found. If you would like to add yourself or anyone else onto the list to receive potential bug reports, please add your email address in this PR. I have added myself to be in the loop for potential breakages. This means that I will be able to see all bug reports, including security vulnerabilities.

If you have any questions or remarks about this integration, please do not hesitate to express them in this PR.