### PR TITLE
[infra][jvm] Add Jazzer UBSan support

### DIFF
--- a/docs/getting-started/new-project-guide/jvm_lang.md
+++ b/docs/getting-started/new-project-guide/jvm_lang.md
@@ -50,8 +50,9 @@ language: jvm
 ```
 
 The only supported fuzzing engine is libFuzzer (`libfuzzer`). So far the only
-supported sanitizer is AddressSanitizer (`address`), which needs to be
-specified explicitly even for pure Java projects.
+supported sanitizers are AddressSanitizer (`address`) and
+UndefinedBehaviorSanitizer (`undefined`). For pure Java projects, specify
+just `address`:
 
 ```yaml
 fuzzing_engines:
@@ -140,6 +141,10 @@ LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\":\$this_dir \
   chmod +x $OUT/$fuzzer_basename
 done
 ```
+
+The [java-example](https://github.com/google/oss-fuzz/blob/master/projects/java-example/build.sh)
+project contains an example of a `build.sh` for Java projects with native
+libraries.
 
 ## FuzzedDataProvider
 

--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -120,8 +120,8 @@ RUN cd $SRC/ && \
     git clone --depth=1 https://github.com/CodeIntelligenceTesting/jazzer && \
     cd jazzer && \
     bazel build --java_runtime_version=localjdk_15 -c opt --cxxopt="-stdlib=libc++" --linkopt=-lc++ \
-        //agent:jazzer_agent_deploy.jar //driver:jazzer_driver //driver:jazzer_driver_asan //agent:jazzer_api_deploy.jar && \
-    cp bazel-bin/agent/jazzer_agent_deploy.jar bazel-bin/driver/jazzer_driver bazel-bin/driver/jazzer_driver_asan /usr/local/bin/ && \
+        //agent:jazzer_agent_deploy.jar //driver:jazzer_driver //driver:jazzer_driver_asan //driver:jazzer_driver_ubsan //agent:jazzer_api_deploy.jar && \
+    cp bazel-bin/agent/jazzer_agent_deploy.jar bazel-bin/driver/jazzer_driver bazel-bin/driver/jazzer_driver_asan bazel-bin/driver/jazzer_driver_ubsan /usr/local/bin/ && \
     cp bazel-bin/agent/jazzer_api_deploy.jar $JAZZER_API_PATH && \
     rm -rf ~/.cache/bazel ~/.cache/bazelisk && \
     rm -rf $SRC/jazzer

--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -27,8 +27,8 @@ if [ "$FUZZING_LANGUAGE" = "jvm" ]; then
     echo "ERROR: JVM projects can be fuzzed with libFuzzer engine only."
     exit 1
   fi
-  if [ "$SANITIZER" != "address" ] && [ "$SANITIZER" != "coverage" ]; then
-    echo "ERROR: JVM projects can be fuzzed with AddressSanitizer only."
+  if [ "$SANITIZER" != "address" ] && [ "$SANITIZER" != "coverage" ] && [ "$SANITIZER" != "undefined" ]; then
+    echo "ERROR: JVM projects can be fuzzed with AddressSanitizer and UndefinedBehaviorSanitizer only."
     exit 1
   fi
   if [ "$ARCHITECTURE" != "x86_64" ]; then
@@ -136,7 +136,13 @@ cp $(which llvm-symbolizer) $OUT/
 
 # Copy Jazzer to $OUT if needed.
 if [ "$FUZZING_LANGUAGE" = "jvm" ]; then
-  cp $(which jazzer_agent_deploy.jar) $(which jazzer_driver) $(which jazzer_driver_asan) $OUT/
+  cp $(which jazzer_agent_deploy.jar) $(which jazzer_driver) $OUT/
+  jazzer_driver_with_sanitizer=$OUT/jazzer_driver_with_sanitizer
+  if [ "$SANITIZER" = "address" ]; then
+    cp $(which jazzer_driver_asan) $jazzer_driver_with_sanitizer
+  elif [ "$SANITIZER" = "undefined" ]; then
+    cp $(which jazzer_driver_ubsan) $jazzer_driver_with_sanitizer
+  fi
 fi
 
 echo "---------------------------------------------------------------"

--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -24,7 +24,7 @@ else
       -e 'llvm-symbolizer' \
       -e 'jazzer_agent_deploy.jar' \
       -e 'jazzer_driver' \
-      -e 'jazzer_driver_asan')"
+      -e 'jazzer_driver_with_sanitizer')"
 fi
 
 DUMPS_DIR="$OUT/dumps"

--- a/projects/java-example/ExampleFuzzerNative.cpp
+++ b/projects/java-example/ExampleFuzzerNative.cpp
@@ -16,15 +16,21 @@
 
 #include "ExampleFuzzerNative.h"
 
+#include <limits>
 #include <string>
 
 // simple function containing a crash that requires coverage and string compare
 // instrumentation for the fuzzer to find
-void parseInternal(const std::string &input) {
+__attribute__((optnone)) void parseInternal(const std::string &input) {
+  constexpr int bar = std::numeric_limits<int>::max() - 5;
+  // Crashes with UBSan.
+  if (bar + input[0] == 300) {
+    return;
+  }
   if (input[0] == 'a' && input[1] == 'b' && input[5] == 'c') {
     if (input.find("secret_in_native_library") != std::string::npos) {
-      // BOOM
-      *(char *)0xFF = 2;
+      // Crashes with ASan.
+      [[maybe_unused]] char foo = input[input.size() + 2];
     }
   }
 }

--- a/projects/java-example/build.sh
+++ b/projects/java-example/build.sh
@@ -31,7 +31,7 @@ for fuzzer in $(find $SRC -name '*Fuzzer.java' -or -name '*FuzzerNative.java'); 
   cp $SRC/$fuzzer_basename.class $OUT/
 
   if [[ $fuzzer_basename == *FuzzerNative ]]; then
-    driver=jazzer_driver_asan
+    driver=jazzer_driver_with_sanitizer
   else
     driver=jazzer_driver
   fi

--- a/projects/java-example/project.yaml
+++ b/projects/java-example/project.yaml
@@ -1,5 +1,5 @@
 homepage: "https://github.com/CodeIntelligenceTesting/jazzer"
-disabled: true
+disabled: false
 language: jvm
 primary_contact: "meumertzheim@code-intelligence.com"
 fuzzing_engines:
@@ -7,3 +7,4 @@ fuzzing_engines:
 main_repo: "https://github.com/CodeIntelligenceTesting/jazzer"
 sanitizers:
   - address
+  - undefined


### PR DESCRIPTION
Jazzer support for UBSan has been added in https://github.com/CodeIntelligenceTesting/jazzer/commit/224e8d00c26d19a78de1720459e3c5b403ae36ca.

The second commit temporarily reenables the `java-example` project to confirm that UBSan findings are properly reported.