### PR TITLE
wazuh: initial integration.

### DIFF
--- a/projects/wazuh/Dockerfile
+++ b/projects/wazuh/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y libpcre2-dev libssl-dev libsystemd-dev autoconf libtool
+RUN git clone https://github.com/wazuh/wazuh
+
+WORKDIR $SRC/wazuh
+COPY build.sh $SRC/
+COPY fuzz_xml.c $SRC/fuzz_xml.c

--- a/projects/wazuh/build.sh
+++ b/projects/wazuh/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd src
+export LDFLAGS="$CFLAGS"
+
+make deps
+make TARGET=local
+$CC $CFLAGS $LIB_FUZZING_ENGINE $SRC/fuzz_xml.c -o $OUT/fuzz_xml -I./ -I./os_xml \
+    ./libwazuh.a ./external/sqlite/libsqlite3.a ./external/cJSON/libcjson.a \
+    ./external/zlib/libz.a ./external/bzip2/libbz2.a

--- a/projects/wazuh/fuzz_xml.c
+++ b/projects/wazuh/fuzz_xml.c
@@ -1,0 +1,72 @@
+/* Copyright 2021 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#include "./os_xml/os_xml.h"
+#include "./os_xml/os_xml_internal.h"
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    char filename[256];
+    sprintf(filename, "/tmp/libfuzzer.%d", getpid());
+
+    FILE *fp = fopen(filename, "wb");
+    if (!fp)
+        return 0;
+    fwrite(data, size, 1, fp);
+    fclose(fp);
+
+    OS_XML xml;
+    if (OS_ReadXML(filename, &xml) < 0) {
+        unlink(filename);
+        return 0;
+    }
+    XML_NODE node = NULL;
+    node = OS_GetElementsbyNode(&xml, NULL);
+    if (node == NULL) {
+        OS_ClearXML(&xml);
+        return 0;
+    }
+    int i = 0;
+
+    while (node[i]) {
+        int j = 0;
+        XML_NODE cnode;
+        cnode = OS_GetElementsbyNode(&xml, node[i]);
+        if (cnode == NULL) {
+            i++;
+            continue;
+        }
+
+        while (cnode[j]) {
+            if (cnode[j]->attributes && cnode[j]->values) {
+                int k = 0;
+                while (cnode[j]->attributes[k]) {
+                    k++;
+                }
+            }
+            j++;
+        }
+
+        OS_ClearNode(cnode);
+        i++;
+    }
+
+    OS_ClearNode(node);
+    OS_ClearXML(&xml);
+    unlink(filename);
+    return 0;
+}
+

--- a/projects/wazuh/fuzz_xml.options
+++ b/projects/wazuh/fuzz_xml.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+detect_leaks=0

--- a/projects/wazuh/project.yaml
+++ b/projects/wazuh/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/wazuh/wazuh"
+primary_contact: "david@adalogics.com"
+language: c++
+auto_ccs:
+  - "david@adalogics.com"
+main_repo: 'https://github.com/wazuh/wazuh'

--- a/projects/wazuh/project.yaml
+++ b/projects/wazuh/project.yaml
@@ -1,6 +1,6 @@
-homepage: "https://github.com/wazuh/wazuh"
-primary_contact: "david@adalogics.com"
-language: c++
+homepage: "https://wazuh.com/"
+main_repo: 'https://github.com/wazuh/wazuh'
+primary_contact: "devel@wazuh.com"
+language: c
 auto_ccs:
   - "david@adalogics.com"
-main_repo: 'https://github.com/wazuh/wazuh'


### PR DESCRIPTION
Wazuh is a free, open source and enterprise-ready security monitoring solution for threat detection, integrity monitoring, incident response and compliance. On the main homepage: https://wazuh.com/ you can see the list of users, which includes salesforce, groupon and other large organisations.

@vikman90 I have set up continuous fuzzing of wazuh.  Is this something you would be happy to have set up? The benefits are that the fuzzers will be run on a regular basis and bug reports will be send to your email with information such as inputs that trigger the bugs, stack traces and more. If you would like to get Wazuh in, the only thing needed from your end is an email that will receive the bugs reports - notice this email should be attached to a Google account for you to see the reports.