### PR TITLE
Final afl++ integration

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -152,7 +152,7 @@ WORKDIR $SRC
 # TODO: switch to -b stable once we can.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git aflplusplus && \
     cd aflplusplus && \
-    git checkout 9bd1e19d7f004b4da6a610b07e59f99d66bb7ec2
+    git checkout fe9da707058b3b2cb1812c3d635d3bb43fe33d13
 
 RUN cd $SRC && \
     curl -L -O https://github.com/google/honggfuzz/archive/oss-fuzz.tar.gz && \

--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -152,7 +152,7 @@ WORKDIR $SRC
 # TODO: switch to -b stable once we can.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git aflplusplus && \
     cd aflplusplus && \
-    git checkout 64e46dcefc938f6a6f6263f66d231009bb8b245c
+    git checkout 129a5adaf1cd5d1b602c49342badf586b415ca30
 
 RUN cd $SRC && \
     curl -L -O https://github.com/google/honggfuzz/archive/oss-fuzz.tar.gz && \

--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -152,7 +152,7 @@ WORKDIR $SRC
 # TODO: switch to -b stable once we can.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git aflplusplus && \
     cd aflplusplus && \
-    git checkout e3a5c31307f323452dc4b5288e0d19a02b596a33
+    git checkout 5dd35f5281afec0955c08fe9f99e3c83222b7764
 
 RUN cd $SRC && \
     curl -L -O https://github.com/google/honggfuzz/archive/oss-fuzz.tar.gz && \

--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -152,7 +152,7 @@ WORKDIR $SRC
 # TODO: switch to -b stable once we can.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git aflplusplus && \
     cd aflplusplus && \
-    git checkout fe9da707058b3b2cb1812c3d635d3bb43fe33d13
+    git checkout e3a5c31307f323452dc4b5288e0d19a02b596a33
 
 RUN cd $SRC && \
     curl -L -O https://github.com/google/honggfuzz/archive/oss-fuzz.tar.gz && \

--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -152,7 +152,7 @@ WORKDIR $SRC
 # TODO: switch to -b stable once we can.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git aflplusplus && \
     cd aflplusplus && \
-    git checkout 129a5adaf1cd5d1b602c49342badf586b415ca30
+    git checkout 1ba5d1008e749a12ac338f57adbac3b2b4cf9ea9
 
 RUN cd $SRC && \
     curl -L -O https://github.com/google/honggfuzz/archive/oss-fuzz.tar.gz && \

--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -152,7 +152,7 @@ WORKDIR $SRC
 # TODO: switch to -b stable once we can.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git aflplusplus && \
     cd aflplusplus && \
-    git checkout aeb7d7048371cd91ab9280c3958f1c35e5d5e758
+    git checkout 64e46dcefc938f6a6f6263f66d231009bb8b245c
 
 RUN cd $SRC && \
     curl -L -O https://github.com/google/honggfuzz/archive/oss-fuzz.tar.gz && \

--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -152,7 +152,7 @@ WORKDIR $SRC
 # TODO: switch to -b stable once we can.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git aflplusplus && \
     cd aflplusplus && \
-    git checkout 1ba5d1008e749a12ac338f57adbac3b2b4cf9ea9
+    git checkout 9bd1e19d7f004b4da6a610b07e59f99d66bb7ec2
 
 RUN cd $SRC && \
     curl -L -O https://github.com/google/honggfuzz/archive/oss-fuzz.tar.gz && \

--- a/infra/base-images/base-builder/compile_afl
+++ b/infra/base-images/base-builder/compile_afl
@@ -15,6 +15,21 @@
 #
 ################################################################################
 
+# afl++ configuration options.
+# The 'env|grep' setup ensures we do not trigger the linter.
+# The variables need to set to "yes" here or before running this script.
+
+# If enabled this provides a safe work around if afl-clang-fast ever break:
+env | grep -qw LLVM_MODE_WORKAROUND || {
+  LLVM_MODE_WORKAROUND="no"
+}
+
+# If a dictionary should be generated based on comparisons at compile time:
+env | grep -qw WANT_DICTIONARY || {
+  WANT_DICTIONARY="no"
+}
+
+# Start compiling afl++.
 echo "Compiling afl++"
 
 # Build and copy afl++ tools necessary for fuzzing.
@@ -22,24 +37,22 @@ pushd $SRC/aflplusplus > /dev/null
 
 # Unset CFLAGS and CXXFLAGS while building AFL since we don't want to slow it
 # down with sanitizers.
