### PR TITLE
tor: Fix libevent build by installing pkg-config

### DIFF
--- a/projects/tor/Dockerfile
+++ b/projects/tor/Dockerfile
@@ -15,7 +15,7 @@
 ##############################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y autoconf automake make libtool
+RUN apt-get update && apt-get install -y autoconf automake make libtool pkg-config
 RUN git clone --depth 1 https://git.torproject.org/tor.git
 RUN git clone --depth 1 https://git.torproject.org/fuzzing-corpora.git tor-fuzz-corpora
 RUN git clone --depth 1 https://github.com/madler/zlib.git


### PR DESCRIPTION
It appears that libevent now requires pkg-config, which was not
previously installed from Tor's Dockerfile.  This change adds
pkg-config.

Adding this dependency should resolve oss-fuzz issue 36048
(https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=36048)