### PR TITLE
Don't upload builds in run_fuzzers.

### DIFF
--- a/infra/cifuzz/build_fuzzers.py
+++ b/infra/cifuzz/build_fuzzers.py
@@ -111,6 +111,13 @@ class Builder:  # pylint: disable=too-many-instance-attributes
       self.handle_msan_postbuild(docker_container)
     return True
 
+  def upload_build(self):
+    """Upload build."""
+    if self.config.builds_storage:
+      self.clusterfuzz_deployment.upload_latest_build()
+
+    return True
+
   def handle_msan_postbuild(self, container):
     """Post-build step for MSAN builds. Patches the build to use MSAN
     libraries."""
@@ -133,7 +140,7 @@ class Builder:  # pylint: disable=too-many-instance-attributes
     and then removes the unaffectted fuzzers. Returns True on success."""
     methods = [
         self.build_image_and_checkout_src, self.build_fuzzers,
-        self.remove_unaffected_fuzz_targets
+        self.upload_build, self.remove_unaffected_fuzz_targets
     ]
     for method in methods:
       if not method():

--- a/infra/cifuzz/build_fuzzers.py
+++ b/infra/cifuzz/build_fuzzers.py
@@ -113,8 +113,9 @@ class Builder:  # pylint: disable=too-many-instance-attributes
 
   def upload_build(self):
     """Upload build."""
-    if self.config.builds_storage:
-      self.clusterfuzz_deployment.upload_latest_build()
+    if self.config.upload_build:
+      self.clusterfuzz_deployment.upload_build(
+          self.repo_manager.get_current_commit())
 
     return True
 

--- a/infra/cifuzz/build_fuzzers_test.py
+++ b/infra/cifuzz/build_fuzzers_test.py
@@ -139,10 +139,10 @@ class InternalGithubBuildTest(unittest.TestCase):
 
     mock_upload_build.assert_not_called()
 
-  @mock.patch('clusterfuzz_deployment.ClusterFuzzLite.upload_build',
-              return_value=True)
   @mock.patch('repo_manager.RepoManager.get_current_commit',
               return_value='commit')
+  @mock.patch('clusterfuzz_deployment.ClusterFuzzLite.upload_build',
+              return_value=True)
   def test_upload_build(self, mock_upload_build, mock_get_current_commit):
     """Test upload build."""
     with tempfile.TemporaryDirectory() as tmp_dir:

--- a/infra/cifuzz/build_fuzzers_test.py
+++ b/infra/cifuzz/build_fuzzers_test.py
@@ -91,13 +91,12 @@ class BuildFuzzersTest(unittest.TestCase):
 
 class InternalGithubBuildTest(unittest.TestCase):
   """Tests for building OSS-Fuzz projects on GitHub actions."""
-  PROJECT_NAME = 'myproject'
   PROJECT_REPO_NAME = 'myproject'
   SANITIZER = 'address'
   COMMIT_SHA = 'fake'
   PR_REF = 'fake'
 
-  def _create_builder(self, tmp_dir, oss_fuzz_project_name=PROJECT_NAME):
+  def _create_builder(self, tmp_dir, oss_fuzz_project_name='myproject'):
     """Creates an InternalGithubBuilder and returns it."""
     config = test_helpers.create_build_config(
         oss_fuzz_project_name=oss_fuzz_project_name,
@@ -151,7 +150,7 @@ class InternalGithubBuildTest(unittest.TestCase):
       builder.config.upload_build = True
       builder.upload_build()
 
-    mock_upload_build.assert_called_once()
+    mock_upload_build.assert_called_with('commit')
 
 
 @unittest.skipIf(not os.getenv('INTEGRATION_TESTS'),

--- a/infra/cifuzz/build_fuzzers_test.py
+++ b/infra/cifuzz/build_fuzzers_test.py
@@ -53,7 +53,7 @@ EXAMPLE_NOCRASH_FUZZER = 'example_nocrash_fuzzer'
 # A fuzzer to be built in build_fuzzers integration tests.
 EXAMPLE_BUILD_FUZZER = 'do_stuff_fuzzer'
 
-# pylint: disable=no-self-use,protected-access,too-few-public-methods
+# pylint: disable=no-self-use,protected-access,too-few-public-methods,unused-argument
 
 
 class BuildFuzzersTest(unittest.TestCase):

--- a/infra/cifuzz/build_fuzzers_test.py
+++ b/infra/cifuzz/build_fuzzers_test.py
@@ -149,7 +149,6 @@ class InternalGithubBuildTest(unittest.TestCase):
     with tempfile.TemporaryDirectory() as tmp_dir:
       builder = self._create_builder(tmp_dir, oss_fuzz_project_name='')
       builder.config.upload_build = True
-      builder.config.oss_fuzz_project_name = ''
       builder.upload_build()
 
     mock_upload_build.assert_called_once()

--- a/infra/cifuzz/clusterfuzz_deployment.py
+++ b/infra/cifuzz/clusterfuzz_deployment.py
@@ -102,13 +102,15 @@ class ClusterFuzzLite(BaseClusterFuzzDeployment):
 
     repo_dir = self.ci_system.repo_dir()
     if not repo_dir:
-      raise RuntimeError('repo checkout does not exist.')
+      raise RuntimeError('Repo checkout does not exist.')
 
     _make_empty_dir_if_nonexistent(self.workspace.clusterfuzz_build)
     repo = repo_manager.RepoManager(repo_dir)
 
     # Builds are stored by commit, so try the latest |LATEST_BUILD_WINDOW|
     # commits before the current.
+    # TODO(ochang): If API usage becomes an issue, this can be optimized by the
+    # filestore accepting a list of filenames to try.
     for old_commit in repo.get_commit_list('HEAD^',
                                            limit=self.LATEST_BUILD_WINDOW):
       logging.info('Trying to downloading previous build %s.', old_commit)

--- a/infra/cifuzz/clusterfuzz_deployment.py
+++ b/infra/cifuzz/clusterfuzz_deployment.py
@@ -118,8 +118,8 @@ class ClusterFuzzLite(BaseClusterFuzzDeployment):
                                          self.workspace.clusterfuzz_build):
           logging.info('Done downloading previus build.')
           return self.workspace.clusterfuzz_build
-        else:
-          logging.info('Build for %s does not exist.', old_commit)
+
+        logging.info('Build for %s does not exist.', old_commit)
       except Exception as err:  # pylint: disable=broad-except
         logging.error('Could not download build for %s because of: %s',
                       old_commit, err)

--- a/infra/cifuzz/clusterfuzz_deployment.py
+++ b/infra/cifuzz/clusterfuzz_deployment.py
@@ -19,10 +19,12 @@ import urllib.error
 import urllib.request
 
 import config_utils
+import continuous_integration
 import filestore
 import filestore_utils
 import http_utils
 import get_coverage
+import repo_manager
 
 # pylint: disable=wrong-import-position,import-error
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -35,6 +37,7 @@ class BaseClusterFuzzDeployment:
   def __init__(self, config, workspace):
     self.config = config
     self.workspace = workspace
+    self.ci_system = continuous_integration.get_ci(config)
 
   def download_latest_build(self):
     """Downloads the latest build from ClusterFuzz.
