### PR TITLE
Adds project paho.mqtt.c

### DIFF
--- a/projects/pahomqttc/Dockerfile
+++ b/projects/pahomqttc/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y build-essential gcc make cmake cmake-gui cmake-curses-gui
+RUN git clone --depth 1 https://github.com/eclipse/paho.mqtt.c.git
+COPY build.sh $SRC/
+COPY patch.diff $SRC/
+WORKDIR $SRC/paho.mqtt.c

--- a/projects/pahomqttc/build.sh
+++ b/projects/pahomqttc/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# build project
+git apply ../patch.diff
+mkdir build
+cd build
+cmake .. -DPAHO_BUILD_STATIC=TRUE -DPAHO_BUILD_SHARED=FALSE
+make -j$(nproc)
+
+cp ./src/fuzz_* $OUT/

--- a/projects/pahomqttc/patch.diff
+++ b/projects/pahomqttc/patch.diff
@@ -1,0 +1,80 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 4137d38..00c063d 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -333,3 +333,8 @@ IF (PAHO_WITH_SSL)
+ 	TARGET_LINK_LIBRARIES( Sha1TestOpenSSL OpenSSL::SSL OpenSSL::Crypto)
+ 	TARGET_COMPILE_DEFINITIONS( Sha1TestOpenSSL PUBLIC "-DSHA1_TEST -DOPENSSL=1" )
+ ENDIF (PAHO_WITH_SSL)
++
++if(DEFINED ENV{LIB_FUZZING_ENGINE})
++  add_executable(fuzz_client_receive fuzz_client_receive.c)
++  target_link_libraries(fuzz_client_receive paho-mqtt3c-static $ENV{LIB_FUZZING_ENGINE})
++endif()
+\ No newline at end of file
+diff --git a/src/fuzz_client_receive.c b/src/fuzz_client_receive.c
+new file mode 100644
+index 0000000..b61cfcc
+--- /dev/null
++++ b/src/fuzz_client_receive.c
+@@ -0,0 +1,60 @@
++#include <pthread.h>
++#include <sys/socket.h>
++#include <netinet/in.h>
++#include <stdint.h>
++#include <unistd.h>
++#include <string.h>
++#include <stdlib.h>
++
++#include "MQTTClient.h"
++
++static int initialized = 0;
++
++size_t fuzz_size = 0;
++const uint8_t *fuzz_data = NULL;
++int listenfd = 0;
++pthread_t thread1;
++char *fuzztopic = "fuzztopic";
++
++void *ServerThread(void *ptr)
++{
++    int connfd;
++    while(1) {
++        connfd = accept(listenfd, (struct sockaddr*)NULL, NULL);
++        write(connfd, fuzz_data, fuzz_size);
++        usleep(10);
++        close(connfd);
++    }
++    return 0;
++}
++
++int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
++    if (initialized == 0) {
++        struct sockaddr_in serv_addr;
++        listenfd = socket(AF_INET, SOCK_STREAM, 0);
++        memset(&serv_addr, '0', sizeof(serv_addr));
++        serv_addr.sin_family = AF_INET;
++        serv_addr.sin_addr.s_addr = htonl(INADDR_ANY);
++        serv_addr.sin_port = htons(1883);
++        bind(listenfd, (struct sockaddr*)&serv_addr, sizeof(serv_addr));
++        listen(listenfd, 2);
++        pthread_create(&thread1, NULL, *ServerThread, NULL);
++        initialized = 1;
++    }
++    fuzz_data = Data;
++    fuzz_size = Size;
++    MQTTClient client;
++    int topiclen = strlen(fuzztopic);
++    MQTTClient_connectOptions conn_opts = MQTTClient_connectOptions_initializer;
++    MQTTClient_message *pubmsg = malloc(sizeof(MQTTClient_message));
++    MQTTClient_deliveryToken token;
++    MQTTClient_create(&client, "tcp://localhost:1883", "FuzzedClient",
++                      MQTTCLIENT_PERSISTENCE_NONE, NULL);
++    if (MQTTClient_connect(client, &conn_opts) == MQTTCLIENT_SUCCESS) {
++        MQTTClient_receive(client, &fuzztopic, &topiclen, &pubmsg, 100);
++    }
++    MQTTClient_disconnect(client, 100);
++    MQTTClient_destroy(&client);
++    free(pubmsg);
++    return 0;
++}

--- a/projects/pahomqttc/project.yaml
+++ b/projects/pahomqttc/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://eclipse.github.io/paho.mqtt.c/MQTTClient/html/"
+language: c++
+primary_contact: "icraggs@eclipse.org"
+auto_ccs :
+- "p.antoine@catenacyber.fr"
+
+sanitizers:
+- address
+- undefined
+main_repo: 'https://github.com/eclipse/paho.mqtt.c.git'


### PR DESCRIPTION
@icraggs would you be interested in continuous fuzzing for pho.mqtt.c ?
This PR enables it with one fuzz target about `MQTTClient_receive`

It quickly finds a Use-After-Free whose fix is obvious
```
diff --git a/src/MQTTPacketOut.c b/src/MQTTPacketOut.c
index b71622d..60ea8ac 100644
--- a/src/MQTTPacketOut.c
+++ b/src/MQTTPacketOut.c
@@ -336,9 +336,9 @@ void* MQTTPacket_suback(int MQTTVersion, unsigned char aHeader, char* data, size
        {
                if (pack->properties.array)
                        free(pack->properties.array);
+               ListFree(pack->qoss);
                if (pack)
                        free(pack);
-               ListFree(pack->qoss);
                pack = NULL;
        }
 exit:
```