### PR TITLE
[mupdf] Copy fuzzer glue code to dir outside of git repo

### DIFF
--- a/projects/mupdf/Dockerfile
+++ b/projects/mupdf/Dockerfile
@@ -22,5 +22,5 @@ RUN git clone --depth 1 https://github.com/mozilla/pdf.js pdf.js && \
     rm -rf pdf.js
 ADD https://raw.githubusercontent.com/rc0r/afl-fuzz/master/dictionaries/pdf.dict $SRC/pdf_fuzzer.dict
 WORKDIR mupdf
-COPY *.cc source/fuzz/
+COPY *.cc $SRC/
 COPY build.sh *.options $SRC/

--- a/projects/mupdf/build.sh
+++ b/projects/mupdf/build.sh
@@ -19,7 +19,7 @@ LDFLAGS="$CXXFLAGS" make -j$(nproc) HAVE_GLUT=no build=debug OUT=$WORK
 fuzz_target=pdf_fuzzer
 
 $CXX $CXXFLAGS -std=c++11 -Iinclude \
-    source/fuzz/pdf_fuzzer.cc -o $OUT/$fuzz_target \
+    $SRC/pdf_fuzzer.cc -o $OUT/$fuzz_target \
     $LIB_FUZZING_ENGINE $WORK/libmupdf.a $WORK/libmupdf-third.a
 
 mv $SRC/{*.zip,*.dict,*.options} $OUT


### PR DESCRIPTION
This makes it easier to build the fuzzer using a locally checked
out git repo without having to manually copy the fuzzer glue code
into the locally checked out git repo first.