### PR TITLE
tidy-html5: fix breaking build.

### DIFF
--- a/projects/tidy-html5/build.sh
+++ b/projects/tidy-html5/build.sh
@@ -27,7 +27,7 @@ for fuzzer in tidy_config_fuzzer tidy_fuzzer; do
         $SRC/${fuzzer}.c -o ${fuzzer}.o
     ${CXX} ${CXXFLAGS} -std=c++11 ${fuzzer}.o \
         -o $OUT/${fuzzer} \
-        $LIB_FUZZING_ENGINE libtidys.a
+        $LIB_FUZZING_ENGINE libtidy.a
 done
 
 cp ${SRC}/*.options ${OUT}/


### PR DESCRIPTION
An issue with the tidy-html5 build came up here https://github.com/google/oss-fuzz/pull/6029 

This PR fixes it.