### PR TITLE
[infra] Remove unneeded binaries, docs from CMake install

### DIFF
--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y wget sudo && \
     ./cmake-$CMAKE_VERSION-Linux-x86_64.sh --skip-license --prefix="/usr/local" && \
     rm cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
     SUDO_FORCE_REMOVE=yes apt-get remove --purge -y wget sudo && \
-    rm -rf /usr/local/doc/cmake /usr/local/bin/cmake-gui /usr/local/bin/cmake
+    rm -rf /usr/local/doc/cmake /usr/local/bin/cmake-gui
 
 COPY checkout_build_install_llvm.sh /root/
 # Keep all steps in the same script to decrease the number of intermediate

--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -25,7 +25,8 @@ RUN apt-get update && apt-get install -y wget sudo && \
     chmod +x cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
     ./cmake-$CMAKE_VERSION-Linux-x86_64.sh --skip-license --prefix="/usr/local" && \
     rm cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
-    SUDO_FORCE_REMOVE=yes apt-get remove --purge -y wget sudo
+    SUDO_FORCE_REMOVE=yes apt-get remove --purge -y wget sudo && \
+    rm -rf /usr/local/doc/cmake /usr/local/bin/cmake-gui /usr/local/bin/cmake
 
 COPY checkout_build_install_llvm.sh /root/
 # Keep all steps in the same script to decrease the number of intermediate


### PR DESCRIPTION
This should reduce the image layer size from 127 MB to 57 MB