### PR TITLE
[tailscale] Initial integration

### DIFF
--- a/projects/tailscale/Dockerfile
+++ b/projects/tailscale/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN git clone --depth 1 https://github.com/tailscale/tailscale
+COPY build.sh $SRC/
+WORKDIR $SRC/tailscale

--- a/projects/tailscale/build.sh
+++ b/projects/tailscale/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+compile_go_fuzzer tailscale.com/net/stun FuzzStunParser stun_parser_fuzzer

--- a/projects/tailscale/project.yaml
+++ b/projects/tailscale/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://tailscale.com/"
+main_repo: "https://github.com/tailscale/tailscale"
+primary_contact: ""
+auto_ccs :
+  - "adam@adalogics.com"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address

--- a/projects/tailscale/project.yaml
+++ b/projects/tailscale/project.yaml
@@ -1,8 +1,10 @@
 homepage: "https://tailscale.com/"
 main_repo: "https://github.com/tailscale/tailscale"
-primary_contact: ""
+primary_contact: "Adam@adalogics.com"
 auto_ccs :
-  - "adam@adalogics.com"
+  - "josh@tailscale.com"
+  - "danderson@tailscale.com"
+  - "bradfitz@tailscale.com"
 language: go
 fuzzing_engines:
   - libfuzzer


### PR DESCRIPTION
This PR adds initial integration of [Tailscale](https://tailscale.com/).

**About Tailscale**: _Based on Google’s zero-trust BeyondCorp architecture, and built using the WireGuard protocol, Tailscale makes network security accessible to teams of any size_[[1](https://www.heavybit.com/library/blog/heavybit-welcomes-tailscale/)]. The company has around 20 employees and raised $12m in november 2020[[2](https://techcrunch.com/2020/11/10/tailscale-raises-12-million-for-its-wireguard-based-corporate-vpn)].

**Users**: One of Tailscales larger customers is VersaBank[[3](https://www.businesswire.com/news/home/20200330005192/en/VersaBank%E2%80%99s-New-High-Security-VPN-Proving-Especially-Valuable-During-COVID-19-Pandemic)] who trades on Toronto Stock Exchange.