### PR TITLE
[CIFuzz][cifuzz-base] Slim down cifuzz-base

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,11 @@
-out
 .git
-
 # Copied from .gitignore.
 .vscode/
 *.pyc
-/build/
+build
 *~
 .DS_Store
 *.swp
+infra/cifuzz/test_files/*
+docs/*
+infra/testcases/*

--- a/infra/.dockerignore
+++ b/infra/.dockerignore
@@ -1,1 +1,2 @@
-test_files
+cifuzz/test_files/*
+testcases/*

--- a/infra/cifuzz/cifuzz-base/Dockerfile
+++ b/infra/cifuzz/cifuzz-base/Dockerfile
@@ -14,24 +14,18 @@
 #
 ################################################################################
 
+# Don't bother with a slimmer base image.
+# When we pull base-builder to build project builder image we need to pull
+# ubuntu:16.04 anyway. So in the long run we probably would waste time if
+# we pulled something like alpine here instead.
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get install -y git \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    gnupg2 \
-    software-properties-common \
-    python3
+RUN apt-get update && \
+    apt-get install ca-certificates wget python3 git-core --no-install-recommends -y && \
+    wget https://download.docker.com/linux/ubuntu/dists/xenial/pool/stable/amd64/docker-ce-cli_20.10.5~3-0~ubuntu-xenial_amd64.deb -O /tmp/docker-ce.deb && \
+    dpkg -i /tmp/docker-ce.deb && rm /tmp/docker-ce.deb && \
+    apt-get remove wget -y --purge
 
-
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && apt-key fingerprint 0EBFCD88
-RUN add-apt-repository \
-   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-   xenial \
-   stable"
-
-RUN apt-get update && apt-get install docker-ce docker-ce-cli containerd.io -y
 
 ENV OSS_FUZZ_ROOT=/opt/oss-fuzz
 ADD . ${OSS_FUZZ_ROOT}


### PR DESCRIPTION
Reduce cifuzz-base size from 846MB to 444MB.

1. Don't install parts of docker that aren't necessary.
2. Install docker-ce-cli via deb instead of apt.
3. Use .dockerignore properly.

Related to #5180 and #5170