### PR TITLE
bitcoin-core: Add i386

### DIFF
--- a/projects/bitcoin-core/project.yaml
+++ b/projects/bitcoin-core/project.yaml
@@ -14,6 +14,7 @@ sanitizers:
   - undefined
 architectures:
   - x86_64
+  - i386
 fuzzing_engines:
   - libfuzzer
   - honggfuzz


### PR DESCRIPTION
* Add workaround for `undefined reference to '__mulodi4'`
* Add missing `git checkout --` (bugfix)
* Add i386 architecture