### PR TITLE
[pillow] Fix recent build failure

### DIFF
--- a/projects/pillow/Dockerfile
+++ b/projects/pillow/Dockerfile
@@ -30,7 +30,8 @@ RUN cat fuzzing/dictionaries/bmp.dict \
       > $OUT/fuzz_pillow.dict
 
 # library build dependencies
-RUN apt-get install -y \
+RUN apt-get update && \
+    apt-get install -y \
       libxau-dev \
       pkg-config \
       rsync \


### PR DESCRIPTION
Fix recent build failure by running apt-get update. 

(https://oss-fuzz-build-logs.storage.googleapis.com/log-e79c5d64-5cf0-4f78-b4be-bf7c182a308f.txt)

```
Step #1: Get:91 http://archive.ubuntu.com/ubuntu xenial/main amd64 xterm amd64 322-1ubuntu1 [607 kB]
Step #1: Err:22 http://security.ubuntu.com/ubuntu xenial-security/main amd64 tzdata all 2020d-0ubuntu0.16.04
Step #1:   404  Not Found [IP: 91.189.88.142 80]
Step #1: Err:22 http://security.ubuntu.com/ubuntu xenial-security/main i386 tzdata all 2020d-0ubuntu0.16.04
Step #1:   404  Not Found [IP: 91.189.88.142 80]
Step #1: Err:22 http://security.ubuntu.com/ubuntu xenial-security/main i386 tzdata all 2020d-0ubuntu0.16.04
Step #1:   404  Not Found [IP: 91.189.88.142 80]
Step #1: [91mE: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/t/tzdata/tzdata_2020d-0ubuntu0.16.04_all.deb  404  Not Found [IP: 91.189.88.142 80]
Step #1: 
Step #1: E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Step #1: [0mFetched 33.7 MB in 4s (7742 kB/s)
Step #1: The command '/bin/sh -c apt-get install -y       libfribidi-dev       libharfbuzz-dev       python3-tk       tcl8.6-dev       tk8.6-dev' returned a non-zero code: 100
Finished Step #1
ERROR
ERROR: build step 1 "gcr.io/cloud-builders/docker" failed: step exited with non-zero status: 100
```