### PR TITLE
[openal] Initial integration

### DIFF
--- a/projects/openal/Dockerfile
+++ b/projects/openal/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autogen \
+	autoconf automake libtool pkg-config wget python
+
+RUN git clone --depth 1 https://gitlab.xiph.org/xiph/ogg.git
+RUN git clone --depth 1 https://gitlab.xiph.org/xiph/vorbis.git
+RUN git clone --depth 1 https://github.com/libsndfile/libsndfile
+RUN git clone --depth 1 https://github.com/kcat/openal-soft openal
+WORKDIR openal
+COPY build.sh fuzzer.c $SRC/

--- a/projects/openal/build.sh
+++ b/projects/openal/build.sh
@@ -1,0 +1,59 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+pushd $SRC/ogg
+./autogen.sh
+./configure --prefix="$WORK" --enable-static --disable-shared --disable-crc
+make clean
+make -j$(nproc)
+make install
+popd
+
+pushd $SRC/vorbis
+./autogen.sh
+./configure --prefix="$WORK" --enable-static --disable-shared
+make clean
+make -j$(nproc)
+make install
+popd
+
+
+pushd $SRC/libsndfile
+./autogen.sh
+./configure --disable-shared --enable-ossfuzzers
+make -j$(nproc)
+popd
+
+
+
+cd $SRC/openal/build
+cmake -DLIBTYPE=STATIC -DLSOFT_EXAMPLES:BOOL=ON \
+	-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ..
+make V=1 -j$(nproc)
+
+$CC $CFLAGS -DAL_LIBTYPE_STATIC -DRESTRICT=__restrict -I/src/openal/common \
+	-I/src/openal/include  -I/src/libsndfile/include -I/src/openal/examples \
+	-O2 -g -D_DEBUG -fvisibility=hidden -pthread -o fuzzer.o -c /src/fuzzer.c
+
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzzer.o -o $OUT/fuzzer \
+	/src/openal/build/libex-common.a /src/openal/build/libopenal.a \
+	/src/libsndfile/src/.libs/libsndfile.a \
+	/src/libsndfile/src/.libs/libcommon.a \
+	/src/vorbis/lib/.libs/libvorbisenc.a \
+	/src/vorbis/lib/.libs/libvorbis.a \
+	/src/vorbis/lib/.libs/libvorbisfile.a \
+	/src/ogg/src/.libs/libogg.a

--- a/projects/openal/fuzzer.c
+++ b/projects/openal/fuzzer.c
@@ -1,0 +1,133 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+
+
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "sndfile.h"
+
+#include "AL/al.h"
+#include "AL/alc.h"
+#include "AL/alext.h"
+#include "AL/efx.h"
+#include "AL/efx-presets.h"
+#include "common/alhelpers.h"
+
+#define INT_MAX 2147483647
+static ALuint LoadSound(const char *filename)
+{
+    ALenum err, format;
+    ALuint buffer;
+    SNDFILE *sndfile;
+    SF_INFO sfinfo;
+    short *membuf;
+    sf_count_t num_frames;
+    ALsizei num_bytes;
+
+    /* Open the audio file and check that it's usable. */
+    sndfile = sf_open(filename, SFM_READ, &sfinfo);
+    if(!sndfile)
+    {
+        return 0;
+    }
+    if(sfinfo.frames < 1 || sfinfo.frames > (sf_count_t)(INT_MAX/sizeof(short))/sfinfo.channels)
+    {
+        sf_close(sndfile);
+        return 0;
+    }
+
+    /* Get the sound format, and figure out the OpenAL format */
+    format = AL_NONE;
+    if(sfinfo.channels == 1)
+        format = AL_FORMAT_MONO16;
+    else if(sfinfo.channels == 2)
+        format = AL_FORMAT_STEREO16;
+    else if(sfinfo.channels == 3)
+    {
+        if(sf_command(sndfile, SFC_WAVEX_GET_AMBISONIC, NULL, 0) == SF_AMBISONIC_B_FORMAT)
+            format = AL_FORMAT_BFORMAT2D_16;
+    }
+    else if(sfinfo.channels == 4)
+    {
+        if(sf_command(sndfile, SFC_WAVEX_GET_AMBISONIC, NULL, 0) == SF_AMBISONIC_B_FORMAT)
+            format = AL_FORMAT_BFORMAT3D_16;
+    }
+    if(!format)
+    {
+        sf_close(sndfile);
+        return 0;
+    }
+
+    /* Decode the whole audio file to a buffer. */
+    membuf = malloc((size_t)(sfinfo.frames * sfinfo.channels) * sizeof(short));
+
+    num_frames = sf_readf_short(sndfile, membuf, sfinfo.frames);
+    if(num_frames < 1)
+    {
+        free(membuf);
+        sf_close(sndfile);
+        return 0;
+    }
+    num_bytes = (ALsizei)(num_frames * sfinfo.channels) * (ALsizei)sizeof(short);
+
+    /* Buffer the audio data into a new buffer object, then free the data and
+     * close the file.
+     */
+    buffer = 0;
+    alGenBuffers(1, &buffer);
+    alBufferData(buffer, format, membuf, num_bytes, sfinfo.samplerate);
+
+    free(membuf);
+    sf_close(sndfile);
+
+    /* Check if an error occured, and clean up if so. */
+    err = alGetError();
+    if(err != AL_NO_ERROR)
+    {
+        if(buffer && alIsBuffer(buffer))
+            alDeleteBuffers(1, &buffer);
+        return 0;
+    }
+
+    return buffer;
+}
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	char filename[256];
+	sprintf(filename, "/tmp/libfuzzer.mp3");
+
+	FILE *fp = fopen(filename, "wb");
+	if (!fp)
+		return 1;
+	fwrite(data, size, 1, fp);
+	fclose(fp);
+
+
+	ALuint buffer;
+	buffer = LoadSound(filename);
+	if(!buffer)
+	{
+		return 1;
+	}
+	unlink(filename);
+
+	return 0;
+}

--- a/projects/openal/project.yaml
+++ b/projects/openal/project.yaml
@@ -1,0 +1,9 @@
+homepage: "://github.com/kcat/openal-soft"
+language: c++
+primary_contact: "chris.kcat@gmail.com"
+auto_ccs:
+  - "Adam@adalogics.com"
+sanitizers:
+  - address
+  - undefined
+main_repo: 'https://github.com/kcat/openal-soft'


### PR DESCRIPTION
Initial integration of [Openal Soft](https://github.com/kcat/openal-soft).

Selected projects in which Openal Soft is used:
- [Unigine engine](https://unigine.com/) (for linux) - which is used by [more than 250 companies](https://unigine.com/company/customers) worldwide.
- Telegram desktop client
- [The Dark Mod](https://www.thedarkmod.com/main/)
- [Super Tux Kart](https://supertuxkart.net/Main_Page)
- [OpenMW](https://openmw.org/en/)
- [LÖVE](https://love2d.org/)

______________________________________________________________________________

@kcat are you interested in integrating in OSS-fuzz? 

This PR adds the build files and a fuzzer.

To finish it up, a maintainers email address is needed for bug reports.