### PR TITLE
[Hermes] Update CMake flag

### DIFF
--- a/projects/hermes/build.sh
+++ b/projects/hermes/build.sh
@@ -26,6 +26,6 @@ else
 fi
 
 ./utils/build/configure.py "${OUT}/build" --build-system "Ninja" ${CONFIGURE_FLAGS} \
-                           --cmake-flags="-DHERMES_USE_STATIC_ICU=ON -DHERMES_FUZZING_FLAG=${LIB_FUZZING_ENGINE} -DHERMES_ENABLE_FUZZING=ON"
+                           --cmake-flags="-DHERMES_USE_STATIC_ICU=ON -DHERMES_FUZZING_FLAG=${LIB_FUZZING_ENGINE} -DHERMES_ENABLE_LIBFUZZER=ON"
 cmake --build "$OUT/build"  --parallel --target fuzzer-jsi-entry
 cp "${OUT}/build/bin/fuzzer-jsi-entry" "${OUT}"


### PR DESCRIPTION
A recent commit in Hermes to add Fuzzilli support requires us to distinguish between the OSS-Fuzz and Fuzzilli fuzzing modes. Update the CMake flag in our build script to reflect the new flag for building in OSS-Fuzz.