### PR TITLE
apache-httpd: initial integration

### DIFF
--- a/projects/apache-httpd/Dockerfile
+++ b/projects/apache-httpd/Dockerfile
@@ -15,9 +15,18 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool wget libpcre3 libpcre3-dev libaprutil1 libaprutil1-dev
-RUN wget https://downloads.apache.org//httpd/httpd-2.4.48.tar.bz2 && tar -xf httpd-2.4.48.tar.bz2
-WORKDIR httpd-2.4.48
+RUN apt-get update && apt-get install -y make autoconf automake libtool wget libpcre3 libpcre3-dev  uuid-dev
+RUN wget https://github.com/libexpat/libexpat/releases/download/R_2_4_1/expat-2.4.1.tar.gz && \
+    tar -xf expat-2.4.1.tar.gz && \
+    cd expat-2.4.1 && \
+    ./configure && \
+    make && \
+    make install
+
+RUN wget https://downloads.apache.org//httpd/httpd-2.4.48.tar.bz2 && \
+    tar -xf httpd-2.4.48.tar.bz2 && \
+    mv httpd-2.4.48 httpd
+WORKDIR httpd
 
 COPY build.sh $SRC/
 COPY fuzz_*.c $SRC/

--- a/projects/apache-httpd/Dockerfile
+++ b/projects/apache-httpd/Dockerfile
@@ -15,18 +15,15 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool wget libpcre3 libpcre3-dev  uuid-dev
+RUN apt-get update && apt-get install -y make autoconf automake libtool wget libpcre3 \
+                                         libpcre3-dev uuid-dev pkg-config libtool-bin
 RUN wget https://github.com/libexpat/libexpat/releases/download/R_2_4_1/expat-2.4.1.tar.gz && \
     tar -xf expat-2.4.1.tar.gz && \
     cd expat-2.4.1 && \
     ./configure && \
     make && \
     make install
-
-RUN wget https://downloads.apache.org//httpd/httpd-2.4.48.tar.bz2 && \
-    tar -xf httpd-2.4.48.tar.bz2 && \
-    mv httpd-2.4.48 httpd
+RUN svn checkout https://svn.apache.org/repos/asf/httpd/httpd/trunk/ httpd
 WORKDIR httpd
-
 COPY build.sh $SRC/
 COPY fuzz_*.c $SRC/

--- a/projects/apache-httpd/Dockerfile
+++ b/projects/apache-httpd/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool wget libpcre3 libpcre3-dev libaprutil1 libaprutil1-dev
+RUN wget https://downloads.apache.org//httpd/httpd-2.4.48.tar.bz2 && tar -xf httpd-2.4.48.tar.bz2
+WORKDIR httpd-2.4.48
+
+COPY build.sh $SRC/
+COPY fuzz_*.c $SRC/

--- a/projects/apache-httpd/build.sh
+++ b/projects/apache-httpd/build.sh
@@ -37,5 +37,5 @@ for fuzzname in utils parse tokenize addr_parse; do
                       ./server/mpm/event/.libs/libevent.a \
                       ./os/unix/.libs/libos.a \
                       ./srclib/apr/.libs/libapr-2.a \
-    -Wl,--end-group -luuid -lpcre
+    -Wl,--end-group -luuid -lpcre -lcrypt
 done

--- a/projects/apache-httpd/build.sh
+++ b/projects/apache-httpd/build.sh
@@ -23,7 +23,7 @@ svn checkout https://svn.apache.org/repos/asf/apr/apr/trunk/ srclib/apr
 
 # Build httpd
 ./buildconf
-./configure --with-included-apr
+./configure --with-included-apr --enable-pool-debug
 make
 
 # Build the fuzzers

--- a/projects/apache-httpd/build.sh
+++ b/projects/apache-httpd/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+unset CPP
+unset CXX
+./configure
+make -i
+
+
+for fuzzname in utils parse; do
+  $CC $CFLAGS $LIB_FUZZING_ENGINE -I./include -I./os/unix -I/usr/include/apr-1.0/ \
+    $SRC/fuzz_${fuzzname}.c -o $OUT/fuzz_${fuzzname} \
+    ./modules.o buildmark.o \
+    -Wl,--start-group ./server/.libs/libmain.a \
+                      ./modules/core/.libs/libmod_so.a \
+                      ./modules/http/.libs/libmod_http.a \
+                      ./server/mpm/event/.libs/libevent.a \
+                      ./os/unix/.libs/libos.a \
+                      /usr/lib/x86_64-linux-gnu/libaprutil-1.a \
+                      /usr/lib/x86_64-linux-gnu/libapr-1.a \
+    -Wl,--end-group -luuid -lpcre
+done

