### PR TITLE
Use Google accounts for espeak-ng email

### DIFF
--- a/projects/espeak-ng/project.yaml
+++ b/projects/espeak-ng/project.yaml
@@ -1,10 +1,10 @@
 homepage: "https://github.com/espeak-ng/espeak-ng"
 language: c++
-primary_contact: "msclrhd@gmail.com"
+primary_contact: "msclrhd@googlemail.com"
 auto_ccs:
 - "valdis.vitolins@odo.lv"
 - "p.antoine@catenacyber.fr"
-- "sascha@brawer.ch"
+- "sascha.brawer@gmail.com"
 
 sanitizers:
 - address


### PR DESCRIPTION
Apparently, aliases to Google accounts do not work, even when they
are registered with Google and can be used to log in on Google sites.