### PR TITLE
build_specified_commit: Add call to fetch_all_remotes on cleanup.

### DIFF
--- a/infra/build_specified_commit.py
+++ b/infra/build_specified_commit.py
@@ -200,6 +200,7 @@ def build_fuzzers_from_commit(commit,
     # Re-copy /src for a clean checkout every time.
     copy_src_from_docker(build_data.project_name,
                          os.path.dirname(host_src_path))
+    build_repo_manager.fetch_all_remotes()
 
   projects_dir = os.path.join('projects', build_data.project_name)
   dockerfile_path = os.path.join(projects_dir, 'Dockerfile')


### PR DESCRIPTION
We need to redo fetch_all_remotes as we re-copy the repo from the docker
container.