### PR TITLE
[lxc] turn off AFL for now

### DIFF
--- a/projects/lxc/project.yaml
+++ b/projects/lxc/project.yaml
@@ -10,3 +10,6 @@ auto_ccs:
   - stgraber@stgraber.org
   - evverx@gmail.com
 main_repo: "https://github.com/lxc/lxc"
+fuzzing_engines:
+  - libfuzzer
+  - honggfuzz


### PR DESCRIPTION
[lxc] turn off AFL for now

It seems LXC is failing to compile with AFL with
```
../../src/lxc/storage -pthread -O1 -fno-omit-frame-pointer -gline-tables-only -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=address -fsanitize-address-use-after-scope -stdlib=libc++ -Wl,--as-needed -Wl,--gc-sections -Wl,-z -Wl,relro -Wl,-z -Wl,now -pie -Wl,-fuse-ld=gold -o fuzz-lxc-define-load fuzz_lxc_define_load-fuzz-lxc-define-load.o  ../lxc/.libs/liblxc.a /usr/lib/libFuzzingEngine.a -lpthread -pthread
Step #32: /usr/bin/ld: /usr/lib/libFuzzingEngine.a(aflpp_driver.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
Step #32: /usr/lib/libFuzzingEngine.a: error adding symbols: Bad value
Step #32: clang-12: [0;1;31merror: [0m[1mlinker command failed with exit code 1 (use -v to see invocation)[0m
Step #32: make[3]: *** [fuzz-lxc-config-read] Error 1
```

Apparently aflpp tends to misdetect compiler/linker features 30% (70%?)
of the time: https://github.com/google/oss-fuzz/issues/4280#issuecomment-829733181