### PR TITLE
Make cairo's issues public by default

### DIFF
--- a/projects/cairo/project.yaml
+++ b/projects/cairo/project.yaml
@@ -4,4 +4,6 @@ primary_contact: security-tps@google.com
 sanitizers:
   - address
   - undefined
+  
+view_restrictions: none
 main_repo: 'https://gitlab.freedesktop.org/cairo/cairo.git'


### PR DESCRIPTION
This is what upstream wants: https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/69#note_768642