### PR TITLE
[p11-kit] Use gmail address for the maintainer

### DIFF
--- a/projects/p11-kit/project.yaml
+++ b/projects/p11-kit/project.yaml
@@ -1,4 +1,4 @@
 homepage: https://p11-glue.github.io/p11-glue/p11-kit.html
 main_repo: https://github.com/p11-glue/p11-kit
 language: c
-primary_contact: "ueno@gnu.org"
+primary_contact: "daiki.ueno@gmail.com"


### PR DESCRIPTION
This changes my address to be the gmail one, so I can access the logs.