### PR TITLE
Adds swift-nio project

### DIFF
--- a/projects/swift-nio/Dockerfile
+++ b/projects/swift-nio/Dockerfile
@@ -15,6 +15,8 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
+
+# generic swift
 RUN apt-get update && apt install -y wget \
            binutils \
            libc6-dev \
@@ -28,11 +30,16 @@ RUN apt-get update && apt install -y wget \
            pkg-config \
            tzdata \
            zlib1g-dev
-
 RUN wget https://swift.org/builds/swift-5.3.3-release/ubuntu1604/swift-5.3.3-RELEASE/swift-5.3.3-RELEASE-ubuntu16.04.tar.gz
 RUN tar xzf swift-5.3.3-RELEASE-ubuntu16.04.tar.gz
 RUN cp -r swift-5.3.3-RELEASE-ubuntu16.04/usr/* /usr/
 
+# generic swift symbolizer
+RUN apt-get update && apt-get install -y build-essential make cmake ninja-build git python3 g++-multilib binutils-dev zlib1g-dev --no-install-recommends
+RUN git clone --depth 1 https://github.com/llvm/llvm-project.git
+COPY llvmsymbol.diff $SRC
+
+# specific swift-nio
 RUN git clone --depth 1 https://github.com/google/fuzzing
 RUN git clone --depth 1 https://github.com/apple/swift-nio.git
 COPY build.sh $SRC

--- a/projects/swift-nio/Dockerfile
+++ b/projects/swift-nio/Dockerfile
@@ -1,0 +1,40 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt install -y wget \
+           binutils \
+           libc6-dev \
+           libcurl3 \
+           libedit2 \
+           libgcc-5-dev \
+           libpython2.7 \
+           libsqlite3-0 \
+           libstdc++-5-dev \
+           libxml2 \
+           pkg-config \
+           tzdata \
+           zlib1g-dev
+
+RUN wget https://swift.org/builds/swift-5.3.3-release/ubuntu1604/swift-5.3.3-RELEASE/swift-5.3.3-RELEASE-ubuntu16.04.tar.gz
+RUN tar xzf swift-5.3.3-RELEASE-ubuntu16.04.tar.gz
+RUN cp -r swift-5.3.3-RELEASE-ubuntu16.04/usr/* /usr/
+
+RUN git clone --depth 1 https://github.com/google/fuzzing
+RUN git clone --depth 1 https://github.com/apple/swift-nio.git
+COPY build.sh $SRC
+COPY *.swift $SRC/
+WORKDIR $SRC/swift-nio

--- a/projects/swift-nio/Package.swift
+++ b/projects/swift-nio/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "swift-nio-fuzz",
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        .package(name: "swift-nio", path: ".."),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "swift-nio-http1-fuzz",
+            dependencies: [.product(name: "NIOHTTP1", package: "swift-nio")]),
+    ]
+)

--- a/projects/swift-nio/build.sh
+++ b/projects/swift-nio/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+
+# build project
+mkdir swift-nio-fuzz
+cd swift-nio-fuzz
+swift package init --type=executable
+rm -Rf Sources/swift-nio-fuzz
+mkdir Sources/swift-nio-http1-fuzz
+cp $SRC/fuzz_http1.swift Sources/swift-nio-http1-fuzz/main.swift
+cp $SRC/Package.swift Package.swift
+swift build -c debug -Xswiftc -sanitize=fuzzer,address -Xswiftc -parse-as-library -Xswiftc -static-stdlib -Xcc="-fsanitize=fuzzer-no-link,address"
+cp .build/x86_64-unknown-linux-gnu/debug/*fuzz $OUT/
+
+cp $SRC/fuzzing/dictionaries/http.dict $OUT/swift-nio-http1-fuzz.dict

--- a/projects/swift-nio/fuzz_http1.swift
+++ b/projects/swift-nio/fuzz_http1.swift
@@ -1,0 +1,21 @@
+import NIOHTTP1
+import NIO
+
+@_cdecl("LLVMFuzzerTestOneInput")
+public func test(_ start: UnsafeRawPointer, _ count: Int) -> CInt {
+    let bytes = UnsafeRawBufferPointer(start: start, count: count)
+    let channel = EmbeddedChannel()
+    var buffer = channel.allocator.buffer(capacity: count)
+    buffer.writeBytes(bytes)
+    do {
+        try channel.pipeline.addHandler(ByteToMessageHandler(HTTPRequestDecoder())).wait()
+        try channel.writeInbound(buffer)
+        channel.embeddedEventLoop.run()
+    } catch {
+    }
+    do {
+        try channel.finish(acceptAlreadyClosed: true)
+    } catch {
+    }
+    return 0
+}

--- a/projects/swift-nio/llvmsymbol.diff
+++ b/projects/swift-nio/llvmsymbol.diff
@@ -1,0 +1,51 @@
+diff --git a/llvm/lib/DebugInfo/Symbolize/CMakeLists.txt b/llvm/lib/DebugInfo/Symbolize/CMakeLists.txt
+index acfb3bd0e..5c4cf9763 100644
+--- a/llvm/lib/DebugInfo/Symbolize/CMakeLists.txt
++++ b/llvm/lib/DebugInfo/Symbolize/CMakeLists.txt
+@@ -12,4 +12,12 @@ add_llvm_component_library(LLVMSymbolize
+   Object
+   Support
+   Demangle
+-  )
++
++  LINK_LIBS
++  /usr/lib/swift_static/linux/libswiftCore.a
++  /usr/lib/swift_static/linux/libswiftImageInspectionShared.a
++  /usr/lib/swift_static/linux/libicui18nswift.a
++  /usr/lib/swift_static/linux/libicuucswift.a
++  /usr/lib/swift_static/linux/libicudataswift.a
++  /usr/lib/x86_64-linux-gnu/libstdc++.so.6
++)
+diff --git a/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp b/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
+index 4c3f3a3767e1..aa7b9f0f5abb 100644
+--- a/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
++++ b/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
+@@ -36,6 +36,13 @@
+ #include <cassert>
+ #include <cstring>
+ 
++
++extern "C" char *swift_demangle(const char *mangledName,
++                     size_t mangledNameLength,
++                     char *outputBuffer,
++                     size_t *outputBufferSize,
++                     uint32_t flags);
++
+ namespace llvm {
+ namespace symbolize {
+ 
+@@ -632,6 +639,14 @@ LLVMSymbolizer::DemangleName(const std::string &Name,
+     free(DemangledName);
+     return Result;
+   }
++  if (!Name.empty() && Name.front() == '$') {
++    char *DemangledName = swift_demangle(Name.c_str(), Name.length(), 0, 0, 0);
++    if (DemangledName) {
++      std::string Result = DemangledName;
++      free(DemangledName);
++      return Result;
++    }
++  }
+ 
+   if (DbiModuleDescriptor && DbiModuleDescriptor->isWin32Module())
+     return std::string(demanglePE32ExternCFunc(Name));

--- a/projects/swift-nio/project.yaml
+++ b/projects/swift-nio/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://github.com/apple/swift-nio"
+language: swift
+primary_contact: "tkientzle@apple.com"
+auto_ccs :
+- "cory@lukasa.co.uk"
+- "p.antoine@catenacyber.fr"
+
+fuzzing_engines:
+- libfuzzer
+sanitizers:
+- address
+main_repo: 'https://github.com/apple/swift-nio.git'

--- a/projects/swift-nio/project.yaml
+++ b/projects/swift-nio/project.yaml
@@ -1,8 +1,9 @@
 homepage: "https://github.com/apple/swift-nio"
 language: swift
-primary_contact: "tkientzle@apple.com"
+primary_contact: "lukasa@apple.com"
 auto_ccs :
-- "cory@lukasa.co.uk"
+- "johannesweiss@apple.com"
+- "pp_adams@apple.com"
 - "p.antoine@catenacyber.fr"
 
 fuzzing_engines:


### PR DESCRIPTION
@oliverchang 
Here is another swift project integration cf https://github.com/google/oss-fuzz/pull/5493

To have a good oss-fuzz integration, I think we would need to
- move the swift compiler in base-builder
- add documentation about swift project integration
- Use the swift demangler in libFuzzer output (I do not know how to do that)
- Have some utility script (to handle different sanitizers, test the coverage)

Do you see anything else ?

cc @inferno-chromium 
