### PR TITLE
Run multiple jobs/workers by setting env vars

### DIFF
--- a/infra/base-images/base-runner/run_fuzzer
+++ b/infra/base-images/base-runner/run_fuzzer
@@ -21,6 +21,18 @@
 export PATH=$OUT:$PATH
 cd $OUT
 
+# Allow to specify the number of jobs for fuzzers that support this natively (i.e., libfuzzer, honggfuzz)
+N_JOBS=${N_JOBS:-}
+if [ -z $N_JOBS ]; then
+  N_JOBS=1
+fi
+
+# Allow to specify the number of workers for fuzzers that support this natively (i.e., libfuzzer)
+N_WORKERS=${N_WORKERS:-}
+if [ -z $N_WORKERS ]; then
+  N_WORKERS=1
+fi
+
 DEBUGGER=${DEBUGGER:-}
 
 FUZZER=$1
@@ -103,17 +115,18 @@ if [[ "$FUZZING_ENGINE" = afl ]]; then
   export UBSAN_OPTIONS="$UBSAN_OPTIONS:symbolize=0"
   export AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
   export AFL_SKIP_CPUFREQ=1
-  export AFL_TRY_AFFINITY=1
+  export AFL_NO_AFFINITY=1
   export AFL_FAST_CAL=1
-  export AFL_CMPLOG_ONLY_NEW=1
-  export AFL_FORKSRV_INIT_TMOUT=30000
   # If $OUT/afl_cmplog.txt is present this means the target was compiled for
-  # CMPLOG. So we have to add the proper parameters to afl-fuzz.
-  test -e "$OUT/afl_cmplog.txt" && AFL_FUZZER_ARGS="$AFL_FUZZER_ARGS -c $OUT/$FUZZER"
+  # CMPLOG. So we have to add the proper parameters to afl-fuzz. `-l 2` is
+  # CMPLOG level 2, which will colorize larger files but not huge files and
+  # not enable transform analysis unless there have been several cycles without
+  # any finds.
+  test -e "$OUT/afl_cmplog.txt" && AFL_FUZZER_ARGS="$AFL_FUZZER_ARGS -l 2 -c $OUT/$FUZZER"
   # If $OUT/afl++.dict we load it as a dictionary for afl-fuzz.
   test -e "$OUT/afl++.dict" && AFL_FUZZER_ARGS="$AFL_FUZZER_ARGS -x $OUT/afl++.dict"
-  # Ensure timeout is a bit larger than 1sec as some of the OSS-Fuzz fuzzers
-  # are slower than this.
+  # Ensure timeout is a bit large than 1sec as some of the OSS-Fuzz fuzzers
+  # are slower than this. 
   AFL_FUZZER_ARGS="$AFL_FUZZER_ARGS -t 5000+"
   # AFL expects at least 1 file in the input dir.
   echo input > ${CORPUS_DIR}/input
@@ -134,9 +147,9 @@ elif [[ "$FUZZING_ENGINE" = honggfuzz ]]; then
   # -P: use persistent mode of fuzzing (i.e. LLVMFuzzerTestOneInput)
   # -f: location of the initial (and destination) file corpus
   # -n: number of fuzzing threads (and processes)
-  CMD_LINE="$OUT/honggfuzz -n 1 --exit_upon_crash -R /tmp/${FUZZER}_honggfuzz.report -W $FUZZER_OUT -v -z -P -f \"$CORPUS_DIR\" $(get_dictionary) $* -- \"$OUT/$FUZZER\""
+  CMD_LINE="$OUT/honggfuzz -n ${N_JOBS} --exit_upon_crash -R /tmp/${FUZZER}_honggfuzz.report -W $FUZZER_OUT -v -z -P -f \"$CORPUS_DIR\" $(get_dictionary) $* -- \"$OUT/$FUZZER\""
 
-else
+else # it's libfuzzer
 
   CMD_LINE="$OUT/$FUZZER $FUZZER_ARGS $*"
 
@@ -153,6 +166,8 @@ else
       CMD_LINE="$CMD_LINE -dict=$FUZZER.dict"
     fi
   fi
+
+  CMD_LINE="${CMD_LINE} -jobs=${N_JOBS} -workers=${N_WORKERS}"
 
   CMD_LINE="$CMD_LINE < /dev/null"
 


### PR DESCRIPTION
```bash
$ infra/base-images/all.sh
$ python3 infra/helper.py run_fuzzer -e N_JOBS=4 -e N_WORKERS=4 --engine $ENGINE $PROJECT_NAME $FUZZ_TARGET
```

I know this feature is not critical when running on a distributed environment (e.g., ClusterFuzz), but I find it very useful when using OSS-Fuzz on a beefy, local machine as a wrapper to various fuzzing engines.