### PR TITLE
nodejs: fix build after experimental-quic flag removed.

### DIFF
--- a/projects/nodejs/build.sh
+++ b/projects/nodejs/build.sh
@@ -19,7 +19,7 @@ cd $SRC/node
 # Build node
 export LDFLAGS="$CXXFLAGS"
 export LD="$CXX"
-./configure --experimental-quic --with-ossfuzz
+./configure --with-ossfuzz
 make -j$(nproc)
 
 # Copy all fuzzers to OUT folder 


### PR DESCRIPTION
`--experimental-quic` was removed in nodejs (https://github.com/nodejs/node/pull/37067) and thus we remove it when building nodejs 