### PR TITLE
claxon: initial integration.

### DIFF
--- a/projects/claxon/Dockerfile
+++ b/projects/claxon/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang
+
+RUN git clone https://github.com/ruuda/claxon
+
+WORKDIR $SRC
+
+COPY build.sh $SRC/

--- a/projects/claxon/build.sh
+++ b/projects/claxon/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC/claxon
+cargo fuzz build -O
+cp fuzz/target/x86_64-unknown-linux-gnu/release/decode_full $OUT/
+cp fuzz/target/x86_64-unknown-linux-gnu/release/decode_header $OUT/
+cp fuzz/target/x86_64-unknown-linux-gnu/release/decode_single_block $OUT/

--- a/projects/claxon/project.yaml
+++ b/projects/claxon/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/ruuda/claxon"
+main_repo: "https://github.com/ruuda/claxon"
+primary_contact: "david@adalogics.com"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+language: rust
+auto_ccs:
+  - "david@adalogics.com"


### PR DESCRIPTION
@ruuda would you be interested in integrating Claxon into oss-fuzz? It will make the fuzzers run continuously and you will receive reports whenever crashes are found. If you would like to integrate, could you please provide a set of email(s) that will get access to the data produced by OSS-Fuzz, such as bug reports. The emails should be linked to a Google account in order to view the detailed reports and notice the emails affiliated with the project will be public in the OSS-Fuzz repo, as they will be part of a configuration file.