### PR TITLE
[matio] Build hdf5 1.12.0

### DIFF
--- a/projects/matio/Dockerfile
+++ b/projects/matio/Dockerfile
@@ -15,9 +15,9 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libhdf5-dev libtool zlib1g-dev
-ENV HDF5_DIR /usr/lib/x86_64-linux-gnu/hdf5/serial
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN git clone --depth 1 https://github.com/madler/zlib
 RUN git clone --depth 1 git://git.code.sf.net/p/matio/matio matio
+ADD https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-1.12.0/src/hdf5-1.12.0.tar.gz hdf5-1.12.0.tar.gz
 WORKDIR matio
-ADD https://support.hdfgroup.org/ftp/lib-external/szip/2.1.1/src/szip-2.1.1.tar.gz szip.tar.gz
 COPY build.sh $SRC/


### PR DESCRIPTION
This updates hdf5 1.8.16 (of xenial) to latest hdf5 1.12.0.