### PR TITLE
[golang] Added 2 fuzzers

### DIFF
--- a/projects/golang/Dockerfile
+++ b/projects/golang/Dockerfile
@@ -17,6 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN git clone --depth 1 https://github.com/dvyukov/go-fuzz-corpus golang
-COPY build.sh $SRC/
+RUN git clone https://github.com/golang/go
+COPY build.sh math_big_fuzzer.go $SRC/
 
 WORKDIR $SRC/golang

--- a/projects/golang/Dockerfile
+++ b/projects/golang/Dockerfile
@@ -17,7 +17,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN git clone --depth 1 https://github.com/dvyukov/go-fuzz-corpus golang
-RUN git clone https://github.com/golang/go
 COPY build.sh math_big_fuzzer.go $SRC/
 
 WORKDIR $SRC/golang

--- a/projects/golang/build.sh
+++ b/projects/golang/build.sh
@@ -35,3 +35,11 @@ compile_go_fuzzer $FUZZ_ROOT/time Fuzz time_fuzzer
 compile_go_fuzzer $FUZZ_ROOT/xml Fuzz xml_fuzzer
 compile_go_fuzzer $FUZZ_ROOT/zip Fuzz zip_fuzzer
 compile_go_fuzzer $FUZZ_ROOT/zlib Fuzz zlib_fuzzer
+
+# math/big fuzzers:
+mv $SRC/math_big_fuzzer.go $SRC/go/src/math/big/
+cd $SRC/go/src/math
+sed -i '10d' big/arith_amd64.go
+sed 's/var support_adx = cpu.X86.HasADX && cpu.X86.HasBMI2/var support_adx = true/g' -i big/arith_amd64.go
+compile_go_fuzzer ./big FuzzCmp big_cmp_fuzzer
+compile_go_fuzzer ./big FuzzExpNN expnn_fuzzer

--- a/projects/golang/build.sh
+++ b/projects/golang/build.sh
@@ -15,8 +15,13 @@
 # These two dependencies cause build issues and are not used by oss-fuzz:
 rm -r sqlparser
 rm -r parser
+
+mkdir math && cp $SRC/math_big_fuzzer.go ./math/
+
 go mod init "github.com/dvyukov/go-fuzz-corpus"
 export FUZZ_ROOT="github.com/dvyukov/go-fuzz-corpus"
+compile_go_fuzzer $FUZZ_ROOT/math FuzzCmp big_cmp_fuzzer
+compile_go_fuzzer $FUZZ_ROOT/math FuzzExpNN big_rat_fuzzer
 compile_go_fuzzer $FUZZ_ROOT/asn1 Fuzz asn_fuzzer
 compile_go_fuzzer $FUZZ_ROOT/csv Fuzz csv_fuzzer
 compile_go_fuzzer $FUZZ_ROOT/elliptic Fuzz elliptic_fuzzer
@@ -35,11 +40,3 @@ compile_go_fuzzer $FUZZ_ROOT/time Fuzz time_fuzzer
 compile_go_fuzzer $FUZZ_ROOT/xml Fuzz xml_fuzzer
 compile_go_fuzzer $FUZZ_ROOT/zip Fuzz zip_fuzzer
 compile_go_fuzzer $FUZZ_ROOT/zlib Fuzz zlib_fuzzer
-
-# math/big fuzzers:
-mv $SRC/math_big_fuzzer.go $SRC/go/src/math/big/
-cd $SRC/go/src/math
-sed -i '10d' big/arith_amd64.go
-sed 's/var support_adx = cpu.X86.HasADX && cpu.X86.HasBMI2/var support_adx = true/g' -i big/arith_amd64.go
-compile_go_fuzzer ./big FuzzCmp big_cmp_fuzzer
-compile_go_fuzzer ./big FuzzExpNN expnn_fuzzer

--- a/projects/golang/build.sh
+++ b/projects/golang/build.sh
@@ -20,8 +20,9 @@ mkdir math && cp $SRC/math_big_fuzzer.go ./math/
 
 go mod init "github.com/dvyukov/go-fuzz-corpus"
 export FUZZ_ROOT="github.com/dvyukov/go-fuzz-corpus"
-compile_go_fuzzer $FUZZ_ROOT/math FuzzCmp big_cmp_fuzzer
-compile_go_fuzzer $FUZZ_ROOT/math FuzzExpNN big_rat_fuzzer
+compile_go_fuzzer $FUZZ_ROOT/math FuzzBigIntCmp1 big_cmp_fuzzer1
+compile_go_fuzzer $FUZZ_ROOT/math FuzzBigIntCmp2 big_cmp_fuzzer2
+compile_go_fuzzer $FUZZ_ROOT/math FuzzRatSetString big_rat_fuzzer
 compile_go_fuzzer $FUZZ_ROOT/asn1 Fuzz asn_fuzzer
 compile_go_fuzzer $FUZZ_ROOT/csv Fuzz csv_fuzzer
 compile_go_fuzzer $FUZZ_ROOT/elliptic Fuzz elliptic_fuzzer

