### PR TITLE
[libjpeg-turbo] DRC’s Google acct—>primary_contact

### DIFF
--- a/projects/libjpeg-turbo/project.yaml
+++ b/projects/libjpeg-turbo/project.yaml
@@ -1,10 +1,11 @@
 homepage: "https://github.com/libjpeg-turbo/libjpeg-turbo"
 language: c++
+primary_contact:
+  - "drc@virtualgl.org"
 vendor_ccs:
   - "aosmond@mozilla.com"
   - "tnikkel@mozilla.com"
   - "twsmith@mozilla.com"
-  - "information@libjpeg-turbo.org"
 sanitizers:
   - address
   - memory


### PR DESCRIPTION
This will enable the libjpeg-turbo maintainer to see oss-fuzz bug reports.