### PR TITLE
[zydis] Initial integration

### DIFF
--- a/projects/zydis/Dockerfile
+++ b/projects/zydis/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+ADD https://github.com/zyantific/zydis/raw/master/assets/ZydisFuzz_seed_corpus.zip \
+    $SRC/ZydisFuzz_seed_corpus.zip
+
+COPY build.sh $SRC/
+
+RUN git clone --recursive https://github.com/zyantific/zydis.git
+WORKDIR zydis

--- a/projects/zydis/build.sh
+++ b/projects/zydis/build.sh
@@ -1,0 +1,45 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+mv $SRC/ZydisFuzz_seed_corpus.zip $OUT/ZydisFuzz_seed_corpus.zip
+
+mkdir build && cd build
+
+cmake                                   \
+    -DZYDIS_BUILD_EXAMPLES=OFF          \
+    -DZYDIS_BUILD_TOOLS=OFF             \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo   \
+    -DCMAKE_C_COMPILER=$CC              \
+    -DCMAKE_CXX_COMPILER=$CXX           \
+    -DCMAKE_C_FLAGS="$CFLAGS"           \
+    -DCMAKE_CXX_FLAGS="$CXXFLAGS"       \
+    ..
+
+make -j8
+
+$CXX                                    \
+    $CXXFLAGS                           \
+    $LIB_FUZZING_ENGINE                 \
+    ../tools/ZydisFuzzIn.c              \
+    -DZYDIS_LIBFUZZER                   \
+    -o $OUT/ZydisFuzz                   \
+    -I .                                \
+    -I ./zycore                         \
+    -I ../include                       \
+    -I ../dependencies/zycore/include   \
+    ./libZydis.a
+

--- a/projects/zydis/project.yaml
+++ b/projects/zydis/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/zyantific/zydis"
+language: c
+primary_contact: "joel.hoener@gmail.com"
+auto_ccs:
+ - "flobernd90@gmail.com"
+sanitizers:
+ - address
+ - memory
+ - undefined


### PR DESCRIPTION
This PR implements the initial integration of [Zydis](https://zydis.re) into OSS-Fuzz.

Zydis is, to my best knowledge, the second most popular disassembler library around after Capstone, which is already being fuzzed by OSS-Fuzz. Notable projects that depend on it are x64dbg and Mozilla Firefox. I'm a maintainer of this library.

Since OSS-Fuzz requires a Google account on the mail and I usually don't commit using such an address, I created a commit with the primary mail specified in `project.yaml` for verification purposes here: https://github.com/zyantific/zydis/commit/84ae0d5b98e5e5dc6295a27cdd4b6eb1dc9c5aae

The `auto_ccs` mail belongs to @flobernd, the other primary maintainer of Zydis.

We tried following the provided documentation closely and tested ASAN, MSAN and UBSAN builds with libfuzzer and ASAN builds with hongfuzz and afl locally and everything appears to be working as intended.

Corresponding PR in Zydis for reference: https://github.com/zyantific/zydis/pull/164

If any additional changes are required, I'll be happy to address that -- please just let me know!