### PR TITLE
libspng: disable msan temporarily

### DIFF
--- a/projects/libspng/project.yaml
+++ b/projects/libspng/project.yaml
@@ -9,5 +9,3 @@ architectures:
 sanitizers:
   - address
   - undefined
-  - memory
-  


### PR DESCRIPTION
The fuzz target using the external [png_mutator](https://github.com/google/fuzzer-test-suite/blob/master/libpng-1.2.56/png_mutator.h) is causing coverage/build issues with msan and I'm not sure how to fix it, this looks like the lowest-impact solution, will rely on unit tests built with msan for the time being.

<details>
  <summary>Expand for error message</summary>
  
  ```
Step #33: INFO: performing bad build checks for /tmp/not-out/spng_read_fuzzer_structure_aware.
Step #33: Broken fuzz targets (1):
Step #33: spng_read_fuzzer_structure_aware:
Step #33: BAD BUILD: /tmp/not-out/spng_read_fuzzer_structure_aware seems to have either startup crash or exit:
Step #33: /tmp/not-out/spng_read_fuzzer_structure_aware -rss_limit_mb=2560 -timeout=25 -seed=1337 -runs=4 < /dev/null
Step #33: INFO: found LLVMFuzzerCustomMutator (0x527170). Disabling -len_control by default.
Step #33: INFO: Running with entropic power schedule (0xFF, 100).
Step #33: INFO: Seed: 1337
Step #33: INFO: Loaded 1 modules   (3866 inline 8-bit counters): 3866 [0x9dc9f8, 0x9dd912), 
Step #33: INFO: Loaded 1 PC tables (3866 PCs): 3866 [0x75d140,0x76c2e0), 
Step #33: INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
Step #33: INFO: A corpus is not provided, starting from an empty corpus
Step #33: #2	INITED cov: 2 ft: 2 corp: 1/1b exec/s: 0 rss: 66Mb
Step #33: 	NEW_FUNC[1/20]: 0x550280 in crc32_z /src/zlib/crc32.c:206
Step #33: 	NEW_FUNC[2/20]: 0x550350 in crc32_little /src/zlib/crc32.c:270
Step #33: #3	NEW    cov: 54 ft: 55 corp: 2/46b lim: 4096 exec/s: 0 rss: 66Mb L: 45/45 MS: 1 Custom-
Step #33: ==94==WARNING: MemorySanitizer: use-of-uninitialized-value
Step #33:     #0 0x529312 in PngMutator::PngMutator(std::__1::basic_istream<char, std::__1::char_traits<char> >&) /src/fuzzer-test-suite/libpng-1.2.56/png_mutator.h:38:9
Step #33:     #1 0x52b906 in LLVMFuzzerCustomCrossOver /src/fuzzer-test-suite/libpng-1.2.56/png_mutator.h:315:14
Step #33:     #2 0x46d41f in fuzzer::MutationDispatcher::Mutate_CustomCrossOver(unsigned char*, unsigned long, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMutate.cpp:84:20
Step #33:     #3 0x46f0b4 in fuzzer::MutationDispatcher::MutateImpl(unsigned char*, unsigned long, unsigned long, std::__Fuzzer::vector<fuzzer::MutationDispatcher::Mutator, fuzzer::fuzzer_allocator<fuzzer::MutationDispatcher::Mutator> >&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMutate.cpp:532:22
Step #33:     #4 0x45cec1 in fuzzer::Fuzzer::MutateAndTestOne() /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:737:20
Step #33:     #5 0x45daa5 in fuzzer::Fuzzer::Loop(std::__Fuzzer::vector<fuzzer::SizedFile, fuzzer::fuzzer_allocator<fuzzer::SizedFile> >&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:883:5
Step #33:     #6 0x44bc2b in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:906:6
Step #33:     #7 0x475c62 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
Step #33:     #8 0x7fb253a3e83f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2083f)
Step #33:     #9 0x420988 in _start (/tmp/not-out/spng_read_fuzzer_structure_aware+0x420988)
Step #33: 
Step #33: DEDUP_TOKEN: PngMutator::PngMutator(std::__1::basic_istream<char, std::__1::char_traits<char> >&)--LLVMFuzzerCustomCrossOver--fuzzer::MutationDispatcher::Mutate_CustomCrossOver(unsigned char*, unsigned long, unsigned long)
Step #33:   Uninitialized value was stored to memory at
Step #33:     #0 0x4cff59 in __msan_memcpy /src/llvm-project/compiler-rt/lib/msan/msan_interceptors.cpp:1558:3
Step #33:     #1 0x5e4436 in copy /work/msan/include/c++/v1/__string:386:56
Step #33:     #2 0x5e4436 in std::__1::basic_streambuf<char, std::__1::char_traits<char> >::xsgetn(char*, long) /work/msan/include/c++/v1/streambuf:414:13
Step #33:     #3 0x5ed757 in sgetn /work/msan/include/c++/v1/streambuf:201:14
Step #33:     #4 0x5ed757 in std::__1::basic_istream<char, std::__1::char_traits<char> >::read(char*, long) /work/msan/include/c++/v1/istream:1058:36
Step #33:     #5 0x52e4c8 in PngMutator::Read4(std::__1::basic_istream<char, std::__1::char_traits<char> >&) /src/fuzzer-test-suite/libpng-1.2.56/png_mutator.h:185:8
Step #33:     #6 0x52e552 in PngMutator::ReadInteger(std::__1::basic_istream<char, std::__1::char_traits<char> >&) /src/fuzzer-test-suite/libpng-1.2.56/png_mutator.h:189:30
Step #33:     #7 0x527d4f in PngMutator::PngMutator(std::__1::basic_istream<char, std::__1::char_traits<char> >&) /src/fuzzer-test-suite/libpng-1.2.56/png_mutator.h:38:9
Step #33:     #8 0x52b906 in LLVMFuzzerCustomCrossOver /src/fuzzer-test-suite/libpng-1.2.56/png_mutator.h:315:14
Step #33:     #9 0x46d41f in fuzzer::MutationDispatcher::Mutate_CustomCrossOver(unsigned char*, unsigned long, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMutate.cpp:84:20
Step #33:     #10 0x46f0b4 in fuzzer::MutationDispatcher::MutateImpl(unsigned char*, unsigned long, unsigned long, std::__Fuzzer::vector<fuzzer::MutationDispatcher::Mutator, fuzzer::fuzzer_allocator<fuzzer::MutationDispatcher::Mutator> >&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMutate.cpp:532:22
Step #33:     #11 0x45cec1 in fuzzer::Fuzzer::MutateAndTestOne() /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:737:20
Step #33:     #12 0x45daa5 in fuzzer::Fuzzer::Loop(std::__Fuzzer::vector<fuzzer::SizedFile, fuzzer::fuzzer_allocator<fuzzer::SizedFile> >&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:883:5
Step #33:     #13 0x44bc2b in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:906:6
Step #33:     #14 0x475c62 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
Step #33:     #15 0x7fb253a3e83f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2083f)
Step #33: 
Step #33: DEDUP_TOKEN: __msan_memcpy--copy--std::__1::basic_streambuf<char, std::__1::char_traits<char> >::xsgetn(char*, long)
Step #33:   Uninitialized value was stored to memory at
Step #33:     #0 0x4cff59 in __msan_memcpy /src/llvm-project/compiler-rt/lib/msan/msan_interceptors.cpp:1558:3
Step #33:     #1 0x5ccfc8 in copy /work/msan/include/c++/v1/__string:386:56
Step #33:     #2 0x5ccfc8 in __grow_by_and_replace /work/msan/include/c++/v1/string:2223:9
Step #33:     #3 0x5ccfc8 in __assign_no_alias<true> /work/msan/include/c++/v1/string:2281:5
Step #33:     #4 0x5ccfc8 in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::operator=(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /work/msan/include/c++/v1/string:2364:16
Step #33:     #5 0x54de27 in std::__1::basic_stringbuf<char, std::__1::char_traits<char>, std::__1::allocator<char> >::str(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /usr/local/bin/../include/c++/v1/sstream:442:12
Step #33:     #6 0x54d748 in std::__1::basic_stringbuf<char, std::__1::char_traits<char>, std::__1::allocator<char> >::basic_stringbuf(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, unsigned int) /usr/local/bin/../include/c++/v1/sstream:221:9
Step #33:     #7 0x527934 in std::__1::basic_stringstream<char, std::__1::char_traits<char>, std::__1::allocator<char> >::basic_stringstream(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, unsigned int) /usr/local/bin/../include/c++/v1/sstream:792:11
Step #33:     #8 0x52b7bc in LLVMFuzzerCustomCrossOver /src/fuzzer-test-suite/libpng-1.2.56/png_mutator.h:311:21
Step #33:     #9 0x46d41f in fuzzer::MutationDispatcher::Mutate_CustomCrossOver(unsigned char*, unsigned long, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMutate.cpp:84:20
Step #33:     #10 0x46f0b4 in fuzzer::MutationDispatcher::MutateImpl(unsigned char*, unsigned long, unsigned long, std::__Fuzzer::vector<fuzzer::MutationDispatcher::Mutator, fuzzer::fuzzer_allocator<fuzzer::MutationDispatcher::Mutator> >&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMutate.cpp:532:22
Step #33:     #11 0x45cec1 in fuzzer::Fuzzer::MutateAndTestOne() /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:737:20
Step #33:     #12 0x45daa5 in fuzzer::Fuzzer::Loop(std::__Fuzzer::vector<fuzzer::SizedFile, fuzzer::fuzzer_allocator<fuzzer::SizedFile> >&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:883:5
Step #33:     #13 0x44bc2b in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:906:6
Step #33:     #14 0x475c62 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
Step #33:     #15 0x7fb253a3e83f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2083f)
Step #33: 
Step #33: DEDUP_TOKEN: __msan_memcpy--copy--__grow_by_and_replace
Step #33:   Uninitialized value was stored to memory at
Step #33:     #0 0x4cff59 in __msan_memcpy /src/llvm-project/compiler-rt/lib/msan/msan_interceptors.cpp:1558:3
Step #33:     #1 0x5c856f in copy /work/msan/include/c++/v1/__string:386:56
Step #33:     #2 0x5c856f in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__init(char const*, unsigned long) /work/msan/include/c++/v1/string:1840:5
Step #33:     #3 0x527783 in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::basic_string(char const*, unsigned long) /usr/local/bin/../include/c++/v1/string:1862:5
Step #33:     #4 0x52b799 in LLVMFuzzerCustomCrossOver /src/fuzzer-test-suite/libpng-1.2.56/png_mutator.h:312:7
Step #33:     #5 0x46d41f in fuzzer::MutationDispatcher::Mutate_CustomCrossOver(unsigned char*, unsigned long, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMutate.cpp:84:20
Step #33:     #6 0x46f0b4 in fuzzer::MutationDispatcher::MutateImpl(unsigned char*, unsigned long, unsigned long, std::__Fuzzer::vector<fuzzer::MutationDispatcher::Mutator, fuzzer::fuzzer_allocator<fuzzer::MutationDispatcher::Mutator> >&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMutate.cpp:532:22
Step #33:     #7 0x45cec1 in fuzzer::Fuzzer::MutateAndTestOne() /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:737:20
Step #33:     #8 0x45daa5 in fuzzer::Fuzzer::Loop(std::__Fuzzer::vector<fuzzer::SizedFile, fuzzer::fuzzer_allocator<fuzzer::SizedFile> >&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:883:5
Step #33:     #9 0x44bc2b in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:906:6
Step #33:     #10 0x475c62 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
Step #33:     #11 0x7fb253a3e83f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2083f)
Step #33: 
Step #33: DEDUP_TOKEN: __msan_memcpy--copy--std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__init(char const*, unsigned long)
Step #33:   Uninitialized value was stored to memory at
Step #33:     #0 0x4cff59 in __msan_memcpy /src/llvm-project/compiler-rt/lib/msan/msan_interceptors.cpp:1558:3
Step #33:     #1 0x45cdfa in fuzzer::Fuzzer::MutateAndTestOne() /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:717:3
Step #33:     #2 0x45daa5 in fuzzer::Fuzzer::Loop(std::__Fuzzer::vector<fuzzer::SizedFile, fuzzer::fuzzer_allocator<fuzzer::SizedFile> >&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:883:5
Step #33:     #3 0x44bc2b in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:906:6
Step #33:     #4 0x475c62 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
Step #33:     #5 0x7fb253a3e83f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2083f)
Step #33: 
Step #33: DEDUP_TOKEN: __msan_memcpy--fuzzer::Fuzzer::MutateAndTestOne()--fuzzer::Fuzzer::Loop(std::__Fuzzer::vector<fuzzer::SizedFile, fuzzer::fuzzer_allocator<fuzzer::SizedFile> >&)
Step #33:   Uninitialized value was created by a heap allocation
Step #33:     #0 0x4d66dd in malloc /src/llvm-project/compiler-rt/lib/msan/msan_interceptors.cpp:901:3
Step #33:     #1 0x4395a7 in operator new(unsigned long) (/tmp/not-out/spng_read_fuzzer_structure_aware+0x4395a7)
Step #33:     #2 0x45c311 in operator= /work/llvm-stage2/projects/compiler-rt/lib/fuzzer/libcxx_fuzzer_x86_64/include/c++/v1/vector:1405:9
Step #33:     #3 0x45c311 in fuzzer::InputCorpus::AddToCorpus(std::__Fuzzer::vector<unsigned char, fuzzer::fuzzer_allocator<unsigned char> > const&, unsigned long, bool, bool, bool, std::__Fuzzer::chrono::duration<long long, std::__Fuzzer::ratio<1l, 1000000l> >, std::__Fuzzer::vector<unsigned int, fuzzer::fuzzer_allocator<unsigned int> > const&, fuzzer::DataFlowTrace const&, fuzzer::InputInfo const*) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerCorpus.h:218:10
Step #33:     #4 0x45b52b in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:528:16
Step #33:     #5 0x45cef7 in fuzzer::Fuzzer::MutateAndTestOne() /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:745:19
Step #33:     #6 0x45daa5 in fuzzer::Fuzzer::Loop(std::__Fuzzer::vector<fuzzer::SizedFile, fuzzer::fuzzer_allocator<fuzzer::SizedFile> >&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:883:5
Step #33:     #7 0x44bc2b in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:906:6
Step #33:     #8 0x475c62 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
Step #33:     #9 0x7fb253a3e83f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2083f)
Step #33: 
Step #33: DEDUP_TOKEN: malloc--operator new(unsigned long)--operator=
Step #33: SUMMARY: MemorySanitizer: use-of-uninitialized-value /src/fuzzer-test-suite/libpng-1.2.56/png_mutator.h:38:9 in PngMutator::PngMutator(std::__1::basic_istream<char, std::__1::char_traits<char> >&)
Step #33: Unique heap origins: 167
Step #33: Stack depot allocated bytes: 16528
Step #33: Unique origin histories: 48
Step #33: History depot allocated bytes: 1152
Step #33: Exiting
Step #33: MS: 0 ; base unit: 51e844219c4b162545dc93937240ad47ea223758
Step #33: 
Step #33: 
Step #33: artifact_prefix='./'; Test unit written to ./crash-da39a3ee5e6b4b0d3255bfef95601890afd80709
Step #33: Base64: 
Step #33: ERROR: 50% of fuzz targets seem to be broken. See the list above for a detailed information.
Step #33: ********************************************************************************
Step #33: Build checks failed.
Step #33: To reproduce, run:
Step #33: python infra/helper.py build_image libspng
Step #33: python infra/helper.py build_fuzzers --sanitizer memory --engine libfuzzer --architecture x86_64 libspng
Step #33: python infra/helper.py check_build --sanitizer memory --engine libfuzzer --architecture x86_64 libspng
  ```
</details>