### PR TITLE
Golang coverage: use absolute paths

### DIFF
--- a/infra/base-images/base-builder/compile_go_fuzzer
+++ b/infra/base-images/base-builder/compile_go_fuzzer
@@ -43,6 +43,8 @@ if [[ $SANITIZER = *coverage* ]]; then
   sed -i -e 's/TestFuzzCorpus/Test'$function'Corpus/' ./"${function,,}"_test.go
 
   fuzzed_repo=`echo $path | cut -d/ -f-3`
+  # give equivalence to absolute paths in another file, as go test -cover uses golangish pkg.Dir
+  echo "s=$fuzzed_repo"=`go list $tags -f {{.Dir}} $fuzzed_repo`= > $OUT/$fuzzer.gocovpath
   go test -run Test${function}Corpus -v $tags -coverpkg $fuzzed_repo/... -c -o $OUT/$fuzzer $path
 else
   # Compile and instrument all Go files relevant to this fuzz target.

--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -118,6 +118,10 @@ function run_go_fuzz_target {
   export FUZZ_CORPUS_DIR="/corpus/${target}/"
   export FUZZ_PROFILE_NAME="$DUMPS_DIR/$target.perf"
   $OUT/$target -test.coverprofile $DUMPS_DIR/$target.profdata &> $LOGS_DIR/$target.log
+  # translate from golangish paths to current absolute paths
+  cat $OUT/$target.gocovpath | while read i; do sed -i $i $DUMPS_DIR/$target.profdata; done
+  # cf PATH_EQUIVALENCE_ARGS
+  sed -i 's=/=$OUT=' $DUMPS_DIR/$target.profdata
   $SYSGOPATH/bin/gocovsum $DUMPS_DIR/$target.profdata > $FUZZER_STATS_DIR/$target.json
 }
 
@@ -162,7 +166,7 @@ wait
 
 if [[ $FUZZING_LANGUAGE == "go" ]]; then
   $SYSGOPATH/bin/gocovmerge $DUMPS_DIR/*.profdata > fuzz.cov
-  GO111MODULE=off go tool cover -html=fuzz.cov -o $REPORT_ROOT_DIR/index.html
+  go tool cover -html=fuzz.cov -o $REPORT_ROOT_DIR/index.html
   $SYSGOPATH/bin/gocovsum fuzz.cov > $SUMMARY_FILE
   cp $REPORT_ROOT_DIR/index.html $REPORT_PLATFORM_DIR/index.html
   $SYSGOPATH/bin/pprof-merge $DUMPS_DIR/*.perf.cpu.prof

--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -121,7 +121,7 @@ function run_go_fuzz_target {
   # translate from golangish paths to current absolute paths
   cat $OUT/$target.gocovpath | while read i; do sed -i $i $DUMPS_DIR/$target.profdata; done
   # cf PATH_EQUIVALENCE_ARGS
-  sed -i 's=/=$OUT=' $DUMPS_DIR/$target.profdata
+  sed -i 's=/='$OUT'/=' $DUMPS_DIR/$target.profdata
   $SYSGOPATH/bin/gocovsum $DUMPS_DIR/$target.profdata > $FUZZER_STATS_DIR/$target.json
 }
 

--- a/infra/base-images/base-runner/gocoverage/gocovsum/gocovsum.go
+++ b/infra/base-images/base-runner/gocoverage/gocovsum/gocovsum.go
@@ -9,8 +9,6 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"os"
-	"path"
 
 	"golang.org/x/tools/cover"
 )
@@ -68,13 +66,9 @@ func main() {
 	r.Type = "oss-fuzz.go.coverage.json.export"
 	r.Version = "1.0.0"
 	r.Data = make([]CoverageData, 1)
-	gopath := os.Getenv("GOPATH")
-	if len(gopath) == 0 {
-		gopath = os.Getenv("HOME") + "/go"
-	}
 	for _, p := range profiles {
 		fset := token.NewFileSet() // positions are relative to fset
-		f, err := parser.ParseFile(fset, path.Join(gopath, "src", p.FileName), nil, 0)
+		f, err := parser.ParseFile(fset, p.FileName, nil, 0)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
This should fix golang coverage build (and keep working for future go 1.17)

Core problem is that `go test -cover` does not output absolute paths in profile data, but golang-ish `pkg.Dir`
While building the fuzz targets, we can output a file containing the translation
And then use this translation in `run_go_fuzz_target` function when running coverage

cc @inferno-chromium 