### PR TITLE
Fix workdir for serenity project

### DIFF
--- a/projects/serenity/Dockerfile
+++ b/projects/serenity/Dockerfile
@@ -17,5 +17,5 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y build-essential cmake curl e2fsprogs libmpfr-dev libmpc-dev libgmp-dev ninja-build
 RUN git clone https://github.com/SerenityOS/serenity
-WORKDIR $SRC
 COPY build.sh $SRC/
+WORKDIR $SRC/serenity/Meta/Lagom

--- a/projects/serenity/build.sh
+++ b/projects/serenity/build.sh
@@ -16,8 +16,7 @@
 ################################################################################
 
 # Now build the content
-cd serenity/Meta/Lagom
-mkdir build
+mkdir -p build
 cd build
 cmake -GNinja \
     -DBUILD_LAGOM=ON \


### PR DESCRIPTION
With this, can build fuzzers against a local checkout with:

    python3 infra/helper.py build_fuzzers serenity $HOME/src/serenity

Similar to 14452cfb3d87f3f54ced75b9d5dd67b1470f2080