### PR TITLE
Fix typos and one link

### DIFF
--- a/docs/further-reading/clusterfuzz.md
+++ b/docs/further-reading/clusterfuzz.md
@@ -46,7 +46,7 @@ information, memory usage) on our fuzzer statistics dashboard.
 
 We provide coverage reports, where we highlight the parts of source code that
 are being reached by your fuzz target. Make sure to look at the uncovered code
-marked in red and add appropriate fuzz targets to cover those usecases.
+marked in red and add appropriate fuzz targets to cover those use cases.
 
 ![coverage_1]({{ site.baseurl }}/images/freetype_coverage_1.png?raw=true)
 ![coverage_2]({{ site.baseurl }}/images/freetype_coverage_2.png?raw=true)

--- a/docs/further-reading/fuzzer_environment.md
+++ b/docs/further-reading/fuzzer_environment.md
@@ -43,7 +43,7 @@ We strongly recommend static linking because it just works.
 However dynamic linking can work if shared objects are included in the `$OUT` directory and are loaded relative
 to `'$ORIGIN'`, the path of the binary (see the discussion of `'$ORIGIN'` [here](http://man7.org/linux/man-pages/man8/ld.so.8.html)).
 A fuzzer can be instructed to load libraries relative to `'$ORIGIN'` during compilation (i.e. `-Wl,-rpath,'$ORIGIN/lib'` )
-or afterwards using `chrpath -r '$ORIGIN/lib' $OUT/$fuzzerName` ([example](https://github.com/google/oss-fuzz/blob/09aa9ac556f97bd4e31928747eca0c8fed42509f/projects/php/build.sh#L40)). Note that `'$ORIGIN'` should be surronded
+or afterwards using `chrpath -r '$ORIGIN/lib' $OUT/$fuzzerName` ([example](https://github.com/google/oss-fuzz/blob/09aa9ac556f97bd4e31928747eca0c8fed42509f/projects/php/build.sh#L40)). Note that `'$ORIGIN'` should be surrounded
 by single quotes because it is not an environment variable like `$OUT` that can be retrieved during execution of `build.sh`.
 Its value is retrieved during execution of the binary. You can verify that you did this correctly using `ldd <fuzz_target_name>` and the `check_build` command in `infra/helper.py`.
 

--- a/docs/getting-started/new-project-guide/bazel.md
+++ b/docs/getting-started/new-project-guide/bazel.md
@@ -28,7 +28,7 @@ For Bazel-based projects, we recommend using the
 for defining fuzz tests. `rules_fuzzing` provides support for building and running
 fuzz tests under
 [multiple sanitizer and fuzzing engine configurations][rules-fuzzing-usage].
-It also supports specifying corpora and dictionaires as part of the fuzz test
+It also supports specifying corpora and dictionaries as part of the fuzz test
 definition.
 
 The fuzzing rules provide out-of-the-box support for building and packaging fuzz
@@ -89,7 +89,7 @@ environment variables. The most common are:
 
 * `BAZEL_EXTRA_BUILD_FLAGS` are extra build flags passed on the Bazel command
    line.
-* `BAZEL_FUZZ_TEST_TAG` and `BAZEL_FUZZ_TEST_EXCLUDE_TAG` can be overriden to
+* `BAZEL_FUZZ_TEST_TAG` and `BAZEL_FUZZ_TEST_EXCLUDE_TAG` can be overridden to
   specify which target tags to use when determining what fuzz tests to include.
   By default, the tool selects all the fuzz tests except for those tagged as
   `"no-oss-fuzz"`.

--- a/docs/getting-started/new_project_guide.md
+++ b/docs/getting-started/new_project_guide.md
@@ -252,7 +252,7 @@ Sometimes not every 3rd party library might be needed to be instrumented or
 tools are being compiled that just support the target built.
 
 If for any reasons part of the build process should not be instrumented
-then the following code snippit can be used for this:
+then the following code snippet can be used for this:
 
 ```
 CFLAGS_SAVE="$CFLAGS"
@@ -392,7 +392,7 @@ of good sample inputs is one of the best ways to improve [fuzz target]({{ site.b
 
 To provide a corpus for `my_fuzzer`, put `my_fuzzer_seed_corpus.zip` file next
 to the [fuzz target]({{ site.baseurl }}/reference/glossary/#fuzz-target)'s binary in `$OUT` during the build. Individual files in this
-archive will be used as starting inputs for mutations. The name of each file in the corpus is the sha1 checksum (which you can get using the `sha1sum` or `shasum` comand) of its contents. You can store the corpus
+archive will be used as starting inputs for mutations. The name of each file in the corpus is the sha1 checksum (which you can get using the `sha1sum` or `shasum` command) of its contents. You can store the corpus
 next to source files, generate during build or fetch it using curl or any other
 tool of your choice.
 (example: [boringssl](https://github.com/google/oss-fuzz/blob/master/projects/boringssl/build.sh#L41)).

--- a/docs/oss-fuzz/architecture.md
+++ b/docs/oss-fuzz/architecture.md
@@ -16,7 +16,7 @@ one or more [fuzz targets](http://libfuzzer.info/#fuzz-target)
 and [integrates]({{ site.baseurl }}/advanced-topics/ideal-integration/) them
 with the project's build and test system.
 1. The project is [accepted to OSS-Fuzz]({{ site.baseurl }}/getting-started/accepting-new-projects/) and the developer commits their build configurations.
-1. The OSS-Fuzz [builder](jenkins.io) builds the project from the committed configs.
+1. The OSS-Fuzz [builder](https://jenkins.io) builds the project from the committed configs.
 1. The builder uploads the fuzz targets to the OSS-Fuzz GCS bucket.
 1. [ClusterFuzz]({{ site.baseurl }}/further-reading/clusterfuzz) downloads the fuzz targets and begins to fuzz the projects.
 1. When Clusterfuzz finds a

--- a/docs/oss-fuzz/architecture.md
+++ b/docs/oss-fuzz/architecture.md
@@ -16,7 +16,7 @@ one or more [fuzz targets](http://libfuzzer.info/#fuzz-target)
 and [integrates]({{ site.baseurl }}/advanced-topics/ideal-integration/) them
 with the project's build and test system.
 1. The project is [accepted to OSS-Fuzz]({{ site.baseurl }}/getting-started/accepting-new-projects/) and the developer commits their build configurations.
-1. The OSS-Fuzz [builder](https://jenkins.io) builds the project from the committed configs.
+1. The OSS-Fuzz [builder](https://github.com/google/oss-fuzz/tree/master/infra/build) builds the project from the committed configs.
 1. The builder uploads the fuzz targets to the OSS-Fuzz GCS bucket.
 1. [ClusterFuzz]({{ site.baseurl }}/further-reading/clusterfuzz) downloads the fuzz targets and begins to fuzz the projects.
 1. When Clusterfuzz finds a

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -92,7 +92,7 @@ These flags can be overridden by specifying `$SANITIZER_FLAGS` directly.
 You can choose which configurations to automatically run your fuzzers with in `project.yaml` file (e.g. [sqlite3](https://github.com/google/oss-fuzz/tree/master/projects/sqlite3/project.yaml)).
 
 ### Architectures
-ClusterFuzz supports fuzzing on x86_64 (aka x64) by default. However you can also fuzz using AddressSanitizer and libFuzzer on i386 (aka x86, or 32 bit) by specifiying the `$ARCHITECTURE` build environment variable using the `--architecture` option:
+ClusterFuzz supports fuzzing on x86_64 (aka x64) by default. However you can also fuzz using AddressSanitizer and libFuzzer on i386 (aka x86, or 32 bit) by specifying the `$ARCHITECTURE` build environment variable using the `--architecture` option:
 
 ```bash
 python infra/helper.py build_fuzzers --architecture i386 json


### PR DESCRIPTION
Hello,

Found a few typos reading the docs, then ran the code inspection tool from within WebStorm. Not a native speaker, so feel free to suggest edits :+1: 

The link to Jenkins was broken due to the missing protocol — Markdown link gets resolved to relative path, causing the error.

Thanks for OSS Fuzz!

Bruno