### PR TITLE
libredwg: update options

### DIFF
--- a/projects/libredwg/build.sh
+++ b/projects/libredwg/build.sh
@@ -17,7 +17,8 @@
 
 cd libredwg
 sh ./autogen.sh
-./configure --disable-shared --disable-bindings
+# enable-release to skip unstable preR13. bindings are not fuzzed.
+./configure --disable-shared --disable-bindings --enable-release
 make
 
 $CC $CFLAGS $LIB_FUZZING_ENGINE examples/llvmfuzz.c -o $OUT/llvmfuzz \


### PR DESCRIPTION
don't test unstable non-release preR13 paths.
add dwg specific memory options, as used locally. Those files get big.