### PR TITLE
[qt] Build from the dev branch

### DIFF
--- a/projects/qt/Dockerfile
+++ b/projects/qt/Dockerfile
@@ -16,9 +16,9 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y libc6-dev:i386
-RUN git clone --branch 5.15 --depth 1 --shallow-submodules \
+RUN git clone --branch dev --depth 1 --shallow-submodules \
         --recurse-submodules=qtbase \
         --recurse-submodules=qtsvg \
         git://code.qt.io/qt/qt5.git qt
-RUN git clone --depth 1 git://code.qt.io/qt/qtqa.git
+RUN git clone --branch dev --depth 1 git://code.qt.io/qt/qtqa.git
 RUN cp qtqa/fuzzing/oss-fuzz/build.sh $SRC/

--- a/projects/qt/project.yaml
+++ b/projects/qt/project.yaml
@@ -5,5 +5,4 @@ auto_ccs:
  - "shawn.t.rutledge@gmail.com"
 architectures:
  - x86_64
- - i386
 main_repo: 'git://code.qt.io/qt/qt5.git'


### PR DESCRIPTION
Removing i386 because it fails with:

../bootstrap/libBootstrap.a(qdatetime.cpp.o): In function `qMulOverflow<long long>':
/work/qtbase/include/QtCore/../../../../src/qt/qtbase/src/corelib/global/qnumeric.h:122: undefined reference to `__mulodi4'