### PR TITLE
[cifuzz][NFC] Refactor tests

### DIFF
--- a/infra/cifuzz/affected_fuzz_targets_test.py
+++ b/infra/cifuzz/affected_fuzz_targets_test.py
@@ -57,17 +57,19 @@ class RemoveUnaffectedFuzzTargets(unittest.TestCase):
   # yapf: enable
   def test_remove_unaffected_fuzz_targets(self, side_effect, expected_dir_len):
     """Tests that remove_unaffected_fuzzers has the intended effect."""
+    # We can't use fakefs in this test because this test executes
+    # utils.is_fuzz_target_local. This function relies on the executable bit
+    # being set, which doesn't work properly in fakefs.
     with tempfile.TemporaryDirectory() as tmp_dir, mock.patch(
-        'coverage._get_fuzzer_stats_dir_url', return_value=1):
-      with mock.patch(
-          'coverage.OssFuzzCoverageGetter.get_files_covered_by_target'
-      ) as mocked_get_files:
-        mocked_get_files.side_effect = side_effect
-        shutil.copy(self.TEST_FUZZER_1, tmp_dir)
-        shutil.copy(self.TEST_FUZZER_2, tmp_dir)
-        affected_fuzz_targets.remove_unaffected_fuzz_targets(
-            EXAMPLE_PROJECT, tmp_dir, [EXAMPLE_FILE_CHANGED], '')
-        self.assertEqual(expected_dir_len, len(os.listdir(tmp_dir)))
+        'coverage.OssFuzzCoverageGetter.get_files_covered_by_target'
+    ) as mocked_get_files, mock.patch('coverage._get_fuzzer_stats_dir_url',
+                                      return_value=1):
+      mocked_get_files.side_effect = side_effect
+      shutil.copy(self.TEST_FUZZER_1, tmp_dir)
+      shutil.copy(self.TEST_FUZZER_2, tmp_dir)
+      affected_fuzz_targets.remove_unaffected_fuzz_targets(
+          EXAMPLE_PROJECT, tmp_dir, [EXAMPLE_FILE_CHANGED], '')
+      self.assertEqual(expected_dir_len, len(os.listdir(tmp_dir)))
 
 
 if __name__ == '__main__':

--- a/infra/cifuzz/affected_fuzz_targets_test.py
+++ b/infra/cifuzz/affected_fuzz_targets_test.py
@@ -62,14 +62,14 @@ class RemoveUnaffectedFuzzTargets(unittest.TestCase):
     # being set, which doesn't work properly in fakefs.
     with tempfile.TemporaryDirectory() as tmp_dir, mock.patch(
         'coverage.OssFuzzCoverageGetter.get_files_covered_by_target'
-    ) as mocked_get_files, mock.patch('coverage._get_fuzzer_stats_dir_url',
-                                      return_value=1):
-      mocked_get_files.side_effect = side_effect
-      shutil.copy(self.TEST_FUZZER_1, tmp_dir)
-      shutil.copy(self.TEST_FUZZER_2, tmp_dir)
-      affected_fuzz_targets.remove_unaffected_fuzz_targets(
-          EXAMPLE_PROJECT, tmp_dir, [EXAMPLE_FILE_CHANGED], '')
-      self.assertEqual(expected_dir_len, len(os.listdir(tmp_dir)))
+    ) as mocked_get_files:
+      with mock.patch('coverage._get_fuzzer_stats_dir_url', return_value=1):
+        mocked_get_files.side_effect = side_effect
+        shutil.copy(self.TEST_FUZZER_1, tmp_dir)
+        shutil.copy(self.TEST_FUZZER_2, tmp_dir)
+        affected_fuzz_targets.remove_unaffected_fuzz_targets(
+            EXAMPLE_PROJECT, tmp_dir, [EXAMPLE_FILE_CHANGED], '')
+        self.assertEqual(expected_dir_len, len(os.listdir(tmp_dir)))
 
 
 if __name__ == '__main__':

--- a/infra/cifuzz/clusterfuzz_deployment_test.py
+++ b/infra/cifuzz/clusterfuzz_deployment_test.py
@@ -80,7 +80,6 @@ class OSSFuzzTest(fake_filesystem_unittest.TestCase):
     call_args, _ = mocked_download_and_unpack_zip.call_args
     self.assertEqual(call_args, (expected_url, expected_corpus_dir))
 
-
   @mock.patch('clusterfuzz_deployment.download_and_unpack_zip',
               return_value=False)
   def test_download_fail(self, _):

