### PR TITLE
[cryptofuzz, bignum-fuzzer] Fix AFL++ builds

### DIFF
--- a/projects/bignum-fuzzer/Dockerfile
+++ b/projects/bignum-fuzzer/Dockerfile
@@ -16,11 +16,8 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y software-properties-common python-software-properties wget curl sudo mercurial autoconf bison texinfo libboost-all-dev cmake
-RUN add-apt-repository -y ppa:gophers/archive && apt-get update && apt-get install -y golang-1.9-go
-RUN ln -s /usr/lib/go-1.9/bin/go /usr/bin/go
 
 RUN wget https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.5.0.tar.gz
-RUN git clone --recursive https://github.com/golang/go
 RUN git clone --depth 1 https://github.com/guidovranken/bignum-fuzzer
 RUN git clone --depth 1 https://github.com/openssl/openssl
 RUN hg clone https://gmplib.org/repo/gmp/ libgmp/

--- a/projects/bignum-fuzzer/build.sh
+++ b/projects/bignum-fuzzer/build.sh
@@ -15,17 +15,6 @@
 #
 ################################################################################
 
-# Compile latest Go
-cd go/src
-CC=clang CFLAGS="" ./make.bash
-cd $SRC
-
-# Remove previous Go install (used for bootstrapping)
-apt-get remove golang-1.9-go -y
-rm /usr/bin/go
-
-export PATH=`realpath $SRC/go/bin`:$PATH
-
 # Install Rust nightly
 #curl https://sh.rustup.rs -sSf | sh -s -- -y
 #source $HOME/.cargo/env

--- a/projects/bignum-fuzzer/build.sh
+++ b/projects/bignum-fuzzer/build.sh
@@ -17,7 +17,7 @@
 
 # Compile latest Go
 cd go/src
-./make.bash
+CC=clang CFLAGS="" ./make.bash
 cd $SRC
 
 # Remove previous Go install (used for bootstrapping)

--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -23,10 +23,6 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y software-properties-common python-software-properties make autoconf automake libtool build-essential cmake mercurial gyp ninja-build zlib1g-dev libsqlite3-dev bison flex texinfo
 
-# BoringSSL needs Go to build
-RUN add-apt-repository -y ppa:gophers/archive && apt-get update && apt-get install -y golang-1.9-go
-RUN ln -s /usr/lib/go-1.9/bin/go /usr/bin/go
-
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora
 RUN git clone --depth 1 https://github.com/openssl/openssl
@@ -39,7 +35,6 @@ RUN git clone --depth 1 git://git.gnupg.org/libgcrypt.git
 RUN wget https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.36.tar.bz2
 RUN git clone --depth 1 -b oss-fuzz https://github.com/project-everest/hacl-star evercrypt
 RUN git clone --depth 1 https://github.com/google/cityhash.git
-RUN git clone --depth 1 https://github.com/golang/go
 RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone --depth 1 https://github.com/wolfSSL/wolfssl.git
 RUN git clone --depth 1 https://github.com/ARMmbed/mbedtls.git

--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -26,7 +26,6 @@ RUN apt-get update && \
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora
 RUN git clone --depth 1 https://github.com/openssl/openssl
-
 RUN git clone --depth 1 https://boringssl.googlesource.com/boringssl
 RUN git clone --depth 1 https://github.com/libressl-portable/portable libressl
 RUN cd $SRC/libressl && ./update.sh

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -48,7 +48,7 @@ fi
 
 export GO111MODULE=off
 cd $SRC/go/src
-./make.bash
+CC=clang CFLAGS="" ./make.bash
 export GOROOT=$(realpath $SRC/go)
 export GOPATH=$GOROOT/packages
 mkdir $GOPATH

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -40,24 +40,6 @@ export INCLUDE_PATH_FLAGS=""
 cd $SRC/cryptofuzz
 python gen_repository.py
 
-if [[ $CFLAGS = *-m32* ]]
-then
-    export GOARCH=386
-    export CGO_ENABLED=1
-fi
-
-export GO111MODULE=off
-cd $SRC/go/src
-CC=clang CFLAGS="" ./make.bash
-export GOROOT=$(realpath $SRC/go)
-export GOPATH=$GOROOT/packages
-mkdir $GOPATH
-export PATH=$GOROOT/bin:$PATH
-export PATH=$GOROOT/packages/bin:$PATH
-
-apt-get remove golang-1.9-go -y
-rm /usr/bin/go
-
 go get golang.org/x/crypto/blake2b
 go get golang.org/x/crypto/blake2s
 go get golang.org/x/crypto/md4


### PR DESCRIPTION
Build Golang with regular clang.

For instrumentation it doesn't matter because this is the Golang compiler, which isn't part of the output binaries.