### PR TITLE
Revert "[systemd] roll back to meson-0.56.2 (#5199)"

### DIFF
--- a/projects/systemd/Dockerfile
+++ b/projects/systemd/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update &&\
     apt-get install -y gperf m4 gettext python3-pip \
         libcap-dev libmount-dev libkmod-dev \
         pkg-config wget &&\
-    pip3 install meson==0.56.2 ninja
+    pip3 install meson ninja
 RUN git clone --depth 1 https://github.com/systemd/systemd systemd
 WORKDIR systemd
 COPY build.sh $SRC/


### PR DESCRIPTION
Now that https://github.com/mesonbuild/meson/issues/8345 is closed,
it should be safe to keep rolling forward.

This reverts commit ac290e7ed7b600c685d3d6b455b58fda122b88b0.