### PR TITLE
Fix Tor build issue related to OpenSSL's use of lib64

### DIFF
--- a/projects/tor/build.sh
+++ b/projects/tor/build.sh
@@ -63,13 +63,14 @@ export ASAN_OPTIONS=detect_leaks=0
     --with-libevent-dir=${SRC}/deps \
     --with-openssl-dir=${SRC}/deps \
     --with-zlib-dir=${SRC}/deps \
-    --disable-gcc-hardening
+    --disable-gcc-hardening \
+    LDFLAGS="-L${TOR_DEPS}/lib64"
 
 make clean
 make -j$(nproc) oss-fuzz-fuzzers
 
 TORLIBS="`make show-testing-libs`"
-TORLIBS="$TORLIBS -lm -Wl,-Bstatic -lssl -lcrypto -levent -lz -L${TOR_DEPS}/lib"
+TORLIBS="$TORLIBS -lm -Wl,-Bstatic -lssl -lcrypto -levent -lz -L${TOR_DEPS}/lib -L${TOR_DEPS}/lib64"
 TORLIBS="$TORLIBS -Wl,-Bdynamic"
 
 for fuzzer in src/test/fuzz/*.a; do


### PR DESCRIPTION
The openssl build process now puts objects into lib64, even if it
wasn't told to do so.  Tor's crufty old library detection code
didn't handle that.

Should fix Issue 36556 in oss-fuzz