### PR TITLE
[systemd] roll back to meson-0.56.2

### DIFF
--- a/projects/systemd/Dockerfile
+++ b/projects/systemd/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update &&\
     apt-get install -y gperf m4 gettext python3-pip \
         libcap-dev libmount-dev libkmod-dev \
         pkg-config wget &&\
-    pip3 install meson ninja
+    pip3 install meson==0.56.2 ninja
 RUN git clone --depth 1 https://github.com/systemd/systemd systemd
 WORKDIR systemd
 COPY build.sh $SRC/


### PR DESCRIPTION
Apparently the latest version of meson (0.57.0) somehow broke systemd
OSS-Fuzz builds. Since it was released systemd has been failing to compile
with
```
2021-02-14T21:23:53.3854577Z [481/664] clang++  -o fuzz-compress fuzz-compress.p/src_fuzz_fuzz-compress.c.o -L/usr/lib/clang/12.0.0/lib/linux -Wl,--as-needed -Wl,--allow-shlib-undefined '-Wl,-rpath,$ORIGIN/src/shared' -Wl,-rpath-link,/work/build/src/shared -Wl,--start-group src/shared/libsystemd-shared-247.so -lFuzzingEngine -Wl,--end-group
2021-02-14T21:23:53.3856578Z FAILED: fuzz-compress
2021-02-14T21:23:53.3858714Z clang++  -o fuzz-compress fuzz-compress.p/src_fuzz_fuzz-compress.c.o -L/usr/lib/clang/12.0.0/lib/linux -Wl,--as-needed -Wl,--allow-shlib-undefined '-Wl,-rpath,$ORIGIN/src/shared' -Wl,-rpath-link,/work/build/src/shared -Wl,--start-group src/shared/libsystemd-shared-247.so -lFuzzingEngine -Wl,--end-group
2021-02-14T21:23:53.4160985Z /usr/lib/gcc/x86_64-linux-gnu/5.4.0/../../../libFuzzingEngine.a(FuzzerTracePC.o): In function `size':
2021-02-14T21:23:53.4162332Z /usr/local/bin/../include/c++/v1/set:641: undefined reference to `__asan_report_load8'
2021-02-14T21:23:53.4164959Z /usr/lib/gcc/x86_64-linux-gnu/5.4.0/../../../libFuzzingEngine.a(FuzzerTracePC.o): In function `fuzzer::TracePC::HandleInline8bitCountersInit(unsigned char*, unsigned char*)':
2021-02-14T21:23:53.4166954Z /src/libfuzzer/FuzzerTracePC.cpp:61: undefined reference to `__asan_report_store1'
2021-02-14T21:23:53.4168493Z /src/libfuzzer/FuzzerTracePC.cpp:59: undefined reference to `__asan_report_store1'
2021-02-14T21:23:53.4170699Z /src/libfuzzer/FuzzerTracePC.cpp:59: undefined reference to `__asan_report_store1'
2021-02-14T21:23:53.4172114Z /src/libfuzzer/FuzzerTracePC.cpp:63: undefined reference to `__asan_report_store1'
2021-02-14T21:23:53.4173550Z /src/libfuzzer/FuzzerTracePC.cpp:63: undefined reference to `__asan_report_store1'
2021-02-14T21:23:53.4174876Z /src/libfuzzer/FuzzerTracePC.cpp:54: undefined reference to `__asan_handle_no_return'
2021-02-14T21:23:53.4176322Z /src/libfuzzer/FuzzerTracePC.cpp:64: undefined reference to `__asan_handle_no_return'
2021-02-14T21:23:53.4177521Z /src/libfuzzer/FuzzerTracePC.cpp:65: undefined reference to `__asan_handle_no_return'
2021-02-14T21:23:53.4178936Z /src/libfuzzer/FuzzerTracePC.cpp:66: undefined reference to `__asan_handle_no_return'
2021-02-14T21:23:53.4180439Z /src/libfuzzer/FuzzerTracePC.cpp:67: undefined reference to `__asan_handle_no_return'
2021-02-14T21:23:53.4182667Z /usr/lib/gcc/x86_64-linux-gnu/5.4.0/../../../libFuzzingEngine.a(FuzzerTracePC.o):/src/libfuzzer/FuzzerTracePC.cpp:44: more undefined references to `__asan_handle_no_return' follow
2021-02-14T21:23:53.4185448Z /usr/lib/gcc/x86_64-linux-gnu/5.4.0/../../../libFuzzingEngine.a(FuzzerTracePC.o): In function `fuzzer::TracePC::HandleInline8bitCountersInit(unsigned char*, unsigned char*)':
2021-02-14T21:23:53.4189221Z /src/libfuzzer/FuzzerTracePC.cpp:61: undefined reference to `__asan_report_load8'
2021-02-14T21:23:53.4190419Z /src/libfuzzer/FuzzerTracePC.cpp:61: undefined reference to `__asan_report_store8'
2021-02-14T21:23:53.4191618Z /src/libfuzzer/FuzzerTracePC.cpp:61: undefined reference to `__asan_report_store8'
2021-02-14T21:23:53.4192815Z /src/libfuzzer/FuzzerTracePC.cpp:41: undefined reference to `__asan_report_load8'
2021-02-14T21:23:53.4194218Z /src/libfuzzer/FuzzerTracePC.cpp:46: undefined reference to `__asan_report_store8'
2021-02-14T21:23:53.4195434Z /src/libfuzzer/FuzzerTracePC.cpp:53: undefined reference to `__asan_report_store8'
2021-02-14T21:23:53.4196673Z /src/libfuzzer/FuzzerTracePC.cpp:55: undefined reference to `__asan_report_store8'
2021-02-14T21:23:53.4278293Z /src/libfuzzer/FuzzerTracePC.cpp:61: undefined reference to `__asan_report_store1'
2021-02-14T21:23:53.4279995Z /src/libfuzzer/FuzzerTracePC.cpp:64: undefined reference to `__asan_report_load8'
```
and so on.