### PR TITLE
Project Orbit: Fix Dockerfile

### DIFF
--- a/projects/orbit/Dockerfile
+++ b/projects/orbit/Dockerfile
@@ -14,14 +14,14 @@
 #
 ################################################################################
 
-  #&& curl -SL https://github.com/google/orbit/archive/master.tar.gz \
+  #&& curl -SL https://github.com/google/orbit/archive/main.tar.gz \
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y m4 libglu1-mesa-dev mesa-common-dev \
   libxmu-dev libxi-dev pkg-config libxxf86vm-dev patchelf
 
-ADD https://github.com/google/orbit/archive/master.tar.gz $SRC/
-RUN mkdir -p $SRC/orbit && tar -xzf $SRC/master.tar.gz \
-  -C $SRC/orbit/ --strip-components 1; rm -f $SRC/master.tar.gz
+ADD https://github.com/google/orbit/archive/main.tar.gz $SRC/
+RUN mkdir -p $SRC/orbit && tar -xzf $SRC/main.tar.gz \
+  -C $SRC/orbit/ --strip-components 1; rm -f $SRC/main.tar.gz
 WORKDIR $SRC
 COPY build.sh $SRC/
 

--- a/projects/orbit/Dockerfile
+++ b/projects/orbit/Dockerfile
@@ -14,7 +14,6 @@
 #
 ################################################################################
 
-  #&& curl -SL https://github.com/google/orbit/archive/main.tar.gz \
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y m4 libglu1-mesa-dev mesa-common-dev \
   libxmu-dev libxi-dev pkg-config libxxf86vm-dev patchelf
@@ -22,7 +21,7 @@ RUN apt-get update && apt-get install -y m4 libglu1-mesa-dev mesa-common-dev \
 ADD https://github.com/google/orbit/archive/main.tar.gz $SRC/
 RUN mkdir -p $SRC/orbit && tar -xzf $SRC/main.tar.gz \
   -C $SRC/orbit/ --strip-components 1; rm -f $SRC/main.tar.gz
-WORKDIR $SRC
+WORKDIR $SRC/orbit
 COPY build.sh $SRC/
 
 # That's a hack. The service needs to have a more recent kernel than what the

--- a/projects/orbit/build.sh
+++ b/projects/orbit/build.sh
@@ -31,8 +31,16 @@ echo "CXXFLAGS=\$BASE_CXXFLAGS" >> ~/.conan/profiles/default
 echo "LDFLAGS=\$BASE_LDFLAGS" >> ~/.conan/profiles/default
 echo "OrbitProfiler:CFLAGS=\$BASE_CFLAGS $CFLAGS" >> ~/.conan/profiles/default
 echo "OrbitProfiler:CXXFLAGS=\$BASE_CFLAGS $CXXFLAGS" >> ~/.conan/profiles/default
-echo "llvm:CFLAGS=\$BASE_CFLAGS $CFLAGS" >> ~/.conan/profiles/default
-echo "llvm:CXXFLAGS=\$BASE_CXXFLAGS $CXXFLAGS" >> ~/.conan/profiles/default
+
+# The following two lines is what should theoretically be correct. The workaround + explanation follows
+# echo "llvm:CFLAGS=\$BASE_CFLAGS $CFLAGS" >> ~/.conan/profiles/default
+# echo "llvm:CXXFLAGS=\$BASE_CXXFLAGS $CXXFLAGS" >> ~/.conan/profiles/default
+
+# For unclear reasons the $CFLAGS and $CXXFLAGS contains "-fsanitize=address -fsanitize-address-use-after-scope -fsanitize=fuzzer-no-link"
+# when this script is called. Since llvm currently cannot be build with address sanatizers, 
+# the flags are set manually here.
+echo "llvm:CFLAGS=\$BASE_CFLAGS -O1 -fno-omit-frame-pointer -gline-tables-only -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION" >> ~/.conan/profiles/default
+echo "llvm:CXXFLAGS=\$BASE_CXXFLAGS -O1 -fno-omit-frame-pointer -gline-tables-only -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -stdlib=libc++" >> ~/.conan/profiles/default
 
 $SRC/orbit/build.sh default
 

--- a/projects/orbit/build.sh
+++ b/projects/orbit/build.sh
@@ -36,8 +36,8 @@ echo "OrbitProfiler:CXXFLAGS=\$BASE_CFLAGS $CXXFLAGS" >> ~/.conan/profiles/defau
 # echo "llvm:CFLAGS=\$BASE_CFLAGS $CFLAGS" >> ~/.conan/profiles/default
 # echo "llvm:CXXFLAGS=\$BASE_CXXFLAGS $CXXFLAGS" >> ~/.conan/profiles/default
 
-# For unclear reasons the $CFLAGS and $CXXFLAGS contains "-fsanitize=address -fsanitize-address-use-after-scope -fsanitize=fuzzer-no-link"
-# when this script is called. Since llvm currently cannot be build with address sanatizers, 
+# The $CFLAGS and $CXXFLAGS contains "-fsanitize=address -fsanitize-address-use-after-scope -fsanitize=fuzzer-no-link"
+# when this script is called. Since llvm currently cannot be build with address sanitizers, 
 # the flags are set manually here.
 echo "llvm:CFLAGS=\$BASE_CFLAGS -O1 -fno-omit-frame-pointer -gline-tables-only -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION" >> ~/.conan/profiles/default
 echo "llvm:CXXFLAGS=\$BASE_CXXFLAGS -O1 -fno-omit-frame-pointer -gline-tables-only -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -stdlib=libc++" >> ~/.conan/profiles/default
@@ -57,6 +57,6 @@ function copy_fuzzer {
   done
 }
 
-find $SRC/build_default/bin -name \*Fuzzer | while read fuzzer; do
+find $SRC/orbit/build_default/bin -name \*Fuzzer | while read fuzzer; do
   copy_fuzzer "$fuzzer"
 done


### PR DESCRIPTION
This change is necessary to reflect the recent branch renaming on
github.com/google/orbit from master to main.

I tested this via
```
python infra/helper.py build_image orbit
```