### PR TITLE
quick-xml: initial integration

### DIFF
--- a/projects/quick-xml/Dockerfile
+++ b/projects/quick-xml/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN git clone --depth 1 https://github.com/tafia/quick-xml
+COPY fuzz_target_1.rs $SRC/quick-xml/fuzz/fuzz_targets/fuzz_target_1.rs
+WORKDIR $SRC
+
+COPY build.sh $SRC/

--- a/projects/quick-xml/build.sh
+++ b/projects/quick-xml/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC/quick-xml
+cargo fuzz build -O 
+cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_target_1 $OUT/

--- a/projects/quick-xml/fuzz_target_1.rs
+++ b/projects/quick-xml/fuzz_target_1.rs
@@ -1,3 +1,18 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+//limitations under the License.
+//
+//###################
 #![no_main]
 #[macro_use] extern crate libfuzzer_sys;
 extern crate quick_xml;

--- a/projects/quick-xml/fuzz_target_1.rs
+++ b/projects/quick-xml/fuzz_target_1.rs
@@ -1,0 +1,20 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate quick_xml;
+use std::io::Cursor;
+
+fuzz_target!(|data: &[u8]| {
+    use quick_xml::Reader;
+    use std::io::Cursor;
+
+    let cursor = Cursor::new(data);
+    let mut reader = Reader::from_reader(cursor);
+    let mut buf = vec![];
+    loop {
+        match reader.read_event(&mut buf) {
+            Ok(quick_xml::events::Event::Eof) | Err(..) => break,
+            _ => buf.clear(),
+        }
+    }
+});
+

--- a/projects/quick-xml/fuzz_target_1.rs
+++ b/projects/quick-xml/fuzz_target_1.rs
@@ -1,20 +1,43 @@
 #![no_main]
 #[macro_use] extern crate libfuzzer_sys;
 extern crate quick_xml;
+
+use quick_xml::Reader;
+use quick_xml::events::Event;
 use std::io::Cursor;
 
 fuzz_target!(|data: &[u8]| {
-    use quick_xml::Reader;
-    use std::io::Cursor;
-
+    // fuzzed code goes here
     let cursor = Cursor::new(data);
     let mut reader = Reader::from_reader(cursor);
     let mut buf = vec![];
     loop {
         match reader.read_event(&mut buf) {
-            Ok(quick_xml::events::Event::Eof) | Err(..) => break,
-            _ => buf.clear(),
+            Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e))=> {
+                if e.unescaped().is_err() {
+                    break;
+                }
+                for a in e.attributes() {
+                    if a.ok().map_or(false, |a| a.unescaped_value().is_err()) {
+                        break;
+                    }
+                }
+            }
+            Ok(Event::Text(ref e)) | Ok(Event::Comment(ref e))
+            | Ok(Event::CData(ref e)) | Ok(Event::PI(ref e))
+            | Ok(Event::DocType(ref e)) => {
+                if e.unescaped().is_err() {
+                    break;
+                }
+            }
+            Ok(Event::Decl(ref e)) => {
+                let _ = e.version();
+                let _ = e.encoding();
+                let _ = e.standalone();
+            }
+            Ok(Event::End(_)) => (),
+            Ok(Event::Eof) | Err(..) => break,
         }
+        buf.clear();
     }
 });
-

--- a/projects/quick-xml/project.yaml
+++ b/projects/quick-xml/project.yaml
@@ -1,6 +1,6 @@
 homepage: "https://github.com/tafia/quick-xml"
 main_repo: "https://github.com/tafia/quick-xml"
-primary_contact: "david@adalogics.com"
+primary_contact: "tafia973@gmail.com"
 sanitizers:
   - address
 fuzzing_engines:

--- a/projects/quick-xml/project.yaml
+++ b/projects/quick-xml/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/tafia/quick-xml"
+main_repo: "https://github.com/tafia/quick-xml"
+primary_contact: "david@adalogics.com"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+language: rust
+auto_ccs:
+  - "david@adalogics.com"


### PR DESCRIPTION
@tafia I have set up continuous fuzzing of quick-xml. The benefits are that the fuzzer will be run on a regular basis and bug reports will be send to your email with details on the oss-fuzz.com interface about the bugs. Is this something you would be happy to have set up? If so, the only thing needed from your end is an email that will receive the bugs reports - notice this email should be attached to a Google account for you to see the reports.
I noticed you had an existing fuzzer in the repo, but I had to make a slight change to make it work as the fuzzer in your repo does not build. 