### PR TITLE
Remove unneeded honggfuzz examples from base-builder.

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -146,6 +146,7 @@ ADD https://github.com/google/honggfuzz/archive/oss-fuzz.tar.gz $SRC/
 RUN mkdir honggfuzz && \
     cd honggfuzz && \
     tar -xzv --strip-components=1 -f $SRC/oss-fuzz.tar.gz && \
+    rm -rf examples && \
     rm -rf $SRC/oss-fuzz.tar.gz
 
 COPY compile compile_afl compile_dataflow compile_libfuzzer compile_honggfuzz \


### PR DESCRIPTION
Save 177Mb.

```
root@eca2ea09a598:/src/honggfuzz/examples# du -h
16K	./glibc
8.0K	./libxml2
2.4M	./openssl/corpus_privkey
5.1M	./openssl/corpus_x509
18M	./openssl/corpus_client
27M	./openssl/corpus_server
52M	./openssl
16K	./externalfuzzers
12K	./libpng
25M	./bind/corpus
25M	./bind
29M	./linux_kernel_ip/corpus
30M	./linux_kernel_ip
16K	./libjpeg
20K	./terminal-emulators
33M	./apache-httpd/corpus_http1
39M	./apache-httpd/corpus_http2
72M	./apache-httpd
12K	./file
16K	./badcode/targets
8.0K	./badcode/inputfiles
36K	./badcode
177M	.
```