### PR TITLE
Set CIFUZZ env var when building/checking/running CIFuzz fuzzers.

### DIFF
--- a/infra/cifuzz/cifuzz.py
+++ b/infra/cifuzz/cifuzz.py
@@ -165,6 +165,8 @@ def build_fuzzers(  # pylint: disable=too-many-arguments,too-many-locals
       '-e',
       'ARCHITECTURE=' + DEFAULT_ARCHITECTURE,
       '-e',
+      'CIFUZZ=True',
+      '-e',
       'FUZZING_LANGUAGE=c++',  # FIXME: Add proper support.
   ]
   container = utils.get_container_name()
@@ -291,6 +293,8 @@ def check_fuzzer_build(out_dir, sanitizer='address'):
       'SANITIZER=' + sanitizer,
       '-e',
       'ARCHITECTURE=' + DEFAULT_ARCHITECTURE,
+      '-e',
+      'CIFUZZ=True',
       '-e',
       'FUZZING_LANGUAGE=c++',  # FIXME: Add proper support.
   ]

--- a/infra/cifuzz/cifuzz_test.py
+++ b/infra/cifuzz/cifuzz_test.py
@@ -66,6 +66,7 @@ UNDEFINED_FUZZER = 'curl_fuzzer_undefined'
 
 class BuildFuzzersTest(unittest.TestCase):
   """Unit tests for build_fuzzers."""
+
   @mock.patch('build_specified_commit.detect_main_repo',
               return_value=('example.com', '/path'))
   @mock.patch('repo_manager.RepoManager', return_value=None)
@@ -75,8 +76,10 @@ class BuildFuzzersTest(unittest.TestCase):
     """Tests that the CIFUZZ env var is set."""
 
     with tempfile.TemporaryDirectory() as tmp_dir:
-      cifuzz.build_fuzzers(
-          EXAMPLE_PROJECT, EXAMPLE_PROJECT, tmp_dir, pr_ref='refs/pull/1757/merge')
+      cifuzz.build_fuzzers(EXAMPLE_PROJECT,
+                           EXAMPLE_PROJECT,
+                           tmp_dir,
+                           pr_ref='refs/pull/1757/merge')
     docker_run_command = mocked_docker_run.call_args_list[0][0][0]
 
     def command_has_env_var_arg(command, env_var_arg):
@@ -84,7 +87,7 @@ class BuildFuzzersTest(unittest.TestCase):
         if idx == 0:
           continue
 
-        if element == env_var_arg and command[idx-1] == '-e':
+        if element == env_var_arg and command[idx - 1] == '-e':
           return True
       return False
 
@@ -360,11 +363,11 @@ class GetFilesCoveredByTargetTest(unittest.TestCase):
   example_fuzzer = 'curl_fuzzer'
 
   def setUp(self):
-    with open(os.path.join(TEST_FILES_PATH, self.example_cov_json)
-              ) as file_handle:
+    with open(os.path.join(TEST_FILES_PATH,
+                           self.example_cov_json)) as file_handle:
       self.proj_cov_report_example = json.loads(file_handle.read())
-    with open(os.path.join(TEST_FILES_PATH, self.example_fuzzer_cov_json)
-              ) as file_handle:
+    with open(os.path.join(TEST_FILES_PATH,
+                           self.example_fuzzer_cov_json)) as file_handle:
       self.fuzzer_cov_report_example = json.loads(file_handle.read())
 
   def test_valid_target(self):
@@ -376,8 +379,8 @@ class GetFilesCoveredByTargetTest(unittest.TestCase):
       file_list = cifuzz.get_files_covered_by_target(
           self.proj_cov_report_example, self.example_fuzzer, '/src/curl')
 
-    curl_files_list_path = os.path.join(
-        TEST_FILES_PATH, 'example_curl_file_list.json')
+    curl_files_list_path = os.path.join(TEST_FILES_PATH,
+                                        'example_curl_file_list.json')
     with open(curl_files_list_path) as file_handle:
       true_files_list = json.load(file_handle)
     self.assertCountEqual(file_list, true_files_list)

