### PR TITLE
[znc] Add maintainers email address

### DIFF
--- a/projects/znc/project.yaml
+++ b/projects/znc/project.yaml
@@ -3,6 +3,7 @@ language: c++
 primary_contact: "alexey+znc@asokolov.org"
 auto_ccs:
   - "Adam@adalogics.com"
+  - "ktonibud@gmail.com"
 sanitizers:
   - address
   - undefined


### PR DESCRIPTION
Solves https://github.com/google/oss-fuzz/issues/5792

Add second email address for @DarthGandalf to access bug reports.