### PR TITLE
[cifuzz][external] Use ssh_url and fix affected fuzzers

### DIFF
--- a/infra/cifuzz/cifuzz.py
+++ b/infra/cifuzz/cifuzz.py
@@ -147,7 +147,10 @@ class Builder:  # pylint: disable=too-many-instance-attributes
   def remove_unaffected_fuzz_targets(self):
     """Removes the fuzzers unaffected by the patch."""
     if self.config.keep_unaffected_fuzz_targets:
+      logging.info('Not removing unaffected fuzz targets.')
       return True
+
+    logging.info('Removing unaffected fuzz targets.')
     changed_files = self.ci_system.get_changed_code_under_test(
         self.repo_manager)
     affected_fuzz_targets.remove_unaffected_fuzz_targets(

--- a/infra/cifuzz/config_utils.py
+++ b/infra/cifuzz/config_utils.py
@@ -120,7 +120,7 @@ class BuildFuzzersConfig(BaseConfig):
           event_data['pull_request']['number'])
       logging.debug('pr_ref: %s', self.pr_ref)
 
-    self.git_url = event_data['repository']['git_url']
+    self.git_url = event_data['repository']['ssh_url']
 
   def __init__(self):
     """Get the configuration from CIFuzz from the environment. These variables

--- a/infra/cifuzz/config_utils.py
+++ b/infra/cifuzz/config_utils.py
@@ -143,5 +143,7 @@ class BuildFuzzersConfig(BaseConfig):
     self.allowed_broken_targets_percentage = os.getenv(
         'ALLOWED_BROKEN_TARGETS_PERCENTAGE')
 
+    # TODO(metzman): Use better system for interpreting env vars. What if env
+    # var is set to '0'?
     self.keep_unaffected_fuzz_targets = bool(
-        os.getenv('KEEP_UNAFFECTED_FUZZERS', 'False'))
+        os.getenv('KEEP_UNAFFECTED_FUZZERS'))

--- a/infra/cifuzz/config_utils.py
+++ b/infra/cifuzz/config_utils.py
@@ -20,7 +20,7 @@ import json
 
 
 def _get_project_repo_name():
-  return os.path.basename(os.getenv('GITHUB_REPOSITORY'))
+  return os.path.basename(os.getenv('GITHUB_REPOSITORY', ''))
 
 
 def _get_pr_ref(event):
@@ -40,7 +40,7 @@ def _get_project_name():
 
 def _is_dry_run():
   """Returns True if configured to do a dry run."""
-  return os.getenv('DRY_RUN', '').lower() == 'true'
+  return os.getenv('DRY_RUN', 'false').lower() == 'true'
 
 
 def get_project_src_path(workspace):

--- a/infra/cifuzz/config_utils.py
+++ b/infra/cifuzz/config_utils.py
@@ -40,7 +40,7 @@ def _get_project_name():
 
 def _is_dry_run():
   """Returns True if configured to do a dry run."""
-  return os.getenv('DRY_RUN').lower() == 'true'
+  return os.getenv('DRY_RUN', '').lower() == 'true'
 
 
 def get_project_src_path(workspace):

--- a/infra/cifuzz/config_utils_test.py
+++ b/infra/cifuzz/config_utils_test.py
@@ -45,4 +45,8 @@ class BuildFuzzersConfigTest(unittest.TestCase):
   def test_keep_unaffected_defaults_to_false(self):
     """Tests that keep_unaffected_fuzz_targets defaults to false."""
     config = self._create_config()
-    self.assertIsNone(config.keep_unaffected_fuzz_targets)
+    self.assertFalse(config.keep_unaffected_fuzz_targets)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/infra/cifuzz/config_utils_test.py
+++ b/infra/cifuzz/config_utils_test.py
@@ -39,3 +39,10 @@ class BuildFuzzersConfigTest(unittest.TestCase):
     """Tests that base_ref is set properly."""
     expected_base_ref = 'expected_base_ref'
     os.environ['GITHUB_BASE_REF'] = expected_base_ref
+    config = self._create_config()
+    self.assertEqual(config.base_ref, expected_base_ref)
+
+  def test_keep_unaffected_defaults_to_false(self):
+    """Tests that keep_unaffected_fuzz_targets defaults to false."""
+    config = self._create_config()
+    self.assertIsNone(config.keep_unaffected_fuzz_targets)


### PR DESCRIPTION
1. ssh url.
This only affects external (non-oss-fuzz) users.
Since there are none, it doesn't affect anyone.
Even if it did, exploitation would require owning the network
Github actions runs on.
This is to prevent MITM attacks.

2. Unaffected bug.
We accidentally were skipping the remove unaffected functionality.