### PR TITLE
cras: Add rust source soft links for coverage build

### DIFF
--- a/projects/cras/build.sh
+++ b/projects/cras/build.sh
@@ -44,3 +44,5 @@ done
 
 zip -j ${OUT}/rclient_message_corpus.zip ${SRC}/adhd/cras/src/fuzz/corpus/*
 cp "${SRC}/adhd/cras/src/fuzz/cras_hfp_slc.dict" "${OUT}/cras_hfp_slc.dict"
+# Add *.rs soft link for coverage build
+ln -s ${SRC}/adhd/cras/src/server/rust/src/* ${SRC}


### PR DESCRIPTION
Fix build failures:
```
error: /out/src/rate_estimator.rs: No such file or directory
warning: The file '/src/rate_estimator.rs' isn't covered.
error: /out/src/rate_estimator_bindings.rs: No such file or directory
warning: The file '/src/rate_estimator_bindings.rs' isn't covered.
```

Bug: crbug/oss-fuzz/31910
Test: {build_fuzzer, coverage} commands in infra/helper.py for cras