### PR TITLE
Enable ssh-agent fuzzer

### DIFF
--- a/projects/openssh/build.sh
+++ b/projects/openssh/build.sh
@@ -16,8 +16,10 @@
 ################################################################################
 
 # Enable null cipher
-mv cipher.c _cipher.c
-sed 's/#define CFLAG_INTERNAL.*/#define CFLAG_INTERNAL 0/' _cipher.c > cipher.c
+sed -i 's/#define CFLAG_INTERNAL.*/#define CFLAG_INTERNAL 0/' cipher.c
+
+# Turn off agent unlock password failure delays
+sed -i 's|\(usleep.*\)|// \1|' ssh-agent.c
 
 # Build project
 autoreconf
@@ -32,36 +34,47 @@ make -j$(nproc) all
 EXTRA_CFLAGS="-DCIPHER_NONE_AVAIL=1"
 STATIC_CRYPTO="-Wl,-Bstatic -lcrypto -Wl,-Bdynamic"
 
-COMMON=ssh-sk-null.o
+SK_NULL=ssh-sk-null.o
+SK_DUMMY=sk-dummy.o
 
-$CXX $CXXFLAGS -std=c++11 $EXTRA_CFLAGS -I. -L. -Lopenbsd-compat -g \
-	regress/misc/fuzz-harness/ssh-sk-null.cc -c -o ssh-sk-null.o
+$CC $CFLAGS $EXTRA_CFLAGS -I. -g -c \
+	regress/misc/fuzz-harness/ssh-sk-null.cc -o ssh-sk-null.o
+$CC $CFLAGS $EXTRA_CFLAGS -I. -g -c \
+	-DSK_DUMMY_INTEGRATE=1 regress/misc/sk-dummy/sk-dummy.c -o sk-dummy.o
 
 $CXX $CXXFLAGS -std=c++11 $EXTRA_CFLAGS -I. -L. -Lopenbsd-compat -g \
 	regress/misc/fuzz-harness/pubkey_fuzz.cc -o $OUT/pubkey_fuzz \
-	-lssh -lopenbsd-compat $COMMON $STATIC_CRYPTO $LIB_FUZZING_ENGINE
+	-lssh -lopenbsd-compat $SK_NULL $STATIC_CRYPTO $LIB_FUZZING_ENGINE
 $CXX $CXXFLAGS -std=c++11 $EXTRA_CFLAGS -I. -L. -Lopenbsd-compat -g \
 	regress/misc/fuzz-harness/privkey_fuzz.cc -o $OUT/privkey_fuzz \
-	-lssh -lopenbsd-compat $COMMON $STATIC_CRYPTO $LIB_FUZZING_ENGINE
+	-lssh -lopenbsd-compat $SK_NULL $STATIC_CRYPTO $LIB_FUZZING_ENGINE
 $CXX $CXXFLAGS -std=c++11 $EXTRA_CFLAGS -I. -L. -Lopenbsd-compat -g \
 	regress/misc/fuzz-harness/sig_fuzz.cc -o $OUT/sig_fuzz \
-	-lssh -lopenbsd-compat $COMMON $STATIC_CRYPTO $LIB_FUZZING_ENGINE
+	-lssh -lopenbsd-compat $SK_NULL $STATIC_CRYPTO $LIB_FUZZING_ENGINE
 $CXX $CXXFLAGS -std=c++11 $EXTRA_CFLAGS -I. -L. -Lopenbsd-compat -g \
 	regress/misc/fuzz-harness/authopt_fuzz.cc -o $OUT/authopt_fuzz \
-	auth-options.o -lssh -lopenbsd-compat $COMMON $STATIC_CRYPTO \
+	auth-options.o -lssh -lopenbsd-compat $SK_NULL $STATIC_CRYPTO \
 	$LIB_FUZZING_ENGINE
 $CXX $CXXFLAGS -std=c++11 $EXTRA_CFLAGS -I. -L. -Lopenbsd-compat -g \
 	regress/misc/fuzz-harness/sshsig_fuzz.cc -o $OUT/sshsig_fuzz \
-	sshsig.o -lssh -lopenbsd-compat $COMMON $STATIC_CRYPTO \
+	sshsig.o -lssh -lopenbsd-compat $SK_NULL $STATIC_CRYPTO \
 	$LIB_FUZZING_ENGINE
 $CXX $CXXFLAGS -std=c++11 $EXTRA_CFLAGS -I. -L. -Lopenbsd-compat -g \
 	regress/misc/fuzz-harness/sshsigopt_fuzz.cc -o $OUT/sshsigopt_fuzz \
-	sshsig.o -lssh -lopenbsd-compat $COMMON $STATIC_CRYPTO \
+	sshsig.o -lssh -lopenbsd-compat $SK_NULL $STATIC_CRYPTO \
 	$LIB_FUZZING_ENGINE
 $CXX $CXXFLAGS -std=c++11 $EXTRA_CFLAGS -I. -L. -Lopenbsd-compat -g \
 	regress/misc/fuzz-harness/kex_fuzz.cc -o $OUT/kex_fuzz \
-	-lssh -lopenbsd-compat -lz $COMMON $STATIC_CRYPTO \
+	-lssh -lopenbsd-compat -lz $SK_NULL $STATIC_CRYPTO \
 	$LIB_FUZZING_ENGINE
+
+$CC $CFLAGS $EXTRA_CFLAGS -I. -g -c \
+	regress/misc/fuzz-harness/agent_fuzz_helper.c -o agent_fuzz_helper.o
+$CC $CFLAGS $EXTRA_CFLAGS -I. -g -c -DENABLE_SK_INTERNAL=1 ssh-sk.c -o ssh-sk.o
+$CXX $CXXFLAGS -std=c++11 $EXTRA_CFLAGS -I. -L. -Lopenbsd-compat -g \
+	regress/misc/fuzz-harness/agent_fuzz.cc -o $OUT/agent_fuzz \
+	$SK_DUMMY agent_fuzz_helper.o ssh-sk.o -lssh -lopenbsd-compat -lz \
+	$STATIC_CRYPTO $LIB_FUZZING_ENGINE
 
 # Prepare seed corpora
 CASES="$SRC/openssh-fuzz-cases"
@@ -72,3 +85,4 @@ CASES="$SRC/openssh-fuzz-cases"
 (set -e ; cd ${CASES}/sshsig ; zip -r $OUT/sshsig_fuzz_seed_corpus.zip .)
 (set -e ; cd ${CASES}/sshsigopt ; zip -r $OUT/sshsigopt_fuzz_seed_corpus.zip .)
 (set -e ; cd ${CASES}/kex ; zip -r $OUT/kex_fuzz_seed_corpus.zip .)
+(set -e ; cd ${CASES}/agent ; zip -r $OUT/agent_fuzz_seed_corpus.zip .)


### PR DESCRIPTION
I recently added a ssh-agent fuzzer to OpenSSH and a corresponding seed corpus. This enables them in oss-fuzz.