@@ -44,11 +47,8 @@ class BaseClusterFuzzDeployment:
     """
     raise NotImplementedError('Child class must implement method.')
 
-  def upload_latest_build(self):
-    """Uploads the latest build to the filestore.
-    Returns:
-      True on success.
-    """
+  def upload_build(self, commit):
+    """Uploads the build with the given commit sha to the filestore."""
     raise NotImplementedError('Child class must implement method.')
 
   def download_corpus(self, target_name, corpus_dir):
@@ -85,6 +85,7 @@ class ClusterFuzzLite(BaseClusterFuzzDeployment):
   """Class representing a deployment of ClusterFuzzLite."""
 
   COVERAGE_NAME = 'latest'
+  LATEST_BUILD_WINDOW = 3
 
   def __init__(self, config, workspace):
     super().__init__(config, workspace)
@@ -99,17 +100,29 @@ class ClusterFuzzLite(BaseClusterFuzzDeployment):
       # called if multiple bugs are found.
       return self.workspace.clusterfuzz_build
 
-    _make_empty_dir_if_nonexistent(self.workspace.clusterfuzz_build)
-    build_name = self._get_build_name()
+    repo_dir = self.ci_system.repo_dir()
+    if not repo_dir:
+      raise RuntimeError('repo checkout does not exist.')
 
-    try:
-      logging.info('Downloading latest build.')
-      if self.filestore.download_build(build_name,
-                                       self.workspace.clusterfuzz_build):
-        logging.info('Done downloading latest build.')
-        return self.workspace.clusterfuzz_build
-    except Exception as err:  # pylint: disable=broad-except
-      logging.error('Could not download latest build because of: %s', err)
+    _make_empty_dir_if_nonexistent(self.workspace.clusterfuzz_build)
+    repo = repo_manager.RepoManager(repo_dir)
+
+    # Builds are stored by commit, so try the latest |LATEST_BUILD_WINDOW|
+    # commits before the current.
+    for old_commit in repo.get_commit_list('HEAD^',
+                                           limit=self.LATEST_BUILD_WINDOW):
+      logging.info('Trying to downloading previous build %s.', old_commit)
+      build_name = self._get_build_name(old_commit)
+      try:
+        if self.filestore.download_build(build_name,
+                                         self.workspace.clusterfuzz_build):
+          logging.info('Done downloading previus build.')
+          return self.workspace.clusterfuzz_build
+        else:
+          logging.info('Build for %s does not exist.', old_commit)
+      except Exception as err:  # pylint: disable=broad-except
+        logging.error('Could not download build for %s because of: %s',
+                      old_commit, err)
 
     return None
 
@@ -126,8 +139,8 @@ class ClusterFuzzLite(BaseClusterFuzzDeployment):
                     target_name, str(err))
     return corpus_dir
 
-  def _get_build_name(self):
-    return self.config.sanitizer + '-latest'
+  def _get_build_name(self, name):
+    return f'{self.config.sanitizer}-{name}'
 
   def _get_corpus_name(self, target_name):  # pylint: disable=no-self-use
     """Returns the name of the corpus artifact."""
@@ -148,10 +161,10 @@ class ClusterFuzzLite(BaseClusterFuzzDeployment):
       logging.error('Failed to upload corpus for target: %s. Error: %s.',
                     target_name, error)
 
-  def upload_latest_build(self):
+  def upload_build(self, commit):
     """Upload the build produced by CIFuzz as the latest build."""
     logging.info('Uploading latest build in %s.', self.workspace.out)
-    build_name = self._get_build_name()
+    build_name = self._get_build_name(commit)
     try:
       result = self.filestore.upload_build(build_name, self.workspace.out)
       logging.info('Done uploading latest build.')
@@ -253,8 +266,8 @@ class OSSFuzz(BaseClusterFuzzDeployment):
 
     return None
 
-  def upload_latest_build(self):  # pylint: disable=no-self-use
-    """Noop Implementation of upload_latest_build."""
+  def upload_build(self, commit):  # pylint: disable=no-self-use
+    """Noop Implementation of upload_build."""
     logging.info('Not uploading latest build because on OSS-Fuzz.')
 
   def upload_corpus(self, target_name, corpus_dir):  # pylint: disable=no-self-use,unused-argument
@@ -303,8 +316,8 @@ class NoClusterFuzzDeployment(BaseClusterFuzzDeployment):
   """ClusterFuzzDeployment implementation used when there is no deployment of
   ClusterFuzz to use."""
 
-  def upload_latest_build(self):  # pylint: disable=no-self-use
-    """Noop Implementation of upload_latest_build."""
+  def upload_build(self, commit):  # pylint: disable=no-self-use
+    """Noop Implementation of upload_build."""
     logging.info('Not uploading latest build because no ClusterFuzz '
                  'deployment.')
 

--- a/infra/cifuzz/clusterfuzz_deployment_test.py
+++ b/infra/cifuzz/clusterfuzz_deployment_test.py
@@ -92,7 +92,7 @@ class OSSFuzzTest(fake_filesystem_unittest.TestCase):
     self.assertTrue('address' in latest_build_name)
 
   @parameterized.parameterized.expand([
-      ('upload_latest_build', tuple(),
+      ('upload_build', ('commit',),
        'Not uploading latest build because on OSS-Fuzz.'),
       ('upload_corpus', ('target', 'corpus-dir'),
        'Not uploading corpus because on OSS-Fuzz.'),
@@ -152,28 +152,38 @@ class ClusterFuzzLiteTest(fake_filesystem_unittest.TestCase):
     self.assertEqual(os.listdir(self.corpus_dir), [])
 
   @mock.patch('filestore.github_actions.GithubActionsFilestore.download_build',
-              return_value=True)
-  def test_download_latest_build(self, mocked_download_build):
+              side_effect=[False, True])
+  @mock.patch('repo_manager.RepoManager.get_commit_list',
+              return_value=['commit1', 'commit2'])
+  @mock.patch('continuous_integration.BaseCi.repo_dir',
+              return_value='/path/to/repo')
+  def test_download_latest_build(self, mock_repo_dir, mock_get_commit_list,
+                                 mocked_download_build):
     """Tests that downloading the latest build works as intended under normal
     circumstances."""
     self.assertEqual(self.deployment.download_latest_build(),
                      EXPECTED_LATEST_BUILD_PATH)
-    expected_artifact_name = 'address-latest'
+    expected_artifact_name = 'address-commit2'
     mocked_download_build.assert_called_with(expected_artifact_name,
                                              EXPECTED_LATEST_BUILD_PATH)
 
   @mock.patch('filestore.github_actions.GithubActionsFilestore.download_build',
               side_effect=Exception)
-  def test_download_latest_build_fail(self, _):
+  @mock.patch('repo_manager.RepoManager.get_commit_list',
+              return_value=['commit1', 'commit2'])
+  @mock.patch('continuous_integration.BaseCi.repo_dir',
+              return_value='/path/to/repo')
+  def test_download_latest_build_fail(self, mock_repo_dir, mock_get_commit_list,
+                                      _):
     """Tests that download_latest_build returns None when it fails to download a
     build."""
     self.assertIsNone(self.deployment.download_latest_build())
 
-  @mock.patch('filestore.github_actions.GithubActionsFilestore.' 'upload_build')
-  def test_upload_latest_build(self, mocked_upload_build):
-    """Tests that upload_latest_build works as intended."""
-    self.deployment.upload_latest_build()
-    mocked_upload_build.assert_called_with('address-latest',
+  @mock.patch('filestore.github_actions.GithubActionsFilestore.upload_build')
+  def test_upload_build(self, mocked_upload_build):
+    """Tests that upload_build works as intended."""
+    self.deployment.upload_build('commit')
+    mocked_upload_build.assert_called_with('address-commit',
                                            '/workspace/build-out')
 
 
@@ -199,7 +209,7 @@ class NoClusterFuzzDeploymentTest(fake_filesystem_unittest.TestCase):
     self.assertTrue(os.path.exists(self.corpus_dir))
 
   @parameterized.parameterized.expand([
-      ('upload_latest_build', tuple(),
+      ('upload_build', ('commit',),
        'Not uploading latest build because no ClusterFuzz deployment.'),
       ('upload_corpus', ('target', 'corpus-dir'),
        'Not uploading corpus because no ClusterFuzz deployment.'),

--- a/infra/cifuzz/clusterfuzz_deployment_test.py
+++ b/infra/cifuzz/clusterfuzz_deployment_test.py
@@ -186,7 +186,7 @@ class ClusterFuzzLiteTest(fake_filesystem_unittest.TestCase):
     """Tests that upload_build works as intended."""
     self.deployment.upload_build('commit')
     mock_upload_build.assert_called_with('address-commit',
-                                           '/workspace/build-out')
+                                         '/workspace/build-out')
 
 
 class NoClusterFuzzDeploymentTest(fake_filesystem_unittest.TestCase):

--- a/infra/cifuzz/clusterfuzz_deployment_test.py
+++ b/infra/cifuzz/clusterfuzz_deployment_test.py
@@ -35,6 +35,8 @@ EXAMPLE_FUZZER = 'example_crash_fuzzer'
 WORKSPACE = '/workspace'
 EXPECTED_LATEST_BUILD_PATH = os.path.join(WORKSPACE, 'cifuzz-prev-build')
 
+# pylint: disable=unused-argument
+
 
 def _create_config(**kwargs):
   """Creates a config object and then sets every attribute that is a key in

