### PR TITLE
Fix Prometheus dependencies fetch

### DIFF
--- a/projects/prometheus/Dockerfile
+++ b/projects/prometheus/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN go get github.com/prometheus/prometheus/cmd/...
+RUN go get github.com/prometheus/prometheus/...
 COPY build.sh $SRC/
 RUN mkdir $SRC/prometheus/
 WORKDIR $SRC/prometheus/


### PR DESCRIPTION
This commits fixes the way we fetch prometheus dependencies. Without
this, we would need to keep a `vendor` directory inside our Prometheus
git tree.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>