### PR TITLE
Adds pcre2 as suricata dependency

### DIFF
--- a/projects/suricata/Dockerfile
+++ b/projects/suricata/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y build-essential autoconf automake libtool make pkg-config  python flex bison zlib1g-dev libpcre3-dev
+RUN apt-get update && apt-get install -y build-essential autoconf automake libtool make pkg-config  python flex bison zlib1g-dev libpcre3-dev libpcre2-dev
 
 #TODO libmagic, liblzma, pcre and other optional libraries
 ADD https://www.tcpdump.org/release/libpcap-1.9.1.tar.gz libpcap-1.9.1.tar.gz


### PR DESCRIPTION
Cf https://github.com/google/oss-fuzz/issues/5479
pcre2 is not yet a dependency, but there is a PR about it cf https://github.com/OISF/suricata/pull/5991, so CIFuzz can get ready