### PR TITLE
Hyperledger Fabric: Initial integration

### DIFF
--- a/projects/fabric/Dockerfile
+++ b/projects/fabric/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/fabric/Dockerfile
+++ b/projects/fabric/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/hyperledger/fabric
+COPY build.sh persistence_fuzzer.go $SRC/
+WORKDIR $SRC/fabric

--- a/projects/fabric/build.sh
+++ b/projects/fabric/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/fabric/build.sh
+++ b/projects/fabric/build.sh
@@ -17,4 +17,3 @@
 
 cp $SRC/persistence_fuzzer.go ./core/chaincode/persistence/mock/
 compile_go_fuzzer github.com/hyperledger/fabric/core/chaincode/persistence/mock FuzzPersistence fuzz_persistence
-

--- a/projects/fabric/build.sh
+++ b/projects/fabric/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cp $SRC/persistence_fuzzer.go ./core/chaincode/persistence/mock/
+compile_go_fuzzer github.com/hyperledger/fabric/core/chaincode/persistence/mock FuzzPersistence fuzz_persistence
+

--- a/projects/fabric/persistence_fuzzer.go
+++ b/projects/fabric/persistence_fuzzer.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/fabric/persistence_fuzzer.go
+++ b/projects/fabric/persistence_fuzzer.go
@@ -1,0 +1,29 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	"github.com/hyperledger/fabric/core/chaincode/persistence"
+	tm "github.com/stretchr/testify/mock"
+)
+
+func FuzzPersistence(data []byte) int {
+	var ccpp persistence.ChaincodePackageParser
+	mockMetaProvider := &MetadataProvider{}
+	mockMetaProvider.On("GetDBArtifacts", tm.Anything).Return([]byte("DB artefacts"), nil)
+	ccpp.MetadataProvider = mockMetaProvider
+	_, _ = ccpp.Parse(data)
+	return 1
+}

--- a/projects/fabric/project.yaml
+++ b/projects/fabric/project.yaml
@@ -1,0 +1,13 @@
+homepage: "https://www.hyperledger.org"
+main_repo: "https://github.com/hyperledger/fabric"
+primary_contact: "ale.linux@sopit.net"
+auto_ccs :
+  - "gari.r.singh@gmail.com"
+vendor_ccs :
+  - "adam@adalogics.com"
+  - "david@adalogics.com"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address

--- a/projects/fabric/project.yaml
+++ b/projects/fabric/project.yaml
@@ -1,9 +1,9 @@
 homepage: "https://www.hyperledger.org"
 main_repo: "https://github.com/hyperledger/fabric"
 primary_contact: "ale.linux@sopit.net"
-auto_ccs :
+auto_ccs:
   - "gari.r.singh@gmail.com"
-vendor_ccs :
+vendor_ccs:
   - "adam@adalogics.com"
   - "david@adalogics.com"
 language: go


### PR DESCRIPTION
This PR adds initial integration of Hyperledger Fabric. Hyperledger Fabric is an enterprise-grade permissioned distributed ledger framework for developing solutions and applications. Its modular and versatile design satisfies a broad range of industry use cases. It offers a unique approach to consensus that enables performance at scale while preserving privacy.

It is used by [a number of companies](https://www.hyperledger.org/learn/case-studies), including: 

- Bosch
- Walmart
- Honeywell
- German stock exchange group
- Sony Global Education
____________________________________________________________________

@sykesm @andrew-coleman @bestbeforetoday @lindluni @mastersingh24 Are you interested in integrating Hyperledger Fabric into OSS-fuzz for continuous fuzzing?

This PR adds the build files and the first fuzzer.

To complete the PR, a maintainers email address is needed for bug reports.