### PR TITLE
[lldb-eval] Initial integration

### DIFF
--- a/projects/lldb-eval/Dockerfile
+++ b/projects/lldb-eval/Dockerfile
@@ -1,3 +1,19 @@
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
 FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN apt-get update \

--- a/projects/lldb-eval/Dockerfile
+++ b/projects/lldb-eval/Dockerfile
@@ -1,0 +1,11 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN apt-get update \
+    && apt-get install -y build-essential make cmake ninja-build git binutils-dev zlib1g-dev libtinfo-dev patchelf --no-install-recommends
+
+RUN git clone --depth 1 --single-branch --branch release/11.x https://github.com/llvm/llvm-project
+RUN git clone --depth 1 https://github.com/google/lldb-eval
+
+COPY build.sh $SRC/
+
+WORKDIR $SRC/lldb-eval

--- a/projects/lldb-eval/Dockerfile
+++ b/projects/lldb-eval/Dockerfile
@@ -17,9 +17,8 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN apt-get update \
-    && apt-get install -y build-essential make cmake ninja-build git binutils-dev zlib1g-dev libtinfo-dev patchelf --no-install-recommends
+    && apt-get install -y wget git patchelf zlib1g-dev libtinfo-dev --no-install-recommends
 
-RUN git clone --depth 1 --single-branch --branch release/11.x https://github.com/llvm/llvm-project
 RUN git clone --depth 1 https://github.com/google/lldb-eval
 
 COPY build.sh $SRC/

--- a/projects/lldb-eval/Dockerfile
+++ b/projects/lldb-eval/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2021 Google Inc.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/lldb-eval/build.sh
+++ b/projects/lldb-eval/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2021 Google Inc.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/lldb-eval/build.sh
+++ b/projects/lldb-eval/build.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+(
+cd $SRC/llvm-project && mkdir build_x64_opt && cd build_x64_opt
+
+if [ "$SANITIZER" = "address" ]
+then
+  LLVM_USE_SANITIZER=Address
+else
+  LLVM_USE_SANITIZER=""
+fi
+
+cmake \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DLLVM_USE_SANITIZER=$LLVM_USE_SANITIZER \
+    -DLLVM_ENABLE_PROJECTS="compiler-rt;clang;lld;lldb" \
+    -DLLVM_USE_LINKER=lld \
+    -DLLVM_TARGETS_TO_BUILD="X86" \
+    -DLLVM_BUILD_TOOLS=OFF \
+    -DLLVM_BUILD_UTILS=OFF \
+    -DLLVM_BUILD_TESTS=OFF \
+    -DLLVM_INCLUDE_TESTS=OFF \
+    -DLLDB_ENABLE_PYTHON=0 \
+    -DLLDB_INCLUDE_TESTS=OFF \
+    -DCMAKE_INSTALL_PREFIX="$SRC/llvm" \
+    -GNinja \
+    ../llvm
+
+ninja \
+    install-clang \
+    install-clang-headers \
+    install-clang-libraries \
+    install-liblldb \
+    install-lld \
+    install-lldb-headers \
+    install-lldb-server \
+    install-llvm-headers \
+    install-llvm-libraries
+)
+export LLVM_INSTALL_PATH=$SRC/llvm
+
+bazel_build_fuzz_tests
+
+# OSS-Fuzz rule doesn't build data dependencies
+bazel build //testdata:fuzzer_binary_gen
+
+# OSS-Fuzz rule doesn't package runfiles yet:
+# https://github.com/bazelbuild/rules_fuzzing/issues/100
+mkdir -p $OUT/lldb_eval_libfuzzer_test.runfiles
+# fuzzer_binary
+mkdir -p $OUT/lldb_eval_libfuzzer_test.runfiles/lldb_eval/testdata
+cp $SRC/lldb-eval/bazel-bin/testdata/fuzzer_binary $OUT/lldb_eval_libfuzzer_test.runfiles/lldb_eval/testdata/
+cp $SRC/lldb-eval/testdata/fuzzer_binary.cc $OUT/lldb_eval_libfuzzer_test.runfiles/lldb_eval/testdata/
+# lldb-server
+mkdir -p $OUT/lldb_eval_libfuzzer_test.runfiles/llvm_project/bin
+cp $SRC/llvm/bin/lldb-server $OUT/lldb_eval_libfuzzer_test.runfiles/llvm_project/bin/lldb-server
+
+# OSS-Fuzz rule doesn't handle dynamic dependencies
+# Copy liblldb.so and path RPATH of the fuzz target
+mkdir -p $OUT/lib
+cp -a $SRC/llvm/lib/liblldb.so* $OUT/lib
+patchelf --set-rpath '$ORIGIN/lib' $OUT/lldb_eval_libfuzzer_test

