### PR TITLE
Fix Freetype upstream repo address.

### DIFF
--- a/projects/ghostscript/Dockerfile
+++ b/projects/ghostscript/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN apt-get update && apt-get install -y autoconf zlibc libtool liblcms2-dev libpng-dev
 RUN git clone --branch branch-2.2 --single-branch --depth 1 https://github.com/apple/cups.git cups
-RUN git clone --branch VER-2-10-1 --single-branch --depth 1 https://git.sv.nongnu.org/r/freetype/freetype2.git freetype
+RUN git clone --branch VER-2-10-1 --single-branch --depth 1 https://git.savannah.gnu.org/git/freetype/freetype2.git freetype
 RUN git clone --single-branch --depth 1 git://git.ghostscript.com/ghostpdl.git ghostpdl
 
 RUN mkdir ghostpdl/fuzz


### PR DESCRIPTION
The reported build failures in the Ghostscript project are because freetype recently changed their git hosting - this changes the ghostscript Dockerfile to point at the new freetype upstream repo.
