### PR TITLE
[relic] Build relic with dynamic allocator

### DIFF
--- a/projects/relic/build.sh
+++ b/projects/relic/build.sh
@@ -33,7 +33,7 @@ export CXXFLAGS="$CXXFLAGS -D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR"
 cd $SRC/relic/
 mkdir build/
 cd build/
-cmake .. -DCOMP="$CFLAGS" -DQUIET=on -DRAND=CALL -DSHLIB=off -DSTBIN=off -DTESTS=0 -DBENCH=0
+cmake .. -DCOMP="$CFLAGS" -DQUIET=on -DRAND=CALL -DSHLIB=off -DSTBIN=off -DTESTS=0 -DBENCH=0 -DALLOC=DYNAMIC
 make -j$(nproc)
 cd ../..
 export RELIC_PATH=$(realpath relic)


### PR DESCRIPTION
Before this PR, relic was built to use stack allocations. Now that all bugs arising from that configuration have been found and fixed, we're activating dynamic allocations, which is expected to find more bugs, like memory leaks.