### PR TITLE
[openexr] remove dep on libIexMath (no longer exists)

### DIFF
--- a/projects/openexr/build.sh
+++ b/projects/openexr/build.sh
@@ -39,7 +39,6 @@ LIBS=(
   "$WORK/src/lib/OpenEXRUtil/libOpenEXRUtil.a"
   "$WORK/src/lib/OpenEXR/libOpenEXR.a"
   "$WORK/src/lib/Iex/libIex.a"
-  "$WORK/src/lib/IexMath/libIexMath.a"
   "$WORK/src/lib/IlmThread/libIlmThread.a"
   "$WORK/_deps/imath-build/src/Imath/libImath*.a"
 )


### PR DESCRIPTION
AcademySoftwareFoundation/openexr#962 removes libIexMath. Update build.sh to stop linking against it.