### PR TITLE
caddy: add new project

### DIFF
--- a/projects/caddy/Dockerfile
+++ b/projects/caddy/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Google Inc.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/caddy/Dockerfile
+++ b/projects/caddy/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN git clone --depth 1  https://github.com/caddyserver/caddy $GOPATH/src/github.com/caddyserver/caddy/v2
+
+COPY build.sh $SRC/
+WORKDIR $SRC/caddy

--- a/projects/caddy/build.sh
+++ b/projects/caddy/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2020 Google Inc.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/caddy/build.sh
+++ b/projects/caddy/build.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+if [[ $SANITIZER = *coverage* ]]; then
+    # we don't support 'coverage' sanitizer yet because 
+    # compile_go_fuzzer doesn't seem to like SIV.
+    # TODO: investigate proper fix for either
+    exit 0
+fi
+
+cd "$GOPATH"/src/github.com/caddyserver/caddy/v2
+
+find . -name '*_fuzz.go' | while read -r target
+do
+# Arguments are :
+#     path of the package with the fuzz target
+#     name of the fuzz function
+#     name of the fuzzer to be built
+#     optional tag to be used by go build and such
+
+    fuzzed_func=$(grep -o "Fuzz[a-zA-Z]\+" "$target")
+    fuzzer_name=$(echo "$fuzzed_func" | sed -E 's/([A-Z])/-\L\1/g' | sed 's/^-//')
+    # find the relative directory and remove the first `.` (`./` is removed for root)
+    target_dir=$(dirname "$target"); target_dir="${target_dir//.}";
+    target_corpus_name="${fuzzer_name}_seed_corpus.zip"
+
+    wget "https://raw.githubusercontent.com/caddyserver/caddy/fuzz-seed-corpus/${target_corpus_name}"
+    compile_go_fuzzer github.com/caddyserver/caddy/v2"$target_dir" "$fuzzed_func" "$fuzzer_name" gofuzz
+done

--- a/projects/caddy/build.sh
+++ b/projects/caddy/build.sh
@@ -38,6 +38,6 @@ do
     target_dir=$(dirname "$target"); target_dir="${target_dir//.}";
     target_corpus_name="${fuzzer_name}_seed_corpus.zip"
 
-    wget "https://raw.githubusercontent.com/caddyserver/caddy/fuzz-seed-corpus/${target_corpus_name}"
+    curl -s -f -O "https://raw.githubusercontent.com/caddyserver/caddy/fuzz-seed-corpus/${target_corpus_name}" || true
     compile_go_fuzzer github.com/caddyserver/caddy/v2"$target_dir" "$fuzzed_func" "$fuzzer_name" gofuzz
 done

--- a/projects/caddy/project.yaml
+++ b/projects/caddy/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://caddyserver.com/"
+language: go
+primary_contact: "msaa1990@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+main_repo: "https://github.com/caddyserver/caddy.git"

--- a/projects/caddy/project.yaml
+++ b/projects/caddy/project.yaml
@@ -1,6 +1,8 @@
 homepage: "https://caddyserver.com/"
 language: go
 primary_contact: "msaa1990@gmail.com"
+auto_ccs:
+  - "Adam@adalogics.com"
 fuzzing_engines:
   - libfuzzer
 sanitizers:


### PR DESCRIPTION
This PR adds Caddy. I've tested the setup locally using the guide described in the [Setting up new project#Testing Locally](https://google.github.io/oss-fuzz/getting-started/new-project-guide/#testing-locally) page.

The coverage sanitizer doesn't seem to work nicely with Go's SIV, so we opted to not support it for now. The fix will either have to be in the shell script used for the coverage sanitizer or we figure out a hack in our `build.sh`.