-INITIAL_CXXFLAGS=$CXXFLAGS
-INITIAL_CFLAGS=$CFLAGS
+SAVE_CXXFLAGS=$CXXFLAGS
+SAVE_CFLAGS=$CFLAGS
 unset CXXFLAGS
 unset CFLAGS
 make clean
 AFL_NO_X86=1 PYTHON_INCLUDE=/ make
-CFLAGS=$INITIAL_CFLAGS
-CXXFLAGS=$INITIAL_CXXFLAGS
+CFLAGS=$SAVE_CFLAGS
+CXXFLAGS=$SAVE_CXXFLAGS
 
 # Build afl++ driver with existing CFLAGS, CXXFLAGS.
 make -C utils/aflpp_driver
-cp libAFLDriver.a $LIB_FUZZING_ENGINE
+cp -f libAFLDriver.a $LIB_FUZZING_ENGINE
 
 # Some important projects include libraries, copy those even when they don't
 # start with "afl-". Use "sort -u" to avoid a warning about duplicates.
 ls afl-* *.txt *.a *.o *.so | sort -u | xargs cp -t $OUT
-popd > /dev/null
-
 export CC="$SRC/aflplusplus/afl-clang-fast"
 export CXX="$SRC/aflplusplus/afl-clang-fast++"
 
@@ -50,8 +63,45 @@ export AFL_QUIET=1
 export AFL_MAP_SIZE=4194304
 # No leak errors during builds.
 export ASAN_OPTIONS="detect_leaks=0:symbolize=0"
-#
-# Placeholder for the upcoming afl++ build options roulette
-#
+
+# AFL compile option roulette. It is OK if they all happen together.
+
+# 40% chance to perform CMPLOG
+test $(($RANDOM % 10)) -lt 4 && {
+  export AFL_LLVM_CMPLOG=1
+  # We need to notify afl-fuzz to activate CMPLOG
+  touch "$OUT/afl_cmplog.txt"
+}
+
+# 10% chance to perform LAF_INTEL
+test $(($RANDOM % 10)) -lt 1 && {
+  export AFL_LLVM_LAF_ALL=1
+}
+
+# In case afl-clang-fast ever breaks, this is a workaround:
+test "$LLVM_MODE_WORKAROUND" = "yes" && {
+  export CC=clang
+  export CXX=clang++
+  WORKAROUND_FLAGS=-fsanitize-coverage=trace-pc-guard
+  # We can still do CMPLOG light:
+  test -e "$OUT/afl_cmplog.txt" && {
+    WORKAROUND_FLAGS="$WORKAROUND_FLAGS",trace-cmp
+  }
+  export CFLAGS="$CFLAGS $WORKAROUND_FLAGS"
+  export CXXFLAGS="$CXXFLAGS $WORKAROUND_FLAGS"
+  # We need to create a new fuzzer lib however.
+  ar ru libAFLDrivernew.a afl-compiler-rt.o utils/aflpp_driver/aflpp_driver.o
+  cp -f libAFLDrivernew.a $LIB_FUZZING_ENGINE
+}
+
+# If the targets whishes a dictionary - then create one.
+test "$AFL_WANT_DICTIONARY" = "yes" && {
+  export AFL_LLVM_DICT2FILE="$OUT/afl++.dict"
+}
+
+# Provide a way to document the afl++ options used in this build:
+env | grep AFL_ > "$OUT/afl_options.txt"
+
+popd > /dev/null
 
 echo " done."

--- a/infra/base-images/base-builder/compile_afl
+++ b/infra/base-images/base-builder/compile_afl
@@ -98,7 +98,7 @@ test "$AFL_LLVM_MODE_WORKAROUND" = "1" && {
 }
 
 # If the targets whishes a dictionary - then create one.
