### PR TITLE
[h2o] Add options for http3 fuzzer

### DIFF
--- a/projects/h2o/build.sh
+++ b/projects/h2o/build.sh
@@ -22,6 +22,7 @@ cp ./h2o-fuzzer-* $OUT/
 
 zip -jr $OUT/h2o-fuzzer-http1_seed_corpus.zip $SRC/h2o/fuzz/http1-corpus
 zip -jr $OUT/h2o-fuzzer-http2_seed_corpus.zip $SRC/h2o/fuzz/http2-corpus
+zip -jr $OUT/h2o-fuzzer-http3_seed_corpus.zip $SRC/h2o/fuzz/http3-corpus
 zip -jr $OUT/h2o-fuzzer-url_seed_corpus.zip $SRC/h2o/fuzz/url-corpus
 
 cp $SRC/*.options $SRC/h2o/fuzz/*.dict $OUT/

--- a/projects/h2o/h2o-fuzzer-http3.options
+++ b/projects/h2o/h2o-fuzzer-http3.options
@@ -1,0 +1,4 @@
+[libfuzzer]
+close_fd_mask = 3
+max_len = 16384
+dict = http.dict


### PR DESCRIPTION
Now that h2o merged a new fuzzer for http3 (https://github.com/h2o/h2o/pull/2696)
this commit adds options for running http3 fuzzer.