### PR TITLE
go: compiles projects without go.mod from their directory

### DIFF
--- a/infra/base-images/base-builder/compile_go_fuzzer
+++ b/infra/base-images/base-builder/compile_go_fuzzer
@@ -29,7 +29,7 @@ cd $GOPATH/src/$path || true
 # in the case we are in the right directory, with go.mod but no go.sum
 go mod tidy || true
 # project was downloaded with go get if go list fails
-go list $tags $path || { cd $GOPATH/pkg/mod/ && cd `echo $path | cut -d/ -f1-3 | awk '{print $1"@*"}'`; }
+go list $tags $path || { cd $GOPATH/pkg/mod/ && cd `echo $path | cut -d/ -f1-3 | awk '{print $1"@*"}'`; } || cd -
 # project does not have go.mod if go list fails again
 go list $tags $path || { go mod init $path && go mod tidy ;}
 


### PR DESCRIPTION
Should fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34965 build failure for json-patch

The problem is for golang projects without go.mod yet, if we are in their directory, we fail to find a directory in /root/go/pkg/ for them...
