### PR TITLE
[envoy] remove third_party

### DIFF
--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -90,7 +90,6 @@ then
   mkdir -p "${REMAP_PATH}"
   # For .cc, we only really care about source/ today.
   rsync -av "${SRC}"/envoy/source "${REMAP_PATH}"
-  rsync -av "${SRC}"/envoy/third_party "${REMAP_PATH}"
   rsync -av "${SRC}"/envoy/test "${REMAP_PATH}"
   # Remove filesystem loop manually.
   rm -rf "${SRC}"/envoy/bazel-envoy/external/envoy


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Build logs for coverage failure
```
Step #3: rsync: link_stat "/src/envoy/third_party" failed: No such file or directory (2)
```
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25808
(at least tested locally. I think there may be some problems with space on coverage builds, will check next logs)