--- a/infra/cifuzz/clusterfuzz_deployment_test.py
+++ b/infra/cifuzz/clusterfuzz_deployment_test.py
@@ -64,13 +64,14 @@ class OSSFuzzTest(fake_filesystem_unittest.TestCase):
 
   def setUp(self):
     self.setUpPyfakefs()
+    self.deployment = _create_deployment()
 
   @mock.patch('clusterfuzz_deployment.download_and_unpack_zip',
-              return_value=False)
+              return_value=True)
   def test_download_corpus(self, mocked_download_and_unpack_zip):
     """Tests that we can download a corpus for a valid project."""
-    deployment = _create_deployment()
-    deployment.download_corpus(EXAMPLE_FUZZER, self.OUT_DIR)
+    result = self.deployment.download_corpus(EXAMPLE_FUZZER, self.OUT_DIR)
+    self.assertIsNotNone(result)
     expected_corpus_dir = os.path.join(self.OUT_DIR, 'cifuzz-corpus',
                                        EXAMPLE_FUZZER)
     expected_url = ('https://storage.googleapis.com/example-backup.'
@@ -79,27 +80,17 @@ class OSSFuzzTest(fake_filesystem_unittest.TestCase):
     call_args, _ = mocked_download_and_unpack_zip.call_args
     self.assertEqual(call_args, (expected_url, expected_corpus_dir))
 
+
   @mock.patch('clusterfuzz_deployment.download_and_unpack_zip',
               return_value=False)
   def test_download_fail(self, _):
     """Tests that when downloading fails, None is returned."""
-    deployment = _create_deployment()
-    corpus_path = deployment.download_corpus(EXAMPLE_FUZZER, self.OUT_DIR)
+    corpus_path = self.deployment.download_corpus(EXAMPLE_FUZZER, self.OUT_DIR)
     self.assertIsNone(corpus_path)
-
-  def test_download_latest_build(self):
-    """Tests that the build directory is downloaded once and no more."""
-    deployment = _create_deployment()
-    latest_name = deployment.get_latest_build_name()
-    with mock.patch('clusterfuzz_deployment.OSSFuzz.get_latest_build_name',
-                    return_value=latest_name):
-      latest_build_path = deployment.download_latest_build(self.OUT_DIR)
-      self.assertNotEqual(len(os.listdir(latest_build_path)), 0)
 
   def test_get_latest_build_name(self):
     """Tests that the latest build name can be retrieved from GCS."""
-    deployment = _create_deployment()
-    latest_build_name = deployment.get_latest_build_name()
+    latest_build_name = self.deployment.get_latest_build_name()
     self.assertTrue(latest_build_name.endswith('.zip'))
     self.assertTrue('address' in latest_build_name)
 

--- a/infra/cifuzz/coverage_test.py
+++ b/infra/cifuzz/coverage_test.py
@@ -80,11 +80,11 @@ class GetTargetCoverageReportTest(unittest.TestCase):
     self.assertIsNone(
         self.coverage_getter.get_target_coverage_report(INVALID_TARGET))
 
-  def test_invalid_project_json(self):
+  @mock.patch('coverage._get_latest_cov_report_info', return_value=None)
+  def test_invalid_project_json(self, _):
     """Tests an invalid project JSON results in None being returned."""
-    with mock.patch('coverage._get_latest_cov_report_info', return_value=None):
-      coverage_getter = coverage.OssFuzzCoverageGetter(PROJECT_NAME, REPO_PATH)
-      self.assertIsNone(coverage_getter.get_target_coverage_report(FUZZ_TARGET))
+    coverage_getter = coverage.OssFuzzCoverageGetter(PROJECT_NAME, REPO_PATH)
+    self.assertIsNone(coverage_getter.get_target_coverage_report(FUZZ_TARGET))
 
 
 class GetFilesCoveredByTargetTest(unittest.TestCase):

--- a/infra/cifuzz/fuzz_target_test.py
+++ b/infra/cifuzz/fuzz_target_test.py
@@ -217,9 +217,8 @@ class IsCrashReportableTest(fake_filesystem_unittest.TestCase):
     """Tests that a nonreportable crash causes the method to return False."""
     with mock.patch('fuzz_target.FuzzTarget.is_reproducible',
                     side_effect=is_reproducible_retvals):
-
       with mock.patch('clusterfuzz_deployment.OSSFuzz.download_latest_build',
-                      return_value=self.oss_fuzz_build_path):
+                 return_value=self.oss_fuzz_build_path):
         self.assertFalse(
             self.test_target.is_crash_reportable(self.testcase_path))
 

--- a/infra/cifuzz/fuzz_target_test.py
+++ b/infra/cifuzz/fuzz_target_test.py
@@ -187,16 +187,14 @@ class IsCrashReportableTest(fake_filesystem_unittest.TestCase):
     self.testcase_path = '/testcase'
     self.fs.create_file(self.testcase_path, contents='')
 
