### PR TITLE
minify: move `git clone` for tdewolff/parse to Dockerfile

### DIFF
--- a/projects/minify/Dockerfile
+++ b/projects/minify/Dockerfile
@@ -18,4 +18,4 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN git clone --depth 1 https://github.com/tdewolff/minify
 RUN git clone --depth 1 https://github.com/tdewolff/parse
 COPY build.sh $SRC/
-WORKDIR $SRC/minify
+WORKDIR $SRC

--- a/projects/minify/Dockerfile
+++ b/projects/minify/Dockerfile
@@ -16,5 +16,6 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN git clone --depth 1 https://github.com/tdewolff/minify
+RUN git clone --depth 1 https://github.com/tdewolff/parse
 COPY build.sh $SRC/
 WORKDIR $SRC/minify


### PR DESCRIPTION
This used to be in the `build.sh` script. Minify and parse is really one package over two repositories, thus it's important that both get fuzz tested!