### PR TITLE
Add recurse-submodules to htslib clone

### DIFF
--- a/projects/htslib/Dockerfile
+++ b/projects/htslib/Dockerfile
@@ -16,6 +16,6 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake zlib1g-dev libbz2-dev liblzma-dev libcurl4-gnutls-dev libssl-dev
-RUN git clone --depth 1 https://github.com/samtools/htslib.git htslib
+RUN git clone --depth 1 --shallow-submodules --recurse-submodules https://github.com/samtools/htslib.git htslib
 WORKDIR htslib
 COPY build.sh $SRC/


### PR DESCRIPTION
In anticipation of samtools/htslib#929 merge, which will add a submodule, among other changes.  This will ensure fuzzing continues to work both before and after the update.
