### PR TITLE
Run fuzzers using AFL now we have fixed the build.

### DIFF
--- a/projects/perfetto/project.yaml
+++ b/projects/perfetto/project.yaml
@@ -20,6 +20,7 @@ vendor_ccs:
 fuzzing_engines:
   - libfuzzer
   - honggfuzz
+  - afl
 sanitizers:
   - address
 main_repo: 'https://android.googlesource.com/platform/external/perfetto/'


### PR DESCRIPTION
Built and ran `python infra/helper.py check_build --engine afl perfetto ...` on all our fuzzers successfully.