### PR TITLE
Remove JDK dependency not available on ClusterFuzz

### DIFF
--- a/infra/base-images/base-runner/Dockerfile
+++ b/infra/base-images/base-runner/Dockerfile
@@ -96,9 +96,6 @@ RUN wget https://download.java.net/java/GA/jdk15.0.2/0d1cfde4252546c6931946de8db
     rm -f openjdk-15.0.2_linux-x64_bin.tar.gz && \
     rm -rf $JAVA_HOME/jmods $JAVA_HOME/lib/src.zip
 
-# Install Java AWT dependencies.
-RUN apt-get install libxext-dev -y
-
 # Install JaCoCo for JVM coverage.
 RUN wget https://repo1.maven.org/maven2/org/jacoco/org.jacoco.cli/0.8.7/org.jacoco.cli-0.8.7-nodeps.jar -O /opt/jacoco-cli.jar && \
     wget https://repo1.maven.org/maven2/org/jacoco/org.jacoco.agent/0.8.7/org.jacoco.agent-0.8.7-runtime.jar -O /opt/jacoco-agent.jar && \


### PR DESCRIPTION
While installing `libxext-dev` in `base-runner` makes it available for local fuzzing via `infra/helper.py run_fuzzer`, it is not installed in the image used by ClusterFuzz to run fuzz targets. ​Fuzz targets that rely on any JDK system dependency rather have to install it manually using the method described in https://google.github.io/oss-fuzz/further-reading/fuzzer-environment/#runtime-dependencies. 

By removing this package from `base-runner`, a failure to do so will already be detected via a local `check_build` rather than only during fuzzer execution on ClusterFuzz.