### PR TITLE
[CIFuzz][fuzz_target] Prepare for ClusterFuzzLite

### DIFF
--- a/infra/cifuzz/fuzz_target.py
+++ b/infra/cifuzz/fuzz_target.py
@@ -47,7 +47,8 @@ COULD_NOT_TEST_ON_RECENT_MESSAGE = (
     'target to determine if this code change (pr/commit) introduced crash. '
     'Assuming this code change introduced crash.')
 
-FuzzResult = collections.namedtuple('FuzzResult', ['testcase', 'stacktrace'])
+FuzzResult = collections.namedtuple('FuzzResult',
+                                    ['testcase', 'stacktrace', 'corpus_path'])
 
 
 class ReproduceError(Exception):
@@ -127,29 +128,29 @@ class FuzzTarget:
       _, stderr = process.communicate(timeout=self.duration + BUFFER_TIME)
     except subprocess.TimeoutExpired:
       logging.error('Fuzzer %s timed out, ending fuzzing.', self.target_name)
-      return FuzzResult(None, None)
+      return FuzzResult(None, None, self.latest_corpus_path)
 
     # Libfuzzer timeout was reached.
     if not process.returncode:
       logging.info('Fuzzer %s finished with no crashes discovered.',
                    self.target_name)
-      return FuzzResult(None, None)
+      return FuzzResult(None, None, self.latest_corpus_path)
 
     # Crash was discovered.
     logging.info('Fuzzer %s, ended before timeout.', self.target_name)
     testcase = self.get_testcase(stderr)
     if not testcase:
       logging.error(b'No testcase found in stacktrace: %s.', stderr)
-      return FuzzResult(None, None)
+      return FuzzResult(None, None, self.latest_corpus_path)
 
     utils.binary_print(b'Fuzzer: %s. Detected bug:\n%s' %
                        (self.target_name.encode(), stderr))
     if self.is_crash_reportable(testcase):
       # We found a bug in the fuzz target and we will report it.
-      return FuzzResult(testcase, stderr)
+      return FuzzResult(testcase, stderr, self.latest_corpus_path)
 
     # We found a bug but we won't report it.
-    return FuzzResult(None, None)
+    return FuzzResult(None, None, self.latest_corpus_path)
 
   def free_disk_if_needed(self):
     """Deletes things that are no longer needed from fuzzing this fuzz target to
@@ -254,13 +255,28 @@ class FuzzTarget:
       logging.info('Failed to reproduce the crash using the obtained testcase.')
       return False
 
+    is_novel = not self.is_crash_novel(testcase)
+
+    if not is_novel:
+      logging.info('The crash is reproducible. The crash doesn\'t reproduce '
+                   'on old builds. This code change probably introduced the '
+                   'crash.')
+      return True
+
+    logging.info('The crash is reproducible on old builds '
+                 '(without the current code change).')
+    return False
+
+  def is_crash_novel(self, testcase):
+    """Returns False if the crash couldn't be reproduced on the ClusterFuzz
+    build of the fuzz target."""
     clusterfuzz_build_dir = self.clusterfuzz_deployment.download_latest_build(
         self.out_dir)
     if not clusterfuzz_build_dir:
       # Crash is reproducible on PR build and we can't test on a recent
       # ClusterFuzz/OSS-Fuzz build.
       logging.info(COULD_NOT_TEST_ON_RECENT_MESSAGE)
-      return True
+      return False
 
     clusterfuzz_target_path = os.path.join(clusterfuzz_build_dir,
                                            self.target_name)
@@ -271,17 +287,17 @@ class FuzzTarget:
       # This happens if the project has ClusterFuzz builds, but the fuzz target
       # is not in it (e.g. because the fuzz target is new).
       logging.info(COULD_NOT_TEST_ON_RECENT_MESSAGE)
-      return True
+      return False
 
     if not reproducible_on_clusterfuzz_build:
       logging.info('The crash is reproducible. The crash doesn\'t reproduce '
                    'on old builds. This code change probably introduced the '
                    'crash.')
-      return True
+      return False
 
     logging.info('The crash is reproducible on old builds '
                  '(without the current code change).')
-    return False
+    return True
 
   def get_testcase(self, error_bytes):
     """Gets the file from a fuzzer run stacktrace.

--- a/infra/cifuzz/fuzz_target.py
+++ b/infra/cifuzz/fuzz_target.py
@@ -255,16 +255,10 @@ class FuzzTarget:
       logging.info('Failed to reproduce the crash using the obtained testcase.')
       return False
 
-    is_novel = not self.is_crash_novel(testcase)
+    is_novel = self.is_crash_novel(testcase)
 
-    if not is_novel:
-      logging.info('The crash is reproducible. The crash doesn\'t reproduce '
-                   'on old builds. This code change probably introduced the '
-                   'crash.')
+    if is_novel:
       return True
