### PR TITLE
Fix #32074 issue with oss-fuzz using old openexr library

### DIFF
--- a/projects/openexr/build.sh
+++ b/projects/openexr/build.sh
@@ -38,9 +38,8 @@ INCLUDES=(
 LIBS=(
   "$WORK/src/lib/OpenEXRUtil/libOpenEXRUtil.a"
   "$WORK/src/lib/OpenEXR/libOpenEXR.a"
-  "$WORK/src/lib/Iex/libIex.a"
-  "$WORK/src/lib/IexMath/libIexMath.a"
   "$WORK/src/lib/IlmThread/libIlmThread.a"
+  "$WORK/src/lib/Iex/libIex.a"
   "$WORK/_deps/imath-build/src/Imath/libImath*.a"
 )
 


### PR DESCRIPTION
OpenEXR 3.0, and the main branch, has accepted a PR to merge libIexMath
into libIex, to lower dependencies. Remove it from the list of libraries
and further sort by dependency order

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>