### PR TITLE
Md4c: Update primary_contact e-mail address

### DIFF
--- a/projects/md4c/project.yaml
+++ b/projects/md4c/project.yaml
@@ -1,6 +1,6 @@
 homepage: "https://github.com/mity/md4c"
 main_repo: "https://github.com/mity/md4c"
-primary_contact: "martin.mitas@morous.org"
+primary_contact: "mity@morous.org"
 language: c
 auto_ccs :
   - "david@adalogics.com"

--- a/projects/md4c/project.yaml
+++ b/projects/md4c/project.yaml
@@ -2,5 +2,5 @@ homepage: "https://github.com/mity/md4c"
 main_repo: "https://github.com/mity/md4c"
 primary_contact: "mity@morous.org"
 language: c
-auto_ccs :
+auto_ccs:
   - "david@adalogics.com"


### PR DESCRIPTION
The original e-mail address `martin.mitas@gmail.com` is associated with a gmail account which is unused and became sort of a zombie years ago, and I am not able even to login into it anymore. (But it still prevents me to use the e-mail as an alternative with my active google account.)

Consequently, I'm unable to get into the reports generated by the fuzz testing.

The `mity@morous.org` is actually an alias of the same mailbox but it was successfully used as an alternative in a newer and active gmail account.

Sorry for the inconvenience.
