### PR TITLE
[CIFuzz] Print crash stacktraces no matter what

### DIFF
--- a/infra/cifuzz/fuzz_target.py
+++ b/infra/cifuzz/fuzz_target.py
@@ -141,8 +141,14 @@ class FuzzTarget:
     if not testcase:
       logging.error(b'No testcase found in stacktrace: %s.', stderr)
       return FuzzResult(None, None)
+
+    utils.binary_print(b'Fuzzer: %s. Detected bug:\n%s' %
+                       (self.target_name.encode(), stderr))
     if self.is_crash_reportable(testcase):
+      # We found a bug in the fuzz target and we will report it.
       return FuzzResult(testcase, stderr)
+
+    # We found a bug but we won't report it.
     return FuzzResult(None, None)
 
   def free_disk_if_needed(self):
@@ -271,7 +277,6 @@ class FuzzTarget:
       logging.info('The crash is reproducible. The crash doesn\'t reproduce '
                    'on old builds. This code change probably introduced the '
                    'crash.')
-
       return True
 
     logging.info('The crash is reproducible on old builds '

--- a/infra/cifuzz/run_fuzzers.py
+++ b/infra/cifuzz/run_fuzzers.py
@@ -145,10 +145,6 @@ class BaseFuzzTargetRunner:
                      target.target_name)
         continue
 
-      # We found a bug in the fuzz target.
-      utils.binary_print(b'Fuzzer: %s. Detected bug:\n%s' %
-                         (target.target_name.encode(), result.stacktrace))
-
       # TODO(metzman): Do this with filestore.
       testcase_artifact_path = self.get_fuzz_target_artifact(
           target, os.path.basename(result.testcase))


### PR DESCRIPTION
Even if we don't want to report them, print the stacktrace.
Related: https://github.com/google/oss-fuzz/issues/5461