### PR TITLE
Install protobuf compile for project Oak

### DIFF
--- a/projects/oak/Dockerfile
+++ b/projects/oak/Dockerfile
@@ -16,6 +16,19 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 
+# Install Protobuf compiler.
+ARG protobuf_version=3.13.0
+ARG protobuf_sha256=4a3b26d1ebb9c1d23e933694a6669295f6a39ddc64c3db2adf671f0a6026f82e
+ARG protobuf_dir=/usr/local/protobuf
+ARG protobuf_temp=/tmp/protobuf.zip
+ENV PATH "${protobuf_dir}/bin:${PATH}"
+RUN curl --location https://github.com/protocolbuffers/protobuf/releases/download/v${protobuf_version}/protoc-${protobuf_version}-linux-x86_64.zip > ${protobuf_temp} \
+  && sha256sum --binary ${protobuf_temp} && echo "${protobuf_sha256} *${protobuf_temp}" | sha256sum --check \
+  && unzip ${protobuf_temp} -d ${protobuf_dir} \
+  && rm ${protobuf_temp} \
+  && chmod --recursive a+rwx ${protobuf_dir} \
+  && protoc --version
+
 RUN git clone --depth 1 https://github.com/project-oak/oak oak
 WORKDIR oak
 COPY build.sh $SRC/


### PR DESCRIPTION
This should fix the following error:
```
Step #4: error: failed to run custom build command for `oak_functions_loader v0.1.0 (/src/oak/oak_functions/loader)`
Step #4: 
Step #4: Caused by:
Step #4:   process didn't exit successfully: `/src/oak/oak_functions/loader/fuzz/target/release/build/oak_functions_loader-8d5170b2c84739ec/build-script-build` (exit status: 1)
Step #4:   --- stdout
Step #4:   cargo:rerun-if-changed=../proto/server.proto
Step #4: 
Step #4:   --- stderr
Step #4:   Error: Custom { kind: NotFound, error: "failed to invoke protoc (hint: https://docs.rs/prost-build/#sourcing-protoc): No such file or directory (os error 2)" }
Step #4: warning: build failed, waiting for other jobs to finish...
Step #4: error: build failed
Step #4: Error: failed to build fuzz script: "cargo" "build" "--manifest-path" "/src/oak/oak_functions/loader/fuzz/Cargo.toml" "--target" "x86_64-unknown-linux-gnu" "--release" "--bins"
```
Logs: https://oss-fuzz-build-logs.storage.googleapis.com/log-3ca0e946-70d9-4564-b1a8-0332d109a579.txt