### PR TITLE
Adds rust project tikv

### DIFF
--- a/projects/rust-tikv/Dockerfile
+++ b/projects/rust-tikv/Dockerfile
@@ -16,7 +16,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN apt update && apt install -y build-essential binutils-dev libunwind-dev libblocksruntime-dev liblzma-dev
-RUN cargo install honggfuzz --version 0.5.47
+RUN cargo install honggfuzz
 
 #TODO back to main repo
 RUN git clone --depth 1 --branch ossfuzz https://github.com/catenacyber/tikv.git

--- a/projects/rust-tikv/Dockerfile
+++ b/projects/rust-tikv/Dockerfile
@@ -1,0 +1,28 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN apt update && apt install -y build-essential binutils-dev libunwind-dev libblocksruntime-dev liblzma-dev
+RUN cargo install honggfuzz --version 0.5.47
+
+#TODO back to main repo
+RUN git clone --depth 1 --branch ossfuzz https://github.com/catenacyber/tikv.git
+
+RUN cd $SRC/tikv/fuzz && cargo build
+
+COPY build.sh $SRC/
+
+WORKDIR $SRC/tikv

--- a/projects/rust-tikv/build.sh
+++ b/projects/rust-tikv/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd fuzz
+../target/debug/fuzz list-targets | while read t; do
+    if [ "$FUZZING_ENGINE" = honggfuzz ]; then
+        CFLAGS="" CXXFLAGS="" ../target/debug/fuzz build $FUZZING_ENGINE ${t}
+    fi
+    if [ "$FUZZING_ENGINE" = afl ]; then
+        CC=clang CXX=clang++ CFLAGS="" CXXFLAGS="" RUSTFLAGS="" ../target/debug/fuzz build $FUZZING_ENGINE ${t}
+    fi
+    if [ "$FUZZING_ENGINE" = libfuzzer ]; then
+        ../target/debug/fuzz build $FUZZING_ENGINE ${t}
+    fi
+    find ../target/ -name ${t} -type f | while read i; do cp $i $OUT/; done
+done

--- a/projects/rust-tikv/build.sh
+++ b/projects/rust-tikv/build.sh
@@ -16,6 +16,9 @@
 ################################################################################
 
 cd fuzz
+if [ "$FUZZING_ENGINE" = honggfuzz ]; then
+    cargo update -p honggfuzz
+fi
 ../target/debug/fuzz list-targets | while read t; do
     if [ "$FUZZING_ENGINE" = honggfuzz ]; then
         CFLAGS="" CXXFLAGS="" ../target/debug/fuzz build $FUZZING_ENGINE ${t}

--- a/projects/rust-tikv/project.yaml
+++ b/projects/rust-tikv/project.yaml
@@ -1,0 +1,11 @@
+homepage: "https://tikv.org"
+primary_contact: "koushiro.cqx@gmail.com"
+auto_ccs:
+- "p.antoine@catenacyber.fr"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+  - honggfuzz
+language: rust
+main_repo: 'https://github.com/tikv/tikv.git'


### PR DESCRIPTION
@koushiro @breeswish @overvenus

would you be interested in continuous fuzzing for tikv ?
This PR enables it with oss-fuzz with your existing fuzz targets, with libFuzzer (only)
I added a quick and dirty patch to be able to build the fuzz targets without running them at once...
