### PR TITLE
Use a special email address to manage security

### DIFF
--- a/projects/gitea/project.yaml
+++ b/projects/gitea/project.yaml
@@ -1,5 +1,5 @@
 homepage: "https://github.com/go-gitea/gitea"
-primary_contact: "admin@gitea.io"
+primary_contact: "security@gitea.io"
 auto_ccs :
   - "adam@adalogics.com"
 language: go


### PR DESCRIPTION
The email should be sent to the security email address of Gitea but not the admin email address. For trust proof, I'm one of the Owners of Gitea. https://github.com/go-gitea/gitea/blob/master/CONTRIBUTING.md#owners