### PR TITLE
qemu: manually build glib

### DIFF
--- a/projects/qemu/Dockerfile
+++ b/projects/qemu/Dockerfile
@@ -16,13 +16,15 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
-    libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev patchelf wget \
-    libattr1 libattr1-dev libcap-ng-dev
+    libfdt-dev libpixman-1-dev zlib1g-dev patchelf wget \
+    libattr1 libattr1-dev libcap-ng-dev pkg-config
 # Ninja in the apt repos is too old. Get it directly from github
 RUN wget https://github.com/ninja-build/ninja/releases/latest/download/ninja-linux.zip \
     && unzip ninja-linux.zip \
     && rm ninja-linux.zip \
     && mv ninja /usr/bin/ninja
+ADD https://download.gnome.org/sources/glib/2.67/glib-2.67.6.tar.xz $SRC
+RUN tar xvJf $SRC/glib-2.67.6.tar.xz
 RUN git clone --depth 1 https://git.qemu.org/git/qemu.git qemu
 WORKDIR qemu
-RUN cp scripts/oss-fuzz/build.sh $SRC
+COPY build.sh $SRC/

--- a/projects/qemu/build.sh
+++ b/projects/qemu/build.sh
@@ -1,0 +1,17 @@
+#!/bin/sh -e
+
+pip3 install meson
+
+# Version of glib in Ubuntu Xenial is too old
+pushd $SRC/glib-2.67.6
+meson _build \
+    -Doss_fuzz=enabled \
+    -Dinternal_pcre=true \
+    --default-library=static \
+    -Db_lundef=false \
+    -Dlibmount=disabled
+ninja -C _build
+ninja -C _build install
+popd
+
+./scripts/oss-fuzz/build.sh

--- a/projects/qemu/build.sh
+++ b/projects/qemu/build.sh
@@ -1,4 +1,19 @@
 #!/bin/sh -e
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
 
 pip3 install meson
 


### PR DESCRIPTION
QEMU builds are failing [1]:
"Step #4: ERROR: glib-2.56 gthread-2.0 is required to compile QEMU"

The version of glib shipped with Ubuntu 18.04 is too old. While we wait
on [2], take some inspiration from poppler [3], and build glib ourselves.

[1] https://oss-fuzz-build-logs.storage.googleapis.com/log-2a22b4e2-d7b7-4695-a4dd-25d8d8407704.txt
[2] https://github.com/google/oss-fuzz/issues/5697
[3] https://github.com/google/oss-fuzz/blob/a44547d8d6f78ad7ce02323ecc33382a1d628e39/projects/poppler/build.sh#L70

Signed-off-by: Alexander Bulekov <alxndr@bu.edu>