### PR TITLE
Update contact address for libsodium

### DIFF
--- a/projects/libsodium/project.yaml
+++ b/projects/libsodium/project.yaml
@@ -1,6 +1,6 @@
 homepage: "https://libsodium.org"
 language: c++
-primary_contact: "ossfuzzz+sodium@gmail.com"
+primary_contact: "ossfuzzz@gmail.com"
 auto_ccs:
  - "chriswwolfe@gmail.com"
 architectures:


### PR DESCRIPTION
Access to oss-fuzz requires an exact match, so remove the suffix from the address.

Fixes #5158