+  @mock.patch('fuzz_target.FuzzTarget.is_reproducible',
+              side_effect=[True, False])
   @mock.patch('logging.info')
-  def test_new_reproducible_crash(self, mocked_info):
+  def test_new_reproducible_crash(self, mocked_info, _):
     """Tests that a new reproducible crash returns True."""
-
-    with mock.patch('fuzz_target.FuzzTarget.is_reproducible',
-                    side_effect=[True, False]):
-      with tempfile.TemporaryDirectory() as tmp_dir:
-        self.test_target.out_dir = tmp_dir
-        self.assertTrue(self.test_target.is_crash_reportable(
-            self.testcase_path))
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      self.test_target.out_dir = tmp_dir
+      self.assertTrue(self.test_target.is_crash_reportable(self.testcase_path))
     mocked_info.assert_called_with(
         'The crash is reproducible. The crash doesn\'t reproduce '
         'on old builds. This code change probably introduced the '

--- a/infra/cifuzz/fuzz_target_test.py
+++ b/infra/cifuzz/fuzz_target_test.py
@@ -218,7 +218,7 @@ class IsCrashReportableTest(fake_filesystem_unittest.TestCase):
     with mock.patch('fuzz_target.FuzzTarget.is_reproducible',
                     side_effect=is_reproducible_retvals):
       with mock.patch('clusterfuzz_deployment.OSSFuzz.download_latest_build',
-                 return_value=self.oss_fuzz_build_path):
+                      return_value=self.oss_fuzz_build_path):
         self.assertFalse(
             self.test_target.is_crash_reportable(self.testcase_path))
 

--- a/infra/cifuzz/run_fuzzers_test.py
+++ b/infra/cifuzz/run_fuzzers_test.py
@@ -237,10 +237,11 @@ class CiFuzzTargetRunnerTest(fake_filesystem_unittest.TestCase):
   def setUp(self):
     self.setUpPyfakefs()
 
+  @mock.patch('utils.get_fuzz_targets')
   @mock.patch('run_fuzzers.CiFuzzTargetRunner.run_fuzz_target')
   @mock.patch('run_fuzzers.CiFuzzTargetRunner.create_fuzz_target_obj')
   def test_run_fuzz_targets_quits(self, mocked_create_fuzz_target_obj,
-                                  mocked_run_fuzz_target):
+                                  mocked_run_fuzz_target, mocked_get_fuzz_targets):
     """Tests that run_fuzz_targets quits on the first crash it finds."""
     workspace = 'workspace'
     out_path = os.path.join(workspace, 'out')
@@ -250,9 +251,8 @@ class CiFuzzTargetRunnerTest(fake_filesystem_unittest.TestCase):
                             project_name=EXAMPLE_PROJECT)
     runner = run_fuzzers.CiFuzzTargetRunner(config)
 
-    with mock.patch('utils.get_fuzz_targets') as mocked_get_fuzz_targets:
-      mocked_get_fuzz_targets.return_value = ['target1', 'target2']
-      runner.initialize()
+    mocked_get_fuzz_targets.return_value = ['target1', 'target2']
+    runner.initialize()
     testcase = os.path.join(workspace, 'testcase')
     self.fs.create_file(testcase)
     stacktrace = b'stacktrace'
@@ -271,10 +271,11 @@ class BatchFuzzTargetRunnerTest(fake_filesystem_unittest.TestCase):
   def setUp(self):
     self.setUpPyfakefs()
 
+  @mock.patch('utils.get_fuzz_targets')
   @mock.patch('run_fuzzers.BatchFuzzTargetRunner.run_fuzz_target')
   @mock.patch('run_fuzzers.BatchFuzzTargetRunner.create_fuzz_target_obj')
   def test_run_fuzz_targets_quits(self, mocked_create_fuzz_target_obj,
-                                  mocked_run_fuzz_target):
+                                  mocked_run_fuzz_target, mocked_get_fuzz_targets):
     """Tests that run_fuzz_targets quits on the first crash it finds."""
     workspace = 'workspace'
     out_path = os.path.join(workspace, 'out')
@@ -284,9 +285,8 @@ class BatchFuzzTargetRunnerTest(fake_filesystem_unittest.TestCase):
                             project_name=EXAMPLE_PROJECT)
     runner = run_fuzzers.BatchFuzzTargetRunner(config)
 
