### PR TITLE
Adds bazel project opencensus-cpp

### DIFF
--- a/projects/opencensus-cpp/.bazelrc
+++ b/projects/opencensus-cpp/.bazelrc
@@ -1,0 +1,24 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Force the use of Clang for C++ builds.
+build --action_env=CC=clang
+build --action_env=CXX=clang++
+
+# Define the --config=asan-libfuzzer configuration.
+build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing_oss_fuzz//:oss_fuzz_engine
+build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine_instrumentation=oss-fuzz
+build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine_sanitizer=none

--- a/projects/opencensus-cpp/Dockerfile
+++ b/projects/opencensus-cpp/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN git clone --depth 1 https://github.com/census-instrumentation/opencensus-cpp
+COPY WORKSPACE .bazelrc $SRC/
+RUN cat WORKSPACE >> $SRC/opencensus-cpp/WORKSPACE
+RUN cat .bazelrc >> $SRC/opencensus-cpp/.bazelrc
+COPY build.sh $SRC/
+WORKDIR $SRC/opencensus-cpp

--- a/projects/opencensus-cpp/WORKSPACE
+++ b/projects/opencensus-cpp/WORKSPACE
@@ -1,0 +1,32 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_fuzzing",
+    sha256 = "71fa2724c9802c597199a86111a0499fc4fb22426d322334d3f191dadeff5132",
+    strip_prefix = "rules_fuzzing-0.1.0",
+    urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/v0.1.0.zip"],
+)
+
+load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
+
+rules_fuzzing_dependencies()
+
+load("@rules_fuzzing//fuzzing:init.bzl", "rules_fuzzing_init")
+
+rules_fuzzing_init()

--- a/projects/opencensus-cpp/build.sh
+++ b/projects/opencensus-cpp/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+git grep cc_fuzz_target.bzl | grep BUILD | cut -d: -f1 | uniq | while read i; do sed -i -e 's=//bazel:cc_fuzz_target.bzl=@rules_fuzzing//fuzzing:cc_defs.bzl=' $i; done
+
+git grep fuzz_target\( | grep BUILD | cut -d: -f1 | uniq | while read i; do sed -i -e 's/fuzz_target/fuzz_test/' $i; done
+
+declare -r QUERY='
+    let all_fuzz_tests = attr(tags, "fuzz-test", "//...") in
+    $all_fuzz_tests - attr(tags, "no-oss-fuzz", $all_fuzz_tests)
+'
+
+declare -r PACKAGE_SUFFIX="_oss_fuzz"
+declare -r OSS_FUZZ_TESTS="$(bazel query "${QUERY}" | sed "s/$/${PACKAGE_SUFFIX}/")"
+
+bazel build -c opt --config=oss-fuzz --linkopt=-lc++ \
+    --action_env=CC="${CC}" --action_env=CXX="${CXX}" \
+    ${OSS_FUZZ_TESTS[*]}
+
+for oss_fuzz_archive in $(find bazel-bin/ -name "*${PACKAGE_SUFFIX}.tar"); do
+    tar -xvf "${oss_fuzz_archive}" -C "${OUT}"
+done

--- a/projects/opencensus-cpp/project.yaml
+++ b/projects/opencensus-cpp/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://opencensus.io/"
+language: c++
+primary_contact: "opentelemetry-dev+opencensus-fuzz@google.com"
+auto_ccs :
+- "p.antoine@catenacyber.fr"
+
+sanitizers:
+- address
+- memory
+main_repo: 'https://github.com/census-instrumentation/opencensus-cpp'

--- a/projects/opencensus-cpp/project.yaml
+++ b/projects/opencensus-cpp/project.yaml
@@ -1,6 +1,6 @@
 homepage: "https://opencensus.io/"
 language: c++
-primary_contact: "opentelemetry-dev+opencensus-fuzz@google.com"
+primary_contact: "joshuasuereth@google.com"
 auto_ccs :
 - "p.antoine@catenacyber.fr"
 


### PR DESCRIPTION
@g-easy would you be interested in continuous fuzzing for opencensus-cpp ?
This PR enables it with oss-fuzz with your fuzz targets.
It changes a bit the Basel build system to use https://github.com/bazelbuild/rules_fuzzing and https://google.github.io/oss-fuzz/getting-started/new-project-guide/bazel/ cf 

cc @stefanbucur could `cc_fuzz_test` support corpus like it is used here https://github.com/census-instrumentation/opencensus-cpp/blob/ba631066779a534267fdb1321b19850eb2b0c000/opencensus/tags/BUILD#L194