### PR TITLE
[base-runner] Reduce size by ~200 MB by using apt better

### DIFF
--- a/infra/base-images/base-runner/Dockerfile
+++ b/infra/base-images/base-runner/Dockerfile
@@ -40,10 +40,13 @@ RUN apt-get update && apt-get install -y \
     file \
     fonts-dejavu \
     git \
+    lib32gcc1 \
+    libc6-i386 \
     libcap2 \
     python3 \
-    wget && \
-    apt-get install -y python3-pip libc6-i386 lib32gcc1 zip --no-install-recommends
+    python3-pip \
+    wget \
+    zip --no-install-recommends
 
 RUN git clone https://chromium.googlesource.com/chromium/src/tools/code_coverage /opt/code_coverage && \
     pip3 install -r /opt/code_coverage/requirements.txt

--- a/infra/base-images/base-runner/Dockerfile
+++ b/infra/base-images/base-runner/Dockerfile
@@ -35,19 +35,15 @@ COPY --from=base-clang /usr/local/bin/llvm-cov \
      /usr/local/bin/llvm-symbolizer \
      /usr/local/bin/
 
-# TODO(metzman): Install libc6-i386 lib32gcc1 instead of libc6-dev-i386 for
-# consistency with ClusterFuzz image and to reduce size.
 RUN apt-get update && apt-get install -y \
     binutils \
     file \
     fonts-dejavu \
     git \
-    libc6-dev-i386 \
     libcap2 \
     python3 \
-    python3-pip \
-    wget \
-    zip
+    wget && \
+    apt-get install -y python3-pip libc6-i386 lib32gcc1 zip --no-install-recommends
 
 RUN git clone https://chromium.googlesource.com/chromium/src/tools/code_coverage /opt/code_coverage && \
     pip3 install -r /opt/code_coverage/requirements.txt


### PR DESCRIPTION
Don't install recommended packages if it means installing an
entire gcc toolchain. We don't need it in the runner.