### PR TITLE
[cifuzz] Don't delete base-runner

### DIFF
--- a/infra/cifuzz/run_fuzzers_entrypoint.py
+++ b/infra/cifuzz/run_fuzzers_entrypoint.py
@@ -36,7 +36,6 @@ def delete_unneeded_docker_images(config):
   project_image = docker.get_project_image_name(config.oss_fuzz_project_name)
   images = [
       project_image,
-      docker.BASE_RUNNER_TAG,
       docker.MSAN_LIBS_BUILDER_TAG,
   ]
   docker.delete_images(images)


### PR DESCRIPTION
We shouldn't delete it, because we need to use it again.
This saves about 13 seconds per run.
Fixes: #5982