### PR TITLE
cilium: Update contact emails

### DIFF
--- a/projects/cilium/project.yaml
+++ b/projects/cilium/project.yaml
@@ -8,6 +8,7 @@ auto_ccs:
 - "robin@isovalent.com"
 - "tom.payne@isovalent.com"
 - "adam@adalogics.com"
+main_repo: "https://github.com/cilium/cilium.git"
 fuzzing_engines:
 - libfuzzer
 sanitizers:

--- a/projects/cilium/project.yaml
+++ b/projects/cilium/project.yaml
@@ -2,8 +2,11 @@ homepage: "https://cilium.io"
 language: go
 primary_contact: "security@cilium.io"
 auto_ccs:
-- "tom@isovalent.com"
+- "andre@isovalent.com"
+- "joe@isovalent.com"
 - "natalia@isovalent.com"
+- "robin@isovalent.com"
+- "tom.payne@isovalent.com"
 - "adam@adalogics.com"
 fuzzing_engines:
 - libfuzzer


### PR DESCRIPTION
This adds three Cilium maintainers and updates one maintainer's email
address to match the Google Account email. Previously an alternative
email was used, which did not give access to the ClusterFuzz dashboard.