### PR TITLE
[infra] Make `targets_list` detect JVM/Python targets

### DIFF
--- a/infra/base-images/base-runner/targets_list
+++ b/infra/base-images/base-runner/targets_list
@@ -2,7 +2,7 @@
 
 for binary in $(find $OUT/ -executable -type f); do
   [[ "$binary" != *.so ]] || continue
-  [[ "$binary" != jazzer_driver* ]] || continue
+  [[ $(basename "$binary") != jazzer_driver* ]] || continue
   file "$binary" | grep -e ELF -e "shell script" > /dev/null 2>&1 || continue
   grep "LLVMFuzzerTestOneInput" "$binary" > /dev/null 2>&1 || continue
 

--- a/infra/base-images/base-runner/targets_list
+++ b/infra/base-images/base-runner/targets_list
@@ -2,7 +2,8 @@
 
 for binary in $(find $OUT/ -executable -type f); do
   [[ "$binary" != *.so ]] || continue
-  file "$binary" | grep ELF > /dev/null 2>&1 || continue
+  [[ "$binary" != jazzer_driver* ]] || continue
+  file "$binary" | grep -e ELF -e "shell script" > /dev/null 2>&1 || continue
   grep "LLVMFuzzerTestOneInput" "$binary" > /dev/null 2>&1 || continue
 
   basename "$binary"


### PR DESCRIPTION
`targets_list` should not detect `jazzer_driver` and `jazzer_driver_asan` as fuzz targets, but should consider shell scripts that contain `LLVMFuzzerTestOneInput`.

@inferno-chromium This should fix https://github.com/google/oss-fuzz/pull/5770#issuecomment-841851786.