### PR TITLE
[wolfssl] Build fuzzers for two bignum implementations

### DIFF
--- a/projects/wolfssl/Dockerfile
+++ b/projects/wolfssl/Dockerfile
@@ -16,11 +16,13 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 
-RUN apt-get update && apt-get install -y make autoconf automake libtool zip
+RUN apt-get update && apt-get install -y make autoconf automake libtool zip wget python
 RUN git clone https://github.com/wolfssl/wolfssl --depth 1 $SRC/wolfssl
 RUN git clone --depth 1 https://github.com/wolfSSL/wolfssh.git
 RUN git clone --depth 1 https://github.com/guidovranken/fuzzing-headers.git
 RUN git clone --depth 1 https://github.com/guidovranken/wolf-ssl-ssh-fuzzers
+RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
+RUN wget https://dl.bintray.com/boostorg/release/1.74.0/source/boost_1_74_0.tar.bz2
 RUN git clone https://github.com/wolfssl/oss-fuzz-targets --depth 1 $SRC/fuzz-targets
 
 WORKDIR wolfssl

--- a/projects/wolfssl/build.sh
+++ b/projects/wolfssl/build.sh
@@ -17,6 +17,12 @@
 
 if [[ $CFLAGS != *sanitize=dataflow* ]]
 then
+    WOLFCRYPT_CONFIGURE_PARAMS="--enable-static --enable-md2 --enable-md4 --enable-ripemd --enable-blake2 --enable-blake2s --enable-pwdbased --enable-scrypt --enable-hkdf --enable-cmac --enable-arc4 --enable-camellia --enable-rabbit --enable-aesccm --enable-aesctr --enable-hc128 --enable-xts --enable-des3 --enable-idea --enable-x963kdf --enable-harden --enable-aescfb --enable-aesofb --enable-aeskeywrap --enable-keygen --enable-curve25519 --enable-curve448 --enable-shake256 --disable-crypttests --disable-examples --enable-compkey --enable-ed448 --enable-ed25519 --enable-ecccustcurves --enable-xchacha --enable-cryptocb --enable-eccencrypt"
+    if [[ $CFLAGS = *sanitize=memory* ]]
+    then
+        WOLFCRYPT_CONFIGURE_PARAMS="$WOLFCRYPT_CONFIGURE_PARAMS --disable-asm"
+    fi
+
     # Install Boost headers
     cd $SRC/
     tar jxf boost_1_74_0.tar.bz2
@@ -43,8 +49,8 @@ then
     cp -R $SRC/wolfssl/ $SRC/wolfssl-sp-math-all/
     cd $SRC/wolfssl-sp-math-all/
     autoreconf -ivf
-    CFLAGS="$CFLAGS -DHAVE_AES_ECB -DWOLFSSL_DES_ECB -DHAVE_ECC_SECPR2 -DHAVE_ECC_SECPR3 -DHAVE_ECC_BRAINPOOL -DHAVE_ECC_KOBLITZ -DWOLFSSL_ECDSA_SET_K -Wno-shorten-64-to-32"
-    ./configure --enable-static --enable-md2 --enable-md4 --enable-ripemd --enable-blake2 --enable-blake2s --enable-pwdbased --enable-scrypt --enable-hkdf --enable-cmac --enable-arc4 --enable-camellia --enable-rabbit --enable-aesccm --enable-aesctr --enable-hc128 --enable-xts --enable-des3 --enable-idea --enable-x963kdf --enable-harden --enable-aescfb --enable-aesofb --enable-aeskeywrap --enable-keygen --enable-curve25519 --enable-curve448 --enable-shake256 --disable-crypttests --disable-examples --enable-compkey --enable-ed448 --enable-ed25519 --enable-ecccustcurves --enable-xchacha --enable-cryptocb --enable-eccencrypt --enable-sp-math-all
+    CFLAGS="$CFLAGS -DHAVE_AES_ECB -DWOLFSSL_DES_ECB -DHAVE_ECC_SECPR2 -DHAVE_ECC_SECPR3 -DHAVE_ECC_BRAINPOOL -DHAVE_ECC_KOBLITZ -DWOLFSSL_ECDSA_SET_K"
+    ./configure $WOLFCRYPT_CONFIGURE_PARAMS --enable-sp-math-all
     sed -i 's/-Werror//g' Makefile # Workaround for https://github.com/wolfSSL/wolfssl/issues/3589
     make -j$(nproc)
     export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL -DCRYPTOFUZZ_WOLFCRYPT"
