### PR TITLE
tmux: take openbsd security list off from CC

### DIFF
--- a/projects/tmux/project.yaml
+++ b/projects/tmux/project.yaml
@@ -1,8 +1,6 @@
 homepage: "https://tmux.github.io/"
 language: c
 primary_contact: nicholas.marriott@gmail.com
-auto_ccs:
-  - security@openbsd.org
 sanitizers:
   - address
   - undefined


### PR DESCRIPTION
_Requested by by @nicm (tmux project's maintainer) in https://github.com/google/oss-fuzz/issues/4593#issuecomment-768161872_