### PR TITLE
[pillow] Fix pillow corpus file name

### DIFF
--- a/projects/pillow/Dockerfile
+++ b/projects/pillow/Dockerfile
@@ -48,9 +48,10 @@ RUN apt-get install -y \
       tk8.6-dev \
       zlib1g-dev 
 RUN git clone --depth 1 https://github.com/python-pillow/Pillow
+# install extra test images for a better starting corpus
+RUN cd Pillow && depends/install_extra_test_images.sh
 
 COPY build.sh $SRC/
 COPY fuzz_* $SRC/Pillow
 
 WORKDIR $SRC/Pillow
-

--- a/projects/pillow/build.sh
+++ b/projects/pillow/build.sh
@@ -46,4 +46,4 @@ ASAN_OPTIONS=\$ASAN_OPTIONS:symbolize=1:external_symbolizer_path=\$this_dir/llvm
   chmod u+x $OUT/$fuzzer_basename
 done
 
-find Tests/images Tests/icc Tests/fonts -print | zip -q $OUT/testfiles_fuzzer_seed_corpus.zip -@
+find Tests/images Tests/icc Tests/fonts -print | zip -q $OUT/fuzz_pillow_seed_corpus.zip -@


### PR DESCRIPTION
Prepatch on master:
```
(vpy38-dbg) erics@wf:~/src/oss-fuzz$ python infra/helper.py run_fuzzer pillow fuzz_pillow --sanitizer=address
/home/erics/vpy38-dbg/lib/python3.8/site.py:165: DeprecationWarning: 'U' mode is deprecated
  f = open(fullname, "rU")
Running: docker run --rm --privileged -i -e FUZZING_ENGINE=libfuzzer -e SANITIZER=address -e RUN_FUZZER_MODE=interactive -v /home/erics/src/oss-fuzz/build/out/pillow:/out -t gcr.io/oss-fuzz-base/base-runner run_fuzzer fuzz_pillow --sanitizer=address
/out/fuzz_pillow -rss_limit_mb=2560 -timeout=25 --sanitizer=address /tmp/fuzz_pillow_corpus < /dev/null
INFO: Configured for Python tracing with opcodes.
INFO: libFuzzer ignores flags that start with '--'
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 2472509883
INFO: Loaded 3 modules   (11036 inline 8-bit counters): 10012 [0x7f3dae474ba0, 0x7f3dae4772bc), 512 [0x615000000a80, 0x615000000c80), 512 [0x615000000d00, 0x615000000f00), 
INFO: Loaded 3 PC tables (11036 PCs): 10012 [0x7f3dae4772c0,0x7f3dae49e480), 512 [0x62500001e100,0x625000020100), 512 [0x625000016900,0x625000018900), 
INFO:        0 files found in /tmp/fuzz_pillow_corpus
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
	NEW_PY_FUNC[1/2]: TestOneInput() fuzz_pillow.py:24
	NEW_PY_FUNC[2/2]: open() PIL/Image.py:2854
INFO: A corpus is not provided, starting from an empty corpus
#2	INITED cov: 1015 ft: 1015 corp: 1/1b exec/s: 0 rss: 65Mb
#4	NEW    cov: 1024 ft: 1025 corp: 2/2b lim: 4 exec/s: 0 rss: 65Mb L: 1/1 MS: 1 ChangeBit-
```

Post patch:
```
(vpy38-dbg) erics@wf:~/src/oss-fuzz$ python infra/helper.py run_fuzzer pillow fuzz_pillow --sanitizer=address
/home/erics/vpy38-dbg/lib/python3.8/site.py:165: DeprecationWarning: 'U' mode is deprecated
  f = open(fullname, "rU")
Running: docker run --rm --privileged -i -e FUZZING_ENGINE=libfuzzer -e SANITIZER=address -e RUN_FUZZER_MODE=interactive -v /home/erics/src/oss-fuzz/build/out/pillow:/out -t gcr.io/oss-fuzz-base/base-runner run_fuzzer fuzz_pillow --sanitizer=address
Using seed corpus: fuzz_pillow_seed_corpus.zip
/out/fuzz_pillow -rss_limit_mb=2560 -timeout=25 --sanitizer=address /tmp/fuzz_pillow_corpus < /dev/null
INFO: Configured for Python tracing with opcodes.
INFO: libFuzzer ignores flags that start with '--'
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 3701693035
INFO: Loaded 3 modules   (11036 inline 8-bit counters): 10012 [0x7ffaeeb3dba0, 0x7ffaeeb402bc), 512 [0x615000000a80, 0x615000000c80), 512 [0x615000000d00, 0x615000000f00), 
INFO: Loaded 3 PC tables (11036 PCs): 10012 [0x7ffaeeb402c0,0x7ffaeeb67480), 512 [0x62500001e100,0x625000020100), 512 [0x625000016900,0x625000018900), 
INFO:      821 files found in /tmp/fuzz_pillow_corpus
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 1048576 bytes
	NEW_PY_FUNC[1/2]: TestOneInput() fuzz_pillow.py:24
	NEW_PY_FUNC[2/2]: open() PIL/Image.py:2854
INFO: seed corpus: files: 821 min: 6b max: 9933474b total: 60622476b rss: 65Mb
	NEW_PY_FUNC[1/2]: _open() PIL/CurImagePlugin.py:39
	NEW_PY_FUNC[2/2]: i16le() PIL/_binary.py:30
	NEW_PY_FUNC[1/2]: _open() PIL/PpmImagePlugin.py:64
```
