### PR TITLE
wasmtime: add new codegen backend, and add contact for it.

### DIFF
--- a/projects/wasmtime/build.sh
+++ b/projects/wasmtime/build.sh
@@ -49,9 +49,11 @@ build() {
   done
 }
 
-# Build with all features to enable the binaryen-using fuzz targets, and
-# the peepmatic fuzz targets.
-build wasmtime "" "" --all-features
+# Build with peepmatic in order to enable the related fuzz targets.
+build wasmtime "" "" --features peepmatic-fuzzing
+
+# Build the differential fuzzer with the new x86-64 backend as well.
+build wasmtime diff-newbe- differential_wasmi --features experimental_x64
 
 build wasm-tools wasm-tools- ""
 build regalloc.rs regalloc- bt bt

--- a/projects/wasmtime/project.yaml
+++ b/projects/wasmtime/project.yaml
@@ -5,6 +5,7 @@ auto_ccs:
   - "alex@alexcrichton.com"
   - "till@tillschneidereit.net"
   - "ydelendik@mozilla.com"
+  - "cfallin@gmail.com"
 sanitizers:
   - address
 fuzzing_engines:


### PR DESCRIPTION
In [Wasmtime](https://github.com/bytecodealliance/wasmtime), we're
planning to transition eventually to a new x86 backend. We recently
added a fuzz target for this backend that differentially fuzzes against
a Wasm interpreter.

This PR adds the new backend's fuzz target and adds a contact (me) to
the notification list.