### PR TITLE
[jazzer][java-example] Fix native library loading.

### DIFF
--- a/projects/java-example/Dockerfile
+++ b/projects/java-example/Dockerfile
@@ -19,6 +19,6 @@ FROM gcr.io/oss-fuzz-base/base-builder
 COPY build.sh $SRC/
 
 COPY ExampleFuzzerNative.h ExampleFuzzerNative.cpp $SRC/
-COPY ExampleFuzzer.java ExampleValueProfileFuzzer.java ExampleFuzzerNative.java $SRC/
+COPY ExampleFuzzer.java ExampleValueProfileFuzzer.java ExampleFuzzerNative.java default.options $SRC/
 
 WORKDIR $SRC/

--- a/projects/java-example/build.sh
+++ b/projects/java-example/build.sh
@@ -36,11 +36,12 @@ for fuzzer in $(find $SRC -name '*Fuzzer.java' -or -name '*FuzzerNative.java'); 
     driver=jazzer_driver
   fi
 
+  cp default.options $OUT/"$fuzzer_basename".options
   # Create execution wrapper.
   echo "#!/bin/sh
 # LLVMFuzzerTestOneInput for fuzzer detection.
 this_dir=\$(dirname \"\$0\")
-LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\":. \
+LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\":\$this_dir \
 ASAN_OPTIONS=\$ASAN_OPTIONS:symbolize=1:external_symbolizer_path=\$this_dir/llvm-symbolizer:detect_leaks=0 \
 \$this_dir/$driver --agent_path=\$this_dir/jazzer_agent_deploy.jar \
 --cp=$RUNTIME_CLASSPATH \

--- a/projects/java-example/default.options
+++ b/projects/java-example/default.options
@@ -1,0 +1,2 @@
+[asan]
+handle_segv=1

--- a/projects/json-sanitizer/build.sh
+++ b/projects/json-sanitizer/build.sh
@@ -47,7 +47,7 @@ for fuzzer in $(find $SRC -name '*Fuzzer.java'); do
   echo "#!/bin/sh
 # LLVMFuzzerTestOneInput for fuzzer detection.
 this_dir=\$(dirname \"\$0\")
-LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\" \
+LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\:\$this_dir" \
 \$this_dir/jazzer_driver --agent_path=\$this_dir/jazzer_agent_deploy.jar \
 --cp=$RUNTIME_CLASSPATH \
 --target_class=$fuzzer_basename \

--- a/projects/json-sanitizer/build.sh
+++ b/projects/json-sanitizer/build.sh
@@ -47,7 +47,7 @@ for fuzzer in $(find $SRC -name '*Fuzzer.java'); do
   echo "#!/bin/sh
 # LLVMFuzzerTestOneInput for fuzzer detection.
 this_dir=\$(dirname \"\$0\")
-LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\:\$this_dir" \
+LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\":\$this_dir \
 \$this_dir/jazzer_driver --agent_path=\$this_dir/jazzer_agent_deploy.jar \
 --cp=$RUNTIME_CLASSPATH \
 --target_class=$fuzzer_basename \


### PR DESCRIPTION
Prior to this change, native library loading failed for
two reasons:
1. Loading from current working directory instead of the fuzzer's
directory.
2. Using ASAN_OPTIONS=handle_segv=2.

Fix these issues by doing the following.
1. Adding the fuzzer's directory to LD_LIBRARY_PATH instead of "."
2. Specifying handle_segv=1 in ASAN_OPTIONS.


Related #5178.