### PR TITLE
Decrease number of build logs to avoid rate limits.

### DIFF
--- a/infra/build/functions/update_build_status.py
+++ b/infra/build/functions/update_build_status.py
@@ -18,7 +18,6 @@ import base64
 import concurrent.futures
 import json
 import sys
-import time
 
 import google.auth
 from googleapiclient.discovery import build
@@ -34,7 +33,7 @@ from datastore_entities import Project
 BADGE_DIR = 'badge_images'
 BADGE_IMAGE_TYPES = {'svg': 'image/svg+xml', 'png': 'image/png'}
 DESTINATION_BADGE_DIR = 'badges'
-MAX_BUILD_LOGS = 7
+MAX_BUILD_LOGS = 5
 
 STATUS_BUCKET = 'oss-fuzz-build-logs'
 
@@ -174,8 +173,6 @@ def update_build_status(build_tag, status_filename):
     project = get_build_history(project_build.build_ids)
     project['name'] = project_build.project
     print('Processing project', project['name'])
-    # Sleep to avoid rate limits.
-    time.sleep(2)
     return project
 
   with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:


### PR DESCRIPTION
Needed for https://github.com/google/oss-fuzz/issues/5968