### PR TITLE
Improve test speed

### DIFF
--- a/.github/workflows/infra_tests.yml
+++ b/.github/workflows/infra_tests.yml
@@ -32,6 +32,6 @@ jobs:
           sudo env "PATH=$PATH" gcloud components install beta cloud-datastore-emulator
 
       - name: Run infra tests
-        run: sudo env "PATH=$PATH" INTEGRATION_TESTS=1 python infra/presubmit.py infra-tests
+        run: sudo env "PATH=$PATH" INTEGRATION_TESTS=1 python infra/presubmit.py infra-tests -p
 
 

--- a/infra/ci/build_test.py
+++ b/infra/ci/build_test.py
@@ -16,8 +16,13 @@
 """Tests for build.py"""
 
 import os
+import sys
 import unittest
 from unittest import mock
+
+# pylint: disable=wrong-import-position
+INFRA_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(INFRA_DIR)
 
 from ci import build
 

--- a/infra/ci/requirements.txt
+++ b/infra/ci/requirements.txt
@@ -2,7 +2,7 @@
 parameterized==0.7.4
 pyfakefs==4.1.0
 pylint==2.5.3
-PyYAML==5.3.1
-yapf==0.30.0
 pytest==6.2.1
 pytest-xdist==2.2.0
+PyYAML==5.3.1
+yapf==0.30.0

--- a/infra/ci/requirements.txt
+++ b/infra/ci/requirements.txt
@@ -4,3 +4,5 @@ pyfakefs==4.1.0
 pylint==2.5.3
 PyYAML==5.3.1
 yapf==0.30.0
+pytest==6.2.1
+pytest-xdist==2.2.0

--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -347,11 +347,9 @@ def run_build_tests():
                                      pattern='*_test.py'),
   ]
   suite = unittest.TestSuite(suite_list)
+  print('Running build tests.')
   result = unittest.TextTestRunner().run(suite)
-  success = not result.failures and not result.errors
-  if not success:
-    print('Build tests failed.')
-  return success
+  return result.failures and not result.errors
 
 
 def run_nonbuild_tests(parallel):
@@ -370,12 +368,14 @@ def run_nonbuild_tests(parallel):
   # pass directories to pytest.
   command = [
       'pytest',
+      # Test errors with error: "ModuleNotFoundError: No module named 'apt'.
       '--ignore-glob=infra/base-images/base-sanitizer-libs-builder/*',
       '--ignore-glob=infra/build/*',
   ]
   if parallel:
     command.extend(['-n', 'auto'])
   command += list(relevant_dirs)
+  print('Running non-build tests.')
   return subprocess.run(command, check=False).returncode == 0
 
 

--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -349,7 +349,7 @@ def run_build_tests():
   suite = unittest.TestSuite(suite_list)
   print('Running build tests.')
   result = unittest.TextTestRunner().run(suite)
-  return result.failures and not result.errors
+  return not result.failures and not result.errors
 
 
 def run_nonbuild_tests(parallel):

--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -368,13 +368,26 @@ def run_nonbuild_tests_parallel():
   """Run all tests but build tests in parallel. The reason why we exclude build
   tests is because they use an emulator that prevents them from being used in
   parallel."""
-  command = ['pytest', '--ignore=infra/build', '-n', 'auto']
+  relevant_dirs = set()
+  all_files = get_all_files()
+  for file_path in all_files:
+    directory = os.path.dirname(file_path)
+    if is_test_dir_blocklisted(directory):
+      continue
+    # if 'infra' not in file_path: continue
+    # if 'base-images' == directory:
+    #   continue
+    relevant_dirs.add(directory)
+  # TODO(fix ci import failure.)!!!
+  command = ['pytest', '--ignore=infra/base-images/base-sanitizer-libs-builder', '--ignore-glob=infra/build/*', '-n', 'auto'] + list(relevant_dirs)
+  print(command)
+
   return subprocess.run(command, check=False).returncode == 0
 
 def run_tests(_=None):
   """Runs all unit tests."""
   success = run_nonbuild_tests_parallel()
-  return success and run_build_tests()
+  return success # and run_build_tests()
 
 
 def get_all_files():

--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -354,8 +354,10 @@ def is_test_dir_blocklisted(directory):
 
 
 def run_build_tests():
-  suite_list = [unittest.TestLoader().discover('infra/build',
-                                               pattern='*_test.py')]
+  """Runs build tests because they can't be run in parallel."""
+  suite_list = [
+      unittest.TestLoader().discover('infra/build', pattern='*_test.py')
+  ]
   suite = unittest.TestSuite(suite_list)
   result = unittest.TextTestRunner().run(suite)
   success = not result.failures and not result.errors
@@ -374,20 +376,18 @@ def run_nonbuild_tests_parallel():
     directory = os.path.dirname(file_path)
     if is_test_dir_blocklisted(directory):
       continue
-    # if 'infra' not in file_path: continue
-    # if 'base-images' == directory:
-    #   continue
     relevant_dirs.add(directory)
-  # TODO(fix ci import failure.)!!!
-  command = ['pytest', '--ignore=infra/base-images/base-sanitizer-libs-builder', '--ignore-glob=infra/build/*', '-n', 'auto'] + list(relevant_dirs)
-  print(command)
-
+  command = [
+      'pytest', '--ignore=infra/base-images/base-sanitizer-libs-builder',
+      '--ignore-glob=infra/build/*', '-n', 'auto'
+  ] + list(relevant_dirs)
   return subprocess.run(command, check=False).returncode == 0
+
 
 def run_tests(_=None):
   """Runs all unit tests."""
   success = run_nonbuild_tests_parallel()
-  return success # and run_build_tests()
+  return success and run_build_tests()
 
 
 def get_all_files():

--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -369,7 +369,8 @@ def run_nonbuild_tests(parallel):
   # Use ignore-glob because ignore doesn't seem to work properly with the way we
   # pass directories to pytest.
   command = [
-      'pytest', '--ignore-glob=infra/base-images/base-sanitizer-libs-builder/*',
+      'pytest',
+      '--ignore-glob=infra/base-images/base-sanitizer-libs-builder/*',
       '--ignore-glob=infra/build/*',
   ]
   if parallel:

--- a/infra/pytest.ini
+++ b/infra/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_files = *_test.py


### PR DESCRIPTION
1. Allow running tests in parallel. Locally this takes the time for running all tests (including integration tests) from 6 minutes to ~50 seconds. We don't do parallel by default since it doesn't really save any time unless running integration tests on my machine (probably due to overhead of starting ~70 processes). This also speeds up CI from about 12 minutes to 6 minutes  (since github actions has 2 cores per machine).
2. Fix how we run tests. I'm not exactly sure why, but the method we used for discovering tests, recursing through every directory and passing to unittest caused the build/infra tests to execute twice. Fixing this makes running unittests take ~20 seconds instead of ~35.

This change also uses pytest for running tests since it's easy to use it to run tests in parallel.
This change was made possible by #5113