### PR TITLE
[CRAS] Fix build error

### DIFF
--- a/projects/cras/Dockerfile
+++ b/projects/cras/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get -y update && \
       libtool \
       libudev-dev \
       wget \
+      vim \
       zip
 RUN apt-get clean
 RUN cd /tmp && git clone https://github.com/ndevilla/iniparser.git && \


### PR DESCRIPTION
Install vim to get `xxd` for source generation.

BUG=oss-fuzz:33362