### PR TITLE
libgcrypt: initial integration.

### DIFF
--- a/projects/libgcrypt/Dockerfile
+++ b/projects/libgcrypt/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y texinfo transfig wget autoconf
+RUN wget https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.41.tar.bz2
+RUN git clone https://github.com/gpg/libgcrypt/
+#RUN apt-get update && apt-get install -y make cmake
+#RUN git clone https://github.com/danielaparker/jsoncons
+
+WORKDIR $SRC
+COPY build.sh $SRC/
+COPY fuzz_* $SRC/

--- a/projects/libgcrypt/build.sh
+++ b/projects/libgcrypt/build.sh
@@ -1,0 +1,41 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+tar -xf libgpg-error-1.41.tar.bz2
+cd libgpg-error-1.41
+./configure
+#make
+#make install
+
+#make clean
+./configure --enable-static
+make
+make install
+
+# Build libgcrypt
+cd $SRC/
+cd libgcrypt/
+./autogen.sh
+./configure --enable-maintainer-mode --enable-static
+make
+
+# Now build the fuzzer
+cp $SRC/fuzz_* .
+$CC $CFLAGS -c fuzz_str.c -I./src -I./random/ -I./
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz_str.o -o $OUT/fuzz_str \
+    ./random/.libs/librandom.a ./src/.libs/libgcrypt.a ./cipher/.libs/libcipher.a \
+    ../libgpg-error-1.41/src/.libs/libgpg-error.a

--- a/projects/libgcrypt/fuzz_str.c
+++ b/projects/libgcrypt/fuzz_str.c
@@ -1,0 +1,41 @@
+/* Copyright 2021 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+#include <config.h>
+
+#include <string.h>
+#include <unistd.h>
+#include <stdint.h>
+
+#include "g10lib.h"
+#include "random.h"
+#include "rand-internal.h"
+#include "../cipher/bufhelp.h"
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    char *new_str = (char *)malloc(size+1);
+    if (new_str == NULL){
+        return 0;
+    }
+    memcpy(new_str, data, size);
+    new_str[size] = '\0';
+
+    _gcry_strtokenize (new_str, NULL);
+
+    free(new_str);
+    return 0;
+}

--- a/projects/libgcrypt/project.yaml
+++ b/projects/libgcrypt/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/gpg/libgcrypt/"
+primary_contact: "david@adalogics.com"
+language: c
+auto_ccs :
+  - "david@adalogics.com"
+main_repo: 'https://github.com/gpg/libgcrypt/'


### PR DESCRIPTION
I worked on libgcrypt but wasn't entirely sure if I should suggest it because it is already being fuzzed by CryptoFuzz. However, with the recent Libgcrypt issue I thought it might be still useful to have it.

A question is if a projects us integrated into CryptoFuzz is it still relevant to have in OSS-Fuzz explicitly? Does CryptoFuzz focus on a specific part of the libraries, i.e. crypto-related APIs, and leaves out analysis of the other parts of a project? Because if that is the case then there is an argument for fuzzing the rest of the projects as well. Would be nice to know your thoughts on this one @guidovranken

It would also be nice to the view of the current sheriff on this one @inferno-chromium @jonathanmetzman @oliverchang 