### PR TITLE
Golang coverage summary updated to version 2.0.1

### DIFF
--- a/infra/base-images/base-runner/gocoverage/gocovsum/gocovsum.go
+++ b/infra/base-images/base-runner/gocoverage/gocovsum/gocovsum.go
@@ -23,13 +23,21 @@ type CoverageTotal struct {
 }
 
 type CoverageTotals struct {
-	Functions CoverageTotal `json:"functions,omitempty"`
-	Lines     CoverageTotal `json:"lines,omitempty"`
-	Regions   CoverageTotal `json:"regions,omitempty"`
+	Functions      CoverageTotal `json:"functions,omitempty"`
+	Lines          CoverageTotal `json:"lines,omitempty"`
+	Regions        CoverageTotal `json:"regions,omitempty"`
+	Instantiations CoverageTotal `json:"instantiations,omitempty"`
+	Branches       CoverageTotal `json:"branches,omitempty"`
+}
+
+type CoverageFile struct {
+	Summary  CoverageTotals `json:"summary,omitempty"`
+	Filename string         `json:"filename,omitempty"`
 }
 
 type CoverageData struct {
 	Totals CoverageTotals `json:"totals,omitempty"`
+	Files  []CoverageFile `json:"files,omitempty"`
 }
 
 type PositionInterval struct {
@@ -54,6 +62,12 @@ func isFunctionCovered(s token.Position, e token.Position, blocks []cover.Profil
 	return false
 }
 
+func computePercent(s *CoverageTotals) {
+	s.Regions.Percent = float64(100*s.Regions.Covered) / float64(s.Regions.Count)
+	s.Lines.Percent = float64(100*s.Lines.Covered) / float64(s.Lines.Count)
+	s.Functions.Percent = float64(100*s.Functions.Covered) / float64(s.Functions.Count)
+}
+
 func main() {
 	flag.Parse()
 
@@ -66,7 +80,7 @@ func main() {
 	}
 	r := CoverageSummary{}
 	r.Type = "oss-fuzz.go.coverage.json.export"
-	r.Version = "1.0.0"
+	r.Version = "2.0.1"
 	r.Data = make([]CoverageData, 1)
 	gopath := os.Getenv("GOPATH")
 	if len(gopath) == 0 {
@@ -78,49 +92,62 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
+		fileCov := CoverageFile{}
+		fileCov.Filename = p.FileName
 		ast.Inspect(f, func(n ast.Node) bool {
 			switch x := n.(type) {
 			case *ast.FuncLit:
 				startf := fset.Position(x.Pos())
 				endf := fset.Position(x.End())
-				r.Data[0].Totals.Functions.Count++
+				fileCov.Summary.Functions.Count++
 				if isFunctionCovered(startf, endf, p.Blocks) {
-					r.Data[0].Totals.Functions.Covered++
+					fileCov.Summary.Functions.Covered++
 				} else {
-					r.Data[0].Totals.Functions.Uncovered++
+					fileCov.Summary.Functions.Uncovered++
 				}
 			case *ast.FuncDecl:
 				startf := fset.Position(x.Pos())
 				endf := fset.Position(x.End())
-				r.Data[0].Totals.Functions.Count++
+				fileCov.Summary.Functions.Count++
 				if isFunctionCovered(startf, endf, p.Blocks) {
-					r.Data[0].Totals.Functions.Covered++
+					fileCov.Summary.Functions.Covered++
 				} else {
-					r.Data[0].Totals.Functions.Uncovered++
+					fileCov.Summary.Functions.Uncovered++
 				}
 			}
 			return true
 		})
 
 		for _, b := range p.Blocks {
-			r.Data[0].Totals.Regions.Count++
+			fileCov.Summary.Regions.Count++
 			if b.Count > 0 {
-				r.Data[0].Totals.Regions.Covered++
+				fileCov.Summary.Regions.Covered++
 			} else {
-				r.Data[0].Totals.Regions.Uncovered++
+				fileCov.Summary.Regions.Uncovered++
 			}
 
-			r.Data[0].Totals.Lines.Count += b.NumStmt
+			fileCov.Summary.Lines.Count += b.NumStmt
 			if b.Count > 0 {
-				r.Data[0].Totals.Lines.Covered += b.NumStmt
+				fileCov.Summary.Lines.Covered += b.NumStmt
 			} else {
-				r.Data[0].Totals.Lines.Uncovered += b.NumStmt
+				fileCov.Summary.Lines.Uncovered += b.NumStmt
 			}
 		}
+		r.Data[0].Totals.Regions.Count += fileCov.Summary.Regions.Count
+		r.Data[0].Totals.Regions.Covered += fileCov.Summary.Regions.Covered
+		r.Data[0].Totals.Regions.Uncovered += fileCov.Summary.Regions.Uncovered
+		r.Data[0].Totals.Lines.Count += fileCov.Summary.Lines.Count
+		r.Data[0].Totals.Lines.Covered += fileCov.Summary.Lines.Covered
+		r.Data[0].Totals.Lines.Uncovered += fileCov.Summary.Lines.Uncovered
+		r.Data[0].Totals.Functions.Count += fileCov.Summary.Functions.Count
+		r.Data[0].Totals.Functions.Covered += fileCov.Summary.Functions.Covered
+		r.Data[0].Totals.Functions.Uncovered += fileCov.Summary.Functions.Uncovered
+
+		computePercent(&fileCov.Summary)
+		r.Data[0].Files = append(r.Data[0].Files, fileCov)
 	}
-	r.Data[0].Totals.Regions.Percent = float64(100*r.Data[0].Totals.Regions.Covered) / float64(r.Data[0].Totals.Regions.Count)
-	r.Data[0].Totals.Lines.Percent = float64(100*r.Data[0].Totals.Lines.Covered) / float64(r.Data[0].Totals.Lines.Count)
-	r.Data[0].Totals.Functions.Percent = float64(100*r.Data[0].Totals.Functions.Covered) / float64(r.Data[0].Totals.Functions.Count)
+
+	computePercent(&r.Data[0].Totals)
 	o, _ := json.Marshal(r)
 	fmt.Printf(string(o))
 }


### PR DESCRIPTION
cf #5337 cc @jonathanmetzman 

On gonids sample, I get
```
{"data":[{"totals":{"functions":{"count":105,"covered":52,"notcovered":53,"percent":49.523809523809526},"lines":{"count":942,"covered":578,"notcovered":364,"percent":61.3588110403397},"regions":{"count":670,"covered":388,"notcovered":282,"percent":57.91044776119403},"instantiations":{"count":0,"covered":0,"notcovered":0,"percent":0},"branches":{"count":0,"covered":0,"notcovered":0,"percent":0}},"files":[{"summary":{"functions":{"count":1,"covered":1,"notcovered":0,"percent":100},"lines":{"count":23,"covered":11,"notcovered":12,"percent":47.82608695652174},"regions":{"count":13,"covered":7,"notcovered":6,"percent":53.84615384615385},"instantiations":{"count":0,"covered":0,"notcovered":0,"percent":0},"branches":{"count":0,"covered":0,"notcovered":0,"percent":0}},"filename":"github.com/google/gonids/fuzz.go"},{"summary":{"functions":{"count":31,"covered":28,"notcovered":3,"percent":90.3225806451613},"lines":{"count":172,"covered":159,"notcovered":13,"percent":92.44186046511628},"regions":{"count":110,"covered":100,"notcovered":10,"percent":90.9090909090909},"instantiations":{"count":0,"covered":0,"notcovered":0,"percent":0},"branches":{"count":0,"covered":0,"notcovered":0,"percent":0}},"filename":"github.com/google/gonids/lex.go"},{"summary":{"functions":{"count":6,"covered":1,"notcovered":5,"percent":16.666666666666668},"lines":{"count":45,"covered":8,"notcovered":37,"percent":17.77777777777778},"regions":{"count":40,"covered":8,"notcovered":32,"percent":20},"instantiations":{"count":0,"covered":0,"notcovered":0,"percent":0},"branches":{"count":0,"covered":0,"notcovered":0,"percent":0}},"filename":"github.com/google/gonids/linters.go"},{"summary":{"functions":{"count":5,"covered":1,"notcovered":4,"percent":20},"lines":{"count":42,"covered":12,"notcovered":30,"percent":28.571428571428573},"regions":{"count":31,"covered":10,"notcovered":21,"percent":32.25806451612903},"instantiations":{"count":0,"covered":0,"notcovered":0,"percent":0},"branches":{"count":0,"covered":0,"notcovered":0,"percent":0}},"filename":"github.com/google/gonids/optimize.go"},{"summary":{"functions":{"count":21,"covered":19,"notcovered":2,"percent":90.47619047619048},"lines":{"count":387,"covered":338,"notcovered":49,"percent":87.33850129198966},"regions":{"count":264,"covered":223,"notcovered":41,"percent":84.46969696969697},"instantiations":{"count":0,"covered":0,"notcovered":0,"percent":0},"branches":{"count":0,"covered":0,"notcovered":0,"percent":0}},"filename":"github.com/google/gonids/parser.go"},{"summary":{"functions":{"count":41,"covered":2,"notcovered":39,"percent":4.878048780487805},"lines":{"count":273,"covered":50,"notcovered":223,"percent":18.315018315018314},"regions":{"count":212,"covered":40,"notcovered":172,"percent":18.867924528301888},"instantiations":{"count":0,"covered":0,"notcovered":0,"percent":0},"branches":{"count":0,"covered":0,"notcovered":0,"percent":0}},"filename":"github.com/google/gonids/rule.go"}]}],"type":"oss-fuzz.go.coverage.json.export","version":"2.0.1"}
```

Does it look good to you ?