### PR TITLE
Build base-images before building projects in CI

### DIFF
--- a/infra/ci/build.py
+++ b/infra/ci/build.py
@@ -214,7 +214,7 @@ def build_base_images():
   ]
   for image in images:
     try:
-      execute_helper_command(['build_image', image])
+      execute_helper_command(['build_image', image, '--no-pull'])
     except subprocess.CalledProcessError:
       return 1
 

--- a/infra/ci/build.py
+++ b/infra/ci/build.py
@@ -194,19 +194,37 @@ def build_modified_projects():
   return BuildModifiedProjectsResult.BUILD_SUCCESS
 
 
-def should_build_canary_project():
-  """Returns True if we should build the canary project."""
+def is_infra_changed():
+  """Returns True if the infra directory was changed."""
   git_output = get_changed_files()
   infra_code_regex = '.*infra/.*\n'
   return re.search(infra_code_regex, git_output) is not None
+
+
+def build_base_images():
+  """Builds base images."""
+  # TODO(jonathanmetzman): Investigate why caching fails so often and
+  # when we improve it, build base-clang as well. Also, move this function
+  # to a helper command when we can support base-clang.
+  execute_helper_command(['pull_images'])
+  images = [
+      'base-image',
+      'base-builder',
+      'base-runner',
+  ]
+  for image in images:
+    try:
+      execute_helper_command(['build_image', image])
+    except subprocess.CalledProcessError:
+      return 1
+
+  return 0
 
 
 def build_canary_project():
   """Builds a specific project when infra/ is changed to verify that infra/
   changes don't break things. Returns False if build was attempted but
   failed."""
-  if not should_build_canary_project():
-    return True
 
   try:
     build_project('skcms')
@@ -218,13 +236,19 @@ def build_canary_project():
 
 def main():
   """Build modified projects or canary project."""
+  infra_changed = is_infra_changed()
+  if infra_changed:
+    print('Pulling and building base images first.')
+    return build_base_images()
+
   result = build_modified_projects()
   if result == BuildModifiedProjectsResult.BUILD_FAIL:
     return 1
 
   # It's unnecessary to build the canary if we've built any projects already.
   no_projects_built = result == BuildModifiedProjectsResult.NONE_BUILT
-  if no_projects_built and not build_canary_project():
+  should_build_canary = no_projects_built and infra_changed
+  if should_build_canary and not build_canary_project():
     return 1
 
   return 0

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -188,6 +188,7 @@ def main():  # pylint: disable=too-many-branches,too-many-return-statements,too-
   _add_environment_args(shell_parser)
 
   subparsers.add_parser('pull_images', help='Pull base images.')
+  subparsers.add_parser('build_base_images', help='Pull and build base images.')
 
   args = parser.parse_args()
 
@@ -219,7 +220,23 @@ def main():  # pylint: disable=too-many-branches,too-many-return-statements,too-
     return shell(args)
   if args.command == 'pull_images':
     return pull_images(args)
+  if args.command == 'build_base_images':
+    return build_base_images(args)
 
+  return 0
+
+
+def build_base_images(args):
+  """Builds base images."""
+  pull_images(args)
+  images = [
+      'base-image',
+      'base-builder',
+      'base-runner',
+  ]
+  for image in images:
+    if not build_image_impl(image):
+      return 1
   return 0
 
 

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -228,7 +228,8 @@ def main():  # pylint: disable=too-many-branches,too-many-return-statements,too-
 
 def build_base_images(args):
   """Builds base images."""
-  pull_images(args)
+  # TODO(jonathanmetzman): Investigate why caching fails so often and
+  # when we improve it, build base-clang as wel..
   images = [
       'base-image',
       'base-builder',

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -188,7 +188,6 @@ def main():  # pylint: disable=too-many-branches,too-many-return-statements,too-
   _add_environment_args(shell_parser)
 
   subparsers.add_parser('pull_images', help='Pull base images.')
-  subparsers.add_parser('build_base_images', help='Pull and build base images.')
 
   args = parser.parse_args()
 
@@ -220,24 +219,7 @@ def main():  # pylint: disable=too-many-branches,too-many-return-statements,too-
     return shell(args)
   if args.command == 'pull_images':
     return pull_images(args)
-  if args.command == 'build_base_images':
-    return build_base_images(args)
 
-  return 0
-
-
-def build_base_images(args):
-  """Builds base images."""
-  # TODO(jonathanmetzman): Investigate why caching fails so often and
-  # when we improve it, build base-clang as wel..
-  images = [
-      'base-image',
-      'base-builder',
-      'base-runner',
-  ]
-  for image in images:
-    if not build_image_impl(image):
-      return 1
   return 0
 
 


### PR DESCRIPTION
This will help us catch breaking changes to the base-images.
Unfortunately caching seems to fail here when I expect it to pass. For example, base-builder doesn't build from cache when I do it locally. This means that every other image I try to build doesn't use the cache. That means that base-clang would take forever to rebuild. So to compromise, I don't rebuild base-clang here.
This means that this PR won't catch breaking changes to base-image or base-clang that break in base-builder.
But it will catch breaking changes to base-image that break in base-runner and it will catch breaking changes to base-runner and base-builder.