### PR TITLE
Update new_project_guide.md

### DIFF
--- a/docs/getting-started/new_project_guide.md
+++ b/docs/getting-started/new_project_guide.md
@@ -253,11 +253,8 @@ alphanumeric characters, underscore(_) or dash(-). Otherwise, they won't run on 
 
 ### Temporarily disabling code instrumentation during builds
 
-Sometimes not every 3rd party library might be needed to be instrumented or
-tools are being compiled that just support the target built.
+In some cases, it's not necessary to instrument every 3rd party library or tool that supports the build target. Use the following code snippet to specify build commands that should not result in instrumented code:
 
-If for any reasons part of the build process should not be instrumented
-then the following code snippet can be used for this:
 
 ```
 CFLAGS_SAVE="$CFLAGS"

--- a/docs/getting-started/new_project_guide.md
+++ b/docs/getting-started/new_project_guide.md
@@ -253,7 +253,7 @@ alphanumeric characters, underscore(_) or dash(-). Otherwise, they won't run on 
 
 ### Temporarily disabling code instrumentation during builds
 
-In some cases, it's not necessary to instrument every 3rd party library or tool that supports the build target. Use the following code snippet to specify build commands that should not result in instrumented code:
+In some cases, it's not necessary to instrument every 3rd party library or tool that supports the build target. Use the following snippet to build tools or libraries without instrumentation:
 
 
 ```


### PR DESCRIPTION
Rewrite instructions under "Temporarily disabling code instrumentation during builds" section for clarity.