### PR TITLE
qemu: install xenial packages for the build

### DIFF
--- a/projects/qemu/Dockerfile
+++ b/projects/qemu/Dockerfile
@@ -15,6 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
+RUN sed -i -e 's/xenial/bionic/g' /etc/apt/sources.list
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
     libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev patchelf wget \
     libattr1 libattr1-dev libcap-ng-dev


### PR DESCRIPTION
QEMU builds are failing [1]:
"Step #4: ERROR: glib-2.56 gthread-2.0 is required to compile QEMU"

The version of glib shipped with Ubuntu 18.04 is too old. While we wait
on [2] , use the same hack [3] as libreoffice to fix the build.

[1] https://oss-fuzz-build-logs.storage.googleapis.com/log-2a22b4e2-d7b7-4695-a4dd-25d8d8407704.txt
[2] https://github.com/google/oss-fuzz/issues/5697
[3] https://github.com/google/oss-fuzz/blob/30f3a8f1c0f5b072e77d5bea82709db04c53453d/projects/libreoffice/Dockerfile#L24

Signed-off-by: Alexander Bulekov <alxndr@bu.edu>

@philmd @stefanha @whitebrandy @darrenkenny 