### PR TITLE
go-ethereum: install go-ethereum in go-path

### DIFF
--- a/projects/go-ethereum/Dockerfile
+++ b/projects/go-ethereum/Dockerfile
@@ -16,16 +16,10 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 
-RUN cd $GOPATH/src && \
-  mkdir -p github.com/ethereum && \
-  cd github.com/ethereum && \
-  git clone --depth=1 --single-branch  https://github.com/ethereum/go-ethereum && \
-  cd go-ethereum && go mod download
-
+RUN git clone --single-branch --depth=1 https://github.com/ethereum/go-ethereum $GOPATH/src/github.com/ethereum/go-ethereum 
 RUN cp $GOPATH/src/github.com/ethereum/go-ethereum/oss-fuzz.sh $SRC/build.sh
 # Enable this for easier local testing / repro
 #ADD build.sh $SRC/build.sh
 
-RUN cp $SRC/go-ethereum/oss-fuzz.sh $SRC/build.sh
 WORKDIR $SRC/
 

--- a/projects/go-ethereum/Dockerfile
+++ b/projects/go-ethereum/Dockerfile
@@ -16,7 +16,16 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 
-RUN (cd $SRC && git clone --single-branch --depth=1 https://github.com/ethereum/go-ethereum)
+RUN cd $GOPATH/src && \
+  mkdir -p github.com/ethereum && \
+  cd github.com/ethereum && \
+  git clone --depth=1 --single-branch  https://github.com/ethereum/go-ethereum && \
+  cd go-ethereum && go mod download
+
+RUN cp $GOPATH/src/github.com/ethereum/go-ethereum/oss-fuzz.sh $SRC/build.sh
+# Enable this for easier local testing / repro
+#ADD build.sh $SRC/build.sh
 
 RUN cp $SRC/go-ethereum/oss-fuzz.sh $SRC/build.sh
 WORKDIR $SRC/
+

--- a/projects/go-ethereum/Dockerfile
+++ b/projects/go-ethereum/Dockerfile
@@ -17,6 +17,8 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN git clone --single-branch --depth=1 https://github.com/ethereum/go-ethereum $GOPATH/src/github.com/ethereum/go-ethereum 
+RUN (cd $GOPATH/src/github.com/ethereum/go-ethereum && go mod download)
+
 RUN cp $GOPATH/src/github.com/ethereum/go-ethereum/oss-fuzz.sh $SRC/build.sh
 # Enable this for easier local testing / repro
 #ADD build.sh $SRC/build.sh


### PR DESCRIPTION
This PR depends on https://github.com/ethereum/go-ethereum/pull/22029 , and makes it possible to fix https://github.com/google/oss-fuzz/issues/4847. 