### PR TITLE
Golang coverage reports for projects with modules

### DIFF
--- a/infra/base-images/base-builder/compile_go_fuzzer
+++ b/infra/base-images/base-builder/compile_go_fuzzer
@@ -24,13 +24,7 @@ if [[ $#  -eq 4 ]]; then
 fi
 
 if [[ $SANITIZER = *coverage* ]]; then
-  if [[ ${GO111MODULE:-} = on ]]; then
-    basemod=`echo $path | cut -d/ -f1-3`
-    cd $GOPATH/pkg/mod/`go list -m $basemod | sed 's/ /@/'`
-    cd ./`echo $path | cut -d/ -f4-`
-  else
-    cd $GOPATH/src/$path
-  fi
+  cd $GOPATH/src/$path
   fuzzed_package=`pwd | rev | cut -d'/' -f 1 | rev`
   cp $GOPATH/ossfuzz_coverage_runner.go ./"${function,,}"_test.go
   sed -i -e 's/FuzzFunction/'$function'/' ./"${function,,}"_test.go
@@ -38,13 +32,7 @@ if [[ $SANITIZER = *coverage* ]]; then
   sed -i -e 's/TestFuzzCorpus/Test'$function'Corpus/' ./"${function,,}"_test.go
 
   echo "#/bin/sh" > $OUT/$fuzzer
-  if [[ ${GO111MODULE:-} = on ]]; then
-    echo "export GO111MODULE=on" >> $OUT/$fuzzer
-    echo "cd ../pkg/mod/"`go list -m $basemod | sed 's/ /@/'` >> $OUT/$fuzzer
-    echo "cd ./"`echo $path | cut -d/ -f4-` >> $OUT/$fuzzer
-  else
-    echo "cd $path" >> $OUT/$fuzzer
-  fi
+  echo "cd $path" >> $OUT/$fuzzer
   echo "go test -run Test${function}Corpus -v $tags -coverprofile \$1 " >> $OUT/$fuzzer
   chmod +x $OUT/$fuzzer
 

--- a/projects/go-coredns/Dockerfile
+++ b/projects/go-coredns/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 ENV GO111MODULE=on
-RUN go get github.com/coredns/coredns
+RUN git clone --depth 1  https://github.com/coredns/coredns $GOPATH/src/github.com/coredns/coredns
 
 COPY build.sh $SRC/
 WORKDIR $SRC/

--- a/projects/go-coredns/build.sh
+++ b/projects/go-coredns/build.sh
@@ -17,7 +17,7 @@
 
 # Same as usual except for added -tags gofuzz.
 
-cd $GOPATH/pkg/mod/`go list -m github.com/coredns/coredns | sed 's/ /@/'`
+cd $GOPATH/src/github.com/coredns/coredns
 
 #make
 ls plugin/*/fuzz.go | while read target


### PR DESCRIPTION
such as coredns
cloning into GOPATH

cc @Dor1s @inferno-chromium 

I am not sure this is the perfect way for projects with go modules, but at least it should work...
This somehow adds the constraint that fuzzed projects must be located in `GOPATH/src`

Any better ideas ?