### PR TITLE
[CIFuzz] Support languages non-C++ projects (e.g. Python projects)

### DIFF
--- a/docs/getting-started/continuous_integration.md
+++ b/docs/getting-started/continuous_integration.md
@@ -39,7 +39,6 @@ fuzzing more effective and gives you regression testing for free.
 
 1. Your project must be integrated with OSS-Fuzz.
 1. Your project is hosted on GitHub.
-1. Your project is written in C or C++.
 
 ## Integrating into your repository
 
@@ -75,13 +74,13 @@ jobs:
      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
      with:
        oss-fuzz-project-name: 'example'
-       dry-run: false
+       language: c++
    - name: Run Fuzzers
      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
      with:
        oss-fuzz-project-name: 'example'
+       language: c++
        fuzz-seconds: 600
-       dry-run: false
    - name: Upload Crash
      uses: actions/upload-artifact@v1
      if: failure() && steps.build.outcome == 'success'
@@ -94,8 +93,16 @@ jobs:
 ### Optional configuration
 
 #### Configurable Variables
+
+`language`: (optional) The language your target program is written in. Defaults
+to `c++`. This shold be the same as the value you set in `project.yaml`. See
+[this explanation]({{ site.baseurl }}//getting-started/new-project-guide/#language)
+for more details.
+
 `fuzz-time`: Determines how long CIFuzz spends fuzzing your project in seconds.
-The default is 600 seconds. The GitHub Actions max run time is 21600 seconds (6 hours).
+The default is 600 seconds. The GitHub Actions max run time is 21600 seconds (6
+hours). This variable is only meaningful when supplied to the `run_fuzzers`
+action, not the `build_fuzzers` action.
 
 `dry-run`: Determines if CIFuzz surfaces errors. The default value is `false`. When set to `true`,
 CIFuzz will never report a failure even if it finds a crash in your project.
@@ -104,7 +111,8 @@ make sure to set the dry-run parameters in both the `Build Fuzzers` and `Run Fuz
 
 `allowed-broken-targets-percentage`: Can be set if you want to set a stricter
 limit for broken fuzz targets than OSS-Fuzz's check_build. Most users should
-not set this.
+not set this. This value is only meaningful when supplied to the `run_fuzzers`
+action, not the `build_fuzzers` action.
 
 `sanitizer`: Determines a sanitizer to build and run fuzz targets with. The choices are `'address'`,
 `'memory'` and `'undefined'`. The default is `'address'`. It is important to note that the `Build Fuzzers`
@@ -129,14 +137,14 @@ jobs:
      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
      with:
        oss-fuzz-project-name: 'example'
-       dry-run: false
+       language: c++
        sanitizer: ${{ matrix.sanitizer }}
    - name: Run Fuzzers (${{ matrix.sanitizer }})
      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
      with:
        oss-fuzz-project-name: 'example'
+       language: c++
        fuzz-seconds: 600
-       dry-run: false
        sanitizer: ${{ matrix.sanitizer }}
    - name: Upload Crash
      uses: actions/upload-artifact@v1
@@ -176,13 +184,13 @@ jobs:
      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
      with:
        oss-fuzz-project-name: 'example'
-       dry-run: false
+       language: c++
    - name: Run Fuzzers
      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
      with:
        oss-fuzz-project-name: 'example'
+       language: c++
        fuzz-seconds: 600
-       dry-run: false
    - name: Upload Crash
      uses: actions/upload-artifact@v1
      if: failure() && steps.build.outcome == 'success'

--- a/infra/cifuzz/actions/build_fuzzers/action.yml
+++ b/infra/cifuzz/actions/build_fuzzers/action.yml
@@ -5,6 +5,10 @@ inputs:
   oss-fuzz-project-name:
     description: 'Name of the corresponding OSS-Fuzz project.'
     required: true
+  language:
+    description: 'Programming language project is written in.'
+    required: false
+    default: 'c++'
   dry-run:
     description: 'If set, run the action without actually reporting a failure.'
     default: false
@@ -25,6 +29,7 @@ runs:
   image: '../../../build_fuzzers.Dockerfile'
   env:
     OSS_FUZZ_PROJECT_NAME: ${{ inputs.oss-fuzz-project-name }}
+    LANGUAGE: ${{ inputs.language }}
     DRY_RUN: ${{ inputs.dry-run}}
     ALLOWED_BROKEN_TARGETS_PERCENTAGE: ${{ inputs.allowed-broken-targets-percentage}}
     SANITIZER: ${{ inputs.sanitizer }}

--- a/infra/cifuzz/actions/run_fuzzers/action.yml
+++ b/infra/cifuzz/actions/run_fuzzers/action.yml
@@ -5,6 +5,10 @@ inputs:
   oss-fuzz-project-name:
     description: 'The OSS-Fuzz project name.'
     required: true
+  language:
+    description: 'Programming language project is written in.'
+    required: false
+    default: 'c++'
   fuzz-seconds:
     description: 'The total time allotted for fuzzing in seconds.'
     required: true
@@ -31,6 +35,7 @@ runs:
   image: '../../../run_fuzzers.Dockerfile'
   env:
     OSS_FUZZ_PROJECT_NAME: ${{ inputs.oss-fuzz-project-name }}
+    LANGUAGE: ${{ inputs.language }}
     FUZZ_SECONDS: ${{ inputs.fuzz-seconds }}
     DRY_RUN: ${{ inputs.dry-run}}
     SANITIZER: ${{ inputs.sanitizer }}

--- a/infra/cifuzz/build_fuzzers.py
+++ b/infra/cifuzz/build_fuzzers.py
@@ -77,8 +77,8 @@ class Builder:  # pylint: disable=too-many-instance-attributes
   def build_fuzzers(self):
     """Moves the source code we want to fuzz into the project builder and builds
     the fuzzers from that source code. Returns True on success."""
-    docker_args = get_common_docker_args(
-        self.config.sanitizer, self.config.language)
+    docker_args = get_common_docker_args(self.config.sanitizer,
+                                         self.config.language)
     container = utils.get_container_name()
 
     if container:

--- a/infra/cifuzz/build_fuzzers.py
+++ b/infra/cifuzz/build_fuzzers.py
@@ -77,7 +77,8 @@ class Builder:  # pylint: disable=too-many-instance-attributes
   def build_fuzzers(self):
     """Moves the source code we want to fuzz into the project builder and builds
     the fuzzers from that source code. Returns True on success."""
-    docker_args = get_common_docker_args(self.config.sanitizer)
+    docker_args = get_common_docker_args(
+        self.config.sanitizer, self.config.language)
     container = utils.get_container_name()
 
     if container:
@@ -185,7 +186,7 @@ def build_fuzzers(config):
   return builder.build()
 
 
-def get_common_docker_args(sanitizer):
+def get_common_docker_args(sanitizer, language):
   """Returns a list of common docker arguments."""
   return [
       '--cap-add',
@@ -199,12 +200,13 @@ def get_common_docker_args(sanitizer):
       '-e',
       'CIFUZZ=True',
       '-e',
-      'FUZZING_LANGUAGE=c++',  # FIXME: Add proper support.
+      'FUZZING_LANGUAGE=' + language,
   ]
 
 
 def check_fuzzer_build(out_dir,
-                       sanitizer='address',
+                       sanitizer,
+                       language,
                        allowed_broken_targets_percentage=None):
   """Checks the integrity of the built fuzzers.
 
@@ -222,7 +224,7 @@ def check_fuzzer_build(out_dir,
     logging.error('No fuzzers found in out directory: %s.', out_dir)
     return False
 
-  command = get_common_docker_args(sanitizer)
+  command = get_common_docker_args(sanitizer, language)
 
   if allowed_broken_targets_percentage is not None:
     command += [

--- a/infra/cifuzz/build_fuzzers_entrypoint.py
+++ b/infra/cifuzz/build_fuzzers_entrypoint.py
@@ -75,7 +75,8 @@ def main():
   # yapf: disable
   if build_fuzzers.check_fuzzer_build(
       out_dir,
-      sanitizer=config.sanitizer,
+      config.sanitizer,
+      config.language,
       allowed_broken_targets_percentage=config.allowed_broken_targets_percentage
   ):
     # yapf: enable

--- a/infra/cifuzz/build_fuzzers_test.py
+++ b/infra/cifuzz/build_fuzzers_test.py
@@ -266,16 +266,20 @@ class CheckFuzzerBuildTest(unittest.TestCase):
     """Checks check_fuzzer_build function returns True for valid fuzzers."""
     test_fuzzer_dir = os.path.join(self.test_files_path, 'out')
     self.assertTrue(
-        build_fuzzers.check_fuzzer_build(test_fuzzer_dir, self.SANITIZER, self.LANGUAGE))
+        build_fuzzers.check_fuzzer_build(test_fuzzer_dir, self.SANITIZER,
+                                         self.LANGUAGE))
 
   def test_not_a_valid_fuzz_path(self):
     """Tests that False is returned when a bad path is given."""
-    self.assertFalse(build_fuzzers.check_fuzzer_build('not/a/valid/path',
-                                                      self.SANITIZER, self.LANGUAGE))
+    self.assertFalse(
+        build_fuzzers.check_fuzzer_build('not/a/valid/path', self.SANITIZER,
+                                         self.LANGUAGE))
 
   def test_not_a_valid_fuzzer(self):
     """Checks a directory that exists but does not have fuzzers is False."""
-    self.assertFalse(build_fuzzers.check_fuzzer_build(self.test_files_path, self.SANITIZER, self.LANGUAGE))
+    self.assertFalse(
+        build_fuzzers.check_fuzzer_build(self.test_files_path, self.SANITIZER,
+                                         self.LANGUAGE))
 
   @mock.patch('helper.docker_run')
   def test_allow_broken_fuzz_targets_percentage(self, mocked_docker_run):

--- a/infra/cifuzz/build_fuzzers_test.py
+++ b/infra/cifuzz/build_fuzzers_test.py
@@ -251,6 +251,9 @@ class BuildFuzzersIntegrationTest(unittest.TestCase):
 class CheckFuzzerBuildTest(unittest.TestCase):
   """Tests the check_fuzzer_build function in the cifuzz module."""
 
+  SANITIZER = 'address'
+  LANGUAGE = 'c++'
+
   def setUp(self):
     self.tmp_dir_obj = tempfile.TemporaryDirectory()
     self.test_files_path = os.path.join(self.tmp_dir_obj.name, 'test_files')
@@ -262,15 +265,17 @@ class CheckFuzzerBuildTest(unittest.TestCase):
   def test_correct_fuzzer_build(self):
     """Checks check_fuzzer_build function returns True for valid fuzzers."""
     test_fuzzer_dir = os.path.join(self.test_files_path, 'out')
-    self.assertTrue(build_fuzzers.check_fuzzer_build(test_fuzzer_dir))
+    self.assertTrue(
+        build_fuzzers.check_fuzzer_build(test_fuzzer_dir, self.SANITIZER, self.LANGUAGE))
 
   def test_not_a_valid_fuzz_path(self):
     """Tests that False is returned when a bad path is given."""
-    self.assertFalse(build_fuzzers.check_fuzzer_build('not/a/valid/path'))
+    self.assertFalse(build_fuzzers.check_fuzzer_build('not/a/valid/path',
+                                                      self.SANITIZER, self.LANGUAGE))
 
   def test_not_a_valid_fuzzer(self):
     """Checks a directory that exists but does not have fuzzers is False."""
-    self.assertFalse(build_fuzzers.check_fuzzer_build(self.test_files_path))
+    self.assertFalse(build_fuzzers.check_fuzzer_build(self.test_files_path, self.SANITIZER, self.LANGUAGE))
 
   @mock.patch('helper.docker_run')
   def test_allow_broken_fuzz_targets_percentage(self, mocked_docker_run):
@@ -279,6 +284,8 @@ class CheckFuzzerBuildTest(unittest.TestCase):
     mocked_docker_run.return_value = 0
     test_fuzzer_dir = os.path.join(TEST_FILES_PATH, 'out')
     build_fuzzers.check_fuzzer_build(test_fuzzer_dir,
+                                     self.SANITIZER,
+                                     self.LANGUAGE,
                                      allowed_broken_targets_percentage='0')
     self.assertIn('-e ALLOWED_BROKEN_TARGETS_PERCENTAGE=0',
                   ' '.join(mocked_docker_run.call_args[0][0]))

--- a/infra/cifuzz/config_utils.py
+++ b/infra/cifuzz/config_utils.py
@@ -94,6 +94,7 @@ class BaseConfig:
     self.dry_run = _is_dry_run()
     self.sanitizer = _get_sanitizer()
     self.build_integration_path = os.getenv('BUILD_INTEGRATION_PATH')
+    self.language = _get_language()
     event_path = os.getenv('GITHUB_EVENT_PATH')
     self.is_github = bool(event_path)
     logging.debug('Is github: %s.', self.is_github)
@@ -153,7 +154,6 @@ class BuildFuzzersConfig(BaseConfig):
     # TODO(metzman): Some of this config is very CI-specific. Move it into the
     # CI class.
     super().__init__()
-    self.language = _get_language()
     self.project_repo_name = _get_project_repo_name()
     self.commit_sha = os.getenv('GITHUB_SHA')
     event = os.getenv('GITHUB_EVENT_NAME')

--- a/infra/cifuzz/config_utils_test.py
+++ b/infra/cifuzz/config_utils_test.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 """Module for getting the configuration CIFuzz needs to run."""
 import os
-import sys
 import unittest
 
+import config_utils
 import test_helpers
 
 # pylint: disable=no-self-use

--- a/infra/cifuzz/config_utils_test.py
+++ b/infra/cifuzz/config_utils_test.py
@@ -16,14 +16,58 @@ import os
 import sys
 import unittest
 
+from pyfakefs import fake_filesystem_unittest
+
 import config_utils
 
 # pylint: disable=wrong-import-position,import-error
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+INFRA_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(INFRA_DIR)
 
 import test_helpers
 
 # pylint: disable=no-self-use
+
+
+class BaseConfigTest(fake_filesystem_unittest.TestCase):
+  """Tests for BaseConfig."""
+  PROJECT_NAME = 'fake-project'
+
+  def setUp(self):
+    test_helpers.patch_environ(self)
+    os.environ['OSS_FUZZ_PROJECT_NAME'] = self.PROJECT_NAME
+
+  def _create_config(self):
+    return config_utils.BuildFuzzersConfig()
+
+  def test_language_internal_default(self):
+    """Tests that the correct default language is set for internal projects."""
+    os.environ['LANGUAGE'] = 'python'  # Make sure we don't use this.
+    config = self._create_config()
+    self.assertEqual(config.language, 'c++')
+
+  def test_language_external_default(self):
+    """Tests that the correct default language is set for internal projects."""
+    os.environ['BUILD_INTEGRATION_PATH'] = '/path'
+    config = self._create_config()
+    self.assertEqual(config.language, 'c++')
+
+  def test_language_internal(self):
+    """Tests that the correct language is set for internal projects."""
+    self.setUpPyfakefs()
+    project_yaml = os.path.join(os.path.dirname(INFRA_DIR), 'projects',
+                                self.PROJECT_NAME, 'project.yaml')
+    self.fs.create_file(project_yaml, contents='language: go')
+    config = self._create_config()
+    self.assertEqual(config.language, 'go')
+
+  def test_language_external(self):
+    """Tests that the correct language is set for external projects."""
+    os.environ['BUILD_INTEGRATION_PATH'] = '/path'
+    language = 'python'
+    os.environ['LANGUAGE'] = language
+    config = self._create_config()
+    self.assertEqual(config.language, language)
 
 
 class BuildFuzzersConfigTest(unittest.TestCase):

--- a/infra/cifuzz/config_utils_test.py
+++ b/infra/cifuzz/config_utils_test.py
@@ -16,8 +16,6 @@ import os
 import sys
 import unittest
 
-from pyfakefs import fake_filesystem_unittest
-
 import config_utils
 
 # pylint: disable=wrong-import-position,import-error
@@ -29,7 +27,7 @@ import test_helpers
 # pylint: disable=no-self-use
 
 
-class BaseConfigTest(fake_filesystem_unittest.TestCase):
+class BaseConfigTest(unittest.TestCase):
   """Tests for BaseConfig."""
 
   def setUp(self):

--- a/infra/cifuzz/config_utils_test.py
+++ b/infra/cifuzz/config_utils_test.py
@@ -16,12 +16,6 @@ import os
 import sys
 import unittest
 
-import config_utils
-
-# pylint: disable=wrong-import-position,import-error
-INFRA_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-sys.path.append(INFRA_DIR)
-
 import test_helpers
 
 # pylint: disable=no-self-use

--- a/infra/cifuzz/config_utils_test.py
+++ b/infra/cifuzz/config_utils_test.py
@@ -31,13 +31,26 @@ import test_helpers
 
 class BaseConfigTest(fake_filesystem_unittest.TestCase):
   """Tests for BaseConfig."""
-  PROJECT_NAME = 'fake-project'
 
   def setUp(self):
     test_helpers.patch_environ(self)
 
   def _create_config(self):
     return config_utils.BuildFuzzersConfig()
+
+  def test_language_default(self):
+    """Tests that the correct default language is set."""
+    os.environ['BUILD_INTEGRATION_PATH'] = '/path'
+    config = self._create_config()
+    self.assertEqual(config.language, 'c++')
+
+  def test_language(self):
+    """Tests that the correct language is set."""
+    os.environ['BUILD_INTEGRATION_PATH'] = '/path'
+    language = 'python'
+    os.environ['LANGUAGE'] = language
+    config = self._create_config()
+    self.assertEqual(config.language, language)
 
 
 class BuildFuzzersConfigTest(unittest.TestCase):
@@ -60,20 +73,6 @@ class BuildFuzzersConfigTest(unittest.TestCase):
     """Tests that keep_unaffected_fuzz_targets defaults to false."""
     config = self._create_config()
     self.assertFalse(config.keep_unaffected_fuzz_targets)
-
-  def test_language_default(self):
-    """Tests that the correct default language is set."""
-    os.environ['BUILD_INTEGRATION_PATH'] = '/path'
-    config = self._create_config()
-    self.assertEqual(config.language, 'c++')
-
-  def test_language(self):
-    """Tests that the correct language is set."""
-    os.environ['BUILD_INTEGRATION_PATH'] = '/path'
-    language = 'python'
-    os.environ['LANGUAGE'] = language
-    config = self._create_config()
-    self.assertEqual(config.language, language)
 
 
 if __name__ == '__main__':

--- a/infra/cifuzz/config_utils_test.py
+++ b/infra/cifuzz/config_utils_test.py
@@ -35,39 +35,9 @@ class BaseConfigTest(fake_filesystem_unittest.TestCase):
 
   def setUp(self):
     test_helpers.patch_environ(self)
-    os.environ['OSS_FUZZ_PROJECT_NAME'] = self.PROJECT_NAME
 
   def _create_config(self):
     return config_utils.BuildFuzzersConfig()
-
-  def test_language_internal_default(self):
-    """Tests that the correct default language is set for internal projects."""
-    os.environ['LANGUAGE'] = 'python'  # Make sure we don't use this.
-    config = self._create_config()
-    self.assertEqual(config.language, 'c++')
-
-  def test_language_external_default(self):
-    """Tests that the correct default language is set for internal projects."""
-    os.environ['BUILD_INTEGRATION_PATH'] = '/path'
-    config = self._create_config()
-    self.assertEqual(config.language, 'c++')
-
-  def test_language_internal(self):
-    """Tests that the correct language is set for internal projects."""
-    self.setUpPyfakefs()
-    project_yaml = os.path.join(os.path.dirname(INFRA_DIR), 'projects',
-                                self.PROJECT_NAME, 'project.yaml')
-    self.fs.create_file(project_yaml, contents='language: go')
-    config = self._create_config()
-    self.assertEqual(config.language, 'go')
-
-  def test_language_external(self):
-    """Tests that the correct language is set for external projects."""
-    os.environ['BUILD_INTEGRATION_PATH'] = '/path'
-    language = 'python'
-    os.environ['LANGUAGE'] = language
-    config = self._create_config()
-    self.assertEqual(config.language, language)
 
 
 class BuildFuzzersConfigTest(unittest.TestCase):
@@ -90,6 +60,20 @@ class BuildFuzzersConfigTest(unittest.TestCase):
     """Tests that keep_unaffected_fuzz_targets defaults to false."""
     config = self._create_config()
     self.assertFalse(config.keep_unaffected_fuzz_targets)
+
+  def test_language_default(self):
+    """Tests that the correct default language is set."""
+    os.environ['BUILD_INTEGRATION_PATH'] = '/path'
+    config = self._create_config()
+    self.assertEqual(config.language, 'c++')
+
+  def test_language(self):
+    """Tests that the correct language is set."""
+    os.environ['BUILD_INTEGRATION_PATH'] = '/path'
+    language = 'python'
+    os.environ['LANGUAGE'] = language
+    config = self._create_config()
+    self.assertEqual(config.language, language)
 
 
 if __name__ == '__main__':

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -307,7 +307,7 @@ def _get_work_dir(project_name=''):
   return directory
 
 
-def _get_project_language(project_name):
+def get_project_language(project_name):
   """Returns project language."""
   project_yaml_path = os.path.join(OSS_FUZZ_DIR, 'projects', project_name,
                                    'project.yaml')
@@ -507,7 +507,7 @@ def build_fuzzers_impl(  # pylint: disable=too-many-arguments,too-many-locals,to
 
   project_out_dir = _get_output_dir(project_name)
   project_work_dir = _get_work_dir(project_name)
-  project_language = _get_project_language(project_name)
+  project_language = get_project_language(project_name)
   if not project_language:
     print('WARNING: language not specified in project.yaml. Build may fail.')
 
@@ -611,7 +611,7 @@ def check_build(args):
       not _check_fuzzer_exists(args.project_name, args.fuzzer_name)):
     return 1
 
-  fuzzing_language = _get_project_language(args.project_name)
+  fuzzing_language = get_project_language(args.project_name)
   if fuzzing_language is None:
     print('WARNING: language not specified in project.yaml. Defaulting to C++.')
     fuzzing_language = 'c++'
@@ -752,7 +752,7 @@ def coverage(args):
   if not check_project_exists(args.project_name):
     return 1
 
-  project_language = _get_project_language(args.project_name)
+  project_language = get_project_language(args.project_name)
   if project_language not in LANGUAGES_WITH_COVERAGE_SUPPORT:
     print(
         'ERROR: Project is written in %s, coverage for it is not supported yet.'
@@ -956,7 +956,7 @@ def shell(args):
       'FUZZING_ENGINE=' + args.engine,
       'SANITIZER=' + args.sanitizer,
       'ARCHITECTURE=' + args.architecture,
-      'FUZZING_LANGUAGE=' + _get_project_language(args.project_name),
+      'FUZZING_LANGUAGE=' + get_project_language(args.project_name),
   ]
 
   if args.e:

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -307,7 +307,7 @@ def _get_work_dir(project_name=''):
   return directory
 
 
-def get_project_language(project_name):
+def _get_project_language(project_name):
   """Returns project language."""
   project_yaml_path = os.path.join(OSS_FUZZ_DIR, 'projects', project_name,
                                    'project.yaml')
@@ -507,7 +507,7 @@ def build_fuzzers_impl(  # pylint: disable=too-many-arguments,too-many-locals,to
 
   project_out_dir = _get_output_dir(project_name)
   project_work_dir = _get_work_dir(project_name)
-  project_language = get_project_language(project_name)
+  project_language = _get_project_language(project_name)
   if not project_language:
     print('WARNING: language not specified in project.yaml. Build may fail.')
 
@@ -611,7 +611,7 @@ def check_build(args):
       not _check_fuzzer_exists(args.project_name, args.fuzzer_name)):
     return 1
 
-  fuzzing_language = get_project_language(args.project_name)
+  fuzzing_language = _get_project_language(args.project_name)
   if fuzzing_language is None:
     print('WARNING: language not specified in project.yaml. Defaulting to C++.')
     fuzzing_language = 'c++'
@@ -752,7 +752,7 @@ def coverage(args):
   if not check_project_exists(args.project_name):
     return 1
 
-  project_language = get_project_language(args.project_name)
+  project_language = _get_project_language(args.project_name)
   if project_language not in LANGUAGES_WITH_COVERAGE_SUPPORT:
     print(
         'ERROR: Project is written in %s, coverage for it is not supported yet.'
@@ -956,7 +956,7 @@ def shell(args):
       'FUZZING_ENGINE=' + args.engine,
       'SANITIZER=' + args.sanitizer,
       'ARCHITECTURE=' + args.architecture,
-      'FUZZING_LANGUAGE=' + get_project_language(args.project_name),
+      'FUZZING_LANGUAGE=' + _get_project_language(args.project_name),
   ]
 
   if args.e:


### PR DESCRIPTION
Allow use of non-C++ projects by specifying the language in the workflow file.
Fixes #5195