### PR TITLE
Add peter's google account to apache commons

### DIFF
--- a/projects/apache-commons/project.yaml
+++ b/projects/apache-commons/project.yaml
@@ -6,6 +6,7 @@ auto_ccs:
   - "boards@gmail.com"
   - "brunodepaulak@gmail.com"
   - "meumertzheim@code-intelligence.com"
+  - "peteralfredlee@gmail.com"
 fuzzing_engines:
   - libfuzzer
 main_repo: "https://gitbox.apache.org/repos/asf/commons-compress.git"


### PR DESCRIPTION
I'm committer of Apache Commons and I got a google account(peteralfredlee@gmail.com), so I'm adding myself to the `auto_ccs` of apache commons. And I'm working with primary contact @bodewig in apache commons.

I'm not familiar with the procedure of oss-fuzz, do I need @bodewig to sign off my PR?