### PR TITLE
[libjpeg-turbo] Remove unneeded pkg in Dockerfile

### DIFF
--- a/projects/libjpeg-turbo/Dockerfile
+++ b/projects/libjpeg-turbo/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make yasm cmake libstdc++-5-dev:i386
+RUN apt-get update && apt-get install -y make yasm cmake
 RUN git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo
 
 RUN git clone --depth 1 https://github.com/libjpeg-turbo/seed-corpora


### PR DESCRIPTION
Installing the i386 libstdc++ SDK was part of a failed effort to fix the
i386 fuzz targets.  They have been fixed in a different way.