--- a/infra/cifuzz/config_utils.py
+++ b/infra/cifuzz/config_utils.py
@@ -209,6 +209,7 @@ class BaseConfig:
     self.git_store_branch = os.environ.get('GIT_STORE_BRANCH')
     self.git_store_branch_coverage = os.environ.get('GIT_STORE_BRANCH_COVERAGE',
                                                     self.git_store_branch)
+    self.builds_storage = os.getenv('BUILDS_STORAGE')
 
     # TODO(metzman): Fix tests to create valid configurations and get rid of
     # CIFUZZ_TEST here and in presubmit.py.
@@ -231,6 +232,9 @@ class BaseConfig:
     if self.language not in constants.LANGUAGES:
       logging.error('Invalid LANGUAGE: %s. Must be one of: %s.', self.language,
                     constants.LANGUAGES)
+
+    if self.builds_storage and self.builds_storage != 'GITHUB_ARTIFACT':
+      logging.error('Only "GITHUB_ARTIFACT" is supported for builds-storage.')
       return False
 
     return True

--- a/infra/cifuzz/config_utils.py
+++ b/infra/cifuzz/config_utils.py
@@ -209,7 +209,7 @@ class BaseConfig:
     self.git_store_branch = os.environ.get('GIT_STORE_BRANCH')
     self.git_store_branch_coverage = os.environ.get('GIT_STORE_BRANCH_COVERAGE',
                                                     self.git_store_branch)
