### PR TITLE
Move python 3 install to base-clang, needed for clang build.

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -23,7 +23,6 @@ RUN dpkg --add-architecture i386 && \
     apt-get update && \
     apt-get install -y \
         binutils-dev \
-        build-essential \
         curl \
         git \
         jq \
@@ -31,32 +30,6 @@ RUN dpkg --add-architecture i386 && \
         patchelf \
         subversion \
         zip
-
-# Build and install latest Python 3 (3.8.3).
-ENV PYTHON_VERSION 3.8.3
-RUN export PYTHON_DEPS="\
-        zlib1g-dev \
-        libncurses5-dev \
-        libgdbm-dev \
-        libnss3-dev \
-        libssl-dev \
-        libsqlite3-dev \
-        libreadline-dev \
-        libffi-dev \
-        libbz2-dev \
-        liblzma-dev" && \
-    unset CFLAGS CXXFLAGS && \
-    apt-get install -y $PYTHON_DEPS && \
-    cd /tmp/ && \
-    curl -O https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tar.xz && \
-    tar -xvf Python-$PYTHON_VERSION.tar.xz && \
-    cd Python-$PYTHON_VERSION && \
-    ./configure --enable-optimizations --enable-shared && \
-    make -j install && \
-    ldconfig && \
-    cd .. && \
-    rm -r /tmp/Python-$PYTHON_VERSION.tar.xz /tmp/Python-$PYTHON_VERSION && \
-    apt-get remove -y $PYTHON_DEPS  # https://github.com/google/oss-fuzz/issues/3888
 
 # Install latest atheris for python fuzzing, pyinstaller for fuzzer packaging.
 RUN unset CFLAGS CXXFLAGS && pip3 install -v atheris pyinstaller==4.1

--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -18,14 +18,43 @@
 
 FROM gcr.io/oss-fuzz-base/base-image
 
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+        wget
+
+# Build and install latest Python 3 (3.8.7).
+ENV PYTHON_VERSION 3.8.7
+RUN export PYTHON_DEPS="\
+        zlib1g-dev \
+        libncurses5-dev \
+        libgdbm-dev \
+        libnss3-dev \
+        libssl-dev \
+        libsqlite3-dev \
+        libreadline-dev \
+        libffi-dev \
+        libbz2-dev \
+        liblzma-dev" && \
+    unset CFLAGS CXXFLAGS && \
+    apt-get install -y $PYTHON_DEPS && \
+    cd /tmp/ && \
+    wget https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tar.xz && \
+    tar -xvf Python-$PYTHON_VERSION.tar.xz && \
+    cd Python-$PYTHON_VERSION && \
+    ./configure --enable-optimizations --enable-shared && \
+    make -j install && \
+    ldconfig && \
+    cd .. && \
+    rm -r /tmp/Python-$PYTHON_VERSION.tar.xz /tmp/Python-$PYTHON_VERSION && \
+    apt-get remove -y $PYTHON_DEPS  # https://github.com/google/oss-fuzz/issues/3888
+
 # Install newer cmake.
 ENV CMAKE_VERSION 3.19.2
-RUN apt-get update && apt-get install -y wget sudo && \
-    wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
+RUN wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
     chmod +x cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
     ./cmake-$CMAKE_VERSION-Linux-x86_64.sh --skip-license --prefix="/usr/local" && \
-    rm cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
-    SUDO_FORCE_REMOVE=yes apt-get remove --purge -y wget sudo
+    rm cmake-$CMAKE_VERSION-Linux-x86_64.sh
 
 COPY checkout_build_install_llvm.sh /root/
 # Keep all steps in the same script to decrease the number of intermediate


### PR DESCRIPTION
Fixes broken base-clang build in https://github.com/google/oss-fuzz/pull/4930#issuecomment-760308849

```
-- Looking for os_signpost_interval_begin - not found
CMake Error at /usr/local/share/cmake-3.19/Modules/FindPackageHandleStandardArgs.cmake:218 (message):
  Could NOT find Python3 (missing: Python3_EXECUTABLE Interpreter)
Call Stack (most recent call first):
  /usr/local/share/cmake-3.19/Modules/FindPackageHandleStandardArgs.cmake:582 (_FPHSA_FAILURE_MESSAGE)
  /usr/local/share/cmake-3.19/Modules/FindPython/Support.cmake:3148 (find_package_handle_standard_args)
  /usr/local/share/cmake-3.19/Modules/FindPython3.cmake:398 (include)
  CMakeLists.txt:711 (find_package)

-- Configuring incomplete, errors occurred!
See also "/work/llvm-stage1/CMakeFiles/CMakeOutput.log".
See also "/work/llvm-stage1/CMakeFiles/CMakeError.log".
The command '/bin/sh -c /root/checkout_build_install_llvm.sh' returned a non-zero code: 1
```