### PR TITLE
mxml: initial integration.

### DIFF
--- a/projects/mxml/Dockerfile
+++ b/projects/mxml/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN git clone https://github.com/michaelrsweet/mxml
+
+COPY build.sh $SRC/
+COPY fuzz_loadfile.c $SRC/
+
+WORKDIR $SRC/mxml

--- a/projects/mxml/build.sh
+++ b/projects/mxml/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+export LDFLAGS=$CFLAGS
+./configure
+make libmxml.a
+$CC $CFLAGS $LIB_FUZZING_ENGINE $SRC/fuzz_loadfile.c -I./ ./libmxml.a \
+    -o $OUT/fuzz_loadfile

--- a/projects/mxml/fuzz_loadfile.c
+++ b/projects/mxml/fuzz_loadfile.c
@@ -1,0 +1,38 @@
+/* Copyright 2021 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#include <mxml.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+	char filename[256];
+	sprintf(filename, "/tmp/libfuzzer.%d", getpid());
+
+	FILE *fp2 = fopen(filename, "wb");
+	if (!fp2)
+			return 0;
+	fwrite(data, size, 1, fp2);
+	fclose(fp2);
+
+	FILE *fp;
+	mxml_node_t *tree;
+
+	fp = fopen(filename, "r");
+	tree = mxmlLoadFile(NULL, fp, MXML_OPAQUE_CALLBACK);
+	fclose(fp);
+
+	unlink(filename);
+
+	return 0;
+}

--- a/projects/mxml/fuzz_loadfile.c
+++ b/projects/mxml/fuzz_loadfile.c
@@ -20,16 +20,21 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	sprintf(filename, "/tmp/libfuzzer.%d", getpid());
 
 	FILE *fp2 = fopen(filename, "wb");
-	if (!fp2)
-			return 0;
+	if (!fp2) {
+        return 0;
+    }
 	fwrite(data, size, 1, fp2);
 	fclose(fp2);
 
 	FILE *fp;
-	mxml_node_t *tree;
+	mxml_node_t *tree = NULL;
 
 	fp = fopen(filename, "r");
 	tree = mxmlLoadFile(NULL, fp, MXML_OPAQUE_CALLBACK);
+    if (tree != NULL) {
+        free(tree);
+    }
+
 	fclose(fp);
 
 	unlink(filename);

--- a/projects/mxml/project.yaml
+++ b/projects/mxml/project.yaml
@@ -1,0 +1,5 @@
+homepage: "https://github.com/michaelrsweet/mxml"
+primary_contact: "david@adalogics.com"
+language: c
+auto_ccs :
+  - "david@adalogics.com"

--- a/projects/mxml/project.yaml
+++ b/projects/mxml/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/michaelrsweet/mxml"
+main_repo: "https://github.com/michaelrsweet/mxml"
 primary_contact: "david@adalogics.com"
 language: c
 auto_ccs :


### PR DESCRIPTION
@michaelrsweet I have set up continuous fuzzing of mxml. The benefits are that the fuzzer will be run on a regular basis and bug reports will be send to your email with information such as inputs that trigger the bugs, stack traces and more. Is this something you would be happy to have set up for mxml? If so, the only thing needed from your end is an email that will receive the bugs reports  - notice this email should be attached to a Google account for you to see the reports. 