### PR TITLE
[infra] Fix java coverage

### DIFF
--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -19,7 +19,12 @@ cd $OUT
 if (( $# > 0 )); then
   FUZZ_TARGETS="$@"
 else
-  FUZZ_TARGETS="$(find . -maxdepth 1 -type f -executable -printf '%P\n')"
+  FUZZ_TARGETS="$(find . -maxdepth 1 -type f -executable -printf '%P\n' | \
+      grep -v -x -F \
+      -e 'llvm-symbolizer' \
+      -e 'jazzer_agent_deploy.jar' \
+      -e 'jazzer_driver' \
+      -e 'jazzer_driver_asan')"
 fi
 
 DUMPS_DIR="$OUT/dumps"

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -680,6 +680,10 @@ def _get_fuzz_targets(project_name):
   for name in os.listdir(_get_out_dir(project_name)):
     if name.startswith('afl-'):
       continue
+    if name.startswith('jazzer_'):
+      continue
+    if name == 'llvm-symbolizer':
+      continue
 
     path = os.path.join(_get_out_dir(project_name), name)
     if os.path.isfile(path) and os.access(path, os.X_OK):

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -686,7 +686,9 @@ def _get_fuzz_targets(project_name):
       continue
 
     path = os.path.join(_get_out_dir(project_name), name)
-    if os.path.isfile(path) and os.access(path, os.X_OK):
+    # Python and JVM fuzz targets are only executable for the root user, so
+    # we can't use os.access.
+    if os.path.isfile(path) and (os.stat(path).st_mode & 0o111):
       fuzz_targets.append(name)
 
   return fuzz_targets


### PR DESCRIPTION
This is a follow-up to #5733 fixing some bugs with Java coverage when running `infra/helper.py coverage <PROJECT>` without specifying a particular fuzz target.