### PR TITLE
dav1d: remove dead email from vendor_ccs

### DIFF
--- a/projects/dav1d/project.yaml
+++ b/projects/dav1d/project.yaml
@@ -7,7 +7,6 @@ auto_ccs:
   - "b@rr-dav.id.au"
   - "dav1d-fuzz@videolan.org"
 vendor_ccs:
-  - "negge@mozilla.com"
   - "twsmith@mozilla.com"
 sanitizers:
   - address


### PR DESCRIPTION
Monorail seems to to detect that the email address bounces and deletes
the CC but something re-adds it regularly.