### PR TITLE
fwupd: Initial integration for possible acceptance

### DIFF
--- a/projects/fwupd/project.yaml
+++ b/projects/fwupd/project.yaml
@@ -1,0 +1,4 @@
+homepage: "https://github.com/fwupd/fwupd"
+language: c
+primary_contact: "hughsient@gmail.com"
+main_repo: 'https://github.com/fwupd/fwupd'


### PR DESCRIPTION
The fwupd daemon is a firmware installer deployed onto tens (hundreds?) of
millions of devices. It parses untrusted firmware blobs from OEMs, ODMs and
IHVs writing using dozens of different protocols.

See https://fwupd.org/ for a whole ton more details about the project.

Using the LVFS we've deployed at least 22 million updates in the last few years,
although that number could be a lot higher in reality as we allow the LVFS to
be anonymously mirrored and for fwupd to be run without phoning home.

We used to fuzz with afl but recently switched to honggfuzz which found an
additional 17 critical warnings or crashes. Hence my interest in oss-fuzz!

My actual email address richard@hughsie.com is aliased to the email address
given here, and I can confirm I'm the upstream maintainer. The github project
has 1.1k stars and 172 forks if that means anything in reality.

The fwupd project is used by almost all distributions, *including* ChromeOS.