-    self.upload_build = os.getenv('UPLOAD_BUILD')
+    self.upload_build = environment.get_bool('UPLOAD_BUILD', False)
 
     # TODO(metzman): Fix tests to create valid configurations and get rid of
     # CIFUZZ_TEST here and in presubmit.py.

--- a/infra/cifuzz/config_utils.py
+++ b/infra/cifuzz/config_utils.py
@@ -209,7 +209,7 @@ class BaseConfig:
     self.git_store_branch = os.environ.get('GIT_STORE_BRANCH')
     self.git_store_branch_coverage = os.environ.get('GIT_STORE_BRANCH_COVERAGE',
                                                     self.git_store_branch)
-    self.builds_storage = os.getenv('BUILDS_STORAGE')
+    self.upload_build = os.getenv('UPLOAD_BUILD')
 
     # TODO(metzman): Fix tests to create valid configurations and get rid of
     # CIFUZZ_TEST here and in presubmit.py.
@@ -232,9 +232,6 @@ class BaseConfig:
     if self.language not in constants.LANGUAGES:
       logging.error('Invalid LANGUAGE: %s. Must be one of: %s.', self.language,
                     constants.LANGUAGES)
-
-    if self.builds_storage and self.builds_storage != 'GITHUB_ARTIFACT':
-      logging.error('Only "GITHUB_ARTIFACT" is supported for builds-storage.')
       return False
 
     return True

