### PR TITLE
minify: get latest version of minify

### DIFF
--- a/projects/minify/Dockerfile
+++ b/projects/minify/Dockerfile
@@ -15,6 +15,6 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN go get -u github.com/tdewolff/minify
+RUN go get -u github.com/tdewolff/minify/v2
 COPY build.sh $SRC/
 WORKDIR $SRC/

--- a/projects/minify/Dockerfile
+++ b/projects/minify/Dockerfile
@@ -15,6 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN go get -u github.com/tdewolff/minify/v2
+RUN git clone --depth 1 https://github.com/tdewolff/minify
+RUN git clone --depth 1 https://github.com/tdewolff/parse
 COPY build.sh $SRC/
 WORKDIR $SRC/


### PR DESCRIPTION
I'm getting build errors for v1 which is not a supported version anymore.