### PR TITLE
[cilium] Add Cilium project

### DIFF
--- a/projects/cilium/project.yaml
+++ b/projects/cilium/project.yaml
@@ -1,0 +1,11 @@
+homepage: "https://cilium.io"
+language: go
+primary_contact: "security@cilium.io"
+auto_ccs:
+- "tom@isovalent.com"
+- "natalia@isovalent.com"
+- "adam@adalogics.com"
+fuzzing_engines:
+- libfuzzer
+sanitizers:
+- address


### PR DESCRIPTION
Cilium provides eBPF-based Networking, Observability, and Security, is widely used (with [over 7K stars on GitHub](https://github.com/cilium/cilium/stargazers)), including by Google as its [GKE Dataplane V2](https://cloud.google.com/blog/products/containers-kubernetes/bringing-ebpf-and-cilium-to-google-kubernetes-engine).

Hopefully it meets the [new OSS-Fuzz project requirements](https://google.github.io/oss-fuzz/getting-started/accepting-new-projects/) of " a significant user base and/or be critical to the global IT infrastructure". We'd love for Cilium to be supported by OSS-Fuzz.

cc @sharlns @AdamKorcz refs https://github.com/cilium/cilium/pull/14202