### PR TITLE
[infra] fix handling Go's SIV in coverage santizer

### DIFF
--- a/infra/base-images/base-builder/compile_go_fuzzer
+++ b/infra/base-images/base-builder/compile_go_fuzzer
@@ -42,7 +42,9 @@ if [[ $SANITIZER = *coverage* ]]; then
   sed -i -e 's/mypackagebeingfuzzed/'$fuzzed_package'/' ./"${function,,}"_test.go
   sed -i -e 's/TestFuzzCorpus/Test'$function'Corpus/' ./"${function,,}"_test.go
 
-  fuzzed_repo=`echo $path | cut -d/ -f-3`
+  # The repo is the module path/name, which is already created above in case it doesn't exist,
+  # but not always the same as the module path. This is necessary to handle SIV properly.
+  fuzzed_repo=$(go list $tags -f {{.Module}} "$path")
   abspath_repo=`go list -m $tags -f {{.Dir}} $fuzzed_repo || go list $tags -f {{.Dir}} $fuzzed_repo`
   # give equivalence to absolute paths in another file, as go test -cover uses golangish pkg.Dir
   echo "s=$fuzzed_repo"="$abspath_repo"= > $OUT/$fuzzer.gocovpath


### PR DESCRIPTION
The previous code assumes the repo URL is always the same as the path and consists of 3 segments separated by forward slash, which is not true in Go modules with modules whose version is above v1, e.g. `github.com/caddyserver/caddy/v2`.