### PR TITLE
Add a maintainer to the Hermes OSS Fuzz project

### DIFF
--- a/projects/hermes/project.yaml
+++ b/projects/hermes/project.yaml
@@ -4,6 +4,8 @@ primary_contact: "neildhar@fb.com"
 auto_ccs:
   - "dulinr@fb.com"
   - "mhl@fb.com"
+  - "avp@fb.com"
+  - "jsx@fb.com"
 vendor_ccs:
   - "oss-fuzz@fb.com"
 fuzzing_engines:


### PR DESCRIPTION
OSS Fuzz tends to mostly find bugs in the parser, which is mostly worked on by @avp and @Huxpro.