### PR TITLE
gnutls: Fix dockerfile and libtasn clone to work with new versioning.

### DIFF
--- a/projects/gnutls/Dockerfile
+++ b/projects/gnutls/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update && apt-get install -y \
  gengetopt \
  wget \
  python \
+
  mercurial
 
 ENV GNULIB_TOOL $SRC/gnulib/gnulib-tool
@@ -38,7 +39,7 @@ RUN git clone git://git.savannah.gnu.org/gnulib.git
 RUN git clone --depth=1 https://git.savannah.gnu.org/git/libunistring.git
 RUN git clone --depth=1 https://gitlab.com/libidn/libidn2.git
 RUN hg clone https://gmplib.org/repo/gmp/ gmp
-RUN git clone --depth=1 https://gitlab.com/gnutls/libtasn1.git
+RUN git clone https://gitlab.com/gnutls/libtasn1.git
 RUN git clone --depth=1 https://git.lysator.liu.se/nettle/nettle.git
 
 RUN git clone --depth=1 --recursive https://gitlab.com/gnutls/gnutls.git

--- a/projects/gnutls/Dockerfile
+++ b/projects/gnutls/Dockerfile
@@ -31,7 +31,6 @@ RUN apt-get update && apt-get install -y \
  gengetopt \
  wget \
  python \
-
  mercurial
 
 ENV GNULIB_TOOL $SRC/gnulib/gnulib-tool


### PR DESCRIPTION
A recent update to libtasn (https://gitlab.com/gnutls/libtasn1/-/commit/a72a8d1ef13436bf8916097f11c3fc90f07ba911 I think) caused some problems identifying versions of libtasn in the gnutls set up. This should fix it. 