### PR TITLE
[pylint] Enable no-member check

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -141,7 +141,6 @@ disable=print-statement,
         comprehension-escape,
         fixme,
         import-error,
-        no-member
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/infra/build/functions/project_sync_test.py
+++ b/infra/build/functions/project_sync_test.py
@@ -32,6 +32,8 @@ from project_sync import ProjectMetadata
 from project_sync import sync_projects
 import test_utils
 
+# pylint: disable=no-member
+
 
 # pylint: disable=too-few-public-methods
 class Repository:

--- a/infra/build/functions/project_sync_test.py
+++ b/infra/build/functions/project_sync_test.py
@@ -30,7 +30,7 @@ from project_sync import get_github_creds
 from project_sync import get_projects
 from project_sync import ProjectMetadata
 from project_sync import sync_projects
-from build.functions import test_utils
+from infra.build.functions import test_utils
 
 
 # pylint: disable=too-few-public-methods

--- a/infra/build/functions/project_sync_test.py
+++ b/infra/build/functions/project_sync_test.py
@@ -25,7 +25,7 @@ from project_sync import get_github_creds
 from project_sync import get_projects
 from project_sync import ProjectMetadata
 from project_sync import sync_projects
-import test_utils
+from build.functions import test_utils
 
 
 # pylint: disable=too-few-public-methods

--- a/infra/build/functions/project_sync_test.py
+++ b/infra/build/functions/project_sync_test.py
@@ -30,7 +30,7 @@ from project_sync import get_github_creds
 from project_sync import get_projects
 from project_sync import ProjectMetadata
 from project_sync import sync_projects
-from infra.build.functions import test_utils
+import test_utils
 
 
 # pylint: disable=too-few-public-methods

--- a/infra/build/functions/request_build_test.py
+++ b/infra/build/functions/request_build_test.py
@@ -31,7 +31,7 @@ from datastore_entities import Project
 from request_build import get_build_steps
 from request_build import get_project_data
 from request_build import update_build_history
-import test_utils
+from build.functions import test_utils
 
 
 class TestRequestBuilds(unittest.TestCase):

--- a/infra/build/functions/request_build_test.py
+++ b/infra/build/functions/request_build_test.py
@@ -34,6 +34,9 @@ from request_build import update_build_history
 import test_utils
 
 
+# pylint: disable=no-member
+
+
 class TestRequestBuilds(unittest.TestCase):
   """Unit tests for sync."""
 

--- a/infra/build/functions/request_build_test.py
+++ b/infra/build/functions/request_build_test.py
@@ -31,7 +31,7 @@ from datastore_entities import Project
 from request_build import get_build_steps
 from request_build import get_project_data
 from request_build import update_build_history
-from infra.build.functions import test_utils
+import test_utils
 
 
 class TestRequestBuilds(unittest.TestCase):

--- a/infra/build/functions/request_build_test.py
+++ b/infra/build/functions/request_build_test.py
@@ -33,7 +33,6 @@ from request_build import get_project_data
 from request_build import update_build_history
 import test_utils
 
-
 # pylint: disable=no-member
 
 

--- a/infra/build/functions/request_build_test.py
+++ b/infra/build/functions/request_build_test.py
@@ -31,7 +31,7 @@ from datastore_entities import Project
 from request_build import get_build_steps
 from request_build import get_project_data
 from request_build import update_build_history
-from build.functions import test_utils
+from infra.build.functions import test_utils
 
 
 class TestRequestBuilds(unittest.TestCase):

--- a/infra/build/functions/request_coverage_build_test.py
+++ b/infra/build/functions/request_coverage_build_test.py
@@ -30,6 +30,8 @@ from datastore_entities import Project
 from build_and_run_coverage import get_build_steps
 import test_utils
 
+# pylint: disable=no-member
+
 
 class TestRequestCoverageBuilds(unittest.TestCase):
   """Unit tests for sync."""

