### PR TITLE
[net-snmp] Split and improve snmp_octet_fuzzer

### DIFF
--- a/projects/net-snmp/build.sh
+++ b/projects/net-snmp/build.sh
@@ -21,7 +21,17 @@
 make
 
 # build fuzzers (remember to link statically)
-for fuzzname in snmp_pdu_parse snmp_parse snmp_scoped_pdu_parse agentx_parse snmp_octet snmp_mib; do
+fuzzers=(
+    agentx_parse
+    parse_octet_hint
+    read_objid
+    snmp_mib
+    snmp_parse
+    snmp_parse_oid
+    snmp_pdu_parse
+    snmp_scoped_pdu_parse
+)
+for fuzzname in "${fuzzers[@]}"; do
   $CC $CFLAGS -c -Iinclude -Iagent/mibgroup/agentx $SRC/${fuzzname}_fuzzer.c -o $WORK/${fuzzname}_fuzzer.o
   $CXX $CXXFLAGS $WORK/${fuzzname}_fuzzer.o \
         $LIB_FUZZING_ENGINE snmplib/.libs/libnetsnmp.a \

--- a/projects/net-snmp/parse_octet_hint_fuzzer.c
+++ b/projects/net-snmp/parse_octet_hint_fuzzer.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <net-snmp/net-snmp-config.h>
+#include <net-snmp/net-snmp-includes.h>
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+int LLVMFuzzerInitialize(int *argc, char ***argv) {
+    if (getenv("NETSNMP_DEBUGGING") != NULL) {
+        /*
+         * Turn on all debugging, to help understand what
+         * bits of the parser are running.
+         */
+        snmp_enable_stderrlog();
+        snmp_set_do_debugging(1);
+        debug_register_tokens("");
+    }
+    return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    char *hint, *value;
+    int value_start, new_val_len;
+    unsigned char *new_val;
+
+    hint = strndup((const char *)data, size);
+    value_start = strlen(hint);
+    assert(value_start <= size);
+    value = strndup((const char *)data + value_start, size - value_start);
+    parse_octet_hint(hint, value, &new_val, &new_val_len);
+    free(new_val);
+    free(hint);
+    free(value);
+    return 0; 
+}

--- a/projects/net-snmp/read_objid_fuzzer.c
+++ b/projects/net-snmp/read_objid_fuzzer.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <net-snmp/net-snmp-config.h>
+#include <net-snmp/net-snmp-includes.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+int LLVMFuzzerInitialize(int *argc, char ***argv) {
+    if (getenv("NETSNMP_DEBUGGING") != NULL) {
+        /*
+         * Turn on all debugging, to help understand what
+         * bits of the parser are running.
+         */
+        snmp_enable_stderrlog();
+        snmp_set_do_debugging(1);
+        debug_register_tokens("");
+    }
+    return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    oid *objid = malloc(MAX_OID_LEN * sizeof(oid));
+    size_t objidlen = MAX_OID_LEN;
+    char *input;
+
+    input = strndup((const char *)data, size);
+    read_objid(input, objid, &objidlen);
+    free(objid);
+    free(input);
+    return 0;
+}

--- a/projects/net-snmp/snmp_mib_fuzzer.c
+++ b/projects/net-snmp/snmp_mib_fuzzer.c
@@ -13,11 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/net-snmp-includes.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 int LLVMFuzzerInitialize(int *argc, char ***argv) {
     if (getenv("NETSNMP_DEBUGGING") != NULL) {

--- a/projects/net-snmp/snmp_parse_oid_fuzzer.c
+++ b/projects/net-snmp/snmp_parse_oid_fuzzer.c
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/net-snmp-includes.h>
 #include <stddef.h>
@@ -37,46 +38,13 @@ int SecmodInMsg_CB(struct snmp_secmod_incoming_params *sp1) {
 }
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-    // We need to have at least oen byte for our decider var.
-    if (size == 0) {
-        return 0;
-    }
-    const uint8_t decider = *data;
-    data += 1;
-    size -= 1;
+    oid *root = malloc(MAX_OID_LEN * sizeof(oid));
+    size_t rootlen;
+    char *input;
 
-    char *new_str = malloc(size+1);
-    if (new_str == NULL){
-        return 0;
-    }
-    memcpy(new_str, data, size);
-    new_str[size] = '\0';
-
-    // This fuzzer hits multiple entrypoints, use the first byte of the fuzz
-    // data to decide which entrypoint. 
-    switch (decider % 3) {
-        case 0:  {
-            oid *root = malloc(MAX_OID_LEN * sizeof(oid));
-            size_t rootlen;
-            snmp_parse_oid(new_str, root, &rootlen);
-            free(root);
-            break;
-        }
-        case 1: {
-            oid *objid = malloc(MAX_OID_LEN * sizeof(oid));
-            size_t objidlen = MAX_OID_LEN;
-            read_objid(new_str, objid, &objidlen);
-            free(objid);
-            break;
-        }
-        case 2: {
-            unsigned char *new_val;
-            size_t new_val_len;
-            parse_octet_hint(new_str, new_str, &new_val, &new_val_len);
-            break;
-        }
-    }
-
-    free(new_str);
+    input = strndup((const char *)data, size);
+    snmp_parse_oid((const char *)input, root, &rootlen);
+    free(root);
+    free(input);
     return 0; 
 }


### PR DESCRIPTION
Split snmp_octet_fuzzer into one fuzzer per function to make bug reports
easier to interpret. See also commit ded876646013 ("net-snmp: add two new
fuzzers and simplify build script. (#6091)").