--- a/projects/golang/math_big_fuzzer.go
+++ b/projects/golang/math_big_fuzzer.go
@@ -1,0 +1,85 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//go:build gofuzz
+// +build gofuzz
+
+package big
+
+import (
+	"strings"
+)
+
+func FuzzCmp(data []byte) int {
+	if !IsDivisibleBy(len(data), 2) {
+		return -1
+	}
+	half := len(data) / 2
+
+	halfOne := data[:half]
+	x, err := natFromString(string(halfOne))
+	if err != nil {
+		return 0
+	}
+
+	halfTwo := data[half:]
+	y, err := natFromString(string(halfTwo))
+	if err != nil {
+		return 0
+	}
+
+	x.cmp(y)
+	return 1
+}
+
+func FuzzExpNN(data []byte) int {
+	if !IsDivisibleBy(len(data), 3) {
+		return -1
+	}
+	firstThird := len(data) / 3
+	x, err := natFromString(string(data[:firstThird]))
+	if err != nil {
+		return 0
+	}
+
+	secondThird := firstThird * 2
+	y, err := natFromString(string(data[firstThird:secondThird]))
+	if err != nil {
+		return 0
+	}
+
+	z, err := natFromString(string(data[secondThird:]))
+	if err != nil {
+		return 0
+	}
+
+	p := nat(nil).expNN(x, y, z)
+
+	const n = 165
+	p = p.shl(p, n)
+	return 1
+}
+
+func IsDivisibleBy(n int, divisibleby int) bool {
+	return (n % divisibleby) == 0
+}
+
+func natFromString(s string) (nat, error) {
+	x, _, _, err := nat(nil).scan(strings.NewReader(s), 0, false)
+	if err != nil {
+		return nil, err
+	}
+	return x, nil
+}

--- a/projects/golang/math_big_fuzzer.go
+++ b/projects/golang/math_big_fuzzer.go
@@ -18,7 +18,7 @@ package mathfuzzer
 
 import "math/big"
 
-func FuzzCmp(data []byte) int {
+func FuzzBigIntCmp1(data []byte) int {
     if !isDivisibleBy(len(data), 2) {
         return -1
     }
@@ -37,11 +37,27 @@ func FuzzCmp(data []byte) int {
     return 1
 }
 
-func FuzzExpNN(data []byte) int {
+func FuzzBigIntCmp2(data []byte) int {
+    if !isDivisibleBy(len(data), 2) {
+        return -1
+    }
+    x, y := new(big.Int), new(big.Int)
+    half := len(data)/2
+    if err := x.UnmarshalText(data[:half]); err != nil {
+      return 0
+    }
+    if err := y.UnmarshalText(data[half:]); err != nil {
+      return 0
+    }
+    x.Cmp(y)
+    return 1
+}
+
+func FuzzRatSetString(data []byte) int {
     _, _ = new(big.Rat).SetString(string(data))
     return 1
 }
 
 func isDivisibleBy(n int, divisibleby int) bool {
-	return (n % divisibleby) == 0
+    return (n % divisibleby) == 0
 }

--- a/projects/golang/math_big_fuzzer.go
+++ b/projects/golang/math_big_fuzzer.go
@@ -13,73 +13,35 @@
 // limitations under the License.
 //
 
-//go:build gofuzz
-// +build gofuzz
 
-package big
+package mathfuzzer
 
-import (
-	"strings"
-)
+import "math/big"
 
 func FuzzCmp(data []byte) int {
-	if !IsDivisibleBy(len(data), 2) {
-		return -1
-	}
-	half := len(data) / 2
+    if !isDivisibleBy(len(data), 2) {
+        return -1
+    }
+    i1 := new(big.Int)
+    i2 := new(big.Int)
 
-	halfOne := data[:half]
-	x, err := natFromString(string(halfOne))
-	if err != nil {
-		return 0
-	}
+    half := len(data) / 2
 
-	halfTwo := data[half:]
-	y, err := natFromString(string(halfTwo))
-	if err != nil {
-		return 0
-	}
+    halfOne := data[:half]
+    halfTwo := data[half:]
 
-	x.cmp(y)
-	return 1
+    i1.SetBytes(halfOne)
+    i2.SetBytes(halfTwo)
+
+    i1.Cmp(i2)
+    return 1
 }
 
 func FuzzExpNN(data []byte) int {
-	if !IsDivisibleBy(len(data), 3) {
-		return -1
-	}
-	firstThird := len(data) / 3
-	x, err := natFromString(string(data[:firstThird]))
-	if err != nil {
-		return 0
-	}
-
-	secondThird := firstThird * 2
-	y, err := natFromString(string(data[firstThird:secondThird]))
-	if err != nil {
-		return 0
-	}
-
-	z, err := natFromString(string(data[secondThird:]))
-	if err != nil {
-		return 0
-	}
-
-	p := nat(nil).expNN(x, y, z)
-
-	const n = 165
-	p = p.shl(p, n)
-	return 1
+    _, _ = new(big.Rat).SetString(string(data))
+    return 1
 }
 
-func IsDivisibleBy(n int, divisibleby int) bool {
+func isDivisibleBy(n int, divisibleby int) bool {
 	return (n % divisibleby) == 0
-}
-
-func natFromString(s string) (nat, error) {
-	x, _, _, err := nat(nil).scan(strings.NewReader(s), 0, false)
-	if err != nil {
-		return nil, err
-	}
-	return x, nil
 }


### PR DESCRIPTION
This PR adds two fuzzers for `math/big` of the golang standard library. The fuzzers were originally uploaded here: https://go-review.googlesource.com/c/go/+/301710, but since maintainers are not interested in adding new fuzzers upstream, I am uploading them directly to OSS-fuzz.