### PR TITLE
Delete unneeded files from cargo-fuzz install

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -87,7 +87,7 @@ ENV CARGO_HOME=/rust
 ENV RUSTUP_HOME=/rust/rustup
 ENV PATH=$PATH:/rust/bin
 RUN curl https://sh.rustup.rs | sh -s -- -y --default-toolchain=nightly --profile=minimal
-RUN cargo install cargo-fuzz
+RUN cargo install cargo-fuzz && rm -rf /rust/registry
 # Needed to recompile rust std library for MSAN
 RUN rustup component add rust-src --toolchain nightly
 


### PR DESCRIPTION
This saves about 100MB in image size.
Related: https://github.com/google/oss-fuzz/issues/5170