### PR TITLE
Implement the Bazel building recipe as a stand-alone script that can be invoked from build.sh.

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -29,6 +29,7 @@ RUN dpkg --add-architecture i386 && \
         jq \
         libc6-dev-i386 \
         patchelf \
+        rsync \
         subversion \
         zip
 
@@ -191,7 +192,7 @@ RUN cd $SRC && \
 
 COPY cargo compile compile_afl compile_dataflow compile_libfuzzer compile_honggfuzz \
     compile_go_fuzzer precompile_honggfuzz precompile_afl debug_afl srcmap \
-    write_labels.py /usr/local/bin/
+    write_labels.py bazel_build_fuzz_tests /usr/local/bin/
 
 COPY detect_repo.py /opt/cifuzz/
 COPY ossfuzz_coverage_runner.go $GOPATH

--- a/infra/base-images/base-builder/bazel_build_fuzz_tests
+++ b/infra/base-images/base-builder/bazel_build_fuzz_tests
@@ -1,0 +1,80 @@
+#!/bin/bash -eu
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+: "${BAZEL_FUZZ_TEST_TAG:=fuzz-test}"
+: "${BAZEL_FUZZ_TEST_EXCLUDE_TAG:=no-oss-fuzz}"
+: "${BAZEL_PACKAGE_SUFFIX:=_oss_fuzz}"
+: "${BAZEL_TOOL:=bazel}"
+: "${BAZEL_EXTRA_BUILD_FLAGS:=}"
+
+if [[ -z "${BAZEL_FUZZ_TEST_QUERY:-}" ]]; then
+    BAZEL_FUZZ_TEST_QUERY="
+        let all_fuzz_tests = attr(tags, \"${BAZEL_FUZZ_TEST_TAG}\", \"//...\") in
+        \$all_fuzz_tests - attr(tags, \"${BAZEL_FUZZ_TEST_EXCLUDE_TAG}\", \$all_fuzz_tests)
+    "
+fi
+
+echo "Using Bazel query to find fuzz targets: ${BAZEL_FUZZ_TEST_QUERY}"
+
+declare -r OSS_FUZZ_TESTS=(
+    $(bazel query "${BAZEL_FUZZ_TEST_QUERY}" | sed "s/$/${BAZEL_PACKAGE_SUFFIX}/")
+)
+
+echo "Found ${#OSS_FUZZ_TESTS[@]} fuzz test packages:"
+for oss_fuzz_test in "${OSS_FUZZ_TESTS[@]}"; do
+    echo "  ${oss_fuzz_test}"
+done
+
+declare -r BAZEL_BUILD_FLAGS=(
+    "-c" "opt"
+    "--//fuzzing:cc_engine=@rules_fuzzing_oss_fuzz//:oss_fuzz_engine" \
+    "--@rules_fuzzing//fuzzing:cc_engine_instrumentation=oss-fuzz" \
+    "--@rules_fuzzing//fuzzing:cc_engine_sanitizer=none" \
+    "--linkopt=-lc++" \
+    "--action_env=CC=${CC}" "--action_env=CXX=${CXX}" \
+    ${BAZEL_EXTRA_BUILD_FLAGS[*]}
+)
+
+echo "Building the fuzz tests with the following Bazel options:"
+echo "  ${BAZEL_BUILD_FLAGS[@]}"
+
+${BAZEL_TOOL} build "${BAZEL_BUILD_FLAGS[@]}" "${OSS_FUZZ_TESTS[@]}"
+
+echo "Extracting the fuzz test packages in the output directory."
+for oss_fuzz_archive in $(find bazel-bin/ -name "*${BAZEL_PACKAGE_SUFFIX}.tar"); do
+    tar -xvf "${oss_fuzz_archive}" -C "${OUT}"
+done
+
+if [ "$SANITIZER" = "coverage" ]; then
+    echo "Collecting the repository source files for coverage tracking."
+    declare -r COVERAGE_SOURCES="${OUT}/proc/self/cwd"
+    mkdir -p "${COVERAGE_SOURCES}"
+    declare -r RSYNC_FILTER_ARGS=(
+        "--include" "*.h"
+        "--include" "*.cc"
+        "--include" "*.hpp"
+        "--include" "*.cpp"
+        "--include" "*.c"
+        "--include" "*.inc"
+        "--include" "*/"
+        "--exclude" "*"
+    )
+    rsync -avLk "${RSYNC_FILTER_ARGS[@]}" \
+        "$(bazel info execution_root)/" \
+        "${COVERAGE_SOURCES}/"
+fi

--- a/projects/bazel-rules-fuzzing-test/build.sh
+++ b/projects/bazel-rules-fuzzing-test/build.sh
@@ -17,36 +17,6 @@
 ################################################################################
 
 # This is an example build script for projects using the rules_fuzzing library
-# for Bazel. Use it as a starting point for your own integration.
+# for Bazel.
 
-# An easy way to build all the relevant fuzz tests for a project is to use a
-# "bazel query" command. Here, we are collecting all fuzz test targets (which
-# are tagged with "fuzz-test" by default). Here we also have a basic opt-out
-# mechanism through the "no-oss-fuzz" tag. You can use additional filtering
-# logic in your own integrations.
-declare -r QUERY='
-    let all_fuzz_tests = attr(tags, "fuzz-test", "//...") in
-    $all_fuzz_tests - attr(tags, "no-oss-fuzz", $all_fuzz_tests)
-'
-
-# The fuzzing rules provide a special `<name>_oss_fuzz` target that creates a
-# TAR archive with all the fuzz test artifacts (binary, corpus, dictionary,
-# etc.) using the layout expected by OSS-Fuzz. We derive the OSS-Fuzz package
-# targets from the fuzz test names using the "sed" command below.
-declare -r PACKAGE_SUFFIX="_oss_fuzz"
-declare -r OSS_FUZZ_TESTS="$(bazel query "${QUERY}" | sed "s/$/${PACKAGE_SUFFIX}/")"
-
-# We now build all the OSS-Fuzz packages using the compiler toolchain provided 
-# by OSS-Fuzz through $CC and $CXX. The `--config=oss-fuzz` flag takes care of
-# using the correct instrumentation and fuzzing engine derived from the OSS-Fuzz
-# environment.
-bazel build -c opt --config=oss-fuzz --linkopt=-lc++ \
-    --action_env=CC="${CC}" --action_env=CXX="${CXX}" \
-    ${OSS_FUZZ_TESTS[*]}
-
-# Finally, we extract the contents of the OSS-Fuzz packages directly into the
-# $OUT/ directory. Recall that the packages already contain all the artifacts in
-# the format expected by OSS-Fuzz.
-for oss_fuzz_archive in $(find bazel-bin/ -name "*${PACKAGE_SUFFIX}.tar"); do
-    tar -xvf "${oss_fuzz_archive}" -C "${OUT}"
-done
+bazel_build_fuzz_tests


### PR DESCRIPTION
Before I update the documentation and other Bazel projects, I wanted to get your early input on the approach.