### PR TITLE
[pillow] Pillow build improvements

### DIFF
--- a/projects/pillow/Dockerfile
+++ b/projects/pillow/Dockerfile
@@ -28,30 +28,38 @@ RUN cat fuzzing/dictionaries/bmp.dict \
         fuzzing/dictionaries/tiff.dict \
         fuzzing/dictionaries/webp.dict \
       > $OUT/fuzz_pillow.dict
+
+# library build dependencies
 RUN apt-get install -y \
-      libfreetype6-dev \
-      libfribidi-dev \
-      libharfbuzz-dev \
-      libjpeg-dev \
-      liblcms2-dev \
-      libopenjp2-7-dev \
-      libpng-dev \
-      libtiff-dev \
-      libwebp-dev \
-      libx11-xcb-dev \
-      libxcb-render0-dev \
-      libxcb-xfixes0-dev \
-      libxcb1-dev \
-      libz-dev \
-      python3-tk \
-      tcl8.6-dev \
-      tk8.6-dev \
+      libxau-dev \
+      pkg-config \
+      rsync \
       zlib1g-dev 
+
 RUN git clone --depth 1 https://github.com/python-pillow/Pillow
+RUN git clone --depth 1 https://github.com/python-pillow/pillow-wheels
+
+COPY build_depends.sh $SRC
+
+RUN ln -s /usr/local/bin/python3 /usr/local/bin/python \
+    && ln -s /bin/true /usr/local/bin/yum_install \
+    && ln -s /bin/true /usr/local/bin/yum \
+    && cd $SRC/pillow-wheels \
+    && git submodule update --init multibuild \
+    && bash $SRC/build_depends.sh
+
 # install extra test images for a better starting corpus
 RUN cd Pillow && depends/install_extra_test_images.sh
 
 COPY build.sh $SRC/
 COPY fuzz_* $SRC/Pillow
+
+# pillow runtime dependencies
+RUN apt-get install -y \
+      libfribidi-dev \
+      libharfbuzz-dev \
+      python3-tk \
+      tcl8.6-dev \
+      tk8.6-dev 
 
 WORKDIR $SRC/Pillow

--- a/projects/pillow/Dockerfile
+++ b/projects/pillow/Dockerfile
@@ -52,7 +52,6 @@ RUN ln -s /usr/local/bin/python3 /usr/local/bin/python \
 RUN cd Pillow && depends/install_extra_test_images.sh
 
 COPY build.sh $SRC/
-COPY fuzz_* $SRC/Pillow
 
 # pillow runtime dependencies
 RUN apt-get install -y \

--- a/projects/pillow/build.sh
+++ b/projects/pillow/build.sh
@@ -29,8 +29,8 @@ fi;
 TS="$(find /usr/local/lib/python3.* -name '_imaging.*.so')"
 $CXX -pthread -shared $CXXFLAGS $LIB_FUZZING_ENGINE ${BUILD_DIR}/*.o ${BUILD_DIR}/libImaging/*.o \
     -L/usr/local/lib -L/lib/x86_64-linux-gnu -L/usr/lib/x86_64-linux-gnu \
-    -L/usr/lib/x86_64-linux-gnu/libfakeroot -L/usr/lib -L/lib \
-    -L/usr/local/lib -ljpeg -lz -lxcb -lfreetype -lopenjp2 -ltiff -llcms2 -lwebp -lwebpmux \
+    -L/usr/lib/x86_64-linux-gnu/libfakeroot -L/usr/lib -L/lib -L/usr/local/lib \
+    -ljpeg -lz -lxcb -lfreetype -lopenjp2 -ltiff -llcms2 -lwebp -lwebpmux -lwebpdemux \
     -o ${TS} -stdlib=libc++
 
 # Build fuzzers in $OUT.

--- a/projects/pillow/build.sh
+++ b/projects/pillow/build.sh
@@ -14,16 +14,19 @@
 # limitations under the License.
 #
 ################################################################################
-make install-req
-python3 setup.py develop
+#make install-req
+python3 setup.py build --build-base=/tmp/build install
 
-bp="$(find ./build -name '_imagingtk.o')"
-BUILD_DIR="${bp/_imagingtk.o/}"
-rm ${BUILD_DIR}/_imagingmath.o
-rm ${BUILD_DIR}/_imagingtk.o
-rm ${BUILD_DIR}/_imagingmorph.o
+bp="$(find /tmp/build -name '_imaging.o')"
+BUILD_DIR="${bp/_imaging.o/}"
+if [ -d "$BUILD_DIR" ]; then
+    find $BUILD_DIR -name _imagingmath.o -delete
+    find $BUILD_DIR -name _imagingtk.o -delete
+    find $BUILD_DIR -name _imagingmorph.o -delete
+fi;
 
-TS="$(find ./src/PIL/ -name '_imaging.*.so')"
+# Relink with fuzzing engine
+TS="$(find /usr/local/lib/python3.* -name '_imaging.*.so')"
 $CXX -pthread -shared $CXXFLAGS $LIB_FUZZING_ENGINE ${BUILD_DIR}/*.o ${BUILD_DIR}/libImaging/*.o \
     -L/usr/local/lib -L/lib/x86_64-linux-gnu -L/usr/lib/x86_64-linux-gnu \
     -L/usr/lib/x86_64-linux-gnu/libfakeroot -L/usr/lib -L/lib \

--- a/projects/pillow/build.sh
+++ b/projects/pillow/build.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 ################################################################################
-#make install-req
+
 python3 setup.py build --build-base=/tmp/build install
 
 bp="$(find /tmp/build -name '_imaging.o')"

--- a/projects/pillow/build_depends.sh
+++ b/projects/pillow/build_depends.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Eric Soroos
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/pillow/build_depends.sh
+++ b/projects/pillow/build_depends.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Copyright 2020 Eric Soroos
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 . multibuild/common_utils.sh
 
 export CONFIGURE_BUILD_SOURCED=1

--- a/projects/pillow/build_depends.sh
+++ b/projects/pillow/build_depends.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+. multibuild/common_utils.sh
+
+export CONFIGURE_BUILD_SOURCED=1
+BUILD_PREFIX="${BUILD_PREFIX:-/usr/local}"
+export CPPFLAGS="-I$BUILD_PREFIX/include $CPPFLAGS"
+export LIBRARY_PATH="$BUILD_PREFIX/lib:$LIBRARY_PATH"
+export PKG_CONFIG_PATH="$BUILD_PREFIX/lib/pkgconfig/:$PKG_CONFIG_PATH"
+
+. multibuild/library_builders.sh
+. config.sh
+
+pre_build


### PR DESCRIPTION
~This depends on https://github.com/python-pillow/Pillow/pull/5189, which sets the zipsafe flag to false in setup.py.~ Merged

There are several things going on here, and I'm willing to split them into issue specific changes if required. (btw, I'm an owner of pillow)

* make install-req is only for development dependencies -- test runners and doc builders. It's not required here. 
* Test using the library versions built for binary distribution, built with the same scripts as for releases.  Out of the box, oss-fuzz installs libraries from ubuntu 16.04, and we're using the latest patch releases of the upstream sources for these dependencies. The distribution manylinux wheels are built on centos, so there's a bit of tweaking to make them build here.  (e.g., linking yum to /bin/true, while preinstalling the dependencies).  Note here that the libraries are downloaded and built at the build_image stage, not the build_fuzzer stage. 
* Don't install in develop mode, build in /tmp, install into site-packages. This minimizes the impact on the source tree when running a custom version. 
* Link was missing libwebpdemux.