### PR TITLE
Adds capnproto project

### DIFF
--- a/projects/capnproto/Dockerfile
+++ b/projects/capnproto/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y cmake zlib1g-dev
+RUN git clone --depth 1 https://github.com/capnproto/capnproto
+WORKDIR $SRC/capnproto
+COPY build.sh $SRC/

--- a/projects/capnproto/build.sh
+++ b/projects/capnproto/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# build project
+mkdir build
+cd build
+cmake -DBUILD_SHARED_LIBS=OFF ..
+make -j$(nproc)
+cp c++/src/capnp/*fuzzer* $OUT/

--- a/projects/capnproto/project.yaml
+++ b/projects/capnproto/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://capnproto.org"
+language: c++
+primary_contact: "security@sandstorm.io"
+auto_ccs:
+  - "p.antoine@catenacyber.fr"
+main_repo: 'https://github.com/capnproto/capnproto'

--- a/projects/capnproto/project.yaml
+++ b/projects/capnproto/project.yaml
@@ -3,4 +3,6 @@ language: c++
 primary_contact: "security@sandstorm.io"
 auto_ccs:
   - "p.antoine@catenacyber.fr"
+sanitizers:
+  - address
 main_repo: 'https://github.com/capnproto/capnproto'


### PR DESCRIPTION
cc @kentonv
Are you interested in continuous fuzzing for capnproto ?
This draft PR enables it with oss-fuzz

(PS : the fuzz target quickly finds what seems to me an infinite loop (resulting in out-of-memory) that I can reproduce with `capnp convert --quiet binary:packed < oom-e188e3b0a20731dad7ed328edc8c13c3b8d09439 > /dev/null`)