### PR TITLE
[libjpeg-turbo] Fix build with libjpeg-turbo 2.1.x

### DIFF
--- a/projects/libjpeg-turbo/Dockerfile
+++ b/projects/libjpeg-turbo/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool nasm curl cmake
+RUN apt-get update && apt-get install -y make autoconf automake libtool yasm curl cmake
 RUN git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo
 
 RUN mkdir afl-testcases


### PR DESCRIPTION
libjpeg-turbo 2.1 now requires NASM 2.13 or later or YASM 1.2.0 or
later.  Since the Docker image is based on Ubuntu 16.04, NASM 2.13 isn't
available, so the easiest workaround is to use YASM instead.

Fixes #4931