### PR TITLE
[libvips] Ensure lcms dependency generates its autotools files

### DIFF
--- a/projects/libvips/build.sh
+++ b/projects/libvips/build.sh
@@ -40,6 +40,7 @@ popd
 
 # lcms
 pushd $SRC/lcms
+./autogen.sh
 ./configure \
   --enable-static \
   --disable-shared \


### PR DESCRIPTION
Required as a result of https://github.com/mm2/Little-CMS/commit/5ef8c971244fe4e8e376afdcfad67899a73a9285

Hopefully fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=35586