-    with mock.patch('utils.get_fuzz_targets') as mocked_get_fuzz_targets:
-      mocked_get_fuzz_targets.return_value = ['target1', 'target2']
-      runner.initialize()
+    mocked_get_fuzz_targets.return_value = ['target1', 'target2']
+    runner.initialize()
     testcase1 = os.path.join(workspace, 'testcase1')
     testcase2 = os.path.join(workspace, 'testcase2')
     self.fs.create_file(testcase1)

--- a/infra/cifuzz/run_fuzzers_test.py
+++ b/infra/cifuzz/run_fuzzers_test.py
@@ -241,7 +241,8 @@ class CiFuzzTargetRunnerTest(fake_filesystem_unittest.TestCase):
   @mock.patch('run_fuzzers.CiFuzzTargetRunner.run_fuzz_target')
   @mock.patch('run_fuzzers.CiFuzzTargetRunner.create_fuzz_target_obj')
   def test_run_fuzz_targets_quits(self, mocked_create_fuzz_target_obj,
-                                  mocked_run_fuzz_target, mocked_get_fuzz_targets):
+                                  mocked_run_fuzz_target,
+                                  mocked_get_fuzz_targets):
     """Tests that run_fuzz_targets quits on the first crash it finds."""
     workspace = 'workspace'
     out_path = os.path.join(workspace, 'out')
@@ -275,7 +276,8 @@ class BatchFuzzTargetRunnerTest(fake_filesystem_unittest.TestCase):
   @mock.patch('run_fuzzers.BatchFuzzTargetRunner.run_fuzz_target')
   @mock.patch('run_fuzzers.BatchFuzzTargetRunner.create_fuzz_target_obj')
   def test_run_fuzz_targets_quits(self, mocked_create_fuzz_target_obj,
-                                  mocked_run_fuzz_target, mocked_get_fuzz_targets):
+                                  mocked_run_fuzz_target,
+                                  mocked_get_fuzz_targets):
     """Tests that run_fuzz_targets quits on the first crash it finds."""
     workspace = 'workspace'
     out_path = os.path.join(workspace, 'out')

--- a/infra/cifuzz/run_fuzzers_test.py
+++ b/infra/cifuzz/run_fuzzers_test.py
@@ -342,25 +342,25 @@ class RunAddressFuzzersIntegrationTest(RunFuzzerIntegrationTestMixin,
 
   @unittest.skipIf(not os.getenv('INTEGRATION_TESTS'),
                    'INTEGRATION_TESTS=1 not set')
-  def test_old_bug_found(self):
+  @mock.patch('fuzz_target.FuzzTarget.is_reproducible',
+              side_effect=[True, True])
+  def test_old_bug_found(self, _):
     """Tests run_fuzzers with a bug found in OSS-Fuzz before."""
     config = _create_config(fuzz_seconds=FUZZ_SECONDS,
                             workspace=TEST_FILES_PATH,
                             project_name=EXAMPLE_PROJECT)
-    with mock.patch('fuzz_target.FuzzTarget.is_reproducible',
-                    side_effect=[True, True]):
-      with tempfile.TemporaryDirectory() as tmp_dir:
-        workspace = os.path.join(tmp_dir, 'workspace')
-        shutil.copytree(TEST_FILES_PATH, workspace)
-        config = _create_config(fuzz_seconds=FUZZ_SECONDS,
-                                workspace=TEST_FILES_PATH,
-                                project_name=EXAMPLE_PROJECT)
-        run_success, bug_found = run_fuzzers.run_fuzzers(config)
-        build_dir = os.path.join(TEST_FILES_PATH, 'out', self.BUILD_DIR_NAME)
-        self.assertTrue(os.path.exists(build_dir))
-        self.assertNotEqual(0, len(os.listdir(build_dir)))
-        self.assertTrue(run_success)
-        self.assertFalse(bug_found)
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      workspace = os.path.join(tmp_dir, 'workspace')
+      shutil.copytree(TEST_FILES_PATH, workspace)
+      config = _create_config(fuzz_seconds=FUZZ_SECONDS,
+                              workspace=TEST_FILES_PATH,
+                              project_name=EXAMPLE_PROJECT)
+      run_success, bug_found = run_fuzzers.run_fuzzers(config)
+      build_dir = os.path.join(TEST_FILES_PATH, 'out', self.BUILD_DIR_NAME)
+      self.assertTrue(os.path.exists(build_dir))
+      self.assertNotEqual(0, len(os.listdir(build_dir)))
+      self.assertTrue(run_success)
+      self.assertFalse(bug_found)
 
   def test_invalid_build(self):
     """Tests run_fuzzers with an invalid ASAN build."""


### PR DESCRIPTION
1. Use pyfakefs when possible instead of tempdir
2. Favor decorators instead of contextmanagers when mocking for less indentation and greater consistency.