### PR TITLE
[firefox/spidermonkey] Fix mach call and install dep

### DIFF
--- a/projects/firefox/Dockerfile
+++ b/projects/firefox/Dockerfile
@@ -31,5 +31,5 @@ WORKDIR mozilla-central
 # Install OS dependencies.
 # Will be re-run in build.sh to install missing dependencies.
 ENV SHELL /bin/bash
-RUN ./mach bootstrap --no-interactive --application-choice browser
+RUN ./mach --no-interactive bootstrap --application-choice browser
 COPY build.sh target.c *.options mozconfig.* $SRC/

--- a/projects/firefox/Dockerfile
+++ b/projects/firefox/Dockerfile
@@ -19,6 +19,7 @@ RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
   gawk \
   libstdc++6 \
+  m4 \
   python \
   software-properties-common
 

--- a/projects/firefox/build.sh
+++ b/projects/firefox/build.sh
@@ -44,7 +44,7 @@ export MOZCONFIG=$SRC/mozconfig.$SANITIZER
 
 # Install remaining dependencies.
 export SHELL=/bin/bash
-./mach bootstrap --no-interactive --application-choice browser
+./mach --no-interactive bootstrap --application-choice browser
 
 # Skip patches for now
 rm tools/fuzzing/libfuzzer/patches/*.patch

--- a/projects/spidermonkey-ufi/Dockerfile
+++ b/projects/spidermonkey-ufi/Dockerfile
@@ -19,7 +19,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     autoconf2.13 \
     python \
     libc++1 \
-    libc++abi1
+    libc++abi1 \
+    m4
 
 # This wrapper of cargo seems to interfere with our build system.
 RUN rm -f /usr/local/bin/cargo

--- a/projects/spidermonkey-ufi/build.sh
+++ b/projects/spidermonkey-ufi/build.sh
@@ -23,7 +23,7 @@ FUZZ_TARGETS=(
 
 # Install dependencies.
 export SHELL=/bin/bash
-../../mach bootstrap --no-interactive --application-choice browser
+../../mach --no-interactive bootstrap --application-choice browser
 
 autoconf2.13
 

--- a/projects/spidermonkey/Dockerfile
+++ b/projects/spidermonkey/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
   autoconf2.13 \
   libc++1 \
   libc++abi1 \
+  m4 \
   yasm \
   python
 

--- a/projects/spidermonkey/build.sh
+++ b/projects/spidermonkey/build.sh
@@ -17,7 +17,7 @@
 
 # Install dependencies.
 export SHELL=/bin/bash
-../../mach bootstrap --no-interactive --application-choice browser
+../../mach --no-interactive bootstrap --application-choice browser
 
 autoconf2.13
 


### PR DESCRIPTION
This should fix/unblock the spidermonkey build. There is an additional failure in the Firefox build but it is unclear what the problem is. Logged at https://bugzilla.mozilla.org/show_bug.cgi?id=1698626. 