### PR TITLE
[jazzer-2] Adapt infra scripting to JVM fuzz targets

### DIFF
--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -22,6 +22,21 @@ if [ "$SANITIZER" = "dataflow" ] && [ "$FUZZING_ENGINE" != "dataflow" ]; then
   exit 1
 fi
 
+if [ "$FUZZING_LANGUAGE" = "jvm" ]; then
+  if [ "$FUZZING_ENGINE" != "libfuzzer" ]; then
+    echo "ERROR: JVM projects can be fuzzed with libFuzzer engine only."
+    exit 1
+  fi
+  if [ "$SANITIZER" != "address" ]; then
+    echo "ERROR: JVM projects can be fuzzed with AddressSanitizer only."
+    exit 1
+  fi
+  if [ "$ARCHITECTURE" != "x86_64" ]; then
+    echo "ERROR: JVM projects can be fuzzed on x86_64 architecture only."
+    exit 1
+  fi
+fi
+
 if [ "$FUZZING_LANGUAGE" = "python" ]; then
   if [ "$FUZZING_ENGINE" != "libfuzzer" ]; then
     echo "ERROR: Python projects can be fuzzed with libFuzzer engine only."
@@ -46,7 +61,8 @@ if [[ $ARCHITECTURE == "i386" ]]; then
     export CFLAGS="-m32 $CFLAGS"
     cp -R /usr/i386/lib/* /usr/lib
 fi
-if [[ $FUZZING_ENGINE != "none" ]]; then
+# JVM projects are fuzzed with Jazzer, which has libFuzzer built in.
+if [[ $FUZZING_ENGINE != "none" ]] && [[ $FUZZING_LANGUAGE != "jvm" ]]; then
   # compile script might override environment, use . to call it.
   . compile_${FUZZING_ENGINE}
 fi

--- a/infra/base-images/base-runner/bad_build_check
+++ b/infra/base-images/base-runner/bad_build_check
@@ -301,6 +301,12 @@ function check_mixed_sanitizers {
   local result=0
   local CALL_INSN=
 
+  if [ "${FUZZING_LANGUAGE:-}" = "jvm" ]; then
+    # Sanitizer runtime is linked into the Jazzer driver, so this check does not
+    # apply.
+    return 0
+  fi
+
   if [ "${FUZZING_LANGUAGE:-}" = "python" ]; then
     # Sanitizer runtime is loaded via LD_PRELOAD, so this check does not apply.
     return 0
@@ -375,6 +381,12 @@ function check_seed_corpus {
 function check_architecture {
   local FUZZER=$1
   local FUZZER_NAME=$(basename $FUZZER)
+
+  if [ "${FUZZING_LANGUAGE:-}" = "jvm" ]; then
+    # The native dependencies of a JVM project are not packaged, but loaded
+    # dynamically at runtime and thus cannot be checked here.
+    return 0;
+  fi
 
   if [ "${FUZZING_LANGUAGE:-}" = "python" ]; then
     FUZZER=${FUZZER}.pkg

--- a/infra/base-images/base-runner/test_all.py
+++ b/infra/base-images/base-runner/test_all.py
@@ -78,11 +78,16 @@ def find_fuzz_targets(directory, fuzzing_language):
       continue
     if filename.startswith('afl-'):
       continue
+    if filename.startswith('jazzer_'):
+      continue
     if not os.path.isfile(path):
       continue
     if not os.stat(path).st_mode & EXECUTABLE:
       continue
-    if fuzzing_language != 'python' and not is_elf(path):
+    # Fuzz targets are expected to be ELF binaries for languages other than
+    # Python and Java.
+    if (fuzzing_language != 'python' and fuzzing_language != 'jvm' and
+        not is_elf(path)):
       continue
     if os.getenv('FUZZING_ENGINE') != 'none':
       with open(path, 'rb') as file_handle:

--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -104,6 +104,7 @@ class ProjectYamlChecker:
       'c',
       'c++',
       'go',
+      'jvm',
       'python',
       'rust',
   ]


### PR DESCRIPTION
compile, bad_build_check, and presubmit.py require small tweaks to
support JVM fuzz targets, most of which are similar to those required
for Python. The following additional changes are required:

* Since the Jazzer driver binary already links in libFuzzer, it should
  not be built as a static library.
* It is not clear how to do architecture checks as JVM fuzz targets can
  load their native dependencies dynamically at runtime. For now, the
  check is disabled.