### PR TITLE
[CIFuzz] Ensure we don't through exception if we can't stop container

### DIFF
--- a/infra/cifuzz/docker.py
+++ b/infra/cifuzz/docker.py
@@ -70,7 +70,11 @@ def _handle_timed_out_container_process(process, cid_filename):
     return None, None
 
   # Use a timeout so we don't wait forever.
-  return process.communicate(timeout=1)
+  try:
+    return process.communicate(timeout=5)
+  except subprocess.TimeoutExpired:
+    logging.error('Docker container still running after stop attempt.')
+    return None, None
 
 
 def run_container_command(command_arguments, timeout=None):


### PR DESCRIPTION
It's probably fine to run another one, so just do that.
Also increase the amount of time we will wait to 5 seconds.
Fixes https://github.com/google/oss-fuzz/issues/5621