### PR TITLE
[postgresql] Remove AFL fuzzing engine.

### DIFF
--- a/projects/postgresql/project.yaml
+++ b/projects/postgresql/project.yaml
@@ -9,6 +9,5 @@ auto_ccs:
 fuzzing_engines:
   - libfuzzer
   - honggfuzz
-  - afl
 sanitizers:
   - address


### PR DESCRIPTION
Build never succeeded and causes ClusterFuzz exceptions.