### PR TITLE
[systemd] turn off AFL

### DIFF
--- a/projects/systemd/project.yaml
+++ b/projects/systemd/project.yaml
@@ -1,11 +1,14 @@
 homepage: "https://freedesktop.org/wiki/Software/systemd/"
-language: c++
+language: c
 primary_contact: "lennart@poettering.net"
 builds_per_day: 4
 sanitizers:
   - address
   - undefined
   - memory
+fuzzing_engines:
+  - libfuzzer
+  - honggfuzz
 auto_ccs:
   - jonathan@titanous.com
   - zbyszek@in.waw.pl


### PR DESCRIPTION
It seems AFLplusplus isn't compatible with meson. Since yesterday systemd has been
failing to build due to an unused command line argument:

```
Compiler stdout:

Compiler stderr:
 clang-12: error: /src/aflplusplus/afl-compiler-rt.o: 'linker' input unused [-Werror,-Wunused-command-line-argument]
clang-12: error: -Wl,--dynamic-list=/src/aflplusplus/dynamic_list.txt: 'linker' input unused [-Werror,-Wunused-command-line-argument]

meson.build:647:16: ERROR: Problem encountered: unable to determine gperf len type
+ exit 1
```

I'm not sure where the argument comes from but it looks like another variation on https://github.com/mesonbuild/meson/issues/4542