### PR TITLE
Adds rust image-rs project

### DIFF
--- a/projects/image-rs/Dockerfile
+++ b/projects/image-rs/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN git clone https://github.com/image-rs/image
+WORKDIR $SRC/image
+
+COPY build.sh $SRC/

--- a/projects/image-rs/build.sh
+++ b/projects/image-rs/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cargo fuzz build -O
+cargo fuzz list | while read i; do
+    cp fuzz/target/x86_64-unknown-linux-gnu/release/$i $OUT/
+done

--- a/projects/image-rs/project.yaml
+++ b/projects/image-rs/project.yaml
@@ -1,0 +1,11 @@
+homepage: "https://docs.rs/image/0.23.14/image"
+main_repo: "https://github.com/image-rs/image"
+primary_contact: "andreas.molzer@gmx.de"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+language: rust
+auto_ccs:
+  - "fintelia@gmail.com"
+  - "p.antoine@catenacyber.fr"


### PR DESCRIPTION
cc @HeroicKatora @fintelia
In addition to image-png, would you be interested in fuzzing the whole image crate ?
This PR enables it with the libfuzzer/cargo fuzz fuzz targets

The AFL targets could be integrated. To do this, the best way I see is to make them generic as in #5798 

cc @DavidKorczynski as you did image-png integration