### PR TITLE
Don't build parts of gdb when testing binutils

### DIFF
--- a/projects/binutils/build.sh
+++ b/projects/binutils/build.sh
@@ -29,7 +29,9 @@ sed -i 's/vfprintf (stderr/\/\//' elfcomm.c
 sed -i 's/fprintf (stderr/\/\//' elfcomm.c
 cd ../
 
-./configure --disable-gdb --enable-targets=all
+./configure --disable-gdb --disable-gdbserver --disable-gdbsupport \
+	    --disable-libdecnumber --disable-readline --disable-sim \
+	    --enable-targets=all
 make MAKEINFO=true && true
 
 # Make fuzzer directory


### PR DESCRIPTION
gdb sources have been reorganised.  Disable more directories when
building the binutils fuzzers.