### PR TITLE
Adds project rust compiler-builtins

### DIFF
--- a/projects/rust-builtins/Cargo.toml
+++ b/projects/rust-builtins/Cargo.toml
@@ -1,0 +1,35 @@
+cargo-features = ['named-profiles']
+
+[package]
+name = "compiler-builtins-fuzz"
+version = "0.0.0"
+authors = ["Philippe Antoine <p.antoine@catenacyber.fr>"]
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.3"
+
+[dependencies.compiler_builtins]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_f32"
+path = "harnesses/fuzz_f32.rs"
+
+[profile.release]
+opt-level = 3
+debug = true
+
+[profile.debug]
+inherits = "release"
+
+[profile.test]
+inherits = "release"

--- a/projects/rust-builtins/Dockerfile
+++ b/projects/rust-builtins/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN git clone --depth 1 https://github.com/rust-lang/compiler-builtins
+WORKDIR $SRC/compiler-builtins
+
+COPY build.sh $SRC
+COPY Cargo.toml $SRC/compiler-builtins/fuzz
+COPY fuzz*.rs $SRC/compiler-builtins/fuzz/harnesses

--- a/projects/rust-builtins/Dockerfile
+++ b/projects/rust-builtins/Dockerfile
@@ -19,5 +19,5 @@ RUN git clone --depth 1 https://github.com/rust-lang/compiler-builtins
 WORKDIR $SRC/compiler-builtins
 
 COPY build.sh $SRC
-COPY Cargo.toml $SRC/compiler-builtins/fuzz
-COPY fuzz*.rs $SRC/compiler-builtins/fuzz/harnesses
+COPY Cargo.toml $SRC/compiler-builtins/fuzz/
+COPY fuzz*.rs $SRC/compiler-builtins/fuzz/harnesses/

--- a/projects/rust-builtins/build.sh
+++ b/projects/rust-builtins/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cargo fuzz build -O -Z build-std
+cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_* $OUT/

--- a/projects/rust-builtins/fuzz_f32.rs
+++ b/projects/rust-builtins/fuzz_f32.rs
@@ -1,0 +1,35 @@
+#![no_main]
+#![feature(rustc_private)]
+use libfuzzer_sys::fuzz_target;
+
+use std::convert::TryFrom;
+
+use compiler_builtins::float::add::__addsf3;
+use compiler_builtins::float::sub::__subsf3;
+use compiler_builtins::float::Float;
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < 8 {
+        return;
+    }
+    let x = f32::from_ne_bytes(<[u8; 4]>::try_from(&data[0..4]).unwrap());
+    let y = f32::from_ne_bytes(<[u8; 4]>::try_from(&data[4..8]).unwrap());
+
+    let add0 = x + y;
+    let add1: f32 = __addsf3(x, y);
+    if !Float::eq_repr(add0, add1) {
+        panic!(
+            "{}({}, {}): std: {}, builtins: {}",
+            stringify!($fn_add), x, y, add0, add1
+        );
+    }
+
+    let sub0 = x - y;
+    let sub1: f32 = __subsf3(x, y);
+    if !Float::eq_repr(sub0, sub1) {
+        panic!(
+            "{}({}, {}): std: {}, builtins: {}",
+            stringify!($fn_sub), x, y, sub0, sub1
+        );
+    }
+});

--- a/projects/rust-builtins/project.yaml
+++ b/projects/rust-builtins/project.yaml
@@ -7,3 +7,4 @@ fuzzing_engines:
 language: rust
 auto_ccs:
   - "p.antoine@catenacyber.fr"
+main_repo: "https://github.com/rust-lang/compiler-builtins"

--- a/projects/rust-builtins/project.yaml
+++ b/projects/rust-builtins/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/rust-lang/compiler-builtins"
+primary_contact: "aaronkutch@att.net"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+language: rust
+auto_ccs:
+  - "p.antoine@catenacyber.fr"


### PR DESCRIPTION
cc @AaronKutch
Would you be interested in continuous fuzzing for rust compiler-builtins ?
I see that you committed https://github.com/rust-lang/compiler-builtins/commit/c2ff1b3119dafb4c56e8e9b8b75f20b9fd4ba3ed

This draft PR enables continuous fuzzing for one simple target about `f32`
