### PR TITLE
Adds cel-cpp project

### DIFF
--- a/projects/cel-cpp/.bazelrc
+++ b/projects/cel-cpp/.bazelrc
@@ -1,4 +1,3 @@
-#!/bin/bash -eu
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,18 +14,15 @@
 #
 ################################################################################
 
-declare -r QUERY='
-    let all_fuzz_tests = attr(tags, "fuzz-test", "//...") in
-    $all_fuzz_tests - attr(tags, "no-oss-fuzz", $all_fuzz_tests)
-'
+# Force the use of Clang for C++ builds.
+build --action_env=CC=clang
+build --action_env=CXX=clang++
 
-declare -r PACKAGE_SUFFIX="_oss_fuzz"
-declare -r OSS_FUZZ_TESTS="$(bazel query "${QUERY}" | sed "s/$/${PACKAGE_SUFFIX}/")"
+# Define the --config=asan-libfuzzer configuration.
+build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing/engines:libfuzzer
+build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=libfuzzer
+build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan
 
-bazel build -c opt --config=oss-fuzz --linkopt=-lc++ \
-    --action_env=CC="${CC}" --action_env=CXX="${CXX}" \
-    ${OSS_FUZZ_TESTS[*]}
-
-for oss_fuzz_archive in $(find bazel-bin/ -name "*${PACKAGE_SUFFIX}.tar"); do
-    tar -xvf "${oss_fuzz_archive}" -C "${OUT}"
-done
+build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing_oss_fuzz//:oss_fuzz_engine
+build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine_instrumentation=oss-fuzz
+build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine_sanitizer=none

--- a/projects/cel-cpp/.bazelrc
+++ b/projects/cel-cpp/.bazelrc
@@ -18,11 +18,6 @@
 build --action_env=CC=clang
 build --action_env=CXX=clang++
 
-# Define the --config=asan-libfuzzer configuration.
-build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing/engines:libfuzzer
-build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=libfuzzer
-build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan
-
 build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing_oss_fuzz//:oss_fuzz_engine
 build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine_instrumentation=oss-fuzz
 build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine_sanitizer=none

--- a/projects/cel-cpp/BUILD
+++ b/projects/cel-cpp/BUILD
@@ -14,7 +14,9 @@
 #
 ################################################################################
 
-cc_binary(
+load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
+
+cc_fuzz_test(
 	name = "fuzz_parse",
 	deps = ["//parser"],
 	srcs = ["fuzz_parse.cc"],

--- a/projects/cel-cpp/BUILD
+++ b/projects/cel-cpp/BUILD
@@ -1,0 +1,21 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cc_binary(
+	name = "fuzz_parse",
+	deps = ["//parser"],
+	srcs = ["fuzz_parse.cc"],
+)

--- a/projects/cel-cpp/Dockerfile
+++ b/projects/cel-cpp/Dockerfile
@@ -20,4 +20,8 @@ RUN git clone --depth 1 https://github.com/google/cel-cpp/
 COPY build.sh $SRC/
 RUN mkdir $SRC/cel-cpp/fuzz/
 COPY BUILD fuzz*.cc $SRC/cel-cpp/fuzz/
+COPY WORKSPACE .bazelrc $SRC/
+RUN cat WORKSPACE >> $SRC/cel-cpp/WORKSPACE
+RUN cat .bazelrc >> $SRC/cel-cpp/.bazelrc
+RUN echo "4.0.0" > $SRC/cel-cpp/.bazelversion
 WORKDIR $SRC/cel-cpp

--- a/projects/cel-cpp/Dockerfile
+++ b/projects/cel-cpp/Dockerfile
@@ -1,0 +1,33 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN apt-get update && apt-get --no-install-recommends install -y build-essential make curl wget
+
+RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
+RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
+RUN apt-get update && apt-get install -y bazel
+RUN curl -Lo /usr/bin/bazel \
+        https://github.com/bazelbuild/bazelisk/releases/download/v1.1.0/bazelisk-linux-amd64 \
+        && \
+    chmod +x /usr/bin/bazel
+
+RUN git clone --depth 1 https://github.com/google/cel-cpp/
+COPY build.sh $SRC/
+RUN mkdir $SRC/cel-cpp/fuzz/
+COPY BUILD fuzz*.cc $SRC/cel-cpp/fuzz/
+WORKDIR $SRC/cel-cpp

--- a/projects/cel-cpp/Dockerfile
+++ b/projects/cel-cpp/Dockerfile
@@ -16,16 +16,6 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 
-RUN apt-get update && apt-get --no-install-recommends install -y build-essential make curl wget
-
-RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
-RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
-RUN apt-get update && apt-get install -y bazel
-RUN curl -Lo /usr/bin/bazel \
-        https://github.com/bazelbuild/bazelisk/releases/download/v1.1.0/bazelisk-linux-amd64 \
-        && \
-    chmod +x /usr/bin/bazel
-
 RUN git clone --depth 1 https://github.com/google/cel-cpp/
 COPY build.sh $SRC/
 RUN mkdir $SRC/cel-cpp/fuzz/

--- a/projects/cel-cpp/WORKSPACE
+++ b/projects/cel-cpp/WORKSPACE
@@ -1,0 +1,41 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "fuzzing_rules_python",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.1.0/rules_python-0.1.0.tar.gz",
+    sha256 = "b6d46438523a3ec0f3cead544190ee13223a52f6a6765a29eae7b7cc24cc83a0",
+)
+
+http_archive(
+    name = "rules_fuzzing",
+    sha256 = "a5734cb42b1b69395c57e0bbd32ade394d5c3d6afbfe782b24816a96da24660d",
+    strip_prefix = "rules_fuzzing-0.1.1",
+    urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/v0.1.1.zip"],
+    repo_mapping = {
+        "@rules_python": "@fuzzing_rules_python",
+    },
+)
+
+load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
+
+rules_fuzzing_dependencies()
+
+load("@rules_fuzzing//fuzzing:init.bzl", "rules_fuzzing_init")
+
+rules_fuzzing_init()

--- a/projects/cel-cpp/build.sh
+++ b/projects/cel-cpp/build.sh
@@ -47,4 +47,4 @@ bazel build \
         ${EXTRA_BAZEL_FLAGS} \
         ${FUZZ_TARGETS[*]}
 
-cp ./bazel-bin/fuzz/fuzz_* $OUT/
+cp ./bazel-bin/fuzz/fuzz_parse $OUT/

--- a/projects/cel-cpp/build.sh
+++ b/projects/cel-cpp/build.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# build project
+readonly EXTRA_BAZEL_FLAGS="$(
+for f in ${CFLAGS}; do
+  echo "--conlyopt=${f}" "--linkopt=${f}"
+done
+for f in ${CXXFLAGS}; do
+  echo "--cxxopt=${f}" "--linkopt=${f}"
+done
+
+if [ "$SANITIZER" = "undefined" ]
+then
+  # Bazel uses clang to link binary, which does not link clang_rt ubsan library for C++ automatically.
+  # See issue: https://github.com/bazelbuild/bazel/issues/8777
+  echo "--linkopt=\"$(find $(llvm-config --libdir) -name libclang_rt.ubsan_standalone_cxx-x86_64.a | head -1)\""
+fi
+)"
+
+declare FUZZ_TARGETS=("fuzz/fuzz_parse")
+
+bazel build \
+        --verbose_failures \
+        --dynamic_mode=off \
+        --spawn_strategy=standalone \
+        --genrule_strategy=standalone \
+        --strip=never \
+        --linkopt=-pthread \
+        --copt=${LIB_FUZZING_ENGINE} \
+        --linkopt=${LIB_FUZZING_ENGINE} \
+        --linkopt=-lc++ \
+        ${EXTRA_BAZEL_FLAGS} \
+        ${FUZZ_TARGETS[*]}
+
+cp ./bazel-bin/fuzz/fuzz_* $OUT/

