### PR TITLE
[java-example] Speculative fix for JVM segfault crashes

### DIFF
--- a/projects/java-example/default.options
+++ b/projects/java-example/default.options
@@ -1,2 +1,3 @@
 [asan]
 handle_segv=1
+allow_user_segv_handler=1


### PR DESCRIPTION
The JVM uses custom SIGSEGV handlers, which leads to fuzzer crashes on
ClusterFuzz when running with ASAN likely due to the
allow_user_segv_handler=1 default on the platform.