### PR TITLE
Use generic compile_go_fuzzer for golang projects

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -149,7 +149,7 @@ RUN mkdir honggfuzz && \
     rm -rf $SRC/oss-fuzz.tar.gz
 
 COPY compile compile_afl compile_dataflow compile_libfuzzer compile_honggfuzz \
-    precompile_honggfuzz srcmap write_labels.py /usr/local/bin/
+    compile_go_fuzzer precompile_honggfuzz srcmap write_labels.py /usr/local/bin/
 
 COPY detect_repo.py /opt/cifuzz/
 COPY ossfuzz_coverage_runner.go $GOPATH

--- a/infra/base-images/base-builder/compile_go_fuzzer
+++ b/infra/base-images/base-builder/compile_go_fuzzer
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2016 Google Inc.
+# Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/base-images/base-builder/compile_go_fuzzer
+++ b/infra/base-images/base-builder/compile_go_fuzzer
@@ -1,0 +1,47 @@
+#!/bin/bash -eu
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+path=$1
+function=$2
+fuzzer=$3
+tags=""
+if [[ $#  -eq 4 ]]; then
+  tags="-tags $4"
+fi
+
+if [[ $SANITIZER = *coverage* ]]; then
+  cd $GOPATH/src/$path
+  fuzzed_package=`pwd | rev | cut -d'/' -f 1 | rev`
+  cp $GOPATH/ossfuzz_coverage_runner.go ./"${function,,}"_test.go
+  sed -i -e 's/FuzzFunction/'$function'/' ./"${function,,}"_test.go
+  sed -i -e 's/mypackagebeingfuzzed/'$fuzzed_package'/' ./"${function,,}"_test.go
+  sed -i -e 's/TestFuzzCorpus/Test'$function'Corpus/' ./"${function,,}"_test.go
+
+  echo "#/bin/sh" > $OUT/$fuzzer
+  echo "cd $path" >> $OUT/$fuzzer
+  echo "go test -run Test${function}Corpus -v $tags -coverprofile \$1 " >> $OUT/$fuzzer
+  chmod +x $OUT/$fuzzer
+
+  cd -
+else
+  # Compile and instrument all Go files relevant to this fuzz target.
+  echo "Running go-fuzz $tags -func $function -o $fuzzer.a $path"
+  go-fuzz $tags -func $function -o $fuzzer.a $path
+
+  # Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
+fi

--- a/projects/cascadia/build.sh
+++ b/projects/cascadia/build.sh
@@ -14,14 +14,6 @@
 # limitations under the License.
 #
 ################################################################################
-function compile_fuzzer {
-  path=$1
-  function=$2
-  fuzzer=$3
 
-  go-fuzz -func $function -o $fuzzer.a $path
 
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
-}
-
-compile_fuzzer github.com/andybalholm/cascadia/fuzz Fuzz fuzz
+compile_go_fuzzer github.com/andybalholm/cascadia/fuzz Fuzz fuzz

--- a/projects/dragonfly/build.sh
+++ b/projects/dragonfly/build.sh
@@ -14,17 +14,9 @@
 # limitations under the License.
 #
 ################################################################################
-function compile_fuzzer {
-  path=$1
-  function=$2
-  fuzzer=$3
 
-  go-fuzz -func $function -o $fuzzer.a $path
-
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
-}
 mkdir $GOPATH/src/github.com/dragonflyoss
 cp -r $SRC/Dragonfly $GOPATH/src/github.com/dragonflyoss/
 
-compile_fuzzer github.com/dragonflyoss/Dragonfly/dfget/core/uploader FuzzParseParams uploader_fuzz
-compile_fuzzer github.com/dragonflyoss/Dragonfly/supernode/daemon/mgr/cdn Fuzz cdn_fuzz
+compile_go_fuzzer github.com/dragonflyoss/Dragonfly/dfget/core/uploader FuzzParseParams uploader_fuzz
+compile_go_fuzzer github.com/dragonflyoss/Dragonfly/supernode/daemon/mgr/cdn Fuzz cdn_fuzz

--- a/projects/fasthttp/build.sh
+++ b/projects/fasthttp/build.sh
@@ -15,18 +15,10 @@
 #
 ################################################################################
 
-function compile_fuzzer {
-  path=$1
-  function=$2
-  fuzzer=$3
 
-  go-fuzz -func $function -o $fuzzer.a $path
-
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
-}
 
 
 ls $GOPATH/src/github.com/valyala/fasthttp/fuzzit | while read target
 do
-    compile_fuzzer github.com/valyala/fasthttp/fuzzit/$target Fuzz fuzz_$target
+    compile_go_fuzzer github.com/valyala/fasthttp/fuzzit/$target Fuzz fuzz_$target
 done

--- a/projects/fastjson/build.sh
+++ b/projects/fastjson/build.sh
@@ -14,14 +14,6 @@
 # limitations under the License.
 #
 ################################################################################
-function compile_fuzzer {
-  path=$1
-  function=$2
-  fuzzer=$3
 
-  go-fuzz -func $function -o $fuzzer.a $path
 
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
-}
-
-compile_fuzzer github.com/valyala/fastjson Fuzz fuzz
+compile_go_fuzzer github.com/valyala/fastjson Fuzz fuzz

--- a/projects/gcloud-go/build.sh
+++ b/projects/gcloud-go/build.sh
@@ -15,14 +15,6 @@
 #
 ################################################################################
 
-function compile_fuzzer() {
-    path=$1
-    function=$2
-    fuzzer=$3
 
-    go-fuzz -func $function -o $fuzzer.a $path
 
-    $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
-}
-
-compile_fuzzer cloud.google.com/go/spanner/spansql FuzzParseQuery fuzz_parse_query
+compile_go_fuzzer cloud.google.com/go/spanner/spansql FuzzParseQuery fuzz_parse_query

--- a/projects/go-attestation/build.sh
+++ b/projects/go-attestation/build.sh
@@ -15,23 +15,13 @@
 #
 ################################################################################
 
-function compile_fuzzer {
-  package=$1
-  function=$2
-  fuzzer=$3
 
-  # Compile and instrument all Go files relevant to this fuzz target.
-  go-fuzz -func $function -o $fuzzer.a $package
 
-  # Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
-}
-
-compile_fuzzer github.com/google/go-attestation/attest FuzzParseEventLog \
+compile_go_fuzzer github.com/google/go-attestation/attest FuzzParseEventLog \
     parse_event_log_fuzzer
-compile_fuzzer github.com/google/go-attestation/attest FuzzParseAKPublic12 \
+compile_go_fuzzer github.com/google/go-attestation/attest FuzzParseAKPublic12 \
     parse_ak_public12_fuzzer
-compile_fuzzer github.com/google/go-attestation/attest FuzzParseAKPublic20 \
+compile_go_fuzzer github.com/google/go-attestation/attest FuzzParseAKPublic20 \
     parse_ak_public20_fuzzer
-compile_fuzzer github.com/google/go-attestation/attest FuzzParseEKCertificate \
+compile_go_fuzzer github.com/google/go-attestation/attest FuzzParseEKCertificate \
     parse_ek_certificate_fuzzer

--- a/projects/go-coredns/build.sh
+++ b/projects/go-coredns/build.sh
@@ -16,24 +16,14 @@
 ################################################################################
 
 # Same as usual except for added -tags gofuzz.
-function compile_fuzzer {
-  path=$1
-  function=$2
-  fuzzer=$3
 
-  # Compile and instrument all Go files relevant to this fuzz target.
-  go-fuzz -func $function -o $fuzzer.a $path
-
-  # Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
-}
 
 cd coredns
 #make
 ls plugin/*/fuzz.go | while read target
 do
     fuzzed_plugin=`echo $target | cut -d'/' -f 2`
-    compile_fuzzer github.com/coredns/coredns/plugin/$fuzzed_plugin Fuzz fuzz_plugin_$fuzzed_plugin
+    compile_go_fuzzer github.com/coredns/coredns/plugin/$fuzzed_plugin Fuzz fuzz_plugin_$fuzzed_plugin
 done
 
-compile_fuzzer github.com/coredns/coredns/test Fuzz fuzz_core
+compile_go_fuzzer github.com/coredns/coredns/test Fuzz fuzz_core

--- a/projects/go-dns/build.sh
+++ b/projects/go-dns/build.sh
@@ -15,34 +15,7 @@
 #
 ################################################################################
 
-function compile_fuzzer {
-  path=$1
-  function=$2
-  fuzzer=$3
-
-  if [[ $SANITIZER = *coverage* ]]; then
-    cd $GOPATH/src/$path
-    fuzzed_package=`pwd | rev | cut -d'/' -f 1 | rev`
-    cp $GOPATH/ossfuzz_coverage_runner.go ./"${function,,}"_test.go
-    sed -i -e 's/FuzzFunction/'$function'/' ./"${function,,}"_test.go
-    sed -i -e 's/mypackagebeingfuzzed/'$fuzzed_package'/' ./"${function,,}"_test.go
-    sed -i -e 's/TestFuzzCorpus/Test'$function'Corpus/' ./"${function,,}"_test.go
-
-    echo "#/bin/sh" > $OUT/$fuzzer
-    echo "cd $path" >> $OUT/$fuzzer
-    echo "go test -run Test${function}Corpus -v -tags fuzz -coverprofile \$1 " >> $OUT/$fuzzer
-    chmod +x $OUT/$fuzzer
-
-    cd -
-    return 0
-  fi
-  # Compile and instrument all Go files relevant to this fuzz target.
-  go-fuzz -tags fuzz -func $function -o $fuzzer.a $path
-
-  # Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
-}
 
 # Same as usual except for added -tags fuzz.
-compile_fuzzer github.com/miekg/dns FuzzNewRR fuzz_newrr
-compile_fuzzer github.com/miekg/dns Fuzz fuzz_msg_unpack
+compile_go_fuzzer github.com/miekg/dns FuzzNewRR fuzz_newrr fuzz
+compile_go_fuzzer github.com/miekg/dns Fuzz fuzz_msg_unpack fuzz

--- a/projects/go-json-iterator/build.sh
+++ b/projects/go-json-iterator/build.sh
@@ -15,16 +15,6 @@
 #
 ################################################################################
 
-function compile_fuzzer {
-  path=$1
-  function=$2
-  fuzzer=$3
 
-  # Compile and instrument all Go files relevant to this fuzz target.
-  go-fuzz -func $function -o $fuzzer.a $path
 
-  # Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
-}
-
-compile_fuzzer . Fuzz fuzz_json
+compile_go_fuzzer . Fuzz fuzz_json

--- a/projects/golang/build.sh
+++ b/projects/golang/build.sh
@@ -15,11 +15,7 @@
 function compile_fuzzer {
   fuzzer=$(basename $1)
 
-  # Compile and instrument all Go files relevant to this fuzz target.
-  go-fuzz -o $fuzzer.a github.com/dvyukov/go-fuzz-corpus/$fuzzer
-
-  # Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/fuzzer-$fuzzer
+  compile_fuzzer "github.com/dvyukov/go-fuzz-corpus/$fuzzer" Fuzz $fuzzer
 
   # Pack the seed corpus
   zip -r $OUT/fuzzer-${fuzzer}_seed_corpus.zip \

--- a/projects/gonids/build.sh
+++ b/projects/gonids/build.sh
@@ -15,35 +15,7 @@
 #
 ################################################################################
 
-function compile_fuzzer {
-  path=$1
-  function=$2
-  fuzzer=$3
-
-  if [[ $SANITIZER = *coverage* ]]; then
-    cd $GOPATH/src/$path
-    fuzzed_package=`pwd | rev | cut -d'/' -f 1 | rev`
-    cp $GOPATH/ossfuzz_coverage_runner.go ./"${function,,}"_test.go
-    sed -i -e 's/FuzzFunction/'$function'/' ./"${function,,}"_test.go
-    sed -i -e 's/mypackagebeingfuzzed/'$fuzzed_package'/' ./"${function,,}"_test.go
-    sed -i -e 's/TestFuzzCorpus/Test'$function'Corpus/' ./"${function,,}"_test.go
-
-    echo "#/bin/sh" > $OUT/$fuzzer
-    echo "cd $path" >> $OUT/$fuzzer
-    echo "go test -run Test${function}Corpus -v -coverprofile \$1 " >> $OUT/$fuzzer
-    chmod +x $OUT/$fuzzer
-
-    cd -
-    return 0
-  fi
-  # Compile and instrument all Go files relevant to this fuzz target.
-  go-fuzz -func $function -o $fuzzer.a $path
-
-  # Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
-}
-
-compile_fuzzer github.com/google/gonids FuzzParseRule fuzz_parserule
+compile_go_fuzzer github.com/google/gonids FuzzParseRule fuzz_parserule
 
 unzip emerging.rules.zip
 cd rules

--- a/projects/gopacket/build.sh
+++ b/projects/gopacket/build.sh
@@ -15,16 +15,6 @@
 #
 ################################################################################
 
-function compile_fuzzer {
-  path=$1
-  function=$2
-  fuzzer=$3
 
-  # Compile and instrument all Go files relevant to this fuzz target.
-  go-fuzz -func $function -o $fuzzer.a $path
 
-  # Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
-}
-
-compile_fuzzer github.com/google/gopacket/layers FuzzLayer fuzz_layers
+compile_go_fuzzer github.com/google/gopacket/layers FuzzLayer fuzz_layers

--- a/projects/grpc-gateway/build.sh
+++ b/projects/grpc-gateway/build.sh
@@ -14,14 +14,6 @@
 # limitations under the License.
 #
 ################################################################################
-function compile_fuzzer {
-  path=$1
-  function=$2
-  fuzzer=$3
 
-  go-fuzz -func $function -o $fuzzer.a $path
 
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
-}
-
-compile_fuzzer github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/httprule Fuzz fuzz
+compile_go_fuzzer github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/httprule Fuzz fuzz

--- a/projects/influxdb/build.sh
+++ b/projects/influxdb/build.sh
@@ -15,16 +15,6 @@
 #
 ################################################################################
 
-function compile_fuzzer {
-  path=$1
-  function=$2
-  fuzzer=$3
 
-   # Instrument all Go files relevant to this fuzzer
-  go-fuzz -func $function -o $fuzzer.a $path
 
-   # Instrumented, compiled Go ($fuzzer.a) + fuzzing engine = fuzzer binary
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
-}
-
-compile_fuzzer github.com/influxdata/influxdb/jsonweb FuzzJsonWeb fuzzjsonweb
+compile_go_fuzzer github.com/influxdata/influxdb/jsonweb FuzzJsonWeb fuzzjsonweb

--- a/projects/kubernetes/build.sh
+++ b/projects/kubernetes/build.sh
@@ -25,11 +25,7 @@ function compile_fuzzer {
   local function=$2
   local fuzzer="${pkg}_${function}"
 
-  # Compile and instrument all Go files relevant to this fuzz target.
-  go-fuzz -func "${function}" -o "${fuzzer}.a" "k8s.io/kubernetes/test/fuzz/${pkg}"
-
-  # Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE "${fuzzer}.a" -o "${OUT}/${fuzzer}"
+  compile_fuzzer "k8s.io/kubernetes/test/fuzz/${pkg}" $function $fuzzer
 }
 
 compile_fuzzer "yaml" "FuzzDurationStrict"

--- a/projects/nats/build.sh
+++ b/projects/nats/build.sh
@@ -15,16 +15,8 @@
 #
 ################################################################################
 
-function compile_fuzzer {
-  path=$1
-  function=$2
-  fuzzer=$3
 
-  go-fuzz -func $function -o $fuzzer.a $path
 
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
-}
-
-compile_fuzzer github.com/nats-io/nats-server/conf Fuzz fuzz_conf
-compile_fuzzer github.com/nats-io/nats-server/server FuzzClient fuzz_client
+compile_go_fuzzer github.com/nats-io/nats-server/conf Fuzz fuzz_conf
+compile_go_fuzzer github.com/nats-io/nats-server/server FuzzClient fuzz_client
 

--- a/projects/p9/build.sh
+++ b/projects/p9/build.sh
@@ -14,16 +14,6 @@
 # limitations under the License.
 #
 ################################################################################
-function compile_fuzzer {
-  path=$1
-  function=$2
-  fuzzer=$3
 
-  # Compile and instrument all Go files relevant to this fuzz target.
-  go-fuzz -func $function -o $fuzzer.a $path
 
-  # Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
-}
-
-compile_fuzzer github.com/hugelgupf/p9/p9 Fuzz p9_fuzzer
+compile_go_fuzzer github.com/hugelgupf/p9/p9 Fuzz p9_fuzzer

--- a/projects/prometheus/build.sh
+++ b/projects/prometheus/build.sh
@@ -14,16 +14,8 @@
 # limitations under the License.
 #
 ################################################################################
-function compile_fuzzer {
-  path=$1
-  function=$2
-  fuzzer=$3
 
-  go-fuzz -func $function -o $fuzzer.a $path
-
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
-}
-compile_fuzzer github.com/prometheus/prometheus/promql FuzzParseMetric fuzzParseMetric
-compile_fuzzer github.com/prometheus/prometheus/promql FuzzParseOpenMetric fuzzParseOpenMetric
-compile_fuzzer github.com/prometheus/prometheus/promql FuzzParseMetricSelector fuzzParseMetricSelector
-compile_fuzzer github.com/prometheus/prometheus/promql FuzzParseExpr fuzzParseExpr
+compile_go_fuzzer github.com/prometheus/prometheus/promql FuzzParseMetric fuzzParseMetric
+compile_go_fuzzer github.com/prometheus/prometheus/promql FuzzParseOpenMetric fuzzParseOpenMetric
+compile_go_fuzzer github.com/prometheus/prometheus/promql FuzzParseMetricSelector fuzzParseMetricSelector
+compile_go_fuzzer github.com/prometheus/prometheus/promql FuzzParseExpr fuzzParseExpr

--- a/projects/quic-go/build.sh
+++ b/projects/quic-go/build.sh
@@ -17,27 +17,17 @@
 
 set -ex
 
-function compile_fuzzer {
-  path=$1
-  function=$2
-  fuzzer=$3
 
-  # Compile and instrument all Go files relevant to this fuzz target.
-  go-fuzz -func $function -o $fuzzer.a $path
-
-  # Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
-}
 
 # Fuzz qpack
-compile_fuzzer github.com/marten-seemann/qpack/fuzzing Fuzz qpack_fuzzer
+compile_go_fuzzer github.com/marten-seemann/qpack/fuzzing Fuzz qpack_fuzzer
 
 # Fuzz quic-go
-compile_fuzzer github.com/lucas-clemente/quic-go/fuzzing/frames Fuzz frame_fuzzer
-compile_fuzzer github.com/lucas-clemente/quic-go/fuzzing/header Fuzz header_fuzzer
-compile_fuzzer github.com/lucas-clemente/quic-go/fuzzing/transportparameters Fuzz transportparameter_fuzzer
-compile_fuzzer github.com/lucas-clemente/quic-go/fuzzing/tokens Fuzz token_fuzzer
-compile_fuzzer github.com/lucas-clemente/quic-go/fuzzing/handshake Fuzz handshake_fuzzer
+compile_go_fuzzer github.com/lucas-clemente/quic-go/fuzzing/frames Fuzz frame_fuzzer
+compile_go_fuzzer github.com/lucas-clemente/quic-go/fuzzing/header Fuzz header_fuzzer
+compile_go_fuzzer github.com/lucas-clemente/quic-go/fuzzing/transportparameters Fuzz transportparameter_fuzzer
+compile_go_fuzzer github.com/lucas-clemente/quic-go/fuzzing/tokens Fuzz token_fuzzer
+compile_go_fuzzer github.com/lucas-clemente/quic-go/fuzzing/handshake Fuzz handshake_fuzzer
 
 # generate seed corpora
 go generate $GOPATH/src/github.com/lucas-clemente/quic-go/fuzzing/...

--- a/projects/radon/build.sh
+++ b/projects/radon/build.sh
@@ -14,14 +14,6 @@
 # limitations under the License.
 #
 ################################################################################
-function compile_fuzzer {
-  path=$1
-  function=$2
-  fuzzer=$3
 
-  go-fuzz -func $function -o $fuzzer.a $path
 
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
-}
-
-compile_fuzzer github.com/radondb/radon/src/fuzz/sqlparser Fuzz fuzz
+compile_go_fuzzer github.com/radondb/radon/src/fuzz/sqlparser Fuzz fuzz

--- a/projects/syzkaller/build.sh
+++ b/projects/syzkaller/build.sh
@@ -15,23 +15,13 @@
 #
 ################################################################################
 
-function compile_fuzzer {
-  path=$1
-  function=$2
-  fuzzer=$3
 
-  # Compile and instrument all Go files relevant to this fuzz target.
-  go-fuzz -func $function -o $fuzzer.a $path
-
-  # Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
-}
 
 make descriptions
-compile_fuzzer github.com/google/syzkaller/pkg/compiler Fuzz compiler_fuzzer
-compile_fuzzer github.com/google/syzkaller/prog/test FuzzDeserialize prog_deserialize_fuzzer
-compile_fuzzer github.com/google/syzkaller/prog/test FuzzParseLog prog_parselog_fuzzer
-compile_fuzzer github.com/google/syzkaller/pkg/report Fuzz report_fuzzer
+compile_go_fuzzer github.com/google/syzkaller/pkg/compiler Fuzz compiler_fuzzer
+compile_go_fuzzer github.com/google/syzkaller/prog/test FuzzDeserialize prog_deserialize_fuzzer
+compile_go_fuzzer github.com/google/syzkaller/prog/test FuzzParseLog prog_parselog_fuzzer
+compile_go_fuzzer github.com/google/syzkaller/pkg/report Fuzz report_fuzzer
 
 # This target is way too spammy and OOMs very quickly.
-# compile_fuzzer ./tools/syz-trace2syz/proggen Fuzz trace2syz_fuzzer
+# compile_go_fuzzer ./tools/syz-trace2syz/proggen Fuzz trace2syz_fuzzer

--- a/projects/teleport/build.sh
+++ b/projects/teleport/build.sh
@@ -14,19 +14,11 @@
 # limitations under the License.
 #
 ################################################################################
-function compile_fuzzer {
-  path=$1
-  function=$2
-  fuzzer=$3
 
-  go-fuzz -func $function -o $fuzzer.a $path
-
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
-}
 
 mkdir -p $GOPATH/src/github.com/gravitational
 cd $GOPATH/src/github.com/gravitational
 git clone https://github.com/gravitational/teleport.git
 
-compile_fuzzer github.com/gravitational/teleport/lib/fuzz FuzzParseProxyJump utils_fuzz
-compile_fuzzer github.com/gravitational/teleport/lib/fuzz FuzzNewExpression parse_fuzz
+compile_go_fuzzer github.com/gravitational/teleport/lib/fuzz FuzzParseProxyJump utils_fuzz
+compile_go_fuzzer github.com/gravitational/teleport/lib/fuzz FuzzNewExpression parse_fuzz

--- a/projects/tidb/build.sh
+++ b/projects/tidb/build.sh
@@ -14,15 +14,7 @@
 # limitations under the License.
 #
 ################################################################################
-function compile_fuzzer {
-  path=$1
-  function=$2
-  fuzzer=$3
 
-  go-fuzz -func $function -o $fuzzer.a $path
-
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
-}
-compile_fuzzer github.com/pingcap/tidb/types FuzzMarshalJSON fuzzMarshalJSON
-compile_fuzzer github.com/pingcap/tidb/types FuzzNewBitLiteral fuzzNewBitLiteral
-compile_fuzzer github.com/pingcap/tidb/types FuzzNewHexLiteral fuzzNewHexLiteral
+compile_go_fuzzer github.com/pingcap/tidb/types FuzzMarshalJSON fuzzMarshalJSON
+compile_go_fuzzer github.com/pingcap/tidb/types FuzzNewBitLiteral fuzzNewBitLiteral
+compile_go_fuzzer github.com/pingcap/tidb/types FuzzNewHexLiteral fuzzNewHexLiteral

--- a/projects/vitess/build.sh
+++ b/projects/vitess/build.sh
@@ -14,13 +14,5 @@
 # limitations under the License.
 #
 ################################################################################
-function compile_fuzzer {
-  path=$1
-  function=$2
-  fuzzer=$3
 
-  go-fuzz -func $function -o $fuzzer.a $path
-
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
-}
-compile_fuzzer github.com/vitessio/vitess/go/vt/sqlparser Fuzz fuzz
+compile_go_fuzzer github.com/vitessio/vitess/go/vt/sqlparser Fuzz fuzz


### PR DESCRIPTION
Following #3142, and as request in #2187
Here is the generic `compile_go_fuzzer` and the migration of projects to use it

24 projects in this PR
go-dns and gonids were already using this script
golang and kubernetes were specially handcrafted (golang has seed_corpus in its build script, and kubernetes has an automatic way of naming the fuzzer)
20 projects were automated (see dummy python script below)

5 projects to go :
ipfs has a specific build script I did not dare to touch
golang-protobuf, jsonparser, minify, mtail build scripts seem to be hosted in upstream repos

Plus excelize and go-ethereum which have project.yaml but no build.sh

cc @Dor1s
How do you want to test this ?

Script to automate
```
import sys

comp="""function compile_fuzzer {
  path=$1
  function=$2
  fuzzer=$3

  # Compile and instrument all Go files relevant to this fuzz target.
  go-fuzz -func $function -o $fuzzer.a $path

  # Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
}"""

f = open(sys.argv[1])
check = 0
l = f.read()
f.close()
f = open(sys.argv[1], "wb")
if l.find(comp) > 0:
    print "ok", sys.argv[1]
    l=l.replace(comp,"")
elif l.find(comp2) > 0:
    print "ok2", sys.argv[1]
    l=l.replace(comp2,"")
else:
    print "fail", sys.argv[1]
    sys.exit(0)
l=l.replace("compile_fuzzer", "compile_go_fuzzer")
f.write(l)
``` 
with some more variants up to comp5