### PR TITLE
Ignore osquery cmake max version check

### DIFF
--- a/projects/osquery/build.sh
+++ b/projects/osquery/build.sh
@@ -25,17 +25,15 @@ PROJECT=osquery
 
 pushd "${SRC}/${PROJECT}"
 
-# Prefer shared libs
-sed -i 's/CMAKE_LINK_SEARCH_START_STATIC ON/CMAKE_LINK_SEARCH_START_STATIC OFF/g' cmake/flags.cmake
-sed -i 's/CMAKE_LINK_SEARCH_END_STATIC ON/CMAKE_LINK_SEARCH_END_STATIC OFF/g' cmake/flags.cmake
-
 mkdir build && pushd build
 
 cmake \
   -DOSQUERY_VERSION:string=0.0.0-fuzz \
   -DOSQUERY_ENABLE_ADDRESS_SANITIZER:BOOL=ON \
   -DOSQUERY_ENABLE_FUZZER_SANITIZERS:BOOL=ON \
+  -DOSQUERY_IGNORE_CMAKE_MAX_VERSION_CHECK:BOOL=ON \
   ..
+
 cmake \
   "-DCMAKE_EXE_LINKER_FLAGS=${LIB_FUZZING_ENGINE} -Wl,-rpath,'\$ORIGIN/lib'" \
   ..


### PR DESCRIPTION
Soon osquery will require that the version of CMake
is not equal or higher than 3.18.0.
We can ignore such requirement since we are not making packages.
See osquery/osquery#6801

Also remove unused sed replacements. Those settings are now the default
when not using the osquery toolchain.