### PR TITLE
Adds go-sftp project

### DIFF
--- a/projects/go-sftp/Dockerfile
+++ b/projects/go-sftp/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN git clone --depth 1 https://github.com/pkg/sftp
+
+COPY build.sh $SRC/
+WORKDIR $SRC/sftp

--- a/projects/go-sftp/build.sh
+++ b/projects/go-sftp/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+compile_go_fuzzer . Fuzz fuzz_sftp

--- a/projects/go-sftp/project.yaml
+++ b/projects/go-sftp/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/pkg/sftp"
+primary_contact: "nicola.murino@gmail.com"
+auto_ccs:
+  - "p.antoine@catenacyber.fr"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+main_repo: 'https://github.com/pkg/sftp'


### PR DESCRIPTION
cc @drakkan
Would you be interested in continuous fuzzing for sftp ?
I see that you already have a fuzz target, and it quickly finds `panic: runtime error: index out of range [3] with length 1` in `sftp.unmarshalUint32`
