### PR TITLE
[infra][jvm] Provide jazzer_driver_with_sanitizer for coverage builds

### DIFF
--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -142,6 +142,9 @@ if [ "$FUZZING_LANGUAGE" = "jvm" ]; then
     cp $(which jazzer_driver_asan) $jazzer_driver_with_sanitizer
   elif [ "$SANITIZER" = "undefined" ]; then
     cp $(which jazzer_driver_ubsan) $jazzer_driver_with_sanitizer
+  elif [ "$SANITIZER" = "coverage" ]; then
+    # Coverage builds require no instrumentation.
+    cp $(which jazzer_driver) $jazzer_driver_with_sanitizer
   fi
 fi
 


### PR DESCRIPTION
Previously, JVM coverage builds for projects with native dependencies would fail: https://oss-fuzz-build-logs.storage.googleapis.com/log-9b66fe39-7e33-4058-812a-c9c52f32e0ea.txt