### PR TITLE
Go 1.16 build fix with right parentheses

### DIFF
--- a/infra/base-images/base-builder/compile_go_fuzzer
+++ b/infra/base-images/base-builder/compile_go_fuzzer
@@ -25,7 +25,7 @@ fi
 
 cd $GOPATH/src/$path || true
 # project was downloaded with go get if go list fails
-go list $path || cd $GOPATH/pkg/mod/ && cd `echo $path | cut -d/ -f1-3 | awk '{print $1"*"}'`
+go list $path || (cd $GOPATH/pkg/mod/ && cd `echo $path | cut -d/ -f1-3 | awk '{print $1"*"}'`)
 # project does not have go.mod if go list fails again
 go list $path || go mod init $path
 

--- a/infra/base-images/base-builder/compile_go_fuzzer
+++ b/infra/base-images/base-builder/compile_go_fuzzer
@@ -25,9 +25,9 @@ fi
 
 cd $GOPATH/src/$path || true
 # project was downloaded with go get if go list fails
-go list $path || (cd $GOPATH/pkg/mod/ && cd `echo $path | cut -d/ -f1-3 | awk '{print $1"*"}'`)
+go list $tags $path || (cd $GOPATH/pkg/mod/ && cd `echo $path | cut -d/ -f1-3 | awk '{print $1"*"}'`)
 # project does not have go.mod if go list fails again
-go list $path || go mod init $path
+go list $tags $path || go mod init $path
 
 if [[ $SANITIZER = *coverage* ]]; then
   fuzzed_package=`go list $tags -f '{{.Name}}' $path`

--- a/projects/cascadia/Dockerfile
+++ b/projects/cascadia/Dockerfile
@@ -15,7 +15,9 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN go get github.com/andybalholm/cascadia
+RUN git clone https://github.com/andybalholm/cascadia
 
 COPY build.sh $SRC/
-WORKDIR $SRC/
+WORKDIR $SRC/cascadia
+# no idea why this is needed
+RUN go mod download golang.org/x/net

--- a/projects/go-json-iterator/Dockerfile
+++ b/projects/go-json-iterator/Dockerfile
@@ -15,7 +15,8 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN go get github.com/json-iterator/go
+RUN git clone https://github.com/json-iterator/go json-iterator
 
-COPY fuzz_json.go $GOPATH/src/github.com/json-iterator/go/
+COPY fuzz_json.go $SRC/json-iterator/
 COPY build.sh $SRC/
+WORKDIR $SRC/json-iterator/

--- a/projects/go-redis/Dockerfile
+++ b/projects/go-redis/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN go get github.com/go-redis/redis
+RUN git clone https://github.com/go-redis/redis redis
 COPY build.sh $SRC/
-WORKDIR $SRC
+WORKDIR $SRC/redis
 

--- a/projects/go-redis/build.sh
+++ b/projects/go-redis/build.sh
@@ -12,5 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
- 
-compile_go_fuzzer github.com/go-redis/redis/fuzz Fuzz fuzz gofuzz
+
+#github.com/go-redis/redis/fuzz is not a module, so needs local build
+compile_go_fuzzer ./fuzz Fuzz fuzz gofuzz


### PR DESCRIPTION
Completes/fixes #5221 

Tested with go-coredns, prometheus, golang, golang-protobuf

For cilium, `go get` fails so I guess this is another specific problem not related to fuzzing...

For other projects, I did not find a good generic way
- go-redis : `go get` seems to get an old version (without fuzz targets), then I need a local build (ie `compile_go_fuzzer ./fuzz` instead of `compile_go_fuzzer github.com/go-redis/redis/fuzz`) otherwise I get `no required module provides package github.com/go-redis/redis/fuzz`
- cascadia : I get the error `missing go.sum entry; to add it: go mod download golang.org/x/net` So I added this command to the Dockerfile
- go-json-iterator : the fuzz target living in oss-fuzz repo was no longer copied in the right directory, looks like it was the only such project cf `git grep GOPATH projects/ | grep COPY`