@@ -66,7 +72,7 @@ then
     cd $SRC/wolfssl-disable-fastmath/
     autoreconf -ivf
     CFLAGS="$CFLAGS -DHAVE_AES_ECB -DWOLFSSL_DES_ECB -DHAVE_ECC_SECPR2 -DHAVE_ECC_SECPR3 -DHAVE_ECC_BRAINPOOL -DHAVE_ECC_KOBLITZ -DWOLFSSL_ECDSA_SET_K"
-    ./configure --enable-static --enable-md2 --enable-md4 --enable-ripemd --enable-blake2 --enable-blake2s --enable-pwdbased --enable-scrypt --enable-hkdf --enable-cmac --enable-arc4 --enable-camellia --enable-rabbit --enable-aesccm --enable-aesctr --enable-hc128 --enable-xts --enable-des3 --enable-idea --enable-x963kdf --enable-harden --enable-aescfb --enable-aesofb --enable-aeskeywrap --enable-keygen --enable-curve25519 --enable-curve448 --enable-shake256 --disable-crypttests --disable-examples --enable-compkey --enable-ed448 --enable-ed25519 --enable-ecccustcurves --enable-xchacha --enable-cryptocb --enable-eccencrypt --enable-disable-fastmath
+    ./configure $WOLFCRYPT_CONFIGURE_PARAMS --disable-fastmath
     make -j$(nproc)
     export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL -DCRYPTOFUZZ_WOLFCRYPT"
     export WOLFCRYPT_LIBWOLFSSL_A_PATH="$SRC/wolfssl-disable-fastmath/src/.libs/libwolfssl.a"

--- a/projects/wolfssl/build.sh
+++ b/projects/wolfssl/build.sh
@@ -15,6 +15,70 @@
 #
 ################################################################################
 
