### PR TITLE
json5format initial integration

### DIFF
--- a/projects/json5format/Dockerfile
+++ b/projects/json5format/Dockerfile
@@ -14,7 +14,6 @@
 #
 ################################################################################
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang
 
 RUN git clone --depth 1 https://github.com/google/json5format
 WORKDIR $SRC

--- a/projects/json5format/Dockerfile
+++ b/projects/json5format/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang
+
+RUN git clone --depth 1 https://github.com/google/json5format
+WORKDIR $SRC
+
+COPY build.sh $SRC/
+COPY fuzz $SRC/json5format/fuzz

--- a/projects/json5format/build.sh
+++ b/projects/json5format/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC/json5format
+cargo fuzz build -O
+ls -la ./fuzz
+ls -la ./fuzz/target
+cp ./fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_parse $OUT/fuzz_parse

--- a/projects/json5format/fuzz/.gitignore
+++ b/projects/json5format/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/projects/json5format/fuzz/Cargo.toml
+++ b/projects/json5format/fuzz/Cargo.toml
@@ -1,0 +1,24 @@
+
+[package]
+name = "json5format-fuzz"
+version = "0.0.0"
+authors = ["David Korczynski <david@adalogics.com>"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.3"
+
+[dependencies.json5format]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_parse"
+path = "fuzz_targets/fuzz_parse.rs"

--- a/projects/json5format/fuzz/fuzz_targets/fuzz_parse.rs
+++ b/projects/json5format/fuzz/fuzz_targets/fuzz_parse.rs
@@ -1,0 +1,10 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use json5format::*;
+use std::str;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(utf8) = str::from_utf8(data) {
+        ParsedDocument::from_str(utf8, None);
+    }
+});

--- a/projects/json5format/project.yaml
+++ b/projects/json5format/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://crates.io/crates/json5format"
+main_repo: "https://github.com/google/json5format"
+primary_contact: "richkadel@google.com"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+language: rust
+auto_ccs:
+  - "david@adalogics.com"


### PR DESCRIPTION
@richkadel - is it in the interest to enable fuzzing of json5format? There are already quite a few of Google's open source repositories on OSS-Fuzz and I thought it would be nice to get json5format on as well. The goal is to catch undesired panics - and the fuzzer I attached to this PR finds a panic instantly (check the failing test in the CI). Let me know! We can also move the fuzzers to the upstream json5format repository. 