### PR TITLE
[FFmpeg] remove libXfixes

### DIFF
--- a/projects/ffmpeg/Dockerfile
+++ b/projects/ffmpeg/Dockerfile
@@ -28,7 +28,6 @@ RUN git clone https://git.ffmpeg.org/ffmpeg.git ffmpeg
 RUN wget https://www.alsa-project.org/files/pub/lib/alsa-lib-1.1.0.tar.bz2
 RUN git clone --depth 1 https://github.com/mstorsjo/fdk-aac.git
 RUN git clone --depth 1 git://anongit.freedesktop.org/xorg/lib/libXext
-RUN git clone --depth 1 git://anongit.freedesktop.org/git/xorg/lib/libXfixes
 RUN git clone --depth 1 https://github.com/intel/libva
 RUN git clone --depth 1 -b libvdpau-1.2 git://people.freedesktop.org/~aplattner/libvdpau
 RUN git clone --depth 1 https://chromium.googlesource.com/webm/libvpx

--- a/projects/ffmpeg/build.sh
+++ b/projects/ffmpeg/build.sh
@@ -50,13 +50,6 @@ make clean
 make -j$(nproc)
 make install
 
-cd $SRC/libXfixes
-./autogen.sh
-./configure --prefix="$FFMPEG_DEPS_PATH" --enable-static
-make clean
-make -j$(nproc)
-make install
-
 cd $SRC/libva
 ./autogen.sh
 ./configure --prefix="$FFMPEG_DEPS_PATH" --enable-static --disable-shared


### PR DESCRIPTION
Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34211
Fixes build (which apparently failed due to incompatibility of unneeded distro
packages being mixed with unneeded git packages)

Signed-off-by: Michael Niedermayer <michaelni@gmx.at>