### PR TITLE
poppler: Fix build

### DIFF
--- a/projects/poppler/Dockerfile
+++ b/projects/poppler/Dockerfile
@@ -26,8 +26,7 @@ RUN git clone --depth 1 https://github.com/glennrp/libpng.git
 RUN git clone --depth 1 https://gitlab.freedesktop.org/fontconfig/fontconfig.git
 RUN git clone --depth 1 https://gitlab.freedesktop.org/cairo/cairo.git
 RUN git clone --depth 1 --branch=5.15 git://code.qt.io/qt/qtbase.git
-ADD http://ftp.gnome.org/pub/gnome/sources/pango/1.48/pango-1.48.0.tar.xz $SRC
-RUN tar xvJf $SRC/pango-1.48.0.tar.xz
+RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/pango.git
 ADD https://ftp.gnome.org/pub/gnome/sources/glib/2.64/glib-2.64.2.tar.xz $SRC
 RUN tar xvJf $SRC/glib-2.64.2.tar.xz
 RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2

--- a/projects/poppler/build.sh
+++ b/projects/poppler/build.sh
@@ -97,7 +97,7 @@ if [ "$SANITIZER" != "memory" ]; then
     ninja -C _builddir install
     popd
 
-    pushd $SRC/pango-1.48.0
+    pushd $SRC/pango
     meson \
         -Ddefault_library=static \
         --prefix=$PREFIX \


### PR DESCRIPTION
released pango wants to download harfbuzz from a branch name that no longer exists, so use git pango

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=35010