### PR TITLE
Only remove `external/org_tensorflow` if it exists

### DIFF
--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -96,7 +96,7 @@ then
   # code that Bazel creates. Not removing this would cause `rsync` to expand a
   # symlink that ends up pointing to itself!
   pushd bazel-tensorflow
-  unlink external/org_tensorflow
+  [[ -e external/org_tensorflow ]] && unlink external/org_tensorflow
   ${RSYNC_CMD} external/ ${REMAP_PATH}
   popd
 fi


### PR DESCRIPTION
This should fix coverage build broken again today. It seems that a recent change in TF toolchains removed the creation of `org_tensorflow` but it is likely that this change will be rolled back in the future.

Hence, to keep OSSFuzz working, we conditionally remove this symlink at least until we fully stabilize the toolchains story.