### PR TITLE
Proposing that maldoca be added to oss-fuzz.

### DIFF
--- a/projects/maldoca/.bazelrc
+++ b/projects/maldoca/.bazelrc
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Force the use of Clang for C++ builds.
+build --action_env=CC=clang
+build --action_env=CXX=clang++
+
+build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing_oss_fuzz//:oss_fuzz_engine
+build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine_instrumentation=oss-fuzz
+build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine_sanitizer=none

--- a/projects/maldoca/BUILD
+++ b/projects/maldoca/BUILD
@@ -1,0 +1,13 @@
+load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+cc_fuzz_test(
+	name = "fuzz_process_doc",
+	deps = [
+        "@com_google_absl//absl/strings",
+        "//maldoca/service/proto:doc_type_cc_proto",
+        "//maldoca/service/proto:processing_config_cc_proto",
+        "//maldoca/service:process_doc"
+    ],
+	srcs = ["fuzz_process_doc.cc"],
+)

--- a/projects/maldoca/Dockerfile
+++ b/projects/maldoca/Dockerfile
@@ -1,0 +1,33 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# FROM gcr.io/oss-fuzz-base/base-builder
+# RUN apt-get update && apt-get install -y make autoconf automake libtool
+# RUN git clone --depth 1 git@github.com:google/maldoca.git maldoca
+# WORKDIR maldoca
+# COPY build.sh $SRC/
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN git clone --depth 1  --recurse-submodules https://github.com/google/maldoca/
+COPY build.sh $SRC/
+RUN mkdir $SRC/maldoca/fuzz/
+COPY BUILD fuzz*.cc $SRC/maldoca/fuzz/
+COPY WORKSPACE .bazelrc $SRC/
+RUN cat WORKSPACE >> $SRC/maldoca/WORKSPACE
+RUN cat .bazelrc >> $SRC/maldoca/.bazelrc
+RUN echo "4.1.0" > $SRC/maldoca/.bazelversion
+WORKDIR $SRC/maldoca

--- a/projects/maldoca/Dockerfile
+++ b/projects/maldoca/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 
-RUN git clone --depth 1  --recurse-submodules https://github.com/google/maldoca/
+RUN git clone --depth 1 --recurse-submodules https://github.com/google/maldoca/
 COPY build.sh $SRC/
 RUN mkdir $SRC/maldoca/fuzz/
 COPY BUILD fuzz*.cc $SRC/maldoca/fuzz/

--- a/projects/maldoca/WORKSPACE
+++ b/projects/maldoca/WORKSPACE
@@ -13,54 +13,19 @@
 # limitations under the License.
 #
 ################################################################################
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-http_archive(
+ 
+maybe(
+    http_archive,
     name = "rules_fuzzing",
     sha256 = "94f25c7a18db0502ace26a3ef7d0a25fd7c195c4e9770ddd1b1ec718e8936091",
     strip_prefix = "rules_fuzzing-0.1.3",
     urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/v0.1.3.zip"],
 )
-
-http_archive(
-    name = "rules_python",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.3.0/rules_python-0.3.0.tar.gz",
-    sha256 = "934c9ceb552e84577b0faf1e5a2f0450314985b4d8712b2b70717dc679fdc01b",
-)
-
-load("@rules_python//python:pip.bzl", "pip_install")
-
+ 
 load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
-
+ 
 rules_fuzzing_dependencies()
-
+ 
 load("@rules_fuzzing//fuzzing:init.bzl", "rules_fuzzing_init")
-
-
-http_archive(
-    name = "rules_cc",
-    sha256 = "35f2fb4ea0b3e61ad64a369de284e4fbbdcdba71836a5555abb5e194cf119509",
-    strip_prefix = "rules_cc-624b5d59dfb45672d4239422fa1e3de1822ee110",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/624b5d59dfb45672d4239422fa1e3de1822ee110.tar.gz",
-        "https://github.com/bazelbuild/rules_cc/archive/624b5d59dfb45672d4239422fa1e3de1822ee110.tar.gz",
-    ],
-)
-
-http_archive(
-    name = "rules_proto",
-    sha256 = "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
-    strip_prefix = "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
-        "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
-    ],
-)
-
-load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies")
-rules_cc_dependencies()
-
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
-rules_proto_dependencies()
-rules_proto_toolchains()
+ 
+rules_fuzzing_init()

