### PR TITLE
No longer disables asm for gcrypt in ecc-diff-fuzzer

### DIFF
--- a/projects/ecc-diff-fuzzer/build.sh
+++ b/projects/ecc-diff-fuzzer/build.sh
@@ -54,9 +54,9 @@ make install
 cd ../gcrypt
 ./autogen.sh
 if [ "$ARCHITECTURE" = 'i386' ]; then
-    ./configure -host=i386 --enable-static --disable-shared --disable-doc --enable-maintainer-mode --disable-asm
+    ./configure -host=i386 --enable-static --disable-shared --disable-doc --enable-maintainer-mode
 else
-    ./configure --enable-static --disable-shared --disable-doc --enable-maintainer-mode --disable-asm
+    ./configure --enable-static --disable-shared --disable-doc --enable-maintainer-mode
 fi
 make -j$(nproc)
 make install


### PR DESCRIPTION
Should fix build failure
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=30001

Otherwise, lib gcrypt compilation got to fail with
```
keccak.c:907:23: error: use of undeclared identifier 'HWF_INTEL_FAST_SHLD'
  else if (features & HWF_INTEL_FAST_SHLD)
``` 