### PR TITLE
leveldb: Fuzzer improvements.

### DIFF
--- a/projects/leveldb/build.sh
+++ b/projects/leveldb/build.sh
@@ -18,13 +18,14 @@
 
 cd $SRC/leveldb
 mkdir -p build && cd build
-cmake -DCMAKE_BUILD_TYPE=Release .. && cmake --build .
+cmake -DCMAKE_BUILD_TYPE=Release -DLEVELDB_BUILD_TESTS=0 \
+    -DLEVELDB_BUILD_BENCHMARKS=0 .. && cmake --build .
 
 for fuzzer in fuzz_db; do
     # Compile
     $CXX $CXXFLAGS -c ../${fuzzer}.cc -o ${fuzzer}.o \
-     -DLEVELDB_PLATFORM_POSIX=1 -std=c++11 \
-    -I$SRC/leveldb/build/include -I$SRC/leveldb/ -I$SRC/leveldb/include
+        -DLEVELDB_PLATFORM_POSIX=1 -std=c++11 -Wall \
+        -I$SRC/leveldb/build/include -I$SRC/leveldb/ -I$SRC/leveldb/include
 
     # Link
     $CXX $LIB_FUZZING_ENGINE $CXXFLAGS ${fuzzer}.o -o $OUT/${fuzzer} libleveldb.a


### PR DESCRIPTION
* Stop when opening a database fails. This will avoid null pointer
  dereferences.

* Use C++11 smart pointers for leveldb::DB and leveldb::Iterator. This
  makes it easier to ensure the fuzzer doesn't leak memory. No leak was
  detected while applying this fix.

* Use the FuzzedDataProvider API exclusively for consuming data. This
  makes it easier to ensure maximum fuzzer coverage.

* Avoid building unnecessary code (tests, benchmarks). This slightly
  reduces oss-fuzz resource usage.

* Use an enum class and FuzzedDataProvider::ConsumeEnum() instead of
  reimplementing it. This makes it easier to extend the fuzzer with new
  operations in the future.

* Use meaningful names (key, value, name) instead of tmp* for local
  variables storing leveldb API inputs.