### PR TITLE
Rustls: fix coverage

### DIFF
--- a/projects/rustls/build.sh
+++ b/projects/rustls/build.sh
@@ -22,5 +22,8 @@ cp fuzz/target/x86_64-unknown-linux-gnu/release/deframer $OUT/
 cp fuzz/target/x86_64-unknown-linux-gnu/release/fragment $OUT/
 cp fuzz/target/x86_64-unknown-linux-gnu/release/hsjoiner $OUT/
 cp fuzz/target/x86_64-unknown-linux-gnu/release/message $OUT/
-cp fuzz/target/x86_64-unknown-linux-gnu/release/server $OUT/
-cp fuzz/target/x86_64-unknown-linux-gnu/release/persist $OUT/
+if [ "$SANITIZER" != "coverage" ]
+then
+    cp fuzz/target/x86_64-unknown-linux-gnu/release/server $OUT/
+    cp fuzz/target/x86_64-unknown-linux-gnu/release/persist $OUT/
+fi


### PR DESCRIPTION
In coverage builds, disable fuzzers that wont work with coverage. A more comprehensive fix will come later.