### PR TITLE
Revert "bitcoin-core: Run zip in parallel"

### DIFF
--- a/projects/bitcoin-core/Dockerfile
+++ b/projects/bitcoin-core/Dockerfile
@@ -22,7 +22,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y \
   build-essential libtool autotools-dev automake pkg-config bsdmainutils python3 \
   make automake cmake curl g++-multilib libtool binutils-gold bsdmainutils pkg-config patch bison \
-  wget zip parallel
+  wget zip
 
 RUN git clone --depth=1 https://github.com/bitcoin/bitcoin.git bitcoin-core
 RUN git clone --depth=1 https://github.com/bitcoin-core/qa-assets bitcoin-core/assets

--- a/projects/bitcoin-core/build.sh
+++ b/projects/bitcoin-core/build.sh
@@ -84,8 +84,7 @@ for fuzz_target in ${FUZZ_TARGETS[@]}; do
   (
     cd assets/fuzz_seed_corpus
     if [ -d "$fuzz_target" ]; then
-      sem -j+0 zip --recurse-paths --quiet --junk-paths "$OUT/${fuzz_target}_seed_corpus.zip" "${fuzz_target}"
+      zip --recurse-paths --quiet --junk-paths "$OUT/${fuzz_target}_seed_corpus.zip" "${fuzz_target}"
     fi
   )
 done
-sem --wait


### PR DESCRIPTION
I suspect that the OSS-Fuzz HDD are too slow to read/write large amounts of data (fuzz binaries and inputs), leading to the error 

```
Step #13: + sem --wait
TIMEOUT
ERROR: context deadline exceeded
```

https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34157#c5


I have no idea if the given patch fixes the issue, because I can't reproduce locally.