### PR TITLE
Set rpath on js binary to properly resolve included libraries on runner

### DIFF
--- a/projects/spidermonkey/Dockerfile
+++ b/projects/spidermonkey/Dockerfile
@@ -21,7 +21,8 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
   libc++abi1 \
   m4 \
   yasm \
-  python
+  python \
+  patchelf
 
 # This wrapper of cargo seems to interfere with our build system.
 RUN rm -f /usr/local/bin/cargo

--- a/projects/spidermonkey/build.sh
+++ b/projects/spidermonkey/build.sh
@@ -41,3 +41,6 @@ cp dist/bin/js $OUT
 mkdir -p $OUT/lib
 cp -L /usr/lib/x86_64-linux-gnu/libc++.so.1 $OUT/lib
 cp -L /usr/lib/x86_64-linux-gnu/libc++abi.so.1 $OUT/lib
+
+# Make sure libs are resolved properly
+patchelf --set-rpath '$ORIGIN/lib'  $OUT/js


### PR DESCRIPTION
Cc @oliverchang @inferno-chromium

This builds locally for me but of course I can't test locally if it will fix the problem.