### PR TITLE
[cifuzz] Handle upgrade to Ubuntu 20.04

### DIFF
--- a/infra/cifuzz/build_fuzzers_test.py
+++ b/infra/cifuzz/build_fuzzers_test.py
@@ -369,16 +369,5 @@ class GetDockerBuildFuzzersArgsNotContainerTest(unittest.TestCase):
     self.assertEqual(result, expected_result)
 
 
-class GetDockerBuildFuzzersArgsMsanTest(unittest.TestCase):
-  """Tests that _get_docker_build_fuzzers_args_msan works as intended."""
-
-  def test_get_docker_build_fuzzers_args_msan(self):
-    """Tests that _get_docker_build_fuzzers_args_msan works as intended."""
-    work_dir = '/work_dir'
-    result = build_fuzzers._get_docker_build_fuzzers_args_msan(work_dir)
-    expected_result = ['-e', 'MSAN_LIBS_PATH=/work_dir/msan']
-    self.assertEqual(result, expected_result)
-
-
 if __name__ == '__main__':
   unittest.main()

--- a/infra/cifuzz/cifuzz-base/Dockerfile
+++ b/infra/cifuzz/cifuzz-base/Dockerfile
@@ -20,12 +20,6 @@ RUN apt-get update && \
     wget https://download.docker.com/linux/ubuntu/dists/xenial/pool/stable/amd64/docker-ce-cli_20.10.5~3-0~ubuntu-xenial_amd64.deb -O /tmp/docker-ce.deb && \
     dpkg -i /tmp/docker-ce.deb && rm /tmp/docker-ce.deb
 
-# Install newer Python from base-builder.
-COPY --from=gcr.io/oss-fuzz-base/base-builder /usr/local/bin/python3 /usr/local/bin/python3
-COPY --from=gcr.io/oss-fuzz-base/base-builder /usr/local/lib/libpython3* /usr/local/lib/
-COPY --from=gcr.io/oss-fuzz-base/base-builder /usr/local/lib/python3.8 /usr/local/lib/python3.8
-RUN ldconfig
-
 ENV OSS_FUZZ_ROOT=/opt/oss-fuzz
 ADD . ${OSS_FUZZ_ROOT}
 RUN python3 -m pip install -r ${OSS_FUZZ_ROOT}/infra/cifuzz/requirements.txt

--- a/infra/cifuzz/docker.py
+++ b/infra/cifuzz/docker.py
@@ -23,7 +23,6 @@ import constants
 import utils
 
 BASE_BUILDER_TAG = 'gcr.io/oss-fuzz-base/base-builder'
-MSAN_LIBS_BUILDER_TAG = 'gcr.io/oss-fuzz-base/msan-libs-builder'
 PROJECT_TAG_PREFIX = 'gcr.io/oss-fuzz/'
 
 # Default fuzz configuration.

--- a/infra/cifuzz/run_fuzzers_entrypoint.py
+++ b/infra/cifuzz/run_fuzzers_entrypoint.py
@@ -36,7 +36,6 @@ def delete_unneeded_docker_images(config):
   project_image = docker.get_project_image_name(config.oss_fuzz_project_name)
   images = [
       project_image,
-      docker.MSAN_LIBS_BUILDER_TAG,
   ]
   docker.delete_images(images)
 


### PR DESCRIPTION
1. Don't do any special handling for MSAN anymore. It isn't needed.
2. Don't do any special handling for msan-libs-builder it doesn't
exist anymore.
3. Don't copy python anymore. python3 comes with base-runner.

Related: https://github.com/google/oss-fuzz/issues/6180