### PR TITLE
[cryptofuzz] Use latest version of xxHash

### DIFF
--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -57,6 +57,7 @@ RUN git clone --depth 1 https://github.com/guidovranken/libfuzzer-js.git
 RUN git clone --depth 1 https://github.com/brix/crypto-js.git
 RUN git clone --depth 1 https://github.com/LoupVaillant/Monocypher.git
 RUN git clone --depth 1 https://github.com/trezor/trezor-firmware.git
+RUN git clone --depth 1 https://github.com/Cyan4973/xxHash.git
 RUN apt-get remove -y libunwind8
 RUN apt-get install -y libssl-dev
 RUN wget https://dl.bintray.com/boostorg/release/1.74.0/source/boost_1_74_0.tar.bz2

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -21,6 +21,10 @@
 # Compile xxd
 $CC $SRC/xxd.c -o /usr/bin/xxd
 
+# Copy the upstream checkout of xxHash over the old version
+rm -rf $SRC/cryptofuzz/modules/reference/xxHash/
+cp -R $SRC/xxHash $SRC/cryptofuzz/modules/reference/
+
 # Install Boost headers
 cd $SRC/
 tar jxf boost_1_74_0.tar.bz2

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -23,7 +23,7 @@ $CC $SRC/xxd.c -o /usr/bin/xxd
 
 # Copy the upstream checkout of xxHash over the old version
 rm -rf $SRC/cryptofuzz/modules/reference/xxHash/
-cp -R $SRC/xxHash $SRC/cryptofuzz/modules/reference/
+cp -R $SRC/xxHash/ $SRC/cryptofuzz/modules/reference/
 
 # Install Boost headers
 cd $SRC/


### PR DESCRIPTION
Cryptofuzz was using an older version of xxHash. This PR ensures the latest version is fetched from the repository and fuzzed.