### PR TITLE
rdkit: fix build

### DIFF
--- a/projects/rdkit/Dockerfile
+++ b/projects/rdkit/Dockerfile
@@ -15,7 +15,13 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y wget libeigen3-dev
+RUN apt-get update && apt-get install -y wget
+
+RUN git clone https://gitlab.com/libeigen/eigen && \
+    mkdir eigen_build && \
+    cd eigen_build && \
+    cmake ../eigen && \
+    make install
 
 RUN git clone --depth 1 https://github.com/rdkit/rdkit.git $SRC/rdkit
 WORKDIR $SRC/rdkit


### PR DESCRIPTION
Build eigen from source because the headers of the libeigen-dev package has issues with clang. 