### PR TITLE
Update wasmtime config to use new x86-64 backend.

### DIFF
--- a/projects/wasmtime/build.sh
+++ b/projects/wasmtime/build.sh
@@ -57,10 +57,7 @@ build() {
 }
 
 # Build with peepmatic in order to enable the related fuzz targets.
-build wasmtime "" "" --features peepmatic-fuzzing
-
-# Build the differential fuzzer with the new x86-64 backend as well.
-build wasmtime diff-newbe- differential_wasmi --features experimental_x64
+build wasmtime "" "" --features "peepmatic-fuzzing experimental_x64"
 
 build wasm-tools wasm-tools- ""
 build regalloc.rs regalloc- bt bt


### PR DESCRIPTION
In bytecodealliance/rfcs#10, we have outlined a process by which we're
switching to a new compiler backend by default. The first step in this
process is to switch our fuzzing targets to use the new backend and wait
for any issues.

This PR adds the Cargo feature that enables the new backend in all
fuzzing targets.