### PR TITLE
[systemd] use pip3 to install jinja2

### DIFF
--- a/projects/systemd/Dockerfile
+++ b/projects/systemd/Dockerfile
@@ -16,10 +16,10 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update &&\
-    apt-get install -y gperf m4 gettext python3-pip python3-jinja2 \
+    apt-get install -y gperf m4 gettext python3-pip \
         libcap-dev libmount-dev libkmod-dev \
         pkg-config wget &&\
-    pip3 install meson ninja
+    pip3 install meson ninja jinja2
 RUN git clone --depth 1 https://github.com/systemd/systemd systemd
 WORKDIR systemd
 COPY build.sh $SRC/


### PR DESCRIPTION
It turns out that the system version of jinja2 is visible to the build
script.

From https://github.com/systemd/systemd/pull/19630#issuecomment-842983177:
> On OSS-Fuzz (and CIFuzz) the latest version of Python is built from
> scratch in the base-builder image. /usr/lib/python3/dist-packages
> (where python3-jinja2 is installed by apt-get) isn't included in
> PYTHONPATH there:
>
> ['', '/usr/local/lib/python38.zip', '/usr/local/lib/python3.8', '/usr/local/lib/python3.8/lib-dynload', '/usr/local/lib/python3.8/site-packages']