### PR TITLE
Switch the cel-cpp project to the new Bazel build script.

### DIFF
--- a/infra/base-images/base-builder/bazel_build_fuzz_tests
+++ b/infra/base-images/base-builder/bazel_build_fuzz_tests
@@ -42,7 +42,7 @@ done
 
 declare -r BAZEL_BUILD_FLAGS=(
     "-c" "opt"
-    "--//fuzzing:cc_engine=@rules_fuzzing_oss_fuzz//:oss_fuzz_engine" \
+    "--@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing_oss_fuzz//:oss_fuzz_engine" \
     "--@rules_fuzzing//fuzzing:cc_engine_instrumentation=oss-fuzz" \
     "--@rules_fuzzing//fuzzing:cc_engine_sanitizer=none" \
     "--linkopt=-lc++" \

--- a/projects/bazel-rules-fuzzing-test/build.sh
+++ b/projects/bazel-rules-fuzzing-test/build.sh
@@ -16,7 +16,12 @@
 #
 ################################################################################
 
-# This is an example build script for projects using the rules_fuzzing library
-# for Bazel.
+# Due to https://github.com/bazelbuild/bazel/issues/11128, affecting Bazel 4.0
+# or earlier, we cannot use the "@rules_fuzzing//" prefix for the label-typed
+# cc_engine configuration flag when fuzzing directly the rules_fuzzing workspace.
+#
+# This is NOT needed for any other Bazel repository that depends on
+# rules_fuzzing.
+export BAZEL_EXTRA_BUILD_FLAGS="--//fuzzing:cc_engine=@rules_fuzzing_oss_fuzz//:oss_fuzz_engine"
 
 bazel_build_fuzz_tests

--- a/projects/cel-cpp/build.sh
+++ b/projects/cel-cpp/build.sh
@@ -15,18 +15,4 @@
 #
 ################################################################################
 
-declare -r QUERY='
-    let all_fuzz_tests = attr(tags, "fuzz-test", "//...") in
-    $all_fuzz_tests - attr(tags, "no-oss-fuzz", $all_fuzz_tests)
-'
-
-declare -r PACKAGE_SUFFIX="_oss_fuzz"
-declare -r OSS_FUZZ_TESTS="$(bazel query "${QUERY}" | sed "s/$/${PACKAGE_SUFFIX}/")"
-
-bazel build -c opt --config=oss-fuzz --linkopt=-lc++ \
-    --action_env=CC="${CC}" --action_env=CXX="${CXX}" \
-    ${OSS_FUZZ_TESTS[*]}
-
-for oss_fuzz_archive in $(find bazel-bin/ -name "*${PACKAGE_SUFFIX}.tar"); do
-    tar -xvf "${oss_fuzz_archive}" -C "${OUT}"
-done
+bazel_build_fuzz_tests


### PR DESCRIPTION
 This reduces the build.sh file to a single line.