### PR TITLE
Consolidate fuzz target detection

### DIFF
--- a/infra/base-images/base-runner/targets_list
+++ b/infra/base-images/base-runner/targets_list
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-for binary in $(find $OUT/ -executable -type f); do
+for binary in $(find $OUT/ -maxdepth 1 -executable -type f); do
   [[ "$binary" != *.so ]] || continue
   [[ $(basename "$binary") != jazzer_driver* ]] || continue
   file "$binary" | grep -e ELF -e "shell script" > /dev/null 2>&1 || continue

--- a/infra/cifuzz/run_fuzzers.py
+++ b/infra/cifuzz/run_fuzzers.py
@@ -175,12 +175,7 @@ class CoverageTargetRunner(BaseFuzzTargetRunner):
 
   def get_fuzz_targets(self):
     """Returns fuzz targets in out directory."""
-    # We only want fuzz targets from the root because during the coverage build,
-    # a lot of the image's filesystem is copied into /out for the purpose of
-    # generating coverage reports.
-    # TOOD(metzman): Figure out if top_level_only should be the only behavior
-    # for this function.
-    return utils.get_fuzz_targets(self.workspace.out, top_level_only=True)
+    return utils.get_fuzz_targets(self.workspace.out)
 
   def run_fuzz_targets(self):
     """Generates a coverage report. Always returns False since it never finds

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -28,6 +28,7 @@ import re
 import subprocess
 import sys
 import templates
+import utils
 
 OSS_FUZZ_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 BUILD_DIR = os.path.join(OSS_FUZZ_DIR, 'build')
@@ -688,22 +689,7 @@ def check_build(args):
 
 def _get_fuzz_targets(project_name):
   """Returns names of fuzz targest build in the project's /out directory."""
-  fuzz_targets = []
-  for name in os.listdir(_get_out_dir(project_name)):
-    if name.startswith('afl-'):
-      continue
-    if name.startswith('jazzer_'):
-      continue
-    if name == 'llvm-symbolizer':
-      continue
-
-    path = os.path.join(_get_out_dir(project_name), name)
-    # Python and JVM fuzz targets are only executable for the root user, so
-    # we can't use os.access.
-    if os.path.isfile(path) and (os.stat(path).st_mode & 0o111):
-      fuzz_targets.append(name)
-
-  return fuzz_targets
+  return utils.get_fuzz_targets(_get_out_dir(project_name))
 
 
 def _get_latest_corpus(project_name, fuzz_target, base_corpus_dir):

--- a/infra/utils.py
+++ b/infra/utils.py
@@ -71,27 +71,24 @@ def execute(command, location=None, check_result=False):
   return out, err, process.returncode
 
 
-def get_fuzz_targets(path, top_level_only=False):
-  """Get list of fuzz targets in a directory.
+def get_fuzz_targets(directory):
+  """Get list of top-level fuzz targets in a directory.
 
   Args:
-    path: A path to search for fuzz targets in.
-    top_level_only: If True, only search |path|, do not recurse into subdirs.
+    directory: A directory to search for fuzz targets in.
 
   Returns:
     A list of paths to fuzzers or an empty list if None.
   """
-  if not os.path.exists(path):
+  if not os.path.exists(directory):
     return []
   fuzz_target_paths = []
-  for root, _, fuzzers in os.walk(path):
-    if top_level_only and path != root:
+  for filename in os.listdir(directory):
+    file_path = os.path.join(directory, filename)
+    if not os.path.isfile(file_path):
       continue
-
-    for fuzzer in fuzzers:
-      file_path = os.path.join(root, fuzzer)
-      if is_fuzz_target_local(file_path):
-        fuzz_target_paths.append(file_path)
+    if is_fuzz_target_local(file_path):
+      fuzz_target_paths.append(file_path)
 
   return fuzz_target_paths
 

--- a/infra/utils.py
+++ b/infra/utils.py
@@ -26,6 +26,7 @@ import helper
 ALLOWED_FUZZ_TARGET_EXTENSIONS = ['', '.exe']
 FUZZ_TARGET_SEARCH_STRING = 'LLVMFuzzerTestOneInput'
 VALID_TARGET_NAME = re.compile(r'^[a-zA-Z0-9_-]+$')
+BLOCKLISTED_TARGET_NAME_REGEX = re.compile(r'^(jazzer_driver.*)$')
 
 # Location of google cloud storage for latest OSS-Fuzz builds.
 GCS_BASE_URL = 'https://storage.googleapis.com/'
@@ -113,9 +114,17 @@ def is_fuzz_target_local(file_path):
   Copied from clusterfuzz src/python/bot/fuzzers/utils.py
   with slight modifications.
   """
+  # Needs to be kept in sync with clusterfuzz' is_fuzz_target_local, which has
+  # this many return statements.
+  # pylint: disable=too-many-return-statements
   filename, file_extension = os.path.splitext(os.path.basename(file_path))
   if not VALID_TARGET_NAME.match(filename):
     # Check fuzz target has a valid name (without any special chars).
+    return False
+
+  if BLOCKLISTED_TARGET_NAME_REGEX.match(filename):
+    # Check fuzz target an explicitly disallowed name (e.g. binaries used for
+    # jazzer-based targets).
     return False
 
   if file_extension not in ALLOWED_FUZZ_TARGET_EXTENSIONS:


### PR DESCRIPTION
Reduces the number of places in the code that detect fuzz targets by two (see list in #5777) and ensures that only top-level fuzz targets are run.

See the individual commit messages for more details on the individual changes.