### PR TITLE
[xxHash] Initial integration

### DIFF
--- a/projects/xxhash/Dockerfile
+++ b/projects/xxhash/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool \
+  pkg-config cmake libcurlpp-dev libcurl4-openssl-dev
+RUN git clone https://github.com/Cyan4973/xxHash
+WORKDIR xxHash
+COPY build.sh fuzzer.c $SRC/

--- a/projects/xxhash/build.sh
+++ b/projects/xxhash/build.sh
@@ -20,3 +20,4 @@ find . -name "*.o" -exec ar rcs fuzz_lib.a {} \;
 mv $SRC/fuzzer.c .
 $CC $CFLAGS -c fuzzer.c -o fuzzer.o
 $CC $CFLAGS $LIB_FUZZING_ENGINE fuzzer.o -o $OUT/fuzzer fuzz_lib.a
+

--- a/projects/xxhash/build.sh
+++ b/projects/xxhash/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+make -j$(nproc)
+find . -name "*.o" -exec ar rcs fuzz_lib.a {} \;
+mv $SRC/fuzzer.c .
+$CC $CFLAGS -c fuzzer.c -o fuzzer.o
+$CC $CFLAGS $LIB_FUZZING_ENGINE fuzzer.o -o $OUT/fuzzer fuzz_lib.a

--- a/projects/xxhash/fuzzer.c
+++ b/projects/xxhash/fuzzer.c
@@ -1,0 +1,36 @@
+/*
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+*/
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include "xxhash.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
+	
+	char *new_str = (char *)malloc(size+1);
+	if (new_str == NULL){
+		return 0;
+	}
+	memcpy(new_str, data, size);
+	new_str[size] = '\0';
+	
+	XXH64_hash_t hash = XXH64(new_str, size, NULL);
+	
+	free(new_str);
+	return 0;
+}

--- a/projects/xxhash/project.yaml
+++ b/projects/xxhash/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://github.com/Cyan4973/xxHash"
+main_repo: "https://github.com/Cyan4973/xxHash"
+language: c
+primary_contact: "cyan@fb.com"
+auto_ccs:
+  - "Adam@adalogics.com"
+sanitizers:
+  - address
+  - undefined
+  - memory
+fuzzing_engines:
+  - libfuzzer


### PR DESCRIPTION
This adds initial integration of xxHash.

The library is widely used, but the fuzzer is very small in terms of coverage (around 60 when running locally) and the total coverage will be small as well.

I checked the coverage report a few days ago and seem to recall that 60 coverage was equal to ~~20-30% of the entire code base.

@inferno-chromium @jonathanmetzman @oliverchang Is this something we want in OSS-fuzz? If not it would be good to have a bit of discussion/reasoning.