### PR TITLE
[java-example] Trigger new native finding

### DIFF
--- a/projects/java-example/ExampleFuzzerNative.cpp
+++ b/projects/java-example/ExampleFuzzerNative.cpp
@@ -24,7 +24,7 @@ void parseInternal(const std::string &input) {
   if (input[0] == 'a' && input[1] == 'b' && input[5] == 'c') {
     if (input.find("secret_in_native_library") != std::string::npos) {
       // BOOM
-      *(char *)1 = 2;
+      *(char *)0xFF = 2;
     }
   }
 }


### PR DESCRIPTION
Java native libraries should now be fuzzed correctly, but the current crash is still reported as flaky due to the multiple fixes required to make it work.

This commit should trigger a clean new finding.