### PR TITLE
[mdbtools] Move test files out of the checkout tree

### DIFF
--- a/projects/mdbtools/Dockerfile
+++ b/projects/mdbtools/Dockerfile
@@ -18,6 +18,6 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf autoconf-archive automake gettext libtool pkg-config
 
 RUN git clone --depth 1 --branch master https://github.com/mdbtools/mdbtools mdbtools
-RUN git clone --depth 1 https://github.com/mdbtools/mdbtestdata mdbtools/test
+RUN git clone --depth 1 https://github.com/mdbtools/mdbtestdata mdbtestdata
 WORKDIR mdbtools
 COPY build.sh $SRC/

--- a/projects/mdbtools/build.sh
+++ b/projects/mdbtools/build.sh
@@ -22,7 +22,7 @@ make clean
 
 make
 
-zip $OUT/fuzz_mdb_seed_corpus.zip test/data/*.mdb test/data/*.accdb
+zip $OUT/fuzz_mdb_seed_corpus.zip ../mdbtestdata/data/*.mdb ../mdbtestdata/data/*.accdb
 
 cd src/fuzz
 make fuzz_mdb


### PR DESCRIPTION
Per #4928, external files are overwritten by CIFuzz if they have been checked out into the main source tree.