### PR TITLE
[juju] Initial integration

### DIFF
--- a/projects/juju/Dockerfile
+++ b/projects/juju/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN git clone --depth 1 https://github.com/juju/juju
+COPY build.sh storage_fuzzer.go $SRC/
+WORKDIR $SRC/juju

--- a/projects/juju/build.sh
+++ b/projects/juju/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+mv $SRC/storage_fuzzer.go $SRC/juju/storage/
+
+if [[ $SANITIZER = *coverage* ]]; then
+	compile_go_fuzzer github.com/juju/juju/storage Fuzz storage_fuzzer
+	exit 0
+fi
+
+compile_go_fuzzer ./storage Fuzz storage_fuzzer

--- a/projects/juju/project.yaml
+++ b/projects/juju/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://juju.is"
+main_repo: "https://github.com/juju/juju"
+primary_contact: "stickupkid@gmail.com"
+auto_ccs :
+  - "adam@adalogics.com"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address

--- a/projects/juju/storage_fuzzer.go
+++ b/projects/juju/storage_fuzzer.go
@@ -1,0 +1,24 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package storage
+
+func Fuzz(data []byte) int {
+	_, err := ParseConstraints(string(data))
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
Initial integration of [Juju](https://github.com/juju/juju). 

Users of Juju include [[src](https://juju.is/)]: 

- Deutsche Telekom
- IBM
- Intel
- Microsoft Azure
- Cisco
- China Telekom
- HP
- Yahoo
- Verizon
- Panasonic
- BT
- Rabobank
- Tele2
____________________________________________________________



@SimonRichardson @achilleasa @wallyworld @ycliuhw

I have been working on setting up continuous fuzzing for Juju and have set up this draft integration application with build files and a fuzzer to get things started.

Integrating with OSS-fuzz is free but is offered with an implied expectation that found bugs are fixed. Once Juju is integrated OSS-fuzz will run all Jujus fuzzers continuously and report bugs to maintainers on the mailing list. 

To finish the integration at least on email address is needed for bug reports.

Let me know if you are interested continuing with integration.