### PR TITLE
libjxl: New JPEG XL library project.

### DIFF
--- a/projects/libjxl/Dockerfile
+++ b/projects/libjxl/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y cmake ninja-build pkg-config
+RUN git clone --depth 1 https://github.com/libjxl/libjxl.git
+# We only need these sub-projects for the fuzzers.
+RUN git -C libjxl submodule update --init --recommend-shallow \
+  third_party/highway third_party/lodepng third_party/skcms third_party/brotli
+
+WORKDIR libjxl
+COPY build.sh $SRC/

--- a/projects/libjxl/build.sh
+++ b/projects/libjxl/build.sh
@@ -1,0 +1,73 @@
+#!/bin/bash -eu
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+build_args=(
+  -G Ninja
+  -DBUILD_TESTING=OFF
+  -DJPEGXL_ENABLE_BENCHMARK=OFF
+  -DJPEGXL_ENABLE_DEVTOOLS=ON
+  -DJPEGXL_ENABLE_EXAMPLES=OFF
+  -DJPEGXL_ENABLE_FUZZERS=ON
+  -DJPEGXL_ENABLE_MANPAGES=OFF
+  -DJPEGXL_ENABLE_SJPEG=OFF
+  -DJPEGXL_ENABLE_VIEWERS=OFF
+  -DCMAKE_BUILD_TYPE=Release
+)
+
+# Build and generate a fuzzer corpus in release mode without instrumentation.
+# This is done in a subshell since we change the environment.
+(
+  unset CFLAGS
+  unset CXXFLAGS
+  export AFL_NOOPT=1
+
+  mkdir -p ${WORK}/libjxl-corpus
+  cd ${WORK}/libjxl-corpus
+  cmake "${build_args[@]}" "${SRC}/libjxl"
+  ninja clean
+  ninja fuzzer_corpus
+
+  # Generate a fuzzer corpus.
+  mkdir -p djxl_fuzzer_corpus
+  tools/fuzzer_corpus -r djxl_fuzzer_corpus
+  zip -j "${OUT}/djxl_fuzzer_seed_corpus.zip" djxl_fuzzer_corpus/*
+)
+
+# Build the fuzzers in release mode but force the inclusion of JXL_DASSERT()
+# checks.
+export CXXFLAGS="${CXXFLAGS} -DJXL_IS_DEBUG_BUILD=1"
+
+mkdir -p ${WORK}/libjxl-fuzzer
+cd ${WORK}/libjxl-fuzzer
+cmake \
+  "${build_args[@]}" \
+  -DJPEGXL_FUZZER_LINK_FLAGS="${LIB_FUZZING_ENGINE}" \
+  "${SRC}/libjxl"
+
+fuzzers=(
+  color_encoding_fuzzer
+  djxl_fuzzer
+  fields_fuzzer
+  icc_codec_fuzzer
+  rans_fuzzer
+)
+
+ninja clean
+ninja "${fuzzers[@]}"
+for fuzzer in "${fuzzers[@]}"; do
+  cp tools/${fuzzer} "${OUT}/"
+done

--- a/projects/libjxl/project.yaml
+++ b/projects/libjxl/project.yaml
@@ -1,0 +1,11 @@
+homepage: "https://github.com/libjxl/libjxl"
+language: c++
+primary_contact: "libjxl-security@google.com"
+auto_ccs:
+  - "deymo@google.com"
+  - "veluca@google.com"
+sanitizers:
+  - address
+  - memory
+  - undefined
+main_repo: 'https://github.com/libjxl/libjxl.git'


### PR DESCRIPTION
libjxl is the reference implementation encoder and decoder for JPEG XL.
This patch adds the main decoder fuzzer (djxl_fuzzer) and a few other
fuzzers for internal parts of the decoder.

There's no encoder fuzzer support.