### PR TITLE
Sets language env variable when running shell

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -961,6 +961,10 @@ def shell(args):
   if args.e:
     env += args.e
 
+  project_language = _get_project_language(args.project_name)
+  if project_language:
+    env.append('FUZZING_LANGUAGE=' + project_language)
+
   if is_base_image(args.project_name):
     image_project = 'oss-fuzz-base'
     out_dir = _get_output_dir()

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -956,14 +956,11 @@ def shell(args):
       'FUZZING_ENGINE=' + args.engine,
       'SANITIZER=' + args.sanitizer,
       'ARCHITECTURE=' + args.architecture,
+      'FUZZING_LANGUAGE=' + _get_project_language(args.project_name),
   ]
 
   if args.e:
     env += args.e
-
-  project_language = _get_project_language(args.project_name)
-  if project_language:
-    env.append('FUZZING_LANGUAGE=' + project_language)
 
   if is_base_image(args.project_name):
     image_project = 'oss-fuzz-base'


### PR DESCRIPTION
Otherwise when I run
```
python infra/helper.py shell project
compile
```
I get the following error : `/usr/local/bin/compile: line 25: FUZZING_LANGUAGE: unbound variable`