### PR TITLE
[poco] Initial integration

### DIFF
--- a/projects/poco/Dockerfile
+++ b/projects/poco/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y openssl libssl-dev git make cmake libssl-dev 
+RUN git clone --depth 1 -b master https://github.com/pocoproject/poco
+WORKDIR $SRC/poco
+COPY build.sh \
+     json_parse_fuzzer.cc \
+     $SRC/

--- a/projects/poco/Dockerfile
+++ b/projects/poco/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y openssl libssl-dev git make cmake libssl-dev 
-RUN git clone --depth 1 -b master https://github.com/pocoproject/poco
+RUN git clone --depth 1 -b poco-1.10.2 https://github.com/pocoproject/poco
 WORKDIR $SRC/poco
 COPY build.sh \
      json_parse_fuzzer.cc \

--- a/projects/poco/build.sh
+++ b/projects/poco/build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+mkdir cmake-build
+cd cmake-build
+cmake -DBUILD_SHARED_LIBS=OFF \
+      -DENABLE_TESTS=OFF \
+      ..
+make -j$(nproc)
+
+$CXX $CXXFLAGS -DPOCO_ENABLE_CPP11 -DPOCO_ENABLE_CPP14 \
+    -DPOCO_HAVE_FD_EPOLL -DPOCO_OS_FAMILY_UNIX \
+    -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE \
+    -D_REENTRANT -D_THREAD_SAFE -D_XOPEN_SOURCE=500 \
+    -I/src/poco/JSON/include \
+    -I/src/poco/Foundation/include \
+    -O2 -g -DNDEBUG -std=gnu++14 \
+    -o json_fuzzer.o -c $SRC/json_parse_fuzzer.cc
+
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE json_fuzzer.o \
+    ./lib/libPocoJSON.a \
+    ./lib/libPocoFoundation.a \
+    -o $OUT/json_parser_fuzzer -lpthread -ldl -lrt

--- a/projects/poco/json_parse_fuzzer.cc
+++ b/projects/poco/json_parse_fuzzer.cc
@@ -1,0 +1,32 @@
+/* Copyright 2021 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "Poco/JSON/JSON.h"
+#include "Poco/JSON/ParserImpl.h"
+#include "Poco/JSON/Parser.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+        std::string json(reinterpret_cast<const char*>(data), size);
+        Poco::JSON::Parser parser;
+
+        Poco::Dynamic::Var result;
+        try
+        {
+                result = parser.parse(json);
+        }
+        catch(const std::exception& e)
+        {
+                return 0;
+        }
+        return 0;
+}

--- a/projects/poco/project.yaml
+++ b/projects/poco/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/pocoproject/poco"
+main_repo: "https://github.com/pocoproject/poco"
+language: c++
+primary_contact: "guenter@pocoproject.org"
+auto_ccs:
+  - "Adam@adalogics.com"
+sanitizers:
+  - address
+  - undefined
+  - memory


### PR DESCRIPTION
This PR adds initial integration of [Poco](https://github.com/pocoproject/poco).

Users include:

- Clickhouse
- Avid
- Cisco
- Malwarebytes
- NetApp
- Oracle
- Symantec
- Sony

And more are available [here](https://pocoproject.org/about.html#users).

______________________________________________________________________________________________

We are currently working with upstream maintainers on the fuzzer here: https://github.com/pocoproject/poco/pull/3149

@obiltschnig I am tagging you to let you know of the build files in this PR. They will allow OSS-fuzz to run the json fuzzer once it has been merged in. If you have any questions, feel free to ask here or on the Poco repository. On the OSS-fuzz side, we need a maintainer email in the `project.yaml` file to complete the integration.