### PR TITLE
Fix typo in path equilavence for golang coverage

### DIFF
--- a/infra/base-images/base-builder/compile_go_fuzzer
+++ b/infra/base-images/base-builder/compile_go_fuzzer
@@ -45,7 +45,7 @@ if [[ $SANITIZER = *coverage* ]]; then
   fuzzed_repo=`echo $path | cut -d/ -f-3`
   abspath_repo=`go list -m $tags -f {{.Dir}} $fuzzed_repo || go list $tags -f {{.Dir}} $fuzzed_repo`
   # give equivalence to absolute paths in another file, as go test -cover uses golangish pkg.Dir
-  echo "s=$fuzzed_repo"="$abspath_repo$"= > $OUT/$fuzzer.gocovpath
+  echo "s=$fuzzed_repo"="$abspath_repo"= > $OUT/$fuzzer.gocovpath
   go test -run Test${function}Corpus -v $tags -coverpkg $fuzzed_repo/... -c -o $OUT/$fuzzer $path
 else
   # Compile and instrument all Go files relevant to this fuzz target.


### PR DESCRIPTION
cc @inferno-chromium cc @jonathanmetzman 
Typo was introduced in #5425