### PR TITLE
Update mtail fuzzing to use compile_go_fuzzer.

### DIFF
--- a/projects/mtail/Dockerfile
+++ b/projects/mtail/Dockerfile
@@ -15,7 +15,6 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN mkdir -p github.com/google
-RUN git clone --depth 1 https://github.com/google/mtail github.com/google/mtail
-WORKDIR github.com/google/mtail
+RUN git clone --depth 1 https://github.com/google/mtail $GOPATH/src/github.com/google/mtail
+WORKDIR $GOPATH/src/github.com/google/mtail
 COPY build.sh $SRC/

--- a/projects/mtail/build.sh
+++ b/projects/mtail/build.sh
@@ -15,12 +15,6 @@
 #
 ################################################################################
 
-# We've used git checkout, not go get to fetch the source so set up the GOPATH to find our source.
-export GOPATH=$GOPATH:/
-
-# go-fuzz-build doesn't like modules until https://github.com/dvyukov/go-fuzz/issues/195 is fixed
-# fetch and vendor all the dependencies so go-fuzz-build can find them
-make GO111MODULE=off --debug install_deps
-go mod vendor
-
-make GO111MODULE=off --debug $OUT/vm-fuzzer.dict $OUT/vm-fuzzer_seed_corpus.zip $OUT/vm-fuzzer
+compile_go_fuzzer github.com/google/mtail/internal/vm Fuzz vm-fuzzer
+# Make the dictionary and seed corpus.
+make --debug $OUT/vm-fuzzer.dict $OUT/vm-fuzzer_seed_corpus.zip


### PR DESCRIPTION
Per email discussion we can enable coverage on mtail by using the provided compile method from https://github.com/google/oss-fuzz/pull/4659.

Additionally per same discussion use the full GOPATH form for Go projects with modules.

Finally remove most of the dependence on the upstream Makefile for the fuzz build as a result of the above changes.