### PR TITLE
linkerd2-proxy: initial integration

### DIFF
--- a/projects/linkerd2-proxy/Dockerfile
+++ b/projects/linkerd2-proxy/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN git clone --depth 1 https://github.com/DavidKorczynski/linkerd2-proxy
+RUN git clone --depth 1 https://github.com/linkerd/linkerd2-proxy
 
 COPY build.sh $SRC/
 WORKDIR $SRC

--- a/projects/linkerd2-proxy/Dockerfile
+++ b/projects/linkerd2-proxy/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN git clone --depth 1 https://github.com/DavidKorczynski/linkerd2-proxy
+
+COPY build.sh $SRC/
+WORKDIR $SRC

--- a/projects/linkerd2-proxy/build.sh
+++ b/projects/linkerd2-proxy/build.sh
@@ -15,26 +15,27 @@
 #
 ################################################################################
 
-TARGET="./fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_target_1"
+TARGET_PATH="./fuzz/target/x86_64-unknown-linux-gnu/release"
 BASE="$SRC/linkerd2-proxy/linkerd"
 BUILD_FUZZER="cargo +nightly fuzz build --features fuzzing"
 
 cd ${BASE}/addr/
 ${BUILD_FUZZER}
-cp ${TARGET} $OUT/fuzz_addr
+cp ${TARGET_PATH}/fuzz_target_1 $OUT/fuzz_addr
 
 cd ${BASE}/dns
 ${BUILD_FUZZER}
-cp ${TARGET} $OUT/fuzz_dns
+cp ${TARGET_PATH}/fuzz_target_1 $OUT/fuzz_dns
 
 cd ${BASE}/proxy/http
 ${BUILD_FUZZER}
-cp ${TARGET} $OUT/fuzz_http
+cp ${TARGET_PATH}/fuzz_target_1 $OUT/fuzz_http
 
 cd ${BASE}/tls
 ${BUILD_FUZZER}
-cp ${TARGET} $OUT/fuzz_tls
+cp ${TARGET_PATH}/fuzz_target_1 $OUT/fuzz_tls
 
 cd ${BASE}/transport-header
 ${BUILD_FUZZER}
-cp ${TARGET} $OUT/fuzz_transport_header
+cp ${TARGET_PATH}/fuzz_target_raw $OUT/fuzz_transport_raw
+cp ${TARGET_PATH}/fuzz_target_structured $OUT/fuzz_transport_structured

--- a/projects/linkerd2-proxy/build.sh
+++ b/projects/linkerd2-proxy/build.sh
@@ -1,0 +1,40 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+TARGET="./fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_target_1"
+BASE="$SRC/linkerd2-proxy/linkerd"
+BUILD_FUZZER="cargo +nightly fuzz build --features fuzzing"
+
+cd ${BASE}/addr/
+${BUILD_FUZZER}
+cp ${TARGET} $OUT/fuzz_addr
+
+cd ${BASE}/dns
+${BUILD_FUZZER}
+cp ${TARGET} $OUT/fuzz_dns
+
+cd ${BASE}/proxy/http
+${BUILD_FUZZER}
+cp ${TARGET} $OUT/fuzz_http
+
+cd ${BASE}/tls
+${BUILD_FUZZER}
+cp ${TARGET} $OUT/fuzz_tls
+
+cd ${BASE}/transport-header
+${BUILD_FUZZER}
+cp ${TARGET} $OUT/fuzz_transport_header

--- a/projects/linkerd2-proxy/build.sh
+++ b/projects/linkerd2-proxy/build.sh
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 ################################################################################
-
 TARGET_PATH="./fuzz/target/x86_64-unknown-linux-gnu/release"
 BASE="$SRC/linkerd2-proxy/linkerd"
 BUILD_FUZZER="cargo +nightly fuzz build --features fuzzing"

--- a/projects/linkerd2-proxy/project.yaml
+++ b/projects/linkerd2-proxy/project.yaml
@@ -1,10 +1,12 @@
 homepage: "https://linkerd.io/"
 main_repo: "https://github.com/linkerd/linkerd2-proxy"
-primary_contact: "david@adalogics.com"
+primary_contact: "ver@buoyant.io"
 sanitizers:
   - address
 fuzzing_engines:
   - libfuzzer
 language: rust
 auto_ccs:
+  - "eliza@buoyant.io"
+  - "kevinl@buoyant.io"
   - "david@adalogics.com"

--- a/projects/linkerd2-proxy/project.yaml
+++ b/projects/linkerd2-proxy/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://linkerd.io/"
+main_repo: "https://github.com/linkerd/linkerd2-proxy"
+primary_contact: "david@adalogics.com"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+language: rust
+auto_ccs:
+  - "david@adalogics.com"


### PR DESCRIPTION
https://github.com/linkerd/linkerd2-proxy

linkerd2-proxy is a proxy for the [linkerd](https://linkerd.io/) service Mesh and is used by many customers including (from https://linkerd.io/ ) Expedia, HP, GoDaddy, Walmart, ...