### PR TITLE
Revert "Switch to using afl-clang-fast for afl++."

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -147,6 +147,8 @@ RUN mkdir $PRECOMPILED_DIR
 
 WORKDIR $SRC
 
+RUN git clone -b stable https://github.com/google/AFL.git afl
+
 RUN git clone -b stable https://github.com/AFLplusplus/AFLplusplus.git aflplusplus && \
     cd aflplusplus && \
     git checkout 068bef5eab942df0a133c92522f2ab81b28ac636

--- a/infra/base-images/base-builder/compile_afl
+++ b/infra/base-images/base-builder/compile_afl
@@ -15,6 +15,20 @@
 #
 ################################################################################
 
+echo "Compiling afl driver to $LIB_FUZZING_ENGINE"
+
+# afl needs its special coverage flags
+export COVERAGE_FLAGS="-fsanitize-coverage=trace-pc-guard"
+
+mkdir -p $WORK/afl
+pushd $WORK/afl > /dev/null
+# Add -Wno-pointer-sign to silence warning (AFL is compiled this way).
+$CC $CFLAGS -Wno-pointer-sign -c $SRC/afl/llvm_mode/afl-llvm-rt.o.c
+$CXX $CXXFLAGS -std=c++11 -O2 -c $SRC/libfuzzer/afl/*.cpp -I$SRC/libfuzzer
+ar r $LIB_FUZZING_ENGINE $WORK/afl/*.o
+popd > /dev/null
+rm -rf $WORK/afl
+
 echo "Compiling afl++"
 
 # Build and copy afl++ tools necessary for fuzzing.
@@ -26,21 +40,17 @@ INITIAL_CXXFLAGS=$CXXFLAGS
 INITIAL_CFLAGS=$CFLAGS
 unset CXXFLAGS
 unset CFLAGS
+
 make clean
 AFL_NO_X86=1 PYTHON_INCLUDE=/ make
+make -C utils/aflpp_driver
+
 CFLAGS=$INITIAL_CFLAGS
 CXXFLAGS=$INITIAL_CXXFLAGS
-
-# Build afl++ driver with existing CFLAGS, CXXFLAGS.
-make -C utils/aflpp_driver
-cp libAFLDriver.a $LIB_FUZZING_ENGINE
 
 # Some important projects include libraries, copy those even when they don't
 # start with "afl-". Use "sort -u" to avoid a warning about duplicates.
 ls afl-* *.a *.o *.so | sort -u | xargs cp -t $OUT
 popd > /dev/null
-
-export CC="$SRC/aflplusplus/afl-clang-fast"
-export CXX="$SRC/aflplusplus/afl-clang-fast++"
 
 echo " done."


### PR DESCRIPTION
Reverts google/oss-fuzz#5074

Revert due to issues cited in https://github.com/google/oss-fuzz/issues/4280#issuecomment-770949515