### PR TITLE
gpac: initial integration

### DIFF
--- a/projects/gpac/Dockerfile
+++ b/projects/gpac/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y build-essential pkg-config libz-dev
+RUN git clone https://github.com/gpac/gpac
+
+WORKDIR $SRC
+COPY build.sh $SRC/
+COPY fuzz_parse.c $SRC/

--- a/projects/gpac/build.sh
+++ b/projects/gpac/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd gpac
+./configure --static-build --extra-cflags="${CFLAGS}" --extra-ldflags="${CFLAGS}"
+make
+cp $SRC/fuzz_parse.c . 
+
+$CC $CFLAGS $LIB_FUZZING_ENGINE fuzz_parse.c -o $OUT/fuzz_parse \
+    -I./include -I./ ./bin/gcc/libgpac_static.a \
+    -lm -lz -lpthread -DGPAC_HAVE_CONFIG_H 

--- a/projects/gpac/fuzz_parse.c
+++ b/projects/gpac/fuzz_parse.c
@@ -1,0 +1,36 @@
+/* Copyright 2021 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <stdio.h>
+#include <unistd.h>
+
+#include <gpac/internal/isomedia_dev.h>
+#include <gpac/constants.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    char filename[256];
+    sprintf(filename, "/tmp/libfuzzer.%d", getpid());
+
+    FILE *fp = fopen(filename, "wb");
+    if (!fp) {
+        return 0;
+    }
+    fwrite(data, size, 1, fp);
+    fclose(fp);
+
+    GF_ISOFile *movie = NULL;
+    movie = gf_isom_open_file(filename, GF_ISOM_OPEN_READ_DUMP, NULL);
+    if (movie != NULL) {
+        gf_isom_close(movie);
+    }
+    unlink(filename);
+    return 0;
+}

--- a/projects/gpac/project.yaml
+++ b/projects/gpac/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/gpac/gpac"
+main_repo: "https://https://gpac.wp.imt.fr/"
+primary_contact: "david@adalogics.com"
+language: c
+auto_ccs :
+  - "david@adalogics.com"

--- a/projects/gpac/project.yaml
+++ b/projects/gpac/project.yaml
@@ -2,5 +2,5 @@ homepage: "https://gpac.wp.imt.fr/"
 main_repo: "https://github.com/gpac/gpac"
 primary_contact: "project.gpac@gmail.com"
 language: c
-auto_ccs :
+auto_ccs:
   - "david@adalogics.com"

--- a/projects/gpac/project.yaml
+++ b/projects/gpac/project.yaml
@@ -1,5 +1,5 @@
-homepage: "https://github.com/gpac/gpac"
-main_repo: "https://https://gpac.wp.imt.fr/"
+homepage: "https://gpac.wp.imt.fr/"
+main_repo: "https://github.com/gpac/gpac"
 primary_contact: "project.gpac@gmail.com"
 language: c
 auto_ccs :

--- a/projects/gpac/project.yaml
+++ b/projects/gpac/project.yaml
@@ -1,6 +1,6 @@
 homepage: "https://github.com/gpac/gpac"
 main_repo: "https://https://gpac.wp.imt.fr/"
-primary_contact: "david@adalogics.com"
+primary_contact: "project.gpac@gmail.com"
 language: c
 auto_ccs :
   - "david@adalogics.com"


### PR DESCRIPTION
GPAC started more than 20 years ago to demonstrate the features of the MPEG-4 Standard which includes ISOBMFF. Soon, GPAC’s MP4Box became the MP4 swiss-army knife used worldwide by MP4 aficionados, by multimedia researchers and by media companies in production (Netflix uses it https://netflixtechblog.com/optimizing-the-aural-experience-on-android-devices-with-xhe-aac-c27714292a33 - the project is also called "MP4Box" which is referenced in the blog)