### PR TITLE
[infra] Unfreeze LLVM updating that was stopped due to #4608.

### DIFF
--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -70,7 +70,7 @@ OUR_LLVM_REVISION=llvmorg-12-init-5627-gf086e85e
 
 # To allow for manual downgrades. Set to 0 to use Chrome's clang version (i.e.
 # *not* force a manual downgrade). Set to 1 to force a manual downgrade.
-FORCE_OUR_REVISION=1
+FORCE_OUR_REVISION=0
 LLVM_REVISION=$(grep -Po "CLANG_REVISION = '\K([^']+)" scripts/update.py)
 
 clone_with_retries https://github.com/llvm/llvm-project.git $LLVM_SRC


### PR DESCRIPTION
Haven't tested locally, but checked that the current version newer than the follow up fix that was landed for #4608.