### PR TITLE
[build/infra] Build engines in alphabetical order.

### DIFF
--- a/infra/build/functions/build_project.py
+++ b/infra/build/functions/build_project.py
@@ -155,7 +155,9 @@ def get_build_steps(project_name, project_yaml_file, dockerfile_lines,
       ],
   })
 
-  for fuzzing_engine in project_yaml['fuzzing_engines']:
+  # Sort engines to make AFL first to test if libFuzzer has an advantage in
+  # finding bugs first since it is generally built first.
+  for fuzzing_engine in sorted(project_yaml['fuzzing_engines']):
     for sanitizer in get_sanitizers(project_yaml):
       for architecture in project_yaml['architectures']:
         if not is_supported_configuration(fuzzing_engine, sanitizer,

--- a/infra/build/functions/expected_build_steps.json
+++ b/infra/build/functions/expected_build_steps.json
@@ -39,103 +39,6 @@
   {
     "name": "gcr.io/oss-fuzz/test-project",
     "env": [
-      "FUZZING_ENGINE=libfuzzer",
-      "SANITIZER=address",
-      "OUT=/workspace/out/address",
-      "MSAN_LIBS_PATH=/workspace/msan",
-      "ARCHITECTURE=x86_64",
-      "FUZZING_LANGUAGE=c++"
-    ],
-    "args": [
-      "bash",
-      "-c",
-      "rm -r /out && cd /src && cd /src && mkdir -p /workspace/out/address && compile || (echo \"********************************************************************************\nFailed to build.\nTo reproduce, run:\npython infra/helper.py build_image test-project\npython infra/helper.py build_fuzzers --sanitizer address --engine libfuzzer --architecture x86_64 test-project\n********************************************************************************\" && false)"
-    ]
-  },
-  {
-    "name": "gcr.io/oss-fuzz-base/base-runner",
-    "env": [
-      "FUZZING_ENGINE=libfuzzer",
-      "SANITIZER=address",
-      "OUT=/workspace/out/address",
-      "MSAN_LIBS_PATH=/workspace/msan",
-      "ARCHITECTURE=x86_64",
-      "FUZZING_LANGUAGE=c++"
-    ],
-    "args": [
-      "bash",
-      "-c",
-      "test_all.py || (echo \"********************************************************************************\nBuild checks failed.\nTo reproduce, run:\npython infra/helper.py build_image test-project\npython infra/helper.py build_fuzzers --sanitizer address --engine libfuzzer --architecture x86_64 test-project\npython infra/helper.py check_build --sanitizer address --engine libfuzzer --architecture x86_64 test-project\n********************************************************************************\" && false)"
-    ]
-  },
-  {
-    "name": "gcr.io/oss-fuzz-base/base-runner",
-    "env": [
-      "FUZZING_ENGINE=libfuzzer",
-      "SANITIZER=address",
-      "OUT=/workspace/out/address",
-      "MSAN_LIBS_PATH=/workspace/msan",
-      "ARCHITECTURE=x86_64",
-      "FUZZING_LANGUAGE=c++"
-    ],
-    "args": [
-      "bash",
-      "-c",
-      "targets_list > /workspace/targets.list.address"
-    ]
-  },
-  {
-    "name": "gcr.io/oss-fuzz/test-project",
-    "args": [
-      "bash",
-      "-c",
-      "cd /workspace/out/address && zip -r test-project-address-202001010000.zip *"
-    ]
-  },
-  {
-    "name": "gcr.io/oss-fuzz-base/uploader",
-    "args": [
-      "/workspace/srcmap.json",
-      "test_url"
-    ]
-  },
-  {
-    "name": "gcr.io/oss-fuzz-base/uploader",
-    "args": [
-      "/workspace/out/address/test-project-address-202001010000.zip",
-      "test_url"
-    ]
-  },
-  {
-    "name": "gcr.io/oss-fuzz-base/uploader",
-    "args": [
-      "/workspace/targets.list.address",
-      "test_url"
-    ]
-  },
-  {
-    "name": "gcr.io/cloud-builders/curl",
-    "args": [
-      "-H",
-      "Content-Type: text/plain",
-      "-X",
-      "PUT",
-      "-d",
-      "test-project-address-202001010000.zip",
-      "test_url"
-    ]
-  },
-  {
-    "name": "gcr.io/oss-fuzz/test-project",
-    "args": [
-      "bash",
-      "-c",
-      "rm -r /workspace/out/address"
-    ]
-  },
-  {
-    "name": "gcr.io/oss-fuzz/test-project",
-    "env": [
       "FUZZING_ENGINE=afl",
       "SANITIZER=address",
       "OUT=/workspace/out/address",
@@ -266,6 +169,103 @@
     "name": "gcr.io/oss-fuzz-base/base-runner",
     "env": [
       "FUZZING_ENGINE=honggfuzz",
+      "SANITIZER=address",
+      "OUT=/workspace/out/address",
+      "MSAN_LIBS_PATH=/workspace/msan",
+      "ARCHITECTURE=x86_64",
+      "FUZZING_LANGUAGE=c++"
+    ],
+    "args": [
+      "bash",
+      "-c",
+      "targets_list > /workspace/targets.list.address"
+    ]
+  },
+  {
+    "name": "gcr.io/oss-fuzz/test-project",
+    "args": [
+      "bash",
+      "-c",
+      "cd /workspace/out/address && zip -r test-project-address-202001010000.zip *"
+    ]
+  },
+  {
+    "name": "gcr.io/oss-fuzz-base/uploader",
+    "args": [
+      "/workspace/srcmap.json",
+      "test_url"
+    ]
+  },
+  {
+    "name": "gcr.io/oss-fuzz-base/uploader",
+    "args": [
+      "/workspace/out/address/test-project-address-202001010000.zip",
+      "test_url"
+    ]
+  },
+  {
+    "name": "gcr.io/oss-fuzz-base/uploader",
+    "args": [
+      "/workspace/targets.list.address",
+      "test_url"
+    ]
+  },
+  {
+    "name": "gcr.io/cloud-builders/curl",
+    "args": [
+      "-H",
+      "Content-Type: text/plain",
+      "-X",
+      "PUT",
+      "-d",
+      "test-project-address-202001010000.zip",
+      "test_url"
+    ]
+  },
+  {
+    "name": "gcr.io/oss-fuzz/test-project",
+    "args": [
+      "bash",
+      "-c",
+      "rm -r /workspace/out/address"
+    ]
+  },
+  {
+    "name": "gcr.io/oss-fuzz/test-project",
+    "env": [
+      "FUZZING_ENGINE=libfuzzer",
+      "SANITIZER=address",
+      "OUT=/workspace/out/address",
+      "MSAN_LIBS_PATH=/workspace/msan",
+      "ARCHITECTURE=x86_64",
+      "FUZZING_LANGUAGE=c++"
+    ],
+    "args": [
+      "bash",
+      "-c",
+      "rm -r /out && cd /src && cd /src && mkdir -p /workspace/out/address && compile || (echo \"********************************************************************************\nFailed to build.\nTo reproduce, run:\npython infra/helper.py build_image test-project\npython infra/helper.py build_fuzzers --sanitizer address --engine libfuzzer --architecture x86_64 test-project\n********************************************************************************\" && false)"
+    ]
+  },
+  {
+    "name": "gcr.io/oss-fuzz-base/base-runner",
+    "env": [
+      "FUZZING_ENGINE=libfuzzer",
+      "SANITIZER=address",
+      "OUT=/workspace/out/address",
+      "MSAN_LIBS_PATH=/workspace/msan",
+      "ARCHITECTURE=x86_64",
+      "FUZZING_LANGUAGE=c++"
+    ],
+    "args": [
+      "bash",
+      "-c",
+      "test_all.py || (echo \"********************************************************************************\nBuild checks failed.\nTo reproduce, run:\npython infra/helper.py build_image test-project\npython infra/helper.py build_fuzzers --sanitizer address --engine libfuzzer --architecture x86_64 test-project\npython infra/helper.py check_build --sanitizer address --engine libfuzzer --architecture x86_64 test-project\n********************************************************************************\" && false)"
+    ]
+  },
+  {
+    "name": "gcr.io/oss-fuzz-base/base-runner",
+    "env": [
+      "FUZZING_ENGINE=libfuzzer",
       "SANITIZER=address",
       "OUT=/workspace/out/address",
       "MSAN_LIBS_PATH=/workspace/msan",

--- a/infra/build/functions/request_build_test.py
+++ b/infra/build/functions/request_build_test.py
@@ -48,7 +48,7 @@ class TestRequestBuilds(unittest.TestCase):
 
   def setUp(self):
     test_utils.reset_ds_emulator()
-    self.maxDiff = None
+    self.maxDiff = None  # pylint: disable=invalid-name
 
   @mock.patch('build_lib.get_signed_url', return_value='test_url')
   @mock.patch('datetime.datetime')

--- a/infra/build/functions/request_build_test.py
+++ b/infra/build/functions/request_build_test.py
@@ -48,6 +48,7 @@ class TestRequestBuilds(unittest.TestCase):
 
   def setUp(self):
     test_utils.reset_ds_emulator()
+    self.maxDiff = None
 
   @mock.patch('build_lib.get_signed_url', return_value='test_url')
   @mock.patch('datetime.datetime')


### PR DESCRIPTION
Previously, a project's fuzz targets were usually built in the order:
libfuzzer, afl, honggfuzz. This can bias results if one is looking
at which engine finds bugs first.