### PR TITLE
Update auto_ccs of opensk project

### DIFF
--- a/projects/opensk/project.yaml
+++ b/projects/opensk/project.yaml
@@ -7,4 +7,7 @@ fuzzing_engines:
   - libfuzzer
 language: rust
 auto_ccs:
+  - "jmichel@google.com"
+  - "kaczmarczyck@google.com"
+  - "cretin@google.com"
   - "david@adalogics.com"


### PR DESCRIPTION
This is to get access to fuzzing stats as per the [documentation](https://google.github.io/oss-fuzz/getting-started/new-project-guide/#primary).

FYI @jmichelp @kaczmarczyck
