### PR TITLE
[h2o] add Hajime Fujita

### DIFF
--- a/projects/h2o/project.yaml
+++ b/projects/h2o/project.yaml
@@ -8,5 +8,6 @@ auto_ccs:
   - "frederik.deweerdt@gmail.com"
   - "kazuhooku@gmail.com"
   - "i.nagata110@gmail.com"
+  - "hfujita@fastly.com"
   - "security@fastly.com"
 main_repo: 'https://github.com/h2o/h2o'


### PR DESCRIPTION
Hello,

Hajime is working on expanding our fuzzers for h2o. It would be helpful for him to have access to our [oss-fuzz dashboard](oss-fuzz.com) so that he can view coverage metrics, access seed files, and so on. Could you please add him?

cc @kazuho, @hfujita

Thanks,
Jon