### PR TITLE
openvpn: hook more functions

### DIFF
--- a/projects/openvpn/build.sh
+++ b/projects/openvpn/build.sh
@@ -30,6 +30,7 @@ sed -i 's/#include "forward.h"/#include "fuzz_header.h"\n#include "forward.h"/g'
 sed -i 's/select(/fuzz_select(/g' ./src/openvpn/proxy.c
 sed -i 's/send(/fuzz_send(/g' ./src/openvpn/proxy.c
 sed -i 's/recv(/fuzz_recv(/g' ./src/openvpn/proxy.c
+sed -i 's/isatty/fuzz_isatty/g' ./src/openvpn/console_builtin.c
 
 sed -i 's/fopen/fuzz_fopen/g' ./src/openvpn/console_builtin.c
 sed -i 's/fclose/fuzz_fclose/g' ./src/openvpn/console_builtin.c

--- a/projects/openvpn/fuzz_header.h
+++ b/projects/openvpn/fuzz_header.h
@@ -32,6 +32,10 @@ ssize_t fuzz_write(int fd, const void *buf, size_t count) {
   return count;
 }
 
+int fuzz_isatty(int fd) {
+  return 1;
+}
+
 char *fuzz_fgets(char *s, int size, FILE *stream) {
   ssize_t v = fuzz_get_random_data(s, size-1);
   // We use fgets to get trusted input. As such, assume we have


### PR DESCRIPTION
These hooks are to ensure openvpn does not exit because some file descriptors may not refer to a terminal.