### PR TITLE
[libigl] Initial integration

### DIFF
--- a/projects/libigl/Dockerfile
+++ b/projects/libigl/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make
+RUN git clone --depth 1 https://github.com/libigl/libigl
+WORKDIR $SRC/libigl
+COPY igl_fuzzer.cpp \
+     build.sh \
+     $SRC/
+

--- a/projects/libigl/build.sh
+++ b/projects/libigl/build.sh
@@ -1,0 +1,39 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+mkdir build-dir && cd build-dir
+cmake -DLIBIGL_WITH_OPENGL=OFF \
+      -DLIBIGL_WITH_OPENGL_GLFW=OFF \
+      -DLIBIGL_WITH_OPENGL_GLFW_IMGUI=OFF \
+      -DLIBIGL_WITH_COMISO=OFF \
+      -DLIBIGL_WITH_EMBREE=OFF \
+      -DLIBIGL_WITH_PNG=OFF \
+      -DLIBIGL_WITH_TETGEN=OFF \
+      -DLIBIGL_WITH_TRIANGLE=OFF \
+      -DLIBIGL_WITH_PREDICATES=OFF \
+      -LIBIGL_WITH_XML=OFF \
+      -DLIBIGL_BUILD_TESTS=ON \
+      ..
+make -j$(nproc)
+
+$CXX $CXXFLAGS -DIGL_STATIC_LIBRARY \
+     -I/src/libigl/include \
+     -isystem /src/libigl/cmake/../include \
+     -isystem /src/libigl/cmake/../external/eigen \
+     -c $SRC/igl_fuzzer.cpp -o fuzzer.o
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzzer.o   \
+     -o $OUT/igl_fuzzer $SRC/libigl/build-dir/libigl.a

--- a/projects/libigl/igl_fuzzer.cpp
+++ b/projects/libigl/igl_fuzzer.cpp
@@ -1,0 +1,37 @@
+/*  Copyright 2021 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <igl/MshLoader.h>
+#include <iostream>
+
+extern "C"
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
+    char *nullt_string = (char *)malloc(size+1);
+    if (nullt_string == NULL){
+            return 0;
+    }
+    memcpy(nullt_string, data, size);
+    nullt_string[size] = '\0';
+    std::ofstream fuzz_file;
+    fuzz_file.open ("fuzz_file.msh");
+    fuzz_file << nullt_string;
+    fuzz_file.close();
+    try {
+    	igl::MshLoader msh_loader("fuzz_file.msh");
+    } catch (...) {}
+    free(nullt_string);
+    return 0;
+}
+

--- a/projects/libigl/project.yaml
+++ b/projects/libigl/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://libigl.github.io"
+language: c++
+primary_contact: ""
+auto_ccs:
+  - "Adam@adalogics.com"
+sanitizers:
+  - address
+  - undefined
+  - memory
+main_repo: "https://github.com/libigl/libigl"

--- a/projects/libigl/project.yaml
+++ b/projects/libigl/project.yaml
@@ -1,6 +1,6 @@
 homepage: "https://libigl.github.io"
 language: c++
-primary_contact: ""
+primary_contact: "github@jdumas.org"
 auto_ccs:
   - "Adam@adalogics.com"
 sanitizers:


### PR DESCRIPTION
Initial integration of [libigl](https://github.com/libigl/libigl).

Companies that use libigl include: 

- Adobe
- Electronic Arts, Inc
- Epic Games
- Microsoft Research
- Ubisoft

An list of selected users can be found here: https://libigl.github.io/#projectsuniversities-using-libigl

______________________________________________________________

@jdumas Are you interested in integrating Libigl into OSS-fuzz?
All we need is an email address for bug reports to complete this PR.
If this gets merged, then https://github.com/libigl/libigl/pull/1802 can be closed.