### PR TITLE
Fix coverage script issues

### DIFF
--- a/infra/base-images/base-runner/Dockerfile
+++ b/infra/base-images/base-runner/Dockerfile
@@ -45,11 +45,13 @@ RUN apt-get update && apt-get install -y \
     libcap2 \
     python3 \
     python3-pip \
+    python3-setuptools \
     unzip \
     wget \
     zip --no-install-recommends
 
 RUN git clone https://chromium.googlesource.com/chromium/src/tools/code_coverage /opt/code_coverage && \
+    pip3 install wheel && \
     pip3 install -r /opt/code_coverage/requirements.txt && \
     pip3 install MarkupSafe==0.23
 

--- a/infra/base-images/base-runner/Dockerfile
+++ b/infra/base-images/base-runner/Dockerfile
@@ -45,14 +45,13 @@ RUN apt-get update && apt-get install -y \
     libcap2 \
     python3 \
     python3-pip \
-    python3-setuptools \
     unzip \
     wget \
     zip --no-install-recommends
 
 RUN git clone https://chromium.googlesource.com/chromium/src/tools/code_coverage /opt/code_coverage && \
-    pip3 install wheel && \
-    pip3 install -r /opt/code_coverage/requirements.txt
+    pip3 install -r /opt/code_coverage/requirements.txt && \
+    pip3 install MarkupSafe==0.23
 
 # Default environment options for various sanitizers.
 # Note that these match the settings used in ClusterFuzz and


### PR DESCRIPTION
Make sure to install MarkupSafe==0.23 instead of >=0.23 which breaks.
Probably the solution is to upgrade Jinja upstream.
Fixes https://github.com/google/oss-fuzz/issues/5763