### PR TITLE
Add a fuzzer for Pygments

### DIFF
--- a/projects/pygments/Dockerfile
+++ b/projects/pygments/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN git clone \
+	--depth 1 \
+	--branch master \
+	https://github.com/pygments/pygments.git
+
+WORKDIR pygments
+
+COPY build.sh pygments_fuzzer.py $SRC/

--- a/projects/pygments/build.sh
+++ b/projects/pygments/build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Build and install project (using current CFLAGS, CXXFLAGS).
+pip3 install .
+
+# Build fuzzers in $OUT.
+for fuzzer in $(find $SRC -name '*_fuzzer.py'); do
+  fuzzer_basename=$(basename -s .py $fuzzer)
+  fuzzer_package=${fuzzer_basename}.pkg
+  pyinstaller --distpath $OUT --onefile --name $fuzzer_package $fuzzer
+
+  # Create execution wrapper.
+  echo "#!/bin/sh
+# LLVMFuzzerTestOneInput for fuzzer detection.
+LD_PRELOAD=\$(dirname "\$0")/libclang_rt.asan-x86_64.so \
+ASAN_OPTIONS=\$ASAN_OPTIONS:symbolize=1:detect_leaks=0 \
+\$(dirname "\$0")/$fuzzer_package \$@" > $OUT/$fuzzer_basename
+  chmod u+x $OUT/$fuzzer_basename
+done

--- a/projects/pygments/build.sh
+++ b/projects/pygments/build.sh
@@ -27,7 +27,6 @@ for fuzzer in $(find $SRC -name '*_fuzzer.py'); do
   # Create execution wrapper.
   echo "#!/bin/sh
 # LLVMFuzzerTestOneInput for fuzzer detection.
-LD_PRELOAD=\$(dirname "\$0")/libclang_rt.asan-x86_64.so \
 ASAN_OPTIONS=\$ASAN_OPTIONS:symbolize=1:detect_leaks=0 \
 \$(dirname "\$0")/$fuzzer_package \$@" > $OUT/$fuzzer_basename
   chmod u+x $OUT/$fuzzer_basename

--- a/projects/pygments/project.yaml
+++ b/projects/pygments/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://pygments.org/"
+main_repo: "https://github.com/pygments/pygments"
 language: python
 primary_contact: "security-tps@google.com"
 auto_ccs:

--- a/projects/pygments/project.yaml
+++ b/projects/pygments/project.yaml
@@ -1,0 +1,11 @@
+homepage: "https://pygments.org/"
+language: python
+primary_contact: "security-tps@google.com"
+auto_ccs:
+  - "jvoisin@google.com"
+  - "ipudney@google.com"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+  - undefined

--- a/projects/pygments/pygments_fuzzer.py
+++ b/projects/pygments/pygments_fuzzer.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python3
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import atheris
+import pygments
+import pygments.formatters
+import pygments.lexers
+
+
+def TestOneInput(input_bytes):
+  try:
+    lexer = pygments.lexers.guess_lexer(str(data))
+  except ValueError:
+    return
+  pygments.highlight(str(data), lexer, pygments.formatters.HtmlFormatter())
+
+
+def main():
+  atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
+  atheris.Fuzz()
+
+
+if __name__ == "__main__":
+  main()

--- a/projects/pygments/pygments_fuzzer.py
+++ b/projects/pygments/pygments_fuzzer.py
@@ -23,10 +23,10 @@ import pygments.lexers
 
 def TestOneInput(input_bytes):
   try:
-    lexer = pygments.lexers.guess_lexer(str(data))
+    lexer = pygments.lexers.guess_lexer(str(input_bytes))
   except ValueError:
     return
-  pygments.highlight(str(data), lexer, pygments.formatters.HtmlFormatter())
+  pygments.highlight(str(input_bytes), lexer, pygments.formatters.HtmlFormatter())
 
 
 def main():


### PR DESCRIPTION
While pygments doesn't use native code for fuzzing,
it's the defacto solution to highlight (untrusted) code,
so unexpected exceptions and timeouts are important.