### PR TITLE
[AFL++][base-builder] Precompile afl++

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -187,11 +187,13 @@ RUN cd $SRC && \
     rm -rf examples $SRC/oss-fuzz.tar.gz
 
 COPY compile compile_afl compile_dataflow compile_libfuzzer compile_honggfuzz \
-    compile_go_fuzzer precompile_honggfuzz srcmap write_labels.py /usr/local/bin/
+    compile_go_fuzzer precompile_honggfuzz precompile_afl srcmap \
+    write_labels.py /usr/local/bin/
 
 COPY detect_repo.py /opt/cifuzz/
 COPY ossfuzz_coverage_runner.go $GOPATH
 
 RUN precompile_honggfuzz
+RUN precompile_afl
 
 CMD ["compile"]

--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -169,9 +169,6 @@ ENV LIB_FUZZING_ENGINE="/usr/lib/libFuzzingEngine.a"
 # TODO: remove after tpm2 catchup.
 ENV FUZZER_LDFLAGS ""
 
-ENV PRECOMPILED_DIR="/usr/lib/precompiled"
-RUN mkdir $PRECOMPILED_DIR
-
 WORKDIR $SRC
 
 # TODO: switch to -b stable once we can.

--- a/infra/base-images/base-builder/compile_afl
+++ b/infra/base-images/base-builder/compile_afl
@@ -19,29 +19,17 @@
 # The 'env|grep' setup ensures we do not trigger the linter.
 # The variables need to be set to "1" here - or before running this script.
 
-# If enabled this provides a safe work around if afl-clang-fast ever break:
-env | grep -qw AFL_LLVM_MODE_WORKAROUND || {
-  # needed until llvm 13 works:
-  AFL_LLVM_MODE_WORKAROUND=0
-}
-
-# If a dictionary should be generated based on comparisons at compile time:
-env | grep -qw AFL_ENABLE_DICTIONARY || {
-  AFL_ENABLE_DICTIONARY=1
-}
-
 # Start compiling afl++.
 echo "Copying precompiled afl++"
 
-# Build and copy afl++ tools necessary for fuzzing.
+# Copy afl++ tools necessary for fuzzing.
 pushd $SRC/aflplusplus > /dev/null
 
-# Build afl++ driver with existing CFLAGS, CXXFLAGS.
-cp -f $PRECOMPILED_DIR/aflplusplus/libAFLDriver.a $LIB_FUZZING_ENGINE
+cp -f libAFLDriver.a $LIB_FUZZING_ENGINE
 
 # Some important projects include libraries, copy those even when they don't
 # start with "afl-". Use "sort -u" to avoid a warning about duplicates.
