### PR TITLE
openvpn: initial integration

### DIFF
--- a/projects/openvpn/Dockerfile
+++ b/projects/openvpn/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool libssl-dev liblzo2-dev libpam-dev 
+RUN git clone --depth 1 https://github.com/OpenVPN/openvpn openvpn
+WORKDIR openvpn
+COPY build.sh $SRC/
+COPY fuzz*.cpp $SRC/

--- a/projects/openvpn/build.sh
+++ b/projects/openvpn/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+autoreconf -ivf
+./configure --disable-lz4
+make V=1
+cd src/openvpn
+rm openvpn.o
+ar r libopenvpn.a *.o
+for fuzzname in fuzz_base64 fuzz_dhcp fuzz_proxy fuzz_misc fuzz_buffer; do
+    $CXX  -I../../src/compat/ -I../../ -I./ $CXXFLAGS -c $SRC/${fuzzname}.cpp -o ${fuzzname}.o
+    $CXX ${CXXFLAGS} ${LIB_FUZZING_ENGINE} ./${fuzzname}.o -o $OUT/${fuzzname} \
+        libopenvpn.a ../../src/compat/.libs/libcompat.a /usr/lib/x86_64-linux-gnu/libnsl.a \
+        /usr/lib/x86_64-linux-gnu/libresolv.a /usr/lib/x86_64-linux-gnu/liblzo2.a \
+        -lssl -lcrypto -ldl
+done

--- a/projects/openvpn/fuzz_base64.cpp
+++ b/projects/openvpn/fuzz_base64.cpp
@@ -31,6 +31,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   char *str = NULL;
   openvpn_base64_encode(data, size, &str);
+  if(str != NULL) {
+    free(str);
+  }
 
   uint16_t outsize = 10000;
   char *output_buf = (char *)malloc(outsize);

