### PR TITLE
Disable java-example

### DIFF
--- a/projects/java-example/project.yaml
+++ b/projects/java-example/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/CodeIntelligenceTesting/jazzer"
+disabled: true
 language: jvm
 primary_contact: "meumertzheim@code-intelligence.com"
 fuzzing_engines:


### PR DESCRIPTION
`java-example` has produced all the expected findings and there are now sufficiently many Java projects with status badges that build failures caused by issues with Jazzer would be noticed quickly.