### PR TITLE
[firefox/spidermonkey] Remove cargo wrapper in /usr/local/bin to fix builds

### DIFF
--- a/projects/firefox/Dockerfile
+++ b/projects/firefox/Dockerfile
@@ -21,6 +21,10 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
   libstdc++6 \
   python \
   software-properties-common
+
+# This wrapper of cargo seems to interfere with our build system.
+RUN rm -f /usr/local/bin/cargo
+
 RUN git clone --depth 1 https://github.com/mozilla/gecko-dev mozilla-central
 RUN git clone --depth 1 https://github.com/mozillasecurity/fuzzdata
 WORKDIR mozilla-central

--- a/projects/spidermonkey-ufi/Dockerfile
+++ b/projects/spidermonkey-ufi/Dockerfile
@@ -20,6 +20,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python \
     libc++1 \
     libc++abi1
+
+# This wrapper of cargo seems to interfere with our build system.
+RUN rm -f /usr/local/bin/cargo
+
 RUN git clone --depth=1 https://github.com/mozilla/gecko-dev mozilla-central
 WORKDIR mozilla-central/js/src/
 COPY build.sh target.c $SRC/

--- a/projects/spidermonkey/Dockerfile
+++ b/projects/spidermonkey/Dockerfile
@@ -22,6 +22,9 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
   yasm \
   python
 
+# This wrapper of cargo seems to interfere with our build system.
+RUN rm -f /usr/local/bin/cargo
+
 RUN git clone --depth=1 https://github.com/mozilla/gecko-dev mozilla-central
 WORKDIR mozilla-central/js/src/
 COPY build.sh $SRC/


### PR DESCRIPTION
For some reason, the presence of this wrapper breaks the build process of Firefox and Spidermonkey. I was not able to figure out so far why exactly this breaks, but I was able to confirm that this wrapper is the source of the problem and that we can get the builds back up and running my removing it in our images.