### PR TITLE
[snappy] Initial integration

### DIFF
--- a/projects/snappy/Dockerfile
+++ b/projects/snappy/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool gettext pkg-config build-essential
+RUN git clone https://github.com/google/snappy
+
+WORKDIR $SRC/
+COPY build.sh $SRC/

--- a/projects/snappy/build.sh
+++ b/projects/snappy/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC/snappy
+mkdir build
+cd build && cmake -DSNAPPY_FUZZING_BUILD=ON -DSNAPPY_BUILD_TESTS=OFF ../ && make
+
+cp *_fuzzer $OUT/

--- a/projects/snappy/project.yaml
+++ b/projects/snappy/project.yaml
@@ -1,6 +1,6 @@
 homepage: "https://github.com/google/snappy"
 language: c++
-primary_contact: ""
+primary_contact: "costan@google.com"
 auto_ccs:
   - "Adam@adalogics.com"
 sanitizers:

--- a/projects/snappy/project.yaml
+++ b/projects/snappy/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/google/snappy"
+language: c++
+primary_contact: ""
+auto_ccs:
+  - "Adam@adalogics.com"
+sanitizers:
+  - address
+  - undefined
+  - memory

--- a/projects/snappy/project.yaml
+++ b/projects/snappy/project.yaml
@@ -5,5 +5,5 @@ auto_ccs:
   - "Adam@adalogics.com"
 sanitizers:
   - address
-  - undefined
-  - memory
+fuzzing_engines:
+  - libfuzzer


### PR DESCRIPTION
This PR adds initial integration of [snappy](https://github.com/google/snappy).

For maintainers of Snappy:
@pwnall

Following integration, oss-fuzz will run Snappys fuzzers continuously. If a bug is discovered, all maintainers get notified by email with a link to a detailed bug report.
To complete this integration, the email addresses of maintainers to receive bug reports are to be added to the contact list, and for that I kindly ask you to write those email addresses in this PR and I will then add them to the list. Note that I have added my own email address to keep an eye out for any breakages, and this means that I will be able to see all bugs including security critical bugs. If you are opposed to having me on the list for a few weeks, please let me know and I will remove myself.

Integration into oss-fuzz is free. Please pay notice to [the bug disclosure policy of oss-fuzz](https://google.github.io/oss-fuzz/getting-started/bug-disclosure-guidelines/).

This PR therefore provides the final step of the work that was started in https://github.com/google/snappy/pull/78 to setup continuous fuzzing of Snappy.  