-cp $PRECOMPILED_DIR/aflplusplus/out/* $OUT
+ls afl-* *.txt *.a *.o *.so | sort -u | xargs cp -t $OUT
 export CC="$SRC/aflplusplus/afl-clang-fast"
 export CXX="$SRC/aflplusplus/afl-clang-fast++"
 
@@ -67,6 +55,9 @@ test $(($RANDOM % 10)) -lt 4 && {
 test $(($RANDOM % 10)) -lt 1 && {
   export AFL_LLVM_LAF_ALL=1
 }
+
+export AFL_LLVM_MODE_WORKAROUND=0
+export AFL_ENABLE_DICTIONARY=0
 
 # In case afl-clang-fast ever breaks, this is a workaround:
 test "$AFL_LLVM_MODE_WORKAROUND" = "1" && {

--- a/infra/base-images/base-builder/compile_afl
+++ b/infra/base-images/base-builder/compile_afl
@@ -31,30 +31,17 @@ env | grep -qw AFL_ENABLE_DICTIONARY || {
 }
 
 # Start compiling afl++.
-echo "Compiling afl++"
+echo "Copying precompiled afl++"
 
 # Build and copy afl++ tools necessary for fuzzing.
 pushd $SRC/aflplusplus > /dev/null
 
-# Unset CFLAGS and CXXFLAGS while building AFL since we don't want to slow it
-# down with sanitizers.
-SAVE_CXXFLAGS=$CXXFLAGS
-SAVE_CFLAGS=$CFLAGS
-unset CXXFLAGS
-unset CFLAGS
-export AFL_IGNORE_UNKNOWN_ENVS=1
-make clean
-AFL_NO_X86=1 PYTHON_INCLUDE=/ make
-CFLAGS=$SAVE_CFLAGS
-CXXFLAGS=$SAVE_CXXFLAGS
-
 # Build afl++ driver with existing CFLAGS, CXXFLAGS.
-make -C utils/aflpp_driver
-cp -f libAFLDriver.a $LIB_FUZZING_ENGINE
+cp -f $PRECOMPILED_DIR/aflplusplus/libAFLDriver.a $LIB_FUZZING_ENGINE
 
 # Some important projects include libraries, copy those even when they don't
 # start with "afl-". Use "sort -u" to avoid a warning about duplicates.
-ls afl-* *.txt *.a *.o *.so | sort -u | xargs cp -t $OUT
+cp $PRECOMPILED_DIR/aflplusplus/out/* $OUT
 export CC="$SRC/aflplusplus/afl-clang-fast"
 export CXX="$SRC/aflplusplus/afl-clang-fast++"
 

--- a/infra/base-images/base-builder/compile_honggfuzz
+++ b/infra/base-images/base-builder/compile_honggfuzz
@@ -17,8 +17,8 @@
 
 echo "Skipping compilation; using precompiled honggfuzz"
 
-cp $PRECOMPILED_DIR/honggfuzz.a $LIB_FUZZING_ENGINE
-cp $PRECOMPILED_DIR/honggfuzz $OUT/
+cp $SRC/honggfuzz/honggfuzz.a $LIB_FUZZING_ENGINE
+cp $SRC/honggfuzz/honggfuzz $OUT/
 
 # Custom coverage flags, roughly in sync with:
 # https://github.com/google/honggfuzz/blob/oss-fuzz/hfuzz_cc/hfuzz-cc.c

--- a/infra/base-images/base-builder/compile_honggfuzz
+++ b/infra/base-images/base-builder/compile_honggfuzz
@@ -17,8 +17,8 @@
 
 echo "Skipping compilation; using precompiled honggfuzz"
 
-cp $PRECOMPILED_DIR/honggfuzz.a $LIB_FUZZING_ENGINE
-cp $PRECOMPILED_DIR/honggfuzz $OUT/
+cp $PRECOMPILED_DIR/honggfuzz/honggfuzz.a $LIB_FUZZING_ENGINE
+cp $PRECOMPILED_DIR/honggfuzz/honggfuzz $OUT/
 
 # Custom coverage flags, roughly in sync with:
 # https://github.com/google/honggfuzz/blob/oss-fuzz/hfuzz_cc/hfuzz-cc.c

--- a/infra/base-images/base-builder/compile_honggfuzz
+++ b/infra/base-images/base-builder/compile_honggfuzz
@@ -17,8 +17,8 @@
 
 echo "Skipping compilation; using precompiled honggfuzz"
 
-cp $PRECOMPILED_DIR/honggfuzz/honggfuzz.a $LIB_FUZZING_ENGINE
-cp $PRECOMPILED_DIR/honggfuzz/honggfuzz $OUT/
+cp $PRECOMPILED_DIR/honggfuzz.a $LIB_FUZZING_ENGINE
+cp $PRECOMPILED_DIR/honggfuzz $OUT/
 
 # Custom coverage flags, roughly in sync with:
 # https://github.com/google/honggfuzz/blob/oss-fuzz/hfuzz_cc/hfuzz-cc.c

--- a/infra/base-images/base-builder/precompile_afl
+++ b/infra/base-images/base-builder/precompile_afl
@@ -26,9 +26,9 @@ SAVE_CFLAGS=$CFLAGS
 unset CXXFLAGS
 unset CFLAGS
 export AFL_IGNORE_UNKNOWN_ENVS=1
-make -j clean
-AFL_NO_X86=1 PYTHON_INCLUDE=/ make -j
-make -j -C utils/aflpp_driver
+make clean
+AFL_NO_X86=1 PYTHON_INCLUDE=/ make
+make -C utils/aflpp_driver
 
 popd > /dev/null
 

--- a/infra/base-images/base-builder/precompile_afl
+++ b/infra/base-images/base-builder/precompile_afl
@@ -19,20 +19,18 @@ echo -n "Precompiling AFLplusplus to $PRECOMPILED_DIR..."
 
 pushd $SRC/aflplusplus > /dev/null
 make clean
-# These CFLAGs match honggfuzz's default, with the exception of -mtune to
-# improve portability and `-D_HF_LINUX_NO_BFD` to remove assembly instructions
-# from the filenames.
-echo "CC $CC CXXFLAGS $CXXFLAGS CFLAG $CFLAGS"
-unset CFLAGS
+# Unset CFLAGS and CXXFLAGS while building AFL since we don't want to slow it
+# down with sanitizers.
+SAVE_CXXFLAGS=$CXXFLAGS
+SAVE_CFLAGS=$CFLAGS
 unset CXXFLAGS
-export CXXFLAGS="-stdlib=libc++"
+unset CFLAGS
 export AFL_IGNORE_UNKNOWN_ENVS=1
 export AFL_LLVM_MODE_WORKAROUND=0
-export AFL_ENABLE_DICTIONARY=1
+export AFL_ENABLE_DICTIONARY=0
 make -j clean
 AFL_NO_X86=1 PYTHON_INCLUDE=/ make -j
 make -j -C utils/aflpp_driver
-make test
 
 PRECOMPILED_AFLPLUSPLUS_DIR=$PRECOMPILED_DIR/aflplusplus
 # Copy things into subdir "out" so we don't copy libAFLDriver.a into $OUT when

--- a/infra/base-images/base-builder/precompile_afl
+++ b/infra/base-images/base-builder/precompile_afl
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 ################################################################################
 
-echo -n "Precompiling AFLplusplus to $PRECOMPILED_DIR..."
+echo "Precompiling AFLplusplus"
 
 pushd $SRC/aflplusplus > /dev/null
 make clean
@@ -26,19 +26,10 @@ SAVE_CFLAGS=$CFLAGS
 unset CXXFLAGS
 unset CFLAGS
 export AFL_IGNORE_UNKNOWN_ENVS=1
-export AFL_LLVM_MODE_WORKAROUND=0
-export AFL_ENABLE_DICTIONARY=0
 make -j clean
 AFL_NO_X86=1 PYTHON_INCLUDE=/ make -j
 make -j -C utils/aflpp_driver
 
-PRECOMPILED_AFLPLUSPLUS_DIR=$PRECOMPILED_DIR/aflplusplus
-# Copy things into subdir "out" so we don't copy libAFLDriver.a into $OUT when
-# compile is called.
-mkdir -p $PRECOMPILED_AFLPLUSPLUS_DIR/out
-ls afl-* *.txt *.a *.o *.so | sort -u | xargs cp -t $PRECOMPILED_AFLPLUSPLUS_DIR/out
-
-cp -f libAFLDriver.a $PRECOMPILED_AFLPLUSPLUS_DIR
 popd > /dev/null
 
-echo " done."
+echo "Done."

--- a/infra/base-images/base-builder/precompile_afl
+++ b/infra/base-images/base-builder/precompile_afl
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2019 Google Inc.
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,34 +15,32 @@
 #
 ################################################################################
 
-echo -n "Precompiling honggfuzz to $PRECOMPILED_DIR..."
-export BUILD_OSSFUZZ_STATIC=true
+echo -n "Precompiling AFLplusplus to $PRECOMPILED_DIR..."
 
-PACKAGES=(
-    libunwind8-dev
-    libblocksruntime-dev
-    liblzma-dev
-    libiberty-dev
-    zlib1g-dev
-    pkg-config)
-
-apt-get install -y ${PACKAGES[@]}
-
-pushd $SRC/honggfuzz > /dev/null
-make -j clean
+pushd $SRC/aflplusplus > /dev/null
+make clean
 # These CFLAGs match honggfuzz's default, with the exception of -mtune to
 # improve portability and `-D_HF_LINUX_NO_BFD` to remove assembly instructions
 # from the filenames.
-CC=clang CFLAGS="-O3 -funroll-loops -D_HF_LINUX_NO_BFD" make -j
+echo "CC $CC CXXFLAGS $CXXFLAGS CFLAG $CFLAGS"
+unset CFLAGS
+unset CXXFLAGS
+export CXXFLAGS="-stdlib=libc++"
+export AFL_IGNORE_UNKNOWN_ENVS=1
+export AFL_LLVM_MODE_WORKAROUND=0
+export AFL_ENABLE_DICTIONARY=1
+make -j clean
+AFL_NO_X86=1 PYTHON_INCLUDE=/ make -j
+make -j -C utils/aflpp_driver
+make test
 
-# libhfuzz.a will be added by CC/CXX linker directly during linking,
-# but it's defined here to satisfy the build infrastructure
-PRECOMPILED_HONGGFUZZ_DIR=$PRECOMPILED_DIR/honggfuzz
-mkdir $PRECOMPILED_HONGGFUZZ_DIR
-ar rcs $PRECOMPILED_HONGGFUZZ_DIR/honggfuzz.a libhfuzz/*.o libhfcommon/*.o
-cp honggfuzz $PRECOMPILED_HONGGFUZZ_DIR
+PRECOMPILED_AFLPLUSPLUS_DIR=$PRECOMPILED_DIR/aflplusplus
+# Copy things into subdir "out" so we don't copy libAFLDriver.a into $OUT when
+# compile is called.
+mkdir -p $PRECOMPILED_AFLPLUSPLUS_DIR/out
+ls afl-* *.txt *.a *.o *.so | sort -u | xargs cp -t $PRECOMPILED_AFLPLUSPLUS_DIR/out
+
+cp -f libAFLDriver.a $PRECOMPILED_AFLPLUSPLUS_DIR
 popd > /dev/null
 
-apt-get remove -y --purge ${PACKAGES[@]}
-apt-get autoremove -y
 echo " done."

--- a/infra/base-images/base-builder/precompile_honggfuzz
+++ b/infra/base-images/base-builder/precompile_honggfuzz
@@ -29,11 +29,11 @@ PACKAGES=(
 apt-get install -y ${PACKAGES[@]}
 
 pushd $SRC/honggfuzz > /dev/null
-make -j clean
+make clean
 # These CFLAGs match honggfuzz's default, with the exception of -mtune to
 # improve portability and `-D_HF_LINUX_NO_BFD` to remove assembly instructions
 # from the filenames.
-CC=clang CFLAGS="-O3 -funroll-loops -D_HF_LINUX_NO_BFD" make -j
+CC=clang CFLAGS="-O3 -funroll-loops -D_HF_LINUX_NO_BFD" make
 
 # libhfuzz.a will be added by CC/CXX linker directly during linking,
 # but it's defined here to satisfy the build infrastructure

--- a/infra/base-images/base-builder/precompile_honggfuzz
+++ b/infra/base-images/base-builder/precompile_honggfuzz
@@ -38,7 +38,7 @@ CC=clang CFLAGS="-O3 -funroll-loops -D_HF_LINUX_NO_BFD" make
 # libhfuzz.a will be added by CC/CXX linker directly during linking,
 # but it's defined here to satisfy the build infrastructure
 ar rcs $PRECOMPILED_DIR/honggfuzz.a libhfuzz/*.o libhfcommon/*.o
-cp honggfuzz $PRECOMPILED_DIR
+cp honggfuzz $PRECOMPILED_DIR/
 popd > /dev/null
 
 apt-get remove -y --purge ${PACKAGES[@]}

--- a/infra/base-images/base-builder/precompile_honggfuzz
+++ b/infra/base-images/base-builder/precompile_honggfuzz
@@ -15,7 +15,7 @@
 #
 ################################################################################
 
-echo -n "Precompiling honggfuzz to $PRECOMPILED_DIR..."
+echo "Precompiling honggfuzz to $PRECOMPILED_DIR..."
 export BUILD_OSSFUZZ_STATIC=true
 
 PACKAGES=(
@@ -37,12 +37,10 @@ CC=clang CFLAGS="-O3 -funroll-loops -D_HF_LINUX_NO_BFD" make -j
 
 # libhfuzz.a will be added by CC/CXX linker directly during linking,
 # but it's defined here to satisfy the build infrastructure
-PRECOMPILED_HONGGFUZZ_DIR=$PRECOMPILED_DIR/honggfuzz
-mkdir $PRECOMPILED_HONGGFUZZ_DIR
-ar rcs $PRECOMPILED_HONGGFUZZ_DIR/honggfuzz.a libhfuzz/*.o libhfcommon/*.o
-cp honggfuzz $PRECOMPILED_HONGGFUZZ_DIR
+ar rcs $PRECOMPILED_DIR/honggfuzz.a libhfuzz/*.o libhfcommon/*.o
+cp honggfuzz $PRECOMPILED_DIR
 popd > /dev/null
 
 apt-get remove -y --purge ${PACKAGES[@]}
 apt-get autoremove -y
-echo " done."
+echo "Done."

--- a/infra/base-images/base-builder/precompile_honggfuzz
+++ b/infra/base-images/base-builder/precompile_honggfuzz
@@ -15,7 +15,7 @@
 #
 ################################################################################
 
-echo "Precompiling honggfuzz to $PRECOMPILED_DIR..."
+echo "Precompiling honggfuzz"
 export BUILD_OSSFUZZ_STATIC=true
 
 PACKAGES=(

--- a/infra/base-images/base-builder/precompile_honggfuzz
+++ b/infra/base-images/base-builder/precompile_honggfuzz
@@ -37,8 +37,7 @@ CC=clang CFLAGS="-O3 -funroll-loops -D_HF_LINUX_NO_BFD" make
 
 # libhfuzz.a will be added by CC/CXX linker directly during linking,
 # but it's defined here to satisfy the build infrastructure
-ar rcs $PRECOMPILED_DIR/honggfuzz.a libhfuzz/*.o libhfcommon/*.o
-cp honggfuzz $PRECOMPILED_DIR/
+ar rcs honggfuzz.a libhfuzz/*.o libhfcommon/*.o
 popd > /dev/null
 
 apt-get remove -y --purge ${PACKAGES[@]}


### PR DESCRIPTION
Precompile AFL like we already do for honggfuzz.
This saves about a minute in compilation time of AFL targets by doing it in base-builder
It only adds about 30 MB to the image size.
It may make debugging breakages somewhat harder for @vanhauser-thc, since it won't be so easy to interactively change the env vars that control AFL compilation.
I was able to run a lot of the tests which passed. However, the unittests require cmocka and failed.
I don't think we need to run these. Maybe we can get another make target that runs tests that don't require these and we can run them during build. We could also look into installing cmocka to run these tests but I think that is another discussion.
Related: #5275