### PR TITLE
nom: initial integration

### DIFF
--- a/projects/nom/Dockerfile
+++ b/projects/nom/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN git clone --depth 1 https://github.com/Geal/nom/
+COPY fuzz $SRC/nom/fuzz
+WORKDIR $SRC
+
+COPY build.sh $SRC/

--- a/projects/nom/build.sh
+++ b/projects/nom/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC/nom
+cargo fuzz build -O 
+cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_arithmetic $OUT/

--- a/projects/nom/fuzz/.gitignore
+++ b/projects/nom/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/projects/nom/fuzz/.gitignore
+++ b/projects/nom/fuzz/.gitignore
@@ -1,4 +1,0 @@
-
-target
-corpus
-artifacts

--- a/projects/nom/fuzz/Cargo.toml
+++ b/projects/nom/fuzz/Cargo.toml
@@ -1,0 +1,24 @@
+
+[package]
+name = "nom-fuzz"
+version = "0.0.0"
+authors = ["David Korczynski <david@adalogics.com>"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.3"
+
+[dependencies.nom]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_arithmetic"
+path = "fuzz_targets/fuzz_arithmetic.rs"

--- a/projects/nom/fuzz/fuzz_targets/fuzz_arithmetic.rs
+++ b/projects/nom/fuzz/fuzz_targets/fuzz_arithmetic.rs
@@ -1,0 +1,71 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use std::str;
+
+extern crate nom;
+
+use nom::{
+  branch::alt,
+  bytes::complete::tag,
+  character::complete::char,
+  character::complete::{digit1 as digit, space0 as space},
+  combinator::map_res,
+  multi::fold_many0,
+  sequence::{delimited, pair},
+  IResult,
+};
+
+use std::str::FromStr;
+
+fn parens(i: &str) -> IResult<&str, i64> {
+      delimited(space, delimited(tag("("), expr, tag(")")), space)(i)
+}
+
+
+fn factor(i: &str) -> IResult<&str, i64> {
+  alt((
+    map_res(delimited(space, digit, space), FromStr::from_str),
+    parens,
+  ))(i)
+}
+
+
+fn term(i: &str) -> IResult<&str, i64> {
+  let (i, init) = factor(i)?;
+
+  fold_many0(
+    pair(alt((char('*'), char('/'))), factor),
+    init,
+    |acc, (op, val): (char, i64)| {
+      if op == '*' {
+        acc * val
+      } else {
+        acc / val
+      }
+    },
+  )(i)
+}
+
+fn expr(i: &str) -> IResult<&str, i64> {
+  let (i, init) = term(i)?;
+
+  fold_many0(
+    pair(alt((char('+'), char('-'))), term),
+    init,
+    |acc, (op, val): (char, i64)| {
+      if op == '+' {
+        acc + val
+      } else {
+        acc - val
+      }
+    },
+  )(i)
+}
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    let temp = match str::from_utf8(data) {
+        Ok(v) => factor(v),
+        Err(e) => factor("2"),
+    };
+});

--- a/projects/nom/project.yaml
+++ b/projects/nom/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/Geal/nom"
+main_repo: "https://github.com/Geal/nom"
+primary_contact: "david@adalogics.com"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+language: rust
+auto_ccs:
+  - "david@adalogics.com"

--- a/projects/nom/project.yaml
+++ b/projects/nom/project.yaml
@@ -1,6 +1,6 @@
 homepage: "https://github.com/Geal/nom"
 main_repo: "https://github.com/Geal/nom"
-primary_contact: "david@adalogics.com"
+primary_contact: "geo.couprie@gmail.com"
 sanitizers:
   - address
 fuzzing_engines:


### PR DESCRIPTION
Nom is a library used for writing parsers in Rust. It is used in a *ton* of parsers written in Rust: https://github.com/Geal/nom#parsers-written-with-nom

@Geal would you be interested in integrating nom into oss-fuzz? By way of OSS-Fuzz we can add fuzzers to nom and run them continuously - you will then receive reports whenever crashes are found. If you would like to integrate, could you please provide a set of email(s) that will get access to the data produced by OSS-Fuzz, such as bug reports. The emails should be linked to a Google account in order to view the detailed reports and notice the emails affiliated with the project will be public in the OSS-Fuzz repo, as they will be part of a configuration file.