### PR TITLE
the fuzz directory was moved to nom's repository

### DIFF
--- a/projects/nom/Dockerfile
+++ b/projects/nom/Dockerfile
@@ -16,7 +16,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN git clone --depth 1 https://github.com/Geal/nom/
-COPY fuzz $SRC/nom/fuzz
 WORKDIR $SRC
 
 COPY build.sh $SRC/


### PR DESCRIPTION
nom's build fails since #5499 because I forgot that the Dockerfile was trying to move the deleted repository

failing build log:

```
FETCHSOURCE
BUILD
Starting Step #0
Step #0: Already have image (with digest): gcr.io/cloud-builders/git
Step #0: Cloning into 'oss-fuzz'...
Finished Step #0
Starting Step #1
Step #1: Already have image (with digest): gcr.io/cloud-builders/docker
Step #1: Sending build context to Docker daemon   5.12kB

Step #1: Step 1/5 : FROM gcr.io/oss-fuzz-base/base-builder
Step #1: latest: Pulling from oss-fuzz-base/base-builder
Step #1: 4007a89234b4: Pulling fs layer
Step #1: c1de0f9cdfc1: Pulling fs layer
Step #1: c8ee6ca703b8: Pulling fs layer
[...]
Step #1: 1af9f6a7b423: Pull complete
Step #1: Digest: sha256:8cf82e8ef96b1d7d89360c40115207eceb8c317c16c1219bb5fe82522aacd3e2
Step #1: Status: Downloaded newer image for gcr.io/oss-fuzz-base/base-builder:latest
Step #1:  ---> b0c90bbd7c3d
Step #1: Step 2/5 : RUN git clone --depth 1 https://github.com/Geal/nom/
Step #1:  ---> Running in 8d6c57a6c433
Step #1: [91mCloning into 'nom'...
Step #1: [0mRemoving intermediate container 8d6c57a6c433
Step #1:  ---> 0c3ce9971c9a
Step #1: Step 3/5 : COPY fuzz $SRC/nom/fuzz
Step #1: COPY failed: stat /var/lib/docker/tmp/docker-builder213462476/fuzz: no such file or directory
Finished Step #1
ERROR
ERROR: build step 1 "gcr.io/cloud-builders/docker" failed: step exited with non-zero status: 1
```