### PR TITLE
Disable clickhouse.

### DIFF
--- a/projects/clickhouse/project.yaml
+++ b/projects/clickhouse/project.yaml
@@ -12,3 +12,4 @@ sanitizers:
     experimental: True
  - undefined
 main_repo: 'https://github.com/ClickHouse/ClickHouse.git'
+disabled: True


### PR DESCRIPTION
I merged https://github.com/google/oss-fuzz/pull/6244
too quickly. Clickhouse fails to build.
Disable temporarily to prevent exceptions since
 clickhouse is new

Change-Id: I5d99f911620d4df3a2b32c2179bca0c5afcd95c6