### PR TITLE
infra: show RUSTFLAGS as well

### DIFF
--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -144,6 +144,7 @@ echo "CC=$CC"
 echo "CXX=$CXX"
 echo "CFLAGS=$CFLAGS"
 echo "CXXFLAGS=$CXXFLAGS"
+echo "RUSTFLAGS=$RUSTFLAGS"
 echo "---------------------------------------------------------------"
 
 BUILD_CMD="bash -eux $SRC/build.sh"


### PR DESCRIPTION
It should make it easier to see where all the rustc flags
come from. RUSTFLAGS along with `cargo fuzz build --verbose` should
help to track down weird issues like https://github.com/google/oss-fuzz/pull/5865#issuecomment-852685588

It's a follow-up to ecf3d384fb0b62069