### PR TITLE
[fribidi] Add fribidi-fuzzer

### DIFF
--- a/projects/fribidi/Dockerfile
+++ b/projects/fribidi/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/fribidi/Dockerfile
+++ b/projects/fribidi/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y python3-pip pkg-config && \
+    pip3 install meson==0.53.0 ninja
+RUN git clone --depth 1 https://github.com/fribidi/fribidi.git
+WORKDIR fribidi
+COPY build.sh $SRC/

--- a/projects/fribidi/build.sh
+++ b/projects/fribidi/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -eu
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# setup
+build=$WORK/build
+
+# cleanup
+rm -rf $build
+mkdir -p $build
+
+# Build the library.
+meson --default-library=static --wrap-mode=nodownload -Ddocs=false \
+      -Dfuzzer_ldflags="$(echo $LIB_FUZZING_ENGINE)" \
+      $build \
+  || (cat build/meson-logs/meson-log.txt && false)
+
+# Build the fuzzers.
+ninja -v -j$(nproc) -C $build bin/fribidi-fuzzer
+mv $build/bin/fribidi-fuzzer $OUT/
+
+# Archive and copy to $OUT seed corpus if the build succeeded.
+zip $OUT/fribidi-fuzzer_seed_corpus.zip test/*.{input,reference} test/fuzzing/*

--- a/projects/fribidi/build.sh
+++ b/projects/fribidi/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2016 Google Inc.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/fribidi/project.yaml
+++ b/projects/fribidi/project.yaml
@@ -10,10 +10,8 @@ fuzzing_engines:
   - libfuzzer
   - afl
   - honggfuzz
-  - dataflow
 sanitizers:
   - address
   - undefined
   - memory
-  - dataflow
 main_repo: 'https://github.com/fribidi/fribidi.git'

--- a/projects/fribidi/project.yaml
+++ b/projects/fribidi/project.yaml
@@ -1,0 +1,19 @@
+homepage: "https://github.com/fribidi/fribidi"
+language: c
+primary_contact: "dov.grobgeld@gmail.com"
+auto_ccs:
+  - "behdad.esfahbod@gmail.com"
+  - "behdad@gnu.org"
+  - "ebrahim@gnu.org"
+  - "dr.khaled.hosny@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+  - dataflow
+sanitizers:
+  - address
+  - undefined
+  - memory
+  - dataflow
+main_repo: 'https://github.com/fribidi/fribidi.git'


### PR DESCRIPTION
fribidi, the free bidi implementation used directly in Pango and https://github.com/fribidi/fribidi/blob/master/USERS and indirectly in many other places. The configuration is based on HarfBuzz's one. The try to add a fuzzer to the project itself has been fruitful as can be seen on https://github.com/fribidi/fribidi/pull/154 yet this hopefully can result in even more interesting cases.