### PR TITLE
libcacard: Update list of NSS libraries needed for build

### DIFF
--- a/projects/libcacard/build.sh
+++ b/projects/libcacard/build.sh
@@ -33,7 +33,11 @@ sed -i "s/Debug//g" dist/Debug/lib/pkgconfig/nss.pc
 sed -i "s/\/lib/\/lib\/Debug/g" dist/Debug/lib/pkgconfig/nss.pc
 sed -i "s/include\/nspr/public\/nss/g" dist/Debug/lib/pkgconfig/nss.pc
 sed -i "s/NSPR/NSS/g" dist/Debug/lib/pkgconfig/nss.pc
-sed -i "s/Libs:.*/Libs: -L\${libdir} -lssl -lsmime -lnssdev -lnss_static -lpk11wrap_static -lcryptohi -lcerthi -lcertdb -lnssb -lnssutil -lnsspki -ldl -lm -lsqlite -lsoftokn_static -lfreebl_static -lgcm-aes-x86_c_lib -lhw-acc-crypto-avx -lhw-acc-crypto-avx2 /g" dist/Debug/lib/pkgconfig/nss.pc
+LIBS="-lssl -lsmime -lnssdev -lnss_static -lpk11wrap_static -lcryptohi"
+LIBS="$LIBS -lcerthi -lcertdb -lnssb -lnssutil -lnsspki -ldl -lm -lsqlite"
+LIBS="$LIBS -lsoftokn_static -lsha-x86_c_lib -lfreebl_static"
+LIBS="$LIBS -lgcm-aes-x86_c_lib -lhw-acc-crypto-avx -lhw-acc-crypto-avx2"
+sed -i "s/Libs:.*/Libs: -L\${libdir} $LIBS/g" dist/Debug/lib/pkgconfig/nss.pc
 echo "Requires: nspr" >> dist/Debug/lib/pkgconfig/nss.pc
 
 export NSS_NSPR_PATH=$(realpath $SRC/nss-nspr/)


### PR DESCRIPTION
Unbreak the build of libcacard fuzzer because of internal changes in NSS.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=35605

And actually makes the infinite line a bit easier to read