### PR TITLE
pigweed: Fix build failure

### DIFF
--- a/projects/pigweed/build.sh
+++ b/projects/pigweed/build.sh
@@ -37,7 +37,6 @@ python $SRC/filter_cipd.py \
       infra/cmake \
       fuchsia/third_party/bazel \
       pigweed/third_party/bloaty-embedded \
-      pigweed/third_party/gcc-arm-none-eabi \
       fuchsia/third_party/clang \
       infra/go \
       pigweed/third_party/protoc-gen-go \


### PR DESCRIPTION
Pigweed python env setup now uses the "arm-none-eabi-gcc" toolchain
to derive some flags for the newly added clang for ARM toolchain.

Bug: https://crbug.com/oss-fuzz/30513