### PR TITLE
"#/bin/bash" is just a comment; change "#/" to "#!/"

### DIFF
--- a/projects/dragonfly/build.sh
+++ b/projects/dragonfly/build.sh
@@ -1,4 +1,4 @@
-#/bin/bash -eu
+#!/bin/bash -eu
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/projects/gitea/build.sh
+++ b/projects/gitea/build.sh
@@ -1,4 +1,4 @@
-#/bin/bash -eu
+#!/bin/bash -eu
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/projects/go-redis/build.sh
+++ b/projects/go-redis/build.sh
@@ -1,4 +1,4 @@
-#/bin/bash -eu
+#!/bin/bash -eu
 # Copyright 2021 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/projects/grpc-gateway/build.sh
+++ b/projects/grpc-gateway/build.sh
@@ -1,4 +1,4 @@
-#/bin/bash -eu
+#!/bin/bash -eu
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/projects/hugo/build.sh
+++ b/projects/hugo/build.sh
@@ -1,4 +1,4 @@
-#/bin/bash -eu
+#!/bin/bash -eu
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/projects/istio/build.sh
+++ b/projects/istio/build.sh
@@ -1,4 +1,4 @@
-#/bin/bash -eu
+#!/bin/bash -eu
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/projects/loki/build.sh
+++ b/projects/loki/build.sh
@@ -1,4 +1,4 @@
-#/bin/bash -eu
+#!/bin/bash -eu
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/projects/lotus/build.sh
+++ b/projects/lotus/build.sh
@@ -1,4 +1,4 @@
-#/bin/bash -eu
+#!/bin/bash -eu
 # Copyright 2021 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/projects/nats/build.sh
+++ b/projects/nats/build.sh
@@ -1,4 +1,4 @@
-#/bin/bash -eu
+#!/bin/bash -eu
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/projects/prometheus/build.sh
+++ b/projects/prometheus/build.sh
@@ -1,4 +1,4 @@
-#/bin/bash -eu
+#!/bin/bash -eu
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/projects/radon/build.sh
+++ b/projects/radon/build.sh
@@ -1,4 +1,4 @@
-#/bin/bash -eu
+#!/bin/bash -eu
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/projects/teleport/build.sh
+++ b/projects/teleport/build.sh
@@ -1,4 +1,4 @@
-#/bin/bash -eu
+#!/bin/bash -eu
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/projects/tidb/build.sh
+++ b/projects/tidb/build.sh
@@ -1,4 +1,4 @@
-#/bin/bash -eu
+#!/bin/bash -eu
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/projects/vitess/build.sh
+++ b/projects/vitess/build.sh
@@ -1,4 +1,4 @@
-#/bin/bash -eu
+#!/bin/bash -eu
 # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Using "#/bin/bash" instead of "#!/bin/bash" only seems to work because the file is often treated as a script by default when there is no "#!" on the top line. The "-eu" options to Bash are ignored, however, and on some systems and OS configurations the files might not default to being executed as scripts.