### PR TITLE
libyang: give access to the bug reports

### DIFF
--- a/projects/libyang/project.yaml
+++ b/projects/libyang/project.yaml
@@ -3,6 +3,7 @@ main_repo: 'https://github.com/CESNET/libyang'
 primary_contact: "mvasko@cesnet.cz"
 language: c
 auto_ccs :
+  - "mv6606@gmail.com"
   - "david@adalogics.com"
 sanitizers:
   - address


### PR DESCRIPTION
Add a gmail account to get access to the detailed reports.