### PR TITLE
cel-go: remove irrelevant panic/assert in target

### DIFF
--- a/projects/cel-go/fuzz_eval.go
+++ b/projects/cel-go/fuzz_eval.go
@@ -29,7 +29,7 @@ func FuzzEval(data []byte) int {
 	}
 	prg, err := env.Program(ast)
 	if err != nil {
-		panic("impossible to create prog from ast")
+		return 0
 	}
 	//fmt.Printf("loltry %#+v\n", gen)
 


### PR DESCRIPTION
Should fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34444