### PR TITLE
[poppler] Build the new fuzzers

### DIFF
--- a/projects/poppler/Dockerfile
+++ b/projects/poppler/Dockerfile
@@ -15,15 +15,27 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config cmake
-RUN git clone --depth 1 https://anongit.freedesktop.org/git/poppler/poppler.git
+RUN apt-get update && apt-get install -y wget autoconf automake libtool pkg-config cmake gperf
+RUN pip3 install meson==0.55.3 ninja
+
+RUN git clone --depth 1 https://github.com/madler/zlib.git
 RUN git clone --depth 1 git://git.sv.nongnu.org/freetype/freetype2.git
 RUN git clone --depth 1 https://github.com/mm2/Little-CMS.git
 RUN git clone --depth 1 https://github.com/uclouvain/openjpeg
+RUN git clone --depth 1 https://github.com/glennrp/libpng.git
+RUN git clone --depth 1 https://gitlab.freedesktop.org/fontconfig/fontconfig.git
+RUN git clone --depth 1 https://gitlab.freedesktop.org/cairo/cairo.git
+RUN git clone --depth 1 --branch=5.15 git://code.qt.io/qt/qtbase.git
+ADD http://ftp.gnome.org/pub/gnome/sources/pango/1.48/pango-1.48.0.tar.xz $SRC
+RUN tar xvJf $SRC/pango-1.48.0.tar.xz
+ADD https://ftp.gnome.org/pub/gnome/sources/glib/2.64/glib-2.64.2.tar.xz $SRC
+RUN tar xvJf $SRC/glib-2.64.2.tar.xz
+RUN git clone --depth 1 --single-branch https://gitlab.freedesktop.org/poppler/poppler.git
+
 RUN git clone --depth 1 https://github.com/mozilla/pdf.js pdf.js && \
