### PR TITLE
[openjpeg] Release cmake build type

### DIFF
--- a/projects/openjpeg/build.sh
+++ b/projects/openjpeg/build.sh
@@ -17,7 +17,7 @@
 
 mkdir build
 cd build
-cmake ..
+cmake -DCMAKE_BUILD_TYPE=Release ..
 make clean -s
 make -j$(nproc) -s
 cd ..


### PR DESCRIPTION
Seems that some bugs in openjpeg can be triggered only in release mode.
More specifically, @elManto and I were trying to reproduce https://github.com/uclouvain/openjpeg/issues/1228 using the OSS-Fuzz harness and we failed.
I figured out that the bug is indeed reachable by the harness, but can be uncovered only in Release mode, otherwise, an assertion error blocks it.
I guess that they use assertions only in Debug mode (WTF) and remove them in Release.
So, IMO openjpeg should be fuzzed in Release mode as the configuration used in production is the one relevant for security.