### PR TITLE
[boost.json] initial submission

### DIFF
--- a/projects/boost-json/Dockerfile
+++ b/projects/boost-json/Dockerfile
@@ -33,6 +33,7 @@ libs/intrusive/ \
 libs/io \
 libs/json \
 libs/move/ \
+libs/mp11/ \
 libs/smart_ptr/ \
 libs/static_assert \
 libs/system/ \

--- a/projects/boost-json/Dockerfile
+++ b/projects/boost-json/Dockerfile
@@ -20,6 +20,8 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN git clone --depth 1 --single-branch --branch master https://github.com/boostorg/boost.git
 RUN pwd
 RUN ls
+RUN git -C boost submodule update --init libs/json
+RUN git -C boost/libs/json checkout develop
 RUN git -C boost submodule update --init --depth 1 \
 libs/align/ \
 libs/assert \
@@ -31,7 +33,6 @@ libs/exception/ \
 libs/headers/ \
 libs/intrusive/ \
 libs/io \
-libs/json \
 libs/move/ \
 libs/mp11/ \
 libs/smart_ptr/ \

--- a/projects/boost-json/Dockerfile
+++ b/projects/boost-json/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 #RUN apt-get update && apt-get install -y g++
 
-RUN git clone --depth 1 --single-branch --branch boost-1.76.0 https://github.com/boostorg/boost.git
+RUN git clone --depth 1 --single-branch --branch master https://github.com/boostorg/boost.git
 RUN pwd
 RUN ls
 RUN git -C boost submodule update --init --depth 1 \

--- a/projects/boost-json/Dockerfile
+++ b/projects/boost-json/Dockerfile
@@ -1,0 +1,46 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+#RUN apt-get update && apt-get install -y g++
+
+RUN git clone --depth 1 --single-branch --branch boost-1.76.0 https://github.com/boostorg/boost.git
+RUN pwd
+RUN ls
+RUN git -C boost submodule update --init --depth 1 \
+libs/align/ \
+libs/assert \
+libs/config/ \
+libs/container \
+libs/container_hash/ \
+libs/core \
+libs/exception/ \
+libs/headers/ \
+libs/intrusive/ \
+libs/io \
+libs/json \
+libs/move/ \
+libs/smart_ptr/ \
+libs/static_assert \
+libs/system/ \
+libs/throw_exception/ \
+libs/type_traits/ \
+libs/utility/ \
+tools/boost_install \
+tools/build
+
+WORKDIR boost
+COPY build.sh *.cc $SRC/

--- a/projects/boost-json/Dockerfile
+++ b/projects/boost-json/Dockerfile
@@ -44,4 +44,5 @@ tools/boost_install \
 tools/build
 
 WORKDIR boost
-COPY build.sh *.cc $SRC/
+COPY build.sh $SRC/
+

--- a/projects/boost-json/build.sh
+++ b/projects/boost-json/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -eu
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+./bootstrap.sh --with-libraries=json
+
+echo "using clang : ossfuzz : $CXX : <compileflags>\"$CXXFLAGS\" <linkflags>\"$CXXFLAGS\" <linkflags>\"${LIB_FUZZING_ENGINE}\" ;" >user-config.jam
+
+./b2 --user-config=user-config.jam --toolset=clang-ossfuzz --prefix=$OUT --with-json link=static install
+
+for i in libs/json/fuzzing/*.cpp; do
+   fuzzer=$(basename $i .cpp)
+   $CXX $CXXFLAGS -pthread libs/json/fuzzing/$fuzzer.cpp -I /out/include/ $OUT/lib/*.a $LIB_FUZZING_ENGINE -o $OUT/$fuzzer
+done
+

--- a/projects/boost-json/project.yaml
+++ b/projects/boost-json/project.yaml
@@ -3,4 +3,5 @@ language: c++
 primary_contact: "pauldreikossfuzz@gmail.com"
 auto_ccs:  
    - "vinnie.falco@gmail.com"
+   - "grisumbras@gmail.com"
 main_repo: 'https://github.com/boostorg/json.git'

--- a/projects/boost-json/project.yaml
+++ b/projects/boost-json/project.yaml
@@ -2,5 +2,5 @@ homepage: "http://www.boost.org/"
 language: c++
 primary_contact: "pauldreikossfuzz@gmail.com"
 auto_ccs:  
-   - "xxxxxxx@gmail.com"
+   - "vinnie.falco@gmail.com"
 main_repo: 'https://github.com/boostorg/json.git'

--- a/projects/boost-json/project.yaml
+++ b/projects/boost-json/project.yaml
@@ -1,0 +1,6 @@
+homepage: "http://www.boost.org/"
+language: c++
+primary_contact: "pauldreikossfuzz@gmail.com"
+auto_ccs:  
+   - "xxxxxxx@gmail.com"
+main_repo: 'https://github.com/boostorg/json.git'


### PR DESCRIPTION
This adds boost.json. There is already a boost job. Since the boost project is huge and consists of separate projects, I think it makes sense to add a separate job for boost.json.

The fuzzers already run in CI since 2020 so I don't expect new bugs.

The upstream authors have given their consent, see https://github.com/boostorg/json/issues/592