### PR TITLE
[CIFuzz] Fix issue where copied repo is named incorrectly. 

### DIFF
--- a/infra/cifuzz/cifuzz.py
+++ b/infra/cifuzz/cifuzz.py
@@ -272,10 +272,14 @@ class InternalGithubBuilder(BaseBuilder):
     git_workspace = os.path.join(self.workspace, 'storage')
     os.makedirs(git_workspace, exist_ok=True)
 
+    # Use the same name used in the docker image so we can overwrite it.
+    image_repo_name = os.path.basename(self.image_repo_path)
+
     # Checkout project's repo in the shared volume.
     self.repo_manager = repo_manager.clone_repo_and_get_manager(
-        inferred_url, git_workspace, repo_name=self.project_repo_name)
+        inferred_url, git_workspace, repo_name=image_repo_name)
 
+    print('self.host_repo_path', self.host_repo_path)
     self.host_repo_path = self.repo_manager.repo_dir
 
     checkout_specified_commit(self.repo_manager, self.pr_ref, self.commit_sha)
@@ -349,7 +353,7 @@ def build_fuzzers(  # pylint: disable=too-many-arguments,too-many-locals
 
   Args:
     project_name: The name of the OSS-Fuzz project being built.
-    project_repo_name: The name of the projects repo.
+    project_repo_name: The name of the project's repo.
     workspace: The location in a shared volume to store a git repo and build
       artifacts.
     pr_ref: The pull request reference to be built.

--- a/infra/cifuzz/cifuzz.py
+++ b/infra/cifuzz/cifuzz.py
@@ -279,7 +279,6 @@ class InternalGithubBuilder(BaseBuilder):
     self.repo_manager = repo_manager.clone_repo_and_get_manager(
         inferred_url, git_workspace, repo_name=image_repo_name)
 
-    print('self.host_repo_path', self.host_repo_path)
     self.host_repo_path = self.repo_manager.repo_dir
 
     checkout_specified_commit(self.repo_manager, self.pr_ref, self.commit_sha)

--- a/infra/cifuzz/cifuzz_test.py
+++ b/infra/cifuzz/cifuzz_test.py
@@ -105,8 +105,10 @@ class InternalGithubBuilderTest(unittest.TestCase):
 
   def _create_builder(self, tmp_dir):
     """Creates an InternalGithubBuilder and returns it."""
-    return cifuzz.InternalGithubBuilder(self.PROJECT_NAME, self.PROJECT_REPO_NAME, tmp_dir, self.SANITIZER, self.COMMIT_SHA, self.PR_REF)
-
+    return cifuzz.InternalGithubBuilder(self.PROJECT_NAME,
+                                        self.PROJECT_REPO_NAME, tmp_dir,
+                                        self.SANITIZER, self.COMMIT_SHA,
+                                        self.PR_REF)
 
   @mock.patch('repo_manager._clone', side_effect=None)
   @mock.patch('cifuzz.checkout_specified_commit', side_effect=None)
@@ -117,8 +119,8 @@ class InternalGithubBuilderTest(unittest.TestCase):
     image/container, so that it will replace the host's copy properly."""
     image_repo_path = '/src/repo_dir'
     with tempfile.TemporaryDirectory() as tmp_dir, mock.patch(
-        'build_specified_commit.detect_main_repo', return_value=(
-            'inferred_url', image_repo_path)):
+        'build_specified_commit.detect_main_repo',
+        return_value=('inferred_url', image_repo_path)):
       builder = self._create_builder(tmp_dir)
       builder.build_image_and_checkout_src()
 

--- a/infra/cifuzz/cifuzz_test.py
+++ b/infra/cifuzz/cifuzz_test.py
@@ -95,6 +95,37 @@ class BuildFuzzersTest(unittest.TestCase):
     self.assertTrue(command_has_env_var_arg(docker_run_command, 'CIFUZZ=True'))
 
 
+class InternalGithubBuilderTest(unittest.TestCase):
+  """Tests for building OSS-Fuzz projects on GitHub actions."""
+  PROJECT_NAME = 'myproject'
+  PROJECT_REPO_NAME = 'myproject'
+  SANITIZER = 'address'
+  COMMIT_SHA = 'fake'
+  PR_REF = 'fake'
+
+  def _create_builder(self, tmp_dir):
+    """Creates an InternalGithubBuilder and returns it."""
+    return cifuzz.InternalGithubBuilder(self.PROJECT_NAME, self.PROJECT_REPO_NAME, tmp_dir, self.SANITIZER, self.COMMIT_SHA, self.PR_REF)
+
+
+  @mock.patch('repo_manager._clone', side_effect=None)
+  @mock.patch('cifuzz.checkout_specified_commit', side_effect=None)
+  def test_correct_host_repo_path(self, _, __):
+    """Tests that the correct self.host_repo_path is set by
+    build_image_and_checkout_src. Specifically, we want the name of the
+    directory the repo is in to match the name used in the docker
+    image/container, so that it will replace the host's copy properly."""
+    image_repo_path = '/src/repo_dir'
+    with tempfile.TemporaryDirectory() as tmp_dir, mock.patch(
+        'build_specified_commit.detect_main_repo', return_value=(
+            'inferred_url', image_repo_path)):
+      builder = self._create_builder(tmp_dir)
+      builder.build_image_and_checkout_src()
+
+    self.assertEqual(os.path.basename(builder.host_repo_path),
+                     os.path.basename(image_repo_path))
+
+
 class BuildFuzzersIntegrationTest(unittest.TestCase):
   """Integration tests for build_fuzzers."""
 


### PR DESCRIPTION
Make sure the cloned repo is copied correctly to the docker container
E.g. https://github.com/OpenSC/OpenSC should be coiped to $SRC/opensc.
Fixes #4810