### PR TITLE
[exprtk] Enable loop upper-bound runtime checks in the fuzzer

### DIFF
--- a/projects/exprtk/exprtk_fuzzer.cpp
+++ b/projects/exprtk/exprtk_fuzzer.cpp
@@ -15,15 +15,17 @@
 #include <cstdint>
 #include <string>
 
+#define exprtk_enable_runtime_checks
 #include "exprtk.hpp"
 
 
 template <typename T>
 void run(const std::string& expression_string)
 {
-   typedef exprtk::symbol_table<T> symbol_table_t;
-   typedef exprtk::expression<T>     expression_t;
-   typedef exprtk::parser<T>             parser_t;
+   typedef exprtk::symbol_table<T>          symbol_table_t;
+   typedef exprtk::expression<T>              expression_t;
+   typedef exprtk::parser<T>                      parser_t;
+   typedef exprtk::loop_runtime_check loop_runtime_check_t;
 
    T x = T(1.2345);
    T y = T(2.2345);
@@ -40,10 +42,24 @@ void run(const std::string& expression_string)
    expression_t expression;
    expression.register_symbol_table(symbol_table);
 
+   loop_runtime_check_t loop_runtime_check;
+   loop_runtime_check.loop_set = loop_runtime_check_t::e_all_loops;
+   loop_runtime_check.max_loop_iterations = 100000000;
+
    parser_t parser;
+
+   parser.register_loop_runtime_check(loop_runtime_check);
+
    if (parser.compile(expression_string, expression))
    {
-      expression.value();
+      try
+      {
+         expression.value();
+      }
+      catch (std::runtime_error& rte)
+      {}
+
+      parser.clear_loop_runtime_check();
    }
 }
 


### PR DESCRIPTION
Enable loop upper-bound runtime checks in the fuzzer

--------------

On another note, I'm not sure what to do about these cases:

https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=28195
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=28169

They are both syntactically valid expressions, yet they trigger the fuzzers due to invalid/bad memory accesses during the evaluation part of the test.

- **Issue 28195:**  'e'[y:3427z]+'e'
- **Issue 28169 :** ''<''[y:z]

**Note:**  Not saying the result is incorrect, just that the exprtk can't do anything about that - like most other languages.


The options I see going forward are:

1. Ignore such testcases as false positives
2. Disable the expression evaluation part

I would rather not do **[2]** as I'd very much like the evaluation part be fuzzed as well.  

Any suggestions on how to proceed will be greatly appreciated.