--- a/infra/build/functions/request_coverage_build_test.py
+++ b/infra/build/functions/request_coverage_build_test.py
@@ -24,7 +24,7 @@ from google.cloud import ndb
 
 from datastore_entities import Project
 from build_and_run_coverage import get_build_steps
-import test_utils
+from build.functions import test_utils
 
 
 class TestRequestCoverageBuilds(unittest.TestCase):

--- a/infra/build/functions/request_coverage_build_test.py
+++ b/infra/build/functions/request_coverage_build_test.py
@@ -28,7 +28,7 @@ sys.path.append(os.path.dirname(__file__))
 
 from datastore_entities import Project
 from build_and_run_coverage import get_build_steps
-from infra.build.functions import test_utils
+import test_utils
 
 
 class TestRequestCoverageBuilds(unittest.TestCase):

--- a/infra/build/functions/request_coverage_build_test.py
+++ b/infra/build/functions/request_coverage_build_test.py
@@ -28,7 +28,7 @@ sys.path.append(os.path.dirname(__file__))
 
 from datastore_entities import Project
 from build_and_run_coverage import get_build_steps
-from build.functions import test_utils
+from infra.build.functions import test_utils
 
 
 class TestRequestCoverageBuilds(unittest.TestCase):

--- a/infra/build/functions/update_build_status_test.py
+++ b/infra/build/functions/update_build_status_test.py
@@ -30,6 +30,8 @@ from datastore_entities import LastSuccessfulBuild
 import test_utils
 import update_build_status
 
+# pylint: disable=no-member
+
 
 # pylint: disable=too-few-public-methods
 class MockGetBuild:

--- a/infra/build/functions/update_build_status_test.py
+++ b/infra/build/functions/update_build_status_test.py
@@ -27,7 +27,7 @@ sys.path.append(os.path.dirname(__file__))
 
 from datastore_entities import BuildsHistory
 from datastore_entities import LastSuccessfulBuild
-from infra.build.functions import test_utils
+import test_utils
 import update_build_status
 
 

--- a/infra/build/functions/update_build_status_test.py
+++ b/infra/build/functions/update_build_status_test.py
@@ -27,7 +27,7 @@ sys.path.append(os.path.dirname(__file__))
 
 from datastore_entities import BuildsHistory
 from datastore_entities import LastSuccessfulBuild
-import test_utils
+from build.functions import test_utils
 import update_build_status
 
 

--- a/infra/build/functions/update_build_status_test.py
+++ b/infra/build/functions/update_build_status_test.py
@@ -27,7 +27,7 @@ sys.path.append(os.path.dirname(__file__))
 
 from datastore_entities import BuildsHistory
 from datastore_entities import LastSuccessfulBuild
-from build.functions import test_utils
+from infra.build.functions import test_utils
 import update_build_status
 
 

--- a/infra/retry.py
+++ b/infra/retry.py
@@ -62,9 +62,8 @@ def wrap(retries,
         sleep(get_delay(num_try, delay, backoff))
         return True
 
-      logging.log_error('Retrying on %s failed with %s. Raise.' %
-                        (function_with_type, sys.exc_info()[1]),
-                        total=tries)
+      logging.error('Retrying on %s failed with %s. Raise.',
+                    function_with_type, sys.exc_info()[1])
       return False
 
     @functools.wraps(func)

--- a/infra/retry.py
+++ b/infra/retry.py
@@ -62,8 +62,8 @@ def wrap(retries,
         sleep(get_delay(num_try, delay, backoff))
         return True
 
-      logging.error('Retrying on %s failed with %s. Raise.',
-                    function_with_type, sys.exc_info()[1])
+      logging.error('Retrying on %s failed with %s. Raise.', function_with_type,
+                    sys.exc_info()[1])
       return False
 
     @functools.wraps(func)


### PR DESCRIPTION
This check is super useful. It can catch use of misspelled functions in other modules and use of misspelled attributes.