### PR TITLE
[infra][build] Set HOME=/root on GCB when doing fuzzer builds.

### DIFF
--- a/infra/build/functions/build_project.py
+++ b/infra/build/functions/build_project.py
@@ -228,7 +228,7 @@ def get_build_steps(project_name, project_yaml_file, dockerfile_lines,
                     # (see https://github.com/google/oss-fuzz/issues/6035).
                     ('export HOME=/root; rm -r /out && cd /src && cd {workdir} '
                      '&& mkdir -p {out} && compile || (echo "{failure_msg}" '
-                     '&& false')
+                     '&& false)'
                     ).format(workdir=workdir, out=out, failure_msg=failure_msg),
                 ],
             })

--- a/infra/build/functions/build_project.py
+++ b/infra/build/functions/build_project.py
@@ -224,8 +224,11 @@ def get_build_steps(project_name, project_yaml_file, dockerfile_lines,
                     # `cd /src && cd {workdir}` (where {workdir} is parsed from
                     # the Dockerfile). Container Builder overrides our workdir
                     # so we need to add this step to set it back.
-                    ('rm -r /out && cd /src && cd {workdir} && mkdir -p {out} '
-                     '&& compile || (echo "{failure_msg}" && false)'
+                    # Reset HOME so that it doesn't point to a persisted volume
+                    # (see https://github.com/google/oss-fuzz/issues/6035).
+                    ('export HOME=/root; rm -r /out && cd /src && cd {workdir} '
+                     '&& mkdir -p {out} && compile || (echo "{failure_msg}" '
+                     '&& false')
                     ).format(workdir=workdir, out=out, failure_msg=failure_msg),
                 ],
             })

--- a/infra/build/functions/build_project.py
+++ b/infra/build/functions/build_project.py
@@ -228,8 +228,9 @@ def get_build_steps(project_name, project_yaml_file, dockerfile_lines,
                     # (see https://github.com/google/oss-fuzz/issues/6035).
                     ('export HOME=/root; rm -r /out && cd /src && cd {workdir} '
                      '&& mkdir -p {out} && compile || (echo "{failure_msg}" '
-                     '&& false)'
-                    ).format(workdir=workdir, out=out, failure_msg=failure_msg),
+                     '&& false)').format(workdir=workdir,
+                                         out=out,
+                                         failure_msg=failure_msg),
                 ],
             })
 

--- a/infra/build/functions/expected_build_steps.json
+++ b/infra/build/functions/expected_build_steps.json
@@ -49,7 +49,7 @@
     "args": [
       "bash",
       "-c",
-      "rm -r /out && cd /src && cd /src && mkdir -p /workspace/out/address && compile || (echo \"********************************************************************************\nFailed to build.\nTo reproduce, run:\npython infra/helper.py build_image test-project\npython infra/helper.py build_fuzzers --sanitizer address --engine afl --architecture x86_64 test-project\n********************************************************************************\" && false)"
+      "export HOME=/root; rm -r /out && cd /src && cd /src && mkdir -p /workspace/out/address && compile || (echo \"********************************************************************************\nFailed to build.\nTo reproduce, run:\npython infra/helper.py build_image test-project\npython infra/helper.py build_fuzzers --sanitizer address --engine afl --architecture x86_64 test-project\n********************************************************************************\" && false)"
     ]
   },
   {
@@ -146,7 +146,7 @@
     "args": [
       "bash",
       "-c",
-      "rm -r /out && cd /src && cd /src && mkdir -p /workspace/out/address && compile || (echo \"********************************************************************************\nFailed to build.\nTo reproduce, run:\npython infra/helper.py build_image test-project\npython infra/helper.py build_fuzzers --sanitizer address --engine honggfuzz --architecture x86_64 test-project\n********************************************************************************\" && false)"
+      "export HOME=/root; rm -r /out && cd /src && cd /src && mkdir -p /workspace/out/address && compile || (echo \"********************************************************************************\nFailed to build.\nTo reproduce, run:\npython infra/helper.py build_image test-project\npython infra/helper.py build_fuzzers --sanitizer address --engine honggfuzz --architecture x86_64 test-project\n********************************************************************************\" && false)"
     ]
   },
   {
@@ -243,7 +243,7 @@
     "args": [
       "bash",
       "-c",
-      "rm -r /out && cd /src && cd /src && mkdir -p /workspace/out/address && compile || (echo \"********************************************************************************\nFailed to build.\nTo reproduce, run:\npython infra/helper.py build_image test-project\npython infra/helper.py build_fuzzers --sanitizer address --engine libfuzzer --architecture x86_64 test-project\n********************************************************************************\" && false)"
+      "export HOME=/root; rm -r /out && cd /src && cd /src && mkdir -p /workspace/out/address && compile || (echo \"********************************************************************************\nFailed to build.\nTo reproduce, run:\npython infra/helper.py build_image test-project\npython infra/helper.py build_fuzzers --sanitizer address --engine libfuzzer --architecture x86_64 test-project\n********************************************************************************\" && false)"
     ]
   },
   {

--- a/projects/myanmar-tools/build.sh
+++ b/projects/myanmar-tools/build.sh
@@ -1,16 +1,19 @@
+#!/bin/bash -eu
 # Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# https://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+################################################################################
 
 cd $SRC/myanmar-tools/clients/cpp
 mkdir build


### PR DESCRIPTION
GCB passes HOME as env var to the docker container. It sets
HOME to /builder/home which is persisted accross builds.
This issue causes build breakages in
https://github.com/google/oss-fuzz/issues/6035
and possibly https://github.com/google/oss-fuzz/issues/5317.
Perhaps more insidiously, it can cause fuzzers to be built with
the wrong instrumentation.