### PR TITLE
tpm2-tss: disable afl

### DIFF
--- a/projects/tpm2-tss/project.yaml
+++ b/projects/tpm2-tss/project.yaml
@@ -6,7 +6,10 @@ auto_ccs:
   - "john.s.andersen@intel.com"
   - "william.c.roberts@intel.com"
   - "tstruk@gmail.com"
+fuzzing_engines:
+  - libfuzzer
 sanitizers:
   - address
   - memory
   - undefined
+main_repo: 'https://github.com/tpm2-software/tpm2-tss.git'


### PR DESCRIPTION
afl build gets killed with error 137 [1], which would indicate that
it ran out of memory and got killed. According to [2] AFL build
requires lots of memory, but the oss limits images to 2GB [3]
Disable AFL to get the build running.

[1] https://github.com/google/oss-fuzz/pull/5410/checks?check_run_id=2124207452#step:8:4277
[2] https://afl-1.readthedocs.io/en/latest/notes_for_asan.html
[3] https://google.github.io/oss-fuzz/faq/#what-are-the-specs-on-your-machines

Signed-off-by: Tadeusz Struk <tstruk@gmail.com>