### PR TITLE
[cifuzz] fix bug appearing in CI

### DIFF
--- a/infra/cifuzz/fuzz_target.py
+++ b/infra/cifuzz/fuzz_target.py
@@ -142,10 +142,10 @@ class FuzzTarget:
       return FuzzResult(None, None)
 
     utils.binary_print(b'Fuzzer: %s. Detected bug:\n%s' %
-                       (self.target_name.encode(), stderr))
+                       (self.target_name.encode(), result.stderr))
     if self.is_crash_reportable(testcase):
       # We found a bug in the fuzz target and we will report it.
-      return FuzzResult(testcase, stderr)
+      return FuzzResult(testcase, result.stderr)
 
     # We found a bug but we won't report it.
     return FuzzResult(None, None)


### PR DESCRIPTION
After https://github.com/google/oss-fuzz/pull/5473:

presubmits fail with
```
************* Module infra.cifuzz.fuzz_target
infra/cifuzz/fuzz_target.py:145:51: E0602: Undefined variable 'stderr' (undefined-variable)
infra/cifuzz/fuzz_target.py:148:34: E0602: Undefined variable 'stderr' (undefined-variable)
```

see https://github.com/google/oss-fuzz/pull/5427/checks?check_run_id=2325894288

Signed-off-by: Asra Ali <asraa@google.com>