### PR TITLE
[clamav] Fix build

### DIFF
--- a/projects/clamav/Dockerfile
+++ b/projects/clamav/Dockerfile
@@ -28,7 +28,7 @@ RUN git clone --depth 1 https://github.com/Cisco-Talos/clamav-mussels-cookbook.g
 
 RUN mkdir /mussels
 RUN cd ${SRC}/clamav-mussels-cookbook && \
-    msl build clamav_deps -t host-static -w /mussels/work -i /mussels/install
+    msl build libclamav_deps -t host-static -w /mussels/work -i /mussels/install
 
 # Collect clamav source & fuzz corpus
 RUN git clone --depth 1 https://github.com/Cisco-Talos/clamav-devel.git


### PR DESCRIPTION
The instructions for building libclamav-only dependencies changed.

The clamav_deps collection is now used for all clamav dependencies.

A) We don't need to waste resources building dependencies used only
   by clamav programs.
B) The ncurses static build seems to be failing on this image, which
   is why the build is broken/needs fixing.