--- a/projects/apache-httpd/build.sh
+++ b/projects/apache-httpd/build.sh
@@ -18,20 +18,11 @@
 unset CPP
 unset CXX
 
-# Download apr and apr-utils and place them in httpd folder
-cd $SRC/
-mkdir deps
-cd deps
-wget https://downloads.apache.org//apr/apr-1.7.0.tar.gz
-tar -xf apr-1.7.0.tar.gz
-mv apr-1.7.0 $SRC/httpd/srclib/apr
-
-wget https://downloads.apache.org//apr/apr-util-1.6.1.tar.gz
-tar -xf apr-util-1.6.1.tar.gz
-mv apr-util-1.6.1 $SRC/httpd/srclib/apr-util
+# Download apr and place in httpd srclib folder. Apr-2.0 includes apr-utils
+svn checkout https://svn.apache.org/repos/asf/apr/apr/trunk/ srclib/apr
 
 # Build httpd
-cd $SRC/httpd
+./buildconf
 ./configure --with-included-apr
 make
 
@@ -45,7 +36,6 @@ for fuzzname in utils parse tokenize addr_parse; do
                       ./modules/http/.libs/libmod_http.a \
                       ./server/mpm/event/.libs/libevent.a \
                       ./os/unix/.libs/libos.a \
-                      ./srclib/apr-util/.libs/libaprutil-1.a \
-                      ./srclib/apr/.libs/libapr-1.a \
+                      ./srclib/apr/.libs/libapr-2.a \
     -Wl,--end-group -luuid -lpcre
 done

