### PR TITLE
[infra] Allow shell script targets for all languages

### DIFF
--- a/infra/base-images/base-runner/test_all_test.py
+++ b/infra/base-images/base-runner/test_all_test.py
@@ -28,11 +28,9 @@ class TestTestAll(unittest.TestCase):
   def test_test_all_no_fuzz_targets(self, mocked_print, _):
     """Tests that test_all returns False when there are no fuzz targets."""
     outdir = '/out'
-    fuzzing_language = 'c++'
     allowed_broken_targets_percentage = 0
     self.assertFalse(
-        test_all.test_all(outdir, fuzzing_language,
-                          allowed_broken_targets_percentage))
+        test_all.test_all(outdir, allowed_broken_targets_percentage))
     mocked_print.assert_called_with('ERROR: No fuzz targets found.')
 
 


### PR DESCRIPTION
For proper support of Bazel's runfiles tree, a shell script wrapper is
also needed for C++ targets, see
https://github.com/bazelbuild/rules_fuzzing/pull/149.

This commit allows shell script fuzz targets for all languages. This
also helps to consolidate the various fuzz target checks in OSS-Fuzz
by removing a dependence on fuzzing_language.