--- a/projects/maldoca/WORKSPACE
+++ b/projects/maldoca/WORKSPACE
@@ -1,0 +1,66 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_fuzzing",
+    sha256 = "94f25c7a18db0502ace26a3ef7d0a25fd7c195c4e9770ddd1b1ec718e8936091",
+    strip_prefix = "rules_fuzzing-0.1.3",
+    urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/v0.1.3.zip"],
+)
+
+http_archive(
+    name = "rules_python",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.3.0/rules_python-0.3.0.tar.gz",
+    sha256 = "934c9ceb552e84577b0faf1e5a2f0450314985b4d8712b2b70717dc679fdc01b",
+)
+
+load("@rules_python//python:pip.bzl", "pip_install")
+
+load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
+
+rules_fuzzing_dependencies()
+
+load("@rules_fuzzing//fuzzing:init.bzl", "rules_fuzzing_init")
+
+
+http_archive(
+    name = "rules_cc",
+    sha256 = "35f2fb4ea0b3e61ad64a369de284e4fbbdcdba71836a5555abb5e194cf119509",
+    strip_prefix = "rules_cc-624b5d59dfb45672d4239422fa1e3de1822ee110",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/624b5d59dfb45672d4239422fa1e3de1822ee110.tar.gz",
+        "https://github.com/bazelbuild/rules_cc/archive/624b5d59dfb45672d4239422fa1e3de1822ee110.tar.gz",
+    ],
+)
+
+http_archive(
+    name = "rules_proto",
+    sha256 = "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
+    strip_prefix = "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
+        "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
+    ],
+)
+
+load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies")
+rules_cc_dependencies()
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+rules_proto_dependencies()
+rules_proto_toolchains()

--- a/projects/maldoca/build.sh
+++ b/projects/maldoca/build.sh
@@ -15,15 +15,7 @@
 #
 ################################################################################
 
-# MALDOCA_DEFINES="-D_MALDOCA_CHROME=1"
-# MALDOCA_WNOS="-Wno-sign-compare -Wno-error=unreachable-code"\ 
-# "-Wno-unused-private-field  -Wno-c++98-compat-pedantic -Wno-comment"\ 
-# "-Wno-ignored-qualifiers -Wno-unused-const-variable"
-# MALDOCA_SRC_DIR = "$SRC/maldoca"
-
-# $CXX $CXXFLAGS -std=c++11 -Iinclude \
-#     /path/to/name_of_fuzzer.cc -o $OUT/name_of_fuzzer \
-#     $LIB_FUZZING_ENGINE /path/to/library.a
+export BAZEL_EXTRA_BUILD_FLAGS="--copt=-DMALDOCA_CHROME=1 --define MALDOCA_CHROME=1 --repo_env=CC=clang --cxxopt=--std=c++14 --cxxopt=-Wno-unused-result --verbose_failures"
 
 bazel clean
 bazel_build_fuzz_tests

--- a/projects/maldoca/build.sh
+++ b/projects/maldoca/build.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# MALDOCA_DEFINES="-D_MALDOCA_CHROME=1"
+# MALDOCA_WNOS="-Wno-sign-compare -Wno-error=unreachable-code"\ 
+# "-Wno-unused-private-field  -Wno-c++98-compat-pedantic -Wno-comment"\ 
+# "-Wno-ignored-qualifiers -Wno-unused-const-variable"
+# MALDOCA_SRC_DIR = "$SRC/maldoca"
+
+# $CXX $CXXFLAGS -std=c++11 -Iinclude \
+#     /path/to/name_of_fuzzer.cc -o $OUT/name_of_fuzzer \
+#     $LIB_FUZZING_ENGINE /path/to/library.a
+
+bazel clean
+bazel_build_fuzz_tests

