### PR TITLE
istio: Move build script upstream

### DIFF
--- a/projects/istio/build.sh
+++ b/projects/istio/build.sh
@@ -15,6 +15,5 @@
 #
 ################################################################################
 
+$SRC/istio/tests/fuzz/oss_fuzz_build.sh
 
-compile_go_fuzzer ./tests/fuzz FuzzParseInputs fuzz_parse_inputs
-compile_go_fuzzer ./tests/fuzz FuzzParseAndBuildSchema fuzz_parse_and_build_schema


### PR DESCRIPTION
The build script has been moved to [tests/fuzz/oss_fuzz_build.sh](https://github.com/istio/istio/blob/master/tests/fuzz/oss_fuzz_build.sh) upstream.