### PR TITLE
Golang coverage improvements

### DIFF
--- a/infra/base-images/base-builder/compile_go_fuzzer
+++ b/infra/base-images/base-builder/compile_go_fuzzer
@@ -25,7 +25,7 @@ fi
 
 if [[ $SANITIZER = *coverage* ]]; then
   cd $GOPATH/src/$path
-  fuzzed_package=`pwd | rev | cut -d'/' -f 1 | rev`
+  fuzzed_package=`go list -f '{{.Name}}'`
   cp $GOPATH/ossfuzz_coverage_runner.go ./"${function,,}"_test.go
   sed -i -e 's/FuzzFunction/'$function'/' ./"${function,,}"_test.go
   sed -i -e 's/mypackagebeingfuzzed/'$fuzzed_package'/' ./"${function,,}"_test.go

--- a/infra/base-images/base-builder/compile_go_fuzzer
+++ b/infra/base-images/base-builder/compile_go_fuzzer
@@ -33,7 +33,9 @@ if [[ $SANITIZER = *coverage* ]]; then
 
   echo "#!/bin/sh" > $OUT/$fuzzer
   echo "cd $path" >> $OUT/$fuzzer
-  echo "go test -run Test${function}Corpus -v $tags -coverprofile \$1 " >> $OUT/$fuzzer
+  # The fuzzer may be in a subdirectory, but we want the coverage report for the whole repository
+  fuzzed_repo=`echo $path | cut -d/ -f-3`
+  echo "go test -run Test${function}Corpus -v $tags -coverpkg $fuzzed_repo/... -coverprofile \$1 " >> $OUT/$fuzzer
   chmod +x $OUT/$fuzzer
 
   cd -


### PR DESCRIPTION
cc @inferno-chromium 

- One fix (did not break the projects already there but broke go-ethereum which had a package named bus in a directory named bls1321)
- One improvement to get the report over all the repository (and not restricted to the subdirectory/package where the target resides)

This should be tested as it concerns all golang projects