### PR TITLE
[cfengine] Initial integration

### DIFF
--- a/projects/cfengine/Dockerfile
+++ b/projects/cfengine/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y \
+    build-essential autoconf automake libssl-dev \
+    libpcre3 libpcre3-dev bison libbison-dev \
+    libacl1 libacl1-dev libpq-dev lmdb-utils \
+    liblmdb-dev libpam0g-dev flex libtool
+
+RUN git clone --depth 1 https://github.com/cfengine/core --recursive
+WORKDIR core
+COPY build.sh string_fuzzer.c $SRC/

--- a/projects/cfengine/build.sh
+++ b/projects/cfengine/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+./autogen.sh
+./configure
+make V=1 -j$(nproc)
+
+cd libpromises
+mv $SRC/string_fuzzer.c .
+find . -name "*.o" -exec ar rcs fuzz_lib.a {} \;
+$CC $CFLAGS -I./ -c string_fuzzer.c -o string_fuzzer.o
+$CC $CXXFLAGS $LIB_FUZZING_ENGINE string_fuzzer.o \
+    -o $OUT/string_fuzzer fuzz_lib.a \
+    ../libntech/libutils/.libs/libutils.a

--- a/projects/cfengine/project.yaml
+++ b/projects/cfengine/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/cfengine/core"
+main_repo: "https://github.com/cfengine/core"
+language: c++
+primary_contact: "vratislav.podzimek@northern.tech"
+auto_ccs:
+  - "Adam@adalogics.com"
+sanitizers:
+  - address
+  - undefined
+  - memory

--- a/projects/cfengine/string_fuzzer.c
+++ b/projects/cfengine/string_fuzzer.c
@@ -1,0 +1,40 @@
+/* Copyright 2021 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <string_expressions.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
+    if(size<4) {
+        return 0;
+    }
+    for (int i=0; i<size; i++) {
+        if(data[i]==0) {
+            return 0;
+        }
+    }
+    char *new_str = (char *)malloc(size+1);
+    if (new_str == NULL){
+        return 0;
+    }
+    memcpy(new_str, data, size);
+    new_str[size] = '\0';
+    int len = strlen(new_str);
+
+    StringParseResult res = ParseStringExpression(new_str, 0, len);
+
+    FreeStringExpression(res.result);
+    free(new_str);
+    return 0;
+}


### PR DESCRIPTION
This PR adds initial integration of [cfengine](https://github.com/cfengine/core).

Users include ([source](https://cfengine.com/)):
- Deutsche Telekom
- Panasonic
- Samsung
- Linkedin
- Pfizer
- DHL

----------------------------------------------------

@olehermanse @vpodzime 
I have been working on integrating cfengine into OSS-fuzz to take the first step with continuous fuzzing and have set up this PR with the build files and a simple fuzzer implemented by way of LibFuzzer.

OSS-fuzz is a free service offered by Google to run the fuzzers of critical open source projects free of charge. If bugs are found, maintainers on the mailing list get notified with a link to a detailed bug report. The service is offered with an implied expectation that bugs are found.

To finish the integration at least one maintainers email address is needed on the OSS-fuzz side.

Let me know if you are interested in proceeding with integration.