### PR TITLE
[systemd]: pull in jinja2

### DIFF
--- a/projects/systemd/Dockerfile
+++ b/projects/systemd/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update &&\
-    apt-get install -y gperf m4 gettext python3-pip \
+    apt-get install -y gperf m4 gettext python3-pip python3-jinja2 \
         libcap-dev libmount-dev libkmod-dev \
         pkg-config wget &&\
     pip3 install meson ninja


### PR DESCRIPTION
For https://github.com/systemd/systemd/pull/19630:
m4 is being replaced by jinja2. Let's pull in both until the dust settles.