### PR TITLE
Adds gnostic project

### DIFF
--- a/projects/gnostic/Dockerfile
+++ b/projects/gnostic/Dockerfile
@@ -1,0 +1,34 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN git clone --depth 1 https://github.com/google/gnostic
+
+RUN apt-get update && apt-get install -y protobuf-compiler libprotobuf-dev binutils cmake \
+   ninja-build liblzma-dev libz-dev pkg-config autoconf libtool
+RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
+RUN mkdir LPM; \
+  cd LPM; \
+  cmake $SRC/libprotobuf-mutator -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release; \
+  ninja;
+
+RUN git clone --depth 1 https://github.com/mdempsky/go114-fuzz-build.git
+
+COPY go-lpm.cc $SRC/
+COPY fuzzproto.go $SRC/gnostic/openapiv2/
+
+COPY build.sh $SRC/
+WORKDIR $SRC/gnostic

--- a/projects/gnostic/build.sh
+++ b/projects/gnostic/build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+mkdir fuzzlpm
+$SRC/LPM/external.protobuf/bin/protoc --cpp_out=fuzzlpm/ openapiv2/OpenAPIv2.proto
+
+$CXX $CXXFLAGS -c -I fuzzlpm/ -I $SRC/LPM/external.protobuf/include fuzzlpm/openapiv2/OpenAPIv2.pb.cc
+$CXX $CXXFLAGS -c -I. -I ../libprotobuf-mutator/ -I $SRC/LPM/external.protobuf/include $SRC/go-lpm.cc
+
+(
+cd $SRC/go114-fuzz-build
+sed -i -e 's/LLVMFuzzerTestOneInput/LPMFuzzerTestOneInput/' main.go
+go build
+)
+
+$SRC/go114-fuzz-build/go114-fuzz-build -func Fuzz -o fuzz_lpm.a ./openapiv2
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE OpenAPIv2.pb.o go-lpm.o fuzz_lpm.a  $SRC/LPM/src/libfuzzer/libprotobuf-mutator-libfuzzer.a $SRC/LPM/src/libprotobuf-mutator.a $SRC/LPM/external.protobuf/lib/libprotobuf.a -o $OUT/fuzz_lpm

--- a/projects/gnostic/fuzzproto.go
+++ b/projects/gnostic/fuzzproto.go
@@ -1,0 +1,18 @@
+// +build gofuzz
+
+package openapi_v2
+
+import (
+	"github.com/golang/protobuf/proto"
+)
+
+func Fuzz(data []byte) int {
+	d := &Document{}
+	err := proto.Unmarshal(data, d)
+	//fmt.Printf("debugd %v\ndebugu %s: %#+v\n", data, err, d)
+	if err != nil {
+		panic("Failed to unmarshal profile")
+	}
+	d.ToRawInfo()
+	return 0
+}

--- a/projects/gnostic/go-lpm.cc
+++ b/projects/gnostic/go-lpm.cc
@@ -1,0 +1,15 @@
+#include "fuzzlpm/openapiv2/OpenAPIv2.pb.h"
+#include "src/libfuzzer/libfuzzer_macro.h"
+
+extern "C" void  LPMFuzzerTestOneInput(const uint8_t *buffer, size_t size);
+
+DEFINE_PROTO_FUZZER(const openapi::v2::Document& input) {
+    size_t size = input.ByteSizeLong();
+    if (size > 0) {
+        uint8_t *buffer = (uint8_t *) malloc(size);
+        //printf("debugs %d: %s\n", size, input.DebugString().c_str());
+        input.SerializeToArray((uint8_t *) buffer, size);
+        LPMFuzzerTestOneInput(buffer, size);
+        free(buffer);
+    }
+}

--- a/projects/gnostic/go-lpm.cc
+++ b/projects/gnostic/go-lpm.cc
@@ -1,3 +1,19 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
 #include "fuzzlpm/openapiv2/OpenAPIv2.pb.h"
 #include "src/libfuzzer/libfuzzer_macro.h"
 

--- a/projects/gnostic/project.yaml
+++ b/projects/gnostic/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/google/gnostic"
+primary_contact: "timburks@google.com"
+auto_ccs:
+  - "p.antoine@catenacyber.fr"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+main_repo: 'https://github.com/google/gnostic'


### PR DESCRIPTION
@timburks would you be interested in continuous fuzzing for gnostic ?
This PR enables it with oss-fuzz with one structure-aware fuzz target against `openapiv2.Document`

It quickly finds a null dereference in `StringArray.ToRawInfo`
It uses C++ libprotobufmutator to generate a valid `openapi::v2::Document` then serializes it to pass it to golang fuzz target 