-    zip -q $SRC/pdf_fuzzer_seed_corpus.zip pdf.js/test/pdfs/*.pdf && \
+    zip -q $SRC/poppler_seed_corpus.zip pdf.js/test/pdfs/*.pdf && \
     rm -rf pdf.js
-ADD https://raw.githubusercontent.com/google/fuzzing/master/dictionaries/pdf.dict $SRC/pdf_fuzzer.dict
+ADD https://raw.githubusercontent.com/google/fuzzing/master/dictionaries/pdf.dict $SRC/poppler.dict
 WORKDIR $SRC/poppler
 COPY *.cc $SRC/fuzz/
 COPY build.sh $SRC/

--- a/projects/poppler/build.sh
+++ b/projects/poppler/build.sh
@@ -14,62 +14,232 @@
 # limitations under the License.
 #
 ################################################################################
+PREFIX=$WORK/prefix
+mkdir -p $PREFIX
+
+export PKG_CONFIG="`which pkg-config` --static"
+export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig
+export PATH=$PREFIX/bin:$PATH
+
+BUILD=$WORK/build
+
+rm -rf $WORK/*
+rm -rf $BUILD
+mkdir -p $BUILD
+
+pushd $SRC/zlib
+CFLAGS=-fPIC ./configure --static --prefix=$PREFIX
+make install -j$(nproc)
 
 pushd $SRC/freetype2
 ./autogen.sh
-./configure --prefix="$WORK" --disable-shared PKG_CONFIG_PATH="$WORK/lib/pkgconfig"
+./configure --prefix="$PREFIX" --disable-shared PKG_CONFIG_PATH="$PKG_CONFIG_PATH"
 make -j$(nproc)
 make install
 
 pushd $SRC/Little-CMS
-./configure --prefix="$WORK" --disable-shared PKG_CONFIG_PATH="$WORK/lib/pkgconfig"
+./configure --prefix="$PREFIX" --disable-shared PKG_CONFIG_PATH="$PKG_CONFIG_PATH"
 make -j$(nproc)
 make install
 
 mkdir -p $SRC/openjpeg/build
 pushd $SRC/openjpeg/build
-cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=$WORK
+cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=$PREFIX
 make -j$(nproc) install
+
+if [ "$SANITIZER" != "memory" ]; then
+
+    pushd $SRC/fontconfig
+    meson \
+        --prefix=$PREFIX \
+        --libdir=lib \
+        --default-library=static \
+        _builddir
+    ninja -C _builddir
+    ninja -C _builddir install
+    popd
+
+    pushd $SRC/glib-2.64.2
+    meson \
+        --prefix=$PREFIX \
+        --libdir=lib \
+        --default-library=static \
+        -Db_lundef=false \
+        -Doss_fuzz=enabled \
+        -Dlibmount=disabled \
+        -Dinternal_pcre=true \
+        _builddir
+    ninja -C _builddir
+    ninja -C _builddir install
+    popd
+
+    pushd $SRC/libpng
+    autoreconf -fi
+    CPPFLAGS=-I$PREFIX/include LDFLAGS=-L$PREFIX/lib ./configure --prefix="$PREFIX" --disable-shared --disable-dependency-tracking
+    make -j$(nproc)
+    make install
+
+    pushd $SRC/cairo
+    meson \
+        --prefix=$PREFIX \
+        --libdir=lib \
+        --default-library=static \
+        _builddir
+    ninja -C _builddir
+    ninja -C _builddir install
+    popd
+
+    pushd $SRC/pango-1.48.0
+    meson \
+        -Ddefault_library=static \
+        --prefix=$PREFIX \
+        --libdir=lib \
+        _builddir
+    sed -i -e 's/ -Werror=implicit-fallthrough//g' _builddir/build.ninja
+    ninja -C _builddir
+    ninja -C _builddir install
+    popd
+fi
+
+pushd $SRC/qtbase
+# add the flags to Qt build too
+sed -i -e "s/QMAKE_CXXFLAGS    += -stdlib=libc++/QMAKE_CXXFLAGS    += -stdlib=libc++  $CXXFLAGS\nQMAKE_CFLAGS += $CFLAGS/g" mkspecs/linux-clang-libc++/qmake.conf
+sed -i -e "s/QMAKE_LFLAGS      += -stdlib=libc++/QMAKE_LFLAGS      += -stdlib=libc++ -lpthread $CXXFLAGS/g" mkspecs/linux-clang-libc++/qmake.conf
+# disable sanitize=vptr for harfbuzz since it compiles without rtti
+sed -i -e "s/TARGET = qtharfbuzz/TARGET = qtharfbuzz\nQMAKE_CXXFLAGS += -fno-sanitize=vptr/g" src/3rdparty/harfbuzz-ng/harfbuzz-ng.pro
+# make qmake compile faster
+sed -i -e "s/MAKE\")/MAKE\" -j$(nproc))/g" configure
+./configure --glib=no --libpng=qt -opensource -confirm-license -static -no-opengl -no-icu -no-pkg-config -platform linux-clang-libc++ -nomake tests -nomake examples -prefix $PREFIX -D QT_NO_DEPRECATED_WARNINGS
+make -j$(nproc)
+make install
+popd
+
+# Poppler complains when PKG_CONFIG is set to `which pkg-config --static` so
+# temporarily removing it
+export PKG_CONFIG="`which pkg-config`"
+
+if [ "$SANITIZER" != "memory" ]; then
+    POPPLER_ENABLE_GLIB=ON
+    POPPLER_FONT_CONFIGURATION=fontconfig
+else
+    POPPLER_ENABLE_GLIB=OFF
+    POPPLER_FONT_CONFIGURATION=generic
+fi
 
 mkdir -p $SRC/poppler/build
 pushd $SRC/poppler/build
 cmake .. \
   -DCMAKE_BUILD_TYPE=debug \
   -DBUILD_SHARED_LIBS=OFF \
-  -DFONT_CONFIGURATION=generic \
+  -DENABLE_FUZZER=OFF \
+  -DFONT_CONFIGURATION=$POPPLER_FONT_CONFIGURATION \
   -DENABLE_DCTDECODER=none \
+  -DENABLE_GOBJECT_INTROSPECTION=OFF \
   -DENABLE_LIBPNG=OFF \
   -DENABLE_ZLIB=OFF \
   -DENABLE_LIBTIFF=OFF \
   -DENABLE_LIBJPEG=OFF \
-  -DENABLE_GLIB=OFF \
+  -DENABLE_GLIB=$POPPLER_ENABLE_GLIB \
   -DENABLE_LIBCURL=OFF \
-  -DENABLE_QT5=OFF \
+  -DENABLE_QT5=ON \
   -DENABLE_UTILS=OFF \
-  -DWITH_Cairo=OFF \
+  -DWITH_Cairo=$POPPLER_ENABLE_GLIB \
   -DWITH_NSS3=OFF \
-  -DCMAKE_INSTALL_PREFIX=$WORK
-make -j$(nproc) poppler poppler-cpp
+  -DCMAKE_INSTALL_PREFIX=$PREFIX
 
-fuzz_target=pdf_fuzzer
+export PKG_CONFIG="`which pkg-config` --static"
+make -j$(nproc) poppler poppler-cpp poppler-qt5
+if [ "$SANITIZER" != "memory" ]; then
+    make -j$(nproc) poppler-glib
+fi
 
-$CXX $CXXFLAGS -std=c++11 -I$SRC/poppler/cpp \
-    $SRC/fuzz/pdf_fuzzer.cc -o $OUT/$fuzz_target \
-    $LIB_FUZZING_ENGINE \
-    $SRC/poppler/build/cpp/libpoppler-cpp.a \
-    $SRC/poppler/build/libpoppler.a \
-    $WORK/lib/libfreetype.a \
-    $WORK/lib/liblcms2.a \
-    $WORK/lib/libopenjp2.a
+PREDEPS_LDFLAGS="-Wl,-Bdynamic -ldl -lm -lc -lz -pthread -lrt -lpthread"
+DEPS="freetype2 lcms2 libopenjp2"
+if [ "$SANITIZER" != "memory" ]; then
+    DEPS="$DEPS fontconfig libpng"
+fi
+BUILD_CFLAGS="$CFLAGS `pkg-config --static --cflags $DEPS`"
+BUILD_LDFLAGS="-Wl,-static `pkg-config --static --libs $DEPS`"
+
+fuzzers=$(find $SRC/poppler/cpp/tests/fuzzing/ -name "*_fuzzer.cc")
+
+for f in $fuzzers; do
+    fuzzer_name=$(basename $f .cc)
+
+    $CXX $CXXFLAGS -std=c++11 -I$SRC/poppler/cpp \
+        $BUILD_CFLAGS \
+        $f -o $OUT/$fuzzer_name \
+        $PREDEPS_LDFLAGS \
+        $SRC/poppler/build/cpp/libpoppler-cpp.a \
+        $SRC/poppler/build/libpoppler.a \
+        $BUILD_LDFLAGS \
+        $LIB_FUZZING_ENGINE \
+        $LIB_FUZZING_ENGINE \
+        -Wl,-Bdynamic
+done
+
+if [ "$SANITIZER" != "memory" ]; then
+    DEPS="gmodule-2.0 glib-2.0 gio-2.0 gobject-2.0 freetype2 lcms2 libopenjp2 cairo cairo-gobject pango fontconfig libpng"
+    BUILD_CFLAGS="$CFLAGS `pkg-config --static --cflags $DEPS`"
+    BUILD_LDFLAGS="-Wl,-static `pkg-config --static --libs $DEPS`"
+
+    fuzzers=$(find $SRC/poppler/glib/tests/fuzzing/ -name "*_fuzzer.cc")
+    for f in $fuzzers; do
+        fuzzer_name=$(basename $f .cc)
+
+        $CXX $CXXFLAGS -std=c++11 -I$SRC/poppler/glib -I$SRC/poppler/build/glib \
+            $BUILD_CFLAGS \
+            $f -o $OUT/$fuzzer_name \
+            $PREDEPS_LDFLAGS \
+            $SRC/poppler/build/glib/libpoppler-glib.a \
+            $SRC/poppler/build/cpp/libpoppler-cpp.a \
+            $SRC/poppler/build/libpoppler.a \
+            $BUILD_LDFLAGS \
+            $LIB_FUZZING_ENGINE \
+            -Wl,-Bdynamic
+    done
+fi
+
+PREDEPS_LDFLAGS="-Wl,-Bdynamic -ldl -lm -lc -lz -pthread -lrt -lpthread"
+DEPS="freetype2 lcms2 libopenjp2 Qt5Core Qt5Gui Qt5Xml"
+if [ "$SANITIZER" != "memory" ]; then
+    DEPS="$DEPS fontconfig libpng"
+fi
+BUILD_CFLAGS="$CFLAGS `pkg-config --static --cflags $DEPS`"
+BUILD_LDFLAGS="-Wl,-static `pkg-config --static --libs $DEPS`"
+
+fuzzers=$(find $SRC/poppler/qt5/tests/fuzzing/ -name "*_fuzzer.cc")
+for f in $fuzzers; do
+    fuzzer_name=$(basename $f .cc)
+
+    $CXX $CXXFLAGS -std=c++11 -fPIC \
+        -I$SRC/poppler/qt5/src \
+        $BUILD_CFLAGS \
+        $f -o $OUT/$fuzzer_name \
+        $PREDEPS_LDFLAGS \
+        $SRC/poppler/build/qt5/src/libpoppler-qt5.a \
+        $SRC/poppler/build/cpp/libpoppler-cpp.a \
+        $SRC/poppler/build/libpoppler.a \
+        $BUILD_LDFLAGS \
+        $LIB_FUZZING_ENGINE \
+        -Wl,-Bdynamic
+done
 
 mv $SRC/{*.zip,*.dict} $OUT
 
-if [ ! -f "${OUT}/${fuzz_target}_seed_corpus.zip" ]; then
-  echo "missing seed corpus"
-  exit 1
+if [ ! -f "${OUT}/poppler_seed_corpus.zip" ]; then
+    echo "missing seed corpus"
+    exit 1
 fi
 
-if [ ! -f "${OUT}/${fuzz_target}.dict" ]; then
-  echo "missing dictionary"
-  exit 1
+if [ ! -f "${OUT}/poppler.dict" ]; then
+    echo "missing dictionary"
+    exit 1
 fi
+
+fuzzers=$(find $OUT -name "*_fuzzer")
+for f in $fuzzers; do
+  fuzzer_name=$(basename $f)
+  ln -sf $OUT/poppler_seed_corpus.zip $OUT/${fuzzer_name}_seed_corpus.zip
+  ln -sf $OUT/poppler.dict $OUT/${fuzzer_name}.dict
+done


### PR DESCRIPTION
The memory sanitizer doesn't build the glib part because it fails, but the cpp and qt5 fuzzers are still built

Code based on code by ecalp-tps from bc358f33ad3243e06c3c9934b54561d31a2aee6b