### PR TITLE
dropbear: move corpus out of the source checkout

### DIFF
--- a/projects/dropbear/Dockerfile
+++ b/projects/dropbear/Dockerfile
@@ -16,8 +16,8 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y libz-dev autoconf mercurial
+RUN hg clone https://hg.ucc.asn.au/dropbear-fuzzcorpus dropbear-corpus
 RUN git clone https://github.com/mkj/dropbear dropbear
-RUN hg clone https://hg.ucc.asn.au/dropbear-fuzzcorpus dropbear/corpus
 WORKDIR dropbear
 COPY build.sh *.options $SRC/
 

--- a/projects/dropbear/build.sh
+++ b/projects/dropbear/build.sh
@@ -27,9 +27,9 @@ make -j$(nproc) fuzz-targets FUZZLIB=$LIB_FUZZING_ENGINE
 
 TARGETS="$(make list-fuzz-targets)"
 
-make -C $SRC/dropbear/corpus
+make -C $SRC/dropbear-corpus
 
 cp -v $TARGETS $OUT/
 cp -v *.options $OUT/
-cp -v $SRC/dropbear/corpus/*.zip $OUT/
-cp -v $SRC/dropbear/corpus/*.dict $OUT/
+cp -v $SRC/dropbear-corpus/*.zip $OUT/
+cp -v $SRC/dropbear-corpus/*.dict $OUT/


### PR DESCRIPTION
cifuzz replaces the dropbear source directory, which won't work if the corpus directory is within it