--- a/projects/apache-httpd/fuzz_addr_parse.c
+++ b/projects/apache-httpd/fuzz_addr_parse.c
@@ -1,0 +1,37 @@
+/* Copyright 2021 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "apr_network_io.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  apr_pool_t *pool;
+  apr_pool_initialize();
+  if (apr_pool_create(&pool, NULL) != APR_SUCCESS) {
+    abort();
+  }
+
+  char *addr = NULL;
+  char *scope_id = NULL;
+  apr_port_t port = 0;
+  char *input_string = strndup((const char *)data, size);
+
+  apr_parse_addr_port(&addr, &scope_id, &port, input_string, pool);
+
+  free(input_string);
+  apr_pool_destroy(pool);
+  apr_terminate();
+
+  return 0;
+}

--- a/projects/apache-httpd/fuzz_parse.c
+++ b/projects/apache-httpd/fuzz_parse.c
@@ -1,0 +1,73 @@
+/* Copyright 2021 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "apr.h"
+#include "apr_portable.h"
+#include "apr_strings.h"
+#include "apr_file_io.h"
+#include "apr_thread_proc.h"
+#include "apr_signal.h"
+#include "apr_thread_mutex.h"
+#include "apr_proc_mutex.h"
+#include "apr_poll.h"
+
+#define APR_WANT_STRFUNC
+#include "apr_want.h"
+#include "apr_file_io.h"
+#include "apr_fnmatch.h"
+
+#include "apr_want.h"
+#include "apr_poll.h"
+
+#include "ap_config.h"
+#include "ap_provider.h"
+#include "ap_listen.h"
+#include "ap_regex.h"
+#include "ap_expr.h"
+
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    char *new_str = (char *)malloc(size+1);
+    if (new_str == NULL){
+        return 0;
+    }
+    memcpy(new_str, data, size);
+    new_str[size] = '\0';
+
+    apr_pool_initialize();
+    apr_pool_t *v = NULL;
+    apr_pool_create(&v, NULL);
+
+    int only_ascii = 1;
+    for (int i = 0; i < size; i++) {
+        // Avoid unnessary exits because of non-ascii characters.
+        if (new_str[i] < 0x01 || new_str[i] > 0x7f) { 
+            only_ascii = 0;
+        }
+        // Avoid forced exits beause of, e.g. unsupported characters or recursion depth
+        if (new_str[i] == 0x5c ||
+            new_str[i] == '{') {
+            only_ascii = 0;
+        }
+    }
+
+    // Now parse
+    if (only_ascii) {
+      ap_expr_info_t val;
+      ap_expr_parse(v, v, &val, new_str, NULL);
+    }
+
+    apr_pool_terminate();
+    free(new_str);
+    return 0;
+}

--- a/projects/apache-httpd/fuzz_parse.c
+++ b/projects/apache-httpd/fuzz_parse.c
@@ -10,64 +10,61 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #include "apr.h"
-#include "apr_portable.h"
-#include "apr_strings.h"
 #include "apr_file_io.h"
-#include "apr_thread_proc.h"
-#include "apr_signal.h"
-#include "apr_thread_mutex.h"
-#include "apr_proc_mutex.h"
 #include "apr_poll.h"
+#include "apr_portable.h"
+#include "apr_proc_mutex.h"
+#include "apr_signal.h"
+#include "apr_strings.h"
+#include "apr_thread_mutex.h"
+#include "apr_thread_proc.h"
 
 #define APR_WANT_STRFUNC
-#include "apr_want.h"
 #include "apr_file_io.h"
 #include "apr_fnmatch.h"
-
 #include "apr_want.h"
+
 #include "apr_poll.h"
+#include "apr_want.h"
 
 #include "ap_config.h"
-#include "ap_provider.h"
-#include "ap_listen.h"
-#include "ap_regex.h"
 #include "ap_expr.h"
+#include "ap_listen.h"
+#include "ap_provider.h"
+#include "ap_regex.h"
 
-
-int
-LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
-{
-    char *new_str = (char *)malloc(size+1);
-    if (new_str == NULL){
-        return 0;
-    }
-    memcpy(new_str, data, size);
-    new_str[size] = '\0';
-
-    apr_pool_initialize();
-    apr_pool_t *v = NULL;
-    apr_pool_create(&v, NULL);
-
-    int only_ascii = 1;
-    for (int i = 0; i < size; i++) {
-        // Avoid unnessary exits because of non-ascii characters.
-        if (new_str[i] < 0x01 || new_str[i] > 0x7f) { 
-            only_ascii = 0;
-        }
-        // Avoid forced exits beause of, e.g. unsupported characters or recursion depth
-        if (new_str[i] == 0x5c ||
-            new_str[i] == '{') {
-            only_ascii = 0;
-        }
-    }
-
-    // Now parse
-    if (only_ascii) {
-      ap_expr_info_t val;
-      ap_expr_parse(v, v, &val, new_str, NULL);
-    }
-
-    apr_pool_terminate();
-    free(new_str);
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  char *new_str = (char *)malloc(size + 1);
+  if (new_str == NULL) {
     return 0;
+  }
+  memcpy(new_str, data, size);
+  new_str[size] = '\0';
+
+  apr_pool_initialize();
+  apr_pool_t *v = NULL;
+  apr_pool_create(&v, NULL);
+
+  int only_ascii = 1;
+  for (int i = 0; i < size; i++) {
+    // Avoid unnessary exits because of non-ascii characters.
+    if (new_str[i] < 0x01 || new_str[i] > 0x7f) {
+      only_ascii = 0;
+    }
+    // Avoid forced exits beause of, e.g. unsupported characters or recursion
+    // depth
+    if (new_str[i] == 0x5c || new_str[i] == '{') {
+      only_ascii = 0;
+    }
+  }
+
+  // Now parse
+  if (only_ascii) {
+    ap_expr_info_t val;
+    ap_expr_parse(v, v, &val, new_str, NULL);
+  }
+
+  apr_pool_terminate();
+  free(new_str);
+  return 0;
 }

--- a/projects/apache-httpd/fuzz_tokenize.c
+++ b/projects/apache-httpd/fuzz_tokenize.c
@@ -1,0 +1,34 @@
+/* Copyright 2021 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "apr_strings.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  apr_pool_t *pool;
+  apr_pool_initialize();
+  if (apr_pool_create(&pool, NULL) != APR_SUCCESS) {
+    abort();
+  }
+
+  char *arg_str = strndup((const char *)data, size);
+  char **argv_out;
+  apr_tokenize_to_argv(arg_str, &argv_out, pool);
+
+  free(arg_str);
+  apr_pool_destroy(pool);
+  apr_terminate();
+
+  return 0;
+}

--- a/projects/apache-httpd/fuzz_utils.c
+++ b/projects/apache-httpd/fuzz_utils.c
@@ -10,73 +10,122 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #include "apr.h"
-#include "apr_portable.h"
-#include "apr_strings.h"
 #include "apr_file_io.h"
-#include "apr_thread_proc.h"
-#include "apr_signal.h"
-#include "apr_thread_mutex.h"
-#include "apr_proc_mutex.h"
 #include "apr_poll.h"
+#include "apr_portable.h"
+#include "apr_proc_mutex.h"
+#include "apr_signal.h"
+#include "apr_strings.h"
+#include "apr_thread_mutex.h"
+#include "apr_thread_proc.h"
 
 #define APR_WANT_STRFUNC
-#include "apr_want.h"
 #include "apr_file_io.h"
 #include "apr_fnmatch.h"
-
 #include "apr_want.h"
+
 #include "apr_poll.h"
+#include "apr_want.h"
 
 #include "ap_config.h"
-#include "ap_provider.h"
-#include "ap_listen.h"
-#include "ap_regex.h"
 #include "ap_expr.h"
+#include "ap_listen.h"
+#include "ap_provider.h"
+#include "ap_regex.h"
 
-int
-LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
-{
-    char *new_str = (char *)malloc(size+1);
-    if (new_str == NULL){
-        return 0;
-    }
-    memcpy(new_str, data, size);
-    new_str[size] = '\0';
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  char *new_str = (char *)malloc(size + 1);
+  if (new_str == NULL) {
+    return 0;
+  }
+  memcpy(new_str, data, size);
+  new_str[size] = '\0';
 
-    // Targets that do not require a pool
-    ap_cstr_casecmp(new_str, new_str);
-    ap_getparents(new_str);
-    ap_unescape_url(new_str);
-    ap_unescape_urlencoded(new_str);
-    ap_strcmp_match(new_str, "AAAAAABDKJSAD");
+  // Targets that do not require a pool
+  ap_cstr_casecmp(new_str, new_str);
+  ap_getparents(new_str);
+  ap_unescape_url(new_str);
+  ap_unescape_urlencoded(new_str);
+  ap_strcmp_match(new_str, "AAAAAABDKJSAD");
 
-    // Pool initialisation
-    apr_pool_initialize();
-    apr_pool_t *v = NULL;
-    apr_pool_create(&v, NULL);
+  // Pool initialisation
+  if (apr_pool_initialize() == APR_SUCCESS) {
+    apr_pool_t *pool = NULL;
+    apr_pool_create(&pool, NULL);
 
     // Targets that require a pool
-    ap_field_noparam(v, new_str);
+    ap_field_noparam(pool, new_str);
 
-    ap_escape_shell_cmd(v, new_str);
-    ap_os_escape_path(v, new_str, 0);
-    ap_escape_html2(v, new_str, 0);
-    ap_escape_logitem(v, new_str);
-    ap_escape_quotes(v, new_str);
+    ap_escape_shell_cmd(pool, new_str);
+    ap_os_escape_path(pool, new_str, 0);
+    ap_escape_html2(pool, new_str, 0);
+    ap_escape_logitem(pool, new_str);
+
+    // This line causes some issues if something bad is allocated
+    ap_escape_quotes(pool, new_str);
 
     if (size > 2) {
-      ap_cstr_casecmpn(new_str, new_str+2, size-2);
+      ap_cstr_casecmpn(new_str, new_str + 2, size - 2);
     }
 
-    char *d = malloc(size*2);
-    ap_escape_errorlog_item(d, new_str, size*2);
+    char *d = malloc(size * 2);
+    ap_escape_errorlog_item(d, new_str, size * 2);
     free(d);
 
+    // base64
     char *decoded = NULL;
-    decoded = ap_pbase64decode(v, new_str);
+    decoded = ap_pbase64decode(pool, new_str);
+    ap_pbase64encode(pool, new_str);
+
+    char *tmp_s = new_str;
+    ap_getword_conf2(pool, &tmp_s);
+
+    // str functions
+    ap_strcasecmp_match(tmp_s, "asdfkj");
+    ap_strcasestr(tmp_s, "AAAAAAAAAAAAAA");
+    ap_strcasestr(tmp_s, "AasdfasbA");
+    ap_strcasestr(tmp_s, "1341234");
+    ap_strcasestr("AAAAAAAAAAAAAA", tmp_s);
+    ap_strcasestr("AasdfasbA", tmp_s);
+    ap_strcasestr("1341234", tmp_s);
+
+    // List functions
+    tmp_s = new_str;
+    ap_get_list_item(pool, &tmp_s);
+    tmp_s = new_str;
+    ap_find_list_item(pool, &tmp_s, "kjahsdfkj");
+    ap_find_token(pool, tmp_s, "klsjdfk");
+    ap_find_last_token(pool, tmp_s, "sdadf");
+    ap_is_chunked(pool, tmp_s);
+
+    apr_array_header_t *offers = NULL;
+    ap_parse_token_list_strict(pool, new_str, &offers, 0);
+
+    char *tmp_null = NULL;
+    ap_pstr2_alnum(pool, new_str, &tmp_null);
+
+    // Word functions
+    tmp_s = new_str;
+    ap_getword(pool, &tmp_s, 0);
+
+    tmp_s = new_str;
+    ap_getword_white_nc(pool, &tmp_s);
+
+    tmp_s = new_str;
+    ap_get_token(pool, &tmp_s, 1);
+
+    tmp_s = new_str;
+    ap_escape_urlencoded(pool, tmp_s);
+
+    apr_interval_time_t timeout;
+    ap_timeout_parameter_parse(new_str, &timeout, "ms");
+
+    tmp_s = new_str;
+    ap_content_type_tolower(tmp_s);
 
     // Cleanup
     apr_pool_terminate();
-    free(new_str);
-    return 0;
+  }
+  free(new_str);
+  return 0;
 }

--- a/projects/apache-httpd/fuzz_utils.c
+++ b/projects/apache-httpd/fuzz_utils.c
@@ -1,0 +1,82 @@
+/* Copyright 2021 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "apr.h"
+#include "apr_portable.h"
+#include "apr_strings.h"
+#include "apr_file_io.h"
+#include "apr_thread_proc.h"
+#include "apr_signal.h"
+#include "apr_thread_mutex.h"
+#include "apr_proc_mutex.h"
+#include "apr_poll.h"
+
+#define APR_WANT_STRFUNC
+#include "apr_want.h"
+#include "apr_file_io.h"
+#include "apr_fnmatch.h"
+
+#include "apr_want.h"
+#include "apr_poll.h"
+
+#include "ap_config.h"
+#include "ap_provider.h"
+#include "ap_listen.h"
+#include "ap_regex.h"
+#include "ap_expr.h"
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    char *new_str = (char *)malloc(size+1);
+    if (new_str == NULL){
+        return 0;
+    }
+    memcpy(new_str, data, size);
+    new_str[size] = '\0';
+
+    // Targets that do not require a pool
+    ap_cstr_casecmp(new_str, new_str);
+    ap_getparents(new_str);
+    ap_unescape_url(new_str);
+    ap_unescape_urlencoded(new_str);
+    ap_strcmp_match(new_str, "AAAAAABDKJSAD");
+
+    // Pool initialisation
+    apr_pool_initialize();
+    apr_pool_t *v = NULL;
+    apr_pool_create(&v, NULL);
+
+    // Targets that require a pool
+    ap_field_noparam(v, new_str);
+
+    ap_escape_shell_cmd(v, new_str);
+    ap_os_escape_path(v, new_str, 0);
+    ap_escape_html2(v, new_str, 0);
+    ap_escape_logitem(v, new_str);
+    ap_escape_quotes(v, new_str);
+
+    if (size > 2) {
+      ap_cstr_casecmpn(new_str, new_str+2, size-2);
+    }
+
+    char *d = malloc(size*2);
+    ap_escape_errorlog_item(d, new_str, size*2);
+    free(d);
+
+    char *decoded = NULL;
+    decoded = ap_pbase64decode(v, new_str);
+
+    // Cleanup
+    apr_pool_terminate();
+    free(new_str);
+    return 0;
+}

--- a/projects/apache-httpd/project.yaml
+++ b/projects/apache-httpd/project.yaml
@@ -1,6 +1,8 @@
 homepage: "https://httpd.apache.org/"
 language: c
-primary_contact: "someone_at_apache@apache.org"
+primary_contact: "david@adalogics.com"
 auto_ccs:
- - "david@adalogics.com"
-main_repo: "https://httpd.apache.org/"
+ - "stefan.eissing@greenbytes.de"
+ - "covener@gmail.com"
+ - "ylavic.dev@gmail.com"
+main_repo: "https://github.com/apache/httpd"

--- a/projects/apache-httpd/project.yaml
+++ b/projects/apache-httpd/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://httpd.apache.org/"
+language: c
+primary_contact: "someone_at_apache@apache.org"
+auto_ccs:
+ - "david@adalogics.com"
+main_repo: "https://httpd.apache.org/"


### PR DESCRIPTION
Integrates apache-httpd.

apr (apache runtime) and apr-util are also compiled with sanitizers. This means the code in those libraries will effectively also be analysed. For this reason following the merge of this PR I will be closing the one that proposes apr https://github.com/google/oss-fuzz/pull/6048

Topic on mailing list where oss-fuzz integration is proposed and discussed: https://mail-archives.apache.org/mod_mbox/httpd-dev/202107.mbox/%3C56a5f294-b724-7a3a-3ef3-0576862d0d92%40adalogics.com%3E