### PR TITLE
projects/tendermint: change tendermint email to interchain.io

### DIFF
--- a/projects/tendermint/project.yaml
+++ b/projects/tendermint/project.yaml
@@ -1,9 +1,11 @@
 homepage: "https://github.com/tendermint/tendermint"
-primary_contact: "security@tendermint.com"
+primary_contact: "security@interchain.io"
 auto_ccs:
   - fuzzing@orijtech.com
   - emmanuel@orijtech.com
   - cuong@orijtech.com
+  - tess@interchain.io
+  - tychoish@interchain.io
 language: go
 fuzzing_engines:
   - libfuzzer


### PR DESCRIPTION
While at it, also add @tessr and @tychoish to cc list, as the primary
contact is an email group, not individual Google Account.