### PR TITLE
Install packages in cosign project to fix fuzzing error

### DIFF
--- a/projects/cosign/Dockerfile
+++ b/projects/cosign/Dockerfile
@@ -15,6 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y pkg-config libpcsclite-dev
 RUN git clone --depth 1 https://github.com/sigstore/cosign
 
 COPY build.sh $SRC/


### PR DESCRIPTION
We added a new Yubikey feature to cosign which depends on these packages

closes https://github.com/google/oss-fuzz/issues/5603