### PR TITLE
Fix kcodecs build

### DIFF
--- a/projects/kcodecs/Dockerfile
+++ b/projects/kcodecs/Dockerfile
@@ -15,7 +15,8 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get install --yes cmake gperf
+RUN apt-get install --yes cmake
+RUN curl -L http://ftp.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz -O
 RUN git clone --depth 1 --branch=5.15 git://code.qt.io/qt/qtbase.git
 RUN git clone --depth 1 https://invent.kde.org/frameworks/kcodecs.git
 RUN git clone --depth 1 https://invent.kde.org/frameworks/extra-cmake-modules.git

--- a/projects/kcodecs/build.sh
+++ b/projects/kcodecs/build.sh
@@ -16,6 +16,20 @@
 ################################################################################
 
 cd $SRC
+tar xzf gperf*.tar.gz && rm -f gperf*.tar.gz
+cd gperf*
+FUZZ_CFLAGS="${CFLAGS}"
+FUZZ_CXXFLAGS="${CXXFLAGS}"
+unset CFLAGS
+unset CXXFLAGS
+# gperf is a code generator, so no need to sanitize it
+./configure --prefix=/usr
+make -j$(nproc) install
+export CFLAGS="${FUZZ_CFLAGS}"
+export CXXFLAGS="${FUZZ_CXXFLAGS}"
+
+
+cd $SRC
 cd extra-cmake-modules
 cmake .
 make install


### PR DESCRIPTION
New kcodecs requires C++17, we need a newer gperf able of generating C++17
compliant code