### PR TITLE
Fix building mruby fails randomly

### DIFF
--- a/projects/mruby/build.sh
+++ b/projects/mruby/build.sh
@@ -20,7 +20,7 @@
 cd $SRC/mruby
 export LD=clang
 export LDFLAGS="$CFLAGS"
-make clean all -j$(nproc)
+rake -m
 
 # build fuzzers
 FUZZ_TARGET=$SRC/mruby/oss-fuzz/mruby_fuzzer.c


### PR DESCRIPTION
Building mruby is done with `make clean all -j$(nproc)`, but build fails
randomly because `clean` and `all` run in parallel, and `clean` may be
executed after `all` starts.

Therefore, change it as follows.

* Remove `clean` because it seems to be unneeded in the first place.
* Use `rake` command because mruby uses Rake for builds (`Makefile` is a
  limited wrapper for calling `rake`).
* Use `-m` option to run builds in parallel.
* Remove `-j` option because build time seems to be almost the same even
  if `-j` option is specified.