### PR TITLE
libfido2: update dependencies

### DIFF
--- a/projects/libfido2/Dockerfile
+++ b/projects/libfido2/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN apt-get install -y cmake libudev-dev pkg-config chrpath
 RUN git clone --branch v0.8.0 https://github.com/PJK/libcbor
 RUN git clone --branch OpenSSL_1_1_1-stable https://github.com/openssl/openssl
+RUN git clone --branch v1.2.11 https://github.com/madler/zlib
 RUN git clone https://github.com/Yubico/libfido2
 # CIFuzz will replace the libfido directory so put the corpus outside
 ADD https://ambientworks.net/libfido2/corpus.tgz corpus.tgz

--- a/projects/libfido2/Dockerfile
+++ b/projects/libfido2/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN apt-get install -y cmake libudev-dev pkg-config chrpath
-RUN git clone --branch v0.7.0 https://github.com/PJK/libcbor
+RUN git clone --branch v0.8.0 https://github.com/PJK/libcbor
 RUN git clone --branch OpenSSL_1_1_1-stable https://github.com/openssl/openssl
 RUN git clone https://github.com/Yubico/libfido2
 # CIFuzz will replace the libfido directory so put the corpus outside

--- a/projects/libfido2/build.sh
+++ b/projects/libfido2/build.sh
@@ -37,6 +37,12 @@ fi
 make -j$(nproc) LDCMD="${CXX} ${CXXFLAGS}"
 make install_sw
 
+# Build zlib, taken from oss-fuzz/projects/zlib.sh
+cd ${SRC}/zlib
+./configure --prefix=${WORK}
+make -j$(nproc) all
+make install
+
 # Building libfido2 with ${LIB_FUZZING_ENGINE} and chosen sanitizer
 cd ${SRC}/libfido2
 mkdir build && cd build

--- a/projects/libfido2/build.sh
+++ b/projects/libfido2/build.sh
@@ -20,7 +20,8 @@
 cd ${SRC}/libcbor
 patch -l -p0 < ${SRC}/libfido2/fuzz/README
 mkdir build && cd build
-cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=${WORK} -DSANITIZE=OFF ..
+cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Debug \
+      -DCMAKE_INSTALL_PREFIX=${WORK} -DSANITIZE=OFF ..
 make -j$(nproc) VERBOSE=1
 make install
 


### PR DESCRIPTION
libfido2 now requires zlib. While here, also bump libcbor to v0.8.0.