### PR TITLE
protobuf-c: fix coverage builds, use latest code

### DIFF
--- a/projects/protobuf-c/Dockerfile
+++ b/projects/protobuf-c/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER guidovranken@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config
 RUN git clone --depth 1 --recursive https://github.com/protocolbuffers/protobuf.git
 RUN git clone --depth 1 https://github.com/protobuf-c/protobuf-c.git
 RUN git clone --depth 1 https://github.com/guidovranken/fuzzing-headers.git

--- a/projects/protobuf-c/Dockerfile
+++ b/projects/protobuf-c/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER guidovranken@gmail.com
 RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config
 RUN git clone --depth 1 --recursive https://github.com/protocolbuffers/protobuf.git
-RUN git clone --depth 1 https://github.com/protobuf-c/protobuf-c.git
+RUN git clone --depth 1 https://github.com/protobuf-c/protobuf-c.git -b next
 RUN git clone --depth 1 https://github.com/guidovranken/fuzzing-headers.git
 RUN git clone --depth 1 https://github.com/guidovranken/protobuf-c-fuzzers.git
 COPY build.sh $SRC/

--- a/projects/protobuf-c/build.sh
+++ b/projects/protobuf-c/build.sh
@@ -43,7 +43,8 @@ export PROTOC="$SRC/protobuf-install/bin/protoc"
 
 cd $SRC/protobuf-c/
 ./autogen.sh
-protobuf_LIBS="-L/$SRC/protobuf-install/lib -lprotobuf" protobuf_CFLAGS="-I $SRC/protobuf-install/include/" ./configure --enable-static=yes --enable-shared=false
+./configure --enable-static=yes --enable-shared=false PKG_CONFIG_PATH=$SRC/protobuf-install/lib/pkgconfig
+
 make -j$(nproc)
 
 cd $SRC/fuzzing-headers/

--- a/projects/protobuf-c/build.sh
+++ b/projects/protobuf-c/build.sh
@@ -27,6 +27,11 @@ then
     export CXXFLAGS="$CXXFLAGS -DMSAN"
 fi
 
+if [[ $SANITIZER = coverage ]]
+then
+    export CXXFLAGS="$CXXFLAGS -fno-use-cxa-atexit"
+fi
+
 mkdir $SRC/protobuf-install/
 cd $SRC/protobuf/
 ./autogen.sh

--- a/projects/protobuf-c/project.yaml
+++ b/projects/protobuf-c/project.yaml
@@ -1,6 +1,8 @@
 homepage: "https://github.com/protobuf-c/protobuf-c"
 language: c
 primary_contact: "guidovranken@gmail.com"
+auto_ccs:
+  - "ilya.lipnitskiy@gmail.com"
 sanitizers:
  - address
  - memory

--- a/projects/protobuf-c/project.yaml
+++ b/projects/protobuf-c/project.yaml
@@ -8,3 +8,4 @@ architectures:
  - x86_64
  - i386
 main_repo: 'https://github.com/protobuf-c/protobuf-c.git'
+coverage_extra_args: -ignore-filename-regex=.*/protobuf-install/.*


### PR DESCRIPTION
- Fix protobuf-c coverage builds (https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=27674)
- Use pkg-config for more readable dependency resolution
- Use the `next` branch in protobuf-c to test latest code
- Add myself to CCs

cc @guidovranken 