### PR TITLE
afl++ CMPLOG test

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -152,7 +152,7 @@ WORKDIR $SRC
 # TODO: switch to -b stable once we can.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git aflplusplus && \
     cd aflplusplus && \
-    git checkout a763c61d89f90330bcde7c294c57cfccda1431b8
+    git checkout aeb7d7048371cd91ab9280c3958f1c35e5d5e758
 
 RUN cd $SRC && \
     curl -L -O https://github.com/google/honggfuzz/archive/oss-fuzz.tar.gz && \

--- a/infra/base-images/base-runner/run_fuzzer
+++ b/infra/base-images/base-runner/run_fuzzer
@@ -106,6 +106,11 @@ if [[ "$FUZZING_ENGINE" = afl ]]; then
   export AFL_NO_AFFINITY=1
   export AFL_FAST_CAL=1
   export AFL_MAP_SIZE=4194304
+  # If $OUT/afl_cmplog.txt is present this means the target was compiled for
+  # CMPLOG. So we have to add the proper parameters to afl-fuzz. `-l 2` is
+  # CMPLOG level 2, which will colorize larger files but not huge files and
+  # not enable transform analysis unless there have been several cycles without
+  # any finds.
   test -e $OUT/afl_cmplog.txt && AFL_FUZZER_ARGS="$AFL_FUZZER_ARGS -l 2 -c $OUT/$FUZZER"
   # AFL expects at least 1 file in the input dir.
   echo input > ${CORPUS_DIR}/input

--- a/infra/base-images/base-runner/run_fuzzer
+++ b/infra/base-images/base-runner/run_fuzzer
@@ -106,9 +106,10 @@ if [[ "$FUZZING_ENGINE" = afl ]]; then
   export AFL_NO_AFFINITY=1
   export AFL_FAST_CAL=1
   export AFL_MAP_SIZE=4194304
+  test -e $OUT/afl_cmplog.txt && AFL_FUZZER_ARGS="$AFL_FUZZER_ARGS -l 2 -c $OUT/$FUZZER"
   # AFL expects at least 1 file in the input dir.
   echo input > ${CORPUS_DIR}/input
-  CMD_LINE="$OUT/afl-fuzz $AFL_FUZZER_ARGS -i $CORPUS_DIR -o $FUZZER_OUT $(get_dictionary) $* $OUT/$FUZZER"
+  CMD_LINE="$OUT/afl-fuzz $AFL_FUZZER_ARGS -i $CORPUS_DIR -o $FUZZER_OUT $(get_dictionary) $* -- $OUT/$FUZZER"
 
 elif [[ "$FUZZING_ENGINE" = honggfuzz ]]; then
 

