### PR TITLE
Fix bisection when the original checkout is for a single branch.

### DIFF
--- a/infra/bisector.py
+++ b/infra/bisector.py
@@ -189,6 +189,8 @@ def _bisect(bisect_type, old_commit, new_commit, test_case_path, fuzz_target,
 
     bisect_repo_manager = repo_manager.RepoManager(
         os.path.join(host_src_dir, os.path.basename(repo_path)))
+    bisect_repo_manager.fetch_all_remotes()
+
     commit_list = bisect_repo_manager.get_commit_list(new_commit, old_commit)
 
     old_idx = len(commit_list) - 1

--- a/infra/repo_manager.py
+++ b/infra/repo_manager.py
@@ -127,6 +127,12 @@ class RepoManager:
 
     return out.strip()
 
+  def fetch_all_remotes(self):
+    """Fetch all remotes for checkouts that track a single branch."""
+    self.git(['config', 'remote.origin.fetch',
+              '"+refs/heads/*:refs/remotes/origin/*"'], check_result=True)
+    self.git(['remote', 'update'], check_result=True)
+
   def get_commit_list(self, newest_commit, oldest_commit=None):
     """Gets the list of commits(inclusive) between the old and new commits.
 

--- a/infra/repo_manager.py
+++ b/infra/repo_manager.py
@@ -130,7 +130,7 @@ class RepoManager:
   def fetch_all_remotes(self):
     """Fetch all remotes for checkouts that track a single branch."""
     self.git([
-        'config', 'remote.origin.fetch', '"+refs/heads/*:refs/remotes/origin/*"'
+        'config', 'remote.origin.fetch', '+refs/heads/*:refs/remotes/origin/*'
     ],
              check_result=True)
     self.git(['remote', 'update'], check_result=True)

--- a/infra/repo_manager.py
+++ b/infra/repo_manager.py
@@ -129,8 +129,10 @@ class RepoManager:
 
   def fetch_all_remotes(self):
     """Fetch all remotes for checkouts that track a single branch."""
-    self.git(['config', 'remote.origin.fetch',
-              '"+refs/heads/*:refs/remotes/origin/*"'], check_result=True)
+    self.git([
+        'config', 'remote.origin.fetch', '"+refs/heads/*:refs/remotes/origin/*"'
+    ],
+             check_result=True)
     self.git(['remote', 'update'], check_result=True)
 
   def get_commit_list(self, newest_commit, oldest_commit=None):


### PR DESCRIPTION
Repos cloned with `--branch BRANCH` will only track that branch, even
when we unshallow. If we provide a git SHA from another branch, it will
not be recognized.

To fix, this, we update the remote tracking config and fetch them.

For https://github.com/google/osv/issues/88.