### PR TITLE
Fixes coverage build for golang project.

### DIFF
--- a/infra/base-images/base-builder/compile_go_fuzzer
+++ b/infra/base-images/base-builder/compile_go_fuzzer
@@ -18,7 +18,7 @@
 path=$1
 function=$2
 fuzzer=$3
-tags=""
+tags="gofuzz"
 if [[ $#  -eq 4 ]]; then
   tags="-tags $4"
 fi
@@ -44,7 +44,7 @@ if [[ $SANITIZER = *coverage* ]]; then
 
   fuzzed_repo=`echo $path | cut -d/ -f-3`
   # give equivalence to absolute paths in another file, as go test -cover uses golangish pkg.Dir
-  echo "s=$fuzzed_repo"=`go list $tags -f {{.Dir}} $fuzzed_repo`= > $OUT/$fuzzer.gocovpath
+  echo "s=$fuzzed_repo"=`go list $tags -f {{.Dir}} $path`= > $OUT/$fuzzer.gocovpath
   go test -run Test${function}Corpus -v $tags -coverpkg $fuzzed_repo/... -c -o $OUT/$fuzzer $path
 else
   # Compile and instrument all Go files relevant to this fuzz target.


### PR DESCRIPTION
- Some project are not providing the gofuzz tag by default.
- go list should be on the targeted package.


Fixes #5320

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>