### PR TITLE
Golang coverage summary for each fuzz target

### DIFF
--- a/docs/getting-started/new-project-guide/go_lang.md
+++ b/docs/getting-started/new-project-guide/go_lang.md
@@ -75,10 +75,12 @@ In order to build a Go fuzz target, you need to call `go-fuzz`
 command first, and then link the resulting `.a` file against
 `$LIB_FUZZING_ENGINE` using the `$CXX $CXXFLAGS ...` command.
 
-An automated way to do this is now present with a `compile_go_fuzzer` script, supporting also coverage builds.
+The best way to do this is by using a `compile_go_fuzzer` script,
+as it also supports coverage builds.
 
 A usage example from go-dns project is
-```
+
+```sh
 compile_go_fuzzer github.com/miekg/dns FuzzNewRR fuzz_newrr fuzz
 ```
 

--- a/docs/getting-started/new-project-guide/go_lang.md
+++ b/docs/getting-started/new-project-guide/go_lang.md
@@ -74,21 +74,16 @@ RUN go get github.com/ianlancetaylor/demangle
 In order to build a Go fuzz target, you need to call `go-fuzz`
 command first, and then link the resulting `.a` file against
 `$LIB_FUZZING_ENGINE` using the `$CXX $CXXFLAGS ...` command.
-[Example](https://github.com/google/oss-fuzz/blob/356f2b947670b7eb33a1f535c71bc5c87a60b0d1/projects/syzkaller/build.sh#L19):
 
-```sh
-function compile_fuzzer {
-  path=$1
-  function=$2
-  fuzzer=$3
+An automated way to do this is now present with a `compile_go_fuzzer` script, supporting also coverage builds.
 
-  # Compile and instrument all Go files relevant to this fuzz target.
-  go-fuzz -func $function -o $fuzzer.a $path
-
-  # Link Go code ($fuzzer.a) with fuzzing engine to produce fuzz target binary.
-  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
-}
-
-compile_fuzzer ./pkg/compiler Fuzz compiler_fuzzer
-compile_fuzzer ./prog/test FuzzDeserialize prog_deserialize_fuzzer
+A usage example from go-dns project is
 ```
+compile_go_fuzzer github.com/miekg/dns FuzzNewRR fuzz_newrr fuzz
+```
+
+Arguments are :
+* path of the package with the fuzz target
+* name of the fuzz function
+* name of the fuzzer to be built
+* optional tag to be used by `go build` and such

--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -111,6 +111,18 @@ function run_fuzz_target {
   fi
 }
 
+function run_go_fuzz_target {
+  local target=$1
+
+  cd $GOPATH/src
+  echo "Running go target $target"
+  export FUZZ_CORPUS_DIR="/corpus/${target}/"
+  export FUZZ_PROFILE_NAME="$DUMPS_DIR/$target.perf"
+  bash $OUT/$target $DUMPS_DIR/$target.profdata
+  $SYSGOPATH/bin/gocovsum $DUMPS_DIR/$target.profdata > $FUZZER_STATS_DIR/$target.json
+  cd $OUT
+}
+
 export SYSGOPATH=$GOPATH
 export GOPATH=$OUT/$GOPATH
 # Run each fuzz target, generate raw coverage dumps.
@@ -121,12 +133,7 @@ for fuzz_target in $FUZZ_TARGETS; do
     if [[ $FUZZING_ENGINE != "none" ]]; then
       grep "go test -run" $fuzz_target > /dev/null 2>&1 || continue
     fi
-    cd $GOPATH/src
-    echo "Running go target $fuzz_target"
-    export FUZZ_CORPUS_DIR="/corpus/${fuzz_target}/"
-    export FUZZ_PROFILE_NAME="$DUMPS_DIR/$fuzz_target.perf"
-    bash $OUT/$fuzz_target $DUMPS_DIR/$fuzz_target.profdata &
-    cd $OUT
+    run_go_fuzz_target $fuzz_target &
   else
     # Continue if not a fuzz target.
     if [[ $FUZZING_ENGINE != "none" ]]; then


### PR DESCRIPTION
Cf #2817 cc @Dor1s 

The one-liner to generate summary.json files for every single fuzz target is adding the new call to `gocovsum`

But then, I created `run_go_fuzz_target` so that targets are run in parallel