### PR TITLE
[Goldmark] Initial integration

### DIFF
--- a/projects/blackfriday/Dockerfile
+++ b/projects/blackfriday/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN go get github.com/russross/blackfriday
+
+COPY fuzz_blackfriday.go $GOPATH/src/github.com/russross/blackfriday/
+COPY build.sh $SRC/

--- a/projects/blackfriday/build.sh
+++ b/projects/blackfriday/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+
+compile_go_fuzzer github.com/russross/blackfriday Fuzz fuzz_blackfriday

--- a/projects/blackfriday/fuzz_blackfriday.go
+++ b/projects/blackfriday/fuzz_blackfriday.go
@@ -1,0 +1,5 @@
+package blackfriday
+
+func Fuzz(data []byte) int {
+	output := blackfriday.Run(data)
+}

--- a/projects/blackfriday/project.yaml
+++ b/projects/blackfriday/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://github.com/russross/blackfriday"
+primary_contact: ""
+auto_ccs : "m.aldofirmansyah@gmail.com"
+language: go
+fuzzing_engines:
+- libfuzzer
+sanitizers:
+- address

--- a/projects/goldmark/Dockerfile
+++ b/projects/goldmark/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+ENV GO111MODULE on
+RUN git clone https://github.com/yuin/goldmark
+COPY build.sh $SRC/
+WORKDIR $SRC/

--- a/projects/goldmark/build.sh
+++ b/projects/goldmark/build.sh
@@ -1,0 +1,22 @@
+#/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+mkdir $GOPATH/src/github.com/yuin
+mv $SRC/goldmark $GOPATH/src/github.com/yuin/
+cd $GOPATH/src/github.com/yuin/goldmark
+
+compile_go_fuzzer github.com/yuin/goldmark/fuzz Fuzz fuzzgoldmark

--- a/projects/goldmark/project.yaml
+++ b/projects/goldmark/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/yuin/goldmark"
+primary_contact: ""
+auto_ccs :
+  - "m.aldofirmansyah@gmail.com"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
Add initial integration for goldmark, a markdown parser in Go.

This is a free service by Google where they perform continuous fuzzing of open-source projects used by industry and with the only expectation that maintainers of the project will patch the bugs found by OSS-Fuzz. Maintainers get a link to detailed bug reports.

Right now I'm waiting for maintainer's email address for primary contact
cc @yuin