### PR TITLE
helper: Make sure directories are created before they are passed to container engine (podman)

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -277,18 +277,27 @@ def get_dockerfile_path(project_name):
 
 
 def _get_corpus_dir(project_name=''):
-  """Returns path to /corpus directory for the given project (if specified)."""
-  return os.path.join(BUILD_DIR, 'corpus', project_name)
+  """Creates and returns path to /corpus directory for the given project (if specified)."""
+  directory = os.path.join(BUILD_DIR, 'corpus', project_name)
+  os.makedirs(directory, exist_ok=True)
+
+  return directory
 
 
 def _get_output_dir(project_name=''):
-  """Returns path to /out directory for the given project (if specified)."""
-  return os.path.join(BUILD_DIR, 'out', project_name)
+  """Creates and returns path to /out directory for the given project (if specified)."""
+  directory = os.path.join(BUILD_DIR, 'out', project_name)
+  os.makedirs(directory, exist_ok=True)
+
+  return directory
 
 
 def _get_work_dir(project_name=''):
-  """Returns path to /work directory for the given project (if specified)."""
-  return os.path.join(BUILD_DIR, 'work', project_name)
+  """Creates and returns path to /work directory for the given project (if specified)."""
+  directory = os.path.join(BUILD_DIR, 'work', project_name)
+  os.makedirs(directory, exist_ok=True)
+
+  return directory
 
 
 def _get_project_language(project_name):


### PR DESCRIPTION
As discussed recently in the containers/podman#8513, there is deliberate difference in the CLI of podman and docker in context of creation of missing directories passed as `-v` arguments. While docker happily creates these, podman is not that generous requires the directory structure to be ready in advance.

This PR makes sure directories are in place before invoking podman (symlinked from `docker` by default).

I am running oss-fuzz with podman for several years, reproducing issues and all works fine aside of couple of quirks that I would like to capture in this and probably some more PRs, if they will be acceptable.