### PR TITLE
highwayhash: initial integration.

### DIFF
--- a/projects/highwayhash/Dockerfile
+++ b/projects/highwayhash/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2021 Google Inc.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/highwayhash/Dockerfile
+++ b/projects/highwayhash/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN git clone --depth=1 https://github.com/google/highwayhash
+
+WORKDIR $SRC/highwayhash/
+COPY build.sh $SRC/build.sh

--- a/projects/highwayhash/build.sh
+++ b/projects/highwayhash/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+export LDFLAGS="${CXXFLAGS}"
+make
+
+# Build the fuzzers
+for fuzzer in highwayhash_fuzzer sip_hash_fuzzer; do
+    $CXX $CXXFLAGS $LIB_FUZZING_ENGINE \
+        ./highwayhash/${fuzzer}.cc ./lib/libhighwayhash.a -I. \
+        -o $OUT/${fuzzer}
+done

--- a/projects/highwayhash/project.yaml
+++ b/projects/highwayhash/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/google/highwayhash"
+primary_contact: "david@adalogics.com"
+language: c++
+auto_ccs :
+  - "david@adalogics.com"
+main_repo: https://github.com/google/highwayhash


### PR DESCRIPTION
Initial integration of highwayhash. This is a fairly small hashing library, but I believe it is of importance to the open source community. 