### PR TITLE
Add AVIF format to kimageformats project

### DIFF
--- a/projects/kimageformats/Dockerfile
+++ b/projects/kimageformats/Dockerfile
@@ -22,6 +22,9 @@ RUN git clone --depth 1 https://invent.kde.org/frameworks/extra-cmake-modules.gi
 RUN git clone --depth 1 --branch=5.15 git://code.qt.io/qt/qtbase.git
 RUN git clone --depth 1 https://invent.kde.org/frameworks/karchive.git
 RUN git clone --depth 1 https://invent.kde.org/frameworks/kimageformats.git
+RUN apt-get install --yes yasm
+RUN git clone --depth 1 -b v2.0.1 https://aomedia.googlesource.com/aom
+RUN git clone --depth 1 -b v0.8.4 https://github.com/AOMediaCodec/libavif.git
 COPY build.sh $SRC
 COPY kimgio_fuzzer.cc $SRC
 WORKDIR kimageformats

--- a/projects/kimageformats/build.sh
+++ b/projects/kimageformats/build.sh
@@ -1,3 +1,20 @@
+#!/bin/bash -eu
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
 cd $SRC
 cd zlib
 ./configure --static

--- a/projects/kimageformats/build.sh
+++ b/projects/kimageformats/build.sh
@@ -33,8 +33,24 @@ cmake . -DBUILD_SHARED_LIBS=OFF -DQt5Core_DIR=$SRC/qtbase/lib/cmake/Qt5Core/ -DB
 make install -j$(nproc)
 
 cd $SRC
+cd aom
+mkdir build.libavif
+cd build.libavif
+cmake -DBUILD_SHARED_LIBS=0 -DENABLE_DOCS=0 -DENABLE_EXAMPLES=0 -DENABLE_TESTDATA=0 -DENABLE_TESTS=0 -DENABLE_TOOLS=0 -DCONFIG_PIC=1 ..
+make -j$(nproc)
+
+cd $SRC
+ln -s "$SRC/aom" "$SRC/libavif/ext/"
+cd libavif
+mkdir build
+cd build
+CFLAGS="-fPIC" cmake -DBUILD_SHARED_LIBS=OFF -DAVIF_ENABLE_WERROR=OFF -DAVIF_CODEC_AOM=ON -DAVIF_LOCAL_AOM=ON ..
+make -j$(nproc)
+
+cd $SRC
 cd kimageformats
-HANDLER_TYPES="KraHandler kra
+HANDLER_TYPES="QAVIFHandler avif
+        KraHandler kra
         OraHandler ora
         PCXHandler pcx
         SoftimagePICHandler pic
@@ -49,7 +65,7 @@ echo "$HANDLER_TYPES" | while read class format; do
   fuzz_target_name=kimgio_${format}_fuzzer
 
   $SRC/qtbase/bin/moc $SRC/kimageformats/src/imageformats/$format.cpp -o $format.moc
-  $CXX $CXXFLAGS -fPIC -DHANDLER=$class -std=c++14 $SRC/kimgio_fuzzer.cc $SRC/kimageformats/src/imageformats/$format.cpp -o $OUT/$fuzz_target_name -I $SRC/qtbase/include/QtCore/ -I $SRC/qtbase/include/ -I $SRC/qtbase/include//QtGui -I $SRC/kimageformats/src/imageformats/ -I $SRC/karchive/src/ -I $SRC/qtbase/mkspecs/linux-clang-libc++/ -I . -L $SRC/qtbase/lib -lQt5Gui -lQt5Core -lqtlibpng -lqtharfbuzz -lm -lqtpcre2 -ldl -lpthread $LIB_FUZZING_ENGINE /usr/local/lib/libzip.a /usr/local/lib/libz.a -lKF5Archive
+  $CXX $CXXFLAGS -fPIC -DHANDLER=$class -std=c++14 $SRC/kimgio_fuzzer.cc $SRC/kimageformats/src/imageformats/$format.cpp -o $OUT/$fuzz_target_name -I $SRC/qtbase/include/QtCore/ -I $SRC/qtbase/include/ -I $SRC/qtbase/include//QtGui -I $SRC/kimageformats/src/imageformats/ -I $SRC/karchive/src/ -I $SRC/qtbase/mkspecs/linux-clang-libc++/ -I $SRC/libavif/include/ -I . -L $SRC/qtbase/lib $SRC/libavif/build/libavif.a $SRC/aom/build.libavif/libaom.a -lQt5Gui -lQt5Core -lqtlibpng -lqtharfbuzz -lm -lqtpcre2 -ldl -lpthread $LIB_FUZZING_ENGINE /usr/local/lib/libzip.a /usr/local/lib/libz.a -lKF5Archive
 
   find . -name "*.${format}" | zip -q $OUT/${fuzz_target_name}_seed_corpus.zip -@
 )

--- a/projects/kimageformats/kimgio_fuzzer.cc
+++ b/projects/kimageformats/kimgio_fuzzer.cc
@@ -20,7 +20,7 @@
   Usage:
     python infra/helper.py build_image kimageformats
     python infra/helper.py build_fuzzers --sanitizer undefined|address|memory kimageformats
-    python infra/helper.py run_fuzzer kimageformats kimgio_[kra|ora|pcx|pic|psd|ras|rgb|tga|xcf]_fuzzer
+    python infra/helper.py run_fuzzer kimageformats kimgio_[avif|kra|ora|pcx|pic|psd|ras|rgb|tga|xcf]_fuzzer
 */
 
 
@@ -28,6 +28,7 @@
 #include <QCoreApplication>
 #include <QImage>
 
+#include "avif_p.h"
 #include "kra.h"
 #include "ora.h"
 #include "pcx_p.h"


### PR DESCRIPTION
[AVIF](https://aomediacodec.github.io/av1-avif/) image format is now supported by KDE in kimageformats project.

This change enables building of the AVIF plug-in fuzzer and link statically with its dependencies (libavif and libaom). yasm is used to build faster libaom.

@tsdgeos FYI