### PR TITLE
[CIFuzz] Give testcases unique names.

### DIFF
--- a/infra/cifuzz/run_fuzzers.py
+++ b/infra/cifuzz/run_fuzzers.py
@@ -150,7 +150,8 @@ class BaseFuzzTargetRunner:
                          (target.target_name.encode(), result.stacktrace))
 
       # TODO(metzman): Do this with filestore.
-      testcase_artifact_path = self.get_fuzz_target_artifact(target, 'testcase')
+      testcase_artifact_path = self.get_fuzz_target_artifact(
+          target, os.path.basename(result.testcase))
       shutil.move(result.testcase, testcase_artifact_path)
       bug_summary_artifact_path = self.get_fuzz_target_artifact(
           target, 'bug-summary.txt')

--- a/infra/cifuzz/run_fuzzers_test.py
+++ b/infra/cifuzz/run_fuzzers_test.py
@@ -280,7 +280,7 @@ class BatchFuzzTargetRunnerTest(fake_filesystem_unittest.TestCase):
   def test_run_fuzz_targets_quits(self, mocked_create_fuzz_target_obj,
                                   mocked_run_fuzz_target,
                                   mocked_get_fuzz_targets):
-    """Tests that run_fuzz_targets quits on the first crash it finds."""
+    """Tests that run_fuzz_targets doesn't quit on the first crash it finds."""
     workspace = 'workspace'
     out_path = os.path.join(workspace, 'out')
     self.fs.create_dir(out_path)
@@ -291,8 +291,8 @@ class BatchFuzzTargetRunnerTest(fake_filesystem_unittest.TestCase):
 
     mocked_get_fuzz_targets.return_value = ['target1', 'target2']
     runner.initialize()
-    testcase1 = os.path.join(workspace, 'testcase1')
-    testcase2 = os.path.join(workspace, 'testcase2')
+    testcase1 = os.path.join(workspace, 'testcase-aaa')
+    testcase2 = os.path.join(workspace, 'testcase-bbb')
     self.fs.create_file(testcase1)
     self.fs.create_file(testcase2)
     stacktrace = b'stacktrace'
@@ -313,7 +313,8 @@ class BatchFuzzTargetRunnerTest(fake_filesystem_unittest.TestCase):
     magic_mock.target_name = 'target1'
     mocked_create_fuzz_target_obj.return_value = magic_mock
     self.assertTrue(runner.run_fuzz_targets())
-    self.assertIn('target1-address-testcase', os.listdir(runner.artifacts_dir))
+    self.assertIn('target1-address-testcase-aaa',
+                  os.listdir(runner.artifacts_dir))
     self.assertEqual(mocked_run_fuzz_target.call_count, 2)
 
 


### PR DESCRIPTION
Don't just call them $TARGET-$SANITIZER-testcase.
Instead include the real names.
Fixes: https://github.com/google/oss-fuzz/issues/5384