### PR TITLE
cifuzz: allow passing additional args to build scripts

### DIFF
--- a/infra/cifuzz/actions/build_fuzzers/action.yml
+++ b/infra/cifuzz/actions/build_fuzzers/action.yml
@@ -15,6 +15,9 @@ inputs:
   allowed-broken-targets-percentage:
     description: 'The percentage of broken targets allowed in bad_build_check.'
     required: false
+  extra-build-args:
+    description: 'Additional arguments passed to build scripts via the EXTRA_BUILD_ARGS variable.'
+    required: false
   sanitizer:
     description: 'The sanitizer to build the fuzzers with.'
     default: 'address'
@@ -36,6 +39,7 @@ runs:
     LANGUAGE: ${{ inputs.language }}
     DRY_RUN: ${{ inputs.dry-run}}
     ALLOWED_BROKEN_TARGETS_PERCENTAGE: ${{ inputs.allowed-broken-targets-percentage}}
+    EXTRA_BUILD_ARGS: ${{ inputs.extra-build-args }}
     SANITIZER: ${{ inputs.sanitizer }}
     PROJECT_SRC_PATH: ${{ inputs.project-src-path }}
     BUILD_INTEGRATION_PATH: ${{ inputs.build-integration-path }}

--- a/infra/cifuzz/build_fuzzers.py
+++ b/infra/cifuzz/build_fuzzers.py
@@ -82,6 +82,10 @@ class Builder:  # pylint: disable=too-many-instance-attributes
                                          self.config.language)
     container = utils.get_container_name()
 
+    if self.config.extra_build_args is not None:
+      docker_args.extend(
+          ('-e', 'EXTRA_BUILD_ARGS=' + self.config.extra_build_args))
+
     if container:
       docker_args.extend(
           _get_docker_build_fuzzers_args_container(self.out_dir, container))

--- a/infra/cifuzz/config_utils.py
+++ b/infra/cifuzz/config_utils.py
@@ -170,6 +170,7 @@ class BuildFuzzersConfig(BaseConfig):
     self.base_ref = os.getenv('GITHUB_BASE_REF')
     self.project_src_path = get_project_src_path(self.workspace)
 
+    self.extra_build_args = os.getenv('EXTRA_BUILD_ARGS')
     self.allowed_broken_targets_percentage = os.getenv(
         'ALLOWED_BROKEN_TARGETS_PERCENTAGE')
     self.bad_build_check = environment.get_bool('BAD_BUILD_CHECK', 'true')


### PR DESCRIPTION
It should make it possible to have two or more GHActions testing
different build configurations. More specifically, the systemd
project is experimenting with Rust in
https://github.com/systemd/systemd/pull/19598 and it
would make sense to cover the Rust code with the fuzz targets
as well. For that to work the build script would have to
add RUSTFLAGS and the -Dbuild-rust option. One way would be
to add another CIFuzz action and set EXTRA_BUILD_ARGS to something
like `rust`. The build script would look for `rust` in
`EXTRA_BUILD_ARGS` and pass the required arguments to `meson` if it's there.

@jonathanmetzman ~~I haven't tested it yet~~. It's just an example of how I think it could be implemented. If there is another way to pass additional arguments to build scripts I'm not aware of it would be great if you could point me in the right direction.