-test "$AFL_WANT_DICTIONARY" = "1" && {
+test "$AFL_ENABLE_DICTIONARY" = "1" && {
   export AFL_LLVM_DICT2FILE="$OUT/afl++.dict"
 }
 

--- a/infra/base-images/base-builder/compile_afl
+++ b/infra/base-images/base-builder/compile_afl
@@ -22,7 +22,7 @@
 # If enabled this provides a safe work around if afl-clang-fast ever break:
 env | grep -qw LLVM_MODE_WORKAROUND || {
   # needed until llvm 13 works:
-  LLVM_MODE_WORKAROUND="yes"
+  LLVM_MODE_WORKAROUND="no"
 }
 
 # If a dictionary should be generated based on comparisons at compile time:

--- a/infra/base-images/base-builder/compile_afl
+++ b/infra/base-images/base-builder/compile_afl
@@ -17,17 +17,17 @@
 
 # afl++ configuration options.
 # The 'env|grep' setup ensures we do not trigger the linter.
-# The variables need to set to "yes" here or before running this script.
+# The variables need to be set to "1" here - or before running this script.
 
 # If enabled this provides a safe work around if afl-clang-fast ever break:
 env | grep -qw LLVM_MODE_WORKAROUND || {
   # needed until llvm 13 works:
-  LLVM_MODE_WORKAROUND="no"
+  AFL_LLVM_MODE_WORKAROUND=0
 }
 
 # If a dictionary should be generated based on comparisons at compile time:
 env | grep -qw WANT_DICTIONARY || {
-  WANT_DICTIONARY="no"
+  AFL_ENABLE_DICTIONARY=1
 }
 
 # Start compiling afl++.
@@ -42,6 +42,7 @@ SAVE_CXXFLAGS=$CXXFLAGS
 SAVE_CFLAGS=$CFLAGS
 unset CXXFLAGS
 unset CFLAGS
+export AFL_IGNORE_UNKNOWN_ENVS=1
 make clean
 AFL_NO_X86=1 PYTHON_INCLUDE=/ make
 CFLAGS=$SAVE_CFLAGS
@@ -81,7 +82,7 @@ test $(($RANDOM % 10)) -lt 1 && {
 }
 
 # In case afl-clang-fast ever breaks, this is a workaround:
-test "$LLVM_MODE_WORKAROUND" = "yes" && {
+test "$LLVM_MODE_WORKAROUND" = "1" && {
   export CC=clang
   export CXX=clang++
   WORKAROUND_FLAGS=-fsanitize-coverage=trace-pc-guard
@@ -97,7 +98,7 @@ test "$LLVM_MODE_WORKAROUND" = "yes" && {
 }
 
 # If the targets whishes a dictionary - then create one.
-test "$AFL_WANT_DICTIONARY" = "yes" && {
+test "$AFL_WANT_DICTIONARY" = "1" && {
   export AFL_LLVM_DICT2FILE="$OUT/afl++.dict"
 }
 

--- a/infra/base-images/base-builder/compile_afl
+++ b/infra/base-images/base-builder/compile_afl
@@ -20,13 +20,13 @@
 # The variables need to be set to "1" here - or before running this script.
 
 # If enabled this provides a safe work around if afl-clang-fast ever break:
-env | grep -qw LLVM_MODE_WORKAROUND || {
+env | grep -qw AFL_LLVM_MODE_WORKAROUND || {
   # needed until llvm 13 works:
   AFL_LLVM_MODE_WORKAROUND=0
 }
 
 # If a dictionary should be generated based on comparisons at compile time:
-env | grep -qw WANT_DICTIONARY || {
+env | grep -qw AFL_ENABLE_DICTIONARY || {
   AFL_ENABLE_DICTIONARY=1
 }
 
@@ -82,7 +82,7 @@ test $(($RANDOM % 10)) -lt 1 && {
 }
 
 # In case afl-clang-fast ever breaks, this is a workaround:
-test "$LLVM_MODE_WORKAROUND" = "1" && {
+test "$AFL_LLVM_MODE_WORKAROUND" = "1" && {
   export CC=clang
   export CXX=clang++
   WORKAROUND_FLAGS=-fsanitize-coverage=trace-pc-guard

--- a/infra/base-images/base-builder/compile_afl
+++ b/infra/base-images/base-builder/compile_afl
@@ -67,6 +67,7 @@ export ASAN_OPTIONS="detect_leaks=0:symbolize=0"
 # AFL compile option roulette. It is OK if they all happen together.
 
 # 40% chance to perform CMPLOG
+rm -f "$OUT/afl_cmplog.txt"
 test $(($RANDOM % 10)) -lt 4 && {
   export AFL_LLVM_CMPLOG=1
   # We need to notify afl-fuzz to activate CMPLOG

--- a/infra/base-images/base-builder/compile_afl
+++ b/infra/base-images/base-builder/compile_afl
@@ -21,7 +21,8 @@
 
 # If enabled this provides a safe work around if afl-clang-fast ever break:
 env | grep -qw LLVM_MODE_WORKAROUND || {
-  LLVM_MODE_WORKAROUND="no"
+  # needed until llvm 13 works:
+  LLVM_MODE_WORKAROUND="yes"
 }
 
 # If a dictionary should be generated based on comparisons at compile time:

--- a/infra/base-images/base-runner/run_fuzzer
+++ b/infra/base-images/base-runner/run_fuzzer
@@ -111,7 +111,9 @@ if [[ "$FUZZING_ENGINE" = afl ]]; then
   # CMPLOG level 2, which will colorize larger files but not huge files and
   # not enable transform analysis unless there have been several cycles without
   # any finds.
-  test -e $OUT/afl_cmplog.txt && AFL_FUZZER_ARGS="$AFL_FUZZER_ARGS -l 2 -c $OUT/$FUZZER"
+  test -e "$OUT/afl_cmplog.txt" && AFL_FUZZER_ARGS="$AFL_FUZZER_ARGS -l 2 -c $OUT/$FUZZER"
+  # If $OUT/afl++.dict we load it as a dictionary for afl-fuzz.
+  test -e "$OUT/afl++.dict" && AFL_FUZZER_ARGS="$AFL_FUZZER_ARGS -x $OUT/afl++.dict"
   # AFL expects at least 1 file in the input dir.
   echo input > ${CORPUS_DIR}/input
   CMD_LINE="$OUT/afl-fuzz $AFL_FUZZER_ARGS -i $CORPUS_DIR -o $FUZZER_OUT $(get_dictionary) $* -- $OUT/$FUZZER"

--- a/projects/libavif/build.sh
+++ b/projects/libavif/build.sh
@@ -15,12 +15,6 @@
 #
 ################################################################################
 
-# afl++ CMPLOG test:
-test "$FUZZING_ENGINE" = "afl" && {
-  export AFL_LLVM_CMPLOG=1
-  touch $OUT/afl_cmplog.txt
-}
-
 # build dav1d
 cd ext && bash dav1d.cmd && cd ..
 

--- a/projects/libcacard/build.sh
+++ b/projects/libcacard/build.sh
@@ -15,12 +15,6 @@
 #
 ################################################################################
 
-# afl++ CMPLOG test:
-test "$FUZZING_ENGINE" = "afl" && {
-  export AFL_LLVM_CMPLOG=1
-  touch $OUT/afl_cmplog.txt
-}
-
 # Workaround for fixing AFL++ build, discarded for others.
 # See https://github.com/google/oss-fuzz/issues/4280#issuecomment-773977943
 export AFL_LLVM_INSTRUMENT=CLASSIC,NGRAM-4

--- a/projects/libxml2/build.sh
+++ b/projects/libxml2/build.sh
@@ -16,12 +16,6 @@
 #
 ################################################################################
 
-# afl++ CMPLOG test:
-test "$FUZZING_ENGINE" = "afl" && {
-  export AFL_LLVM_CMPLOG=1
-  touch $OUT/afl_cmplog.txt
-}
-
 if [ "$SANITIZER" = undefined ]; then
     export CFLAGS="$CFLAGS -fsanitize=unsigned-integer-overflow -fno-sanitize-recover=unsigned-integer-overflow"
     export CXXFLAGS="$CXXFLAGS -fsanitize=unsigned-integer-overflow -fno-sanitize-recover=unsigned-integer-overflow"

--- a/projects/openssl/build.sh
+++ b/projects/openssl/build.sh
@@ -15,12 +15,6 @@
 #
 ################################################################################
 
-# afl++ CMPLOG test:
-test "$FUZZING_ENGINE" = "afl" && {
-  export AFL_LLVM_CMPLOG=1
-  touch $OUT/afl_cmplog.txt
-}
-
 CONFIGURE_FLAGS=""
 if [[ $CFLAGS = *sanitize=memory* ]]
 then

--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -15,12 +15,6 @@
 #
 ################################################################################
 
-# afl++ CMPLOG test:
-test "$FUZZING_ENGINE" = "afl" && {
-  export AFL_LLVM_CMPLOG=1
-  touch $OUT/afl_cmplog.txt
-}
-
 # Build SwiftShader
 pushd third_party/externals/swiftshader/
 export SWIFTSHADER_INCLUDE_PATH=$PWD/include

--- a/projects/wireshark/build.sh
+++ b/projects/wireshark/build.sh
@@ -15,12 +15,6 @@
 #
 ################################################################################
 
-# afl++ CMPLOG test:
-test "$FUZZING_ENGINE" = "afl" && {
-  export AFL_LLVM_CMPLOG=1
-  touch $OUT/afl_cmplog.txt
-}
-
 WIRESHARK_BUILD_PATH="$WORK/build"
 mkdir -p "$WIRESHARK_BUILD_PATH"
 


### PR DESCRIPTION
If the 5 CMPLOG test targets produced no issues - then this is the final afl++ integration PR.
It randomly enables CMPLOG and/or LAF, plus documents the options in $OUT/afl_options.txt

I also included two configurable options - for world-wide or per project configuration:

`LLVM_MODE_WORKAROUND` - if set to "yes" then a fallback to clang + -fsanitize-coverage is performed, in case afl-clang-fast ever breaks and this becomes a major issue.

`WANT_DICTIONARY` - if set to "yes" this will generate a dictionary based on comparisons extracted at compile time.  run_fuzzer + clusterfuzz will check for this file and if present load+use it.
