### PR TITLE
[NFC][base-builder] Fix order so comment is in right place

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -57,8 +57,8 @@ RUN export PYTHON_DEPS="\
     ln -s /usr/bin/python3 /usr/bin/python && \
     cd .. && \
     rm -r /tmp/Python-$PYTHON_VERSION.tar.xz /tmp/Python-$PYTHON_VERSION && \
-    apt-get remove -y $PYTHON_DEPS  && \
-    rm -rf /usr/local/lib/python3.8/test # https://github.com/google/oss-fuzz/issues/3888
+    rm -rf /usr/local/lib/python3.8/test && \
+    apt-get remove -y $PYTHON_DEPS # https://github.com/google/oss-fuzz/issues/3888
 
 # Install latest atheris for python fuzzing, pyinstaller for fuzzer packaging,
 # six for Bazel rules.


### PR DESCRIPTION
The comment is meant to be on the line with the package removal.