### PR TITLE
fwupd: Include fuzz targets

### DIFF
--- a/projects/fwupd/Dockerfile
+++ b/projects/fwupd/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update
+RUN apt-get install -y pkg-config zlib1g-dev libffi-dev
+RUN pip3 install -U meson ninja
+RUN git clone --depth 1 https://github.com/fwupd/fwupd.git fwupd
+WORKDIR .
+COPY build.sh $SRC/

--- a/projects/fwupd/build.sh
+++ b/projects/fwupd/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+python3 fwupd/contrib/ci/oss-fuzz.py

--- a/projects/fwupd/project.yaml
+++ b/projects/fwupd/project.yaml
@@ -2,3 +2,7 @@ homepage: "https://github.com/fwupd/fwupd"
 language: c
 primary_contact: "hughsient@gmail.com"
 main_repo: 'https://github.com/fwupd/fwupd'
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
INFO: performing bad build checks for /tmp/not-out/wac_fuzzer
INFO: performing bad build checks for /tmp/not-out/synaptics-rmi_fuzzer
INFO: performing bad build checks for /tmp/not-out/dfuse_fuzzer
INFO: performing bad build checks for /tmp/not-out/bcm57xx_fuzzer
INFO: performing bad build checks for /tmp/not-out/ihex_fuzzer
INFO: performing bad build checks for /tmp/not-out/fmap_fuzzer
INFO: performing bad build checks for /tmp/not-out/cros-ec_fuzzer
INFO: performing bad build checks for /tmp/not-out/solokey_fuzzer
INFO: performing bad build checks for /tmp/not-out/srec_fuzzer
INFO: performing bad build checks for /tmp/not-out/ebitdo_fuzzer
INFO: performing bad build checks for /tmp/not-out/synaprom_fuzzer
Check build passed.