### PR TITLE
pigweed: Filter out example fuzzers in pw_fuzzer

### DIFF
--- a/projects/pigweed/extract_pw_fuzzers.py
+++ b/projects/pigweed/extract_pw_fuzzers.py
@@ -45,7 +45,7 @@ def main():
       continue
     fuzzer = test['test_name']
     objdir = test['test_directory']
-    module = os.path.basename(objdir)
+    module = os.path.basename(os.path.dirname(objdir))
     if module == 'pw_fuzzer':
       # Skip examples
       continue


### PR DESCRIPTION
Do not run example fuzzers in pw_fuzzer as those are for demonstration
purposes.

Test: run `python infra/helper.py build_fuzzers  pigweed` and observe
      pw_fuzzer/toy_fuzzer in pw_fuzzer is NOT copied to out directory.