### PR TITLE
Adds go json-patch project

### DIFF
--- a/projects/json-patch/Dockerfile
+++ b/projects/json-patch/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN git clone --depth 1 https://github.com/evanphx/json-patch
+
+COPY fuzz_*.go $SRC/json-patch/
+
+COPY build.sh $SRC/
+WORKDIR $SRC/json-patch

--- a/projects/json-patch/build.sh
+++ b/projects/json-patch/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+compile_go_fuzzer github.com/evanphx/json-patch FuzzCreateMerge fuzz_create_merge
+compile_go_fuzzer github.com/evanphx/json-patch FuzzDecodeApply fuzz_decode_apply

--- a/projects/json-patch/fuzz_create_merge.go
+++ b/projects/json-patch/fuzz_create_merge.go
@@ -1,0 +1,26 @@
+package jsonpatch
+
+import (
+	"bytes"
+)
+
+func FuzzCreateMerge(data []byte) int {
+	s := bytes.Split(data, []byte{0})
+	if len(s) != 3 {
+		return 0
+	}
+	original := s[0]
+	target := s[1]
+	alternative := s[2]
+
+	patch, err := CreateMergePatch(original, target)
+	if err != nil {
+		return 0
+	}
+	_, err = MergePatch(alternative, patch)
+	if err != nil {
+		return 0
+	}
+
+	return 1
+}

--- a/projects/json-patch/fuzz_decode_apply.go
+++ b/projects/json-patch/fuzz_decode_apply.go
@@ -1,0 +1,25 @@
+package jsonpatch
+
+import (
+	"bytes"
+)
+
+func FuzzDecodeApply(data []byte) int {
+	s := bytes.Split(data, []byte{0})
+	if len(s) != 2 {
+		return 0
+	}
+	patchJSON := s[0]
+	original := s[1]
+
+	patch, err := DecodePatch(patchJSON)
+	if err != nil {
+		return 0
+	}
+
+	_, err = patch.Apply(original)
+	if err != nil {
+		return 0
+	}
+	return 1
+}

--- a/projects/json-patch/project.yaml
+++ b/projects/json-patch/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/evanphx/json-patch"
+primary_contact: "evan@phx.io"
+auto_ccs:
+  - "p.antoine@catenacyber.fr"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+main_repo: 'https://github.com/evanphx/json-patch'


### PR DESCRIPTION
@evanphx would you be interested in continuous fuzzing for json-patch ?
This PR enables it with 2 fuzz targets inspired by the use cases from the README

It quickly finds a panic from a buffer over read in `json-patch.Patch.Apply