### PR TITLE
[libvips] Ensure linker is aware of selinux/resolv dependencies

### DIFF
--- a/projects/libvips/Dockerfile
+++ b/projects/libvips/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y \
   libfftw3-dev \
   libexpat1-dev \
   libffi-dev \
+  libselinux1-dev \
   glib2.0-dev
 RUN mkdir afl-testcases
 RUN curl https://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz | tar xzC afl-testcases

--- a/projects/libvips/build.sh
+++ b/projects/libvips/build.sh
@@ -169,6 +169,7 @@ for fuzzer in fuzz/*_fuzzer.cc; do
     $LIB_FUZZING_ENGINE \
     -Wl,-Bstatic \
     -lfftw3 -lgmodule-2.0 -lgio-2.0 -lgobject-2.0 -lffi -lglib-2.0 -lpcre -lexpat \
+    -lresolv -lsepol -lselinux \
     -Wl,-Bdynamic -pthread
   ln -sf "seed_corpus.zip" "$OUT/${target}_seed_corpus.zip"
 done


### PR DESCRIPTION
This should fix the currently-failing libvips build - see https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=31530