### PR TITLE
[crossplane] Initial integration

### DIFF
--- a/projects/crossplane/Dockerfile
+++ b/projects/crossplane/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/crossplane/Dockerfile
+++ b/projects/crossplane/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/crossplane/crossplane
+COPY build.sh fuzz.go $SRC/
+WORKDIR $SRC/crossplane

--- a/projects/crossplane/build.sh
+++ b/projects/crossplane/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/crossplane/build.sh
+++ b/projects/crossplane/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+mv $SRC/fuzz.go $SRC/crossplane/internal/xpkg/
+go mod tidy
+rm /root/go/pkg/mod/github.com/aws/aws-sdk-go-v2/internal/ini@v1.3.11/fuzz.go
+
+compile_go_fuzzer github.com/crossplane/crossplane/internal/xpkg FuzzParse fuzz_parse

--- a/projects/crossplane/fuzz.go
+++ b/projects/crossplane/fuzz.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/crossplane/fuzz.go
+++ b/projects/crossplane/fuzz.go
@@ -1,0 +1,34 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package xpkg
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+
+	"github.com/crossplane/crossplane-runtime/pkg/parser"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func FuzzParse(data []byte) int {
+	objScheme := runtime.NewScheme()
+	metaScheme := runtime.NewScheme()
+	p := parser.New(metaScheme, objScheme)
+	r := ioutil.NopCloser(bytes.NewReader(data))
+	_, _ = p.Parse(context.TODO(), r)
+	return 1
+}

--- a/projects/crossplane/project.yaml
+++ b/projects/crossplane/project.yaml
@@ -1,0 +1,13 @@
+homepage: "https://github.com/crossplane/crossplane"
+main_repo: "https://github.com/crossplane/crossplane"
+primary_contact: "jbw976@gmail.com"
+auto_ccs :
+  - "me@muvaf.com"
+  - "nicc@rk0n.org"
+vendor_ccs :
+  - "adam@adalogics.com"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
Crossplane is a framework for building cloud native control planes without needing to write code. It has a highly extensible backend that enables users to build a control plane that can orchestrate applications and infrastructure no matter where they run, and a highly configurable frontend that puts you in control of the schema of the declarative API it offers.

Crossplane is a [CNCF](https://www.cncf.io/) project. It is used by companies like:

- Alibaba
- Redhat
- GitLab
- Microsoft
[[reference](https://crossplane.io/#:~:text=Started%20by%20Upbound%20and%20adopted%20by%20the%20Cloud%20Native%20community)]

____________________________________________________________

@hasheddan @negz @muvaf Are you interested in integrating Crossplane into OSS-fuzz for continuous fuzzing?
This PR adds the build files and the first fuzzer to get fuzzing started.