### PR TITLE
Use more RUSTFLAGS for Suricata

### DIFF
--- a/projects/suricata/build.sh
+++ b/projects/suricata/build.sh
@@ -45,7 +45,6 @@ make install
 cd ..
 
 export CARGO_BUILD_TARGET="x86_64-unknown-linux-gnu"
-export RUSTFLAGS="$RUSTFLAGS -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=4 -Cllvm-args=-sanitizer-coverage-trace-compares -Cllvm-args=-sanitizer-coverage-inline-8bit-counters -Cllvm-args=-sanitizer-coverage-trace-geps -Cllvm-args=-sanitizer-coverage-prune-blocks=0 -Cllvm-args=-sanitizer-coverage-pc-table -Clink-dead-code -Cllvm-args=-sanitizer-coverage-stack-depth"
 
 #we did not put libhtp there before so that cifuzz does not remove it
 mv libhtp suricata/
@@ -55,12 +54,16 @@ sh autogen.sh
 #run configure with right options
 if [ "$SANITIZER" = "coverage" ]
 then
-export RUSTFLAGS="$RUSTFLAGS -C debug-assertions=no"
-chmod +x $SRC/rustc.py
-export RUSTC="$SRC/rustc.py"
-./configure --disable-shared --enable-fuzztargets --enable-debug
+    export RUSTFLAGS="$RUSTFLAGS -C debug-assertions=no"
+    chmod +x $SRC/rustc.py
+    export RUSTC="$SRC/rustc.py"
+    ./configure --disable-shared --enable-fuzztargets --enable-debug
 else
-./src/tests/fuzz/oss-fuzz-configure.sh
+    if [ "$SANITIZER" = "address" ]
+    then
+        export RUSTFLAGS="$RUSTFLAGS -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=4 -Cllvm-args=-sanitizer-coverage-trace-compares -Cllvm-args=-sanitizer-coverage-inline-8bit-counters -Cllvm-args=-sanitizer-coverage-trace-geps -Cllvm-args=-sanitizer-coverage-prune-blocks=0 -Cllvm-args=-sanitizer-coverage-pc-table -Clink-dead-code -Cllvm-args=-sanitizer-coverage-stack-depth"
+    fi
+    ./src/tests/fuzz/oss-fuzz-configure.sh
 fi
 make -j$(nproc)
 

--- a/projects/suricata/build.sh
+++ b/projects/suricata/build.sh
@@ -45,6 +45,7 @@ make install
 cd ..
 
 export CARGO_BUILD_TARGET="x86_64-unknown-linux-gnu"
+export RUSTFLAGS="$RUSTFLAGS -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=4 -Cllvm-args=-sanitizer-coverage-trace-compares -Cllvm-args=-sanitizer-coverage-inline-8bit-counters -Cllvm-args=-sanitizer-coverage-trace-geps -Cllvm-args=-sanitizer-coverage-prune-blocks=0 -Cllvm-args=-sanitizer-coverage-pc-table -Clink-dead-code -Cllvm-args=-sanitizer-coverage-stack-depth"
 
 #we did not put libhtp there before so that cifuzz does not remove it
 mv libhtp suricata/


### PR DESCRIPTION
Taken from libra and cargo fuzz

Rust coverage is pretty low for Suricata
Using env variable `FUZZ_APPLAYER=29` and running the target fuzz_applayerparserparse, I find in minutes paths that are not in the corpus

cc @jonathanmetzman 
Have you any idea why ? Is this because of hash collision in this large target ?