### PR TITLE
[ghostscript] Copy fuzzer glue code to dir outside of git repo

### DIFF
--- a/projects/ghostscript/Dockerfile
+++ b/projects/ghostscript/Dockerfile
@@ -20,8 +20,9 @@ RUN apt-get update && apt-get install -y autoconf zlibc libtool liblcms2-dev lib
 RUN git clone --branch branch-2.2 --single-branch --depth 1 https://github.com/apple/cups.git cups
 RUN git clone --branch VER-2-10-1 --single-branch --depth 1 https://git.savannah.gnu.org/git/freetype/freetype2.git freetype
 RUN git clone --single-branch --depth 1 git://git.ghostscript.com/ghostpdl.git ghostpdl
-
 RUN mkdir ghostpdl/fuzz
-COPY gstoraster_fuzzer.cc ghostpdl/fuzz
 
+WORKDIR ghostpdl
+
+COPY gstoraster_fuzzer.cc $SRC/
 COPY build.sh $SRC/

--- a/projects/ghostscript/build.sh
+++ b/projects/ghostscript/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 # Build CUPS
-pushd cups
+pushd $SRC/cups
 # Fix bad line
 sed -i '2110s/\(\s\)f->value/\1(int)f->value/' cups/ppd-cache.c
 
@@ -29,13 +29,12 @@ make -C filter libs install-libs
 install -m755 cups-config "$WORK"/cups-config
 popd
 
-cd ghostpdl
 rm -rf cups/libs || die
 rm -rf freetype || die
 rm -rf libpng || die
 rm -rf zlib || die
 
-mv ../freetype freetype
+mv $SRC/freetype freetype
 
 CUPSCONFIG="$WORK/cups-config"
 CUPS_CFLAGS=$($CUPSCONFIG --cflags)
@@ -51,7 +50,7 @@ CPPFLAGS="${CPPFLAGS:-} $CUPS_CFLAGS -DPACIFY_VALGRIND" ./autogen.sh \
 make -j$(nproc) libgs
 
 $CXX $CXXFLAGS $CUPS_LDFLAGS -std=c++11 -I. \
-    fuzz/gstoraster_fuzzer.cc \
+    $SRC/gstoraster_fuzzer.cc \
     -o "$OUT/gstoraster_fuzzer" \
     -Wl,-rpath='$ORIGIN' \
     $CUPS_LIBS \


### PR DESCRIPTION
This makes it easier to build the fuzzer using a locally checked
out git repo without having to manually copy the fuzzer glue code
into the locally checked out git repo first.