--- a/projects/cel-cpp/fuzz_parse.cc
+++ b/projects/cel-cpp/fuzz_parse.cc
@@ -1,0 +1,30 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include <string>
+
+#include "parser/parser.h"
+
+#define MAX_RECURSION 0x100
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    std::string str (reinterpret_cast<const char*>(data), size);
+    auto parse_status = google::api::expr::parser::Parse(str, "fuzzinput", MAX_RECURSION);
+    if (!parse_status.ok()) {
+        parse_status.status().message();
+    }
+    return 0;
+}

--- a/projects/cel-cpp/fuzz_parse.cc
+++ b/projects/cel-cpp/fuzz_parse.cc
@@ -22,9 +22,13 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     std::string str (reinterpret_cast<const char*>(data), size);
-    auto parse_status = google::api::expr::parser::Parse(str, "fuzzinput", MAX_RECURSION);
-    if (!parse_status.ok()) {
-        parse_status.status().message();
+    try {
+        auto parse_status = google::api::expr::parser::Parse(str, "fuzzinput", MAX_RECURSION);
+        if (!parse_status.ok()) {
+            parse_status.status().message();
+        }
+    } catch (const std::exception& e) {
+        return 0;
     }
     return 0;
 }

--- a/projects/cel-cpp/project.yaml
+++ b/projects/cel-cpp/project.yaml
@@ -1,0 +1,11 @@
+homepage: "https://opensource.google/projects/cel"
+language: c++
+primary_contact: "kyessenov@gmail.com"
+auto_ccs :
+- "p.antoine@catenacyber.fr"
+
+sanitizers:
+- address
+- memory
+- undefined
+main_repo: 'https://github.com/google/cel-cpp'

--- a/projects/cel-cpp/project.yaml
+++ b/projects/cel-cpp/project.yaml
@@ -6,4 +6,6 @@ auto_ccs :
 
 sanitizers:
 - address
+- memory
+- undefined
 main_repo: 'https://github.com/google/cel-cpp'

--- a/projects/cel-cpp/project.yaml
+++ b/projects/cel-cpp/project.yaml
@@ -2,6 +2,7 @@ homepage: "https://opensource.google/projects/cel"
 language: c++
 primary_contact: "kyessenov@gmail.com"
 auto_ccs :
+- "tswadell@google.com"
 - "p.antoine@catenacyber.fr"
 
 sanitizers:

--- a/projects/cel-cpp/project.yaml
+++ b/projects/cel-cpp/project.yaml
@@ -6,6 +6,4 @@ auto_ccs :
 
 sanitizers:
 - address
-- memory
-- undefined
 main_repo: 'https://github.com/google/cel-cpp'

--- a/projects/cel-cpp/project.yaml
+++ b/projects/cel-cpp/project.yaml
@@ -8,5 +8,4 @@ auto_ccs :
 sanitizers:
 - address
 - memory
-- undefined
 main_repo: 'https://github.com/google/cel-cpp'


### PR DESCRIPTION
@kyessenov would you be interested in continuous fuzzing for cel-cpp ?
This Pull Request enables it with oss-fuzz adding one simple fuzz target for `parser::Parse` which could be added to the upstream repository

This fuzz target quickly finds an unhandled exception
Should I wrap it into a `try catch (const std::exception& e)` ?