### PR TITLE
[mongoose][draft: waiting for upstream] initial integration 

### DIFF
--- a/projects/mongoose/Dockerfile
+++ b/projects/mongoose/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Google Inc.
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/mongoose/Dockerfile
+++ b/projects/mongoose/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update 
+RUN git clone https://github.com/cesanta/mongoose
+WORKDIR $SRC
+COPY build.sh $SRC/

--- a/projects/mongoose/build.sh
+++ b/projects/mongoose/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2020 Google Inc.
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,5 +14,4 @@
 # limitations under the License.
 #
 cd $SRC/mongoose/test
-cp $SRC/fuzz.c .
-clang -fsanitize=fuzzer,address fuzz.c ../mongoose.c  -g -I../ -o $OUT/fuzz
+$CC $CFLAGS $LIB_FUZZING_ENGINE fuzz.c ../mongoose.c  -g -I../ -o $OUT/fuzz

--- a/projects/mongoose/build.sh
+++ b/projects/mongoose/build.sh
@@ -14,4 +14,7 @@
 # limitations under the License.
 #
 cd $SRC/mongoose/test
-$CC $CFLAGS $LIB_FUZZING_ENGINE fuzz.c ../mongoose.c  -g -I../ -o $OUT/fuzz
+$CC $CFLAGS -c fuzz.c -g -I../ -o fuzz.o
+$CC $CFLAGS -c ../mongoose.c -g -I../ -o mongoose.o
+
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz.o mongoose.o -o $OUT/fuzz

--- a/projects/mongoose/build.sh
+++ b/projects/mongoose/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+cd $SRC/mongoose/test
+cp $SRC/fuzz.c .
+clang -fsanitize=fuzzer,address fuzz.c ../mongoose.c  -g -I../ -o $OUT/fuzz

--- a/projects/mongoose/project.yaml
+++ b/projects/mongoose/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/cesanta/mongoose"
 language: c++
-primary_contact: "david@adalogics.com"
-
+primary_contact: "support@cesanta.com"
+auto_ccs:
+  - "david@adalogics.com"

--- a/projects/mongoose/project.yaml
+++ b/projects/mongoose/project.yaml
@@ -1,0 +1,4 @@
+homepage: "https://github.com/cesanta/mongoose"
+language: c++
+primary_contact: "david@adalogics.com"
+


### PR DESCRIPTION
PR in upstream to fuzzer addition: https://github.com/cesanta/mongoose/pull/1162

mongoose is an embedded networking library. From the upstream repo: "On the market since 2004, used by vast number of open source and commercial products - it even runs on the International Space station!" 