### PR TITLE
Fix kubernetes coverage build.

### DIFF
--- a/projects/kubernetes/Dockerfile
+++ b/projects/kubernetes/Dockerfile
@@ -16,11 +16,9 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 
-ENV GOPATH /gopath
-
 RUN go get github.com/ianlancetaylor/demangle
-RUN git clone --depth 1 https://github.com/kubernetes/kubernetes.git /gopath/src/k8s.io/kubernetes
+RUN git clone --depth 1 https://github.com/kubernetes/kubernetes.git $GOPATH/src/k8s.io/kubernetes
 
-WORKDIR /gopath/src/k8s.io/kubernetes
+WORKDIR $GOPATH/src/k8s.io/kubernetes
 
 COPY build.sh $SRC/build.sh


### PR DESCRIPTION
Fixes
```
+ compile_go_fuzzer k8s.io/kubernetes/test/fuzz/yaml FuzzDurationStrict yaml_FuzzDurationStrict
cp: cannot stat '/gopath/ossfuzz_coverage_runner.go': No such file or directory
********************************************************************************
```