### PR TITLE
Fix TensorFlow coverage build.

### DIFF
--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -92,7 +92,11 @@ then
   ${RSYNC_CMD} ./bazel-out/k8-opt/bin/tensorflow/core/protobuf ${REMAP_PATH}
 
   # Sync external dependencies. We don't need to include `bazel-tensorflow`.
+  # Also, remove `external/org_tensorflow` which is a copy of the entire source
+  # code that Bazel creates. Not removing this would cause `rsync` to expand a
+  # symlink that ends up pointing to itself!
   pushd bazel-tensorflow
+  unlink external/org_tensorflow
   ${RSYNC_CMD} external/ ${REMAP_PATH}
   popd
 fi


### PR DESCRIPTION
It seems that due to some recent change in `BUILD` rules, `bazel` creates a copy of the code tree under `bazel-tensorflow/external/org_tensorflow` symlink. However, the tree contains a `bazel-tensorflow` symlink so we get to an infinite symlink expansion issue. This breaks coverage build.

The fix is simple: before copying `bazel-tensorflow/external` to `${OUT}` in coverage builds, remove `org_tensorflow` symlink. This is not an issue for the coverage build since we copy the entire source tree to the coverage directory in a previous step.