### PR TITLE
build_specified_commit: Remove an exception.

### DIFF
--- a/infra/build_specified_commit.py
+++ b/infra/build_specified_commit.py
@@ -59,7 +59,8 @@ class BaseBuilderRepo:
     if index > 0:
       return self.digests[index - 1]
 
-    raise ValueError('Failed to find suitable base-builder.')
+    logging.error('Failed to find suitable base-builder.')
+    return None
 
 
 def _replace_gitdir(src_dir, file_path):
@@ -269,6 +270,9 @@ def build_fuzzers_from_commit(commit,
     # Also use the closest base-builder we can find.
     if base_builder_repo:
       base_builder_digest = base_builder_repo.find_digest(commit_date)
+      if not base_builder_digest:
+        return False
+
       logging.info('Using base-builder with digest %s.', base_builder_digest)
       _replace_base_builder_digest(dockerfile_path, base_builder_digest)
 


### PR DESCRIPTION
Return None rather than exceptioning out when a suitable base-builder
cannot be found to allow more graceful error handling.