### PR TITLE
proj4/Dockerfile: install wget

### DIFF
--- a/projects/proj4/Dockerfile
+++ b/projects/proj4/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && \
-    apt-get install -y make autoconf automake libtool g++ sqlite3 pkg-config
+    apt-get install -y make autoconf automake libtool g++ sqlite3 pkg-config wget
 
 RUN git clone --depth 1 https://github.com/OSGeo/proj proj
 


### PR DESCRIPTION
Builds are currently broken since running libtiff ./autogen.sh requires
wget
```
autoconf
echo ./autogen.sh: getting config.guess...
./autogen.sh: getting config.guess...
 wget -q --timeout=5 -O config/config.guess.tmp https://git.savannah.gnu.org/cgit/config.git/plain/config.guess
```