### PR TITLE
Make oss-fuzz-project-name optional.

### DIFF
--- a/infra/cifuzz/actions/run_fuzzers/action.yml
+++ b/infra/cifuzz/actions/run_fuzzers/action.yml
@@ -48,9 +48,6 @@ runs:
     DRY_RUN: ${{ inputs.dry-run}}
     SANITIZER: ${{ inputs.sanitizer }}
     RUN_FUZZERS_MODE: ${{ inputs.run-fuzzers-mode }}
-    # TODO(metzman): Even though this param is used for building, it's needed
-    # for running because we use it to distinguish OSS-Fuzz from non-OSS-Fuzz.
-    # We should do something explicit instead.
     BUILD_INTEGRATION_PATH: ${{ inputs.build-integration-path }}
     GITHUB_TOKEN: ${{ inputs.github-token }}
     LOW_DISK_SPACE: 'True'

--- a/infra/cifuzz/affected_fuzz_targets.py
+++ b/infra/cifuzz/affected_fuzz_targets.py
@@ -27,7 +27,7 @@ def remove_unaffected_fuzz_targets(clusterfuzz_deployment, out_dir,
   """Removes all non affected fuzz targets in the out directory.
 
   Args:
-    project_name: The name of the relevant OSS-Fuzz project.
+    oss_fuzz_project_name: The name of the relevant OSS-Fuzz project.
     out_dir: The location of the fuzz target binaries.
     files_changed: A list of files changed compared to HEAD.
     repo_path: The location of the OSS-Fuzz repo in the docker image.

--- a/infra/cifuzz/affected_fuzz_targets.py
+++ b/infra/cifuzz/affected_fuzz_targets.py
@@ -27,7 +27,6 @@ def remove_unaffected_fuzz_targets(clusterfuzz_deployment, out_dir,
   """Removes all non affected fuzz targets in the out directory.
 
   Args:
-    oss_fuzz_project_name: The name of the relevant OSS-Fuzz project.
     out_dir: The location of the fuzz target binaries.
     files_changed: A list of files changed compared to HEAD.
     repo_path: The location of the OSS-Fuzz repo in the docker image.

--- a/infra/cifuzz/affected_fuzz_targets_test.py
+++ b/infra/cifuzz/affected_fuzz_targets_test.py
@@ -60,9 +60,10 @@ class RemoveUnaffectedFuzzTargets(unittest.TestCase):
   # yapf: enable
   def test_remove_unaffected_fuzz_targets(self, side_effect, expected_dir_len):
     """Tests that remove_unaffected_fuzzers has the intended effect."""
-    config = test_helpers.create_run_config(is_github=True,
-                                            project_name=EXAMPLE_PROJECT,
-                                            workspace='/workspace')
+    config = test_helpers.create_run_config(
+        is_github=True,
+        oss_fuzz_project_name=EXAMPLE_PROJECT,
+        workspace='/workspace')
     workspace = docker.Workspace(config)
     deployment = clusterfuzz_deployment.get_clusterfuzz_deployment(
         config, workspace)

--- a/infra/cifuzz/build_fuzzers.py
+++ b/infra/cifuzz/build_fuzzers.py
@@ -89,7 +89,7 @@ class Builder:  # pylint: disable=too-many-instance-attributes
       self.handle_msan_prebuild(docker_container)
 
     docker_args.extend([
-        docker.get_project_image_name(self.config.project_name),
+        docker.get_project_image_name(self.config.oss_fuzz_project_name),
         '/bin/bash',
         '-c',
     ])

--- a/infra/cifuzz/build_fuzzers_entrypoint.py
+++ b/infra/cifuzz/build_fuzzers_entrypoint.py
@@ -44,9 +44,8 @@ def build_fuzzers_entrypoint():
     return returncode
 
   if not build_fuzzers.build_fuzzers(config):
-    logging.error(
-        'Error building fuzzers for project %s (commit: %s, pr_ref: %s).',
-        config.project_name, config.commit_sha, config.pr_ref)
+    logging.error('Error building fuzzers for (commit: %s, pr_ref: %s).',
+                  config.commit_sha, config.pr_ref)
     return returncode
 
   if not config.bad_build_check:

--- a/infra/cifuzz/build_fuzzers_test.py
+++ b/infra/cifuzz/build_fuzzers_test.py
@@ -151,7 +151,6 @@ class BuildFuzzersIntegrationTest(unittest.TestCase):
     # This test is dependant on the state of
     # github.com/jonathanmetzman/cifuzz-external-example.
     config = test_helpers.create_build_config(
-        oss_fuzz_project_name=oss_fuzz_project_name,
         project_repo_name=oss_fuzz_project_name,
         workspace=self.workspace,
         build_integration_path=build_integration_path,
@@ -175,7 +174,6 @@ class BuildFuzzersIntegrationTest(unittest.TestCase):
         self.tmp_dir_obj.name)
     project_src_path = manager.repo_dir
     config = test_helpers.create_build_config(
-        oss_fuzz_project_name=oss_fuzz_project_name,
         project_repo_name=oss_fuzz_project_name,
         workspace=self.workspace,
         build_integration_path=build_integration_path,

--- a/infra/cifuzz/build_fuzzers_test.py
+++ b/infra/cifuzz/build_fuzzers_test.py
@@ -69,10 +69,11 @@ class BuildFuzzersTest(unittest.TestCase):
 
     with tempfile.TemporaryDirectory() as tmp_dir:
       build_fuzzers.build_fuzzers(
-          test_helpers.create_build_config(project_name=EXAMPLE_PROJECT,
-                                           project_repo_name=EXAMPLE_PROJECT,
-                                           workspace=tmp_dir,
-                                           pr_ref='refs/pull/1757/merge'))
+          test_helpers.create_build_config(
+              oss_fuzz_project_name=EXAMPLE_PROJECT,
+              project_repo_name=EXAMPLE_PROJECT,
+              workspace=tmp_dir,
+              pr_ref='refs/pull/1757/merge'))
 
       docker_run_command = mocked_docker_run.call_args_list[0][0][0]
 
@@ -99,7 +100,7 @@ class InternalGithubBuildTest(unittest.TestCase):
   def _create_builder(self, tmp_dir):
     """Creates an InternalGithubBuilder and returns it."""
     config = test_helpers.create_build_config(
-        project_name=self.PROJECT_NAME,
+        oss_fuzz_project_name=self.PROJECT_NAME,
         project_repo_name=self.PROJECT_REPO_NAME,
         workspace=tmp_dir,
         sanitizer=self.SANITIZER,
@@ -144,14 +145,14 @@ class BuildFuzzersIntegrationTest(unittest.TestCase):
 
   def test_external_github_project(self):
     """Tests building fuzzers from an external project on Github."""
-    project_name = 'external-project'
+    oss_fuzz_project_name = 'external-project'
     build_integration_path = 'fuzzer-build-integration'
     git_url = 'https://github.com/jonathanmetzman/cifuzz-external-example.git'
     # This test is dependant on the state of
     # github.com/jonathanmetzman/cifuzz-external-example.
     config = test_helpers.create_build_config(
-        project_name=project_name,
-        project_repo_name=project_name,
+        oss_fuzz_project_name=oss_fuzz_project_name,
+        project_repo_name=oss_fuzz_project_name,
         workspace=self.workspace,
         build_integration_path=build_integration_path,
         git_url=git_url,
@@ -164,7 +165,7 @@ class BuildFuzzersIntegrationTest(unittest.TestCase):
 
   def test_external_generic_project(self):
     """Tests building fuzzers from an external project not on Github."""
-    project_name = 'cifuzz-external-example'
+    oss_fuzz_project_name = 'cifuzz-external-example'
     build_integration_path = 'fuzzer-build-integration'
     git_url = 'https://github.com/jonathanmetzman/cifuzz-external-example.git'
     # This test is dependant on the state of
@@ -174,8 +175,8 @@ class BuildFuzzersIntegrationTest(unittest.TestCase):
         self.tmp_dir_obj.name)
     project_src_path = manager.repo_dir
     config = test_helpers.create_build_config(
-        project_name=project_name,
-        project_repo_name=project_name,
+        oss_fuzz_project_name=oss_fuzz_project_name,
+        project_repo_name=oss_fuzz_project_name,
         workspace=self.workspace,
         build_integration_path=build_integration_path,
         git_url=git_url,
@@ -189,7 +190,7 @@ class BuildFuzzersIntegrationTest(unittest.TestCase):
   def test_valid_commit(self):
     """Tests building fuzzers with valid inputs."""
     config = test_helpers.create_build_config(
-        project_name=EXAMPLE_PROJECT,
+        oss_fuzz_project_name=EXAMPLE_PROJECT,
         project_repo_name='oss-fuzz',
         workspace=self.workspace,
         commit_sha='0b95fe1039ed7c38fea1f97078316bfc1030c523',
@@ -202,30 +203,32 @@ class BuildFuzzersIntegrationTest(unittest.TestCase):
   def test_valid_pull_request(self):
     """Tests building fuzzers with valid pull request."""
     # TODO(metzman): What happens when this branch closes?
-    config = test_helpers.create_build_config(project_name=EXAMPLE_PROJECT,
-                                              project_repo_name='oss-fuzz',
-                                              workspace=self.workspace,
-                                              pr_ref='refs/pull/1757/merge',
-                                              base_ref='master',
-                                              is_github=True)
+    config = test_helpers.create_build_config(
+        oss_fuzz_project_name=EXAMPLE_PROJECT,
+        project_repo_name='oss-fuzz',
+        workspace=self.workspace,
+        pr_ref='refs/pull/1757/merge',
+        base_ref='master',
+        is_github=True)
     self.assertTrue(build_fuzzers.build_fuzzers(config))
     self.assertTrue(
         os.path.exists(os.path.join(self.out_dir, EXAMPLE_BUILD_FUZZER)))
 
   def test_invalid_pull_request(self):
     """Tests building fuzzers with invalid pull request."""
-    config = test_helpers.create_build_config(project_name=EXAMPLE_PROJECT,
-                                              project_repo_name='oss-fuzz',
-                                              workspace=self.workspace,
-                                              pr_ref='ref-1/merge',
-                                              base_ref='master',
-                                              is_github=True)
+    config = test_helpers.create_build_config(
+        oss_fuzz_project_name=EXAMPLE_PROJECT,
+        project_repo_name='oss-fuzz',
+        workspace=self.workspace,
+        pr_ref='ref-1/merge',
+        base_ref='master',
+        is_github=True)
     self.assertTrue(build_fuzzers.build_fuzzers(config))
 
-  def test_invalid_project_name(self):
+  def test_invalid_oss_fuzz_project_name(self):
     """Tests building fuzzers with invalid project name."""
     config = test_helpers.create_build_config(
-        project_name='not_a_valid_project',
+        oss_fuzz_project_name='not_a_valid_project',
         project_repo_name='oss-fuzz',
         workspace=self.workspace,
         commit_sha='0b95fe1039ed7c38fea1f97078316bfc1030c523')
@@ -234,7 +237,7 @@ class BuildFuzzersIntegrationTest(unittest.TestCase):
   def test_invalid_repo_name(self):
     """Tests building fuzzers with invalid repo name."""
     config = test_helpers.create_build_config(
-        project_name=EXAMPLE_PROJECT,
+        oss_fuzz_project_name=EXAMPLE_PROJECT,
         project_repo_name='not-real-repo',
         workspace=self.workspace,
         commit_sha='0b95fe1039ed7c38fea1f97078316bfc1030c523')
@@ -242,18 +245,19 @@ class BuildFuzzersIntegrationTest(unittest.TestCase):
 
   def test_invalid_commit_sha(self):
     """Tests building fuzzers with invalid commit SHA."""
-    config = test_helpers.create_build_config(project_name=EXAMPLE_PROJECT,
-                                              project_repo_name='oss-fuzz',
-                                              workspace=self.workspace,
-                                              commit_sha='',
-                                              is_github=True)
+    config = test_helpers.create_build_config(
+        oss_fuzz_project_name=EXAMPLE_PROJECT,
+        project_repo_name='oss-fuzz',
+        workspace=self.workspace,
+        commit_sha='',
+        is_github=True)
     with self.assertRaises(AssertionError):
       build_fuzzers.build_fuzzers(config)
 
   def test_invalid_workspace(self):
     """Tests building fuzzers with invalid workspace."""
     config = test_helpers.create_build_config(
-        project_name=EXAMPLE_PROJECT,
+        oss_fuzz_project_name=EXAMPLE_PROJECT,
         project_repo_name='oss-fuzz',
         workspace=os.path.join(self.workspace, 'not', 'a', 'dir'),
         commit_sha='0b95fe1039ed7c38fea1f97078316bfc1030c523')
@@ -318,11 +322,12 @@ class BuildSantizerIntegrationTest(unittest.TestCase):
 
   @classmethod
   def _create_config(cls, tmp_dir, sanitizer):
-    return test_helpers.create_build_config(project_name=cls.PROJECT_NAME,
-                                            project_repo_name=cls.PROJECT_NAME,
-                                            workspace=tmp_dir,
-                                            pr_ref=cls.PR_REF,
-                                            sanitizer=sanitizer)
+    return test_helpers.create_build_config(
+        oss_fuzz_project_name=cls.PROJECT_NAME,
+        project_repo_name=cls.PROJECT_NAME,
+        workspace=tmp_dir,
+        pr_ref=cls.PR_REF,
+        sanitizer=sanitizer)
 
   @parameterized.parameterized.expand([('memory',), ('undefined',)])
   def test_valid_project_curl(self, sanitizer):

--- a/infra/cifuzz/clusterfuzz_deployment.py
+++ b/infra/cifuzz/clusterfuzz_deployment.py
@@ -210,15 +210,17 @@ class OSSFuzz(BaseClusterFuzzDeployment):
     Returns:
       A string with the latest build version or None.
     """
-    version_file = (f'{self.config.project_name}-{self.config.sanitizer}'
-                    '-latest.version')
+    version_file = (
+        f'{self.config.oss_fuzz_project_name}-{self.config.sanitizer}'
+        '-latest.version')
     version_url = utils.url_join(utils.GCS_BASE_URL, self.CLUSTERFUZZ_BUILDS,
-                                 self.config.project_name, version_file)
+                                 self.config.oss_fuzz_project_name,
+                                 version_file)
     try:
       response = urllib.request.urlopen(version_url)
     except urllib.error.HTTPError:
       logging.error('Error getting latest build version for %s from: %s.',
-                    self.config.project_name, version_url)
+                    self.config.oss_fuzz_project_name, version_url)
       return None
     return response.read().decode()
 
@@ -241,7 +243,7 @@ class OSSFuzz(BaseClusterFuzzDeployment):
 
     oss_fuzz_build_url = utils.url_join(utils.GCS_BASE_URL,
                                         self.CLUSTERFUZZ_BUILDS,
-                                        self.config.project_name,
+                                        self.config.oss_fuzz_project_name,
                                         latest_build_name)
     if http_utils.download_and_unpack_zip(oss_fuzz_build_url,
                                           self.workspace.clusterfuzz_build):
@@ -269,11 +271,11 @@ class OSSFuzz(BaseClusterFuzzDeployment):
     """
     corpus_dir = self.make_empty_corpus_dir(target_name)
     project_qualified_fuzz_target_name = target_name
-    qualified_name_prefix = self.config.project_name + '_'
+    qualified_name_prefix = self.config.oss_fuzz_project_name + '_'
     if not target_name.startswith(qualified_name_prefix):
       project_qualified_fuzz_target_name = qualified_name_prefix + target_name
 
-    corpus_url = (f'{utils.GCS_BASE_URL}{self.config.project_name}'
+    corpus_url = (f'{utils.GCS_BASE_URL}{self.config.oss_fuzz_project_name}'
                   '-backup.clusterfuzz-external.appspot.com/corpus/'
                   f'libFuzzer/{project_qualified_fuzz_target_name}/'
                   f'{self.CORPUS_ZIP_NAME}')

--- a/infra/cifuzz/clusterfuzz_deployment.py
+++ b/infra/cifuzz/clusterfuzz_deployment.py
@@ -118,6 +118,7 @@ class ClusterFuzzLite(BaseClusterFuzzDeployment):
     return None
 
   def download_corpus(self, target_name):
+    print('here')
     corpus_dir = self.make_empty_corpus_dir(target_name)
     logging.debug('ClusterFuzzLite: downloading corpus for %s to %s.',
                   target_name, corpus_dir)
@@ -291,7 +292,8 @@ class OSSFuzz(BaseClusterFuzzDeployment):
   def get_coverage(self, repo_path):
     """Returns the project coverage object for the project."""
     try:
-      return get_coverage.OSSFuzzCoverage(repo_path, self.config.project_name)
+      return get_coverage.OSSFuzzCoverage(
+          repo_path, self.config.oss_fuzz_project_name)
     except get_coverage.CoverageError:
       return None
 

--- a/infra/cifuzz/clusterfuzz_deployment.py
+++ b/infra/cifuzz/clusterfuzz_deployment.py
@@ -292,8 +292,8 @@ class OSSFuzz(BaseClusterFuzzDeployment):
   def get_coverage(self, repo_path):
     """Returns the project coverage object for the project."""
     try:
-      return get_coverage.OSSFuzzCoverage(
-          repo_path, self.config.oss_fuzz_project_name)
+      return get_coverage.OSSFuzzCoverage(repo_path,
+                                          self.config.oss_fuzz_project_name)
     except get_coverage.CoverageError:
       return None
 

--- a/infra/cifuzz/clusterfuzz_deployment_test.py
+++ b/infra/cifuzz/clusterfuzz_deployment_test.py
@@ -131,7 +131,9 @@ class ClusterFuzzLiteTest(fake_filesystem_unittest.TestCase):
   def setUp(self):
     self.setUpPyfakefs()
     self.deployment = _create_deployment(run_fuzzers_mode='batch',
-                                         build_integration_path='/')
+                                         build_integration_path='/',
+                                         oss_fuzz_project_name='',
+                                         is_github=True)
 
   @mock.patch('filestore.github_actions.GithubActionsFilestore.download_corpus',
               return_value=True)
@@ -181,7 +183,6 @@ class NoClusterFuzzDeploymentTest(fake_filesystem_unittest.TestCase):
   def setUp(self):
     self.setUpPyfakefs()
     config = test_helpers.create_run_config(
-        oss_fuzz_project_name=EXAMPLE_PROJECT,
         build_integration_path='/',
         workspace=WORKSPACE,
         is_github=False)

--- a/infra/cifuzz/clusterfuzz_deployment_test.py
+++ b/infra/cifuzz/clusterfuzz_deployment_test.py
@@ -42,7 +42,7 @@ def _create_config(**kwargs):
   attribute of Config."""
   defaults = {
       'is_github': True,
-      'project_name': EXAMPLE_PROJECT,
+      'oss_fuzz_project_name': EXAMPLE_PROJECT,
       'workspace': WORKSPACE,
   }
   for default_key, default_value in defaults.items():
@@ -180,10 +180,11 @@ class NoClusterFuzzDeploymentTest(fake_filesystem_unittest.TestCase):
 
   def setUp(self):
     self.setUpPyfakefs()
-    config = test_helpers.create_run_config(project_name=EXAMPLE_PROJECT,
-                                            build_integration_path='/',
-                                            workspace=WORKSPACE,
-                                            is_github=False)
+    config = test_helpers.create_run_config(
+        oss_fuzz_project_name=EXAMPLE_PROJECT,
+        build_integration_path='/',
+        workspace=WORKSPACE,
+        is_github=False)
     workspace = docker.Workspace(config)
     self.deployment = clusterfuzz_deployment.get_clusterfuzz_deployment(
         config, workspace)

--- a/infra/cifuzz/clusterfuzz_deployment_test.py
+++ b/infra/cifuzz/clusterfuzz_deployment_test.py
@@ -182,10 +182,9 @@ class NoClusterFuzzDeploymentTest(fake_filesystem_unittest.TestCase):
 
   def setUp(self):
     self.setUpPyfakefs()
-    config = test_helpers.create_run_config(
-        build_integration_path='/',
-        workspace=WORKSPACE,
-        is_github=False)
+    config = test_helpers.create_run_config(build_integration_path='/',
+                                            workspace=WORKSPACE,
+                                            is_github=False)
     workspace = docker.Workspace(config)
     self.deployment = clusterfuzz_deployment.get_clusterfuzz_deployment(
         config, workspace)

--- a/infra/cifuzz/config_utils.py
+++ b/infra/cifuzz/config_utils.py
@@ -95,11 +95,9 @@ class BaseConfig:
     # Check if failures should not be reported.
     self.dry_run = _is_dry_run()
     self.sanitizer = _get_sanitizer()
+    # TODO(ochang): Error out if both oss_fuzz and build_integration_path is not
+    # set.
     self.build_integration_path = os.getenv('BUILD_INTEGRATION_PATH')
-
-    if not self.oss_fuzz_project_name and not self.build_integration_path:
-      raise RuntimeError(
-          'build-integration-path must be set if not an OSS-Fuzz project.')
 
     self.language = _get_language()
     event_path = os.getenv('GITHUB_EVENT_PATH')

--- a/infra/cifuzz/config_utils.py
+++ b/infra/cifuzz/config_utils.py
@@ -37,11 +37,6 @@ def _get_sanitizer():
   return os.getenv('SANITIZER', 'address').lower()
 
 
-def _get_project_name():
-  # TODO(metzman): Remove OSS-Fuzz reference.
-  return os.getenv('OSS_FUZZ_PROJECT_NAME')
-
-
 def _is_dry_run():
   """Returns True if configured to do a dry run."""
   return environment.get_bool('DRY_RUN', 'false')
@@ -94,13 +89,18 @@ class BaseConfig:
 
   def __init__(self):
     self.workspace = os.getenv('GITHUB_WORKSPACE')
-    self.project_name = _get_project_name()
+    self.oss_fuzz_project_name = os.getenv('OSS_FUZZ_PROJECT_NAME')
     self.project_repo_owner, self.project_repo_name = (
         _get_project_repo_owner_and_name())
     # Check if failures should not be reported.
     self.dry_run = _is_dry_run()
     self.sanitizer = _get_sanitizer()
     self.build_integration_path = os.getenv('BUILD_INTEGRATION_PATH')
+
+    if not self.oss_fuzz_project_name and not self.build_integration_path:
+      raise RuntimeError(
+          'build-integration-path must be set if not an OSS-Fuzz project.')
+
     self.language = _get_language()
     event_path = os.getenv('GITHUB_EVENT_PATH')
     self.is_github = bool(event_path)
@@ -113,7 +113,7 @@ class BaseConfig:
   @property
   def is_internal(self):
     """Returns True if this is an OSS-Fuzz project."""
-    return not self.build_integration_path
+    return bool(self.oss_fuzz_project_name)
 
   @property
   def platform(self):

--- a/infra/cifuzz/docker.py
+++ b/infra/cifuzz/docker.py
@@ -33,6 +33,8 @@ _DEFAULT_DOCKER_RUN_ARGS = [
     'ARCHITECTURE=' + DEFAULT_ARCHITECTURE, '-e', 'CIFUZZ=True'
 ]
 
+EXTERNAL_PROJECT_IMAGE = 'external-project'
+
 _DEFAULT_DOCKER_RUN_COMMAND = [
     'docker',
     'run',
@@ -43,7 +45,10 @@ _DEFAULT_DOCKER_RUN_COMMAND = [
 
 def get_project_image_name(project):
   """Returns the name of the project builder image for |project_name|."""
-  return PROJECT_TAG_PREFIX + project
+  if project:
+    return PROJECT_TAG_PREFIX + project
+
+  return EXTERNAL_PROJECT_IMAGE
 
 
 def delete_images(images):

--- a/infra/cifuzz/docker.py
+++ b/infra/cifuzz/docker.py
@@ -45,6 +45,7 @@ _DEFAULT_DOCKER_RUN_COMMAND = [
 
 def get_project_image_name(project):
   """Returns the name of the project builder image for |project_name|."""
+  # TODO(ochang): We may need unique names to support parallel fuzzing.
   if project:
     return PROJECT_TAG_PREFIX + project
 

--- a/infra/cifuzz/fuzz_target_test.py
+++ b/infra/cifuzz/fuzz_target_test.py
@@ -47,7 +47,7 @@ def _create_config(**kwargs):
   attribute of Config."""
   defaults = {
       'is_github': True,
-      'project_name': EXAMPLE_PROJECT,
+      'oss_fuzz_project_name': EXAMPLE_PROJECT,
       'workspace': '/workspace'
   }
   for default_key, default_value in defaults.items():

--- a/infra/cifuzz/generate_coverage_report_test.py
+++ b/infra/cifuzz/generate_coverage_report_test.py
@@ -30,7 +30,7 @@ class TestRunCoverageCommand(unittest.TestCase):
   @mock.patch('helper.docker_run')
   def test_run_coverage_command(self, mocked_docker_run):  # pylint: disable=no-self-use
     """Tests that run_coverage_command works as intended."""
-    config = test_helpers.create_run_config(project_name=PROJECT,
+    config = test_helpers.create_run_config(oss_fuzz_project_name=PROJECT,
                                             sanitizer=SANITIZER)
     workspace = test_helpers.create_workspace()
     expected_docker_args = [

--- a/infra/cifuzz/run_fuzzers_entrypoint.py
+++ b/infra/cifuzz/run_fuzzers_entrypoint.py
@@ -33,7 +33,7 @@ def delete_unneeded_docker_images(config):
   if not config.low_disk_space:
     return
   logging.info('Deleting builder docker images to save disk space.')
-  project_image = docker.get_project_image_name(config.project_name)
+  project_image = docker.get_project_image_name(config.oss_fuzz_project_name)
   images = [
       project_image,
       docker.BASE_RUNNER_TAG,

--- a/infra/cifuzz/run_fuzzers_test.py
+++ b/infra/cifuzz/run_fuzzers_test.py
@@ -65,7 +65,7 @@ class RunFuzzerIntegrationTestMixin:  # pylint: disable=too-few-public-methods,i
     with test_helpers.temp_dir_copy(fuzzer_dir) as fuzzer_dir_copy:
       config = test_helpers.create_run_config(fuzz_seconds=FUZZ_SECONDS,
                                               workspace=fuzzer_dir_copy,
-                                              project_name='curl',
+                                              oss_fuzz_project_name='curl',
                                               sanitizer=sanitizer)
       result = run_fuzzers.run_fuzzers(config)
     self.assertEqual(result, run_fuzzers.RunFuzzersResult.NO_BUG_FOUND)
@@ -101,7 +101,10 @@ class BaseFuzzTargetRunnerTest(unittest.TestCase):
   """Tests BaseFuzzTargetRunner."""
 
   def _create_runner(self, **kwargs):  # pylint: disable=no-self-use
-    defaults = {'fuzz_seconds': FUZZ_SECONDS, 'project_name': EXAMPLE_PROJECT}
+    defaults = {
+        'fuzz_seconds': FUZZ_SECONDS,
+        'oss_fuzz_oss_fuzz_project_name': EXAMPLE_PROJECT
+    }
     for default_key, default_value in defaults.items():
       if default_key not in kwargs:
         kwargs[default_key] = default_value
@@ -241,9 +244,10 @@ class CiFuzzTargetRunnerTest(fake_filesystem_unittest.TestCase):
     workspace = 'workspace'
     out_path = os.path.join(workspace, 'build-out')
     self.fs.create_dir(out_path)
-    config = test_helpers.create_run_config(fuzz_seconds=FUZZ_SECONDS,
-                                            workspace=workspace,
-                                            project_name=EXAMPLE_PROJECT)
+    config = test_helpers.create_run_config(
+        fuzz_seconds=FUZZ_SECONDS,
+        workspace=workspace,
+        oss_fuzz_project_name=EXAMPLE_PROJECT)
     runner = run_fuzzers.CiFuzzTargetRunner(config)
 
     mocked_get_fuzz_targets.return_value = ['target1', 'target2']
@@ -278,11 +282,12 @@ class BatchFuzzTargetRunnerTest(fake_filesystem_unittest.TestCase):
     self.fs.create_file(self.testcase1)
     self.testcase2 = os.path.join(out_dir, 'testcase-bbb')
     self.fs.create_file(self.testcase2)
-    self.config = test_helpers.create_run_config(fuzz_seconds=FUZZ_SECONDS,
-                                                 workspace=self.WORKSPACE,
-                                                 project_name=EXAMPLE_PROJECT,
-                                                 build_integration_path='/',
-                                                 is_github=True)
+    self.config = test_helpers.create_run_config(
+        fuzz_seconds=FUZZ_SECONDS,
+        workspace=self.WORKSPACE,
+        oss_fuzz_project_name=EXAMPLE_PROJECT,
+        build_integration_path='/',
+        is_github=True)
 
   @mock.patch('utils.get_fuzz_targets', return_value=['target1', 'target2'])
   @mock.patch('clusterfuzz_deployment.ClusterFuzzLite.upload_latest_build',
@@ -349,7 +354,7 @@ class CoverageReportIntegrationTest(unittest.TestCase):
       try:
         # Do coverage build.
         build_config = test_helpers.create_build_config(
-            project_name=EXAMPLE_PROJECT,
+            oss_fuzz_project_name=EXAMPLE_PROJECT,
             project_repo_name='oss-fuzz',
             workspace=workspace,
             commit_sha='0b95fe1039ed7c38fea1f97078316bfc1030c523',
@@ -362,7 +367,7 @@ class CoverageReportIntegrationTest(unittest.TestCase):
         run_config = test_helpers.create_run_config(
             fuzz_seconds=FUZZ_SECONDS,
             workspace=workspace,
-            project_name=EXAMPLE_PROJECT,
+            oss_fuzz_project_name=EXAMPLE_PROJECT,
             sanitizer=self.SANITIZER,
             run_fuzzers_mode='coverage')
         result = run_fuzzers.run_fuzzers(run_config)
@@ -405,9 +410,10 @@ class RunAddressFuzzersIntegrationTest(RunFuzzerIntegrationTestMixin,
       with tempfile.TemporaryDirectory() as tmp_dir:
         workspace = os.path.join(tmp_dir, 'workspace')
         shutil.copytree(TEST_DATA_PATH, workspace)
-        config = test_helpers.create_run_config(fuzz_seconds=FUZZ_SECONDS,
-                                                workspace=workspace,
-                                                project_name=EXAMPLE_PROJECT)
+        config = test_helpers.create_run_config(
+            fuzz_seconds=FUZZ_SECONDS,
+            workspace=workspace,
+            oss_fuzz_project_name=EXAMPLE_PROJECT)
         result = run_fuzzers.run_fuzzers(config)
         self.assertEqual(result, run_fuzzers.RunFuzzersResult.BUG_FOUND)
 
@@ -418,9 +424,10 @@ class RunAddressFuzzersIntegrationTest(RunFuzzerIntegrationTestMixin,
     with tempfile.TemporaryDirectory() as tmp_dir:
       workspace = os.path.join(tmp_dir, 'workspace')
       shutil.copytree(TEST_DATA_PATH, workspace)
-      config = test_helpers.create_run_config(fuzz_seconds=FUZZ_SECONDS,
-                                              workspace=workspace,
-                                              project_name=EXAMPLE_PROJECT)
+      config = test_helpers.create_run_config(
+          fuzz_seconds=FUZZ_SECONDS,
+          workspace=workspace,
+          oss_fuzz_project_name=EXAMPLE_PROJECT)
       result = run_fuzzers.run_fuzzers(config)
       self.assertEqual(result, run_fuzzers.RunFuzzersResult.NO_BUG_FOUND)
 
@@ -429,9 +436,10 @@ class RunAddressFuzzersIntegrationTest(RunFuzzerIntegrationTestMixin,
     with tempfile.TemporaryDirectory() as tmp_dir:
       out_path = os.path.join(tmp_dir, 'build-out')
       os.mkdir(out_path)
-      config = test_helpers.create_run_config(fuzz_seconds=FUZZ_SECONDS,
-                                              workspace=tmp_dir,
-                                              project_name=EXAMPLE_PROJECT)
+      config = test_helpers.create_run_config(
+          fuzz_seconds=FUZZ_SECONDS,
+          workspace=tmp_dir,
+          oss_fuzz_project_name=EXAMPLE_PROJECT)
       result = run_fuzzers.run_fuzzers(config)
     self.assertEqual(result, run_fuzzers.RunFuzzersResult.ERROR)
 
@@ -452,7 +460,7 @@ class GetFuzzTargetRunnerTest(unittest.TestCase):
       run_config = test_helpers.create_run_config(
           fuzz_seconds=FUZZ_SECONDS,
           workspace=tmp_dir,
-          project_name='example',
+          oss_fuzz_project_name='example',
           run_fuzzers_mode=run_fuzzers_mode)
       runner = run_fuzzers.get_fuzz_target_runner(run_config)
       self.assertTrue(isinstance(runner, fuzz_target_runner_cls))

--- a/infra/cifuzz/run_fuzzers_test.py
+++ b/infra/cifuzz/run_fuzzers_test.py
@@ -282,11 +282,10 @@ class BatchFuzzTargetRunnerTest(fake_filesystem_unittest.TestCase):
     self.fs.create_file(self.testcase1)
     self.testcase2 = os.path.join(out_dir, 'testcase-bbb')
     self.fs.create_file(self.testcase2)
-    self.config = test_helpers.create_run_config(
-        fuzz_seconds=FUZZ_SECONDS,
-        workspace=self.WORKSPACE,
-        build_integration_path='/',
-        is_github=True)
+    self.config = test_helpers.create_run_config(fuzz_seconds=FUZZ_SECONDS,
+                                                 workspace=self.WORKSPACE,
+                                                 build_integration_path='/',
+                                                 is_github=True)
 
   @mock.patch('utils.get_fuzz_targets', return_value=['target1', 'target2'])
   @mock.patch('clusterfuzz_deployment.ClusterFuzzLite.upload_latest_build',

--- a/infra/cifuzz/run_fuzzers_test.py
+++ b/infra/cifuzz/run_fuzzers_test.py
@@ -103,7 +103,7 @@ class BaseFuzzTargetRunnerTest(unittest.TestCase):
   def _create_runner(self, **kwargs):  # pylint: disable=no-self-use
     defaults = {
         'fuzz_seconds': FUZZ_SECONDS,
-        'oss_fuzz_oss_fuzz_project_name': EXAMPLE_PROJECT
+        'oss_fuzz_project_name': EXAMPLE_PROJECT
     }
     for default_key, default_value in defaults.items():
       if default_key not in kwargs:

--- a/infra/cifuzz/run_fuzzers_test.py
+++ b/infra/cifuzz/run_fuzzers_test.py
@@ -285,7 +285,6 @@ class BatchFuzzTargetRunnerTest(fake_filesystem_unittest.TestCase):
     self.config = test_helpers.create_run_config(
         fuzz_seconds=FUZZ_SECONDS,
         workspace=self.WORKSPACE,
-        oss_fuzz_project_name=EXAMPLE_PROJECT,
         build_integration_path='/',
         is_github=True)
 

--- a/infra/cifuzz/test_helpers.py
+++ b/infra/cifuzz/test_helpers.py
@@ -36,7 +36,6 @@ def _create_config(config_cls, **kwargs):
   for key, value in kwargs.items():
     assert hasattr(config, key), 'Config doesn\'t have attribute: ' + key
     setattr(config, key, value)
-
   return config
 
 

--- a/infra/cifuzz/test_helpers.py
+++ b/infra/cifuzz/test_helpers.py
@@ -36,6 +36,7 @@ def _create_config(config_cls, **kwargs):
   for key, value in kwargs.items():
     assert hasattr(config, key), 'Config doesn\'t have attribute: ' + key
     setattr(config, key, value)
+
   return config
 
 


### PR DESCRIPTION
For external fuzzing.

This wasn't really used for external fuzzing, except to build 
docker image tags (`gcr.io/oss-fuzz/PROJECT`). We don't really need this, so we
just use a hardcoded tag (`external-project'`) in such cases instead.

Also rename the variable from `project_name` to `oss_fuzz_project_name`, to
be more explicit, and use it to determine whether or not we're running
an OSS-Fuzz project.

For #6051.