### PR TITLE
[stb] update Dockerfile for CIFuzz

### DIFF
--- a/projects/stb/Dockerfile
+++ b/projects/stb/Dockerfile
@@ -31,5 +31,8 @@ RUN wget -O $SRC/stbi/tga.zip https://github.com/richgel999/tga_test_files/archi
 
 RUN wget -O $SRC/stbi/gif.dict https://raw.githubusercontent.com/mirrorer/afl/master/dictionaries/gif.dict
 
+# Maintain compatibility with master branch until a new release
+RUN cp $SRC/stbi/gif.tar.gz $SRC/stbi/jpg.tar.gz $SRC/stbi/bmp.zip $SRC/stbi/gif.dict $SRC/stb
+
 WORKDIR stb
 COPY build.sh $SRC/

--- a/projects/stb/Dockerfile
+++ b/projects/stb/Dockerfile
@@ -22,12 +22,14 @@ RUN apt-get update && \
 
 RUN git clone --depth 1 https://github.com/nothings/stb.git
 
-RUN wget -O $SRC/stb/gif.tar.gz https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/imagetestsuite/imagetestsuite-gif-1.00.tar.gz
-RUN wget -O $SRC/stb/jpg.tar.gz https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/imagetestsuite/imagetestsuite-jpg-1.00.tar.gz
-RUN wget -O $SRC/stb/bmp.zip http://entropymine.com/jason/bmpsuite/releases/bmpsuite-2.6.zip
-RUN wget -O $SRC/stb/tga.zip https://github.com/richgel999/tga_test_files/archive/master.zip
+RUN mkdir $SRC/stbi # CIFuzz workaround
 
-RUN wget -O $SRC/stb/tests/gif.dict https://raw.githubusercontent.com/mirrorer/afl/master/dictionaries/gif.dict &> /dev/null
+RUN wget -O $SRC/stbi/gif.tar.gz https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/imagetestsuite/imagetestsuite-gif-1.00.tar.gz
+RUN wget -O $SRC/stbi/jpg.tar.gz https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/imagetestsuite/imagetestsuite-jpg-1.00.tar.gz
+RUN wget -O $SRC/stbi/bmp.zip http://entropymine.com/jason/bmpsuite/releases/bmpsuite-2.6.zip
+RUN wget -O $SRC/stbi/tga.zip https://github.com/richgel999/tga_test_files/archive/master.zip
+
+RUN wget -O $SRC/stbi/gif.dict https://raw.githubusercontent.com/mirrorer/afl/master/dictionaries/gif.dict
 
 WORKDIR stb
 COPY build.sh $SRC/


### PR DESCRIPTION
Encountered an issue similar to https://github.com/google/oss-fuzz/pull/5315. The copying of the seed corpus is done to keep it working with the old build script, the fix upstream will be on another branch instead of `master` for a week or so.

https://github.com/nothings/stb/pull/1058