### PR TITLE
dav1d: fetch nasm from Ubuntu 20.04 LTS (focal)

### DIFF
--- a/projects/dav1d/nasm.list
+++ b/projects/dav1d/nasm.list
@@ -1,2 +1,2 @@
 # use nasm from a newer ubuntu release
-deb http://archive.ubuntu.com/ubuntu/ eoan universe
+deb http://archive.ubuntu.com/ubuntu/ focal universe

--- a/projects/dav1d/nasm_apt.pin
+++ b/projects/dav1d/nasm_apt.pin
@@ -1,7 +1,7 @@
 Package: *
-Pin: release n=eoan
+Pin: release n=focal
 Pin-Priority: 1
 
 Package: nasm
-Pin: release n=eoan
+Pin: release n=focal
 Pin-Priority: 555


### PR DESCRIPTION
Fixes broken dav1d build due EOL for for eoan