### PR TITLE
Run all tests when infra-tests is run from presubmit

### DIFF
--- a/.github/workflows/infra_tests.yml
+++ b/.github/workflows/infra_tests.yml
@@ -30,7 +30,6 @@ jobs:
           version: '298.0.0'
       - run: |
           sudo env "PATH=$PATH" gcloud components install beta cloud-datastore-emulator
-          sudo env "PATH=$PATH" gcloud info
 
       - name: Run infra tests
         run: sudo env "PATH=$PATH" INTEGRATION_TESTS=1 python infra/presubmit.py infra-tests

--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -26,6 +26,7 @@ import yaml
 
 _SRC_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 TEST_BLOCKLIST = [
+    # Test fails with error: `ModuleNotFoundError: No module named 'apt'`.
     re.compile(r'.*\/infra\/base-images\/base-sanitizer-libs-builder'),
     # TODO(https://github.com/google/oss-fuzz/issues/5025): Reenable these
     # tests.

--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -17,6 +17,7 @@
 """Check code for common issues before submitting."""
 
 import argparse
+import pathlib
 import os
 import subprocess
 import sys
@@ -24,6 +25,9 @@ import unittest
 import yaml
 
 _SRC_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TEST_DIR_BLOCKLIST = {
+    os.path.join(_SRC_ROOT, 'infra/base-images/base-sanitizer-libs-builder')
+}
 
 
 def _is_project_file(actual_path, expected_filename):
@@ -330,8 +334,13 @@ def get_changed_files():
 def run_tests(relevant_files):
   """Run all unit tests in directories that are different from HEAD."""
   changed_dirs = set()
-  for file in relevant_files:
-    changed_dirs.add(os.path.dirname(file))
+  for file_path in relevant_files:
+    directory = os.path.dirname(file_path)
+    if directory in TEST_DIR_BLOCKLIST:
+      continue
+    if not directory.endswith('build'):
+      continue
+    changed_dirs.add(directory)
 
   # TODO(metzman): This approach for running tests is flawed since tests can
   # fail even if their directory isn't changed. Figure out if it is needed (to

--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -26,7 +26,7 @@ import yaml
 
 _SRC_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 TEST_BLOCKLIST = [
-    # Test fails with error: `ModuleNotFoundError: No module named 'apt'`.
+    # Test errors with error: "ModuleNotFoundError: No module named 'apt'".
     re.compile(r'.*\/infra\/base-images\/base-sanitizer-libs-builder'),
     # TODO(https://github.com/google/oss-fuzz/issues/5025): Reenable these
     # tests.
@@ -345,20 +345,17 @@ def is_test_dir_blocklisted(directory):
 
 def run_tests(_=None):
   """Run all unit tests."""
-  changed_dirs = set()
+  relevant_dirs = set()
   all_files = get_all_files()
   for file_path in all_files:
     directory = os.path.dirname(file_path)
     if is_test_dir_blocklisted(directory):
       continue
-    changed_dirs.add(directory)
+    relevant_dirs.add(directory)
 
-  # TODO(metzman): This approach for running tests is flawed since tests can
-  # fail even if their directory isn't changed. Figure out if it is needed (to
-  # save time) and remove it if it isn't.
   suite_list = []
-  for change_dir in changed_dirs:
-    suite_list.append(unittest.TestLoader().discover(change_dir,
+  for relevant_dir in relevant_dirs:
+    suite_list.append(unittest.TestLoader().discover(relevant_dir,
                                                      pattern='*_test.py'))
   suite = unittest.TestSuite(suite_list)
   result = unittest.TextTestRunner().run(suite)

--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -17,7 +17,6 @@
 """Check code for common issues before submitting."""
 
 import argparse
-import pathlib
 import os
 import re
 import subprocess
@@ -336,25 +335,22 @@ def get_changed_files():
 
 
 def is_test_dir_blocklisted(directory):
+  """Returns True if |directory| is blocklisted."""
   for blocklisted_regex in TEST_BLOCKLIST:
     if blocklisted_regex.search(directory):
       return True
   return False
 
-def run_tests(relevant_files):
-  """Run all unit tests in directories that are different from HEAD."""
+
+def run_tests(_=None):
+  """Run all unit tests."""
   changed_dirs = set()
-  for file_path in relevant_files:
+  all_files = get_all_files()
+  for file_path in all_files:
     directory = os.path.dirname(file_path)
     if is_test_dir_blocklisted(directory):
       continue
     changed_dirs.add(directory)
-
-  for d in changed_dirs:
-    if 'functions' in directory:
-      import ipdb; ipdb.set_trace()
-      pass
-
 
   # TODO(metzman): This approach for running tests is flawed since tests can
   # fail even if their directory isn't changed. Figure out if it is needed (to


### PR DESCRIPTION
The previous approach of only running tests in changed directories is broken.
Tests can fail even when files outside of their directory are modified.
Also blocklist failing tests (see https://github.com/google/oss-fuzz/issues/5025) for why build tests are blocklisted.