--- a/infra/cifuzz/external-actions/build_fuzzers/action.yml
+++ b/infra/cifuzz/external-actions/build_fuzzers/action.yml
@@ -35,10 +35,10 @@ inputs:
     description: |
       The branch of the git repo to use for storing coverage reports.
     required: false
-  builds-storage:
+  upload-build:
     description: |
-      If set, will upload the build. The only currently supported value is "GITHUB_ARTIFACT".
-    required: false
+      If set, will upload the build.
+    default: false
   github-token:
     description: |
       Token for GitHub API. WARNING: THIS SHOULD NOT BE USED IN PRODUCTION YET
@@ -60,4 +60,4 @@ runs:
     GITHUB_TOKEN: ${{ inputs.github-token }}
     LOW_DISK_SPACE: 'True'
     BAD_BUILD_CHECK: ${{ inputs.bad-build-check }}
-    BUILDS_STORAGE: ${{ inputs.builds-storage }}
+    UPLOAD_BUILD: ${{ inputs.upload-build }}

--- a/infra/cifuzz/external-actions/build_fuzzers/action.yml
+++ b/infra/cifuzz/external-actions/build_fuzzers/action.yml
@@ -35,6 +35,10 @@ inputs:
     description: |
       The branch of the git repo to use for storing coverage reports.
     required: false
