### PR TITLE
projects/zeek: update build script to fix coverage build

### DIFF
--- a/projects/zeek/build.sh
+++ b/projects/zeek/build.sh
@@ -74,3 +74,11 @@ for f in ${fuzzers}; do
 
     fuzzer_count=$((fuzzer_count + 1))
 done
+
+if [ "${SANITIZER}" = "coverage" ]; then
+  # Normally, base-builder/compile copies sources for use in coverage reports,
+  # but its use of `cp -rL` omits the "zeek -> ." symlink used by #includes,
+  # causing the coverage build to fail.
+  mkdir -p $OUT/$(basename $SRC)
+  cp -r $SRC/zeek $OUT/$(basename $SRC)/zeek
+fi


### PR DESCRIPTION
I don't know if this PR is actually the best fix, but the underlying issue was that the `cp -L` of this:

https://github.com/google/oss-fuzz/blob/a7a973458c9fae6b1ea600810de528069654245a/infra/base-images/base-builder/compile#L95

will omit this symlink in our source tree:

https://github.com/zeek/zeek/blob/a6a4b976ecc59ed7a5ce1b8dc8c2a30568043364/src/zeek

and we have various `#include`s that resolve header files via that symlink resulting in a broken oss-fuzz coverage build with example error output shown here:

https://github.com/zeek/zeek/issues/1260

By changing our build script to preemptively do a `cp -r` of the source tree, the symlink seemed to be preserved and coverage build worked again when I tested locally.