### PR TITLE
PowerDNS: Move to a newer boost in preparation for the move to C++17

### DIFF
--- a/projects/powerdns/Dockerfile
+++ b/projects/powerdns/Dockerfile
@@ -20,7 +20,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 # maintainer for this file
 
 # install required packages to build your project
-RUN apt-get update && apt-get install -y autoconf automake bison dh-autoreconf flex libboost-all-dev libluajit-5.1-dev libedit-dev libprotobuf-dev libssl-dev libtool make pkg-config protobuf-compiler ragel
+RUN add-apt-repository -y ppa:savoury1/boost-defaults-1.71 && apt-get update && apt-get install -y autoconf automake bison dh-autoreconf flex boost1.71-dev libluajit-5.1-dev libedit-dev libprotobuf-dev libssl-dev libtool make pkg-config protobuf-compiler ragel
 
 # checkout all sources needed to build your project
 RUN git clone https://github.com/PowerDNS/pdns.git pdns


### PR DESCRIPTION
Hello,

This PR moves to a newer (third party) boost lib, and supersedes #4924 (CLA issue). The provided boost by Xenial is too old to be compiled in C++17 mode.

Thanks!