### PR TITLE
[infra] Fix base-runner build

### DIFF
--- a/infra/base-images/base-runner/Dockerfile
+++ b/infra/base-images/base-runner/Dockerfile
@@ -45,11 +45,13 @@ RUN apt-get update && apt-get install -y \
     libcap2 \
     python3 \
     python3-pip \
+    python3-setuptools \
     unzip \
     wget \
     zip --no-install-recommends
 
 RUN git clone https://chromium.googlesource.com/chromium/src/tools/code_coverage /opt/code_coverage && \
+    pip3 install wheel && \
     pip3 install -r /opt/code_coverage/requirements.txt
 
 # Default environment options for various sanitizers.


### PR DESCRIPTION
Builds of base-runner fail as the Chromium coverage helper script has a
transitive dependency on MarkupSafe, which as of version 2.0 requires
additional python packaging tools to be installed.

This commit installs python3-setuptools and wheels, which fixes the
build.