### PR TITLE
infra: perf flame graph

### DIFF
--- a/infra/base-images/base-runner/Dockerfile
+++ b/infra/base-images/base-runner/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get update && apt-get install -y \
     lib32gcc1 \
     libc6-i386 \
     libcap2 \
+    linux-tools-generic linux-tools-`uname -r` \
     python3 \
     python3-pip \
     python3-setuptools \
@@ -104,6 +105,8 @@ RUN wget https://repo1.maven.org/maven2/org/jacoco/org.jacoco.cli/0.8.7/org.jaco
     wget https://repo1.maven.org/maven2/org/jacoco/org.jacoco.agent/0.8.7/org.jacoco.agent-0.8.7-runtime.jar -O /opt/jacoco-agent.jar && \
     echo "37df187b76888101ecd745282e9cd1ad4ea508d6  /opt/jacoco-agent.jar" | shasum --check && \
     echo "c1814e7bba5fd8786224b09b43c84fd6156db690  /opt/jacoco-cli.jar" | shasum --check
+
+RUN git clone --depth 1 https://github.com/brendangregg/FlameGraph /root/perf
 
 # Do this last to make developing these files easier/faster due to caching.
 COPY bad_build_check \

--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -82,7 +82,7 @@ function run_fuzz_target {
   local args="-merge=1 -timeout=100 -close_fd_mask=3 $corpus_dummy $corpus_real"
 
   export LLVM_PROFILE_FILE=$profraw_file
-  timeout $TIMEOUT $OUT/$target $args &> $LOGS_DIR/$target.log
+  timeout $TIMEOUT perf record -g -o $DUMPS_DIR/$target.perf $OUT/$target $args &> $LOGS_DIR/$target.log
   if (( $? != 0 )); then
     echo "Error occured while running $target:"
     cat $LOGS_DIR/$target.log
@@ -114,6 +114,8 @@ function run_fuzz_target {
     llvm-cov export -instr-profile=$profdata_file -object=$target \
       $shared_libraries $LLVM_COV_COMMON_ARGS > $LOGS_DIR/$target.json
   fi
+
+  perf script -i $DUMPS_DIR/$target.perf | /root/perf/stackcollapse-perf.pl | grep LLVMFuzzerTestOneInput | /root/perf/flamegraph.pl > $REPORT_ROOT_DIR/perf-$target.svg
 }
 
 function run_go_fuzz_target {

--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -115,7 +115,7 @@ function run_fuzz_target {
       $shared_libraries $LLVM_COV_COMMON_ARGS > $LOGS_DIR/$target.json
   fi
 
-  perf script -i $DUMPS_DIR/$target.perf | /root/perf/stackcollapse-perf.pl | grep LLVMFuzzerTestOneInput | /root/perf/flamegraph.pl > $REPORT_ROOT_DIR/perf-$target.svg
+  perf script -i $DUMPS_DIR/$target.perf | /root/perf/stackcollapse-perf.pl | grep LLVMFuzzerTestOneInput | rcfilt | /root/perf/flamegraph.pl > $REPORT_ROOT_DIR/perf-$target.svg
 }
 
 function run_go_fuzz_target {


### PR DESCRIPTION
cc @jonathanmetzman @inferno-chromium 

This allows to have perf flame graph along with coverage reports for C/C++/Rust

Tested with
```
python infra/helper.py build_fuzzers --sanitizer coverage suricata
python3 infra/helper.py build_image --no-pull base-runner
python3 infra/helper.py coverage --fuzz-target fuzz_sigpcap_aware --corpus-dir /path/to/corpus-libFuzzer-suricata_fuzz_sigpcap_aware-latest/ suricata
```
after having downloaded the corpus directory

Result is available here https://catenacyber.fr/perf-fuzz_sigpcap_aware.svg

In this case, the flame graph allows for instance to see that we spend 17% of the time in `JsonAnomalyLogger`
Even if this function may have bugs, it is clearly way too much time that is not spent on something else...