### PR TITLE
Adds golang snappy project

### DIFF
--- a/projects/go-snappy/Dockerfile
+++ b/projects/go-snappy/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN git clone --depth 1 https://github.com/golang/snappy
+
+COPY build.sh $SRC/
+COPY fuzz.go $SRC/snappy
+WORKDIR $SRC/snappy

--- a/projects/go-snappy/build.sh
+++ b/projects/go-snappy/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+compile_go_fuzzer . FuzzRoundTrip fuzz_roundtrip gofuzz
+compile_go_fuzzer . FuzzDecode fuzz_decode gofuzz

--- a/projects/go-snappy/fuzz.go
+++ b/projects/go-snappy/fuzz.go
@@ -1,0 +1,27 @@
+// +build gofuzz
+
+package snappy
+
+import (
+	"bytes"
+)
+
+func FuzzRoundTrip(data []byte) int {
+	encoded := Encode(nil, data)
+	decoded, err := Decode(nil, encoded)
+	if err != nil {
+		panic("Error decoding snappy-encoded")
+	}
+	if !bytes.Equal(data, decoded) {
+		panic("Different result on roundtrip encode/decode")
+	}
+	return 1
+}
+
+func FuzzDecode(data []byte) int {
+	_, err := Decode(nil, data)
+	if err != nil {
+		return 0
+	}
+	return 1
+}

--- a/projects/go-snappy/project.yaml
+++ b/projects/go-snappy/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/golang/snappy"
+primary_contact: "nigeltao@golang.org"
+auto_ccs:
+  - "p.antoine@catenacyber.fr"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+main_repo: 'https://github.com/golang/snappy'


### PR DESCRIPTION
@nigeltao would you be interested in continuous fuzzing for snappy ?
This PR enables it on oss-fuzz.

The simple `Decode` fuzz target quickly runs out of memory
I think that there needs to wait a bit before allocating a big slice in https://github.com/golang/snappy/blob/196ae77b8a26000fa30caa8b2b541e09674dbc43/decode.go#L65
I have encountered the same problem with lzma in Suricata, ending up in customizing the lzma library so as not to get denial of service by memory exhaustion

cc @dgrinsky, as I see that you fuzzed snappy already