### PR TITLE
[clamav] Fix build after libxml2 cmake change

### DIFF
--- a/projects/clamav/build.sh
+++ b/projects/clamav/build.sh
@@ -42,7 +42,7 @@ cmake ${SRC}/clamav-devel \
     -DOPENSSL_CRYPTO_LIBRARY="$CLAMAV_DEPENDENCIES/lib/libcrypto.a"    \
     -DOPENSSL_SSL_LIBRARY="$CLAMAV_DEPENDENCIES/lib/libssl.a"          \
     -DZLIB_LIBRARY="$CLAMAV_DEPENDENCIES/lib/libssl.a"                 \
-    -DLIBXML2_INCLUDE_DIR="$CLAMAV_DEPENDENCIES/include"               \
+    -DLIBXML2_INCLUDE_DIR="$CLAMAV_DEPENDENCIES/include/libxml2"       \
     -DLIBXML2_LIBRARY="$CLAMAV_DEPENDENCIES/lib/libxml2.a"             \
     -DPCRE2_INCLUDE_DIR="$CLAMAV_DEPENDENCIES/include"                 \
     -DPCRE2_LIBRARY="$CLAMAV_DEPENDENCIES/lib/libpcre2-8.a"            \


### PR DESCRIPTION
I updated ClamAV's Mussels recipe for libxml2 to the new 2.9.12 release
and to use CMake instead of the old build system. It seems the new CMake
build system installs the headers under <prefix>/include/libxml2 though.

This commit accounts for the header path change.