### PR TITLE
[jazzer] Migrate projects to new void fuzzerTestOneInput

### DIFF
--- a/projects/java-example/ExampleFuzzer.java
+++ b/projects/java-example/ExampleFuzzer.java
@@ -22,13 +22,12 @@ public class ExampleFuzzer {
     // Optional initialization to be run before the first call to fuzzerTestOneInput.
   }
 
-  public static boolean fuzzerTestOneInput(FuzzedDataProvider data) {
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     String input = data.consumeRemainingAsString();
     long random = 123123132;
     if (input.startsWith("magicstring" + random) && input.length() > 30
         && input.charAt(25) == 'C') {
-      return true;
+      throw new IllegalStateException("Not reached");
     }
-    return false;
   }
 }

--- a/projects/java-example/ExampleFuzzerNative.java
+++ b/projects/java-example/ExampleFuzzerNative.java
@@ -21,14 +21,13 @@ public class ExampleFuzzerNative {
     System.loadLibrary("native");
   }
 
-  public static boolean fuzzerTestOneInput(FuzzedDataProvider data) {
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     int val = data.consumeInt();
     String stringData = data.consumeRemainingAsString();
     if (val == 17759716 && stringData.length() > 10 && stringData.contains("jazzer")) {
       // call native function which contains a crash
       parse(stringData);
     }
-    return false;
   }
 
   private static native boolean parse(String bytes);

--- a/projects/java-example/ExampleValueProfileFuzzer.java
+++ b/projects/java-example/ExampleValueProfileFuzzer.java
@@ -27,14 +27,14 @@ public class ExampleValueProfileFuzzer {
     return input ^ key;
   }
 
-  public static boolean fuzzerTestOneInput(FuzzedDataProvider data) {
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     // Without -use_value_profile=1, the fuzzer gets stuck here as there is no direct correspondence
     // between the input bytes and the compared string. With value profile, the fuzzer can guess the
     // expected input byte by byte, which takes linear rather than exponential time.
     if (base64(data.consumeBytes(6)).equals("SmF6emVy")) {
       long[] plaintextBlocks = data.consumeLongs(2);
       if (plaintextBlocks.length != 2)
-        return false;
+        return;
       if (insecureEncrypt(plaintextBlocks[0]) == 0x9fc48ee64d3dc090L) {
         // Without --fake_pcs (enabled by default with -use_value_profile=1), the fuzzer would get
         // stuck here as the value profile information for long comparisons would not be able to
@@ -44,7 +44,6 @@ public class ExampleValueProfileFuzzer {
         }
       }
     }
-    return false;
   }
 
   private static void mustNeverBeCalled() {

--- a/projects/json-sanitizer/DenylistFuzzer.java
+++ b/projects/json-sanitizer/DenylistFuzzer.java
@@ -19,7 +19,7 @@ import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.google.json.JsonSanitizer;
 
 public class DenylistFuzzer {
-  public static boolean fuzzerTestOneInput(FuzzedDataProvider data) {
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     String input = data.consumeRemainingAsString();
     String output;
     try {
@@ -27,15 +27,14 @@ public class DenylistFuzzer {
     } catch (ArrayIndexOutOfBoundsException e) {
       // ArrayIndexOutOfBoundsException is expected if nesting depth is
       // exceeded.
-      return false;
+      return;
     }
     // See https://github.com/OWASP/json-sanitizer#output.
     if (output.contains("</script") || output.contains("<script")
         || output.contains("<!--") || output.contains("]]>")) {
       System.err.println("input : " + input);
       System.err.println("output: " + output);
-      return true;
+      throw new IllegalStateException("Output contains forbidden substring");
     }
-    return false;
   }
 }

--- a/projects/json-sanitizer/IdempotenceFuzzer.java
+++ b/projects/json-sanitizer/IdempotenceFuzzer.java
@@ -19,7 +19,7 @@ import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.google.json.JsonSanitizer;
 
 public class IdempotenceFuzzer {
-  public static boolean fuzzerTestOneInput(FuzzedDataProvider data) {
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     String input = data.consumeRemainingAsString();
     String output1;
     try {
@@ -27,15 +27,14 @@ public class IdempotenceFuzzer {
     } catch (ArrayIndexOutOfBoundsException e) {
       // ArrayIndexOutOfBoundsException is expected if nesting depth is
       // exceeded.
-      return false;
+      return;
     }
     String output2 = JsonSanitizer.sanitize(output1, 10);
     if (!output1.equals(output2)) {
       System.err.println("input  : " + input);
       System.err.println("output1: " + output1);
       System.err.println("output2: " + output2);
-      return true;
+      throw new IllegalStateException("Non-idempotence detected");
     }
-    return false;
   }
 }

--- a/projects/json-sanitizer/ValidJsonFuzzer.java
+++ b/projects/json-sanitizer/ValidJsonFuzzer.java
@@ -23,7 +23,7 @@ import com.google.json.JsonSanitizer;
 public class ValidJsonFuzzer {
   private static Gson gson = new Gson();
 
-  public static boolean fuzzerTestOneInput(FuzzedDataProvider data) {
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     String input = data.consumeRemainingAsString();
     String output;
     try {
@@ -31,7 +31,7 @@ public class ValidJsonFuzzer {
     } catch (ArrayIndexOutOfBoundsException e) {
       // ArrayIndexOutOfBoundsException is expected if nesting depth is
       // exceeded.
-      return false;
+      return;
     }
     try {
       gson.fromJson(output, JsonElement.class);
@@ -40,6 +40,5 @@ public class ValidJsonFuzzer {
       System.err.println("output : " + output);
       throw e;
     }
-    return false;
   }
 }


### PR DESCRIPTION
Jazzer has made fuzzerTestOneInput return void instead of boolean (see https://github.com/CodeIntelligenceTesting/jazzer/commit/541c5c63f1f1e3025da8073fc106a7ffe5ce73b2). This commit adapts the existing Jazzer fuzz targets to this change.

Previously, returning true from a fuzz target would be recorded as a crash. However, since there is no stack trace in that case, such crashes cause issues with deduplication. Additionally, the behavior is easy to replicate with assert or a an if with a throw statement.