### PR TITLE
afl++ commit id update

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -177,7 +177,7 @@ WORKDIR $SRC
 # TODO: switch to -b stable once we can.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git aflplusplus && \
     cd aflplusplus && \
-    git checkout a252943236b12c080248747bee06c9c5084b871e
+    git checkout 78d96c4dc86ac20e2a6e244017407ccc037ff13b
 
 RUN cd $SRC && \
     curl -L -O https://github.com/google/honggfuzz/archive/oss-fuzz.tar.gz && \

--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -177,7 +177,7 @@ WORKDIR $SRC
 # TODO: switch to -b stable once we can.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git aflplusplus && \
     cd aflplusplus && \
-    git checkout a81b5aa921567ba92c22c9ab1c4493725c43e8aa
+    git checkout a252943236b12c080248747bee06c9c5084b871e
 
 RUN cd $SRC && \
     curl -L -O https://github.com/google/honggfuzz/archive/oss-fuzz.tar.gz && \

--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -177,7 +177,7 @@ WORKDIR $SRC
 # TODO: switch to -b stable once we can.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git aflplusplus && \
     cd aflplusplus && \
-    git checkout 5dd35f5281afec0955c08fe9f99e3c83222b7764
+    git checkout a81b5aa921567ba92c22c9ab1c4493725c43e8aa
 
 RUN cd $SRC && \
     curl -L -O https://github.com/google/honggfuzz/archive/oss-fuzz.tar.gz && \

--- a/infra/base-images/base-runner/run_fuzzer
+++ b/infra/base-images/base-runner/run_fuzzer
@@ -119,6 +119,9 @@ if [[ "$FUZZING_ENGINE" = afl ]]; then
   AFL_FUZZER_ARGS="$AFL_FUZZER_ARGS -t 5000+"
   # AFL expects at least 1 file in the input dir.
   echo input > ${CORPUS_DIR}/input
+  echo afl++ setup:
+  env|grep AFL_
+  cat "$OUT/afl_options.txt"
   CMD_LINE="$OUT/afl-fuzz $AFL_FUZZER_ARGS -i $CORPUS_DIR -o $FUZZER_OUT $(get_dictionary) $* -- $OUT/$FUZZER"
 
 elif [[ "$FUZZING_ENGINE" = honggfuzz ]]; then


### PR DESCRIPTION
among other fixes, this changes the -t + parameter to autodetect the timeout value to up to the specified value, depending on the slowest seed in the initial corpus.

maybe it is time now to switch to the stable branch of afl++ so the commit id doesnt need to be updated anymore?