### PR TITLE
Duckdb: initial integration

### DIFF
--- a/projects/duckdb/Dockerfile
+++ b/projects/duckdb/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN git clone https://github.com/duckdb/duckdb duckdb
+WORKDIR duckdb
+COPY build.sh $SRC/
+COPY parse_fuzz_test.cpp $SRC/duckdb/parse_fuzz_test.cpp

--- a/projects/duckdb/build.sh
+++ b/projects/duckdb/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+make
+THIRD_PARTY_LIBS=$(find ./build/release/third_party/ -name "*.a")
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE ./parse_fuzz_test.cpp \
+    -o $OUT/parse_fuzz_test -I./ -I./src/include \
+    ./build/release/src/libduckdb_static.a \
+    ${THIRD_PARTY_LIBS}

--- a/projects/duckdb/parse_fuzz_test.cpp
+++ b/projects/duckdb/parse_fuzz_test.cpp
@@ -1,0 +1,23 @@
+/* Copyright 2021 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "duckdb/parser/parser.hpp"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    std::string input(reinterpret_cast<const char*>(data), size);
+    duckdb::Parser parser;
+    try {
+       parser.ParseQuery(input);
+    } catch (std::exception &e) {}
+
+    return 0;
+}

--- a/projects/duckdb/project.yaml
+++ b/projects/duckdb/project.yaml
@@ -1,4 +1,7 @@
 homepage: "https://duckdb.org/"
 language: c++
-primary_contact: "david@adalogics.com"
+primary_contact: "quack@duckdb.org"
 main_repo: "https://github.com/duckdb/duckdb/"
+auto_ccs: 
+  - "hannes.muehleisen@gmail.com"
+  - "david@adalogics.com

--- a/projects/duckdb/project.yaml
+++ b/projects/duckdb/project.yaml
@@ -1,0 +1,4 @@
+homepage: "https://duckdb.org/"
+language: c++
+primary_contact: "david@adalogics.com"
+main_repo: "https://github.com/duckdb/duckdb/"

--- a/projects/duckdb/project.yaml
+++ b/projects/duckdb/project.yaml
@@ -4,4 +4,4 @@ primary_contact: "quack@duckdb.org"
 main_repo: "https://github.com/duckdb/duckdb/"
 auto_ccs: 
   - "hannes.muehleisen@gmail.com"
-  - "david@adalogics.com
+  - "david@adalogics.com"


### PR DESCRIPTION
DuckDB is a an in-process SQL OLAP database management system (https://duckdb.org/) and is used in production by several projects (discussed here https://github.com/duckdb/duckdb/pull/1127).  Another list of projects that use DuckDB is shown here https://duckdb.org/docs/why_duckdb  and is developed by researchers from https://www.cwi.nl/ 


@hannesmuehleisen would you be interested in getting DuckDB into OSS-Fuzz? I can see you already spoke to Adam here https://github.com/duckdb/duckdb/pull/1127 so we completed the integration. If you are interested, the only thing we will need from you is an email(s) that will receive bug reports from OSS-Fuzz which will be listed in the `project.yaml` (see the files added in this commit). 