### PR TITLE
Try to add code coverage support for Rust projects

### DIFF
--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -80,12 +80,11 @@ fi
 
 # Rust does not support sanitizers and coverage flags via CFLAGS/CXXFLAGS, so
 # use RUSTFLAGS.
-# FIXME: Support code coverage once support is in.
-# See https://github.com/rust-lang/rust/issues/34701.
-if [ "$SANITIZER" != "undefined" ] && [ "$SANITIZER" != "coverage" ] && [ "$ARCHITECTURE" != 'i386' ]; then
-  export RUSTFLAGS="--cfg fuzzing -Zsanitizer=${SANITIZER} -Cdebuginfo=1 -Cforce-frame-pointers"
-else
-  export RUSTFLAGS="--cfg fuzzing -Cdebuginfo=1 -Cforce-frame-pointers"
+export RUSTFLAGS="--cfg fuzzing -Cdebuginfo=1 -Cforce-frame-pointers"
+if [ "$SANITIZER" = "coverage" ]; then
+  export RUSTFLAGS="${RUSTFLAGS} -Zinstrument-coverage"
+elif [ "$SANITIZER" != "undefined" ] && [ "$ARCHITECTURE" != 'i386' ]; then
+  export RUSTFLAGS="${RUSTFLAGS} -Zsanitizer=${SANITIZER}"
 fi
 
 # Add Rust libfuzzer flags.


### PR DESCRIPTION
Support for LLVM-based code coverage for Rust was implemented awhile
back (and has a [nice blog post][post] with [documentation]), and we ran
across this internally today. I'm curious if this change is all that's
needed to enable source coverage for Rust builds! I'm not 100% sure how
coverage is all set up in oss-fuzz but I figured this might be a good
place to get the ball rolling.

cc #3469

[post]: https://blog.rust-lang.org/inside-rust/2020/11/12/source-based-code-coverage.html
[documentation]: https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/source-based-code-coverage.html