### PR TITLE
dropbear: Use github so cifuzz might work

### DIFF
--- a/projects/dropbear/Dockerfile
+++ b/projects/dropbear/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y libz-dev autoconf mercurial
-RUN hg clone https://hg.ucc.asn.au/dropbear dropbear
+RUN git clone https://github.com/mkj/dropbear dropbear
 RUN hg clone https://hg.ucc.asn.au/dropbear-fuzzcorpus dropbear/corpus
 WORKDIR dropbear
 COPY build.sh *.options $SRC/

--- a/projects/dropbear/project.yaml
+++ b/projects/dropbear/project.yaml
@@ -2,4 +2,4 @@ homepage: "https://matt.ucc.asn.au/dropbear/dropbear.html"
 language: c++
 primary_contact: "matt@ucc.asn.au"
 builds_per_day: 4
-main_repo: "https://hg.ucc.asn.au/dropbear"
+main_repo: "https://github.com/mkj/dropbear"


### PR DESCRIPTION
Use the official Dropbear github mirror since cifuzz needs github