### PR TITLE
Initial support for ujson (as a Python fuzzing sample).

### DIFF
--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -103,6 +103,7 @@ class ProjectYamlChecker:
       'c',
       'c++',
       'go',
+      'python',
       'rust',
   ]
 

--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -286,15 +286,15 @@ def bool_to_returncode(success):
   return 1
 
 
-def is_python(path):
+def is_nonfuzzer_python(path):
   """Returns True if |path| ends in .py."""
-  return os.path.splitext(path)[1] == '.py'
+  return os.path.splitext(path)[1] == '.py' and '/projects/' not in path
 
 
 def lint(paths):
   """Run python's linter on |paths| if it is a python file. Return False if it
   fails linting."""
-  paths = [path for path in paths if is_python(path)]
+  paths = [path for path in paths if is_nonfuzzer_python(path)]
   if not paths:
     return True
 
@@ -309,7 +309,7 @@ def yapf(paths, validate=True):
   """Do yapf on |path| if it is Python file. Only validates format if
   |validate| otherwise, formats the file. Returns False if validation
   or formatting fails."""
-  paths = [path for path in paths if is_python(path)]
+  paths = [path for path in paths if is_nonfuzzer_python(path)]
   if not paths:
     return True
 

--- a/projects/ujson/Dockerfile
+++ b/projects/ujson/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+
+RUN git clone \
+	--depth 1 \
+	--branch master \
+	https://github.com/ultrajson/ultrajson.git
+
+WORKDIR ultrajson
+
+COPY build.sh json_differential_fuzzer.py ujson_fuzzer.py $SRC/

--- a/projects/ujson/build.sh
+++ b/projects/ujson/build.sh
@@ -16,5 +16,4 @@
 ################################################################################
 
 # build and install fuzzers
-# TODO(mbarbella): Don't set CFLAGS/CXXFLAGS directly.
-CFLAGS="-fsanitize=address,fuzzer-no-link" CXXFLAGS="-fsanitize=address,fuzzer-no-link" pip3 install . -t $OUT
+CFLAGS="$CFLAGS -fsanitize=fuzzer-no-link" CXXFLAGS="$CXXFLAGS -fsanitize=fuzzer-no-link" pip3 install . -t $OUT

--- a/projects/ujson/build.sh
+++ b/projects/ujson/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# build and install fuzzers
+# TODO(mbarbella): Don't set CFLAGS/CXXFLAGS directly.
+CFLAGS="-fsanitize=address,fuzzer-no-link" CXXFLAGS="-fsanitize=address,fuzzer-no-link" pip3 install . -t $OUT

--- a/projects/ujson/build.sh
+++ b/projects/ujson/build.sh
@@ -16,4 +16,4 @@
 ################################################################################
 
 # build and install fuzzers
-CFLAGS="$CFLAGS -fsanitize=fuzzer-no-link" CXXFLAGS="$CXXFLAGS -fsanitize=fuzzer-no-link" pip3 install . -t $OUT
+pip3 install . -t $OUT

