### PR TITLE
Adds go-cmp project

### DIFF
--- a/projects/go-cmp/Dockerfile
+++ b/projects/go-cmp/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN go get -u github.com/google/go-cmp/cmp
+
+COPY fuzz_diff.go $GOPATH/src/github.com/google/go-cmp/cmp
+COPY build.sh $SRC/

--- a/projects/go-cmp/build.sh
+++ b/projects/go-cmp/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+
+compile_go_fuzzer github.com/google/go-cmp/cmp FuzzDiff fuzz_diff

--- a/projects/go-cmp/fuzz_diff.go
+++ b/projects/go-cmp/fuzz_diff.go
@@ -1,0 +1,66 @@
+// Copyright 2015 go-fuzz project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE.
+// Modified from original file https://github.com/dvyukov/go-fuzz-corpus/blob/master/json/json.go
+
+package cmp
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+func FuzzDiff(data []byte) int {
+	score := 0
+	sep := bytes.IndexByte(data, 0)
+	if sep < 0 {
+		return 0
+	}
+	for _, ctor := range []func() interface{}{
+		//func() interface{} { return nil },
+		func() interface{} { return new([]interface{}) },
+		func() interface{} { m := map[string]string{}; return &m },
+		func() interface{} { m := map[string]interface{}{}; return &m },
+		func() interface{} { return new(S) },
+	} {
+		vj := ctor()
+		err := json.Unmarshal(data[:sep], vj)
+		if err != nil {
+			continue
+		}
+		vj2 := ctor()
+		err = json.Unmarshal(data[sep+1:], vj)
+		if err != nil {
+			continue
+		}
+		score = 1
+		Diff(vj, vj2)
+	}
+	return score
+}
+
+type S struct {
+	A int    `json:",omitempty"`
+	B string `json:"B1,omitempty"`
+	C float64
+	D bool
+	E uint8
+	F []byte
+	G interface{}
+	H map[string]interface{}
+	I map[string]string
+	J []interface{}
+	K []string
+	L S1
+	M *S1
+	N *int
+	O **int
+	//	P json.RawMessage
+	//Q Marshaller
+	R int `json:"-"`
+	S int `json:",string"`
+}
+
+type S1 struct {
+	A int
+	B string
+}

--- a/projects/go-cmp/project.yaml
+++ b/projects/go-cmp/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://pkg.go.dev/github.com/google/go-cmp/"
+primary_contact: "joetsai@digital-static.net"
+auto_ccs:
+  - "p.antoine@catenacyber.fr"
+language: go
+fuzzing_engines:
+- libfuzzer
+sanitizers:
+- address
+main_repo: 'https://github.com/google/go-cmp/'


### PR DESCRIPTION
cc @dsnet

Would you like to have continuous fuzzing for go-cmp ?
This Pull Request enables this with oss-fuzz.

The fuzz target converts the binary input blob into 2 Golang structures with the use of json unmarshalling, before comparing them.
Does it make sense to you ?
Could there be more assertions on the result ? 
Differential fuzzing against `reflect.DeepEqual` ?