### PR TITLE
libvips: remove libjxl patch merged upstream

### DIFF
--- a/projects/libvips/Dockerfile
+++ b/projects/libvips/Dockerfile
@@ -40,7 +40,7 @@ RUN git clone --depth 1 https://chromium.googlesource.com/webm/libwebp
 RUN git clone --depth 1 https://gitlab.com/libtiff/libtiff 
 RUN git clone --depth 1 https://aomedia.googlesource.com/aom
 RUN git clone --depth 1 https://github.com/strukturag/libheif
-RUN git clone --depth 1 --recursive https://gitlab.com/wg1/jpeg-xl.git
+RUN git clone --depth 1 --recursive https://github.com/libjxl/libjxl.git
 
 WORKDIR libvips
 COPY build.sh $SRC/

--- a/projects/libvips/build.sh
+++ b/projects/libvips/build.sh
@@ -145,13 +145,10 @@ make install
 popd
 
 # jpeg-xl (libjxl)
-pushd $SRC/jpeg-xl
+pushd $SRC/libjxl
 sed -i'.bak' "/add_subdirectory(tools)/d" CMakeLists.txt
 # Don't overwrite our linker flags
 sed -i'.bak' "/set(CMAKE_EXE_LINKER_FLAGS/{N;d;}" CMakeLists.txt
-# Ensure pkg-config file is installed when -DJPEGXL_STATIC=1, see:
-# https://gitlab.com/wg1/jpeg-xl/-/issues/224
-curl -Ls https://gist.github.com/kleisauke/d54b5e62367d20e66dd58ca19a2234c9/raw/1dfd4398de87e1997f21a216a1c28de730deb2d9/jpeg-xl-pkg-config.patch | patch -p1 || true
 cmake -G "Unix Makefiles" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_C_COMPILER=$CC \


### PR DESCRIPTION
This PR removes a libjxl patch in libvips' fuzzer that was merged upstream with commit https://github.com/libjxl/libjxl/commit/0f6ddd4727f2c51bb2396872599d4f86f19bf064. 

It also adapts the Dockerfile to reflect the new development location of libjxl: https://github.com/libjxl/libjxl.