### PR TITLE
Remove manual denylisting in tensorflow

### DIFF
--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -48,7 +48,7 @@ fi
 # Determine all fuzz targets. To control what gets fuzzed with OSSFuzz, all
 # supported fuzzers are in `//tensorflow/security/fuzzing`.
 # Ignore the identity and AttrValues fuzzer in opensource.
-declare -r FUZZERS=$(bazel query 'kind(cc_.*, tests(//tensorflow/security/fuzzing/...)) - attr(tags, notap, kind(cc_.*, tests(//tensorflow/security/fuzzing/...)))')
+declare -r FUZZERS=$(bazel query 'kind(cc_.*, tests(//tensorflow/security/fuzzing/...)) - attr(tags, no_oss, kind(cc_.*, tests(//tensorflow/security/fuzzing/...)))')
 
 # Build the fuzzer targets.
 # Pass in `--config=libc++` to link against libc++.

--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -48,7 +48,7 @@ fi
 # Determine all fuzz targets. To control what gets fuzzed with OSSFuzz, all
 # supported fuzzers are in `//tensorflow/security/fuzzing`.
 # Ignore the identity and AttrValues fuzzer in opensource.
-declare -r FUZZERS=$(bazel query 'kind(cc_.*, tests(//tensorflow/security/fuzzing/...))' | grep -v identity | grep -v AttrValues | grep -v bfloat16)
+declare -r FUZZERS=$(bazel query 'kind(cc_.*, tests(//tensorflow/security/fuzzing/...))- attr(tags, notap, kind(cc_.*, tests(//tensorflow/security/fuzzing/...)))')
 
 # Build the fuzzer targets.
 # Pass in `--config=libc++` to link against libc++.

--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -47,7 +47,7 @@ fi
 
 # Determine all fuzz targets. To control what gets fuzzed with OSSFuzz, all
 # supported fuzzers are in `//tensorflow/security/fuzzing`.
-# Ignore the identity and AttrValues fuzzer in opensource.
+# Ignore fuzzers tagged with `no_oss` in opensource.
 declare -r FUZZERS=$(bazel query 'kind(cc_.*, tests(//tensorflow/security/fuzzing/...)) - attr(tags, no_oss, kind(cc_.*, tests(//tensorflow/security/fuzzing/...)))')
 
 # Build the fuzzer targets.

--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -48,7 +48,7 @@ fi
 # Determine all fuzz targets. To control what gets fuzzed with OSSFuzz, all
 # supported fuzzers are in `//tensorflow/security/fuzzing`.
 # Ignore the identity and AttrValues fuzzer in opensource.
-declare -r FUZZERS=$(bazel query 'kind(cc_.*, tests(//tensorflow/security/fuzzing/...))- attr(tags, notap, kind(cc_.*, tests(//tensorflow/security/fuzzing/...)))')
+declare -r FUZZERS=$(bazel query 'kind(cc_.*, tests(//tensorflow/security/fuzzing/...)) - attr(tags, notap, kind(cc_.*, tests(//tensorflow/security/fuzzing/...)))')
 
 # Build the fuzzer targets.
 # Pass in `--config=libc++` to link against libc++.


### PR DESCRIPTION
Remove manual denylisting of fuzzing targets using bazel query via tags. Excluding the `no_oss` tag targets.

@mihaimaruseac @pak-laura
