### PR TITLE
Enable generated dict in AFL++

### DIFF
--- a/infra/base-images/base-builder/compile_afl
+++ b/infra/base-images/base-builder/compile_afl
@@ -21,7 +21,7 @@
 
 # AFL++ settings.
 export AFL_LLVM_MODE_WORKAROUND=0
-export AFL_ENABLE_DICTIONARY=0
+export AFL_ENABLE_DICTIONARY=1
 
 # Start compiling afl++.
 echo "Copying precompiled afl++"


### PR DESCRIPTION
This was accidently disabled, noticed by @vanhauser-thc 