### PR TITLE
projects/lxc: update mail addresses

### DIFF
--- a/projects/lxc/project.yaml
+++ b/projects/lxc/project.yaml
@@ -1,12 +1,12 @@
 homepage: "https://github.com/lxc/lxc"
 language: c
-primary_contact: "christian.brauner@ubuntu.com"
+primary_contact: "christian@brauner.io"
 builds_per_day: 4
 sanitizers:
   - address
   - undefined
   - memory
 auto_ccs:
-  - stgraber@ubuntu.com
+  - stgraber@stgraber.org
   - evverx@gmail.com
 main_repo: "https://github.com/lxc/lxc"


### PR DESCRIPTION
The other two mail addresses are aliases and so we can't use them to
access oss-fuzz.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>