### PR TITLE
[apache-commons] Run fuzzers in headless mode

### DIFF
--- a/projects/apache-commons/build.sh
+++ b/projects/apache-commons/build.sh
@@ -50,7 +50,7 @@ LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\":\$this_dir \
 \$this_dir/jazzer_driver --agent_path=\$this_dir/jazzer_agent_deploy.jar \
 --cp=$RUNTIME_CLASSPATH \
 --target_class=$fuzzer_basename \
---jvm_args=\"-Xmx2048m\" \
+--jvm_args=\"-Xmx2048m;-Djava.awt.headless=true\" \
 \$@" > $OUT/$fuzzer_basename
     chmod +x $OUT/$fuzzer_basename
   done


### PR DESCRIPTION
Running the fuzzers in headless mode works around missing dependencies
for the full Java AWT libraries. It is likely that the commons-imaging
only uses features available in headless mode, in which case this would
be a complete fix for the fuzzer startup crashes observed on
ClusterFuzz.