### PR TITLE
Adds project freeradius

### DIFF
--- a/projects/freeradius/Dockerfile
+++ b/projects/freeradius/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt install -y libtalloc-dev libkqueue-dev libssl-dev
+RUN git clone --depth 1 https://github.com/FreeRADIUS/freeradius-server.git
+COPY build.sh $SRC
+COPY patch.diff $SRC
+WORKDIR $SRC/freeradius-server

--- a/projects/freeradius/build.sh
+++ b/projects/freeradius/build.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+function copy_lib
+    {
+    local fuzzer_path=$1
+    local lib=$2
+    cp $(ldd ${fuzzer_path} | grep "${lib}" | awk '{ print $3 }') ${OUT}/lib
+    }
+
+mkdir -p $OUT/lib
+
+git apply --ignore-whitespace $SRC/patch.diff
+# build project
+./configure --enable-fuzzer --enable-address-sanitizer
+# make tries to compile regular programs as fuzz targets
+# so -i flag ignores these errors
+make -i -j$(nproc)
+make -i install
+# use shared libraries
+ldconfig
+ls ./build/bin/local/fuzzer_* | while read i; do
+    patchelf --set-rpath '$ORIGIN/lib' ${i}
+    copy_lib ${i} libfreeradius
+    copy_lib ${i} talloc
+    copy_lib ${i} ssl
+    copy_lib ${i} kqueue
+    cp ${i} $OUT/
+done
+cp -r /usr/local/share/freeradius/dictionary /out/dict
+# export FR_DICTIONARY_DIR=/out/dictionary/
+# export FR_LIBRARY_PATH=/out/lib/

--- a/projects/freeradius/patch.diff
+++ b/projects/freeradius/patch.diff
@@ -1,0 +1,23 @@
+diff --git a/src/bin/fuzzer.c b/src/bin/fuzzer.c
+index 9c2eb50..6352aa0 100644
+--- a/src/bin/fuzzer.c
++++ b/src/bin/fuzzer.c
+@@ -125,7 +125,17 @@ int LLVMFuzzerInitialize(int *argc, char ***argv)
+                }
+        }
+
+-       if (!dict_dir) dict_dir = DICTDIR;
++       if (!dict_dir) {
++               dict_dir = malloc(strlen((*argv)[0]) + 1);
++               memcpy(dict_dir, (*argv)[0], strlen((*argv)[0]) + 1);
++               snprintf(strrchr(dict_dir, '/'), 6, "/dict");
++       }
++       if (!lib_dir) {
++                lib_dir = malloc(strlen((*argv)[0]) + 1);
++                memcpy(lib_dir, (*argv)[0], strlen((*argv)[0]) + 1);
++                snprintf(strrchr(lib_dir, '/'), 5, "/lib");
++                setenv("FR_LIBRARY_PATH", lib_dir, 1);
++       }
+
+        /*
+         *      When jobs=N is specified the fuzzer spawns worker processes via

--- a/projects/freeradius/project.yaml
+++ b/projects/freeradius/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://freeradius.org"
+language: c++
+primary_contact: "a.cudbardb@freeradius.org"
+auto_ccs:
+- "p.antoine@catenacyber.fr"
+main_repo: 'https://github.com/FreeRADIUS/freeradius-server.git'
+fuzzing_engines:
+- libfuzzer
+- afl
+- honggfuzz
+sanitizers:
+- address

--- a/projects/freeradius/project.yaml
+++ b/projects/freeradius/project.yaml
@@ -6,7 +6,5 @@ auto_ccs:
 main_repo: 'https://github.com/FreeRADIUS/freeradius-server.git'
 fuzzing_engines:
 - libfuzzer
-- afl
-- honggfuzz
 sanitizers:
 - address


### PR DESCRIPTION
@arr2036 would you be interested in continuous fuzzing for freeradius ?
This PR enables it with the fuzz targets already there.

As oss-fuzz does not allow to define environment variables before running the fuzzers, a small patch was needed to find the right directories...