### PR TITLE
Ignore useless-object-inheritance lint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -141,7 +141,8 @@ disable=print-statement,
         comprehension-escape,
         fixme,
         import-error,
-        no-member
+        no-member,
+        useless-object-inheritance
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
The codebase has both Python 2 and Python 3 code, so classes should be allowed to explicitly inherit from object.