### PR TITLE
Update Prometheus team members

### DIFF
--- a/projects/prometheus/project.yaml
+++ b/projects/prometheus/project.yaml
@@ -2,7 +2,7 @@ homepage: "https://github.com/prometheus/prometheus"
 primary_contact: "prometheus-team@googlegroups.com"
 auto_ccs :
   - "julius.volz@gmail.com"
-  - "brian.brazil@robustperception.io"
+  - "beorn@grafana.com"
   - "roidelapluie@prometheus.io"
   - "richih@richih.org"
 language: go


### PR DESCRIPTION
Dear OSS-Fuzz maintainers,

Brian Brazil has resigned from the Prometheus project, and we have
decided to put Björn Rabenstein in place for the OSS-Fuzz reports.

cc @beorn7

Thanks

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>