### PR TITLE
zeek: add extra configure option

### DIFF
--- a/projects/zeek/build.sh
+++ b/projects/zeek/build.sh
@@ -20,11 +20,11 @@ CFLAGS="${CFLAGS} -pthread" CXXFLAGS="${CXXFLAGS} -pthread" \
                 --build-type=debug \
                 --generator=Ninja \
                 --enable-fuzzers \
+                --enable-mobile-ipv6 \
                 --disable-python \
                 --disable-zeekctl \
                 --disable-auxtools \
                 --disable-broker-tests
-
 
 cd build
 ninja install

--- a/projects/zeek/project.yaml
+++ b/projects/zeek/project.yaml
@@ -11,6 +11,9 @@ auto_ccs:
   - "vern@corelight.com"
   - "vlad@es.net"
   - "dominik.charousset@corelight.com"
+fuzzing_engines:
+  - libfuzzer
+  - honggfuzz
 sanitizers:
   - address
 main_repo: 'https://github.com/zeek/zeek'


### PR DESCRIPTION
This PR adds the `--enable-mobile-ipv6` option to the build for the Zeek project, since we were lacking coverage for that code.