### PR TITLE
sudoers: update fuzzers

### DIFF
--- a/projects/sudoers/fuzz_iolog_json_parse.c
+++ b/projects/sudoers/fuzz_iolog_json_parse.c
@@ -47,22 +47,27 @@ limitations under the License.
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     char filename[256];
-    sprintf(filename, "/tmp/libfuzzer.%d", getpid());
-
-    FILE *fp = fopen(filename, "wb");
-    if (!fp) {
+    sprintf(filename, "/tmp/fuzz-iolog.XXXXXX", getpid());
+  
+    int fp = mkstemp(filename);
+    if (fp < 0) {
         return 0;
     }
-    fwrite(data, size, 1, fp);
-    fclose(fp);
+    write(fp, data, size);
+    close(fp);
 
-    fp = fopen(filename, "rb");
-    struct json_object root;
-    if (iolog_parse_json(fp, "libfuzzer_input.txt", &root)) {
-        free_json_items(&root.items);
+    FILE *fd = fopen(filename,"rb");
+    if (fd == -1) {
+        return 0;
     }
 
-    unlink(filename);
+    struct json_object root;
+    if (iolog_parse_json(fd, filename, &root)) {
+        free_json_items(&root.items);
+    }
+    fclose(fd);
+
+    remove(filename);
 
     return 0;
 }

--- a/projects/sudoers/fuzz_iolog_json_parse.c
+++ b/projects/sudoers/fuzz_iolog_json_parse.c
@@ -43,8 +43,6 @@ limitations under the License.
 
 #include "iolog_json.h"
 
-
-
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     char filename[256];
     sprintf(filename, "/tmp/fuzz-iolog.XXXXXX", getpid());
@@ -68,7 +66,5 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     fclose(fd);
 
     remove(filename);
-
     return 0;
 }
-

--- a/projects/sudoers/fuzz_sudoers_parse.c
+++ b/projects/sudoers/fuzz_sudoers_parse.c
@@ -59,7 +59,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     if (fd == NULL) {
         return 0;
     }
-
     
     init_parser(filename, false, true);
     sudoers_parse_ldif(&parsed_policy, fd, NULL, true);

--- a/projects/sudoers/fuzz_sudoers_parse.c
+++ b/projects/sudoers/fuzz_sudoers_parse.c
@@ -41,6 +41,10 @@ limitations under the License.
 
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size < 5) {
+        return 0;
+    }
+
     char filename[256];
     sprintf(filename, "/tmp/libfuzzer.%d", getpid());
 

--- a/projects/sudoers/fuzz_sudoers_parse.c
+++ b/projects/sudoers/fuzz_sudoers_parse.c
@@ -56,10 +56,14 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
     // main entry point for the fuzzer
     FILE *fd = fopen(filename, "rb");
-    if (fd != NULL) {
-        init_parser(filename, false, true);
-        sudoers_parse_ldif(&parsed_policy, fd, NULL, true);
+    if (fd == NULL) {
+        return 0;
     }
+
+    
+    init_parser(filename, false, true);
+    sudoers_parse_ldif(&parsed_policy, fd, NULL, true);
+    
     remove(filename);
     return 0;
 }


### PR DESCRIPTION
This changes the fuzzers of sudoers, in particular to using `mkstemp` as per request from the maintainer here https://github.com/google/oss-fuzz/pull/5052#discussion_r565796971