### PR TITLE
wasmtime: provide OCaml packages for build

### DIFF
--- a/projects/wasmtime/Dockerfile
+++ b/projects/wasmtime/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang ocaml-nox ocamlbuild
+RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang ocaml-nox
 
 RUN git clone --depth 1 https://github.com/bytecodealliance/wasm-tools wasm-tools
 

--- a/projects/wasmtime/Dockerfile
+++ b/projects/wasmtime/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang
+RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang ocaml-nox ocamlbuild
 
 RUN git clone --depth 1 https://github.com/bytecodealliance/wasm-tools wasm-tools
 


### PR DESCRIPTION
In order to build the WebAssembly spec interpreter, these packages are needed.