### PR TITLE
[libheif] Ensure libaom can be found

### DIFF
--- a/projects/libheif/build.sh
+++ b/projects/libheif/build.sh
@@ -74,7 +74,8 @@ PKG_CONFIG="pkg-config --static" PKG_CONFIG_PATH="$DEPS_PATH/lib/pkgconfig" ./co
     --enable-static \
     --disable-examples \
     --disable-go \
-    --enable-libfuzzer="$LIB_FUZZING_ENGINE"
+    --enable-libfuzzer="$LIB_FUZZING_ENGINE" \
+    CPPFLAGS="-I$DEPS_PATH/include"
 make clean
 make -j$(nproc)
 


### PR DESCRIPTION
It seems that since commit https://github.com/strukturag/libheif/commit/3c9e58125109cc604f953a3dbeb985a40ba2b461 libheif was unable to find the headers of libaom since they are installed in a non-standard prefix.
```
checking for aom... yes
checking aom/aom_decoder.h usability... no
checking aom/aom_decoder.h presence... no
checking for aom/aom_decoder.h... no
checking aom/aom_encoder.h usability... no
checking aom/aom_encoder.h presence... no
checking for aom/aom_encoder.h... no
<snip />
configure: libaom decoder: no
configure: libaom encoder: no
```

This PR resolves that by ensuring that autotools is aware of libaom's include directory.

/cc @fancycode