### PR TITLE
Update Boost download location in all projects

### DIFF
--- a/projects/bearssl/Dockerfile
+++ b/projects/bearssl/Dockerfile
@@ -20,5 +20,5 @@ RUN git clone --depth 1 https://www.bearssl.org/git/BearSSL
 RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora
-RUN wget https://dl.bintray.com/boostorg/release/1.74.0/source/boost_1_74_0.tar.bz2
+RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 COPY build.sh $SRC/

--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -54,6 +54,6 @@ RUN git clone --depth 1 https://github.com/trezor/trezor-firmware.git
 RUN git clone --depth 1 https://github.com/Cyan4973/xxHash.git
 RUN apt-get remove -y libunwind8
 RUN apt-get install -y libssl-dev
-RUN wget https://dl.bintray.com/boostorg/release/1.74.0/source/boost_1_74_0.tar.bz2
+RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 
 COPY build.sh xxd.c $SRC/

--- a/projects/libecc/Dockerfile
+++ b/projects/libecc/Dockerfile
@@ -19,5 +19,5 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool wget pyt
 RUN git clone https://github.com/ANSSI-FR/libecc.git
 RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
-RUN wget https://dl.bintray.com/boostorg/release/1.74.0/source/boost_1_74_0.tar.bz2
+RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 COPY build.sh $SRC/

--- a/projects/libressl/Dockerfile
+++ b/projects/libressl/Dockerfile
@@ -20,7 +20,7 @@ RUN git clone --depth 1 https://github.com/libressl-portable/portable.git libres
 RUN git clone --depth 1 https://github.com/libressl-portable/fuzz.git libressl.fuzzers
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora
-RUN wget https://dl.bintray.com/boostorg/release/1.74.0/source/boost_1_74_0.tar.bz2
+RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 WORKDIR libressl
 RUN ./update.sh
 COPY build.sh *.options $SRC/

--- a/projects/msgpack-c/Dockerfile
+++ b/projects/msgpack-c/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y cmake wget bzip2
 RUN git clone --depth 1 --single-branch --branch cpp_master https://github.com/msgpack/msgpack-c.git msgpack-c
 
-RUN wget https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 && \
+RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.70.0/source/boost_1_70_0.tar.bz2 && \
     tar xf boost_1_70_0.tar.bz2 && \
     cd boost_1_70_0 && \
     ./bootstrap.sh --with-toolset=clang --prefix=/usr && \

--- a/projects/nettle/Dockerfile
+++ b/projects/nettle/Dockerfile
@@ -20,6 +20,6 @@ RUN git clone --depth 1 https://git.lysator.liu.se/nettle/nettle
 RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora
-RUN wget https://dl.bintray.com/boostorg/release/1.74.0/source/boost_1_74_0.tar.bz2
+RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 RUN wget https://gmplib.org/download/gmp/gmp-6.2.0.tar.lz
 COPY build.sh $SRC/

--- a/projects/relic/Dockerfile
+++ b/projects/relic/Dockerfile
@@ -19,5 +19,5 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool wget pyt
 RUN git clone --depth 1 https://github.com/relic-toolkit/relic.git
 RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
-RUN wget https://dl.bintray.com/boostorg/release/1.74.0/source/boost_1_74_0.tar.bz2
+RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 COPY build.sh $SRC/

--- a/projects/solidity/Dockerfile
+++ b/projects/solidity/Dockerfile
@@ -28,7 +28,7 @@ RUN git clone --branch="v0.4.0" --recurse-submodules \
 # Install statically built dependencies in "/usr" directory
 # Install boost
 RUN cd $SRC; \
-    wget -q 'https://dl.bintray.com/boostorg/release/1.73.0/source/boost_1_73_0.tar.bz2' -O boost.tar.bz2; \
+    wget -q 'https://boostorg.jfrog.io/artifactory/main/release/1.73.0/source/boost_1_73_0.tar.bz2' -O boost.tar.bz2; \
     test "$(sha256sum boost.tar.bz2)" = "4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402  boost.tar.bz2"; \
     tar -xf boost.tar.bz2; \
     rm boost.tar.bz2; \

--- a/projects/wolfssl/Dockerfile
+++ b/projects/wolfssl/Dockerfile
@@ -24,7 +24,7 @@ RUN git clone --depth 1 https://github.com/guidovranken/wolf-ssl-ssh-fuzzers
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone --depth 1 https://github.com/google/wycheproof.git
-RUN wget https://dl.bintray.com/boostorg/release/1.74.0/source/boost_1_74_0.tar.bz2
+RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 RUN git clone https://github.com/wolfssl/oss-fuzz-targets --depth 1 $SRC/fuzz-targets
 
 WORKDIR wolfssl


### PR DESCRIPTION
Bintray, where Boost was hosted, is shutting down, and downloads
from this location will eventually fail.
Files are now hosted at jfrog.io.
See also: https://lists.boost.org/Archives/boost/2021/04/251458.php