### PR TITLE
[civetweb] Disable DFSAN builds.

### DIFF
--- a/projects/civetweb/project.yaml
+++ b/projects/civetweb/project.yaml
@@ -4,7 +4,6 @@ language: c
 fuzzing_engines:
   - libfuzzer
   - honggfuzz
-  - dataflow
 auto_ccs:
   - "xt4ubq@gmail.com"
   - "david@adalogics.com"


### PR DESCRIPTION
DFSAN builds are failing, causing ClusterFuzz exceptions.
DFSAN isn't really supported right now anyway.