### PR TITLE
[flatbuffers] Copy dictionaries and schemas to the OUT directory

### DIFF
--- a/projects/flatbuffers/build.sh
+++ b/projects/flatbuffers/build.sh
@@ -21,5 +21,6 @@ cd build
 cmake -DOSS_FUZZ:BOOL=ON -G "Unix Makefiles" ../tests/fuzzer
 make
 
+cp ../tests/fuzzer/*.dict $OUT/
+cp *.bfbs $OUT/
 cp *_fuzzer $OUT/
-


### PR DESCRIPTION
This commit adds copies of dictionaries and auxiliary files to the $OUT folder.
CC: @aardappel

