### PR TITLE
Adds grpc-swift project

### DIFF
--- a/projects/grpc-swift/Dockerfile
+++ b/projects/grpc-swift/Dockerfile
@@ -35,7 +35,10 @@ RUN tar xzf swift-5.3.3-RELEASE-ubuntu16.04.tar.gz
 RUN cp -r swift-5.3.3-RELEASE-ubuntu16.04/usr/* /usr/
 
 # generic swift symbolizer
-RUN apt-get update && apt-get install -y build-essential make cmake ninja-build git python3 g++-multilib binutils-dev zlib1g-dev --no-install-recommends
+RUN apt-get update && apt-get install -y build-essential make \
+    ninja-build git python3 g++-multilib binutils-dev zlib1g-dev \
+    --no-install-recommends
+
 RUN git clone --depth 1 https://github.com/llvm/llvm-project.git
 COPY llvmsymbol.diff $SRC
 

--- a/projects/grpc-swift/Dockerfile
+++ b/projects/grpc-swift/Dockerfile
@@ -1,0 +1,47 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+# generic swift
+RUN apt-get update && apt install -y wget \
+           binutils \
+           libc6-dev \
+           libcurl3 \
+           libedit2 \
+           libgcc-5-dev \
+           libpython2.7 \
+           libsqlite3-0 \
+           libstdc++-5-dev \
+           libxml2 \
+           pkg-config \
+           tzdata \
+           zlib1g-dev
+RUN wget https://swift.org/builds/swift-5.3.3-release/ubuntu1604/swift-5.3.3-RELEASE/swift-5.3.3-RELEASE-ubuntu16.04.tar.gz
+RUN tar xzf swift-5.3.3-RELEASE-ubuntu16.04.tar.gz
+RUN cp -r swift-5.3.3-RELEASE-ubuntu16.04/usr/* /usr/
+
+# generic swift symbolizer
+RUN apt-get update && apt-get install -y build-essential make cmake ninja-build git python3 g++-multilib binutils-dev zlib1g-dev --no-install-recommends
+RUN git clone --depth 1 https://github.com/llvm/llvm-project.git
+COPY llvmsymbol.diff $SRC
+
+# specific to project
+RUN git clone --depth 1 https://github.com/grpc/grpc-swift
+COPY build.sh $SRC
+COPY *.swift $SRC/
+COPY patch.diff $SRC/
+WORKDIR $SRC/grpc-swift

--- a/projects/grpc-swift/Package.swift
+++ b/projects/grpc-swift/Package.swift
@@ -1,0 +1,39 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "grpc-swift-fuzz",
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        .package(name: "grpc-swift", path: ".."),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "grpc-swift-fuzz",
+            dependencies: [
+                .target(name: "EchoImplementation"),
+                .product(name: "GRPC", package: "grpc-swift")
+            ]),
+
+        .target(
+            name: "EchoImplementation",
+            dependencies: [
+                .target(name: "EchoModel"),
+                .product(name: "GRPC", package: "grpc-swift"),
+                ],
+            path: "Sources/Echo/Implementation"
+        ),
+
+        .target(
+            name: "EchoModel",
+            dependencies: [
+                .product(name: "GRPC", package: "grpc-swift"),
+                ],
+            path: "Sources/Echo/Model"
+        ),
+    ]
+)

--- a/projects/grpc-swift/build.sh
+++ b/projects/grpc-swift/build.sh
@@ -19,7 +19,16 @@
 (
 cd $SRC/llvm-project
 git apply ../llvmsymbol.diff
-cmake -G "Ninja" -DLIBCXX_ENABLE_SHARED=OFF -DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON -DLIBCXXABI_ENABLE_SHARED=OFF -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=X86 -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLLVM_BUILD_TESTS=OFF -DLLVM_INCLUDE_TESTS=OFF llvm
+cmake -G "Ninja" \
+    -DLIBCXX_ENABLE_SHARED=OFF \
+    -DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON \
+    -DLIBCXXABI_ENABLE_SHARED=OFF \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DLLVM_TARGETS_TO_BUILD=X86 \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    -DLLVM_BUILD_TESTS=OFF \
+    -DLLVM_INCLUDE_TESTS=OFF llvm
 ninja -j$(nproc) llvm-symbolizer
 cp bin/llvm-symbolizer $OUT/
 )
@@ -34,12 +43,21 @@ cp -r ../Sources/Examples/Echo Sources/
 cp $SRC/Package.swift Package.swift
 # Maybe we should have a helper script to set $SWIFT_FLAGS
 # for instance about -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION in -Xcc
-swift build -c debug -Xswiftc -sanitize=fuzzer,address -Xswiftc -parse-as-library -Xswiftc -static-stdlib -Xswiftc -use-ld=/usr/bin/ld --static-swift-stdlib  --sanitize=address -Xcc="-fsanitize=fuzzer-no-link,address" -Xcxx="-fsanitize=fuzzer-no-link,address"
+swift build -c debug -Xswiftc -sanitize=fuzzer,address \
+    -Xswiftc -parse-as-library -Xswiftc -static-stdlib \
+    -Xswiftc -use-ld=/usr/bin/ld --static-swift-stdlib \
+    --sanitize=address -Xcc="-fsanitize=fuzzer-no-link,address" \
+    -Xcxx="-fsanitize=fuzzer-no-link,address"
+
 (
 cd .build/debug/
 find . -maxdepth 1 -type f -name "*fuzz" -executable | while read i; do cp $i $OUT/"$i"-debug; done
 )
-swift build -c release -Xswiftc -sanitize=fuzzer,address -Xswiftc -parse-as-library -Xswiftc -static-stdlib -Xswiftc -use-ld=/usr/bin/ld --static-swift-stdlib  --sanitize=address -Xcc="-fsanitize=fuzzer-no-link,address" -Xcxx="-fsanitize=fuzzer-no-link,address"
+swift build -c release -Xswiftc -sanitize=fuzzer,address \
+    -Xswiftc -parse-as-library -Xswiftc -static-stdlib \
+    -Xswiftc -use-ld=/usr/bin/ld --static-swift-stdlib \
+    --sanitize=address -Xcc="-fsanitize=fuzzer-no-link,address" \
+    -Xcxx="-fsanitize=fuzzer-no-link,address"
 (
 cd .build/release/
 find . -maxdepth 1 -type f -name "*fuzz" -executable | while read i; do cp $i $OUT/"$i"-release; done

--- a/projects/grpc-swift/build.sh
+++ b/projects/grpc-swift/build.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# generic swift symbolizer
+(
+cd $SRC/llvm-project
+git apply ../llvmsymbol.diff
+cmake -G "Ninja" -DLIBCXX_ENABLE_SHARED=OFF -DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON -DLIBCXXABI_ENABLE_SHARED=OFF -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=X86 -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLLVM_BUILD_TESTS=OFF -DLLVM_INCLUDE_TESTS=OFF llvm
+ninja -j$(nproc) llvm-symbolizer
+cp bin/llvm-symbolizer $OUT/
+)
+
+git apply $SRC/patch.diff
+# build project
+mkdir grpc-swift-fuzz
+cd grpc-swift-fuzz
+swift package init --type=executable
+cp $SRC/fuzz_pipeline_configurator.swift Sources/grpc-swift-fuzz/main.swift
+cp -r ../Sources/Examples/Echo Sources/
+cp $SRC/Package.swift Package.swift
+# Maybe we should have a helper script to set $SWIFT_FLAGS
+# for instance about -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION in -Xcc
+swift build -c debug -Xswiftc -sanitize=fuzzer,address -Xswiftc -parse-as-library -Xswiftc -static-stdlib -Xswiftc -use-ld=/usr/bin/ld --static-swift-stdlib  --sanitize=address -Xcc="-fsanitize=fuzzer-no-link,address" -Xcxx="-fsanitize=fuzzer-no-link,address"
+(
+cd .build/debug/
+find . -maxdepth 1 -type f -name "*fuzz" -executable | while read i; do cp $i $OUT/"$i"-debug; done
+)
+swift build -c release -Xswiftc -sanitize=fuzzer,address -Xswiftc -parse-as-library -Xswiftc -static-stdlib -Xswiftc -use-ld=/usr/bin/ld --static-swift-stdlib  --sanitize=address -Xcc="-fsanitize=fuzzer-no-link,address" -Xcxx="-fsanitize=fuzzer-no-link,address"
+(
+cd .build/release/
+find . -maxdepth 1 -type f -name "*fuzz" -executable | while read i; do cp $i $OUT/"$i"-release; done
+)

--- a/projects/grpc-swift/fuzz_pipeline_configurator.swift
+++ b/projects/grpc-swift/fuzz_pipeline_configurator.swift
@@ -1,0 +1,30 @@
+import GRPC
+import NIO
+import EchoImplementation
+
+@_cdecl("LLVMFuzzerTestOneInput")
+public func test(_ start: UnsafeRawPointer, _ count: Int) -> CInt {
+    let bytes = UnsafeRawBufferPointer(start: start, count: count)
+
+    let channel = EmbeddedChannel()
+    let configuration = Server.Configuration(
+        target: .unixDomainSocket("/ignored"),
+        eventLoopGroup: channel.eventLoop,
+        serviceProviders: [EchoProvider()]
+    )
+    let handler = GRPCServerPipelineConfigurator(configuration: configuration)
+
+    var buffer = channel.allocator.buffer(capacity: count)
+    buffer.writeBytes(bytes)
+    do {
+        try channel.pipeline.addHandler(handler).wait()
+        try channel.writeInbound(buffer)
+        channel.embeddedEventLoop.run()
+    } catch {
+    }
+    do {
+        try _ = channel.finish(acceptAlreadyClosed: true)
+    } catch {
+    }
+    return 0
+}

--- a/projects/grpc-swift/llvmsymbol.diff
+++ b/projects/grpc-swift/llvmsymbol.diff
@@ -1,0 +1,51 @@
+diff --git a/llvm/lib/DebugInfo/Symbolize/CMakeLists.txt b/llvm/lib/DebugInfo/Symbolize/CMakeLists.txt
+index acfb3bd0e..5c4cf9763 100644
+--- a/llvm/lib/DebugInfo/Symbolize/CMakeLists.txt
++++ b/llvm/lib/DebugInfo/Symbolize/CMakeLists.txt
+@@ -12,4 +12,12 @@ add_llvm_component_library(LLVMSymbolize
+   Object
+   Support
+   Demangle
+-  )
++
++  LINK_LIBS
++  /usr/lib/swift_static/linux/libswiftCore.a
++  /usr/lib/swift_static/linux/libswiftImageInspectionShared.a
++  /usr/lib/swift_static/linux/libicui18nswift.a
++  /usr/lib/swift_static/linux/libicuucswift.a
++  /usr/lib/swift_static/linux/libicudataswift.a
++  /usr/lib/x86_64-linux-gnu/libstdc++.so.6
++)
+diff --git a/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp b/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
+index 4c3f3a3767e1..aa7b9f0f5abb 100644
+--- a/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
++++ b/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
+@@ -36,6 +36,13 @@
+ #include <cassert>
+ #include <cstring>
+ 
++
++extern "C" char *swift_demangle(const char *mangledName,
++                     size_t mangledNameLength,
++                     char *outputBuffer,
++                     size_t *outputBufferSize,
++                     uint32_t flags);
++
+ namespace llvm {
+ namespace symbolize {
+ 
+@@ -632,6 +639,14 @@ LLVMSymbolizer::DemangleName(const std::string &Name,
+     free(DemangledName);
+     return Result;
+   }
++  if (!Name.empty() && Name.front() == '$') {
++    char *DemangledName = swift_demangle(Name.c_str(), Name.length(), 0, 0, 0);
++    if (DemangledName) {
++      std::string Result = DemangledName;
++      free(DemangledName);
++      return Result;
++    }
++  }
+ 
+   if (DbiModuleDescriptor && DbiModuleDescriptor->isWin32Module())
+     return std::string(demanglePE32ExternCFunc(Name));

--- a/projects/grpc-swift/patch.diff
+++ b/projects/grpc-swift/patch.diff
@@ -1,0 +1,62 @@
+diff --git a/Sources/GRPC/GRPCServerPipelineConfigurator.swift b/Sources/GRPC/GRPCServerPipelineConfigurator.swift
+index 4a0c143..1a02cd7 100644
+--- a/Sources/GRPC/GRPCServerPipelineConfigurator.swift
++++ b/Sources/GRPC/GRPCServerPipelineConfigurator.swift
+@@ -25,9 +25,9 @@ import NIOTLS
+ /// If TLS is enabled then the handler listens for an 'TLSUserEvent.handshakeCompleted' event and
+ /// configures the pipeline appropriately for the protocol negotiated via ALPN. If TLS is not
+ /// configured then the HTTP version is determined by parsing the inbound byte stream.
+-final class GRPCServerPipelineConfigurator: ChannelInboundHandler, RemovableChannelHandler {
+-  internal typealias InboundIn = ByteBuffer
+-  internal typealias InboundOut = ByteBuffer
++public final class GRPCServerPipelineConfigurator: ChannelInboundHandler, RemovableChannelHandler {
++  public typealias InboundIn = ByteBuffer
++  public typealias InboundOut = ByteBuffer
+ 
+   /// The server configuration.
+   private let configuration: Server.Configuration
+@@ -57,7 +57,7 @@ final class GRPCServerPipelineConfigurator: ChannelInboundHandler, RemovableChan
+     case configuring
+   }
+ 
+-  init(configuration: Server.Configuration) {
++  public init(configuration: Server.Configuration) {
+     if let tls = configuration.tls {
+       self.state = .notConfigured(alpn: .expected(required: tls.requireALPN))
+     } else {
+@@ -251,7 +251,7 @@ final class GRPCServerPipelineConfigurator: ChannelInboundHandler, RemovableChan
+ 
+   // MARK: - Channel Handler
+ 
+-  internal func errorCaught(context: ChannelHandlerContext, error: Error) {
++  public func errorCaught(context: ChannelHandlerContext, error: Error) {
+     if let delegate = self.configuration.errorDelegate {
+       let baseError: Error
+ 
+@@ -267,7 +267,7 @@ final class GRPCServerPipelineConfigurator: ChannelInboundHandler, RemovableChan
+     context.close(mode: .all, promise: nil)
+   }
+ 
+-  internal func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
++  public func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
+     switch self.state {
+     case let .notConfigured(alpn: .expected(required)):
+       if let event = event as? TLSUserEvent {
+@@ -283,7 +283,7 @@ final class GRPCServerPipelineConfigurator: ChannelInboundHandler, RemovableChan
+     context.fireUserInboundEventTriggered(event)
+   }
+ 
+-  internal func channelRead(context: ChannelHandlerContext, data: NIOAny) {
++  public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+     self.bufferedReads.append(data)
+ 
+     switch self.state {
+@@ -302,7 +302,7 @@ final class GRPCServerPipelineConfigurator: ChannelInboundHandler, RemovableChan
+     // Don't forward the reads: we'll do so when we have configured the pipeline.
+   }
+ 
+-  internal func removeHandler(
++  public func removeHandler(
+     context: ChannelHandlerContext,
+     removalToken: ChannelHandlerContext.RemovalToken
+   ) {

--- a/projects/grpc-swift/project.yaml
+++ b/projects/grpc-swift/project.yaml
@@ -1,7 +1,9 @@
 homepage: "https://github.com/grpc/grpc-swift"
 language: swift
-primary_contact: "timburks@google.com"
+primary_contact: "gbarnett@apple.com"
 auto_ccs :
+- "lukasa@apple.com"
+- "pp_adams@apple.com"
 - "p.antoine@catenacyber.fr"
 fuzzing_engines:
 - libfuzzer

--- a/projects/grpc-swift/project.yaml
+++ b/projects/grpc-swift/project.yaml
@@ -1,0 +1,11 @@
+homepage: "https://github.com/grpc/grpc-swift"
+language: swift
+primary_contact: "timburks@google.com"
+auto_ccs :
+- "p.antoine@catenacyber.fr"
+
+fuzzing_engines:
+- libfuzzer
+sanitizers:
+- address
+main_repo: 'https://github.com/grpc/grpc-swift'

--- a/projects/grpc-swift/project.yaml
+++ b/projects/grpc-swift/project.yaml
@@ -3,7 +3,6 @@ language: swift
 primary_contact: "timburks@google.com"
 auto_ccs :
 - "p.antoine@catenacyber.fr"
-
 fuzzing_engines:
 - libfuzzer
 sanitizers:


### PR DESCRIPTION
@timburks would you be interested in continuous fuzzing for grpc-swift ?
This would be the 3rd swift project on oss-fuzz

I built a fuzz target with `GRPCServerPipelineConfigurator` as is done in unit tests
So I need a small patch to make this structure public...
I tried with a TCP server, but that was like 100 times slower...
I guess a long term solution would be to have fuzz integration in swift like there is unit tests integration...

With the HTTP2 magic sequence as corpus, it finds a `Fatal error: Unexpectedly found nil while unwrapping an Optional value` in `NIOHTTP2`

