### PR TITLE
bad_build_check: also look for call on x86_64

### DIFF
--- a/infra/base-images/base-runner/bad_build_check
+++ b/infra/base-images/base-runner/bad_build_check
@@ -312,7 +312,7 @@ function check_mixed_sanitizers {
   else
     case $(uname -m) in
       x86_64)
-        CALL_INSN="callq\s+[0-9a-f]+\s+<"
+        CALL_INSN="callq?\s+[0-9a-f]+\s+<"
         ;;
       aarch64)
         CALL_INSN="bl\s+[0-9a-f]+\s+<"


### PR DESCRIPTION
It should make the script compatible with binutils-2.36.1 (where
"callq" is no longer present in the output of objdump)

It was spotted in https://github.com/systemd/systemd/pull/18528