### PR TITLE
[scapy] Change primary contact

### DIFF
--- a/projects/scapy/project.yaml
+++ b/projects/scapy/project.yaml
@@ -1,7 +1,7 @@
 homepage: "https://scapy.net"
 main_repo: "https://github.com/secdev/scapy"
 language: python
-primary_contact: "guillaume@valadon.net"
+primary_contact: "guedou@gmail.com"
 auto_ccs:
   - "jvoisin@google.com"
   - "ipudney@google.com"


### PR DESCRIPTION
It cannot use my main email address to access the bug report. I would like to use my main gmail address instead.