### PR TITLE
compile_go_fuzzer: pass build tags to `go list`

### DIFF
--- a/infra/base-images/base-builder/compile_go_fuzzer
+++ b/infra/base-images/base-builder/compile_go_fuzzer
@@ -25,7 +25,7 @@ fi
 
 if [[ $SANITIZER = *coverage* ]]; then
   cd $GOPATH/src/$path
-  fuzzed_package=`go list -f '{{.Name}}'`
+  fuzzed_package=`go list $tags -f '{{.Name}}'`
   cp $GOPATH/ossfuzz_coverage_runner.go ./"${function,,}"_test.go
   sed -i -e 's/FuzzFunction/'$function'/' ./"${function,,}"_test.go
   sed -i -e 's/mypackagebeingfuzzed/'$fuzzed_package'/' ./"${function,,}"_test.go

--- a/projects/teleport/build.sh
+++ b/projects/teleport/build.sh
@@ -20,5 +20,5 @@ mkdir -p $GOPATH/src/github.com/gravitational
 cd $GOPATH/src/github.com/gravitational
 git clone https://github.com/gravitational/teleport.git
 
-compile_go_fuzzer github.com/gravitational/teleport/lib/fuzz FuzzParseProxyJump utils_fuzz
-compile_go_fuzzer github.com/gravitational/teleport/lib/fuzz FuzzNewExpression parse_fuzz
+compile_go_fuzzer github.com/gravitational/teleport/lib/fuzz FuzzParseProxyJump utils_fuzz gofuzz
+compile_go_fuzzer github.com/gravitational/teleport/lib/fuzz FuzzNewExpression parse_fuzz gofuzz


### PR DESCRIPTION
`go list` will fail if all files in the fuzzed package use a build tag restriction (like the common `gofuzz` tag).
    
Also, pass the `gofuzz` tag in the teleport build to plumb it through.