### PR TITLE
Update another e-mail address for espeak-ng

### DIFF
--- a/projects/espeak-ng/project.yaml
+++ b/projects/espeak-ng/project.yaml
@@ -2,7 +2,7 @@ homepage: "https://github.com/espeak-ng/espeak-ng"
 language: c++
 primary_contact: "msclrhd@googlemail.com"
 auto_ccs:
-- "valdis.vitolins@odo.lv"
+- "valdis.vitolins@gmail.com"
 - "p.antoine@catenacyber.fr"
 - "sascha.brawer@gmail.com"
 


### PR DESCRIPTION
Confirmed via https://bugs.chromium.org/u/valdis.vitolins@gmail.com/ that this is not an alias.
/cc @valdisvi