### PR TITLE
Enable fuzzing of key exchange

### DIFF
--- a/projects/openssh/build.sh
+++ b/projects/openssh/build.sh
@@ -15,6 +15,10 @@
 #
 ################################################################################
 
+# Enable null cipher
+mv cipher.c _cipher.c
+sed 's/#define CFLAG_INTERNAL.*/#define CFLAG_INTERNAL 0/' _cipher.c > cipher.c
+
 # Build project
 autoreconf
 env
@@ -25,31 +29,32 @@ env CFLAGS="" ./configure \
 make -j$(nproc) all
 
 # Build fuzzers
+EXTRA_CFLAGS="-DCIPHER_NONE_AVAIL=1"
 STATIC_CRYPTO="-Wl,-Bstatic -lcrypto -Wl,-Bdynamic"
 
 COMMON=ssh-sk-null.o
 
-$CXX $CXXFLAGS -std=c++11 -I. -L. -Lopenbsd-compat -g \
+$CXX $CXXFLAGS -std=c++11 $EXTRA_CFLAGS -I. -L. -Lopenbsd-compat -g \
 	regress/misc/fuzz-harness/ssh-sk-null.cc -c -o ssh-sk-null.o
 
-$CXX $CXXFLAGS -std=c++11 -I. -L. -Lopenbsd-compat -g \
+$CXX $CXXFLAGS -std=c++11 $EXTRA_CFLAGS -I. -L. -Lopenbsd-compat -g \
 	regress/misc/fuzz-harness/pubkey_fuzz.cc -o $OUT/pubkey_fuzz \
 	-lssh -lopenbsd-compat $COMMON $STATIC_CRYPTO $LIB_FUZZING_ENGINE
-$CXX $CXXFLAGS -std=c++11 -I. -L. -Lopenbsd-compat -g \
+$CXX $CXXFLAGS -std=c++11 $EXTRA_CFLAGS -I. -L. -Lopenbsd-compat -g \
 	regress/misc/fuzz-harness/privkey_fuzz.cc -o $OUT/privkey_fuzz \
 	-lssh -lopenbsd-compat $COMMON $STATIC_CRYPTO $LIB_FUZZING_ENGINE
-$CXX $CXXFLAGS -std=c++11 -I. -L. -Lopenbsd-compat -g \
+$CXX $CXXFLAGS -std=c++11 $EXTRA_CFLAGS -I. -L. -Lopenbsd-compat -g \
 	regress/misc/fuzz-harness/sig_fuzz.cc -o $OUT/sig_fuzz \
 	-lssh -lopenbsd-compat $COMMON $STATIC_CRYPTO $LIB_FUZZING_ENGINE
-$CXX $CXXFLAGS -std=c++11 -I. -L. -Lopenbsd-compat -g \
+$CXX $CXXFLAGS -std=c++11 $EXTRA_CFLAGS -I. -L. -Lopenbsd-compat -g \
 	regress/misc/fuzz-harness/authopt_fuzz.cc -o $OUT/authopt_fuzz \
 	auth-options.o -lssh -lopenbsd-compat $COMMON $STATIC_CRYPTO \
 	$LIB_FUZZING_ENGINE
-$CXX $CXXFLAGS -std=c++11 -I. -L. -Lopenbsd-compat -g \
+$CXX $CXXFLAGS -std=c++11 $EXTRA_CFLAGS -I. -L. -Lopenbsd-compat -g \
 	regress/misc/fuzz-harness/sshsig_fuzz.cc -o $OUT/sshsig_fuzz \
 	sshsig.o -lssh -lopenbsd-compat $COMMON $STATIC_CRYPTO \
 	$LIB_FUZZING_ENGINE
-$CXX $CXXFLAGS -std=c++11 -I. -L. -Lopenbsd-compat -g \
+$CXX $CXXFLAGS -std=c++11 $EXTRA_CFLAGS -I. -L. -Lopenbsd-compat -g \
 	regress/misc/fuzz-harness/sshsigopt_fuzz.cc -o $OUT/sshsigopt_fuzz \
 	sshsig.o -lssh -lopenbsd-compat $COMMON $STATIC_CRYPTO \
 	$LIB_FUZZING_ENGINE

--- a/projects/openssh/build.sh
+++ b/projects/openssh/build.sh
@@ -58,6 +58,10 @@ $CXX $CXXFLAGS -std=c++11 $EXTRA_CFLAGS -I. -L. -Lopenbsd-compat -g \
 	regress/misc/fuzz-harness/sshsigopt_fuzz.cc -o $OUT/sshsigopt_fuzz \
 	sshsig.o -lssh -lopenbsd-compat $COMMON $STATIC_CRYPTO \
 	$LIB_FUZZING_ENGINE
+$CXX $CXXFLAGS -std=c++11 $EXTRA_CFLAGS -I. -L. -Lopenbsd-compat -g \
+	regress/misc/fuzz-harness/kex_fuzz.cc -o $OUT/kex_fuzz \
+	-lssh -lopenbsd-compat -lz $COMMON $STATIC_CRYPTO \
+	$LIB_FUZZING_ENGINE
 
 # Prepare seed corpora
 CASES="$SRC/openssh-fuzz-cases"
@@ -67,3 +71,4 @@ CASES="$SRC/openssh-fuzz-cases"
 (set -e ; cd ${CASES}/authopt ; zip -r $OUT/authopt_fuzz_seed_corpus.zip .)
 (set -e ; cd ${CASES}/sshsig ; zip -r $OUT/sshsig_fuzz_seed_corpus.zip .)
 (set -e ; cd ${CASES}/sshsigopt ; zip -r $OUT/sshsigopt_fuzz_seed_corpus.zip .)
+(set -e ; cd ${CASES}/kex ; zip -r $OUT/kex_fuzz_seed_corpus.zip .)


### PR DESCRIPTION
This enables fuzzing of the key exchange process, using a fuzzer already shipped in Portable OpenSSH.

It also enables the null cipher for fuzzing builds, as this is faster and allows for better coverage.