+  builds-storage:
+    description: |
+      If set, will upload the build. The only currently supported value is "GITHUB_ARTIFACT".
+    required: false
   github-token:
     description: |
       Token for GitHub API. WARNING: THIS SHOULD NOT BE USED IN PRODUCTION YET
@@ -56,3 +60,4 @@ runs:
     GITHUB_TOKEN: ${{ inputs.github-token }}
     LOW_DISK_SPACE: 'True'
     BAD_BUILD_CHECK: ${{ inputs.bad-build-check }}
+    BUILDS_STORAGE: ${{ inputs.builds-storage }}

--- a/infra/cifuzz/run_fuzzers.py
+++ b/infra/cifuzz/run_fuzzers.py
@@ -258,21 +258,7 @@ class BatchFuzzTargetRunner(BaseFuzzTargetRunner):
 
   def run_fuzz_targets(self):
     result = super().run_fuzz_targets()
-
     self.clusterfuzz_deployment.upload_crashes()
-
-    # We want to upload the build to the filestore after we do batch fuzzing.
-    # There are some is a problem with this. We don't want to upload the build
-    # before fuzzing, because if we download the latest build, we will consider
-    # the build we just uploaded to be the latest even though it shouldn't be
-    # (we really intend to download the build before the curent one.
-    # TODO(metzman): We should really be uploading latest build in build_fuzzers
-    # before we remove unaffected fuzzers. Otherwise, we can lose fuzzers. This
-    # is probably more of a theoretical concern since in batch fuzzing, there is
-    # no code change and thus no fuzzers that are removed, but it's inelegant to
-    # put this here.
-
-    self.clusterfuzz_deployment.upload_latest_build()
     return result
 
 

--- a/infra/cifuzz/run_fuzzers_test.py
+++ b/infra/cifuzz/run_fuzzers_test.py
@@ -324,8 +324,8 @@ class BatchFuzzTargetRunnerTest(fake_filesystem_unittest.TestCase):
   @mock.patch('run_fuzzers.BaseFuzzTargetRunner.run_fuzz_targets',
               return_value=False)
   @mock.patch('clusterfuzz_deployment.ClusterFuzzLite.upload_crashes')
-  def test_run_fuzz_targets_upload_crashes_and_builds(
-      self, mocked_upload_crashes,  _):
+  def test_run_fuzz_targets_upload_crashes_and_builds(self,
+                                                      mocked_upload_crashes, _):
     """Tests that run_fuzz_targets uploads crashes and builds correctly."""
     runner = run_fuzzers.BatchFuzzTargetRunner(self.config)
     # TODO(metzman): Don't rely on this failing gracefully.

--- a/infra/cifuzz/run_fuzzers_test.py
+++ b/infra/cifuzz/run_fuzzers_test.py
@@ -290,7 +290,7 @@ class BatchFuzzTargetRunnerTest(fake_filesystem_unittest.TestCase):
                                                  is_github=True)
 
   @mock.patch('utils.get_fuzz_targets', return_value=['target1', 'target2'])
