### PR TITLE
Revert "Capstone: do not use flags for corpus building"

### DIFF
--- a/projects/capstone/build.sh
+++ b/projects/capstone/build.sh
@@ -25,15 +25,13 @@ do
     # + make.sh overwrites CFLAGS
     cd build
     cmake -DCAPSTONE_BUILD_SHARED=0 ..
-    make -j$(nproc)
+    make
 
-if [ "$FUZZING_ENGINE" != 'afl' ]; then
     cd $SRC/capstone$branch/bindings/python
     #better debug info
     sed -i -e 's/#print/print/' capstone/__init__.py
     (
     export CFLAGS=""
-    export CXXFLAGS=""
     python setup.py install
     )
     cd $SRC/capstone$branch/suite
@@ -47,7 +45,6 @@ if [ "$FUZZING_ENGINE" != 'afl' ]; then
     cp fuzz_disasm.options $OUT/fuzz_disasm$branch.options
 
     cd ../../build
-fi
     # build fuzz target
     FUZZO=CMakeFiles/fuzz_disasm.dir/suite/fuzz/fuzz_disasm.c.o
     if [ -f CMakeFiles/fuzz_disasm.dir/suite/fuzz/platform.c.o ]; then


### PR DESCRIPTION
Reverts google/oss-fuzz#5464

Looks like @vanhauser-thc has a better fix in https://github.com/google/oss-fuzz/pull/5462/files