### PR TITLE
libplist: Make sure to use clang/clang++ when building

### DIFF
--- a/projects/libplist/build.sh
+++ b/projects/libplist/build.sh
@@ -16,6 +16,14 @@
 #
 ################################################################################
 
+# prefer clang if it is available
+if test -x "`which clang`"; then
+  export CC=clang
+fi
+if test -x "`which clang++`"; then
+  export CXX=clang++
+fi
+
 ./autogen.sh --without-cython --enable-debug
 make -j$(nproc) clean
 make -j$(nproc) all


### PR DESCRIPTION
Just a small change that makes sure it prefers clang during building, if available.