### PR TITLE
Start using afl++ instead of afl.

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -148,6 +148,7 @@ RUN mkdir $PRECOMPILED_DIR
 WORKDIR $SRC
 
 RUN git clone -b stable https://github.com/google/AFL.git afl
+RUN git clone -b stable https://github.com/AFLplusplus/AFLplusplus.git aflplusplus
 
 RUN cd $SRC && \
     curl -L -O https://github.com/google/honggfuzz/archive/oss-fuzz.tar.gz && \

--- a/infra/base-images/base-builder/compile_afl
+++ b/infra/base-images/base-builder/compile_afl
@@ -29,8 +29,8 @@ ar r $LIB_FUZZING_ENGINE $WORK/afl/*.o
 popd > /dev/null
 rm -rf $WORK/afl
 
-# Build and copy afl tools necessary for fuzzing.
-pushd $SRC/afl > /dev/null
+# Build and copy afl++ tools necessary for fuzzing.
+pushd $SRC/aflplusplus > /dev/null
 
 # Unset CFLAGS and CXXFLAGS while building AFL since we don't want to slow it
 # down with sanitizers.
@@ -38,11 +38,14 @@ INITIAL_CXXFLAGS=$CXXFLAGS
 INITIAL_CFLAGS=$CFLAGS
 unset CXXFLAGS
 unset CFLAGS
-make clean && AFL_NO_X86=1 make
+make clean
+AFL_NO_X86=1 PYTHON_INCLUDE=/ make
+make -C utils/aflpp_driver
 CFLAGS=$INITIAL_CFLAGS
 CXXFLAGS=$INITIAL_CXXFLAGS
 
-find . -name 'afl-*' -executable -type f | xargs cp -t $OUT
+# Not all important files start with afl-*, but all are in the project root.
+ls afl-* *.a *.o *.so | sort -u | xargs cp -t $OUT
 popd > /dev/null
 
 echo " done."


### PR DESCRIPTION
* Build and run_fuzzer tested with 5 projects ffmpeg, skia, wireshark, fio, htslib.
* Reproduction tested on 4 projects, using afl-fuzz in shell
  and same env vars in clusterfuzz/oss-fuzz run_fuzzer scripts + with error stack generated in file
  (since infra/helper.py reproduce supports libfuzzer only).
* Slight rebase of https://github.com/google/oss-fuzz/pull/4434
* Once this stabilizes, can think of enabling lto and more instrumentation modes e.g. cmplog, etc