### PR TITLE
[pulldown-cmark] initial integration

### DIFF
--- a/projects/pulldown-cmark/Dockerfile
+++ b/projects/pulldown-cmark/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2021 Google LL
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update &&\
+    apt-get install -y wget
+RUN git clone --depth 1 https://github.com/raphlinus/pulldown-cmark
+WORKDIR pulldown-cmark
+COPY fuzz ./fuzz
+COPY build.sh $SRC/

--- a/projects/pulldown-cmark/Dockerfile
+++ b/projects/pulldown-cmark/Dockerfile
@@ -17,5 +17,5 @@ RUN apt-get update &&\
     apt-get install -y wget
 RUN git clone --depth 1 https://github.com/raphlinus/pulldown-cmark
 WORKDIR pulldown-cmark
-COPY fuzz ./fuzz
+COPY fuzz $SRC/fuzz
 COPY build.sh $SRC/

--- a/projects/pulldown-cmark/build.sh
+++ b/projects/pulldown-cmark/build.sh
@@ -15,3 +15,6 @@ fi
 
 cargo fuzz build $build_args --debug-assertions --verbose
 cp "fuzz/target/x86_64-unknown-linux-gnu/$build_type/fuzz_pulldown_cmark_read" $OUT/
+
+git clone --depth 1 https://github.com/michelf/mdtest
+zip -r $OUT/fuzz_pulldown_cmark_read_seed_corpus.zip mdtest

--- a/projects/pulldown-cmark/build.sh
+++ b/projects/pulldown-cmark/build.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
 
 set -eux
 
@@ -13,6 +28,7 @@ if [[ "$build_type" =~ "dev" ]]; then
     build_args="--dev"
 fi
 
+cp -r "$SRC/fuzz" fuzz
 cargo fuzz build $build_args --debug-assertions --verbose
 cp "fuzz/target/x86_64-unknown-linux-gnu/$build_type/fuzz_pulldown_cmark_read" $OUT/
 

--- a/projects/pulldown-cmark/build.sh
+++ b/projects/pulldown-cmark/build.sh
@@ -18,3 +18,6 @@ cp "fuzz/target/x86_64-unknown-linux-gnu/$build_type/fuzz_pulldown_cmark_read" $
 
 git clone --depth 1 https://github.com/michelf/mdtest
 zip -r $OUT/fuzz_pulldown_cmark_read_seed_corpus.zip mdtest
+
+git clone --depth 1 https://github.com/commonmark/cmark
+cp cmark/test/fuzzing_dictionary $OUT/fuzz_pulldown_cmark_read.dict

--- a/projects/pulldown-cmark/build.sh
+++ b/projects/pulldown-cmark/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -eux
+
+# https://google.github.io/oss-fuzz/getting-started/new-project-guide/#buildsh
+OUT=${OUT:-out}
+mkdir -p "$OUT"
+
+build_type=${1:-"release"}
+build_args="--release"
+if [[ "$build_type" =~ "dev" ]]; then
+    build_type="debug"
+    build_args="--dev"
+fi
+
+cargo fuzz build $build_args --debug-assertions --verbose
+cp "fuzz/target/x86_64-unknown-linux-gnu/$build_type/fuzz_pulldown_cmark_read" $OUT/

--- a/projects/pulldown-cmark/fuzz/.gitignore
+++ b/projects/pulldown-cmark/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target
+corpus
+artifacts

--- a/projects/pulldown-cmark/fuzz/Cargo.toml
+++ b/projects/pulldown-cmark/fuzz/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "pulldown-cmark-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.pulldown-cmark]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_pulldown_cmark_read"
+path = "fuzz_targets/fuzz_pulldown_cmark_read.rs"
+test = false
+doc = false

--- a/projects/pulldown-cmark/fuzz/fuzz_targets/fuzz_pulldown_cmark_read.rs
+++ b/projects/pulldown-cmark/fuzz/fuzz_targets/fuzz_pulldown_cmark_read.rs
@@ -1,0 +1,10 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+extern crate pulldown_cmark;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        let parser = pulldown_cmark::Parser::new(s);
+        for _ in parser {}
+    }
+});

--- a/projects/pulldown-cmark/project.yaml
+++ b/projects/pulldown-cmark/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/raphlinus/pulldown-cmark"
+main_repo: "https://github.com/raphlinus/pulldown-cmark"
+primary_contact: ""
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+language: rust
+auto_ccs:
+  - "evverx@gmail.com"


### PR DESCRIPTION
It's triggered three different panics so far
```
thread '<unnamed>' panicked at 'range start index 23 out of range for slice of length 21', /src/pulldown-cmark/src/scanners.rs:871:17
```
```
thread '<unnamed>' panicked at 'range start index 6 out of range for slice of length 5', /src/pulldown-cmark/src/scanners.rs:1061:45
```
```
thread '<unnamed>' panicked at 'begin <= end (1 <= 0) when slicing `
-                                                                    \
`', /home/vagrant/RUST/pulldown-cmark/src/parse.rs:1388:46
```
so it seems to be working.