### PR TITLE
[firefox] Fix various build problems

### DIFF
--- a/projects/firefox/build.sh
+++ b/projects/firefox/build.sh
@@ -47,6 +47,16 @@ export ASAN_OPTIONS="detect_leaks=0"
 
 # Install remaining dependencies.
 export SHELL=/bin/bash
+
+# Firefox might not be buildable on the latest Rust Nightly, so we should try
+# to use the same version that we use in our CI.
+RUST_NIGHTLY_VERSION=$(sed -n 's/^.*--channel.*\(nightly-[0-9-]*\).*$/\1/p' \
+  $SRC/mozilla-central/taskcluster/ci/toolchain/rust.yml
+)
+
+rustup toolchain install ${RUST_NIGHTLY_VERSION}
+rustup default ${RUST_NIGHTLY_VERSION}-x86_64-unknown-linux-gnu
+
 ./mach --no-interactive bootstrap --application-choice browser
 
 # Skip patches for now

--- a/projects/firefox/build.sh
+++ b/projects/firefox/build.sh
@@ -42,6 +42,9 @@ FUZZ_TARGETS=(
 export MOZ_OBJDIR=$WORK/obj-fuzz
 export MOZCONFIG=$SRC/mozconfig.$SANITIZER
 
+# Without this, a host tool used during Rust part of the build will fail
+export ASAN_OPTIONS="detect_leaks=0"
+
 # Install remaining dependencies.
 export SHELL=/bin/bash
 ./mach --no-interactive bootstrap --application-choice browser

--- a/projects/firefox/mozconfig.address
+++ b/projects/firefox/mozconfig.address
@@ -1,4 +1,7 @@
 . $SRC/mozconfig.coverage
 
 ac_add_options --enable-address-sanitizer
-mk_add_options CFLAGS= CXXFLAGS=
+
+# Don't use standard CFLAGS/CXXFLAGS provided by oss-fuzz
+export CFLAGS=""
+export CXXFLAGS=""


### PR DESCRIPTION
While trying to get the Firefox build to work locally, I found 3 issues:

1) A recent change in our build system causes a particular binary used during the Rust build process to be built with ASan and it seems to have issues that LeakSanitizer detects and that fails the build.

2) Apparently we did not properly ignore the `CFLAGS` set in the environment and that caused another recent build problem.

3) It looks like the newest Rust Nightly doesn't build mozilla-central properly. It is never guaranteed that any newer Rust Nightly does build because we usually have a Rust Nightly version pinned in CI for sanitizers. I've modified the build to use the exact same version (I agree this is fragile, but it is probably more robust than simply using the newest version).

With these changes, the build succeeds locally for me.

Cc @tysmith @jonathanmetzman 