### PR TITLE
[base-clang] Reduce build time by ~65%

### DIFF
--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -15,7 +15,13 @@
 #
 ################################################################################
 
-NPROC=$(expr $(nproc) / 2)  # See issue #4270. The compiler crashes on GCB instance with 32 vCPUs.
+# See issue #4270. The compiler crashes on GCB instance with 32 vCPUs, so when
+# we compile on GCB we want 16 cores. But locally we want more (so use nproc /
+# 2).
+NPROC=$(expr $(nproc) / 2)
+# On CI this means 1, which is too little in CI, so use max of NPROC or 2 (2
+# core instances on CI).
+NPROC=$((NPROC>2 ? NPROC : 2))
 
 LLVM_DEP_PACKAGES="build-essential make cmake ninja-build git python3 g++-multilib binutils-dev"
 apt-get install -y $LLVM_DEP_PACKAGES --no-install-recommends

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -15,10 +15,10 @@
 #
 ################################################################################
 
-NPROC=16  # See issue #4270. The compiler crashes on GCB instance with 32 vCPUs.
+NPROC=$(expr $(nproc) / 2)  # See issue #4270. The compiler crashes on GCB instance with 32 vCPUs.
 
 LLVM_DEP_PACKAGES="build-essential make cmake ninja-build git python3 g++-multilib binutils-dev"
-apt-get install -y $LLVM_DEP_PACKAGES
+apt-get install -y $LLVM_DEP_PACKAGES --no-install-recommends
 
 # Checkout
 CHECKOUT_RETRIES=10
@@ -60,7 +60,7 @@ function cmake_llvm {
 # Use chromium's clang revision
 mkdir $SRC/chromium_tools
 cd $SRC/chromium_tools
-git clone https://chromium.googlesource.com/chromium/src/tools/clang
+git clone https://chromium.googlesource.com/chromium/src/tools/clang --depth 1
 cd clang
 
 LLVM_SRC=$SRC/llvm-project
@@ -89,11 +89,9 @@ fi
 git -C $LLVM_SRC checkout $LLVM_REVISION
 echo "Using LLVM revision: $LLVM_REVISION"
 
-# Build & install. We build clang in two stages because gcc can't build a
-# static version of libcxxabi
-# (see https://github.com/google/oss-fuzz/issues/2164).
+# Build & install.
 mkdir -p $WORK/llvm-stage2 $WORK/llvm-stage1
-cd $WORK/llvm-stage1
+python3 $SRC/chromium_tools/clang/scripts/update.py --output-dir $WORK/llvm-stage1
 
 TARGET_TO_BUILD=
 case $(uname -m) in
@@ -110,9 +108,6 @@ case $(uname -m) in
 esac
 
 PROJECTS_TO_BUILD="libcxx;libcxxabi;compiler-rt;clang;lld"
-
-cmake_llvm
-ninja -j $NPROC
 
 cd $WORK/llvm-stage2
 export CC=$WORK/llvm-stage1/bin/clang

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -19,9 +19,6 @@
 # we compile on GCB we want 16 cores. But locally we want more (so use nproc /
 # 2).
 NPROC=$(expr $(nproc) / 2)
-# On CI this means 1, which is too little in CI, so use max of NPROC or 2 (2
-# core instances on CI).
-NPROC=$((NPROC>2 ? NPROC : 2))
 
 LLVM_DEP_PACKAGES="build-essential make cmake ninja-build git python3 g++-multilib binutils-dev"
 apt-get install -y $LLVM_DEP_PACKAGES --no-install-recommends

--- a/infra/ci/build.py
+++ b/infra/ci/build.py
@@ -212,7 +212,6 @@ def build_base_images():
   execute_helper_command(['pull_images'])
   images = [
       'base-image',
-      'base-clang',
       'base-builder',
       'base-runner',
   ]

--- a/infra/ci/build.py
+++ b/infra/ci/build.py
@@ -212,6 +212,7 @@ def build_base_images():
   execute_helper_command(['pull_images'])
   images = [
       'base-image',
+      'base-clang',
       'base-builder',
       'base-runner',
   ]


### PR DESCRIPTION
Reduce build time by doing the following:
1. Building the second stage clang build with a clang binary we download
from chromium.
2. Changing NPROC to be half of the cores instead of assuming it's 16
cores. This still addresses the OOM when building on GCB but speeds up
local building.
3. Don't install recommended packages and use --depth 1 when possible
(very minor improvements compared to the above).

In all this reduces local build time of base-clang from 32 minutes
to 11 minutes.

Because build times are improved so much, also build base-clang
when testing infra changes in CI.

Also because build times are reduced, it will be easier to
iteratively develop changes needed for #5170