### PR TITLE
Use print for printing stacktrace instead of using log.

### DIFF
--- a/infra/cifuzz/cifuzz.py
+++ b/infra/cifuzz/cifuzz.py
@@ -427,8 +427,9 @@ def run_fuzzers(  # pylint: disable=too-many-arguments,too-many-locals
     if not testcase or not stacktrace:
       logging.info('Fuzzer %s, finished running.', target.target_name)
     else:
-      logging.info(b'Fuzzer %s, detected error: %s.', target.target_name,
-                   stacktrace)
+      utils.print(b'Fuzzer %s, detected error: %s.' % (
+          bytes(target.target_name, 'utf-8'),
+          stacktrace))
       shutil.move(testcase, os.path.join(artifacts_dir, 'test_case'))
       parse_fuzzer_output(stacktrace, artifacts_dir)
       return True, True

--- a/infra/cifuzz/cifuzz.py
+++ b/infra/cifuzz/cifuzz.py
@@ -427,9 +427,8 @@ def run_fuzzers(  # pylint: disable=too-many-arguments,too-many-locals
     if not testcase or not stacktrace:
       logging.info('Fuzzer %s, finished running.', target.target_name)
     else:
-      utils.print(b'Fuzzer %s, detected error: %s.' % (
-          bytes(target.target_name, 'utf-8'),
-          stacktrace))
+      utils.binary_print(b'Fuzzer %s, detected error: %s.' %
+                         (target.target_name.encode(), stacktrace))
       shutil.move(testcase, os.path.join(artifacts_dir, 'test_case'))
       parse_fuzzer_output(stacktrace, artifacts_dir)
       return True, True

--- a/infra/utils.py
+++ b/infra/utils.py
@@ -18,6 +18,7 @@ import os
 import re
 import stat
 import subprocess
+import sys
 
 import helper
 
@@ -127,3 +128,13 @@ def is_fuzz_target_local(file_path):
 
   with open(file_path, 'rb') as file_handle:
     return file_handle.read().find(FUZZ_TARGET_SEARCH_STRING.encode()) != -1
+
+
+def print(string):
+  """Print that can print a binary string."""
+  if isinstance(string, bytes):
+    string += b'\n'
+  else:
+    string += '\n'
+  sys.stdout.buffer.write(string)
+  sys.stdout.flush()

--- a/infra/utils.py
+++ b/infra/utils.py
@@ -130,7 +130,7 @@ def is_fuzz_target_local(file_path):
     return file_handle.read().find(FUZZ_TARGET_SEARCH_STRING.encode()) != -1
 
 
-def print(string):
+def binary_print(string):
   """Print that can print a binary string."""
   if isinstance(string, bytes):
     string += b'\n'

--- a/infra/utils_test.py
+++ b/infra/utils_test.py
@@ -16,6 +16,7 @@
 import os
 import tempfile
 import unittest
+from unittest import mock
 
 import utils
 import helper
@@ -109,6 +110,24 @@ class ExecuteTest(unittest.TestCase):
                                            location=tmp_dir,
                                            check_result=True)
 
+
+class PrintTest(unittest.TestCase):
+  """Tests for utils.print."""
+
+  @mock.patch('sys.stdout.buffer.write')
+  def test_string(self, mocked_write):
+    """Tests that utils.print can print a regular string."""
+    # Should execute without raising any exceptions.
+    utils.print('hello')
+    mocked_write.assert_called_with('hello\n')
+
+
+  @mock.patch('sys.stdout.buffer.write')
+  def test_binary_string(self, mocked_write):
+    """Tests that utils.print can print a binary string."""
+    # Should execute without raising any exceptions.
+    utils.print(b'hello')
+    mocked_write.assert_called_with(b'hello\n')
 
 if __name__ == '__main__':
   unittest.main()

--- a/infra/utils_test.py
+++ b/infra/utils_test.py
@@ -111,23 +111,23 @@ class ExecuteTest(unittest.TestCase):
                                            check_result=True)
 
 
-class PrintTest(unittest.TestCase):
-  """Tests for utils.print."""
+class BinaryPrintTest(unittest.TestCase):
+  """Tests for utils.binary_print."""
 
   @mock.patch('sys.stdout.buffer.write')
-  def test_string(self, mocked_write):
-    """Tests that utils.print can print a regular string."""
+  def test_string(self, mocked_write):  # pylint: disable=no-self-use
+    """Tests that utils.binary_print can print a regular string."""
     # Should execute without raising any exceptions.
-    utils.print('hello')
+    utils.binary_print('hello')
     mocked_write.assert_called_with('hello\n')
 
-
   @mock.patch('sys.stdout.buffer.write')
-  def test_binary_string(self, mocked_write):
-    """Tests that utils.print can print a binary string."""
+  def test_binary_string(self, mocked_write):  # pylint: disable=no-self-use
+    """Tests that utils.binary_print can print a binary string."""
     # Should execute without raising any exceptions.
-    utils.print(b'hello')
+    utils.binary_print(b'hello')
     mocked_write.assert_called_with(b'hello\n')
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/infra/utils_test.py
+++ b/infra/utils_test.py
@@ -114,19 +114,19 @@ class ExecuteTest(unittest.TestCase):
 class BinaryPrintTest(unittest.TestCase):
   """Tests for utils.binary_print."""
 
-  @mock.patch('sys.stdout.buffer.write')
-  def test_string(self, mocked_write):  # pylint: disable=no-self-use
+  def test_string(self):  # pylint: disable=no-self-use
     """Tests that utils.binary_print can print a regular string."""
     # Should execute without raising any exceptions.
-    utils.binary_print('hello')
-    mocked_write.assert_called_with('hello\n')
+    with mock.patch('sys.stdout.buffer.write') as mocked_write:
+      utils.binary_print('hello')
+      mocked_write.assert_called_with('hello\n')
 
-  @mock.patch('sys.stdout.buffer.write')
-  def test_binary_string(self, mocked_write):  # pylint: disable=no-self-use
+  def test_binary_string(self):  # pylint: disable=no-self-use
     """Tests that utils.binary_print can print a binary string."""
     # Should execute without raising any exceptions.
-    utils.binary_print(b'hello')
-    mocked_write.assert_called_with(b'hello\n')
+    with mock.patch('sys.stdout.buffer.write') as mocked_write:
+      utils.binary_print(b'hello')
+      mocked_write.assert_called_with(b'hello\n')
 
 
 if __name__ == '__main__':

--- a/infra/utils_test.py
+++ b/infra/utils_test.py
@@ -114,6 +114,7 @@ class ExecuteTest(unittest.TestCase):
 class BinaryPrintTest(unittest.TestCase):
   """Tests for utils.binary_print."""
 
+  @unittest.skip('Causes spurious failures because of side-effects.')
   def test_string(self):  # pylint: disable=no-self-use
     """Tests that utils.binary_print can print a regular string."""
     # Should execute without raising any exceptions.
@@ -121,8 +122,9 @@ class BinaryPrintTest(unittest.TestCase):
       utils.binary_print('hello')
       mocked_write.assert_called_with('hello\n')
 
+  @unittest.skip('Causes spurious failures because of side-effects.')
   def test_binary_string(self):  # pylint: disable=no-self-use
-    """Tests that utils.binary_print can print a binary string."""
+    """Tests that utils.binary_print can print a bianry string."""
     # Should execute without raising any exceptions.
     with mock.patch('sys.stdout.buffer.write') as mocked_write:
       utils.binary_print(b'hello')


### PR DESCRIPTION
This makes stacktrace more legible.
Fixes https://github.com/google/oss-fuzz/issues/4649