### PR TITLE
libjxl: make the fuzzer corpus generation step quiet

### DIFF
--- a/projects/libjxl/build.sh
+++ b/projects/libjxl/build.sh
@@ -43,8 +43,8 @@ build_args=(
 
   # Generate a fuzzer corpus.
   mkdir -p djxl_fuzzer_corpus
-  tools/fuzzer_corpus -r djxl_fuzzer_corpus
-  zip -j "${OUT}/djxl_fuzzer_seed_corpus.zip" djxl_fuzzer_corpus/*
+  tools/fuzzer_corpus -q -r djxl_fuzzer_corpus
+  zip -q -j "${OUT}/djxl_fuzzer_seed_corpus.zip" djxl_fuzzer_corpus/*
 )
 
 # Build the fuzzers in release mode but force the inclusion of JXL_DASSERT()


### PR DESCRIPTION
fuzzer_corpus generators emits two lines per test case generated and the
following zip command emits another line for each generated test case.

This patch makes both commands quiet which facilitates spotting error
messages.