### PR TITLE
[wavpack] fix issue #34149 (new configure script requires gettext)

### DIFF
--- a/projects/wavpack/Dockerfile
+++ b/projects/wavpack/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN apt-get update && apt-get install -y make autoconf automake libtool gettext
 RUN git clone --depth 1 https://github.com/dbry/WavPack.git wavpack
 RUN cp wavpack/fuzzing/build.sh $SRC
 WORKDIR wavpack


### PR DESCRIPTION
A recent update to the `autotools` build configuration for WavPack requires that the `gettext` package be installed (for the `AM_ICONV` macro). This PR addresses that and fixes the build (locally, at least) for [issue #34149](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34149)

Thanks!