### PR TITLE
[containerd] Initial integration

### DIFF
--- a/projects/containerd/Dockerfile
+++ b/projects/containerd/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN git clone --depth 1 https://github.com/containerd/containerd
+COPY build.sh $SRC/
+WORKDIR $SRC/containerd

--- a/projects/containerd/build.sh
+++ b/projects/containerd/build.sh
@@ -1,0 +1,19 @@
+#/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+compile_go_fuzzer github.com/containerd/containerd/contrib/fuzz FuzzFiltersParse fuzz_filters_parse
+compile_go_fuzzer github.com/containerd/containerd/contrib/fuzz FuzzPlatformsParse fuzz_platforms_parse

--- a/projects/containerd/project.yaml
+++ b/projects/containerd/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/containerd/containerd"
+main_repo: "https://github.com/containerd/containerd"
+primary_contact: "security@containerd.io"
+auto_ccs :
+  - "adam@adalogics.com"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
This PR adds initial integration of Containerd, an industry-standard container runtime.

Selected adopters include:

1. [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/)
2. [IBM Cloud Kubernetes Service](https://www.ibm.com/cloud/kubernetes-service)
3. [Firecracker](https://github.com/firecracker-microvm/firecracker)
4. [Katacontainers](https://katacontainers.io/)
5. [Cloudfoundry](https://www.cloudfoundry.org/)
6. Docker

Containerd graduated CNCF in 2019.

2 fuzzers have been merged upstream here: https://github.com/containerd/containerd/pull/4841

__________________________________________________________________________________

@kzys @mxpv @cpuguy83 @estesp @AkihiroSuda

### For the Containerd maintainers:
The files in this PR allows Containerd's fuzzers to be run continuously. All that is needed on this side is at least one maintainers email address in the `project.yaml` file. You can add it per your convenience or you can leave your email address in this thread and I will make sure to add it. The list can be changed at any time by making a pull request with the desired changes. If you have any questions about this integration, feel free to drop them in this PR or in the PR on the Containerd repository. Please note that I have added my own email address on the mailing list to see the integration through to completion. This does mean that all bugs and vulnerabilities will be visible by me as all email addresses on that list will have access to these, and if you prefer me off the list, just let me know, and I will remove myself.