### PR TITLE
More generic target directory for rust coverage

### DIFF
--- a/infra/base-images/base-builder/cargo
+++ b/infra/base-images/base-builder/cargo
@@ -21,8 +21,6 @@
 #
 ################################################################################
 
-export PATH="/rust/bin:$PATH"
-
 if [ "$SANITIZER" = "coverage" ] && [ $1 = "build" ]
 then
     crate_src_abspath=`cargo metadata --no-deps --format-version 1 | jq -r '.workspace_root'`
@@ -48,4 +46,4 @@ then
     exit 0
 fi
 
-cargo "$@"
+/rust/bin/cargo "$@"

--- a/infra/base-images/base-builder/cargo
+++ b/infra/base-images/base-builder/cargo
@@ -41,7 +41,7 @@ then
     # do not optimize with --release, leading to Malformed instrumentation profile data
     cargo build --bins
     # copies the build output in the expected target directory
-    cd target
+    cd `cargo metadata --format-version 1 --no-deps | jq -r '.target_directory'`
     mkdir -p x86_64-unknown-linux-gnu/release
     cp -r debug/* x86_64-unknown-linux-gnu/release/
     )


### PR DESCRIPTION
cc @alexcrichton for the tip in https://github.com/google/oss-fuzz/pull/4697#discussion_r591889184
(just needed to add `-r` to jq)
This should fix wasmtime coverage build (works locally)

cc @inferno-chromium 