### PR TITLE
[toml-rs] initial integration

### DIFF
--- a/projects/toml-rs/Dockerfile
+++ b/projects/toml-rs/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2021 Google LL
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update &&\
+    apt-get install -y wget
+RUN git clone --depth 1 https://github.com/alexcrichton/toml-rs
+WORKDIR toml-rs
+COPY build.sh $SRC/

--- a/projects/toml-rs/Dockerfile
+++ b/projects/toml-rs/Dockerfile
@@ -15,6 +15,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update &&\
     apt-get install -y wget
-RUN git clone --depth 1 https://github.com/alexcrichton/toml-rs
+RUN git clone --depth 1 https://github.com/evverx/toml-rs && cd toml-rs && git fetch origin fuzz && git checkout FETCH_HEAD
 WORKDIR toml-rs
 COPY build.sh $SRC/

--- a/projects/toml-rs/build.sh
+++ b/projects/toml-rs/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+fuzz/oss-fuzz.sh

--- a/projects/toml-rs/project.yaml
+++ b/projects/toml-rs/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/alexcrichton/toml-rs"
+main_repo: "https://github.com/alexcrichton/toml-rs"
+primary_contact: "alex@alexcrichton.com"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+language: rust
+auto_ccs:
+  - "evverx@gmail.com"


### PR DESCRIPTION
I'm trying to figure out how `cargo fuzz` is integrated into OSS-Fuzz. The build script points to my fork: https://github.com/evverx/toml-rs/commits/fuzz

The fuzz target has found a stack-overflow locally (as far as I can tell, it's the same stack overflow as the one reported in https://github.com/alexcrichton/toml-rs/issues/428) so it seems to be working more or less

@alexcrichton I'd appreciate it if you could take a look at the fuzzer. It's currently at https://github.com/alexcrichton/toml-rs/pull/430