### PR TITLE
[draco][AFL] Disable AFL builds to stop ClusterFuzz exceptions

### DIFF
--- a/projects/draco/project.yaml
+++ b/projects/draco/project.yaml
@@ -4,4 +4,7 @@ primary_contact: "fgalligan@google.com"
 auto_ccs:
   - "ostava@google.com"
   - "vytyaz@google.com"
+fuzzing_engines:
+  - libfuzzer
+  - honggfuzz
 main_repo: 'https://github.com/google/draco'


### PR DESCRIPTION
All draco builds have been broken since December.
This means that the old AFL builds are still running on ClusterFuzz.
This is causing exceptions because the old AFL builds don't work
with the ClusterFuzz code which assumes AFL++.
Fixes #5610