### PR TITLE
Revert "[lxc] turn off AFL for now (#5685)"

### DIFF
--- a/projects/lxc/project.yaml
+++ b/projects/lxc/project.yaml
@@ -10,6 +10,3 @@ auto_ccs:
   - stgraber@stgraber.org
   - evverx@gmail.com
 main_repo: "https://github.com/lxc/lxc"
-fuzzing_engines:
-  - libfuzzer
-  - honggfuzz


### PR DESCRIPTION
This reverts commit 181b3575afc392c704ae3be02baf0c4b8150cd87.

The issue was fixed in https://github.com/google/oss-fuzz/pull/5691

It should be merged once https://github.com/google/oss-fuzz/pull/5691 lands in the base-builder image