-
-    logging.info('The crash is reproducible on old builds '
-                 '(without the current code change).')
     return False
 
   def is_crash_novel(self, testcase):
@@ -276,7 +270,7 @@ class FuzzTarget:
       # Crash is reproducible on PR build and we can't test on a recent
       # ClusterFuzz/OSS-Fuzz build.
       logging.info(COULD_NOT_TEST_ON_RECENT_MESSAGE)
-      return False
+      return True
 
     clusterfuzz_target_path = os.path.join(clusterfuzz_build_dir,
                                            self.target_name)
@@ -287,17 +281,17 @@ class FuzzTarget:
       # This happens if the project has ClusterFuzz builds, but the fuzz target
       # is not in it (e.g. because the fuzz target is new).
       logging.info(COULD_NOT_TEST_ON_RECENT_MESSAGE)
-      return False
+      return True
 
     if not reproducible_on_clusterfuzz_build:
       logging.info('The crash is reproducible. The crash doesn\'t reproduce '
                    'on old builds. This code change probably introduced the '
                    'crash.')
-      return False
+      return True
 
     logging.info('The crash is reproducible on old builds '
                  '(without the current code change).')
-    return True
+    return False
 
   def get_testcase(self, error_bytes):
     """Gets the file from a fuzzer run stacktrace.

--- a/infra/cifuzz/fuzz_target.py
+++ b/infra/cifuzz/fuzz_target.py
@@ -255,11 +255,7 @@ class FuzzTarget:
       logging.info('Failed to reproduce the crash using the obtained testcase.')
       return False
 
-    is_novel = self.is_crash_novel(testcase)
-
-    if is_novel:
-      return True
-    return False
+    return self.is_crash_novel(testcase)
 
   def is_crash_novel(self, testcase):
     """Returns False if the crash couldn't be reproduced on the ClusterFuzz

--- a/infra/cifuzz/fuzz_target.py
+++ b/infra/cifuzz/fuzz_target.py
@@ -258,8 +258,8 @@ class FuzzTarget:
     return self.is_crash_novel(testcase)
 
   def is_crash_novel(self, testcase):
-    """Returns False if the crash couldn't be reproduced on the ClusterFuzz
-    build of the fuzz target."""
+    """Returns whether or not the crash is new. A crash is considered new if it
+    can't be reproduced on an older ClusterFuzz build of the target."""
     clusterfuzz_build_dir = self.clusterfuzz_deployment.download_latest_build(
         self.out_dir)
     if not clusterfuzz_build_dir:

--- a/infra/cifuzz/run_fuzzers_test.py
+++ b/infra/cifuzz/run_fuzzers_test.py
@@ -309,7 +309,6 @@ class BatchFuzzTargetRunnerTest(fake_filesystem_unittest.TestCase):
         testcase = testcase2
       assert call_count != 2
       call_count += 1
-      self.fs.create_dir(corpus_dir)
       return fuzz_target.FuzzResult(testcase, stacktrace, corpus_dir)
 
     mocked_run_fuzz_target.side_effect = mock_run_fuzz_target

--- a/infra/cifuzz/run_fuzzers_test.py
+++ b/infra/cifuzz/run_fuzzers_test.py
@@ -258,8 +258,10 @@ class CiFuzzTargetRunnerTest(fake_filesystem_unittest.TestCase):
     testcase = os.path.join(workspace, 'testcase')
     self.fs.create_file(testcase)
     stacktrace = b'stacktrace'
+    corpus_dir = 'corpus'
+    self.fs.create_dir(corpus_dir)
     mocked_run_fuzz_target.return_value = fuzz_target.FuzzResult(
-        testcase, stacktrace)
+        testcase, stacktrace, corpus_dir)
     magic_mock = mock.MagicMock()
     magic_mock.target_name = 'target1'
     mocked_create_fuzz_target_obj.return_value = magic_mock
@@ -297,6 +299,7 @@ class BatchFuzzTargetRunnerTest(fake_filesystem_unittest.TestCase):
     self.fs.create_file(testcase2)
     stacktrace = b'stacktrace'
     call_count = 0
+    corpus_dir = 'corpus'
 
     def mock_run_fuzz_target(_):
       nonlocal call_count
@@ -306,7 +309,8 @@ class BatchFuzzTargetRunnerTest(fake_filesystem_unittest.TestCase):
         testcase = testcase2
       assert call_count != 2
       call_count += 1
-      return fuzz_target.FuzzResult(testcase, stacktrace)
+      self.fs.create_dir(corpus_dir)
+      return fuzz_target.FuzzResult(testcase, stacktrace, corpus_dir)
 
     mocked_run_fuzz_target.side_effect = mock_run_fuzz_target
     magic_mock = mock.MagicMock()


### PR DESCRIPTION
Return the path to the corpus in FuzzResult.
Also, refactor is_reportable: move code testing crash novelty
into its own method.