### PR TITLE
tcpreplay: initial integration

### DIFF
--- a/projects/tcpreplay/Dockerfile
+++ b/projects/tcpreplay/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y automake autoconf autogen libtool libpcap-dev 
+RUN git clone https://github.com/appneta/tcpreplay
+
+COPY build.sh $SRC/
+COPY fuzz_portmap.c $SRC/
+
+WORKDIR $SRC/tcpreplay

--- a/projects/tcpreplay/build.sh
+++ b/projects/tcpreplay/build.sh
@@ -32,4 +32,5 @@ $CC $CFLAGS $LIB_FUZZING_ENGINE -DTCPBRIDGE "-D_U_=__attribute__((unused))" ../f
     ./src/tcpbridge-tcpbridge_opts.o ./src/tcpbridge-tcpbridge.o ./src/tcpbridge-bridge.o \
     ./src/tcpedit/libtcpedit.a ./src/common/libcommon.a ./lib/libstrl.a \
     /usr/lib/x86_64-linux-gnu/libopts.a \
-    -I./src/ -I./src/tcpedit/ -I./ -lpcap  -lrt -lnsl
+    /usr/lib/x86_64-linux-gnu/libpcap.a
+    -I./src/ -I./src/tcpedit/ -I./ -lrt -lnsl

--- a/projects/tcpreplay/build.sh
+++ b/projects/tcpreplay/build.sh
@@ -32,5 +32,5 @@ $CC $CFLAGS $LIB_FUZZING_ENGINE -DTCPBRIDGE "-D_U_=__attribute__((unused))" ../f
     ./src/tcpbridge-tcpbridge_opts.o ./src/tcpbridge-tcpbridge.o ./src/tcpbridge-bridge.o \
     ./src/tcpedit/libtcpedit.a ./src/common/libcommon.a ./lib/libstrl.a \
     /usr/lib/x86_64-linux-gnu/libopts.a \
-    /usr/lib/x86_64-linux-gnu/libpcap.a
+    /usr/lib/x86_64-linux-gnu/libpcap.a \
     -I./src/ -I./src/tcpedit/ -I./ -lrt -lnsl

--- a/projects/tcpreplay/build.sh
+++ b/projects/tcpreplay/build.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+./autogen.sh
+./configure --disable-local-libopts
+make
+
+# Recompile main
+cd src
+sed -i 's/main(/main2(/g' tcpbridge.c
+$CC $CFLAGS -DHAVE_CONFIG_H -I. -I./.. -I./tcpedit -DTCPBRIDGE -D_U_="__attribute__((unused))" \
+    -I/usr/include -MT tcpbridge-tcpbridge.o -MD -MP -MF .deps/tcpbridge-tcpbridge.Tpo \
+    -c -o tcpbridge-tcpbridge.o `test -f 'tcpbridge.c' || echo './'`tcpbridge.c
+cd ../
+
+# Compile the fuzzer
+$CC $CFLAGS $LIB_FUZZING_ENGINE -DTCPBRIDGE "-D_U_=__attribute__((unused))" ../fuzz_portmap.c -o $OUT/fuzz_portmap \
+    ./src/tcpbridge-tcpbridge_opts.o ./src/tcpbridge-tcpbridge.o ./src/tcpbridge-bridge.o \
+    ./src/tcpedit/libtcpedit.a ./src/common/libcommon.a ./lib/libstrl.a \
+    /usr/lib/x86_64-linux-gnu/libopts.a \
+    -I./src/ -I./src/tcpedit/ -I./ -lpcap  -lrt -lnsl

--- a/projects/tcpreplay/fuzz_portmap.c
+++ b/projects/tcpreplay/fuzz_portmap.c
@@ -1,0 +1,38 @@
+/* Copyright 2021 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <stdlib.h>
+#include <stdint.h>
+
+#include "tcpreplay.h"
+#include "tcpedit.h"
+#include "portmap.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size < 5) return 0;
+
+	char *new_str = (char *)malloc(size+1);
+	if (new_str == NULL){
+			return 0;
+	}
+	memcpy(new_str, data, size);
+	new_str[size] = '\0';
+
+	tcpedit_portmap_t *tcp_ptr = NULL;
+	parse_portmap(&tcp_ptr, new_str);
+
+    if (tcp_ptr) {
+        free(tcp_ptr);
+    }
+
+	free(new_str);
+	return 0;
+}

--- a/projects/tcpreplay/project.yaml
+++ b/projects/tcpreplay/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/appneta/tcpreplay"
+main_repo: "https://github.com/appneta/tcpreplay"
+primary_contact: "david@adalogics.com"
+language: c
+auto_ccs :
+  - "david@adalogics.com"


### PR DESCRIPTION
@fklassen I have set up continuous fuzzing of tcpreplay. The benefits are that the fuzzer will be run on a regular basis and bug reports will be send to your email with information such as inputs that trigger the bugs, stack traces and more. Is this something you would be happy to have set up? If so, the only thing needed from your end is an email that will receive the bugs reports - notice this email should be attached to a Google account for you to see the reports.