### PR TITLE
[muduo] Initial integration

### DIFF
--- a/projects/muduo/Dockerfile
+++ b/projects/muduo/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make libboost-dev
+RUN git clone --depth 1 https://github.com/chenshuo/muduo
+WORKDIR muduo
+COPY build.sh muduo_http_fuzzer.cpp $SRC/

--- a/projects/muduo/build.sh
+++ b/projects/muduo/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+sed -i '34 a $ENV{CXXFLAGS}' CMakeLists.txt
+mkdir -p build-dir && cd build-dir
+cmake -DCMAKE_BUILD_TYPE="release" \
+      ..
+make -j$(nproc)
+
+$CXX $CXXFLAGS -I/src/muduo \
+	-o muduo_http_fuzzer.o \
+    -c $SRC/muduo_http_fuzzer.cpp
+
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE \
+	muduo_http_fuzzer.o \
+    -o $OUT/muduo_http_fuzzer \
+	./lib/libmuduo_http.a \
+	./lib/libmuduo_net.a \
+	./lib/libmuduo_base.a 

--- a/projects/muduo/muduo_http_fuzzer.cpp
+++ b/projects/muduo/muduo_http_fuzzer.cpp
@@ -1,0 +1,35 @@
+/*  Copyright 2021 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "muduo/net/http/HttpContext.h"
+#include "muduo/net/Buffer.h"
+#include "muduo/base/Timestamp.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
+	char *new_str = (char *)malloc(size+1);
+	if (new_str == NULL){
+		return 0;
+	}
+	memcpy(new_str, data, size);
+	new_str[size] = '\0';
+	
+	muduo::net::HttpContext context;
+	muduo::net::Buffer input;
+	input.append(new_str);
+	context.parseRequest(&input, muduo::Timestamp::now());
+	free(new_str);
+	return 0;
+}

--- a/projects/muduo/project.yaml
+++ b/projects/muduo/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/chenshuo/muduo"
+language: c++
+primary_contact: "chenshuo@chenshuo.com"
+auto_ccs:
+  - "Adam@adalogics.com"
+sanitizers:
+  - address
+  - undefined
+  - memory
+main_repo: "https://github.com/chenshuo/muduo"


### PR DESCRIPTION
Initial integration of [muduo](https://github.com/chenshuo/muduo).

About Muduo usage:

- Muduo is deployed in production to serve hundreds of millions of daily connections (https://github.com/chenshuo/muduo/pull/199#issue-71736961)
- Is considered a competitor to evpp - a project that is used to handle 1000+ billions networking communications every day in production (https://github.com/Qihoo360/evpp#benchmark)
------------------------------------------------------------
@chenshuo Are you interested in fuzzing muduo?
This PR adds sets up continuous fuzzing through OSS-fuzz. To complete the PR a maintainers email address is needed for bug reports.