### PR TITLE
[Pillow] Removed zlib1g-dev installation

### DIFF
--- a/projects/pillow/Dockerfile
+++ b/projects/pillow/Dockerfile
@@ -21,8 +21,7 @@ RUN apt-get update && \
     apt-get install -y \
       libxau-dev \
       pkg-config \
-      rsync \
-      zlib1g-dev 
+      rsync
 
 RUN git clone --depth 1 https://github.com/python-pillow/Pillow
 RUN git clone --depth 1 https://github.com/python-pillow/pillow-wheels
@@ -47,6 +46,6 @@ COPY build.sh $SRC/
 RUN apt-get install -y \
      python3-tk \
      tcl8.6-dev \
-     tk8.6-dev 
+     tk8.6-dev
 
 WORKDIR $SRC/Pillow


### PR DESCRIPTION
Pillow recently started [building zlib on Linux in it's wheels](https://github.com/python-pillow/pillow-wheels/pull/204), and that is conflicting with the [installation of zlib1g-dev from our oss-fuzz Dockerfile.](https://github.com/google/oss-fuzz/blob/8d0531dca85230fa90518094d0d05f8c7e339469/projects/pillow/Dockerfile#L25)
> [./.libs/libpng16.so: undefined reference to `inflateValidate'](https://github.com/python-pillow/Pillow/runs/2870070374#step:4:2502)

[Copying files from here as a test](https://github.com/radarhere/docker-images/commit/d779c506965d0022f4cf29caa1108308efe017a6), it [fails with the same error](https://github.com/radarhere/docker-images/runs/2871736946?check_suite_focus=true#step:5:2528), and then [with this PR](https://github.com/radarhere/docker-images/commit/968220582251b146a6e867564daca3ee738579b4), it ... well, it doesn't pass exactly, but it makes it to ["FUZZING_LANGUAGE: unbound variable"](https://github.com/radarhere/docker-images/runs/2871740337?check_suite_focus=true#step:5:6680), which I presume is just an artefact of my testing setup.

So this PR removes zlib1g-dev from the list of apt-get installations.

cc @wiredfool