### PR TITLE
[znc] Initial integration

### DIFF
--- a/projects/znc/Dockerfile
+++ b/projects/znc/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make
+RUN git clone --depth 1 https://github.com/znc/znc
+WORKDIR $SRC/znc
+COPY build.sh msg_parse_fuzzer.cpp $SRC/

--- a/projects/znc/build.sh
+++ b/projects/znc/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+git submodule update --init --recursive
+mkdir build && cd build
+cmake -DBUILD_SHARED_LIBS=OFF \
+	  -DWANT_ICU=OFF \
+	  -DWANT_OPENSSL=OFF \
+	  -DWANT_ZLIB=OFF \
+	  -DWANT_IPV6=OFF ..
+make -j$(nproc)
+
+$CXX $CXXFLAGS -DGTEST_HAS_POSIX_RE=0 \
+	-I/src/znc/include -I/src/znc/build/include \
+	-fPIE -include znc/zncconfig.h -std=c++11 \
+	-c $SRC/msg_parse_fuzzer.cpp -o msg_parse_fuzzer.o
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE \
+	msg_parse_fuzzer.o -o $OUT/msg_parse_fuzzer \
+	/src/znc/build/src/libznc.a 

--- a/projects/znc/msg_parse_fuzzer.cpp
+++ b/projects/znc/msg_parse_fuzzer.cpp
@@ -1,0 +1,30 @@
+/*
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+*/
+
+#include <stdint.h>
+#include <znc/Message.h>
+
+extern "C"
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
+	std::string input(reinterpret_cast<const char*>(data), size);
+	CMessage msg;
+	msg.Parse(input);
+	msg.SetParam(1, input);
+	msg.GetParams();
+	return 0;
+}

--- a/projects/znc/project.yaml
+++ b/projects/znc/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://znc.in"
+language: c++
+primary_contact: "alexey+znc@asokolov.org"
+auto_ccs:
+  - "Adam@adalogics.com"
+sanitizers:
+  - address
+  - undefined
+  - memory
+main_repo: "https://github.com/znc/znc"


### PR DESCRIPTION
Initial integration of ZNC [Github](https://github.com/znc/znc) [homepage](https://wiki.znc.in/ZNC)

ZNC is an IRC network bouncer and according to Wikipedia https://en.wikipedia.org/wiki/ZNC has been in development since July 2004. It's users include popularity of iPhone users (also from Wiki) and the project is available in package managers by several common Linux distros https://wiki.znc.in/Installation and also for Mac by way of Homebrew.

It has integrations with various IRC clients, e.g. [[1](https://blog.weechat.org/post/2012/11/27/Tags-in-IRC-messages)][[2](https://hexchat.github.io/news/2.9.6.html)][[3](https://web.archive.org/web/20150127002353/http://www.mirc.com/whatsnew.txt)] 