### PR TITLE
Go coverage : use gofuzz tag by default

### DIFF
--- a/infra/base-images/base-builder/compile_go_fuzzer
+++ b/infra/base-images/base-builder/compile_go_fuzzer
@@ -18,7 +18,7 @@
 path=$1
 function=$2
 fuzzer=$3
-tags=""
+tags="-tags gofuzz"
 if [[ $#  -eq 4 ]]; then
   tags="-tags $4"
 fi
@@ -43,8 +43,9 @@ if [[ $SANITIZER = *coverage* ]]; then
   sed -i -e 's/TestFuzzCorpus/Test'$function'Corpus/' ./"${function,,}"_test.go
 
   fuzzed_repo=`echo $path | cut -d/ -f-3`
+  abspath_repo=`go list -m $tags -f {{.Dir}} $fuzzed_repo || go list $tags -f {{.Dir}} $fuzzed_repo`
   # give equivalence to absolute paths in another file, as go test -cover uses golangish pkg.Dir
-  echo "s=$fuzzed_repo"=`go list $tags -f {{.Dir}} $fuzzed_repo`= > $OUT/$fuzzer.gocovpath
+  echo "s=$fuzzed_repo"="$abspath_repo$"= > $OUT/$fuzzer.gocovpath
   go test -run Test${function}Corpus -v $tags -coverpkg $fuzzed_repo/... -c -o $OUT/$fuzzer $path
 else
   # Compile and instrument all Go files relevant to this fuzz target.


### PR DESCRIPTION
as is done by gofuzz build

cc @cyriltovena

Loki uses `gofuzz` tag which was not used by default for coverage.
And `go list -m` gives absolute path for /src/loki even if there are no Go files in it but there is a go.mod