--- a/infra/cifuzz/cifuzz_test.py
+++ b/infra/cifuzz/cifuzz_test.py
@@ -64,6 +64,15 @@ UNDEFINED_FUZZER = 'curl_fuzzer_undefined'
 # pylint: disable=no-self-use
 
 
+class BuildFuzzersTest(unittest.TestCase):
+  """Unit tests for build_fuzzers."""
+  def test_cifuzz_env_var(self):
+    """Tests that the CIFUZZ env var is set."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      import pdb; pdb.set_trace()
+      build_fuzzers(EXAMPLE_PROJECT, EXAMPLE_PROJECT, tmp_dir, pr_ref='refs/pull/1757/merge')
+
+
 class BuildFuzzersIntegrationTest(unittest.TestCase):
   """Integration tests for build_fuzzers."""
 

--- a/infra/cifuzz/cifuzz_test.py
+++ b/infra/cifuzz/cifuzz_test.py
@@ -66,11 +66,29 @@ UNDEFINED_FUZZER = 'curl_fuzzer_undefined'
 
 class BuildFuzzersTest(unittest.TestCase):
   """Unit tests for build_fuzzers."""
-  def test_cifuzz_env_var(self):
+  @mock.patch('build_specified_commit.detect_main_repo',
+              return_value=('example.com', '/path'))
+  @mock.patch('repo_manager.RepoManager', return_value=None)
+  @mock.patch('cifuzz.checkout_specified_commit')
+  @mock.patch('helper.docker_run')
+  def test_cifuzz_env_var(self, mocked_docker_run, _, __, ___):
     """Tests that the CIFUZZ env var is set."""
+
     with tempfile.TemporaryDirectory() as tmp_dir:
-      import pdb; pdb.set_trace()
-      build_fuzzers(EXAMPLE_PROJECT, EXAMPLE_PROJECT, tmp_dir, pr_ref='refs/pull/1757/merge')
+      cifuzz.build_fuzzers(
+          EXAMPLE_PROJECT, EXAMPLE_PROJECT, tmp_dir, pr_ref='refs/pull/1757/merge')
+    docker_run_command = mocked_docker_run.call_args_list[0][0][0]
+
+    def command_has_env_var_arg(command, env_var_arg):
+      for idx, element in enumerate(command):
+        if idx == 0:
+          continue
+
+        if element == env_var_arg and command[idx-1] == '-e':
+          return True
+      return False
+
+    self.assertTrue(command_has_env_var_arg(docker_run_command, 'CIFUZZ=True'))
 
 
 class BuildFuzzersIntegrationTest(unittest.TestCase):

--- a/infra/cifuzz/fuzz_target.py
+++ b/infra/cifuzz/fuzz_target.py
@@ -125,9 +125,8 @@ class FuzzTarget:
 
     command += [
         '-e', 'FUZZING_ENGINE=libfuzzer', '-e', 'SANITIZER=' + self.sanitizer,
-        '-e', 'CIFUZZ=True',
-        '-e', 'RUN_FUZZER_MODE=interactive', 'gcr.io/oss-fuzz-base/base-runner',
-        'bash', '-c'
+        '-e', 'CIFUZZ=True', '-e', 'RUN_FUZZER_MODE=interactive',
+        'gcr.io/oss-fuzz-base/base-runner', 'bash', '-c'
     ]
 
     run_fuzzer_command = 'run_fuzzer {fuzz_target} {options}'.format(

--- a/infra/cifuzz/fuzz_target.py
+++ b/infra/cifuzz/fuzz_target.py
@@ -125,6 +125,7 @@ class FuzzTarget:
 
     command += [
         '-e', 'FUZZING_ENGINE=libfuzzer', '-e', 'SANITIZER=' + self.sanitizer,
+        '-e', 'CIFUZZ=True',
         '-e', 'RUN_FUZZER_MODE=interactive', 'gcr.io/oss-fuzz-base/base-runner',
         'bash', '-c'
     ]


### PR DESCRIPTION
Do this so that build.sh can behave differently under CIFuzz.