### PR TITLE
[json-sanitizer] Add severity markup

### DIFF
--- a/projects/json-sanitizer/IdempotenceFuzzer.java
+++ b/projects/json-sanitizer/IdempotenceFuzzer.java
@@ -21,20 +21,18 @@ import com.google.json.JsonSanitizer;
 public class IdempotenceFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     String input = data.consumeRemainingAsString();
-    String output1;
+    String output;
     try {
-      output1 = JsonSanitizer.sanitize(input, 10);
+      output = JsonSanitizer.sanitize(input, 10);
     } catch (ArrayIndexOutOfBoundsException e) {
       // ArrayIndexOutOfBoundsException is expected if nesting depth is
       // exceeded.
       return;
     }
-    String output2 = JsonSanitizer.sanitize(output1, 10);
-    if (!output1.equals(output2)) {
-      System.err.println("input  : " + input);
-      System.err.println("output1: " + output1);
-      System.err.println("output2: " + output2);
-      throw new IllegalStateException("Non-idempotence detected");
-    }
+
+    // Ensure that sanitizing twice does not give different output
+    // (idempotence). Since failure to be idempotent is not a security issue in
+    // itself, fail with a regular AssertionError.
+    assert JsonSanitizer.sanitize(output).equals(output) : "Not idempotent";
   }
 }

--- a/projects/json-sanitizer/ValidJsonFuzzer.java
+++ b/projects/json-sanitizer/ValidJsonFuzzer.java
@@ -15,6 +15,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.api.FuzzerSecurityIssueLow;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
@@ -33,12 +34,14 @@ public class ValidJsonFuzzer {
       // exceeded.
       return;
     }
+
+    // Check that the output is valid JSON. Invalid JSON may crash other parts
+    // of the application that trust the output of the sanitizer.
     try {
+      Gson gson = new Gson();
       gson.fromJson(output, JsonElement.class);
     } catch (Exception e) {
-      System.err.println("input  : " + input);
-      System.err.println("output : " + output);
-      throw e;
+      throw new FuzzerSecurityIssueLow("Output is invalid JSON", e);
     }
   }
 }


### PR DESCRIPTION
Annotates the findings of the various json-sanitizer fuzzers with
severities as follows:

* XSS: High
* Comment injection: Medium
* Invalid JSON: Low
* Failure to be idempotent: Not a security issue
* Undeclared exceptions: Not a security issue

This commit takes advantage of the support for severity markers in stack
traces introduced in https://github.com/google/clusterfuzz/pull/2270.