### PR TITLE
Update h3 contact email

### DIFF
--- a/projects/h3/project.yaml
+++ b/projects/h3/project.yaml
@@ -1,9 +1,10 @@
 homepage: "https://github.com/uber/h3"
 language: c
-primary_contact: "isaac@isaacbrodsky.com"
+primary_contact: "isaacbrodsky@live.com"
 auto_ccs:
   - "Adam@adalogics.com"
   - "h3-dev@googlegroups.com"
+  - "isv.damocles@gmail.com"
 sanitizers:
   - address
   - undefined


### PR DESCRIPTION
It doesn't seem to be possible to log in and view reports without the contact email being associated with a Google account. I'm replacing my email address with a Gmail one, and adding another H3 contributor's Gmail email address as well (he's subscribed to the list that receives reports but also could not login.)

Please let me know if my understanding of how reports are made visible to some email addresses is not correct. Thanks!

cc @dfellis @nrabinowitz @ajfriend (didn't know your Gmail addresses off hand)