--- a/projects/openvpn/fuzz_base64.cpp
+++ b/projects/openvpn/fuzz_base64.cpp
@@ -1,0 +1,42 @@
+/* Copyright 2021 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern "C" {
+#include "base64.h"
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  if (size > 500) {
+    return 0;
+  }
+
+  char *new_str = (char *)malloc(size + 1);
+  if (new_str == NULL) {
+    return 0;
+  }
+  memcpy(new_str, data, size);
+  new_str[size] = '\0';
+
+  char *str = NULL;
+  openvpn_base64_encode(data, size, &str);
+
+  uint16_t outsize = 10000;
+  char *output_buf = (char *)malloc(outsize);
+  openvpn_base64_decode(new_str, output_buf, outsize);
+  free(output_buf);
+
+  free(new_str);
+  return 0;
+}

--- a/projects/openvpn/fuzz_buffer.cpp
+++ b/projects/openvpn/fuzz_buffer.cpp
@@ -1,0 +1,72 @@
+/* Copyright 2021 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <fuzzer/FuzzedDataProvider.h>
+
+extern "C" {
+#include "config.h"
+#include "syshead.h"
+#include "misc.h"
+#include "buffer.h"
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  FuzzedDataProvider provider(data, size);
+
+  struct gc_arena gc;
+  struct buffer *bufp;
+  struct buffer buf, buf2;
+  struct buffer_list *buflistp = NULL;
+
+  gc = gc_new();
+  bufp = NULL;
+
+  std::string inp1 = provider.ConsumeRandomLengthString();
+  std::string inp2 = provider.ConsumeRandomLengthString();
+
+  // Single buffer testing
+  buf = string_alloc_buf(inp1.c_str(), &gc);
+  bufp = &buf;
+
+  buf_clear(bufp);
+  buf2 = clone_buf(bufp);
+  free_buf(&buf2);
+
+  buf_defined(bufp);
+  buf_str(bufp);
+  buf_len(bufp);
+  buf_bend(bufp);
+  buf_bptr(bufp);
+
+  skip_leading_whitespace(inp1.c_str());
+
+  buf_string_match_head_str(bufp, inp1.c_str());
+
+  buf_reverse_capacity(bufp);
+  buf_forward_capacity_total(bufp);
+  buf_forward_capacity(bufp);
+  convert_to_one_line(bufp);
+  buf_catrunc(bufp, inp2.c_str());
+
+  // buflist testing
+  buflistp = buffer_list_new(10);
+  buffer_list_push(buflistp, inp1.c_str());
+  buffer_list_push(buflistp, inp2.c_str());
+  buffer_list_defined(buflistp);
+  buffer_list_peek(buflistp);
+  buffer_list_pop(buflistp);
+
+  // Cleanup
+  buffer_list_free(buflistp);
+  gc_free(&gc);
+
+  return 0;
+}

--- a/projects/openvpn/fuzz_dhcp.cpp
+++ b/projects/openvpn/fuzz_dhcp.cpp
@@ -17,6 +17,7 @@ extern "C" {
 #include "config.h"
 #include "syshead.h"
 #include "dhcp.h"
+#include "buffer.h"
 }
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
@@ -27,6 +28,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   if (buf_write(&ipbuf, data, size) != false) {
     ret = dhcp_extract_router_msg(&ipbuf);
   }
+  free_buf(&ipbuf);
 
   return 0;
 }

--- a/projects/openvpn/fuzz_dhcp.cpp
+++ b/projects/openvpn/fuzz_dhcp.cpp
@@ -1,0 +1,32 @@
+/* Copyright 2021 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern "C" {
+#include "config.h"
+#include "syshead.h"
+#include "dhcp.h"
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  struct buffer ipbuf;
+  in_addr_t ret;
+
+  ipbuf = alloc_buf(size);
+  if (buf_write(&ipbuf, data, size) != false) {
+    ret = dhcp_extract_router_msg(&ipbuf);
+  }
+
+  return 0;
+}

--- a/projects/openvpn/fuzz_misc.cpp
+++ b/projects/openvpn/fuzz_misc.cpp
@@ -1,0 +1,67 @@
+/* Copyright 2021 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <fuzzer/FuzzedDataProvider.h>
+
+extern "C" {
+#include "config.h"
+#include "syshead.h"
+#include "misc.h"
+#include "buffer.h"
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  FuzzedDataProvider provider(data, size);
+
+  struct gc_arena gc;
+  struct env_set *es;
+  gc = gc_new();
+  es = env_set_create(&gc);
+
+  int total_to_fuzz = provider.ConsumeIntegralInRange(1, 10);
+  for (int i = 0; i < total_to_fuzz; i++) {
+    int type = provider.ConsumeIntegralInRange(1, 7);
+    std::string inp1 = provider.ConsumeRandomLengthString();
+    std::string inp2 = provider.ConsumeRandomLengthString();
+
+    switch (type) {
+    case 0:
+      env_set_del(es, inp1.c_str());
+      break;
+    case 1:
+      env_set_add(es, inp2.c_str());
+      break;
+    case 2:
+      env_set_get(es, inp1.c_str());
+      break;
+    case 3:
+      if (strlen(inp1.c_str()) > 1 && strlen(inp2.c_str()) > 1) {
+        setenv_str(es, inp2.c_str(), inp1.c_str());
+      }
+      break;
+    case 4:
+      hostname_randomize(inp1.c_str(), &gc);
+      break;
+    case 5:
+      if (strlen(inp1.c_str()) > 0) {
+        get_auth_challenge(inp1.c_str(), &gc);
+      }
+      break;
+    default:
+      sanitize_control_message(inp1.c_str(), &gc);
+    }
+  }
+
+  env_set_destroy(es);
+  gc_free(&gc);
+
+  return 0;
+}

--- a/projects/openvpn/fuzz_proxy.cpp
+++ b/projects/openvpn/fuzz_proxy.cpp
@@ -1,0 +1,101 @@
+/* Copyright 2021 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <fuzzer/FuzzedDataProvider.h>
+
+extern "C" {
+#include "config.h"
+#include "syshead.h"
+#include "proxy.h"
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  FuzzedDataProvider provider(data, size);
+
+  struct gc_arena gc = gc_new();
+  struct http_proxy_info pi;
+  ssize_t generic_ssizet;
+  int signal_received = 0;
+  struct buffer lookahead = alloc_buf(1024);
+
+  memset(&pi, 0, sizeof(pi));
+  pi.proxy_authenticate = NULL;
+
+  generic_ssizet = 0;
+  std::string username = provider.ConsumeBytesAsString(
+      (provider.ConsumeIntegralInRange<uint32_t>(1, 100)));
+  strcpy(pi.up.username, username.c_str());
+  if (strlen(pi.up.username) == 0) {
+    gc_free(&gc);
+    free_buf(&lookahead);
+    return 0;
+  }
+
+  std::string pass = provider.ConsumeBytesAsString(
+      (provider.ConsumeIntegralInRange<uint32_t>(1, 100)));
+  strcpy(pi.up.password, pass.c_str());
+  if (strlen(pi.up.password) == 0) {
+    gc_free(&gc);
+    free_buf(&lookahead);
+    return 0;
+  }
+
+  generic_ssizet = provider.ConsumeIntegralInRange(0, 4);
+  switch (generic_ssizet) {
+  case 0:
+    pi.auth_method = HTTP_AUTH_NONE;
+    break;
+  case 1:
+    pi.auth_method = HTTP_AUTH_NONE;
+    // pi.auth_method = HTTP_AUTH_BASIC;
+    break;
+  case 2:
+    // pi.auth_method = HTTP_AUTH_DIGEST;
+    pi.auth_method = HTTP_AUTH_NONE;
+    break;
+  case 3:
+    // pi.auth_method = HTTP_AUTH_NTLM;
+    pi.auth_method = HTTP_AUTH_NONE;
+    break;
+  case 4:
+    pi.auth_method = HTTP_AUTH_NTLM2;
+    break;
+  }
+  pi.options.http_version = "1.1";
+
+  generic_ssizet = provider.ConsumeIntegralInRange(0, 4);
+  switch (generic_ssizet) {
+  case 0:
+    pi.options.auth_retry = PAR_NO;
+    break;
+  case 1:
+    pi.options.auth_retry = PAR_ALL;
+    break;
+  case 2:
+    pi.options.auth_retry = PAR_NCT;
+    break;
+  }
+
+  std::string proxy_authenticate = provider.ConsumeBytesAsString(
+      (provider.ConsumeIntegralInRange<uint32_t>(1, 100)));
+  char *tmp_authenticate = (char *)malloc(proxy_authenticate.size());
+  memcpy(tmp_authenticate, proxy_authenticate.c_str(),
+         proxy_authenticate.size());
+  pi.proxy_authenticate = tmp_authenticate;
+  establish_http_proxy_passthru(&pi, 0, "1.2.3.4", "777", NULL, &lookahead,
+                                &signal_received);
+  free(pi.proxy_authenticate);
+  gc_free(&gc);
+  free_buf(&lookahead);
+  return 0;
+}

--- a/projects/openvpn/project.yaml
+++ b/projects/openvpn/project.yaml
@@ -1,0 +1,4 @@
+homepage: "http://community.openvpn.net"
+language: c
+primary_contact: "david@adalogics.com"
+main_repo: "https://github.com/OpenVPN/openvpn"

--- a/projects/openvpn/project.yaml
+++ b/projects/openvpn/project.yaml
@@ -1,4 +1,6 @@
 homepage: "http://community.openvpn.net"
 language: c
-primary_contact: "david@adalogics.com"
+primary_contact: "arne@rfc2549.org"
 main_repo: "https://github.com/OpenVPN/openvpn"
+auto_ccs:
+ - "david@adalogics.com"


### PR DESCRIPTION
@schwabe I have been doing some initial work on integrating OpenVPN into OSS-Fuzz to run fuzzers continuously on OpenVPN. I would be very happy to continue working on this and improving the integration as there are a lot more that can be done. If you are happy to integrate could you provide me with an email(s) that will receive bug reports? The email should be affiliated with a Google account.

The specific integration here is a first-step adoption of the work by @guidovranken described [here](https://guidovranken.com/2017/06/26/openvpn-fuzzers-released-notes/) - @guidovranken are you okay with me migrating your fuzzers?

@schwabe Let me know what you think as I would be very happy to get proper fuzzing integrated in OpenVPN. 