### PR TITLE
Install rust in base-builder with minimal profile.

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -83,7 +83,7 @@ RUN go get -u github.com/mdempsky/go114-fuzz-build && \
 ENV CARGO_HOME=/rust
 ENV RUSTUP_HOME=/rust/rustup
 ENV PATH=$PATH:/rust/bin
-RUN curl https://sh.rustup.rs | sh -s -- -y --default-toolchain=nightly
+RUN curl https://sh.rustup.rs | sh -s -- -y --default-toolchain=nightly --profile=minimal
 RUN cargo install cargo-fuzz
 # Needed to recompile rust std library for MSAN
 RUN rustup component add rust-src --toolchain nightly


### PR DESCRIPTION
Remove docs and other unneeded stuff.
https://blog.rust-lang.org/2019/10/15/Rustup-1.20.0.html