### PR TITLE
projects/golang: add Emmanuel Odeke as a Go maintainer

### DIFF
--- a/projects/golang/project.yaml
+++ b/projects/golang/project.yaml
@@ -3,6 +3,7 @@ primary_contact: "golang-fuzz@googlegroups.com"
 auto_ccs:
  - "mmoroz@chromium.org"
  - "josharian@gmail.com"
+ - "emmanuel@orijtech.com"
 language: go
 sanitizers:
  - address


### PR DESCRIPTION
This way I can help coordinate and fix found bugs for the Go project. Following up on the conversation started at https://github.com/google/oss-fuzz/pull/2188#issuecomment-777998105.