### PR TITLE
[bitcoin-core] Enable libsecp256k1 Schnorr signature fuzzing

### DIFF
--- a/projects/bitcoin-core/build_cryptofuzz.sh
+++ b/projects/bitcoin-core/build_cryptofuzz.sh
@@ -42,9 +42,9 @@ function build_libsecp256k1() {
 
     if [[ $CFLAGS = *sanitize=memory* ]]
     then
-        ./configure --enable-static --disable-tests --disable-benchmark --disable-exhaustive-tests --enable-module-recovery --enable-experimental --with-asm=no "$@"
+        ./configure --enable-static --disable-tests --disable-benchmark --disable-exhaustive-tests --enable-module-recovery --enable-experimental --enable-module-schnorrsig --with-asm=no "$@"
     else
-        ./configure --enable-static --disable-tests --disable-benchmark --disable-exhaustive-tests --enable-module-recovery --enable-experimental "$@"
+        ./configure --enable-static --disable-tests --disable-benchmark --disable-exhaustive-tests --enable-module-recovery --enable-experimental --enable-module-schnorrsig "$@"
     fi
     make
 
@@ -84,13 +84,27 @@ cd $SRC/cryptofuzz
 python gen_repository.py
 rm extra_options.h
 echo -n '"' >>extra_options.h
-echo -n '--operations=Digest,HMAC,KDF_HKDF,SymmetricEncrypt,SymmetricDecrypt,ECC_PrivateToPublic,ECC_ValidatePubkey,ECDSA_Sign,ECDSA_Verify,ECDSA_Recover,BignumCalc_Mod_2Exp256 ' >>extra_options.h
+echo -n '--operations=' >>extra_options.h
+echo -n 'Digest,' >>extra_options.h
+echo -n 'HMAC,' >>extra_options.h
+echo -n 'KDF_HKDF,' >>extra_options.h
+echo -n 'SymmetricEncrypt,' >>extra_options.h
+echo -n 'SymmetricDecrypt,' >>extra_options.h
+echo -n 'ECC_PrivateToPublic,' >>extra_options.h
+echo -n 'ECC_ValidatePubkey,' >>extra_options.h
+echo -n 'ECDSA_Sign,' >>extra_options.h
+echo -n 'ECDSA_Verify,' >>extra_options.h
+echo -n 'ECDSA_Recover,' >>extra_options.h
+echo -n 'Schnorr_Sign,' >>extra_options.h
+echo -n 'Schnorr_Verify,' >>extra_options.h
+echo -n 'BignumCalc_Mod_2Exp256 ' >>extra_options.h
 echo -n '--curves=secp256k1 ' >>extra_options.h
 echo -n '--digests=NULL,SHA1,SHA256,SHA512,RIPEMD160,SHA3-256,SIPHASH64 ' >>extra_options.h
 echo -n '--ciphers=CHACHA20,AES_256_CBC ' >>extra_options.h
 echo -n '--calcops=Add,And,Div,IsEq,IsGt,IsGte,IsLt,IsLte,IsOdd,Mul,NumBits,Or,Set,Sub,Xor ' >>extra_options.h
 echo -n '"' >>extra_options.h
 cd modules/bitcoin/
+export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_BITCOIN"
 make -B -j$(nproc)
 cd ../trezor/
 make -B -j$(nproc)


### PR DESCRIPTION
Also enable the Bitcoin crypto module (e.g. the harness in https://github.com/guidovranken/cryptofuzz/tree/master/modules/bitcoin) which I had unfortunately forgotten to enable last time.

CC @MarcoFalke 