### PR TITLE
[clamav] Switch from autotools to cmake

### DIFF
--- a/projects/clamav/Dockerfile
+++ b/projects/clamav/Dockerfile
@@ -17,9 +17,20 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y \
     flex bison \
-    automake autoconf pkg-config m4 libtool \
-    libssl-dev \
-    libcurl4-openssl-dev
+    python3-dev \
+    pkg-config
+
+#
+# Build static libs for dependencies
+#
+RUN python3 -m pip install mussels
+RUN git clone --depth 1 https://github.com/Cisco-Talos/clamav-mussels-cookbook.git
+
+RUN mkdir /mussels
+RUN cd ${SRC}/clamav-mussels-cookbook && \
+    msl build clamav_deps -t host-static -w /mussels/work -i /mussels/install
+
+# Collect clamav source & fuzz corpus
 RUN git clone --depth 1 https://github.com/Cisco-Talos/clamav-devel.git
 RUN git clone --depth 1 https://github.com/Cisco-Talos/clamav-fuzz-corpus.git
 


### PR DESCRIPTION
For the CMake build, build all dependencies as static libraries first.
To automate this, the Dockerfile uses the Mussels tool.

The HAVE_MMAP variable is explicitly disabled so that malloc is used in
place of mmap, which will yield better fuzzing results.