### PR TITLE
Fix the coverage measurement of cel-cpp by copying all original and generated source files to the path expected by llvm-cov.

### DIFF
--- a/projects/cel-cpp/Dockerfile
+++ b/projects/cel-cpp/Dockerfile
@@ -16,6 +16,8 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 
+RUN apt-get update && apt-get -y install rsync
+
 RUN git clone --depth 1 https://github.com/google/cel-cpp/
 COPY build.sh $SRC/
 RUN mkdir $SRC/cel-cpp/fuzz/

--- a/projects/cel-cpp/build.sh
+++ b/projects/cel-cpp/build.sh
@@ -30,3 +30,21 @@ bazel build -c opt --config=oss-fuzz --linkopt=-lc++ \
 for oss_fuzz_archive in $(find bazel-bin/ -name "*${PACKAGE_SUFFIX}.tar"); do
     tar -xvf "${oss_fuzz_archive}" -C "${OUT}"
 done
+
+if [ "$SANITIZER" = "coverage" ]; then
+    declare -r COVERAGE_SOURCES="${OUT}/proc/self/cwd"
+    mkdir -p "${COVERAGE_SOURCES}"
+    declare -r RSYNC_FILTER_ARGS=(
+        "--include" "*.h"
+        "--include" "*.cc"
+        "--include" "*.hpp"
+        "--include" "*.cpp"
+        "--include" "*.c"
+        "--include" "*.inc"
+        "--include" "*/"
+        "--exclude" "*"
+    )
+    rsync -avLk "${RSYNC_FILTER_ARGS[@]}" \
+        "$(bazel info execution_root)/" \
+        "${COVERAGE_SOURCES}/"
+fi


### PR DESCRIPTION
This fix is rather generic, so we could add it to the example Bazel test project too.

However, this does introduce an extra dependency on rsync. Would it make sense to include this dependency in the base image?