### PR TITLE
[mdbtools] Remove path components from zipped corpus

### DIFF
--- a/projects/mdbtools/build.sh
+++ b/projects/mdbtools/build.sh
@@ -22,7 +22,7 @@ make clean
 
 make
 
-zip $OUT/fuzz_mdb_seed_corpus.zip ../mdbtestdata/data/*.mdb ../mdbtestdata/data/*.accdb
+zip -j $OUT/fuzz_mdb_seed_corpus.zip ../mdbtestdata/data/*.mdb ../mdbtestdata/data/*.accdb
 
 cd src/fuzz
 make fuzz_mdb


### PR DESCRIPTION
Intended to resolve issue described here: https://github.com/google/oss-fuzz/issues/4956