### PR TITLE
[fastjson2] Initial integration of alibaba/fastjson

### DIFF
--- a/projects/fastjson2/Dockerfile
+++ b/projects/fastjson2/Dockerfile
@@ -1,0 +1,28 @@
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y maven
+
+RUN git clone --depth 1 https://github.com/google/fuzzing
+RUN cat fuzzing/dictionaries/json.dict > $OUT/JsonFuzzer.dict
+
+RUN git clone --depth 1 https://github.com/alibaba/fastjson
+
+COPY build.sh $SRC/
+COPY JsonFuzzer.java $SRC/
+WORKDIR $SRC/fastjson

--- a/projects/fastjson2/JsonFuzzer.java
+++ b/projects/fastjson2/JsonFuzzer.java
@@ -1,0 +1,28 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONException;
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+public class JsonFuzzer {
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+    try {
+      JSON.parse(data.consumeRemainingAsString());
+    } catch (JSONException ignored) {
+    }
+  }
+}

--- a/projects/fastjson2/build.sh
+++ b/projects/fastjson2/build.sh
@@ -1,0 +1,48 @@
+#!/bin/bash -eu
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+mvn package -Dmaven.test.skip=true -Djdk.version=15
+CURRENT_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate \
+ -Dexpression=project.version -q -DforceStdout)
+cp "target/fastjson-$CURRENT_VERSION.jar" $OUT/fastjson.jar
+
+PROJECT_JARS="fastjson.jar"
+
+# The classpath at build-time includes the project jars in $OUT as well as the
+# Jazzer API.
+BUILD_CLASSPATH=$(echo $PROJECT_JARS | xargs printf -- "$OUT/%s:"):$JAZZER_API_PATH
+
+# All .jar and .class files lie in the same directory as the fuzzer at runtime.
+RUNTIME_CLASSPATH=$(echo $PROJECT_JARS | xargs printf -- "\$this_dir/%s:"):\$this_dir
+
+for fuzzer in $(find $SRC -name '*Fuzzer.java'); do
+  fuzzer_basename=$(basename -s .java $fuzzer)
+  javac -cp $BUILD_CLASSPATH $fuzzer
+  cp $SRC/$fuzzer_basename.class $OUT/
+
+  # Create an execution wrapper that executes Jazzer with the correct arguments.
+  echo "#!/bin/sh
+# LLVMFuzzerTestOneInput for fuzzer detection.
+this_dir=\$(dirname \"\$0\")
+LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\":\$this_dir \
+\$this_dir/jazzer_driver --agent_path=\$this_dir/jazzer_agent_deploy.jar \
+--cp=$RUNTIME_CLASSPATH \
+--target_class=$fuzzer_basename \
+--jvm_args=\"-Xmx2048m\" \
+\$@" > $OUT/$fuzzer_basename
+  chmod u+x $OUT/$fuzzer_basename
+done

--- a/projects/fastjson2/project.yaml
+++ b/projects/fastjson2/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/alibaba/fastjson"
+language: jvm
+primary_contact: "shaojin.wensj@alibaba-inc.com"
+auto_ccs:
+  - "meumertzheim@code-intelligence.com"
+fuzzing_engines:
+  - libfuzzer
+main_repo: "https://github.com/alibaba/fastjson"
+sanitizers:
+  - address


### PR DESCRIPTION
@wenshao OSS-Fuzz uses [Jazzer](https://github.com/CodeIntelligenceTesting/jazzer) under the hood to test Java projects, which is the fuzzer that found the issues in https://github.com/alibaba/fastjson/issues/3631. It will continuously test the newest revision in the https://github.com/alibaba/fastjson repository and send actionable reports about bugs (OutOfMemoryError, undeclared exceptions) to your GitHub email (see [the project config](https://github.com/google/oss-fuzz/compare/master...CodeIntelligenceTesting:fastjson2?expand=1#diff-de1d9d931afd47b420363a2c5adcece244da7e22b1b01bcaaa7d116ceff3e660R3)). If you would like to use a different (or additional) email addresses or have any general questions about the OSS-Fuzz integration, let me know.