### PR TITLE
[presubmit] Make sure to run build tests even if nonbuild tests fail

### DIFF
--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -381,8 +381,9 @@ def run_nonbuild_tests(parallel):
 
 def run_tests(_=None, parallel=False):
   """Runs all unit tests."""
-  success = run_nonbuild_tests(parallel)
-  return success and run_build_tests()
+  nonbuild_success = run_nonbuild_tests(parallel)
+  build_success = run_build_tests()
+  return nonbuild_success and build_success
 
 
 def get_all_files():


### PR DESCRIPTION
Previously "and" shortcircuiting caused the build tests not to be
run if the non-build tests (which are run first) failed.