### PR TITLE
[java-example] Don't assume that fuzzer is run from its directory

### DIFF
--- a/projects/java-example/build.sh
+++ b/projects/java-example/build.sh
@@ -23,7 +23,7 @@ $CXX $CXXFLAGS $JVM_INCLUDES -fPIC -shared \
 BUILD_CLASSPATH=$JAZZER_API_PATH
 
 # All class files lie in the same directory as the fuzzer at runtime.
-RUNTIME_CLASSPATH=.
+RUNTIME_CLASSPATH=\$this_dir
 
 for fuzzer in $(find $SRC -name '*Fuzzer.java' -or -name '*FuzzerNative.java'); do
   fuzzer_basename=$(basename -s .java $fuzzer)
@@ -43,9 +43,9 @@ this_dir=\$(dirname \"\$0\")
 LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\":. \
 ASAN_OPTIONS=\$ASAN_OPTIONS:symbolize=1:external_symbolizer_path=\$this_dir/llvm-symbolizer:detect_leaks=0 \
 \$this_dir/$driver --agent_path=\$this_dir/jazzer_agent_deploy.jar \
-                   --cp=$RUNTIME_CLASSPATH \
-                   --target_class=$fuzzer_basename \
-                   --jvm_args=\"-Xmx2048m\" \
-                   \$@" > $OUT/$fuzzer_basename
+--cp=$RUNTIME_CLASSPATH \
+--target_class=$fuzzer_basename \
+--jvm_args=\"-Xmx2048m\" \
+\$@" > $OUT/$fuzzer_basename
   chmod u+x $OUT/$fuzzer_basename
 done


### PR DESCRIPTION
The same speculative fix as in #5217.

The current working directory "." should have no reason to be in the
classpath if it is not equal to "$this_dir", hence it is removed.