### PR TITLE
[infra] do not close file descriptors in coverage runs.

### DIFF
--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -79,7 +79,7 @@ function run_fuzz_target {
   # because (A) corpuses are already minimized; (B) we do not use sancov, and so
   # libFuzzer always finishes merge with an empty output dir.
   # Use 100s timeout instead of 25s as code coverage builds can be very slow.
-  local args="-merge=1 -timeout=100 -close_fd_mask=3 $corpus_dummy $corpus_real"
+  local args="-merge=1 -timeout=100 $corpus_dummy $corpus_real"
 
   export LLVM_PROFILE_FILE=$profraw_file
   timeout $TIMEOUT $OUT/$target $args &> $LOGS_DIR/$target.log


### PR DESCRIPTION
Currently standard file descriptors are closed in coverage builds. This was added here https://github.com/google/oss-fuzz/commit/72b82ee08ffd39e284a7271bb556ba0e5b7b3e39 with the goal of speeding up noisy fuzz targets. However, the consequence is that the runtime environment is a bit different from when the fuzzers run which can make the coverage reports be different than what is actually exercised by the coverage. 

An example is OpenVPN where the following line https://github.com/OpenVPN/openvpn/blob/ccee09d1478aa69783926c208bfa235dcb055124/src/openvpn/console_builtin.c#L215 checks the openness of stdin and stderr. In non-coverage builds the line fails and execution continues, but in coverage builds the line evaluates to true and the fuzzer, therefore, exits. 

The alternative to removing the use of `close_fd_mask=3` is patching targets on an per-project basis but I think a cleaner solution is simply removing `close_fd_mask=3`.

There are some other issues with coverage discrepancies (https://github.com/google/oss-fuzz/issues/5994) but I don't think this PR solves that issue. 