+# Install Boost headers
+cd $SRC/
+tar jxf boost_1_74_0.tar.bz2
+cd boost_1_74_0/
+CFLAGS="" CXXFLAGS="" ./bootstrap.sh
+CFLAGS="" CXXFLAGS="" ./b2 headers
+cp -R boost/ /usr/include/
+
+OLD_CFLAGS="$CFLAGS"
+OLD_CXXFLAGS="$CXXFLAGS"
+
+# Configure Cryptofuzz
+cd $SRC/cryptofuzz/
+python gen_repository.py
+rm extra_options.h
+echo -n '"' >>extra_options.h
+echo -n '--force-module=wolfCrypt ' >>extra_options.h
+echo -n '--digests=NULL ' >>extra_options.h
+echo -n '--operations=BignumCalc,DH_GenerateKeyPair,DH_Derive,ECC_GenerateKeyPair,ECC_PrivateToPublic,ECC_ValidatePubkey,ECDSA_Verify,ECDSA_Sign' >>extra_options.h
+echo -n '"' >>extra_options.h
+
+# Build sp-math-all fuzzer
+cp -R $SRC/cryptofuzz/ $SRC/cryptofuzz-sp-math-all/
+cp -R $SRC/wolfssl/ $SRC/wolfssl-sp-math-all/
+cd $SRC/wolfssl-sp-math-all/
+autoreconf -ivf
+CFLAGS="$CFLAGS -DHAVE_AES_ECB -DWOLFSSL_DES_ECB -DHAVE_ECC_SECPR2 -DHAVE_ECC_SECPR3 -DHAVE_ECC_BRAINPOOL -DHAVE_ECC_KOBLITZ -DWOLFSSL_ECDSA_SET_K -Wno-shorten-64-to-32"
+./configure --enable-static --enable-md2 --enable-md4 --enable-ripemd --enable-blake2 --enable-blake2s --enable-pwdbased --enable-scrypt --enable-hkdf --enable-cmac --enable-arc4 --enable-camellia --enable-rabbit --enable-aesccm --enable-aesctr --enable-hc128 --enable-xts --enable-des3 --enable-idea --enable-x963kdf --enable-harden --enable-aescfb --enable-aesofb --enable-aeskeywrap --enable-keygen --enable-curve25519 --enable-curve448 --enable-shake256 --disable-crypttests --disable-examples --enable-compkey --enable-ed448 --enable-ed25519 --enable-ecccustcurves --enable-xchacha --enable-cryptocb --enable-eccencrypt --enable-sp-math-all
+sed -i 's/-Werror//g' Makefile # Workaround for https://github.com/wolfSSL/wolfssl/issues/3589
+make -j$(nproc)
+export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL -DCRYPTOFUZZ_WOLFCRYPT"
+export WOLFCRYPT_LIBWOLFSSL_A_PATH="$SRC/wolfssl-sp-math-all/src/.libs/libwolfssl.a"
+export WOLFCRYPT_INCLUDE_PATH="$SRC/wolfssl-sp-math-all/"
+cd $SRC/cryptofuzz-sp-math-all/modules/wolfcrypt
+make -j$(nproc)
+cd $SRC/cryptofuzz-sp-math-all/
+LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" make -B -j$(nproc)
+cp cryptofuzz $OUT/cryptofuzz-sp-math-all
+CFLAGS="$OLD_CFLAGS"
+CXXFLAGS="$OLD_CXXFLAGS"
+unset WOLFCRYPT_LIBWOLFSSL_A_PATH
+unset WOLFCRYPT_INCLUDE_PATH
+
+# Build disable-fastmath fuzzer
+cp -R $SRC/cryptofuzz/ $SRC/cryptofuzz-disable-fastmath/
+cp -R $SRC/wolfssl/ $SRC/wolfssl-disable-fastmath/
+cd $SRC/wolfssl-disable-fastmath/
+autoreconf -ivf
+CFLAGS="$CFLAGS -DHAVE_AES_ECB -DWOLFSSL_DES_ECB -DHAVE_ECC_SECPR2 -DHAVE_ECC_SECPR3 -DHAVE_ECC_BRAINPOOL -DHAVE_ECC_KOBLITZ -DWOLFSSL_ECDSA_SET_K"
+./configure --enable-static --enable-md2 --enable-md4 --enable-ripemd --enable-blake2 --enable-blake2s --enable-pwdbased --enable-scrypt --enable-hkdf --enable-cmac --enable-arc4 --enable-camellia --enable-rabbit --enable-aesccm --enable-aesctr --enable-hc128 --enable-xts --enable-des3 --enable-idea --enable-x963kdf --enable-harden --enable-aescfb --enable-aesofb --enable-aeskeywrap --enable-keygen --enable-curve25519 --enable-curve448 --enable-shake256 --disable-crypttests --disable-examples --enable-compkey --enable-ed448 --enable-ed25519 --enable-ecccustcurves --enable-xchacha --enable-cryptocb --enable-eccencrypt --enable-disable-fastmath
+make -j$(nproc)
+export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL -DCRYPTOFUZZ_WOLFCRYPT"
+export WOLFCRYPT_LIBWOLFSSL_A_PATH="$SRC/wolfssl-disable-fastmath/src/.libs/libwolfssl.a"
+export WOLFCRYPT_INCLUDE_PATH="$SRC/wolfssl-disable-fastmath/"
+cd $SRC/cryptofuzz-disable-fastmath/modules/wolfcrypt
+make -j$(nproc)
+cd $SRC/cryptofuzz-disable-fastmath/
+LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" make -B -j$(nproc)
+cp cryptofuzz $OUT/cryptofuzz-disable-fastmath
+CFLAGS="$OLD_CFLAGS"
+CXXFLAGS="$OLD_CXXFLAGS"
+unset WOLFCRYPT_LIBWOLFSSL_A_PATH
+unset WOLFCRYPT_INCLUDE_PATH
+
 if [[ $CFLAGS != *sanitize=dataflow* ]]
 then
     NEW_SRC=$SRC/wolf-ssl-ssh-fuzzers/oss-fuzz/projects/wolf-ssl-ssh/
@@ -23,6 +87,8 @@ then
     cp -R $SRC/fuzzing-headers/ $NEW_SRC
     OSS_FUZZ_BUILD=1 SRC="$NEW_SRC" $NEW_SRC/build.sh
 fi
+
+cd $SRC/wolfssl
 
 # target_dir determined by Dockerfile
 target_dir="$SRC/fuzz-targets"

