### PR TITLE
ci: Fix get_changed_files_output

### DIFF
--- a/.github/workflows/infra_tests.yml
+++ b/.github/workflows/infra_tests.yml
@@ -15,8 +15,8 @@ jobs:
           access_token: ${{ github.token }}
 
       - uses: actions/checkout@v2
-      - run: |  # Needed for git diff to work.
-          git fetch origin master --depth 1
+      - run: |  # Needed for git diff to work. (get_changed_files)
+          git fetch origin master --unshallow
           git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master
 
       - name: Setup python environment

--- a/.github/workflows/infra_tests.yml
+++ b/.github/workflows/infra_tests.yml
@@ -15,8 +15,9 @@ jobs:
           access_token: ${{ github.token }}
 
       - uses: actions/checkout@v2
-      - run: |  # Needed for git diff to work. (get_changed_files)
-          git fetch origin master --unshallow
+        with:  # Needed for git diff to work. (get_changed_files)
+          fetch-depth: 0
+      - run: |
           git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master
 
       - name: Setup python environment

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -16,8 +16,9 @@ jobs:
           access_token: ${{ github.token }}
 
       - uses: actions/checkout@v2
-      - run: |  # Needed for git diff to work. (get_changed_files)
-          git fetch origin master --unshallow
+        with:  # Needed for git diff to work. (get_changed_files)
+          fetch-depth: 0
+      - run: |
           git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master
 
       - name: Setup python environment

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -16,8 +16,8 @@ jobs:
           access_token: ${{ github.token }}
 
       - uses: actions/checkout@v2
-      - run: |  # Needed for git diff to work.
-          git fetch origin master --depth 1
+      - run: |  # Needed for git diff to work. (get_changed_files)
+          git fetch origin master --unshallow
           git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master
 
       - name: Setup python environment

--- a/.github/workflows/project_tests.yml
+++ b/.github/workflows/project_tests.yml
@@ -48,8 +48,8 @@ jobs:
           access_token: ${{ github.token }}
 
       - uses: actions/checkout@v2
-      - run: |  # Needed for git diff to work.
-          git fetch origin master --depth 1
+      - run: |  # Needed for git diff to work. (get_changed_files_output)
+          git fetch origin master --unshallow
           git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master
 
       - name: Clear unnecessary files

--- a/.github/workflows/project_tests.yml
+++ b/.github/workflows/project_tests.yml
@@ -48,8 +48,9 @@ jobs:
           access_token: ${{ github.token }}
 
       - uses: actions/checkout@v2
-      - run: |  # Needed for git diff to work. (get_changed_files_output)
-          git fetch origin master --unshallow
+        with:  # Needed for git diff to work. (get_changed_files)
+          fetch-depth: 0
+      - run: |
           git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master
 
       - name: Clear unnecessary files

--- a/infra/ci/build.py
+++ b/infra/ci/build.py
@@ -38,7 +38,7 @@ LANGUAGES_WITH_COVERAGE_SUPPORT = ['c', 'c++', 'go', 'jvm', 'rust']
 def get_changed_files_output():
   """Returns the output of a git command that discovers changed files."""
   branch_commit_hash = subprocess.check_output(
-      ['git', 'merge-base', 'FETCH_HEAD', 'origin/HEAD']).strip().decode()
+      ['git', 'merge-base', 'HEAD', 'origin/HEAD']).strip().decode()
 
   return subprocess.check_output(
       ['git', 'diff', '--name-only', branch_commit_hash + '..']).decode()

--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -346,7 +346,7 @@ def yapf(paths, validate=True):
 def get_changed_files():
   """Return a list of absolute paths of files changed in this git branch."""
   branch_commit_hash = subprocess.check_output(
-      ['git', 'merge-base', 'FETCH_HEAD', 'origin/HEAD']).strip().decode()
+      ['git', 'merge-base', 'HEAD', 'origin/HEAD']).strip().decode()
 
   diff_commands = [
       # Return list of modified files in the commits on this branch.


### PR DESCRIPTION
`FETCH_HEAD` will actually refer to `origin/master` (aka `origin/HEAD`), and not the current pull request.