### PR TITLE
[cryptofuzz] Fix build, disable SymCrypt

### DIFF
--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -41,7 +41,7 @@ RUN hg clone https://hg.mozilla.org/projects/nspr
 RUN hg clone https://hg.mozilla.org/projects/nss
 RUN git clone --depth 1 https://github.com/jedisct1/libsodium.git
 RUN git clone --depth 1 https://github.com/libtom/libtomcrypt.git
-RUN git clone --depth 1 https://github.com/microsoft/SymCrypt.git
+#RUN git clone --depth 1 https://github.com/microsoft/SymCrypt.git
 RUN hg clone https://gmplib.org/repo/gmp/ libgmp/
 RUN wget https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.5.1.tar.gz
 RUN git clone --depth 1 https://github.com/indutny/bn.js.git

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -180,7 +180,7 @@ else
     ./configure --enable-static --disable-tests --disable-benchmark --disable-exhaustive-tests --enable-module-recovery --enable-experimental --enable-module-schnorrsig --enable-module-ecdh
 fi
 make
-export SECP256K1_INCLUDE_PATH=$(realpath include)
+export SECP256K1_INCLUDE_PATH=$(realpath .)
 export LIBSECP256K1_A_PATH=$(realpath .libs/libsecp256k1.a)
 
 # Compile Cryptofuzz libsecp256k1 module
@@ -213,27 +213,27 @@ then
     make -B
 fi
 
-# Compile SymCrypt
-cd $SRC/SymCrypt/
-if [[ $CFLAGS != *sanitize=array-bounds* ]]
-then
-    # Unittests don't build with clang and are not needed anyway
-    sed -i "s/^add_subdirectory(unittest)$//g" CMakeLists.txt
-
-    mkdir b/
-    cd b/
-    cmake ../
-    make -j$(nproc)
-
-    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_SYMCRYPT"
-    export SYMCRYPT_INCLUDE_PATH=$(realpath ../inc/)
-    export LIBSYMCRYPT_COMMON_A_PATH=$(realpath lib/x86_64/Generic/libsymcrypt_common.a)
-    export SYMCRYPT_GENERIC_A_PATH=$(realpath lib/x86_64/Generic/symcrypt_generic.a)
-
-    # Compile Cryptofuzz SymCrypt module
-    cd $SRC/cryptofuzz/modules/symcrypt
-    make -B
-fi
+## Compile SymCrypt
+#cd $SRC/SymCrypt/
+#if [[ $CFLAGS != *sanitize=array-bounds* ]]
+#then
+#    # Unittests don't build with clang and are not needed anyway
+#    sed -i "s/^add_subdirectory(unittest)$//g" CMakeLists.txt
+#
+#    mkdir b/
+#    cd b/
+#    cmake ../
+#    make -j$(nproc)
+#
+#    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_SYMCRYPT"
+#    export SYMCRYPT_INCLUDE_PATH=$(realpath ../inc/)
+#    export LIBSYMCRYPT_COMMON_A_PATH=$(realpath lib/x86_64/Generic/libsymcrypt_common.a)
+#    export SYMCRYPT_GENERIC_A_PATH=$(realpath lib/x86_64/Generic/symcrypt_generic.a)
+#
+#    # Compile Cryptofuzz SymCrypt module
+#    cd $SRC/cryptofuzz/modules/symcrypt
+#    make -B
+#fi
 
 # Compile libgmp
 if [[ $CFLAGS != *sanitize=memory* ]]


### PR DESCRIPTION
I'm working with Microsoft to resolve some issues in SymCrypt. They only update the public SymCrypt repo occasionally and I want to prevent that the other subscribers to Cryptofuzz bug reports will get notifications about these bugs for months to come. So I'm disabling SymCrypt now and will enable it again once those bugs are resolved.

Also fix libsecp256k1 build.