### PR TITLE
clean up linkerd2 build.

### DIFF
--- a/projects/linkerd2-proxy/build.sh
+++ b/projects/linkerd2-proxy/build.sh
@@ -19,12 +19,9 @@ TARGET_PATH="./fuzz/target/x86_64-unknown-linux-gnu/release"
 BASE="$SRC/linkerd2-proxy/linkerd"
 BUILD_FUZZER="cargo +nightly fuzz build --features fuzzing"
 
-# Only compile inbound if there is no coverage
-if [ $SANITIZER != "coverage" ]; then
-	cd ${BASE}/app/inbound
-	RUSTFLAGS="--cap-lints warn" ${BUILD_FUZZER}
-	cp ${TARGET_PATH}/fuzz_target_1 $OUT/fuzz_inbound
-fi
+cd ${BASE}/app/inbound
+${BUILD_FUZZER}
+cp ${TARGET_PATH}/fuzz_target_1 $OUT/fuzz_inbound
 
 cd ${BASE}/addr/
 ${BUILD_FUZZER}
@@ -45,6 +42,4 @@ cp ${TARGET_PATH}/fuzz_target_1 $OUT/fuzz_tls
 cd ${BASE}/transport-header
 ${BUILD_FUZZER}
 cp ${TARGET_PATH}/fuzz_target_raw $OUT/fuzz_transport_raw
-if [ $SANITIZER != "coverage" ]; then
-	cp ${TARGET_PATH}/fuzz_target_structured $OUT/fuzz_transport_structured
-fi
+cp ${TARGET_PATH}/fuzz_target_structured $OUT/fuzz_transport_structured


### PR DESCRIPTION
Enable coverage for all fuzzers and remove limitation on lints. 
This is following upstream fixes, namely https://github.com/linkerd/linkerd2-proxy/pull/983 and https://github.com/linkerd/linkerd2-proxy/pull/977