--- a/projects/wolfssl/build.sh
+++ b/projects/wolfssl/build.sh
@@ -15,72 +15,73 @@
 #
 ################################################################################
 
-# Install Boost headers
-cd $SRC/
-tar jxf boost_1_74_0.tar.bz2
-cd boost_1_74_0/
-CFLAGS="" CXXFLAGS="" ./bootstrap.sh
-CFLAGS="" CXXFLAGS="" ./b2 headers
-cp -R boost/ /usr/include/
-
-OLD_CFLAGS="$CFLAGS"
-OLD_CXXFLAGS="$CXXFLAGS"
-
-# Configure Cryptofuzz
-cd $SRC/cryptofuzz/
-python gen_repository.py
-rm extra_options.h
-echo -n '"' >>extra_options.h
-echo -n '--force-module=wolfCrypt ' >>extra_options.h
-echo -n '--digests=NULL ' >>extra_options.h
-echo -n '--operations=BignumCalc,DH_GenerateKeyPair,DH_Derive,ECC_GenerateKeyPair,ECC_PrivateToPublic,ECC_ValidatePubkey,ECDSA_Verify,ECDSA_Sign' >>extra_options.h
-echo -n '"' >>extra_options.h
-
-# Build sp-math-all fuzzer
-cp -R $SRC/cryptofuzz/ $SRC/cryptofuzz-sp-math-all/
-cp -R $SRC/wolfssl/ $SRC/wolfssl-sp-math-all/
-cd $SRC/wolfssl-sp-math-all/
-autoreconf -ivf
-CFLAGS="$CFLAGS -DHAVE_AES_ECB -DWOLFSSL_DES_ECB -DHAVE_ECC_SECPR2 -DHAVE_ECC_SECPR3 -DHAVE_ECC_BRAINPOOL -DHAVE_ECC_KOBLITZ -DWOLFSSL_ECDSA_SET_K -Wno-shorten-64-to-32"
-./configure --enable-static --enable-md2 --enable-md4 --enable-ripemd --enable-blake2 --enable-blake2s --enable-pwdbased --enable-scrypt --enable-hkdf --enable-cmac --enable-arc4 --enable-camellia --enable-rabbit --enable-aesccm --enable-aesctr --enable-hc128 --enable-xts --enable-des3 --enable-idea --enable-x963kdf --enable-harden --enable-aescfb --enable-aesofb --enable-aeskeywrap --enable-keygen --enable-curve25519 --enable-curve448 --enable-shake256 --disable-crypttests --disable-examples --enable-compkey --enable-ed448 --enable-ed25519 --enable-ecccustcurves --enable-xchacha --enable-cryptocb --enable-eccencrypt --enable-sp-math-all
-sed -i 's/-Werror//g' Makefile # Workaround for https://github.com/wolfSSL/wolfssl/issues/3589
-make -j$(nproc)
-export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL -DCRYPTOFUZZ_WOLFCRYPT"
-export WOLFCRYPT_LIBWOLFSSL_A_PATH="$SRC/wolfssl-sp-math-all/src/.libs/libwolfssl.a"
-export WOLFCRYPT_INCLUDE_PATH="$SRC/wolfssl-sp-math-all/"
-cd $SRC/cryptofuzz-sp-math-all/modules/wolfcrypt
-make -j$(nproc)
-cd $SRC/cryptofuzz-sp-math-all/
-LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" make -B -j$(nproc)
-cp cryptofuzz $OUT/cryptofuzz-sp-math-all
-CFLAGS="$OLD_CFLAGS"
-CXXFLAGS="$OLD_CXXFLAGS"
-unset WOLFCRYPT_LIBWOLFSSL_A_PATH
-unset WOLFCRYPT_INCLUDE_PATH
-
-# Build disable-fastmath fuzzer
-cp -R $SRC/cryptofuzz/ $SRC/cryptofuzz-disable-fastmath/
-cp -R $SRC/wolfssl/ $SRC/wolfssl-disable-fastmath/
-cd $SRC/wolfssl-disable-fastmath/
-autoreconf -ivf
-CFLAGS="$CFLAGS -DHAVE_AES_ECB -DWOLFSSL_DES_ECB -DHAVE_ECC_SECPR2 -DHAVE_ECC_SECPR3 -DHAVE_ECC_BRAINPOOL -DHAVE_ECC_KOBLITZ -DWOLFSSL_ECDSA_SET_K"
-./configure --enable-static --enable-md2 --enable-md4 --enable-ripemd --enable-blake2 --enable-blake2s --enable-pwdbased --enable-scrypt --enable-hkdf --enable-cmac --enable-arc4 --enable-camellia --enable-rabbit --enable-aesccm --enable-aesctr --enable-hc128 --enable-xts --enable-des3 --enable-idea --enable-x963kdf --enable-harden --enable-aescfb --enable-aesofb --enable-aeskeywrap --enable-keygen --enable-curve25519 --enable-curve448 --enable-shake256 --disable-crypttests --disable-examples --enable-compkey --enable-ed448 --enable-ed25519 --enable-ecccustcurves --enable-xchacha --enable-cryptocb --enable-eccencrypt --enable-disable-fastmath
-make -j$(nproc)
-export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL -DCRYPTOFUZZ_WOLFCRYPT"
-export WOLFCRYPT_LIBWOLFSSL_A_PATH="$SRC/wolfssl-disable-fastmath/src/.libs/libwolfssl.a"
-export WOLFCRYPT_INCLUDE_PATH="$SRC/wolfssl-disable-fastmath/"
-cd $SRC/cryptofuzz-disable-fastmath/modules/wolfcrypt
-make -j$(nproc)
-cd $SRC/cryptofuzz-disable-fastmath/
-LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" make -B -j$(nproc)
-cp cryptofuzz $OUT/cryptofuzz-disable-fastmath
-CFLAGS="$OLD_CFLAGS"
-CXXFLAGS="$OLD_CXXFLAGS"
-unset WOLFCRYPT_LIBWOLFSSL_A_PATH
-unset WOLFCRYPT_INCLUDE_PATH
-
 if [[ $CFLAGS != *sanitize=dataflow* ]]
 then
