### PR TITLE
[infra][jvm] Create per-target summary.json

### DIFF
--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -158,6 +158,17 @@ function run_java_fuzz_target {
     # Skip fuzz targets that failed to produce .exec files.
     return 0
   fi
+
+  # Generate XML report only as input to jacoco_report_converter.
+  # Source files are not needed for the summary.
+  local xml_report="$DUMPS_DIR/${target}.xml"
+  local summary_file="$FUZZER_STATS_DIR/$target.json"
+  java -jar /opt/jacoco-cli.jar report $exec_file \
+      --xml $xml_report \
+      --classfiles $class_dump_dir
+
+  # Write llvm-cov summary file.
+  jacoco_report_converter.py $xml_report $summary_file
 }
 
 export SYSGOPATH=$GOPATH


### PR DESCRIPTION
Creates the missing per-target `summary.json` for JVM targets.

@inferno-chromium This addresses the first point of https://github.com/google/oss-fuzz/pull/5770#issuecomment-842027559.

The logs at https://console.cloud.google.com/cloud-build/builds;region=global/92fbac4f-c6c7-474f-a3d8-e9f101d213cf;step=9;tab=detail?src=ac&project=oss-fuzz show that the missing files in `fuzzer_stats` are causing the build failure, so hopefully this PR will fix that.