### PR TITLE
[exprtk] Set maximum expression size during evaluation phase

### DIFF
--- a/projects/exprtk/exprtk_fuzzer.cpp
+++ b/projects/exprtk/exprtk_fuzzer.cpp
@@ -52,14 +52,19 @@ void run(const std::string& expression_string)
 
    if (parser.compile(expression_string, expression))
    {
-      try
-      {
-         expression.value();
-      }
-      catch (std::runtime_error& rte)
-      {}
+      const std::size_t max_expression_size = 64 * 1024;
 
-      parser.clear_loop_runtime_check();
+      if (expression_string.size() <= max_expression_size)
+      {
+         try
+         {
+            expression.value();
+         }
+         catch (std::runtime_error& rte)
+         {}
+
+         parser.clear_loop_runtime_check();
+      }
    }
 }
 


### PR DESCRIPTION
Timeouts are causing test failures. To prevent such failures, during the evaluation phase will only consider expressions of size 64KB and less.