### PR TITLE
infra: Set -ftrivial-auto-var-init=pattern for address sanitizer

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -127,7 +127,7 @@ RUN cd $SRC/ && \
     rm -rf $SRC/jazzer
 
 # Default build flags for various sanitizers.
-ENV SANITIZER_FLAGS_address "-fsanitize=address -fsanitize-address-use-after-scope"
+ENV SANITIZER_FLAGS_address "-fsanitize=address -fsanitize-address-use-after-scope -ftrivial-auto-var-init=pattern"
 
 # Set of '-fsanitize' flags matches '-fno-sanitize-recover' + 'unsigned-integer-overflow'.
 ENV SANITIZER_FLAGS_undefined "-fsanitize=array-bounds,bool,builtin,enum,float-divide-by-zero,function,integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,shift,signed-integer-overflow,unsigned-integer-overflow,unreachable,vla-bound,vptr -fno-sanitize-recover=array-bounds,bool,builtin,enum,float-divide-by-zero,function,integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,shift,signed-integer-overflow,unreachable,vla-bound,vptr"

--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -127,7 +127,7 @@ RUN cd $SRC/ && \
     rm -rf $SRC/jazzer
 
 # Default build flags for various sanitizers.
-ENV SANITIZER_FLAGS_address "-fsanitize=address -fsanitize-address-use-after-scope -ftrivial-auto-var-init=pattern"
+ENV SANITIZER_FLAGS_address "-fsanitize=address,bool,enum -fsanitize-address-use-after-scope -ftrivial-auto-var-init=pattern"
 
 # Set of '-fsanitize' flags matches '-fno-sanitize-recover' + 'unsigned-integer-overflow'.
 ENV SANITIZER_FLAGS_undefined "-fsanitize=array-bounds,bool,builtin,enum,float-divide-by-zero,function,integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,shift,signed-integer-overflow,unsigned-integer-overflow,unreachable,vla-bound,vptr -fno-sanitize-recover=array-bounds,bool,builtin,enum,float-divide-by-zero,function,integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,shift,signed-integer-overflow,unreachable,vla-bound,vptr"

--- a/infra/base-images/base-runner/bad_build_check
+++ b/infra/base-images/base-runner/bad_build_check
@@ -326,7 +326,9 @@ function check_mixed_sanitizers {
   local ASAN_CALLS=$(objdump -dC $FUZZER | egrep "${CALL_INSN}__asan" -c)
   local DFSAN_CALLS=$(objdump -dC $FUZZER | egrep "${CALL_INSN}__dfsan" -c)
   local MSAN_CALLS=$(objdump -dC $FUZZER | egrep "${CALL_INSN}__msan" -c)
-  local UBSAN_CALLS=$(objdump -dC $FUZZER | egrep "${CALL_INSN}__ubsan" -c)
+  # Ignore __ubsan_handle_load_invalid_value as it is used by the ASan config,
+  # too. See SANITIZER_FLAGS_address.
+  local UBSAN_CALLS=$(objdump -dC $FUZZER | grep -v '__ubsan_handle_load_invalid_value' | egrep "${CALL_INSN}__ubsan" -c)
 
 
   if [[ "$SANITIZER" = address ]]; then


### PR DESCRIPTION
Reading uninitialized memory is undefined behaviour, thus non-deterministic. Non-determinism makes it harder to reproduce a bug. To fix some cases of non-determinism, I suggest to add `-ftrivial-auto-var-init=pattern` to the address sanitizer.

Obviously not all uninitialized reads can be caught by this and Valgrind or MSAN are still recommended tools to fight this class of bug.

Even though `-ftrivial-auto-var-init=pattern` will *hide* some bugs from Valgrind or MSAN, those tools are largely incompatible with ASAN, so adding the option to the ASAN flags should be fine.