### PR TITLE
gnupg: Try to fix build issues

### DIFF
--- a/projects/gnupg/Dockerfile
+++ b/projects/gnupg/Dockerfile
@@ -16,6 +16,11 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool gettext bzip2 gnupg bison flex
+# Install automake 1.16.3 from future. See:
+# * https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=commit;h=6ca540715139899137e1f86c7e1dcbd0288f15b3
+# * https://packages.ubuntu.com/en/hirsute/automake
+RUN sed -i -e 's/xenial/hirsute/g' /etc/apt/sources.list
+RUN apt-get update && apt-get install -y --reinstall automake
 
 RUN git clone --depth 1 git://git.gnupg.org/libgpg-error.git libgpg-error
 RUN git clone --depth 1 git://git.gnupg.org/libgcrypt.git libgcrypt

--- a/projects/gnupg/fuzzgnupg.diff
+++ b/projects/gnupg/fuzzgnupg.diff
@@ -1,10 +1,10 @@
 diff --git a/configure.ac b/configure.ac
-index 5bb366e76..ee9403149 100644
+index a3207dc9f..627c93285 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -991,6 +991,15 @@ AC_CHECK_LIB(util, openpty,
-              ])
- AC_SUBST(LIBUTIL_LIBS)
+@@ -991,6 +991,15 @@ if test x"$use_tofu" = xyes ; then
+   fi
+ fi
  
 +# TODO choose when to build fuzzing with option ?
 +AC_CHECK_LIB(FuzzingEngine, main,
@@ -15,19 +15,19 @@ index 5bb366e76..ee9403149 100644
 +AC_CHECK_PROG(HAVE_CLANGXX, clang++, 1)
 +AM_CONDITIONAL(HAVE_LIB_FUZZING_ENGINE, [test "$have_fuzz" = yes -a "$HAVE_CLANGXX" = 1])
 +
- # shred is used to clean temporary plain text files.
- AC_PATH_PROG(SHRED, shred, /usr/bin/shred)
- AC_DEFINE_UNQUOTED(SHRED,
-@@ -2094,6 +2103,7 @@ tests/migrations/Makefile
+ AM_CONDITIONAL(SQLITE3, test "$have_sqlite" = "yes")
+ 
+ if test x"$use_tofu" = xyes ; then
+@@ -2149,6 +2158,7 @@ tests/migrations/Makefile
  tests/gpgsm/Makefile
  tests/gpgme/Makefile
  tests/pkits/Makefile
 +tests/fuzz/Makefile
  g10/gpg.w32-manifest
- ])
- 
+ tools/gpg-connect-agent.w32-manifest
+ tools/gpgconf.w32-manifest
 diff --git a/g10/Makefile.am b/g10/Makefile.am
-index 2b92daf33..505d98f5e 100644
+index eb23573b7..785ac2b4b 100644
 --- a/g10/Makefile.am
 +++ b/g10/Makefile.am
 @@ -47,6 +47,7 @@ endif
@@ -38,14 +38,14 @@ index 2b92daf33..505d98f5e 100644
  if !HAVE_W32CE_SYSTEM
  noinst_PROGRAMS += gpgv
  endif
-@@ -164,6 +165,9 @@ gpg_SOURCES  = gpg.c \
+@@ -164,6 +165,9 @@ gpg_sources = server.c          \
+ gpg_SOURCES  = gpg.c \
  	keyedit.c keyedit.h	\
  	$(gpg_sources)
- 
 +libgpg_a_SOURCES  = keyedit.c keyedit.h	\
 +	$(gpg_sources)
 +
- #gpgcompose_SOURCES  = gpgcompose.c  $(gpg_sources)
+ 
  gpgv_SOURCES = gpgv.c           \
  	      $(common_source)  \
 diff --git a/g10/armor.c b/g10/armor.c
@@ -63,7 +63,7 @@ index eb2d28bca..594f5bd2d 100644
  
  
 diff --git a/g10/call-dirmngr.h b/g10/call-dirmngr.h
-index 285c4cb4d..7af328c2a 100644
+index c0f1e0cec..52652a0e0 100644
 --- a/g10/call-dirmngr.h
 +++ b/g10/call-dirmngr.h
 @@ -19,6 +19,8 @@
@@ -122,10 +122,10 @@ index e7a6f2b11..9a9ab5460 100644
      } while (zs->avail_out && zrc != Z_STREAM_END && zrc != Z_BUF_ERROR
               && !leave);
 diff --git a/g10/parse-packet.c b/g10/parse-packet.c
-index 2f92c1d2c..41e077a6a 100644
+index bb05eabb7..638d895d0 100644
 --- a/g10/parse-packet.c
 +++ b/g10/parse-packet.c
