### PR TITLE
wasmtime: add register allocator to fuzz targets.

### DIFF
--- a/projects/wasmtime/Dockerfile
+++ b/projects/wasmtime/Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool curl cma
 
 RUN git clone --depth 1 https://github.com/bytecodealliance/wasm-tools wasm-tools
 
+RUN git clone --depth 1 https://github.com/bytecodealliance/regalloc.rs regalloc.rs
+
 RUN git clone --depth 1 https://github.com/bytecodealliance/wasmtime wasmtime
 WORKDIR wasmtime
 RUN git submodule update --init --recursive

--- a/projects/wasmtime/build.sh
+++ b/projects/wasmtime/build.sh
@@ -22,13 +22,19 @@ build() {
   shift
   fuzzer_prefix=$1
   shift
+  fuzz_targets=$1
+  shift
   PROJECT_DIR=$SRC/$project
 
   cd $PROJECT_DIR/fuzz && cargo fuzz build -O --debug-assertions "$@"
 
   FUZZ_TARGET_OUTPUT_DIR=$PROJECT_DIR/target/x86_64-unknown-linux-gnu/release
 
-  for f in $PROJECT_DIR/fuzz/fuzz_targets/*.rs; do
+  if [ "x$fuzz_targets" = "x" ]; then
+      fuzz_targets=$PROJECT_DIR/fuzz/fuzz_targets/*.rs
+  fi
+
+  for f in $fuzz_targets; do
       src_name=$(basename ${f%.*})
       dst_name=$fuzzer_prefix$src_name
       cp $FUZZ_TARGET_OUTPUT_DIR/$src_name $OUT/$dst_name
@@ -45,6 +51,7 @@ build() {
 
 # Build with all features to enable the binaryen-using fuzz targets, and
 # the peepmatic fuzz targets.
-build wasmtime "" --all-features
+build wasmtime "" "" --all-features
 
-build wasm-tools wasm-tools-
+build wasm-tools wasm-tools- ""
+build regalloc.rs regalloc- bt bt


### PR DESCRIPTION
Wasmtime uses [regalloc.rs](https://github.com/bytecodealliance/regalloc.rs), a
register allocator written in Rust that was developed for use in
Cranelift (but is also an independently-usable crate). While it will be
indirectly fuzzed by wasmtime itself once we start fuzzing the new
backends that use it, we should also fuzz it directly, since it exposes
targets just for this. The regalloc fuzzing makes use of a symbolic
checker as an oracle for allocation results, so should be relatively
high-quality. This PR enables the `bt` (backtracking) allocator's fuzz
target, as this is the default allocator.