### PR TITLE
[infra][NFC] Use one source of truth for engines, languages etc.

### DIFF
--- a/infra/cifuzz/config_utils.py
+++ b/infra/cifuzz/config_utils.py
@@ -19,25 +19,12 @@ import os
 import json
 
 import environment
+import helper
 
 RUN_FUZZERS_MODES = ['batch', 'ci', 'coverage']
 
 # TODO(metzman): Make one source of truth for these in helper.py
 SANITIZERS = ['address', 'memory', 'undefined', 'coverage']
-LANGUAGES = [
-    'c',
-    'c++',
-    'go',
-    'jvm',
-    'python',
-    'rust',
-    'swift',
-]
-
-DEFAULT_ENGINE = 'libfuzzer'
-DEFAULT_ARCHITECTURE = 'x86_64'
-DEFAULT_LANGUAGE = 'c++'
-DEFAULT_SANITIZER = 'address'
 
 # This module deals a lot with env variables. Many of these will be set by users
 # and others beyond CIFuzz's control. Thus, you should be careful about using
@@ -54,7 +41,7 @@ def _get_pr_ref(event):
 
 
 def _get_sanitizer():
-  return os.getenv('SANITIZER', DEFAULT_SANITIZER).lower()
+  return os.getenv('SANITIZER', helper.DEFAULT_SANITIZER).lower()
 
 
 def _is_dry_run():
@@ -69,7 +56,7 @@ def _get_language():
   # getting it from the project.yaml) is outweighed by the complexity in
   # implementing this. A lot of the complexity comes from our unittests not
   # setting a proper projet at this point.
-  return os.getenv('LANGUAGE', DEFAULT_LANGUAGE)
+  return os.getenv('LANGUAGE', helper.DEFAULT_LANGUAGE)
 
 
 # pylint: disable=too-few-public-methods,too-many-instance-attributes
@@ -240,9 +227,9 @@ class BaseConfig:
                     self.sanitizer, SANITIZERS)
       return False
 
-    if self.language not in LANGUAGES:
+    if self.language not in helper.LANGUAGES:
       logging.error('Invalid LANGUAGE: %s. Must be one of: %s.', self.language,
-                    LANGUAGES)
+                    helper.LANGUAGES)
       return False
 
     return True

--- a/infra/cifuzz/config_utils_test.py
+++ b/infra/cifuzz/config_utils_test.py
@@ -17,6 +17,7 @@ import unittest
 from unittest import mock
 
 import config_utils
+import helper
 import test_helpers
 
 # pylint: disable=no-self-use,protected-access
@@ -88,7 +89,7 @@ class BaseConfigTest(unittest.TestCase):
     self.assertFalse(config.validate())
     mocked_error.assert_called_with('Invalid LANGUAGE: %s. Must be one of: %s.',
                                     os.environ['LANGUAGE'],
-                                    config_utils.LANGUAGES)
+                                    helper.LANGUAGES)
 
   @mock.patch('logging.error')
   def test_validate_invalid_sanitizer(self, mocked_error):

--- a/infra/cifuzz/docker.py
+++ b/infra/cifuzz/docker.py
@@ -20,6 +20,7 @@ import config_utils
 # pylint: disable=wrong-import-position,import-error
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+import helper
 import utils
 
 BASE_BUILDER_TAG = 'gcr.io/oss-fuzz-base/base-builder'
@@ -28,9 +29,8 @@ MSAN_LIBS_BUILDER_TAG = 'gcr.io/oss-fuzz-base/msan-libs-builder'
 PROJECT_TAG_PREFIX = 'gcr.io/oss-fuzz/'
 
 _DEFAULT_DOCKER_RUN_ARGS = [
-    '--cap-add', 'SYS_PTRACE', '-e',
-    'FUZZING_ENGINE=' + config_utils.DEFAULT_ENGINE, '-e',
-    'ARCHITECTURE=' + config_utils.DEFAULT_ARCHITECTURE, '-e', 'CIFUZZ=True'
+    '--cap-add', 'SYS_PTRACE', '-e', 'FUZZING_ENGINE=' + helper.DEFAULT_ENGINE,
+    '-e', 'ARCHITECTURE=' + helper.DEFAULT_ARCHITECTURE, '-e', 'CIFUZZ=True'
 ]
 
 EXTERNAL_PROJECT_IMAGE = 'external-project'
@@ -60,8 +60,8 @@ def delete_images(images):
 
 
 def get_base_docker_run_args(workspace,
-                             sanitizer=config_utils.DEFAULT_SANITIZER,
-                             language=config_utils.DEFAULT_LANGUAGE):
+                             sanitizer=helper.DEFAULT_SANITIZER,
+                             language=helper.DEFAULT_LANGUAGE):
   """Returns arguments that should be passed to every invocation of 'docker
   run'."""
   docker_args = _DEFAULT_DOCKER_RUN_ARGS.copy()
@@ -81,8 +81,8 @@ def get_base_docker_run_args(workspace,
 
 
 def get_base_docker_run_command(workspace,
-                                sanitizer=config_utils.DEFAULT_SANITIZER,
-                                language=config_utils.DEFAULT_LANGUAGE):
+                                sanitizer=helper.DEFAULT_SANITIZER,
+                                language=helper.DEFAULT_LANGUAGE):
   """Returns part of the command that should be used everytime 'docker run' is
   invoked."""
   docker_args, docker_container = get_base_docker_run_args(

--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -23,6 +23,8 @@ import sys
 import unittest
 import yaml
 
+import helper
+
 _SRC_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
@@ -73,9 +75,9 @@ class ProjectYamlChecker:
   # Sections in a project.yaml and the constant values that they are allowed
   # to have.
   SECTIONS_AND_CONSTANTS = {
-      'sanitizers': {'address', 'none', 'memory', 'undefined', 'dataflow'},
-      'architectures': {'i386', 'x86_64'},
-      'fuzzing_engines': {'afl', 'libfuzzer', 'honggfuzz', 'dataflow', 'none'},
+      'sanitizers': helper.SANITIZERS,
+      'architectures': helper.ARCHITECTURES,
+      'fuzzing_engines': helper.ENGINES,
   }
 
   # Note: this list must be updated when we allow new sections.
@@ -98,16 +100,6 @@ class ProjectYamlChecker:
       'selective_unpack',
       'vendor_ccs',
       'view_restrictions',
-  ]
-
-  SUPPORTED_LANGUAGES = [
-      'c',
-      'c++',
-      'go',
-      'jvm',
-      'python',
-      'rust',
-      'swift',
   ]
 
   # Note that some projects like boost only have auto-ccs. However, forgetting
@@ -226,10 +218,10 @@ class ProjectYamlChecker:
     language = self.data.get('language')
     if not language:
       self.error('Missing "language" attribute in project.yaml.')
-    elif language not in self.SUPPORTED_LANGUAGES:
+    elif language not in helper.LANGUAGES:
       self.error(
           '"language: {language}" is not supported ({supported}).'.format(
-              language=language, supported=self.SUPPORTED_LANGUAGES))
+              language=language, supported=helper.LANGUAGES))
 
 
 def _check_one_project_yaml(project_yaml_filename):


### PR DESCRIPTION
Do this only where it makes sense. For example, since CIFuzz doesn't
support dataflow, maintain a seperate soruce of truth.
One potential downside is now presubmit.py depends on helper.py not
having syntax errors.