### PR TITLE
[wasm3] Initial integration

### DIFF
--- a/projects/wasm3/Dockerfile
+++ b/projects/wasm3/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make
+RUN git clone --depth 1 https://github.com/wasm3/wasm3
+WORKDIR wasm3
+COPY build.sh $SRC/

--- a/projects/wasm3/build.sh
+++ b/projects/wasm3/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+mkdir build && cd build
+cmake -DBUILD_WASI=none ..
+make -j$(nproc)
+$CC $CFLAGS -c $SRC/wasm3/platforms/app_fuzz/fuzzer.c -o fuzzer.o -I/src/wasm3/source
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE -o $OUT/fuzzer fuzzer.o /src/wasm3/build/source/libm3.a

--- a/projects/wasm3/project.yaml
+++ b/projects/wasm3/project.yaml
@@ -1,0 +1,14 @@
+homepage: "https://github.com/wasm3/wasm3"
+main_repo: "https://github.com/wasm3/wasm3"
+language: c
+primary_contact: "vshymanskyi@gmail.com"
+auto_ccs:
+  - "Adam@adalogics.com"
+sanitizers:
+  - address
+  - undefined
+  - memory
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz


### PR DESCRIPTION
@vshymanskyy 
Would you be interested in integrating with OSS-fuzz.
This will allow OSS-fuzz to run the fuzzer continuously and notify you via email when bugs are found.

The build script has a few debugging leftovers, but I will remove those before merging.
To complete this draft, a maintainers email address is needed for the project.yaml file.

~~Currently the AFL returns the following error (It has therefore been disabled for now). It looks unrelated to AFL itself. @vshymanskyy Do you see an easy fix here?~~