### PR TITLE
[Pillow] Use upstream support for fuzzing build

### DIFF
--- a/projects/pillow/Dockerfile
+++ b/projects/pillow/Dockerfile
@@ -54,12 +54,10 @@ RUN cd Pillow && depends/install_extra_test_images.sh
 
 COPY build.sh $SRC/
 
-# pillow runtime dependencies
+# pillow optional runtime dependencies
 RUN apt-get install -y \
-      libfribidi-dev \
-      libharfbuzz-dev \
-      python3-tk \
-      tcl8.6-dev \
-      tk8.6-dev 
+     python3-tk \
+     tcl8.6-dev \
+     tk8.6-dev 
 
 WORKDIR $SRC/Pillow

--- a/projects/pillow/build.sh
+++ b/projects/pillow/build.sh
@@ -17,27 +17,21 @@
 
 python3 setup.py build --build-base=/tmp/build install
 
-bp="$(find /tmp/build -name '_imaging.o')"
-BUILD_DIR="${bp/_imaging.o/}"
-if [ -d "$BUILD_DIR" ]; then
-    find $BUILD_DIR -name _imagingmath.o -delete
-    find $BUILD_DIR -name _imagingtk.o -delete
-    find $BUILD_DIR -name _imagingmorph.o -delete
-fi;
-
-# Relink with fuzzing engine
-TS="$(find /usr/local/lib/python3.* -name '_imaging.*.so')"
-$CXX -pthread -shared $CXXFLAGS $LIB_FUZZING_ENGINE ${BUILD_DIR}/*.o ${BUILD_DIR}/libImaging/*.o \
-    -L/usr/local/lib -L/lib/x86_64-linux-gnu -L/usr/lib/x86_64-linux-gnu \
-    -L/usr/lib/x86_64-linux-gnu/libfakeroot -L/usr/lib -L/lib -L/usr/local/lib \
-    -ljpeg -lz -lxcb -lfreetype -lopenjp2 -ltiff -llcms2 -lwebp -lwebpmux -lwebpdemux \
-    -o ${TS} -stdlib=libc++
-
 # Build fuzzers in $OUT.
 for fuzzer in $(find $SRC -name 'fuzz_*.py'); do
   fuzzer_basename=$(basename -s .py $fuzzer)
   fuzzer_package=${fuzzer_basename}.pkg
-  pyinstaller --distpath $OUT --onefile --name $fuzzer_package $fuzzer
+  pyinstaller \
+      --add-binary /usr/local/lib/libjpeg.so.9:. \
+      --add-binary /usr/local/lib/libfreetype.so.6:. \
+      --add-binary /usr/local/lib/liblcms2.so.2:. \
+      --add-binary /usr/local/lib/libopenjp2.so.7:. \
+      --add-binary /usr/local/lib/libpng16.so.16:. \
+      --add-binary /usr/local/lib/libtiff.so.5:. \
+      --add-binary /usr/local/lib/libwebp.so.7:. \
+      --add-binary /usr/local/lib/libwebpdemux.so.2:. \
+      --add-binary /usr/local/lib/libwebpmux.so.3:. \
+      --distpath $OUT --onefile --name $fuzzer_package $fuzzer
 
   # Create execution wrapper.
   echo "#!/bin/sh


### PR DESCRIPTION
Pillow now has support (https://github.com/python-pillow/Pillow/pull/5199) for properly linking the fuzzers in the core setup.py build script. 

This change 
* removes the manual linking step from build.sh 
* explicitly includes some of the external libraries in the pyinstaller build
* removes the libraries for the currently un-fuzzed raqm/fribidi/harfbuzz font stack, which are optional pillow dependencies.  