### PR TITLE
[relic] Add project relic

### DIFF
--- a/projects/relic/Dockerfile
+++ b/projects/relic/Dockerfile
@@ -17,6 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool wget python
 RUN git clone --depth 1 https://github.com/relic-toolkit/relic.git
+RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN wget https://dl.bintray.com/boostorg/release/1.74.0/source/boost_1_74_0.tar.bz2
 COPY build.sh $SRC/

--- a/projects/relic/Dockerfile
+++ b/projects/relic/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool wget python
+RUN git clone --depth 1 https://github.com/relic-toolkit/relic.git
+RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
+RUN wget https://dl.bintray.com/boostorg/release/1.74.0/source/boost_1_74_0.tar.bz2
+COPY build.sh $SRC/

--- a/projects/relic/build.sh
+++ b/projects/relic/build.sh
@@ -1,0 +1,53 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL"
+export LIBFUZZER_LINK="$LIB_FUZZING_ENGINE"
+
+# Install Boost headers
+cd $SRC/
+tar jxf boost_1_74_0.tar.bz2
+cd boost_1_74_0/
+CFLAGS="" CXXFLAGS="" ./bootstrap.sh
+CFLAGS="" CXXFLAGS="" ./b2 headers
+cp -R boost/ /usr/include/
+
+# Prevent Boost compilation error with -std=c++17
+export CXXFLAGS="$CXXFLAGS -D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR"
+
+cd $SRC/relic/
+mkdir build/
+cd build/
+cmake .. -DCOMP="$CFLAGS" -DQUIET=on
+make -j$(nproc)
+cd ../..
+export RELIC_PATH=$(realpath relic)
+export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_RELIC"
+
+cd $SRC/cryptofuzz
+python gen_repository.py
+rm extra_options.h
+echo -n '"' >>extra_options.h
+echo -n '--force-module=relic ' >>extra_options.h
+echo -n '--operations=BignumCalc ' >>extra_options.h
+echo -n '"' >>extra_options.h
+cd modules/relic/
+make -B -j$(nproc)
+cd ../../
+make -B -j$(nproc)
+
+cp cryptofuzz $OUT/cryptofuzz-relic

--- a/projects/relic/build.sh
+++ b/projects/relic/build.sh
@@ -29,6 +29,7 @@ cp -R boost/ /usr/include/
 # Prevent Boost compilation error with -std=c++17
 export CXXFLAGS="$CXXFLAGS -D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR"
 
+# Build Relic
 cd $SRC/relic/
 mkdir build/
 cd build/
@@ -38,14 +39,33 @@ cd ../..
 export RELIC_PATH=$(realpath relic)
 export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_RELIC"
 
+# Build Botan
+cd $SRC/botan
+if [[ $CFLAGS != *-m32* ]]
+then
+    ./configure.py --cc-bin=$CXX --cc-abi-flags="$CXXFLAGS" --disable-shared --disable-modules=locking_allocator --build-targets=static --without-documentation
+else
+    ./configure.py --cpu=x86_32 --cc-bin=$CXX --cc-abi-flags="$CXXFLAGS" --disable-shared --disable-modules=locking_allocator --build-targets=static --without-documentation
+fi
+make -j$(nproc)
+
+export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_BOTAN"
+export LIBBOTAN_A_PATH="$SRC/botan/libbotan-3.a"
+export BOTAN_INCLUDE_PATH="$SRC/botan/build/include"
+
+# Build Cryptofuzz
 cd $SRC/cryptofuzz
 python gen_repository.py
 rm extra_options.h
 echo -n '"' >>extra_options.h
 echo -n '--force-module=relic ' >>extra_options.h
-echo -n '--operations=BignumCalc ' >>extra_options.h
+echo -n '--operations=BignumCalc,ECC_PrivateToPublic,ECDSA_Sign,ECDSA_Verify ' >>extra_options.h
+echo -n '--curves=secp256k1,secp256r1 ' >>extra_options.h
+echo -n '--digests=NULL ' >>extra_options.h
 echo -n '"' >>extra_options.h
 cd modules/relic/
+make -B -j$(nproc)
+cd ../botan/
 make -B -j$(nproc)
 cd ../../
 make -B -j$(nproc)

--- a/projects/relic/build.sh
+++ b/projects/relic/build.sh
@@ -32,7 +32,7 @@ export CXXFLAGS="$CXXFLAGS -D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR"
 cd $SRC/relic/
 mkdir build/
 cd build/
-cmake .. -DCOMP="$CFLAGS" -DQUIET=on
+cmake .. -DCOMP="$CFLAGS" -DQUIET=on -DRAND=CALL -DSHLIB=off -DSTBIN=off -DTESTS=0 -DBENCH=0
 make -j$(nproc)
 cd ../..
 export RELIC_PATH=$(realpath relic)

--- a/projects/relic/project.yaml
+++ b/projects/relic/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://github.com/relic-toolkit/relic"
+language: c++
+primary_contact: "guidovranken@gmail.com"
+main_repo: "https://github.com/relic-toolkit/relic"
+auto_ccs:
+    - "dfaranha@gmail..com"
+sanitizers:
+ - address
+ - undefined
+ - memory
+architectures:
+ - x86_64

--- a/projects/relic/project.yaml
+++ b/projects/relic/project.yaml
@@ -3,7 +3,7 @@ language: c++
 primary_contact: "guidovranken@gmail.com"
 main_repo: "https://github.com/relic-toolkit/relic"
 auto_ccs:
-    - "dfaranha@gmail..com"
+    - "dfaranha@gmail.com"
 sanitizers:
  - address
  - undefined


### PR DESCRIPTION
relic is a cryptographic library.

Some projects that use relic:

https://github.com/imichaelmiers/libforwardsec
https://github.com/zeutro/openabe
https://github.com/vmware/concord-bft
https://github.com/JHUISI/charm
https://github.com/Chia-Network/bls-signatures/
https://gitlab.com/neucrypt/anonize2
https://github.com/encryptogroup/OPPRF-PSI

The relic maintainer is aware of this integration, see also https://github.com/relic-toolkit/relic/issues/171