### PR TITLE
Use upstream repo for go-sqlite3 project

### DIFF
--- a/projects/go-sqlite3/Dockerfile
+++ b/projects/go-sqlite3/Dockerfile
@@ -15,9 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-# TODO use upstream repo
-# RUN go get -t github.com/mattn/go-sqlite3
-RUN git clone --branch fuzz --depth 1 http://github.com/catenacyber/go-sqlite3 $GOPATH/src/github.com/mattn/go-sqlite3
+RUN git clone --depth 1 http://github.com/mattn/go-sqlite3 $GOPATH/src/github.com/mattn/go-sqlite3
 
-COPY build.sh fuzz*.go $SRC/
+COPY build.sh $SRC/
 WORKDIR $SRC/


### PR DESCRIPTION
Now that fuzz target got merged upstream cf https://github.com/mattn/go-sqlite3/pull/908