### PR TITLE
ossec: initial integration

### DIFF
--- a/projects/ossec/Dockerfile
+++ b/projects/ossec/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y libpcre2-dev libssl-dev libsystemd-dev
+RUN git clone https://github.com/ossec/ossec-hids
+
+WORKDIR $SRC
+COPY build.sh $SRC/
+COPY fuzz_xml.c $SRC/

--- a/projects/ossec/Dockerfile
+++ b/projects/ossec/Dockerfile
@@ -20,4 +20,4 @@ RUN git clone https://github.com/ossec/ossec-hids
 
 WORKDIR $SRC
 COPY build.sh $SRC/
-COPY fuzz_xml.c $SRC/
+COPY fuzz_*.c $SRC/

--- a/projects/ossec/build.sh
+++ b/projects/ossec/build.sh
@@ -20,5 +20,6 @@ make TARGET=local
 $CC $CFLAGS $LIB_FUZZING_ENGINE $SRC/fuzz_xml.c -o $OUT/fuzz_xml \
     -I./ ./os_xml.a
 
+static_pcre=($(find /usr/lib -name "libpcre2-8.a"))
 $CC $CFLAGS $LIB_FUZZING_ENGINE $SRC/fuzz_regex.c -o $OUT/fuzz_regex \
-    -I./ -I./os_regex/ ./os_regex.a -lpcre2-8
+    -I./ -I./os_regex/ ./os_regex.a ${static_pcre}

--- a/projects/ossec/build.sh
+++ b/projects/ossec/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC/ossec-hids/src
+make TARGET=local
+$CC $CFLAGS $LIB_FUZZING_ENGINE $SRC/fuzz_xml.c -o $OUT/fuzz_xml -I./ ./os_xml.a

--- a/projects/ossec/build.sh
+++ b/projects/ossec/build.sh
@@ -17,4 +17,8 @@
 
 cd $SRC/ossec-hids/src
 make TARGET=local
-$CC $CFLAGS $LIB_FUZZING_ENGINE $SRC/fuzz_xml.c -o $OUT/fuzz_xml -I./ ./os_xml.a
+$CC $CFLAGS $LIB_FUZZING_ENGINE $SRC/fuzz_xml.c -o $OUT/fuzz_xml \
+    -I./ ./os_xml.a
+
+$CC $CFLAGS $LIB_FUZZING_ENGINE $SRC/fuzz_regex.c -o $OUT/fuzz_regex \
+    -I./ -I./os_regex/ ./os_regex.a -lpcre2-8

--- a/projects/ossec/fuzz_regex.c
+++ b/projects/ossec/fuzz_regex.c
@@ -1,0 +1,51 @@
+/* Copyright 2021 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <string.h>
+#include "os_regex.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size < 25) {
+        return 0;
+    }
+    // Regex pattern
+    char *pattern = (char *)malloc(24);
+    if (pattern == NULL){
+        return 0;
+    }
+    memcpy(pattern, data, 23);
+    pattern[23] = '\0';
+
+    data += 23;
+    size -= 23;
+
+    // text patterns
+    char *str = (char *)malloc(size+1);
+    if (str == NULL){
+        free(pattern);
+        return 0;
+    }
+    memcpy(str, data, size);
+    str[size] = '\0';
+
+    OSRegex reg;
+    if( OSRegex_Compile(pattern, &reg, OS_RETURN_SUBSTRING)) {
+        if(OSRegex_Execute(str, &reg)) {
+            OSRegex_FreeSubStrings(&reg);
+        }
+        OSRegex_FreePattern(&reg);
+    }
+
+    free(pattern);
+    free(str);
+    return 0;
+}
+

--- a/projects/ossec/fuzz_xml.c
+++ b/projects/ossec/fuzz_xml.c
@@ -1,0 +1,72 @@
+/* Copyright 2021 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#include "./os_xml/os_xml.h"
+#include "./os_xml/os_xml_internal.h"
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    char filename[256];
+    sprintf(filename, "/tmp/libfuzzer.%d", getpid());
+
+    FILE *fp = fopen(filename, "wb");
+    if (!fp)
+        return 0;
+    fwrite(data, size, 1, fp);
+    fclose(fp);
+
+    OS_XML xml;
+    if (OS_ReadXML(filename, &xml) < 0) {
+        unlink(filename);
+        return 0;
+    }
+    XML_NODE node = NULL;
+    node = OS_GetElementsbyNode(&xml, NULL);
+    if (node == NULL) {
+        OS_ClearXML(&xml);
+        return 0;
+    }
+    int i = 0;
+
+    while (node[i]) {
+        int j = 0;
+        XML_NODE cnode;
+        cnode = OS_GetElementsbyNode(&xml, node[i]);
+        if (cnode == NULL) {
+            i++;
+            continue;
+        }
+
+        while (cnode[j]) {
+            if (cnode[j]->attributes && cnode[j]->values) {
+                int k = 0;
+                while (cnode[j]->attributes[k]) {
+                    k++;
+                }
+            }
+            j++;
+        }
+
+        OS_ClearNode(cnode);
+        i++;
+    }
+
+    OS_ClearNode(node);
+    OS_ClearXML(&xml);
+    unlink(filename);
+    return 0;
+}
+

--- a/projects/ossec/project.yaml
+++ b/projects/ossec/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/ossec/ossec-hids"
+main_repo: 'https://github.com/ossec/ossec-hids'
+primary_contact: "david@adalogics.com"
+language: c
+auto_ccs:
+  - "david@adalogics.com"


### PR DESCRIPTION
@atomicturtle @ddpbsd I have set up continuous fuzzing of ossec. The benefits are that the fuzzers will be run on a regular basis and bug reports will be send to your email with information such as inputs that trigger the bugs, stack traces and more. Is this something you would be happy to have set up? If so, the only thing needed from your end is an email that will receive the bugs reports - notice this email should be attached to a Google account for you to see the reports.
Cross-referencing an issue on the ossec repo that proposes integration with oss-fuzz https://github.com/ossec/ossec-hids/issues/1789 