### PR TITLE
Remove the constant fuzzer from oss-fuzz.

### DIFF
--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -48,7 +48,7 @@ fi
 # Determine all fuzz targets. To control what gets fuzzed with OSSFuzz, all
 # supported fuzzers are in `//tensorflow/security/fuzzing`.
 # Ignore the identity and AttrValues fuzzer in opensource.
-declare -r FUZZERS=$(bazel query 'tests(//tensorflow/security/fuzzing/...)' | grep -v identity | grep -v AttrValues | grep -v bfloat16)
+declare -r FUZZERS=$(bazel query 'tests(//tensorflow/security/fuzzing/...)' | grep -v identity | grep -v AttrValues | grep -v bfloat16 | grep -v constant)
 
 # Build the fuzzer targets.
 # Pass in `--config=libc++` to link against libc++.


### PR DESCRIPTION
We are adding a `tf.constant` fuzzer for Python in oss-fuzz. We do not want it to run on oss-fuzz yet until we are confident it works. Sorry for the repeated PRs into the oss-fuzz directory. Working to alleviate this.

@mihaimaruseac 