### PR TITLE
Golang coverage: build binary instead of bash script

### DIFF
--- a/infra/base-images/base-builder/compile_go_fuzzer
+++ b/infra/base-images/base-builder/compile_go_fuzzer
@@ -42,12 +42,8 @@ if [[ $SANITIZER = *coverage* ]]; then
   sed -i -e 's/mypackagebeingfuzzed/'$fuzzed_package'/' ./"${function,,}"_test.go
   sed -i -e 's/TestFuzzCorpus/Test'$function'Corpus/' ./"${function,,}"_test.go
 
-  echo "#!/bin/sh" > $OUT/$fuzzer
-  echo "cd \$OUT/$abspath" >> $OUT/$fuzzer
-  # The fuzzer may be in a subdirectory, but we want the coverage report for the whole repository
   fuzzed_repo=`echo $path | cut -d/ -f-3`
-  echo "go test -run Test${function}Corpus -v $tags -coverpkg $fuzzed_repo/... -coverprofile \$1 " >> $OUT/$fuzzer
-  chmod +x $OUT/$fuzzer
+  go test -run Test${function}Corpus -v $tags -coverpkg $fuzzed_repo/... -c -o $OUT/$fuzzer $path
 else
   # Compile and instrument all Go files relevant to this fuzz target.
   echo "Running go-fuzz $tags -func $function -o $fuzzer.a $path"

--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -114,13 +114,11 @@ function run_fuzz_target {
 function run_go_fuzz_target {
   local target=$1
 
-  cd $GOPATH/src
   echo "Running go target $target"
   export FUZZ_CORPUS_DIR="/corpus/${target}/"
   export FUZZ_PROFILE_NAME="$DUMPS_DIR/$target.perf"
-  bash $OUT/$target $DUMPS_DIR/$target.profdata &> $LOGS_DIR/$target.log
+  $OUT/$target -test.coverprofile $DUMPS_DIR/$target.profdata &> $LOGS_DIR/$target.log
   $SYSGOPATH/bin/gocovsum $DUMPS_DIR/$target.profdata > $FUZZER_STATS_DIR/$target.json
-  cd $OUT
 }
 
 export SYSGOPATH=$GOPATH
@@ -131,7 +129,7 @@ for fuzz_target in $FUZZ_TARGETS; do
   if [[ $FUZZING_LANGUAGE == "go" ]]; then
     # Continue if not a fuzz target.
     if [[ $FUZZING_ENGINE != "none" ]]; then
-      grep "go test -run" $fuzz_target > /dev/null 2>&1 || continue
+      grep "FUZZ_CORPUS_DIR" $fuzz_target > /dev/null 2>&1 || continue
     fi
     run_go_fuzz_target $fuzz_target &
   else


### PR DESCRIPTION
cf #5537
cc @jonathanmetzman 

We can indeed build a golang test program in base-builder, so we do not any longer need gcc in base-runner
This also should help getting rid of the directory logic...