### PR TITLE
[jazzer-1] Add Jazzer to base-builder and base-runner

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -96,6 +96,31 @@ ENV BAZELISK_VERSION 1.7.4
 RUN curl -L https://github.com/bazelbuild/bazelisk/releases/download/v$BAZELISK_VERSION/bazelisk-linux-amd64 -o /usr/local/bin/bazel && \
     chmod +x /usr/local/bin/bazel
 
+# Install OpenJDK 15 and trim its size by removing unused components.
+ENV JAVA_HOME=/usr/lib/jvm/java-15-openjdk-amd64
+ENV JVM_LD_LIBRARY_PATH=$JAVA_HOME/lib/server
+ENV PATH=$PATH:$JAVA_HOME/bin
+RUN cd /tmp && \
+    curl -L -O https://download.java.net/java/GA/jdk15.0.2/0d1cfde4252546c6931946de8db48ee2/7/GPL/openjdk-15.0.2_linux-x64_bin.tar.gz && \
+    mkdir -p $JAVA_HOME && \
+    tar -xzv --strip-components=1 -f openjdk-15.0.2_linux-x64_bin.tar.gz --directory $JAVA_HOME && \
+    rm -f openjdk-15.0.2_linux-x64_bin.tar.gz && \
+    rm -rf $JAVA_HOME/jmods $JAVA_HOME/lib/src.zip
+
+# Install the latest Jazzer in $OUT.
+# jazzer_api_deploy.jar is required only at build-time, the agent and the
+# drivers are copied to $OUT as they need to be present on the runners.
+ENV JAZZER_API_PATH "/usr/local/lib/jazzer_api_deploy.jar"
+RUN cd $SRC/ && \
+    git clone --depth=1 https://github.com/CodeIntelligenceTesting/jazzer && \
+    cd jazzer && \
+    bazel build --java_runtime_version=localjdk_15 -c opt --cxxopt="-stdlib=libc++" --linkopt=-lc++ \
+        //agent:jazzer_agent_deploy.jar //driver:jazzer_driver //driver:jazzer_driver_asan //agent:jazzer_api_deploy.jar && \
+    cp bazel-bin/agent/jazzer_agent_deploy.jar bazel-bin/driver/jazzer_driver bazel-bin/driver/jazzer_driver_asan /usr/local/bin/ && \
+    cp bazel-bin/agent/jazzer_api_deploy.jar $JAZZER_API_PATH && \
+    rm -rf ~/.cache/bazel ~/.cache/bazelisk && \
+    rm -rf $SRC/jazzer
+
 # Default build flags for various sanitizers.
 ENV SANITIZER_FLAGS_address "-fsanitize=address -fsanitize-address-use-after-scope"
 

--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -113,6 +113,11 @@ fi
 # Copy latest llvm-symbolizer in $OUT for stack symbolization.
 cp $(which llvm-symbolizer) $OUT/
 
+# Copy Jazzer to $OUT if needed.
+if [ "$FUZZING_LANGUAGE" = "jvm" ]; then
+  cp $(which jazzer_agent_deploy.jar) $(which jazzer_driver) $(which jazzer_driver_asan) $OUT/
+fi
+
 echo "---------------------------------------------------------------"
 echo "CC=$CC"
 echo "CXX=$CXX"

--- a/infra/base-images/base-runner/Dockerfile
+++ b/infra/base-images/base-runner/Dockerfile
@@ -68,6 +68,17 @@ ENV PATH $PATH:/root/.go/bin:$GOPATH/bin
 # Set up Golang coverage modules.
 RUN go get github.com/google/oss-fuzz/infra/go/coverage/...
 
+# Install OpenJDK 15 and trim its size by removing unused components.
+ENV JAVA_HOME=/usr/lib/jvm/java-15-openjdk-amd64
+ENV JVM_LD_LIBRARY_PATH=$JAVA_HOME/lib/server
+ENV PATH=$PATH:$JAVA_HOME/bin
+ADD https://download.java.net/java/GA/jdk15.0.2/0d1cfde4252546c6931946de8db48ee2/7/GPL/openjdk-15.0.2_linux-x64_bin.tar.gz /tmp
+RUN cd /tmp && \
+    mkdir -p $JAVA_HOME && \
+    tar -xzv --strip-components=1 -f openjdk-15.0.2_linux-x64_bin.tar.gz --directory $JAVA_HOME && \
+    rm -f openjdk-15.0.2_linux-x64_bin.tar.gz && \
+    rm -rf $JAVA_HOME/jmods $JAVA_HOME/lib/src.zip
+
 # Do this last to make developing these files easier/faster due to caching.
 COPY bad_build_check \
     collect_dft \


### PR DESCRIPTION
Jazzer is built from HEAD using Bazel and the clang toolchain provided by base-clang. While it could be built with OpenJDK 8, which is available as a package, JVM fuzz targets should not be forced to be compatible with Java 8. For this reason, the official binary release of OpenJDK 15 is pulled into both base-builder and base-runner and set as JAVA_HOME.

Jazzer consists of the following four components:

* The API (`jazzer_api_deploy.jar`), which is required for fuzz targets that use FuzzedDataProvider or custom method hooks, is made available in /usr/local/lib in base-builder.
* The driver (`jazzer_driver`), which links in libFuzzer and is reused across fuzz targets. Since it is used to run fuzz targets, it is included into base-runner.
* The agent (`jazzer_agent_deploy.jar`), which bundles the runtime instrumentation agent with the Jazzer API. It is loaded by the driver and thus also included into base-runner.
* The wrapper script (`jazzer`), which runs the driver with LD_PRELOAD set so that it picks up the native libraries of the local JDK in JAVA_HOME. It is also included in base-runner.

The changes to the infra scripts required by JVM fuzz targets will be submitted as a separate PR.