-  @mock.patch('clusterfuzz_deployment.ClusterFuzzLite.upload_latest_build',
+  @mock.patch('clusterfuzz_deployment.ClusterFuzzLite.upload_build',
               return_value=True)
   @mock.patch('run_fuzzers.BatchFuzzTargetRunner.run_fuzz_target')
   @mock.patch('run_fuzzers.BatchFuzzTargetRunner.create_fuzz_target_obj')

--- a/infra/cifuzz/run_fuzzers_test.py
+++ b/infra/cifuzz/run_fuzzers_test.py
@@ -322,7 +322,8 @@ class BatchFuzzTargetRunnerTest(fake_filesystem_unittest.TestCase):
   @mock.patch('run_fuzzers.BaseFuzzTargetRunner.run_fuzz_targets',
               return_value=False)
   @mock.patch('clusterfuzz_deployment.ClusterFuzzLite.upload_crashes')
-  def test_run_fuzz_targets_upload_crashes_and_builds(self, mock_upload_crashes, _):
+  def test_run_fuzz_targets_upload_crashes_and_builds(self, mock_upload_crashes,
+                                                      _):
     """Tests that run_fuzz_targets uploads crashes and builds correctly."""
     runner = run_fuzzers.BatchFuzzTargetRunner(self.config)
     # TODO(metzman): Don't rely on this failing gracefully.

--- a/infra/cifuzz/run_fuzzers_test.py
+++ b/infra/cifuzz/run_fuzzers_test.py
@@ -323,10 +323,9 @@ class BatchFuzzTargetRunnerTest(fake_filesystem_unittest.TestCase):
 
   @mock.patch('run_fuzzers.BaseFuzzTargetRunner.run_fuzz_targets',
               return_value=False)
-  @mock.patch('clusterfuzz_deployment.ClusterFuzzLite.upload_latest_build')
   @mock.patch('clusterfuzz_deployment.ClusterFuzzLite.upload_crashes')
   def test_run_fuzz_targets_upload_crashes_and_builds(
-      self, mocked_upload_crashes, mocked_upload_latest_build, _):
+      self, mocked_upload_crashes,  _):
     """Tests that run_fuzz_targets uploads crashes and builds correctly."""
     runner = run_fuzzers.BatchFuzzTargetRunner(self.config)
     # TODO(metzman): Don't rely on this failing gracefully.

--- a/infra/cifuzz/run_fuzzers_test.py
+++ b/infra/cifuzz/run_fuzzers_test.py
@@ -334,7 +334,6 @@ class BatchFuzzTargetRunnerTest(fake_filesystem_unittest.TestCase):
 
     self.assertFalse(runner.run_fuzz_targets())
     self.assertEqual(mocked_upload_crashes.call_count, 1)
-    self.assertEqual(mocked_upload_latest_build.call_count, 1)
 
 
 @unittest.skipIf(not os.getenv('INTEGRATION_TESTS'),

--- a/infra/cifuzz/workspace_utils.py
+++ b/infra/cifuzz/workspace_utils.py
@@ -27,6 +27,11 @@ class Workspace:
     os.makedirs(directory, exist_ok=True)
 
   @property
+  def repo_storage(self):
+    """The local directory for repo storage."""
+    return os.path.join(self.workspace, 'storage')
+
+  @property
   def out(self):
     """The out directory used for storing the fuzzer build built by
     build_fuzzers."""

--- a/infra/cifuzz/workspace_utils.py
+++ b/infra/cifuzz/workspace_utils.py
@@ -28,7 +28,7 @@ class Workspace:
 
   @property
   def repo_storage(self):
-    """The local directory for repo storage."""
+    """The parent directory for repo storage."""
     return os.path.join(self.workspace, 'storage')
 
   @property

--- a/infra/repo_manager.py
+++ b/infra/repo_manager.py
@@ -135,7 +135,7 @@ class RepoManager:
              check_result=True)
     self.git(['remote', 'update'], check_result=True)
 
-  def get_commit_list(self, newest_commit, oldest_commit=None):
+  def get_commit_list(self, newest_commit, oldest_commit=None, limit=None):
     """Gets the list of commits(inclusive) between the old and new commits.
 
     Args:
@@ -162,7 +162,11 @@ class RepoManager:
     else:
       commit_range = newest_commit
 
-    out, _, err_code = self.git(['rev-list', commit_range])
+    limit_args = []
+    if limit:
+      limit_args.append(f'--max-count={limit}')
+
+    out, _, err_code = self.git(['rev-list', commit_range] + limit_args)
     commits = out.split('\n')
     commits = [commit for commit in commits if commit]
     if err_code or not commits:


### PR DESCRIPTION
The current way adds a lot of ordering assumptions, and doesn't fit too
well with parallel batch fuzzing either. Add a "upload-build" boolean action
input that can be added to "build_fuzzers" to upload latest builds
instead.

Builds are now uploaded by commit hash, rather than a fixed "latest" name. 
ClusterFuzzLite's download_latest_build will check the last 3 commits and download the
first available build by git hash.