### PR TITLE
include extra email in auto_ccs

### DIFF
--- a/projects/nats/project.yaml
+++ b/projects/nats/project.yaml
@@ -2,6 +2,7 @@ homepage: "https://github.com/nats-io/nats-server"
 primary_contact: "security@nats.io"
 auto_ccs :
   - "adam@adalogics.com"
+  - "mh@synadia.com"
 language: go
 fuzzing_engines:
   - libfuzzer


### PR DESCRIPTION
@inferno-chromium for your consideration

We have received several bug reports but had issues logging in.
We presume this is due to security@nats.io only being an alias.
Because of this I want to add my email so I can check out the bug reports.

I am a member of the nats organization that maintains the nats-server repo.

- Thanks, Matthias