--- a/projects/maldoca/fuzz_process_doc.cc
+++ b/projects/maldoca/fuzz_process_doc.cc
@@ -1,0 +1,47 @@
+#include "maldoca/service/common/process_doc.h"
+
+#include <string>
+#include <string_view>
+#include "maldoca/service/proto/doc_type.pb.h"
+#include "maldoca/service/proto/processing_config.pb.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    const string config_data = R"pb(
+        handler_configs {
+        key: "office_parser"
+        value {
+            doc_type: OFFICE
+            parser_config {
+            handler_type: DEFAULT_VBA_PARSER
+            use_sandbox: false
+            handler_config {
+                default_office_parser_config {
+                extract_vba_settings {
+                    extraction_method: EXTRACTION_TYPE_LIGHTWEIGHT
+                    allow_errors: true
+                    run_for_all_files: true
+                }
+                }
+            }
+            }
+        }
+        })pb";
+
+    ProcessorConfig processor_config;
+    processor_config.ParseFromString(config_data);
+    DocProcessor doc_processor = DocProcessor(processor_config);
+    doc_processor.Init();
+
+    ProcessDocumentRequest* process_doc_request;
+    std::string_view file_name{ "document.docx" };
+    std::string_view input = string_view(reinterpret_cast<const char *>(data), size);
+    process_doc_request.set_file_name(file_name);
+    process_doc_request.set_doc_content(input);
+
+    ProcessDocumentRequest* document_response;
+
+    ProcessDoc(file_name, doc, process_doc_request, document_response);
+
+    return 0;
+
+}

--- a/projects/maldoca/fuzz_process_doc.cc
+++ b/projects/maldoca/fuzz_process_doc.cc
@@ -6,7 +6,7 @@
 #include "maldoca/service/proto/processing_config.pb.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
-    const string config_data = R"pb(
+    const std::string config_data = R"pb(
         handler_configs {
         key: "office_parser"
         value {
@@ -27,20 +27,20 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
         }
         })pb";
 
-    ProcessorConfig processor_config;
+    maldoca::ProcessorConfig processor_config;
     processor_config.ParseFromString(config_data);
-    DocProcessor doc_processor = DocProcessor(processor_config);
-    doc_processor.Init();
+    maldoca::DocProcessor doc_processor(processor_config);
 
-    ProcessDocumentRequest* process_doc_request;
-    std::string_view file_name{ "document.docx" };
-    std::string_view input = string_view(reinterpret_cast<const char *>(data), size);
+    maldoca::ProcessDocumentRequest process_doc_request;
+    const std::string file_name = "document.docx";
+    const char *input = reinterpret_cast<const char *>(data);
+
     process_doc_request.set_file_name(file_name);
     process_doc_request.set_doc_content(input);
 
-    ProcessDocumentRequest* document_response;
+    maldoca::ProcessDocumentResponse document_response;
 
-    ProcessDoc(file_name, doc, process_doc_request, document_response);
+    doc_processor.ProcessDoc(&process_doc_request, &document_response);
 
     return 0;
 

--- a/projects/maldoca/project.yaml
+++ b/projects/maldoca/project.yaml
@@ -1,0 +1,13 @@
+
+homepage: "https://github.com/google/maldoca"
+language: c++
+primary_contact: "bgrill@google.com"
+auto_ccs:
+  - "dtao@google.com"
+  - "anise@google.com"
+sanitizers:
+  - address
+  - memory:
+     experimental: True
+  - undefined
+main_repo: 'git@github.com:google/maldoca.git'

--- a/projects/maldoca/project.yaml
+++ b/projects/maldoca/project.yaml
@@ -1,13 +1,7 @@
-
 homepage: "https://github.com/google/maldoca"
 language: c++
 primary_contact: "bgrill@google.com"
 auto_ccs:
   - "dtao@google.com"
   - "anise@google.com"
-sanitizers:
-  - address
-  - memory:
-     experimental: True
-  - undefined
 main_repo: 'git@github.com:google/maldoca.git'

--- a/projects/maldoca/project.yaml
+++ b/projects/maldoca/project.yaml
@@ -1,9 +1,8 @@
 homepage: "https://github.com/google/maldoca"
 language: c++
-primary_contact: "bgrill@google.com"
+primary_contact: maldoca-eng@google.com
 auto_ccs:
-  - "dtao@google.com"
-  - "anise@google.com"
+  - anise@google.com
 main_repo: 'git@github.com:google/maldoca.git'
 sanitizers:
  - address

--- a/projects/maldoca/project.yaml
+++ b/projects/maldoca/project.yaml
@@ -5,3 +5,8 @@ auto_ccs:
   - "dtao@google.com"
   - "anise@google.com"
 main_repo: 'git@github.com:google/maldoca.git'
+sanitizers:
+ - address
+ - memory:
+    experimental: True
+ - undefined


### PR DESCRIPTION
Following the [process](https://google.github.io/oss-fuzz/getting-started/accepting-new-projects/) to add a new library to OSS-Fuzz. [MalDocA](https://github.com/google/maldoca) is a new open-source project released by Google.