### PR TITLE
sudoers: fuzz targets are now integrated into sudo's build system

### DIFF
--- a/projects/sudoers/build.sh
+++ b/projects/sudoers/build.sh
@@ -18,67 +18,85 @@
 # Debugging
 env
 
-# Move ASAN-specific flags into ASAN_CFLAGS and ASAN_LDFLAGS
-# That way they don't affect configure but will get used when building.
+# Some of the sanitizer flags cause issues with configure tests.
+# Pull them out of CFLAGS and pass them to configure instead.
 if [ $SANITIZER == "coverage" ]; then
-    export ASAN_CFLAGS="$COVERAGE_FLAGS"
-    export ASAN_LDFLAGS="$COVERAGE_FLAGS"
     CFLAGS="`echo \"$CFLAGS\" | sed \"s/ $COVERAGE_FLAGS//\"`"
+    sanitizer_opts="$COVERAGE_FLAGS"
 else
-    export ASAN_CFLAGS="$SANITIZER_FLAGS"
-    export ASAN_LDFLAGS="$SANITIZER_FLAGS"
     CFLAGS="`echo \"$CFLAGS\" | sed \"s/ $SANITIZER_FLAGS//\"`"
+    sanitizer_opts="$SANITIZER_FLAGS"
 fi
+# This is already added by --enable-fuzzer
+CFLAGS="`echo \"$CFLAGS\" | sed \"s/ -fsanitize=fuzzer-no-link//\"`"
 
-# Build sudo with static libs for simpler fuzzing
-./configure --enable-static-sudoers --enable-static --disable-shared-libutil \
+# Build sudo with static libs and enable fuzzing targets.
+# All fuzz targets are integrated into the build process.
+./configure --disable-shared --disable-shared-libutil --enable-static-sudoers \
+    --enable-sanitizer="$sanitizer_opts" --enable-fuzzer \
+    --enable-fuzzer-engine="$LIB_FUZZING_ENGINE" --enable-fuzzer-linker="$CXX" \
     --disable-leaks --enable-warnings --enable-werror
 make -j$(nproc)
 
-# Fuzz I/O log JSON parser
+# I/O log fuzzers
 cd lib/iolog
-$CC $CFLAGS $ASAN_CFLAGS -c -I../../include -I../.. -I. \
-    regress/fuzz/fuzz_iolog_json.c
-$CXX $CXXFLAGS $LIB_FUZZING_ENGINE -o $OUT/fuzz_iolog_json \
-    fuzz_iolog_json.o .libs/libsudo_iolog.a \
-    ../eventlog/.libs/libsudo_eventlog.a ../util/.libs/libsudo_util.a
 
-# Corpus for fuzzing I/O log JSON parser
+# Fuzz legacy I/O log info parser
+make fuzz_iolog_legacy && cp fuzz_iolog_legacy $OUT
+rm -rf $WORK/corpus
 mkdir $WORK/corpus
-for f in `find regress/iolog_json -name '*.in'`; do
+for f in `find regress/corpus/log_legacy -type f`; do
+    cp $f $WORK/corpus/`sha1sum $f | cut -d' ' -f1`
+done
+zip -j $OUT/fuzz_iolog_legacy_seed_corpus.zip $WORK/corpus/*
+
+# Fuzz I/O log JSON parser
+make fuzz_iolog_json && cp fuzz_iolog_json $OUT
+rm -rf $WORK/corpus
+mkdir $WORK/corpus
+for f in `find regress/iolog_json -name '*.in'` `find regress/corpus/log_json -type f`; do
     cp $f $WORK/corpus/`sha1sum $f | cut -d' ' -f1`
 done
 zip -j $OUT/fuzz_iolog_json_seed_corpus.zip $WORK/corpus/*
+
+# Fuzz I/O log timing file parser
+make fuzz_iolog_timing && cp fuzz_iolog_timing $OUT
 rm -rf $WORK/corpus
+mkdir $WORK/corpus
+for f in `find regress/corpus/timing -type f`; do
+    cp $f $WORK/corpus/`sha1sum $f | cut -d' ' -f1`
+done
+zip -j $OUT/fuzz_iolog_timing_seed_corpus.zip $WORK/corpus/*
+
+# Sudoers module fuzzers
+cd ../../plugins/sudoers
 
 # Fuzz sudoers parser
-cd ../../plugins/sudoers
-$CC $CFLAGS $ASAN_CFLAGS -c -I../../include -I../.. -I. \
-    regress/fuzz/fuzz_sudoers.c
-$CXX $CXXFLAGS $LIB_FUZZING_ENGINE -o $OUT/fuzz_sudoers \
-    fuzz_sudoers.o locale.o stubs.o sudo_printf.o \
-    .libs/libparsesudoers.a ../../lib/util/.libs/libsudo_util.a
-
-# Corpus for fuzzing sudoers parser
+make fuzz_sudoers && cp fuzz_sudoers $OUT
+rm -rf $WORK/corpus
 mkdir $WORK/corpus
-for f in sudoers `find regress/sudoers -name '*.in'`; do
+for f in ../../examples/sudoers `find regress/sudoers -name '*.in'`; do
     cp $f $WORK/corpus/`sha1sum $f | cut -d' ' -f1`
 done
 zip -j $OUT/fuzz_sudoers_seed_corpus.zip $WORK/corpus/*
-rm -rf $WORK/corpus
 
 # Fuzz sudoers LDIF parser (used by cvtsudoers)
-cd ../../plugins/sudoers
-$CC $CFLAGS $ASAN_CFLAGS -c -I../../include -I../.. -I. \
-    regress/fuzz/fuzz_sudoers_ldif.c
-$CXX $CXXFLAGS $LIB_FUZZING_ENGINE -o $OUT/fuzz_sudoers_ldif \
-    fuzz_sudoers_ldif.o parse_ldif.o ldap_util.o fmtsudoers.o locale.o stubs.o \
-    sudo_printf.o .libs/libparsesudoers.a ../../lib/util/.libs/libsudo_util.a
-
-# Corpus for fuzzing sudoers LDIF parser
+make fuzz_sudoers_ldif && cp fuzz_sudoers_ldif $OUT
+rm -rf $WORK/corpus
 mkdir $WORK/corpus
 for f in `find regress/sudoers -name '*.ldif.ok' \! -size 0`; do
     cp $f $WORK/corpus/`sha1sum $f | cut -d' ' -f1`
 done
 zip -j $OUT/fuzz_sudoers_ldif_seed_corpus.zip $WORK/corpus/*
+
+# Fuzz sudoers policy module
+make fuzz_policy && cp fuzz_policy $OUT
+rm -rf $WORK/corpus
+mkdir $WORK/corpus
+for f in `find regress/corpus/policy -type f`; do
+    cp $f $WORK/corpus/`sha1sum $f | cut -d' ' -f1`
+done
+zip -j $OUT/fuzz_policy_seed_corpus.zip $WORK/corpus/*
+
+# Cleanup
 rm -rf $WORK/corpus


### PR DESCRIPTION
Now that fuzzers are integrated into sudo's build system the build.sh script no longer needs to build the fuzz targets itself.  This will avoid bit rot and inconsistencies between sudo's build config and build.sh in oss-fuzz.  Fuzzer options are passed in via configure arguments, just as they would be when building with fuzzing support outside of oss-fuzz.  Multiple fuzzing engines are supported.

This PR also adds additional fuzzers, including one for the policy module that catches CVE-2021-3156.