### PR TITLE
[etcd] Initial integration

### DIFF
--- a/projects/etcd/Dockerfile
+++ b/projects/etcd/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN git clone --depth 1 https://github.com/etcd-io/etcd
+COPY wal_fuzzer.go build.sh $SRC/
+WORKDIR $SRC/etcd

--- a/projects/etcd/build.sh
+++ b/projects/etcd/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+mv $SRC/wal_fuzzer.go $SRC/etcd/server/wal/
+compile_go_fuzzer go.etcd.io/etcd/server/v3/wal FuzzWalCreate fuzz_wal_create
+

--- a/projects/etcd/project.yaml
+++ b/projects/etcd/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://etcd.io"
+main_repo: "https://github.com/etcd-io/etcd"
+primary_contact: ""
+auto_ccs :
+  - "adam@adalogics.com"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address

--- a/projects/etcd/project.yaml
+++ b/projects/etcd/project.yaml
@@ -1,6 +1,6 @@
 homepage: "https://etcd.io"
 main_repo: "https://github.com/etcd-io/etcd"
-primary_contact: ""
+primary_contact: "ptab@google.com"
 auto_ccs :
   - "adam@adalogics.com"
 language: go

--- a/projects/etcd/wal_fuzzer.go
+++ b/projects/etcd/wal_fuzzer.go
@@ -1,0 +1,37 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package wal
+
+import (
+	"io/ioutil"
+	"os"
+
+	"go.uber.org/zap"
+)
+
+func FuzzWalCreate(data []byte) int {
+	p, err := ioutil.TempDir("/tmp", "waltest")
+	if err != nil {
+		return -1
+	}
+	defer os.RemoveAll(p)
+	w, err := Create(zap.NewExample(), p, data)
+	if err != nil {
+		return 0
+	}
+	defer w.Close()
+	return 1
+}

--- a/projects/etcd/wal_fuzzer.go
+++ b/projects/etcd/wal_fuzzer.go
@@ -52,7 +52,7 @@ func FuzzWalCreate(data []byte) int {
 		return 0
 	}
 	if !bytes.Equal(data, metadata) {
-		panic("data and metadata are not similar, but they should be")
+		panic("data and metadata are not equal, but they should be")
 	}
 	return 1
 }


### PR DESCRIPTION
Initial integration of [etcd](https://github.com/etcd-io/etcd).
etcd is a consistent and highly-available key value store used as Kubernetes' backing store for all cluster data.

_____________________________________________________________


@ptabor Are you interested in integrating etcd into OSS-fuzz for continuous fuzzing? This PR adds the build files and the first fuzzer.
To complete the PR an email address is needed for bug reports.