+    # Install Boost headers
+    cd $SRC/
+    tar jxf boost_1_74_0.tar.bz2
+    cd boost_1_74_0/
+    CFLAGS="" CXXFLAGS="" ./bootstrap.sh
+    CFLAGS="" CXXFLAGS="" ./b2 headers
+    cp -R boost/ /usr/include/
+
+    OLD_CFLAGS="$CFLAGS"
+    OLD_CXXFLAGS="$CXXFLAGS"
+
+    # Configure Cryptofuzz
+    cd $SRC/cryptofuzz/
+    python gen_repository.py
+    rm extra_options.h
+    echo -n '"' >>extra_options.h
+    echo -n '--force-module=wolfCrypt ' >>extra_options.h
+    echo -n '--digests=NULL ' >>extra_options.h
+    echo -n '--operations=BignumCalc,DH_GenerateKeyPair,DH_Derive,ECC_GenerateKeyPair,ECC_PrivateToPublic,ECC_ValidatePubkey,ECDSA_Verify,ECDSA_Sign' >>extra_options.h
+    echo -n '"' >>extra_options.h
+
+    # Build sp-math-all fuzzer
+    cp -R $SRC/cryptofuzz/ $SRC/cryptofuzz-sp-math-all/
+    cp -R $SRC/wolfssl/ $SRC/wolfssl-sp-math-all/
+    cd $SRC/wolfssl-sp-math-all/
+    autoreconf -ivf
+    CFLAGS="$CFLAGS -DHAVE_AES_ECB -DWOLFSSL_DES_ECB -DHAVE_ECC_SECPR2 -DHAVE_ECC_SECPR3 -DHAVE_ECC_BRAINPOOL -DHAVE_ECC_KOBLITZ -DWOLFSSL_ECDSA_SET_K -Wno-shorten-64-to-32"
+    ./configure --enable-static --enable-md2 --enable-md4 --enable-ripemd --enable-blake2 --enable-blake2s --enable-pwdbased --enable-scrypt --enable-hkdf --enable-cmac --enable-arc4 --enable-camellia --enable-rabbit --enable-aesccm --enable-aesctr --enable-hc128 --enable-xts --enable-des3 --enable-idea --enable-x963kdf --enable-harden --enable-aescfb --enable-aesofb --enable-aeskeywrap --enable-keygen --enable-curve25519 --enable-curve448 --enable-shake256 --disable-crypttests --disable-examples --enable-compkey --enable-ed448 --enable-ed25519 --enable-ecccustcurves --enable-xchacha --enable-cryptocb --enable-eccencrypt --enable-sp-math-all
+    sed -i 's/-Werror//g' Makefile # Workaround for https://github.com/wolfSSL/wolfssl/issues/3589
+    make -j$(nproc)
+    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL -DCRYPTOFUZZ_WOLFCRYPT"
+    export WOLFCRYPT_LIBWOLFSSL_A_PATH="$SRC/wolfssl-sp-math-all/src/.libs/libwolfssl.a"
+    export WOLFCRYPT_INCLUDE_PATH="$SRC/wolfssl-sp-math-all/"
+    cd $SRC/cryptofuzz-sp-math-all/modules/wolfcrypt
+    make -j$(nproc)
+    cd $SRC/cryptofuzz-sp-math-all/
+    LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" make -B -j$(nproc)
+    cp cryptofuzz $OUT/cryptofuzz-sp-math-all
+    CFLAGS="$OLD_CFLAGS"
+    CXXFLAGS="$OLD_CXXFLAGS"
+    unset WOLFCRYPT_LIBWOLFSSL_A_PATH
+    unset WOLFCRYPT_INCLUDE_PATH
+
+    # Build disable-fastmath fuzzer
+    cp -R $SRC/cryptofuzz/ $SRC/cryptofuzz-disable-fastmath/
+    cp -R $SRC/wolfssl/ $SRC/wolfssl-disable-fastmath/
+    cd $SRC/wolfssl-disable-fastmath/
+    autoreconf -ivf
+    CFLAGS="$CFLAGS -DHAVE_AES_ECB -DWOLFSSL_DES_ECB -DHAVE_ECC_SECPR2 -DHAVE_ECC_SECPR3 -DHAVE_ECC_BRAINPOOL -DHAVE_ECC_KOBLITZ -DWOLFSSL_ECDSA_SET_K"
+    ./configure --enable-static --enable-md2 --enable-md4 --enable-ripemd --enable-blake2 --enable-blake2s --enable-pwdbased --enable-scrypt --enable-hkdf --enable-cmac --enable-arc4 --enable-camellia --enable-rabbit --enable-aesccm --enable-aesctr --enable-hc128 --enable-xts --enable-des3 --enable-idea --enable-x963kdf --enable-harden --enable-aescfb --enable-aesofb --enable-aeskeywrap --enable-keygen --enable-curve25519 --enable-curve448 --enable-shake256 --disable-crypttests --disable-examples --enable-compkey --enable-ed448 --enable-ed25519 --enable-ecccustcurves --enable-xchacha --enable-cryptocb --enable-eccencrypt --enable-disable-fastmath
+    make -j$(nproc)
+    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL -DCRYPTOFUZZ_WOLFCRYPT"
+    export WOLFCRYPT_LIBWOLFSSL_A_PATH="$SRC/wolfssl-disable-fastmath/src/.libs/libwolfssl.a"
+    export WOLFCRYPT_INCLUDE_PATH="$SRC/wolfssl-disable-fastmath/"
+    cd $SRC/cryptofuzz-disable-fastmath/modules/wolfcrypt
+    make -j$(nproc)
+    cd $SRC/cryptofuzz-disable-fastmath/
+    LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" make -B -j$(nproc)
+    cp cryptofuzz $OUT/cryptofuzz-disable-fastmath
+    CFLAGS="$OLD_CFLAGS"
+    CXXFLAGS="$OLD_CXXFLAGS"
+    unset WOLFCRYPT_LIBWOLFSSL_A_PATH
+    unset WOLFCRYPT_INCLUDE_PATH
+
+    # Build SSL/SSH fuzzers
     NEW_SRC=$SRC/wolf-ssl-ssh-fuzzers/oss-fuzz/projects/wolf-ssl-ssh/
     cp -R $SRC/wolfssl/ $NEW_SRC
     cp -R $SRC/wolfssh/ $NEW_SRC


### PR DESCRIPTION
wolfCrypt contains several separate bignum implementations. The OSS-Fuzz Cryptofuzz project fuzzes one of them. This PR adds a fuzzer for the other two.