### PR TITLE
[cryptofuzz] Add Noble libraries

### DIFF
--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -42,7 +42,6 @@ RUN hg clone https://hg.mozilla.org/projects/nss
 RUN git clone --depth 1 https://github.com/jedisct1/libsodium.git
 RUN git clone --depth 1 https://github.com/libtom/libtomcrypt.git
 RUN git clone --depth 1 https://github.com/microsoft/SymCrypt.git
-RUN git clone --depth 1 https://git.lysator.liu.se/nettle/nettle
 RUN hg clone https://gmplib.org/repo/gmp/ libgmp/
 RUN wget https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.5.1.tar.gz
 RUN git clone --depth 1 https://github.com/indutny/bn.js.git
@@ -52,8 +51,14 @@ RUN git clone --depth 1 https://github.com/brix/crypto-js.git
 RUN git clone --depth 1 https://github.com/LoupVaillant/Monocypher.git
 RUN git clone --depth 1 https://github.com/trezor/trezor-firmware.git
 RUN git clone --depth 1 https://github.com/Cyan4973/xxHash.git
+RUN git clone --depth 1 https://github.com/paulmillr/noble-ed25519.git
+RUN git clone --depth 1 https://github.com/paulmillr/noble-bls12-381.git
+RUN git clone --depth 1 https://github.com/paulmillr/noble-secp256k1.git
+RUN git clone --depth 1 https://github.com/supranational/blst.git
+RUN git clone --depth 1 https://github.com/bitcoin-core/secp256k1.git
 RUN apt-get remove -y libunwind8
 RUN apt-get install -y libssl-dev
 RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
+RUN wget https://nodejs.org/dist/v14.17.1/node-v14.17.1-linux-x64.tar.xz
 
 COPY build.sh xxd.c $SRC/


### PR DESCRIPTION
- Add the libraries noble-secp256k1, noble-ed25519, noble-bls12-381 (see also: https://github.com/google/oss-fuzz/issues/5945)
- Add blst for comparing noble-bls12-381 against
- Add libsecp256k1 for comparing the Schnorr component of noble-secp256k1 against
- Install nodejs/npm for building noble-bls12-381 in a way that's usable by the fuzzer
- Remove nettle because it has been having its own project for a while: https://github.com/google/oss-fuzz/tree/master/projects/nettle

The author of Noble does not have a Google account and has chosen to let me forward relevant bug reports to him, hence no modifications to the project.yaml CC list have been made.