### PR TITLE
Suricata more targets

### DIFF
--- a/projects/suricata/build.sh
+++ b/projects/suricata/build.sh
@@ -52,6 +52,8 @@ make install
 cd ..
 
 export CARGO_BUILD_TARGET="x86_64-unknown-linux-gnu"
+# cf https://github.com/google/sanitizers/issues/1389
+export MSAN_OPTIONS=strict_memcmp=false
 
 #we did not put libhtp there before so that cifuzz does not remove it
 mv libhtp suricata/

--- a/projects/suricata/build.sh
+++ b/projects/suricata/build.sh
@@ -66,10 +66,14 @@ fi
 ./src/tests/fuzz/oss-fuzz-configure.sh
 make -j$(nproc)
 
+./src/suricata --list-app-layer-protos | tail -n +2 | while read i; do cp src/fuzz_applayerparserparse $OUT/fuzz_applayerparserparse_$i; done
+
 cp src/fuzz_* $OUT/
 
 # dictionaries
 ./src/suricata --list-keywords | grep "\- " | sed 's/- //' | awk '{print "\""$0"\""}' > $OUT/fuzz_siginit.dict
+
+echo \"SMB\" > $OUT/fuzz_applayerparserparse_smb.dict
 
 # build corpuses
 # default configuration file


### PR DESCRIPTION
Improves suricata fuzzing by having dedicated fuzz targets per protocol.
SMB had pretty ow coverage and having a dictionary for its custom fuzz target allows it to get much more coverage

Also improves `MSAN_OPTIONS` as advised in https://github.com/google/sanitizers/issues/1389