### PR TITLE
Uses git clone instead of go get for gonids

### DIFF
--- a/projects/gonids/Dockerfile
+++ b/projects/gonids/Dockerfile
@@ -15,9 +15,9 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN go get -t github.com/google/gonids
+RUN git clone --depth 1 https://github.com/google/gonids
 
 ADD https://rules.emergingthreats.net/open/suricata/emerging.rules.zip emerging.rules.zip
 
 COPY build.sh $SRC/
-WORKDIR $SRC/
+WORKDIR $SRC/gonids

--- a/projects/gonids/build.sh
+++ b/projects/gonids/build.sh
@@ -17,6 +17,7 @@
 
 compile_go_fuzzer github.com/google/gonids FuzzParseRule fuzz_parserule
 
+cd $SRC
 unzip emerging.rules.zip
 cd rules
 i=0


### PR DESCRIPTION
So that CIFuzz works
As it looks for the main repo in $SRC

cf https://github.com/google/gonids/issues/157
cc @duanehoward