### PR TITLE
httparse: Initial integration

### DIFF
--- a/projects/httparse/Dockerfile
+++ b/projects/httparse/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang
+
+RUN git clone https://github.com/seanmonstar/httparse
+WORKDIR $SRC
+
+COPY build.sh $SRC/

--- a/projects/httparse/Dockerfile
+++ b/projects/httparse/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Google Inc.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 #
 ################################################################################
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang
 
 RUN git clone https://github.com/seanmonstar/httparse
 WORKDIR $SRC

--- a/projects/httparse/build.sh
+++ b/projects/httparse/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC
+cd httparse
+cargo fuzz build -O
+cp fuzz/target/x86_64-unknown-linux-gnu/release/parse_request $OUT/
+cp fuzz/target/x86_64-unknown-linux-gnu/release/parse_headers $OUT/
+cp fuzz/target/x86_64-unknown-linux-gnu/release/parse_chunk_size $OUT/

--- a/projects/httparse/build.sh
+++ b/projects/httparse/build.sh
@@ -15,8 +15,7 @@
 #
 ################################################################################
 
-cd $SRC
-cd httparse
+cd $SRC/httparse
 cargo fuzz build -O
 cp fuzz/target/x86_64-unknown-linux-gnu/release/parse_request $OUT/
 cp fuzz/target/x86_64-unknown-linux-gnu/release/parse_headers $OUT/

--- a/projects/httparse/project.yaml
+++ b/projects/httparse/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/seanmonstar/httparse"
+main_repo: "https://github.com/seanmonstar/httparse"
+primary_contact: "david@adalogics.com"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+language: rust
+auto_ccs:
+  - "david@adalogics.com"

--- a/projects/httparse/project.yaml
+++ b/projects/httparse/project.yaml
@@ -1,6 +1,6 @@
 homepage: "https://github.com/seanmonstar/httparse"
 main_repo: "https://github.com/seanmonstar/httparse"
-primary_contact: "david@adalogics.com"
+primary_contact: "seanmonstar@gmail.com"
 sanitizers:
   - address
 fuzzing_engines:


### PR DESCRIPTION
[httparse](https://crates.io/crates/httparse) is a http parser user by widely-used Rust libraries e.g. Tokio-core (used by many to implement asynchronous I/O) and hyper https://crates.io/crates/httparse/reverse_dependencies. 

@seanmonstar would you be interested in integrating httparse into oss-fuzz? It will make the fuzzers run continuously and you will receive reports whenever crashes are found. If you would like to integrate, could you please provide a set of email(s) that will get access to the data produced by OSS-Fuzz, such as bug reports. The emails should be linked to a Google account in order to view the detailed reports and notice the emails affiliated with the project will be public in the OSS-Fuzz repo, as they will be part of a configuration file.