### PR TITLE
rustls: initial integration.

### DIFF
--- a/projects/rustls/Dockerfile
+++ b/projects/rustls/Dockerfile
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 ################################################################################
+
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang
 

--- a/projects/rustls/Dockerfile
+++ b/projects/rustls/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang
+
+RUN git clone https://github.com/ctz/rustls
+
+WORKDIR $SRC
+
+COPY build.sh $SRC/
+COPY persist.rs $SRC/rustls/fuzz/fuzzers/persist.rs

--- a/projects/rustls/build.sh
+++ b/projects/rustls/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC/rustls
+cargo fuzz build -O
+cp fuzz/target/x86_64-unknown-linux-gnu/release/client $OUT/
+cp fuzz/target/x86_64-unknown-linux-gnu/release/deframer $OUT/
+cp fuzz/target/x86_64-unknown-linux-gnu/release/fragment $OUT/
+cp fuzz/target/x86_64-unknown-linux-gnu/release/hsjoiner $OUT/
+cp fuzz/target/x86_64-unknown-linux-gnu/release/message $OUT/
+cp fuzz/target/x86_64-unknown-linux-gnu/release/server $OUT/
+

--- a/projects/rustls/build.sh
+++ b/projects/rustls/build.sh
@@ -23,4 +23,3 @@ cp fuzz/target/x86_64-unknown-linux-gnu/release/fragment $OUT/
 cp fuzz/target/x86_64-unknown-linux-gnu/release/hsjoiner $OUT/
 cp fuzz/target/x86_64-unknown-linux-gnu/release/message $OUT/
 cp fuzz/target/x86_64-unknown-linux-gnu/release/server $OUT/
-

--- a/projects/rustls/persist.rs
+++ b/projects/rustls/persist.rs
@@ -11,6 +11,5 @@ fn try_type<T>(data: &[u8]) where T: Codec {
 }
 
 fuzz_target!(|data: &[u8]| {
-    //try_type::<persist::ClientSessionValue>(data);
-    //try_type::<persist::ServerSessionValue>(data);
+    try_type::<persist::ServerSessionValue>(data);
 });

--- a/projects/rustls/persist.rs
+++ b/projects/rustls/persist.rs
@@ -1,3 +1,18 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+//limitations under the License.
+//
+//################################################################################
 #![no_main]
 #[macro_use] extern crate libfuzzer_sys;
 extern crate rustls;

--- a/projects/rustls/persist.rs
+++ b/projects/rustls/persist.rs
@@ -1,0 +1,16 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate rustls;
+
+use rustls::internal::msgs::persist;
+use rustls::internal::msgs::codec::{Reader, Codec};
+
+fn try_type<T>(data: &[u8]) where T: Codec {
+    let mut rdr = Reader::init(data);
+    T::read(&mut rdr);
+}
+
+fuzz_target!(|data: &[u8]| {
+    //try_type::<persist::ClientSessionValue>(data);
+    //try_type::<persist::ServerSessionValue>(data);
+});

--- a/projects/rustls/project.yaml
+++ b/projects/rustls/project.yaml
@@ -1,6 +1,6 @@
 homepage: "https://github.com/ctz/rustls"
 main_repo: "https://github.com/ctz/rustls"
-primary_contact: "david@adalogics.com"
+primary_contact: "jpixton@gmail.com"
 sanitizers:
   - address
 fuzzing_engines:

--- a/projects/rustls/project.yaml
+++ b/projects/rustls/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/ctz/rustls"
+main_repo: "https://github.com/ctz/rustls"
+primary_contact: "david@adalogics.com"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+language: rust
+auto_ccs:
+  - "david@adalogics.com"


### PR DESCRIPTION
Rustls is a modern TLS library written in Rust used by production systems, e.g. the purpose-built service mesh proxy linkerd2-proxy.

@ctz @briansmith would you be interested in integrating rustls into oss-fuzz? It will make the fuzzers run continuously and you will receive reports whenever crashes are found. If you would like to integrate, could you please provide a set of email(s) that will get access to the data produced by OSS-Fuzz, such as bug reports. The emails should be linked to a Google account in order to view the detailed reports and notice the emails affiliated with the project will be public in the OSS-Fuzz repo, as they will be part of a configuration file.