### PR TITLE
infra: Remove unused import from update_build_status

### DIFF
--- a/infra/build/functions/update_build_status.py
+++ b/infra/build/functions/update_build_status.py
@@ -18,7 +18,6 @@ import base64
 import concurrent.futures
 import json
 import sys
-import time
 
 import google.auth
 from googleapiclient.discovery import build


### PR DESCRIPTION
In this commit https://github.com/google/oss-fuzz/commit/0370821e3944a938775f45b3631a7aecf68ed138 the use of the `time` import was removed. This causes the CI to complain about `infra/build/functions/update_build_status.py:21:0: W0611: Unused import time (unused-import)` in this PR https://github.com/google/oss-fuzz/pull/5980 and the presubmit checks here https://github.com/google/oss-fuzz/pull/5980/checks?check_run_id=2941631092