### PR TITLE
[lxc] initial integration

### DIFF
--- a/projects/lxc/Dockerfile
+++ b/projects/lxc/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2021 Google Inc.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/lxc/Dockerfile
+++ b/projects/lxc/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && \
+    apt-get install -y pkgconf make libtool automake autoconf
+RUN git clone --depth 1 https://github.com/lxc/lxc
+WORKDIR lxc
+COPY build.sh *.c $SRC/

--- a/projects/lxc/build.sh
+++ b/projects/lxc/build.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -e
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# -fsanitize=... isn't compatible with -Wl,-no-undefined
+# https://github.com/google/sanitizers/issues/380
+sed -i 's/-Wl,-no-undefined *\\/\\/' src/lxc/Makefile.am
+
+# AFL++ and hoggfuzz are both incompatible with lto=thin apparently
+sed -i '/-flto=thin/d' configure.ac
+
+# turn off the libutil dependency
+sed -i 's/^AC_CHECK_LIB(util/#/' configure.ac
+
+./autogen.sh
+./configure \
+    --disable-tools \
+    --disable-commands \
+    --disable-apparmor \
+    --disable-openssl \
+    --disable-selinux \
+    --disable-seccomp \
+    --disable-capabilities
+
+make -j$(nproc)
+
+$CC -c -o fuzz-lxc-config-read.o $CFLAGS -Isrc -Isrc/lxc $SRC/fuzz-lxc-config-read.c
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz-lxc-config-read.o src/lxc/.libs/liblxc.a -o $OUT/fuzz-lxc-config-read
+
+zip -r $OUT/fuzz-lxc-config-read_seed_corpus.zip doc/examples

--- a/projects/lxc/build.sh
+++ b/projects/lxc/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-# Copyright 2021 Google Inc.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/lxc/fuzz-lxc-config-read.c
+++ b/projects/lxc/fuzz-lxc-config-read.c
@@ -1,5 +1,5 @@
 /*
-# Copyright 2021 Google Inc.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/lxc/fuzz-lxc-config-read.c
+++ b/projects/lxc/fuzz-lxc-config-read.c
@@ -1,0 +1,41 @@
+/*
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+*/
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "conf.h"
+#include "confile.h"
+#include "utils.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+	int fd = -1;
+	char tmpf[] = "fuzz-lxc-config-read-XXXXXX";
+	struct lxc_conf *conf = NULL;
+
+	fd = lxc_make_tmpfile(tmpf, false);
+	lxc_write_nointr(fd, data, size);
+	close(fd);
+
+	conf = lxc_conf_init();
+	lxc_config_read(tmpf, conf, false);
+	lxc_conf_free(conf);
+
+	(void) unlink(tmpf);
+	return 0;
+}

--- a/projects/lxc/project.yaml
+++ b/projects/lxc/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://github.com/lxc/lxc"
+language: c
+primary_contact: "christian.brauner@ubuntu.com"
+builds_per_day: 4
+sanitizers:
+  - address
+  - undefined
+  - memory
+auto_ccs:
+  - stgraber@ubuntu.com
+  - evverx@gmail.com
+main_repo: "https://github.com/lxc/lxc"


### PR DESCRIPTION
It seems to be working in the sense that the fuzz target has found a bunch of issues like
```
==13==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7f90db82553f at pc 0x00000067ebde bp 0x7ffcfe224790 sp 0x7ffcfe224788
READ of size 1 at 0x7f90db82553f thread T0
SCARINESS: 27 (1-byte-read-stack-buffer-overflow)
    #0 0x67ebdd in parse_byte_size_string /src/lxc/src/lxc/string_utils.c:926:24
    #1 0x426525 in set_config_console_buffer_size /src/lxc/src/lxc/confile.c:2436:8
    #2 0x5b2f04 in parse_line /src/lxc/src/lxc/confile.c:2953:9
    #3 0x448691 in lxc_file_for_each_line_mmap /src/lxc/src/lxc/parse.c:125:9
    #4 0x5b27e5 in lxc_config_read /src/lxc/src/lxc/confile.c:3024:9
    #5 0x581c03 in LLVMFuzzerTestOneInput /src/fuzz-lxc-config-read.c:18:2
    #6 0x484783 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:599:15
    #7 0x483c8a in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:505:3
    #8 0x4859e7 in fuzzer::Fuzzer::MutateAndTestOne() /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:745:19
    #9 0x486575 in fuzzer::Fuzzer::Loop(std::__Fuzzer::vector<fuzzer::SizedFile, fuzzer::fuzzer_allocator<fuzzer::SizedFile> >&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:883:5
    #10 0x474307 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:906:6
    #11 0x4a0162 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
    #12 0x7f90da7c683f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2083f)
    #13 0x449278 in _start (/out/fuzz-lxc-config-read+0x449278)
```
and
```
==31==ERROR: AddressSanitizer: heap-use-after-free on address 0x6120000268c0 at pc 0x0000005c4093 bp 0x7ffeaa8eb1b0 sp 0x7ffeaa8eb1a8
READ of size 8 at 0x6120000268c0 thread T0
SCARINESS: 51 (8-byte-read-heap-use-after-free)
    #0 0x5c4092 in lxc_get_netdev_by_idx /src/lxc/src/lxc/confile_utils.c:210:16
    #1 0x44024f in set_config_net_nic /src/lxc/src/lxc/confile.c:5261:11
    #2 0x5b2f04 in parse_line /src/lxc/src/lxc/confile.c:2953:9
    #3 0x448691 in lxc_file_for_each_line_mmap /src/lxc/src/lxc/parse.c:125:9
    #4 0x5b27e5 in lxc_config_read /src/lxc/src/lxc/confile.c:3024:9
    #5 0x581c03 in LLVMFuzzerTestOneInput /src/fuzz-lxc-config-read.c:18:2
    #6 0x484783 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:599:15
    #7 0x483c8a in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:505:3
    #8 0x4859e7 in fuzzer::Fuzzer::MutateAndTestOne() /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:745:19
    #9 0x486575 in fuzzer::Fuzzer::Loop(std::__Fuzzer::vector<fuzzer::SizedFile, fuzzer::fuzzer_allocator<fuzzer::SizedFile> >&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:883:5
    #10 0x474307 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:906:6
    #11 0x4a0162 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
    #12 0x7fd8d480b83f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2083f)
    #13 0x449278 in _start (/out/fuzz-lxc-config-read+0x449278)
```

As far as I know, the lxc team is interested in integrating lxc into OSS-Fuzz.

cc @brauner