### PR TITLE
qemu: disable honggfuzz fuzzing

### DIFF
--- a/projects/qemu/project.yaml
+++ b/projects/qemu/project.yaml
@@ -12,7 +12,6 @@ sanitizers:
   - undefined
 fuzzing_engines:
   - libfuzzer
-  - honggfuzz
 architectures:
   - x86_64
 main_repo: 'https://git.qemu.org/git/qemu.git'


### PR DESCRIPTION
We don't do any internal tests using honggfuzz, and our code is highly
unlikely to work with honggfuzz in the current shape. All of the
true-positive bugs seem to be libfuzzer bugs.

Lets disable honggfuzz, to avoid wasting resources. We will try to get
afl++ working, before taking another look at honggfuzz.

Signed-off-by: Alexander Bulekov <alxndr@bu.edu>