### PR TITLE
[libvips] Add imagequant and cgif dependencies

### DIFF
--- a/projects/libvips/Dockerfile
+++ b/projects/libvips/Dockerfile
@@ -22,11 +22,13 @@ RUN apt-get update && apt-get install -y \
   nasm \
   gtk-doc-tools \
   gobject-introspection \
+  python3-pip \
   libfftw3-dev \
   libexpat1-dev \
   libffi-dev \
   libselinux1-dev \
   glib2.0-dev
+RUN pip3 install meson ninja
 RUN mkdir afl-testcases
 RUN curl https://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz | tar xzC afl-testcases
 RUN git clone --depth 1 https://github.com/libvips/libvips
@@ -41,6 +43,8 @@ RUN git clone --depth 1 https://gitlab.com/libtiff/libtiff
 RUN git clone --depth 1 https://aomedia.googlesource.com/aom
 RUN git clone --depth 1 https://github.com/strukturag/libheif
 RUN git clone --depth 1 --recursive https://github.com/libjxl/libjxl.git
+RUN git clone --depth 1 https://github.com/lovell/libimagequant.git
+RUN git clone --depth 1 https://github.com/dloebl/cgif.git
 
 WORKDIR libvips
 COPY build.sh $SRC/

--- a/projects/libvips/build.sh
+++ b/projects/libvips/build.sh
@@ -182,7 +182,25 @@ sed -i'.bak' "s/-lbrotlidec/&-static/" $WORK/lib/pkgconfig/libbrotlidec.pc
 sed -i'.bak' "s/-lbrotlicommon/&-static/" $WORK/lib/pkgconfig/libbrotlicommon.pc
 popd
 
+# libimagequant
+pushd $SRC/libimagequant
+meson setup --prefix=$WORK --libdir=lib --default-library=static build
+cd build
+ninja -j$(nproc)
+ninja install
+popd
+
+# cgif
+pushd $SRC/cgif
+meson setup --prefix=$WORK --libdir=lib --default-library=static build
+cd build
+ninja -j$(nproc)
+ninja install
+popd
+
 # libvips
+sed -i'.bak' "/test/d" Makefile.am
+sed -i'.bak' "/tools/d" Makefile.am
 PKG_CONFIG="pkg-config --static" ./autogen.sh \
   --disable-shared \
   --disable-modules \
@@ -229,6 +247,8 @@ for fuzzer in fuzz/*_fuzzer.cc; do
     $WORK/lib/libbrotlienc-static.a \
     $WORK/lib/libbrotlidec-static.a \
     $WORK/lib/libbrotlicommon-static.a \
+    $WORK/lib/libimagequant.a \
+    $WORK/lib/libcgif.a \
     $LIB_FUZZING_ENGINE \
     -Wl,-Bstatic \
     -lfftw3 -lgmodule-2.0 -lgio-2.0 -lgobject-2.0 -lffi -lglib-2.0 -lpcre -lexpat \


### PR DESCRIPTION
This will allow the creation of additional fuzzers to test the code paths these dependencies add.

(Also skips the `test` and `tools` subdirs when building libvips as these are not directly fuzz tested and can cause static linking problems.)