-@@ -738,7 +738,12 @@ parse (parse_packet_ctx_t ctx, PACKET *pkt, int onlykeypkts, off_t * retpos,
+@@ -806,7 +806,12 @@ parse (parse_packet_ctx_t ctx, PACKET *pkt, int onlykeypkts, off_t * retpos,
         * the uncompressing layer - in some error cases it just loops
         * and spits out 0xff bytes. */
        log_error ("%s: garbled packet detected\n", iobuf_where (inp));
@@ -139,10 +139,10 @@ index 2f92c1d2c..41e077a6a 100644
  
    if (out && pkttype)
 diff --git a/g10/plaintext.c b/g10/plaintext.c
-index f9e0a4296..7b9709c08 100644
+index 3e169d93f..aa83ffbe0 100644
 --- a/g10/plaintext.c
 +++ b/g10/plaintext.c
-@@ -656,10 +656,16 @@ ask_for_detached_datafile (gcry_md_hd_t md, gcry_md_hd_t md2,
+@@ -617,10 +617,16 @@ ask_for_detached_datafile (gcry_md_hd_t md, gcry_md_hd_t md2,
  
    if (!fp)
      {
@@ -160,10 +160,10 @@ index f9e0a4296..7b9709c08 100644
    do_hash (md, md2, fp, textmode);
    iobuf_close (fp);
 diff --git a/g10/sig-check.c b/g10/sig-check.c
-index 4c172d692..bd87f00ad 100644
+index 8dd18b2e2..9f5db89f9 100644
 --- a/g10/sig-check.c
 +++ b/g10/sig-check.c
-@@ -760,8 +760,9 @@ check_revocation_keys (ctrl_t ctrl, PKT_public_key *pk, PKT_signature *sig)
+@@ -783,8 +783,9 @@ check_revocation_keys (ctrl_t ctrl, PKT_public_key *pk, PKT_signature *sig)
  	    {
                gcry_md_hd_t md;
  
@@ -176,15 +176,15 @@ index 4c172d692..bd87f00ad 100644
  	      /* Note: check_signature only checks that the signature
  		 is good.  It does not fail if the key is revoked.  */
 diff --git a/tests/Makefile.am b/tests/Makefile.am
-index b9be6aaa6..d6659eaf1 100644
+index 624334c63..fbace1381 100644
 --- a/tests/Makefile.am
 +++ b/tests/Makefile.am
-@@ -18,7 +18,13 @@
+@@ -24,7 +24,13 @@ else
+ tpm2dtests =
+ endif
  
- ## Process this file with automake to produce Makefile.in
- 
--SUBDIRS = gpgscm openpgp migrations gpgsm gpgme pkits .
-+SUBDIRS = gpgscm openpgp migrations gpgsm gpgme pkits
+-SUBDIRS = gpgscm openpgp migrations gpgsm gpgme pkits $(tpm2dtests) .
++SUBDIRS = gpgscm openpgp migrations gpgsm gpgme pkits $(tpm2dtests)
 +
 +if MAINTAINER_MODE
 +SUBDIRS += fuzz
@@ -196,7 +196,7 @@ index b9be6aaa6..d6659eaf1 100644
  
 diff --git a/tests/fuzz/Makefile.am b/tests/fuzz/Makefile.am
 new file mode 100644
-index 000000000..3bf039a54
+index 000000000..eb2216d3e
 --- /dev/null
 +++ b/tests/fuzz/Makefile.am
 @@ -0,0 +1,84 @@


### PR DESCRIPTION
According to https://oss-fuzz-build-logs.storage.googleapis.com/index.html#gnupg the build is failing for the last 4 months.

For example https://oss-fuzz-build-logs.storage.googleapis.com/log-57c64478-ca6d-42f7-b498-f153dad5fe1a.txt ends with:

```
Step #4: + cd gnupg
Step #4: + mkdir tests/fuzz
Step #4: + cp ../fuzz_decrypt.c ../fuzz_decrypt.options ../fuzz_import.c ../fuzz_list.c ../fuzz_list.options ../fuzz_verify.c tests/fuzz
Step #4: + git apply ../fuzz.diff
Step #4: error: patch failed: configure.ac:991
Step #4: error: configure.ac: patch does not apply
Step #4: error: patch failed: g10/Makefile.am:164
Step #4: error: g10/Makefile.am: patch does not apply
Step #4: error: patch failed: tests/Makefile.am:18
Step #4: error: tests/Makefile.am: patch does not apply
Step #4: ********************************************************************************
Step #4: Failed to build.
Step #4: To reproduce, run:
Step #4: python infra/helper.py build_image gnupg
Step #4: python infra/helper.py build_fuzzers --sanitizer address --engine libfuzzer --architecture x86_64 gnupg
Step #4: ********************************************************************************
Finished Step #4
ERROR
ERROR: build step 4 "gcr.io/oss-fuzz/gnupg" failed: step exited with non-zero status: 1
```

Another issue I ran into was an outdated `automake`.

I worked around both issues.

