### PR TITLE
fix boost.json build error

### DIFF
--- a/projects/boost-json/build.sh
+++ b/projects/boost-json/build.sh
@@ -23,6 +23,6 @@ echo "using clang : ossfuzz : $CXX : <compileflags>\"$CXXFLAGS\" <linkflags>\"$C
 
 for i in libs/json/fuzzing/*.cpp; do
    fuzzer=$(basename $i .cpp)
-   $CXX $CXXFLAGS -pthread libs/json/fuzzing/$fuzzer.cpp -I /out/include/ $OUT/lib/*.a $LIB_FUZZING_ENGINE -o $OUT/$fuzzer
+   $CXX $CXXFLAGS -pthread libs/json/fuzzing/$fuzzer.cpp -I $OUT/include/ $OUT/lib/*.a $LIB_FUZZING_ENGINE -o $OUT/$fuzzer
 done
 


### PR DESCRIPTION
I had mistakenly used "/out" instead of "$OUT" in one place. That worked fine locally.

Perhaps it would be useful to have a CI job testing using /out2/ etc to see that the build scripts are correct.