--- a/projects/lldb-eval/build.sh
+++ b/projects/lldb-eval/build.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
 
 (
 cd $SRC/llvm-project && mkdir build_x64_opt && cd build_x64_opt

--- a/projects/lldb-eval/build.sh
+++ b/projects/lldb-eval/build.sh
@@ -16,46 +16,28 @@
 ################################################################################
 
 (
-cd $SRC/llvm-project && mkdir build_x64_opt && cd build_x64_opt
+cd $SRC/
+GITHUB_RELEASE="https://github.com/google/lldb-eval/releases/download/oss-fuzz-llvm-11"
+
+wget --quiet --show-progress $GITHUB_RELEASE/llvm-11.1.0-source.tar.gz
+tar -xzf llvm-11.1.0-source.tar.gz
+
+wget --quiet --show-progress $GITHUB_RELEASE/llvm-11.1.0-x86_64-linux-release-genfiles.tar.gz
+tar -xzf llvm-11.1.0-x86_64-linux-release-genfiles.tar.gz
 
 if [ "$SANITIZER" = "address" ]
 then
-  LLVM_USE_SANITIZER=Address
+  LLVM_ARCHIVE="llvm-11.1.0-x86_64-linux-release-address.tar.gz"
 else
-  LLVM_USE_SANITIZER=""
+  LLVM_ARCHIVE="llvm-11.1.0-x86_64-linux-release-coverage.tar.gz"
 fi
 
-cmake \
-    -DCMAKE_C_COMPILER=clang \
-    -DCMAKE_CXX_COMPILER=clang++ \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DLLVM_USE_SANITIZER=$LLVM_USE_SANITIZER \
-    -DLLVM_ENABLE_PROJECTS="compiler-rt;clang;lld;lldb" \
-    -DLLVM_USE_LINKER=lld \
-    -DLLVM_TARGETS_TO_BUILD="X86" \
-    -DLLVM_BUILD_TOOLS=OFF \
-    -DLLVM_BUILD_UTILS=OFF \
-    -DLLVM_BUILD_TESTS=OFF \
-    -DLLVM_INCLUDE_TESTS=OFF \
-    -DLLDB_ENABLE_PYTHON=0 \
-    -DLLDB_INCLUDE_TESTS=OFF \
-    -DCMAKE_INSTALL_PREFIX="$SRC/llvm" \
-    -GNinja \
-    ../llvm
-
-ninja \
-    install-clang \
-    install-clang-headers \
-    install-clang-libraries \
-    install-liblldb \
-    install-lld \
-    install-lldb-headers \
-    install-lldb-server \
-    install-llvm-headers \
-    install-llvm-libraries
+wget --quiet --show-progress $GITHUB_RELEASE/$LLVM_ARCHIVE
+mkdir -p llvm && tar -xzf $LLVM_ARCHIVE --strip-components 1 -C llvm
 )
 export LLVM_INSTALL_PATH=$SRC/llvm
 
+# Run the build!
 bazel_build_fuzz_tests
 
 # OSS-Fuzz rule doesn't build data dependencies

--- a/projects/lldb-eval/project.yaml
+++ b/projects/lldb-eval/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://github.com/google/lldb-eval"
+main_repo: "https://github.com/google/lldb-eval"
+language: c++
+
+primary_contact: "werat@google.com"
+auto_ccs:
+  - "tsabolcec@google.com"
+
+fuzzing_engines:
+  - libfuzzer
+santizers:
+  - address

--- a/projects/lldb-eval/project.yaml
+++ b/projects/lldb-eval/project.yaml
@@ -5,8 +5,7 @@ language: c++
 primary_contact: "werat@google.com"
 auto_ccs:
   - "tsabolcec@google.com"
-
 fuzzing_engines:
   - libfuzzer
-santizers:
+sanitizers:
   - address

--- a/projects/lldb-eval/project.yaml
+++ b/projects/lldb-eval/project.yaml
@@ -1,7 +1,6 @@
 homepage: "https://github.com/google/lldb-eval"
 main_repo: "https://github.com/google/lldb-eval"
 language: c++
-
 primary_contact: "werat@google.com"
 auto_ccs:
   - "tsabolcec@google.com"


### PR DESCRIPTION
lldb-eval (https://github.com/google/lldb-eval) is an LLDB-based library for evaluating expressions in debug context. It is used in Visual Studio extension for Stadia (https://github.com/googlestadia/vsi-lldb).