### PR TITLE
Improve support for podman out of the box

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -907,12 +907,15 @@ def reproduce_impl(  # pylint: disable=too-many-arguments
   if env_to_add:
     env += env_to_add
 
+  run_args = _env_to_docker_args(env)
+
   # for podman, we need to make sure the mounted testcase has proper SELinux context
   # to be accessible by the container
   if CONTAINER_ENGINE == 'podman':
     fix_selinux_context(testcase_path)
+    run_args += ['--cap-add', 'SYS_PTRACE']
 
-  run_args = _env_to_docker_args(env) + [
+  run_args += [
       '-v',
       '%s:/out' % _get_output_dir(project_name),
       '-v',

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -61,6 +61,12 @@ PROJECT_LANGUAGE_REGEX = re.compile(r'\s*language\s*:\s*([^\s]+)')
 # Languages from project.yaml that have code coverage support.
 LANGUAGES_WITH_COVERAGE_SUPPORT = ['c', 'c++', 'go']
 
+# not all the world is docker
+if os.path.exists('/bin/podman'):
+  CONTAINER_ENGINE = 'podman'
+else:
+  CONTAINER_ENGINE = 'docker'
+
 
 def main():  # pylint: disable=too-many-branches,too-many-return-statements,too-many-statements
   """Get subcommand from program arguments and do it."""
@@ -239,7 +245,7 @@ def check_project_exists(project_name):
 
 def _check_fuzzer_exists(project_name, fuzzer_name):
   """Checks if a fuzzer exists."""
-  command = ['docker', 'run', '--rm']
+  command = [CONTAINER_ENGINE, 'run', '--rm']
   command.extend(['-v', '%s:/out' % _get_output_dir(project_name)])
   command.append('ubuntu:16.04')
 
@@ -405,7 +411,10 @@ def _workdir_from_dockerfile(project_name):
 
 def docker_run(run_args, print_output=True):
   """Call `docker run`."""
-  command = ['docker', 'run', '--rm', '--privileged']
+  command = [CONTAINER_ENGINE, 'run', '--rm']
+
+  if CONTAINER_ENGINE != 'podman':
+    command.append('--privileged')
 
   # Support environments with a TTY.
   if sys.stdin.isatty():
@@ -428,7 +437,7 @@ def docker_run(run_args, print_output=True):
 
 def docker_build(build_args, pull=False):
   """Call `docker build`."""
-  command = ['docker', 'build']
+  command = [CONTAINER_ENGINE, 'build']
   if pull:
     command.append('--pull')
 
@@ -446,7 +455,7 @@ def docker_build(build_args, pull=False):
 
 def docker_pull(image):
   """Call `docker pull`."""
-  command = ['docker', 'pull', image]
+  command = [CONTAINER_ENGINE, 'pull', image]
   print('Running:', _get_command_string(command))
 
   try:

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -73,6 +73,10 @@ def main():  # pylint: disable=too-many-branches,too-many-return-statements,too-
   os.chdir(OSS_FUZZ_DIR)
   if not os.path.exists(BUILD_DIR):
     os.mkdir(BUILD_DIR)
+    if CONTAINER_ENGINE == 'podman':
+      # we do not need to do it for the rest of the files under this path
+      # as the context is inherited from the parent directory
+      fix_selinux_context(BUILD_DIR)
 
   parser = argparse.ArgumentParser('helper.py', description='oss-fuzz helpers')
   subparsers = parser.add_subparsers(dest='command')


### PR DESCRIPTION
As stated in #4763 I am using the helper script with podman for some time, but it does not work out of the box so I had to maintain couple of changes and make sure the correct selinux permissions are in place and containers run as expected.

This PR provides a couple of changes that should make the use of podman as a container engine more usable out of the box, but it will probably require some polishing:

 * `podman` is detected by existence of `/bin/podman` -- the simplest I was able to figure out.
   * It can be invoked through the `docker` CLI, but why when we already know it is there.
 * `podman` requires the files and directories that are mounted to the container to have `container_file_t` SELinux type as a security measure to make sure evil containers do not have access unintended files on the whole local filesystem (if used improperly)
   * This is certainly needed for the `build` directory (all the other files created under it inherit this context by itself)
   * This is needed for the testcase files, but only from not-privileged container (see later)
   * This is needed for the source files if local checkout is used to build fuzzers (not included here as it might be more intrusive than users would expect as it requires recursive change of context of all the source files)
 * in `podman` having both `--privileged` and `--cap-add SYS_PTRACE` is invalid (not sure what it should do with `docker` anyway -- maybe worth checking `docker` docs):
    ```
    Error: invalid config provided: CapAdd and privileged are mutually exclusive options
    ```
    * `podman` very happily run all stuff in non-privileged containers, but the only issue I noticed was in `reproduce` subcommand, that Leaksanitizer complains (not sure if it has any functional difference, but it goes away when I add `--cap-add SYS_PTRACE` instead, which sounds a better solution):
    ```
    ==8==LeakSanitizer has encountered a fatal error.
    ==8==HINT: For debugging, try setting environment variable LSAN_OPTIONS=verbosity=1:log_threads=1
    ==8==HINT: LeakSanitizer does not work under ptrace (strace, gdb, etc)
    ```

I did no run any comprehensive testsuite of the helper so there might be still some corner cases that will not work. This could be solved by running some tests in CI not only on your default systems, but also in Fedora.