### PR TITLE
Rust coverage : source remap after changing dir

### DIFF
--- a/infra/base-images/base-builder/cargo
+++ b/infra/base-images/base-builder/cargo
@@ -31,13 +31,13 @@ fi
 
 if [ "$SANITIZER" = "coverage" ] && [ $1 = "fuzz" ]
 then
-    fuzz_src_abspath=`pwd`
-    export RUSTFLAGS="$RUSTFLAGS --remap-path-prefix fuzz_targets=$fuzz_src_abspath/fuzz_targets"
     # hack to turn cargo fuzz build into cargo build so as to get coverage
     # cargo fuzz adds "--target" "x86_64-unknown-linux-gnu"
     (
     # go into fuzz directory if not already the case
     cd fuzz || true
+    fuzz_src_abspath=`pwd`
+    export RUSTFLAGS="$RUSTFLAGS --remap-path-prefix fuzz_targets=$fuzz_src_abspath/fuzz_targets"
     # do not optimize with --release, leading to Malformed instrumentation profile data
     cargo build --bins
     # copies the build output in the expected target directory


### PR DESCRIPTION
cc @inferno-chromium 
Should fix #5341 

Rust cargo does not use absolute paths for the current crate being built
So we need to hack it with `RUSTFLAGS --remap-path-prefix`

As `cargo fuzz` works both in the `fuzz` directory and its parent (and is so used in oss-fuzz)
we change to the `fuzz` directory.
But we need to set the ` --remap-path-prefix` after changing the directory

Thanks @jrmuizel for the report