### PR TITLE
Adds rust syn project

### DIFF
--- a/projects/rust-syn/Cargo.toml
+++ b/projects/rust-syn/Cargo.toml
@@ -1,0 +1,26 @@
+cargo-features = ['named-profiles']
+
+[package]
+name = "syn-fuzz"
+version = "0.0.0"
+authors = ["Philippe Antoine <p.antoine@catenacyber.fr>"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.3"
+
+[dependencies.syn]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_parse_str"
+path = "fuzz_targets/fuzz_parse_str.rs"
+

--- a/projects/rust-syn/Dockerfile
+++ b/projects/rust-syn/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN git clone --depth 1 https://github.com/dtolnay/syn
+
+COPY build.sh $SRC/
+RUN mkdir -p $SRC/syn/fuzz/fuzz_targets/
+COPY Cargo.toml $SRC/syn/fuzz/
+COPY fuzz*.rs $SRC/syn/fuzz/fuzz_targets/
+WORKDIR $SRC/syn

--- a/projects/rust-syn/build.sh
+++ b/projects/rust-syn/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cargo fuzz build -O -s $SANITIZER
+cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_parse_str $OUT/

--- a/projects/rust-syn/fuzz_parse_str.rs
+++ b/projects/rust-syn/fuzz_parse_str.rs
@@ -3,6 +3,9 @@ use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
     if let Ok(sd) = std::str::from_utf8(data) {
-        syn::parse_str::<syn::Expr>(sd);
+        // limit size cf https://github.com/dtolnay/syn/issues/901
+        if sd.len() < 128 {
+            syn::parse_str::<syn::Expr>(sd);
+        }
     }
 });

--- a/projects/rust-syn/fuzz_parse_str.rs
+++ b/projects/rust-syn/fuzz_parse_str.rs
@@ -1,0 +1,8 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(sd) = std::str::from_utf8(data) {
+        syn::parse_str::<syn::Expr>(sd);
+    }
+});

--- a/projects/rust-syn/project.yaml
+++ b/projects/rust-syn/project.yaml
@@ -1,0 +1,11 @@
+homepage: "https://github.com/dtolnay/syn"
+primary_contact: "dtolnay@gmail.com"
+sanitizers:
+  - address
+  - memory
+fuzzing_engines:
+  - libfuzzer
+language: rust
+auto_ccs:
+  - "p.antoine@catenacyber.fr"
+main_repo: 'https://github.com/dtolnay/syn'


### PR DESCRIPTION
cc @dtolnay
Would you be interested in continuous fuzzing for syn crate ?
This Pull Request enables it with oss-fuzz and adds a fuzz target for `parse_str<Expr>` which could be added to the upstream repository

This fuzz target quickly finds a timeout