--- a/projects/ujson/json_differential_fuzzer.py
+++ b/projects/ujson/json_differential_fuzzer.py
@@ -1,0 +1,94 @@
+#!/usr/bin/python3
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" An example native JSON vs uJSON differential fuzzer.
+
+This fuzzer looks for differences between the built-in json library and the
+native ujson library. The ujson library should be built for coverage (see
+build_install_ujson.sh), and the Python fuzzer should be executed under ASAN.
+As an example:
+    LD_PRELOAD="/usr/lib/llvm-9/lib/clang/9.0.1/lib/linux/libclang_rt.asan-x86_64.so
+    $(python3 -c "import atheris; print(atheris.path())")" python3
+    ./ujson_fuzzer.py -detect_leaks=0
+
+This fuzzer has found a bug with inconsistent handling of integers with
+too-high magnitude. uJSON sometimes refuses to process numbers that are too far
+from 0 with "Value is too big!" or the equivalent for values that are too
+negative. However, other times it happily processes them with two's compliment
+mod. As an example, it refuses to parse "-9223372036854775809" (the first
+integer not representable in a 64-bit signed number) with "Value is too small";
+but it will happily parse "-80888888888888888888", a significantly more negative
+number. However, it parses it as -9223372036854775808. The JSON spec
+(https://tools.ietf.org/html/rfc7159#section-6) "allows implementations to set
+limits on the range and precision of numbers accepted", so failing to parse
+values that are too big or too small is techincally fine; however,
+misinterpreting them is not.
+"""
+
+import atheris
+import json
+import ujson
+import sys
+
+
+def ClearAllIntegers(data):
+  """Used to prevent known bug; sets all integers in data recursively to 0."""
+  if type(data) == int:
+    return 0
+  if type(data) == list:
+    for i in range(0, len(data)):
+      data[i] = ClearAllIntegers(data[i])
+  if type(data) == dict:
+    for k, v in data:
+      data[k] = ClearAllIntegers(v)
+  return data
+
+
+def TestOneInput(input_bytes):
+  fdp = atheris.FuzzedDataProvider(input_bytes)
+  original = fdp.ConsumeUnicode(sys.maxsize)
+
+  try:
+    json_data = json.loads(original)
+    ujson_data = ujson.loads(original)
+  except Exception as e:
+    # It would be interesting to enforce that if one of the libraries throws an
+    # exception, the other does too. However, uJSON accepts many invalid inputs
+    # that are uninteresting, such as "00". So, that is not done.
+    return
+
+
+
+  # Uncomment these lines to ignore the errors described in the docstring of
+  # this file.
+  json_data = ClearAllIntegers(json_data)
+  ujson_data = ClearAllIntegers(ujson_data)
+
+  json_dumped = json.dumps(json_data)
+  ujson_dumped = json.dumps(ujson_data)
+
+  if json_dumped != ujson_dumped:
+    raise RuntimeError(
+        "Decoding/encoding disagreement!\nInput: %s\nJSON data: %s\nuJSON data: %s\nJSON-dumped: %s\nuJSON-dumped: %s\n"
+        % (original, json_data, ujson_data, json_dumped, ujson_dumped))
+
+
+def main():
+  atheris.Setup(sys.argv, TestOneInput)
+  atheris.Fuzz()
+
+if __name__ == "__main__":
+  main()
+

--- a/projects/ujson/json_differential_fuzzer.py
+++ b/projects/ujson/json_differential_fuzzer.py
@@ -87,6 +87,6 @@ def main():
   atheris.Setup(sys.argv, TestOneInput)
   atheris.Fuzz()
 
+
 if __name__ == "__main__":
   main()
-

--- a/projects/ujson/json_differential_fuzzer.py
+++ b/projects/ujson/json_differential_fuzzer.py
@@ -69,8 +69,6 @@ def TestOneInput(input_bytes):
     # that are uninteresting, such as "00". So, that is not done.
     return
 
-
-
   # Uncomment these lines to ignore the errors described in the docstring of
   # this file.
   json_data = ClearAllIntegers(json_data)

--- a/projects/ujson/project.yaml
+++ b/projects/ujson/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://github.com/ultrajson/ultrajson"
+language: python
+# TODO(mbarbella): Reach out to project maintainers for a better primary contact.
+primary_contact: "mbarbella@google.com"
+auto_ccs:
+  - "ipudney@google.com"
+sanitizers:
+  - address

--- a/projects/ujson/project.yaml
+++ b/projects/ujson/project.yaml
@@ -4,5 +4,7 @@ language: python
 primary_contact: "mbarbella@google.com"
 auto_ccs:
   - "ipudney@google.com"
+fuzzing_engines:
+  - libfuzzer
 sanitizers:
   - address

--- a/projects/ujson/ujson_fuzzer.py
+++ b/projects/ujson/ujson_fuzzer.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python3
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This fuzzer is an example of native extension fuzzing with coverage.
+
+This requires that the fuzzer be built with coverage:
+see build_install_ujson.sh.
+The fuzzer should then be executed under ASAN.
+
+As an example, this is the run command under the author's machine:
+    LD_PRELOAD="/usr/lib/llvm-9/lib/clang/9.0.1/lib/linux/libclang_rt.asan-x86_64.so
+    $(python3 -c "import atheris; print(atheris.path())")" python3
+    ./ujson_fuzzer.py -detect_leaks=0
+
+This fuzzer is provided mainly as an example for how to deal with native
+coverage.
+"""
+
+import sys
+import atheris
+import ujson
+
+
+def TestOneInput(input_bytes):
+  fdp = atheris.FuzzedDataProvider(input_bytes)
+  original = fdp.ConsumeUnicode(sys.maxsize)
+
+  try:
+    ujson_data = ujson.loads(original)
+  except ValueError:
+    return
+
+  # We make sure there's no error in encoding, but we don't actually compare
+  # (encoded == original) because it's not entirely preserving. For example,
+  # it does not preserve whitespace.
+  encoded = ujson.dumps(ujson_data)
+  del encoded
+
+
+def main():
+  # Since everything interesting in this fuzzer is in native code, we can
+  # disable Python coverage to improve performance and reduce coverage noise.
+  atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=False)
+  atheris.Fuzz()
+
+if __name__ == "__main__":
+  main()

--- a/projects/ujson/ujson_fuzzer.py
+++ b/projects/ujson/ujson_fuzzer.py
@@ -55,5 +55,6 @@ def main():
   atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=False)
   atheris.Fuzz()
 
+
 if __name__ == "__main__":
   main()


### PR DESCRIPTION
This adds the fuzzers and builds ujson in the correct format for Atheris to use it. It doesn't yet copy the fuzzers to the archive (pending whatever we decide for how we want to bundle things together). I'm going to hold off a little bit on reaching out to the maintainers, but it looks like the project is well-maintained and we should be able to add a reasonable primary contact when we're ready.