### PR TITLE
Fix git build by ignoring leaks in build.sh

### DIFF
--- a/projects/git/build.sh
+++ b/projects/git/build.sh
@@ -34,7 +34,7 @@ done
 zip -j $OUT/fuzz-pack-headers_seed_corpus.zip .git/objects/pack/*.pack.trimmed
 
 # build commit-graph corpus
-./git commit-graph write
+ASAN_OPTIONS=detect_leaks=0 ./git commit-graph write
 zip -j $OUT/fuzz-commit-graph_seed_corpus .git/objects/info/commit-graph
 
 # Mute stderr


### PR DESCRIPTION
The oss-fuzz git ASAN build fails due to a leak inside git iself:
the build script builds a copy of git, and then uses that binary to
prepare the corpus - and although the git invocation itself
succeeds, ASAN causes the script to fail due to the leak:
https://oss-fuzz-build-logs.storage.googleapis.com/log-2eee2921-1b3f-4dd8-a902-50474e8fed55.txt

This was reproduced locally using:
 $ python infra/helper.py build_fuzzers --sanitizer address git

Disabling leak checking for all invocations of git in the script
is enough to avoid this failure, and has been verified to fix
the build locally.

The leak itself is being fixed in git in the following commit (which
is now in next, which I believe is what oss-fuzz is building):
https://git.kernel.org/pub/scm/git/git.git/commit/?id=bf4bb9f9f5130a7b299f7810fb87a40cdd1bd8ee

Nevertheless, I still believe we should be disabling leak checking during
the build script in this way because:

1. This issue persisted for close to one month before being fixed,
   and blocking oss-fuzz runs on a leak during the build process
   for that long seems counter-productive.
2. An alternative would be to use a pre-built copy of git to build
   the corpus (thus sidestepping ASAN in the first place), but IMHO
   installing git via the Dockerfile seems more wasteful AND it's
   unclear if that would have side effects (I'm not sure if the
   commit-graph format changes between versions).