### PR TITLE
Store triage party image in oss-fuzz-base repo

### DIFF
--- a/infra/triage-party/deploy.sh
+++ b/infra/triage-party/deploy.sh
@@ -16,7 +16,7 @@ set -eux
 
 
 export PROJECT=oss-fuzz
-export IMAGE=gcr.io/oss-fuzz/triage-party
+export IMAGE=gcr.io/oss-fuzz-base/triage-party
 export SERVICE_NAME=triage-party
 export CONFIG_FILE=config/examples/oss-fuzz.yaml
 


### PR DESCRIPTION
I've already redeployed with this image, seems to be working as expected.