### PR TITLE
[bitcoin-core] Updates to libsecp256k1 Cryptofuzz build

### DIFF
--- a/projects/bitcoin-core/build_cryptofuzz.sh
+++ b/projects/bitcoin-core/build_cryptofuzz.sh
@@ -58,7 +58,7 @@ function build_libsecp256k1() {
     fi
     make
 
-    export SECP256K1_INCLUDE_PATH=$(realpath include)
+    export SECP256K1_INCLUDE_PATH=$(realpath .)
     export LIBSECP256K1_A_PATH=$(realpath .libs/libsecp256k1.a)
 
     # Build libsecp256k1 Cryptofuzz module
@@ -102,6 +102,8 @@ echo -n 'SymmetricEncrypt,' >>extra_options.h
 echo -n 'SymmetricDecrypt,' >>extra_options.h
 echo -n 'ECC_PrivateToPublic,' >>extra_options.h
 echo -n 'ECC_ValidatePubkey,' >>extra_options.h
+echo -n 'ECC_Point_Add,' >>extra_options.h
+echo -n 'ECC_Point_Mul,' >>extra_options.h
 echo -n 'ECDSA_Sign,' >>extra_options.h
 echo -n 'ECDSA_Verify,' >>extra_options.h
 echo -n 'ECDSA_Recover,' >>extra_options.h
@@ -109,10 +111,15 @@ echo -n 'Schnorr_Sign,' >>extra_options.h
 echo -n 'Schnorr_Verify,' >>extra_options.h
 echo -n 'ECDH_Derive,' >>extra_options.h
 echo -n 'BignumCalc_Mod_2Exp256 ' >>extra_options.h
+echo -n 'BignumCalc_Mod_SECP256K1 ' >>extra_options.h
 echo -n '--curves=secp256k1 ' >>extra_options.h
 echo -n '--digests=NULL,SHA1,SHA256,SHA512,RIPEMD160,SHA3-256,SIPHASH64 ' >>extra_options.h
 echo -n '--ciphers=CHACHA20,AES_256_CBC ' >>extra_options.h
-echo -n '--calcops=Add,And,Div,IsEq,IsGt,IsGte,IsLt,IsLte,IsOdd,Mul,NumBits,Or,Set,Sub,Xor ' >>extra_options.h
+echo -n '--calcops=' >>extra_options.h
+# Bitcoin Core arith_uint256.cpp operations
+echo -n 'Add,And,Div,IsEq,IsGt,IsGte,IsLt,IsLte,IsOdd,Mul,NumBits,Or,Set,Sub,Xor,' >>extra_options.h
+# libsecp256k1 scalar operations
+echo -n 'IsZero,IsOne,IsEven,Add,Mul,InvMod,IsEq,CondSet,Bit,Set,RShift ' >>extra_options.h
 echo -n '"' >>extra_options.h
 cd modules/bitcoin/
 export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_BITCOIN"


### PR DESCRIPTION
CC @sipa @MarcoFalke @real-or-random @practicalswift

Updates to the Cryptofuzz libsecp256k1 module and corresponding build script updates.

- scalar math operations. Results are automatically compared against Botan and Bitcoin Core's arith_uint256.cpp. https://github.com/guidovranken/cryptofuzz/blob/fcfca5774d3519ef15fdbd0346dc9736ff1e6262/modules/secp256k1/module.cpp#L1117-L1218
- point addition. alternate between secp256k1_gej_add_ge and secp256k1_gej_add_ge_var. Results are compared against Botan. https://github.com/guidovranken/cryptofuzz/blob/fcfca5774d3519ef15fdbd0346dc9736ff1e6262/modules/secp256k1/module.cpp#L1001-L1005
- enable point multiplication. Not yet implemented but enabling this now saves a PR later
- assert that all `int`-returning functions that signal success or failure only return 0 or 1, crash if it returns another value. https://github.com/guidovranken/cryptofuzz/blob/fcfca5774d3519ef15fdbd0346dc9736ff1e6262/modules/secp256k1/module.cpp#L23-L26
- secp256k1_context: randomly clone and randomize. https://github.com/guidovranken/cryptofuzz/blob/fcfca5774d3519ef15fdbd0346dc9736ff1e6262/modules/secp256k1/module.cpp#L115-L132
- secp256k1_ecdsa_recoverable_signature: randomly convert and serialize/deserialize, and assert subsequent deserialization always succeeds. https://github.com/guidovranken/cryptofuzz/blob/fcfca5774d3519ef15fdbd0346dc9736ff1e6262/modules/secp256k1/module.cpp#L171-L194
- secp256k1_pubkey: randomly serialize with random output size, and assert subsequent deserialization always succeeds. https://github.com/guidovranken/cryptofuzz/blob/fcfca5774d3519ef15fdbd0346dc9736ff1e6262/modules/secp256k1/module.cpp#L252-L297
- secp256k1_ecdsa_signature: randomly serialize (DER and compact), and assert subsequent deserialization always succeeds. https://github.com/guidovranken/cryptofuzz/blob/fcfca5774d3519ef15fdbd0346dc9736ff1e6262/modules/secp256k1/module.cpp#L398-L438
- With functions that consume a (pointer, size) pair, if size is 0, pass a randomized pointer. This can catch invalid pointer dereferences (if size is 0, pointer should never be dereferenced).
- Assert output buffer is zeroed if function fails: [1](https://github.com/guidovranken/cryptofuzz/blob/fcfca5774d3519ef15fdbd0346dc9736ff1e6262/modules/secp256k1/module.cpp#L237-L238), [2](https://github.com/guidovranken/cryptofuzz/blob/fcfca5774d3519ef15fdbd0346dc9736ff1e6262/modules/secp256k1/module.cpp#L379-L380)
- Adapt to Schnorr API changes that were introduced in https://github.com/bitcoin-core/secp256k1/commit/0440945fb5ce69d335fed32827b5166e84b02e05

I've tested this fairly extensively but it's a lot of changes and it's possible I made an error. I'm not part of the CC list of this project, so please notify me if you encounter any crashes.
