### PR TITLE
[distribution] Initial integration

### DIFF
--- a/projects/distribution/Dockerfile
+++ b/projects/distribution/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/distribution/distribution
+RUN git clone --depth 1 https://github.com/cncf/cncf-fuzzing
+COPY build.sh $SRC/
+WORKDIR $SRC/distribution

--- a/projects/distribution/build.sh
+++ b/projects/distribution/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+$SRC/cncf-fuzzing/projects/distribution/build.sh
+

--- a/projects/distribution/project.yaml
+++ b/projects/distribution/project.yaml
@@ -1,0 +1,24 @@
+homepage: "https://github.com/distribution/distribution"
+main_repo: "https://github.com/distribution/distribution"
+primary_contact: "cncf-distribution-security@lists.cncf.io"
+auto_ccs :
+  - "adam@adalogics.com"
+  - "david@adalogics.com"
+  - "chrispat@github.com"
+  - "clarkbw@github.com"
+  - "csnider@mirantis.com"
+  - "hswimelar@gitlab.com"
+  - "hweiwei@vmware.com"
+  - "jpereira@gitlab.com"
+  - "justin.cormack@docker.com"
+  - "ksquizzato@mirantis.com"
+  - "milos.gajdos@docker.com"
+  - "sargun@sargun.me"
+  - "wwarren@digitalocean.com"
+  - "wangyan@vmware.com"
+  - "steve.lasker@microsoft.com"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
Adds initial integration of Distribution.

Distribution is a core library for many registry operators including Docker Hub, GitHub Container Registry, GitLab Container Registry and DigitalOcean Container Registry, as well as the CNCF Harbor Project, and VMware Harbor Registry.

__________________________________________________

@dmcgowan Can we also integrate Distribution into OSS-fuzz? No changes are needed at this point upstream, just an email address for bug reports.