### PR TITLE
[jazzer-3] Add json-sanitizer as the first JVM project

### DIFF
--- a/projects/json-sanitizer/DenylistFuzzer.java
+++ b/projects/json-sanitizer/DenylistFuzzer.java
@@ -1,0 +1,41 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+import com.google.json.JsonSanitizer;
+
+public class DenylistFuzzer {
+  public static boolean fuzzerTestOneInput(FuzzedDataProvider data) {
+    String input = data.consumeRemainingAsString();
+    String output;
+    try {
+      output = JsonSanitizer.sanitize(input, 10);
+    } catch (ArrayIndexOutOfBoundsException e) {
+      // ArrayIndexOutOfBoundsException is expected if nesting depth is
+      // exceeded.
+      return false;
+    }
+    // See https://github.com/OWASP/json-sanitizer#output.
+    if (output.contains("</script") || output.contains("<script")
+        || output.contains("<!--") || output.contains("]]>")) {
+      System.err.println("input : " + input);
+      System.err.println("output: " + output);
+      return true;
+    }
+    return false;
+  }
+}

--- a/projects/json-sanitizer/Dockerfile
+++ b/projects/json-sanitizer/Dockerfile
@@ -1,0 +1,40 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN apt-get update && apt-get install -y maven
+
+RUN git clone --depth 1 https://github.com/google/fuzzing
+RUN cat fuzzing/dictionaries/json.dict \
+        fuzzing/dictionaries/html.dict \
+        fuzzing/dictionaries/xml.dict \
+      > $OUT/DenylistFuzzer.dict
+RUN cat fuzzing/dictionaries/json.dict \
+        fuzzing/dictionaries/html.dict \
+        fuzzing/dictionaries/xml.dict \
+      > $OUT/IdempotenceFuzzer.dict
+RUN cat fuzzing/dictionaries/json.dict \
+        fuzzing/dictionaries/html.dict \
+        fuzzing/dictionaries/xml.dict \
+      > $OUT/ValidJsonFuzzer.dict
+
+RUN git clone --depth 1 https://github.com/OWASP/json-sanitizer
+COPY build.sh $SRC/
+
+COPY DenylistFuzzer.java IdempotenceFuzzer.java ValidJsonFuzzer.java $SRC/
+
+WORKDIR $SRC/json-sanitizer

--- a/projects/json-sanitizer/IdempotenceFuzzer.java
+++ b/projects/json-sanitizer/IdempotenceFuzzer.java
@@ -1,0 +1,41 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+import com.google.json.JsonSanitizer;
+
+public class IdempotenceFuzzer {
+  public static boolean fuzzerTestOneInput(FuzzedDataProvider data) {
+    String input = data.consumeRemainingAsString();
+    String output1;
+    try {
+      output1 = JsonSanitizer.sanitize(input, 10);
+    } catch (ArrayIndexOutOfBoundsException e) {
+      // ArrayIndexOutOfBoundsException is expected if nesting depth is
+      // exceeded.
+      return false;
+    }
+    String output2 = JsonSanitizer.sanitize(output1, 10);
+    if (!output1.equals(output2)) {
+      System.err.println("input  : " + input);
+      System.err.println("output1: " + output1);
+      System.err.println("output2: " + output2);
+      return true;
+    }
+    return false;
+  }
+}

--- a/projects/json-sanitizer/ValidJsonFuzzer.java
+++ b/projects/json-sanitizer/ValidJsonFuzzer.java
@@ -1,0 +1,45 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.json.JsonSanitizer;
+
+public class ValidJsonFuzzer {
+  private static Gson gson = new Gson();
+
+  public static boolean fuzzerTestOneInput(FuzzedDataProvider data) {
+    String input = data.consumeRemainingAsString();
+    String output;
+    try {
+      output = JsonSanitizer.sanitize(input, 10);
+    } catch (ArrayIndexOutOfBoundsException e) {
+      // ArrayIndexOutOfBoundsException is expected if nesting depth is
+      // exceeded.
+      return false;
+    }
+    try {
+      gson.fromJson(output, JsonElement.class);
+    } catch (Exception e) {
+      System.err.println("input  : " + input);
+      System.err.println("output : " + output);
+      throw e;
+    }
+    return false;
+  }
+}

--- a/projects/json-sanitizer/build.sh
+++ b/projects/json-sanitizer/build.sh
@@ -1,0 +1,57 @@
+#!/bin/bash -eu
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Build the json-sanitizer jar.
+CURRENT_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate \
+-Dexpression=project.version -q -DforceStdout)
+mvn package
+cp "target/json-sanitizer-$CURRENT_VERSION.jar" $OUT/json-sanitizer.jar
+
+# The jar files containing the project (separated by spaces).
+PROJECT_JARS=json-sanitizer.jar
+
+# Get the fuzzer dependencies (gson).
+mvn dependency:copy -Dartifact=com.google.code.gson:gson:2.8.6 -DoutputDirectory=$OUT/
+
+# The jar files containing further dependencies of the fuzz targets (separated
+# by spaces).
+FUZZER_JARS=gson-2.8.6.jar
+
+# Build fuzzers in $OUT.
+ALL_JARS="$PROJECT_JARS $FUZZER_JARS"
+BUILD_CLASSPATH=$(echo $ALL_JARS | xargs printf -- "$OUT/%s:"):$JAZZER_API_PATH
+
+# All jars and class files lie in the same directory as the fuzzer at runtime.
+RUNTIME_CLASSPATH=$(echo $ALL_JARS | xargs printf -- "%s:"):.
+
+for fuzzer in $(find $SRC -name '*Fuzzer.java'); do
+  fuzzer_basename=$(basename -s .java $fuzzer)
+  javac -cp $BUILD_CLASSPATH $fuzzer
+  cp $SRC/$fuzzer_basename.class $OUT/
+
+  # Create execution wrapper.
+  echo "#!/bin/sh
+# LLVMFuzzerTestOneInput for fuzzer detection.
+this_dir=\$(dirname \"\$0\")
+LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\" \
+\$this_dir/jazzer_driver --agent_path=\$this_dir/jazzer_agent_deploy.jar \
+                         --cp=$RUNTIME_CLASSPATH \
+                         --target_class=$fuzzer_basename \
+                         --jvm_args=\"-Xmx2048m\" \
+                         \$@" > $OUT/$fuzzer_basename
+  chmod u+x $OUT/$fuzzer_basename
+done

--- a/projects/json-sanitizer/project.yaml
+++ b/projects/json-sanitizer/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/OWASP/json-sanitizer"
+language: jvm
+primary_contact: "mikesamuel@gmail.com"
+auto_ccs:
+  - "meumertzheim@code-intelligence.com"
+fuzzing_engines:
+  - libfuzzer
+main_repo: "https://github.com/OWASP/json-sanitizer"
+sanitizers:
+  - address


### PR DESCRIPTION
json-sanitizer uses Maven and has no native dependencies.

The build file is loosely divided into two parts. The first part is project-specific, the second one can serve as a template for JVM fuzz targets without native dependencies.

The following three fuzz targets are added to OSS-Fuzz and can later be moved into the json-sanitizer tree:

* DenylistFuzzer verifies that the output of json-sanitizer never contains certain substrings that can lead to HTML or XML injections.
* IdempotenceFuzzer verifies that json-sanitizer is idempotent.
* ValidJsonFuzzer verifies that the output of json-sanitizer is valid JSON by passing it into gson.