--- a/projects/libavif/build.sh
+++ b/projects/libavif/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 # afl++ CMPLOG test:
-test -n "$AFL_MAP_SIZE" && {
+test "$FUZZING_ENGINE" = "afl" && {
   export AFL_LLVM_CMPLOG=1
   touch $OUT/afl_cmplog.txt
 }

--- a/projects/libavif/build.sh
+++ b/projects/libavif/build.sh
@@ -15,6 +15,12 @@
 #
 ################################################################################
 
+# afl++ CMPLOG test:
+test -n "$AFL_MAP_SIZE" && {
+  export AFL_LLVM_CMPLOG=1
+  touch $OUT/afl_cmplog.txt
+}
+
 # build dav1d
 cd ext && bash dav1d.cmd && cd ..
 

--- a/projects/libcacard/build.sh
+++ b/projects/libcacard/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 # afl++ CMPLOG test:
-test -n "$AFL_MAP_SIZE" && {
+test "$FUZZING_ENGINE" = "afl" && {
   export AFL_LLVM_CMPLOG=1
   touch $OUT/afl_cmplog.txt
 }

--- a/projects/libcacard/build.sh
+++ b/projects/libcacard/build.sh
@@ -15,6 +15,12 @@
 #
 ################################################################################
 
+# afl++ CMPLOG test:
+test -n "$AFL_MAP_SIZE" && {
+  export AFL_LLVM_CMPLOG=1
+  touch $OUT/afl_cmplog.txt
+}
+
 # Workaround for fixing AFL++ build, discarded for others.
 # See https://github.com/google/oss-fuzz/issues/4280#issuecomment-773977943
 export AFL_LLVM_INSTRUMENT=CLASSIC,NGRAM-4

--- a/projects/libxml2/build.sh
+++ b/projects/libxml2/build.sh
@@ -16,6 +16,12 @@
 #
 ################################################################################
 
+# afl++ CMPLOG test:
+test -n "$AFL_MAP_SIZE" && {
+  export AFL_LLVM_CMPLOG=1
+  touch $OUT/afl_cmplog.txt
+}
+
 if [ "$SANITIZER" = undefined ]; then
     export CFLAGS="$CFLAGS -fsanitize=unsigned-integer-overflow -fno-sanitize-recover=unsigned-integer-overflow"
     export CXXFLAGS="$CXXFLAGS -fsanitize=unsigned-integer-overflow -fno-sanitize-recover=unsigned-integer-overflow"

--- a/projects/libxml2/build.sh
+++ b/projects/libxml2/build.sh
@@ -17,7 +17,7 @@
 ################################################################################
 
 # afl++ CMPLOG test:
-test -n "$AFL_MAP_SIZE" && {
+test "$FUZZING_ENGINE" = "afl" && {
   export AFL_LLVM_CMPLOG=1
   touch $OUT/afl_cmplog.txt
 }

--- a/projects/openssl/build.sh
+++ b/projects/openssl/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 # afl++ CMPLOG test:
-test -n "$AFL_MAP_SIZE" && {
+test "$FUZZING_ENGINE" = "afl" && {
   export AFL_LLVM_CMPLOG=1
   touch $OUT/afl_cmplog.txt
 }

--- a/projects/openssl/build.sh
+++ b/projects/openssl/build.sh
@@ -15,6 +15,12 @@
 #
 ################################################################################
 
+# afl++ CMPLOG test:
+test -n "$AFL_MAP_SIZE" && {
+  export AFL_LLVM_CMPLOG=1
+  touch $OUT/afl_cmplog.txt
+}
+
 CONFIGURE_FLAGS=""
 if [[ $CFLAGS = *sanitize=memory* ]]
 then

--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 # afl++ CMPLOG test:
-test -n "$AFL_MAP_SIZE" && {
+test "$FUZZING_ENGINE" = "afl" && {
   export AFL_LLVM_CMPLOG=1
   touch $OUT/afl_cmplog.txt
 }

--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -15,6 +15,12 @@
 #
 ################################################################################
 
+# afl++ CMPLOG test:
+test -n "$AFL_MAP_SIZE" && {
+  export AFL_LLVM_CMPLOG=1
+  touch $OUT/afl_cmplog.txt
+}
+
 # Build SwiftShader
 pushd third_party/externals/swiftshader/
 export SWIFTSHADER_INCLUDE_PATH=$PWD/include

--- a/projects/wireshark/build.sh
+++ b/projects/wireshark/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 # afl++ CMPLOG test:
-test -n "$AFL_MAP_SIZE" && {
+test "$FUZZING_ENGINE" = "afl" && {
   export AFL_LLVM_CMPLOG=1
   touch $OUT/afl_cmplog.txt
 }

--- a/projects/wireshark/build.sh
+++ b/projects/wireshark/build.sh
@@ -15,6 +15,12 @@
 #
 ################################################################################
 
+# afl++ CMPLOG test:
+test -n "$AFL_MAP_SIZE" && {
+  export AFL_LLVM_CMPLOG=1
+  touch $OUT/afl_cmplog.txt
+}
+
 WIRESHARK_BUILD_PATH="$WORK/build"
 mkdir -p "$WIRESHARK_BUILD_PATH"
 


### PR DESCRIPTION
Selected targets: livavif, libcacard, libxml2, openssl, skia and wireshark
Tested: libcacard and skia.
I do not expect any issues as this has been running fine with all 33 fuzzbench targets.

I wanted to test the running as well as I modified the run_fuzzer but couldn't figure out how ;-)
```
# python infra/helper.py build_fuzzers libcacard --engine afl
[...]
#  python infra/helper.py run_fuzzer libcacard afl                 
afl does not seem to exist. Please run build_fuzzers first.
# python infra/helper.py run_fuzzer --engine afl libcacard afl
afl does not seem to exist. Please run build_fuzzers first.
# python infra/helper.py run_fuzzer --engine afl libcacard    
usage: helper.py run_fuzzer [-h]
                            [--engine {libfuzzer,afl,honggfuzz,dataflow,none}]
                            [--sanitizer {address,memory,undefined,coverage,dataflow}]
                            [-e E] [--corpus-dir CORPUS_DIR]
                            project_name fuzzer_name ...
helper.py run_fuzzer: error: the following arguments are required: fuzzer_name, fuzzer_args
```
