### PR TITLE
[infra][jvm] Don't override jvm_args in coverage builds

### DIFF
--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -145,7 +145,7 @@ function run_java_fuzz_target {
   # Use 100s timeout instead of 25s as code coverage builds can be very slow.
   local jacoco_args="destfile=$exec_file,classdumpdir=$class_dump_dir,excludes=com.code_intelligence.jazzer.*"
   local args="-merge=1 -timeout=100 -close_fd_mask=3 --nohooks \
-      --jvm_args=-javaagent:/opt/jacoco-agent.jar=$jacoco_args \
+      --additional_jvm_args=-javaagent:/opt/jacoco-agent.jar=$jacoco_args \
       $corpus_dummy $corpus_real"
 
   timeout $TIMEOUT $OUT/$target $args &> $LOGS_DIR/$target.log


### PR DESCRIPTION
Specify `--additional_jvm_args` instead of `--jvm_args` so that custom target JVM args (e.g. `--enable-preview`) are preserved in coverage runs.

Fixes the coverage build for `kryo`.

@inferno-chromium This requires an update of base-builder (it needs latest Jazzer) or all coverage builds will fail. 