### PR TITLE
[CI] Switch to google-github-actions/setup-gcloud

### DIFF
--- a/.github/workflows/infra_tests.yml
+++ b/.github/workflows/infra_tests.yml
@@ -31,7 +31,7 @@ jobs:
           sudo env "PATH=$PATH" pip install -r infra/ci/requirements.txt
           sudo env "PATH=$PATH" pip install -r infra/build/functions/requirements.txt
 
-      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      - uses: google-github-actions/setup-gcloud@master
         with:
           version: '298.0.0'
       - run: |

--- a/.github/workflows/infra_tests.yml
+++ b/.github/workflows/infra_tests.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - 'infra/**'
+      - '.github/workflows/**'
 
 jobs:
   build:


### PR DESCRIPTION
GoogleCloudPlatform/github-actions/setup-gcloud is deprecated.
See warning here: https://github.com/google/oss-fuzz/actions/runs/957528283