### PR TITLE
[ffmpeg] Don't rely on cd accepting multiple arguments.

### DIFF
--- a/projects/ffmpeg/Dockerfile
+++ b/projects/ffmpeg/Dockerfile
@@ -19,7 +19,7 @@ ADD bionic.list /etc/apt/sources.list.d/bionic.list
 ADD nasm_apt.pin /etc/apt/preferences
 RUN apt-get update && apt-get install -y make autoconf automake libtool build-essential \
     libass-dev libfreetype6-dev libsdl1.2-dev \
-    libvdpau-dev libxcb1-dev libxcb-shm0-dev \
+    libvdpau-dev libxcb1-dev libxcb-shm0-dev libdrm-dev \
     pkg-config texinfo libbz2-dev zlib1g-dev yasm cmake mercurial wget \
     xutils-dev libpciaccess-dev nasm rsync
 

--- a/projects/ffmpeg/build.sh
+++ b/projects/ffmpeg/build.sh
@@ -29,6 +29,7 @@ export LD_LIBRARY_PATH="$FFMPEG_DEPS_PATH/lib"
 cd $SRC
 bzip2 -f -d alsa-lib-*
 tar xf alsa-lib-*
+rm alsa-lib-*.tar
 cd alsa-lib-*
 ./configure --prefix="$FFMPEG_DEPS_PATH" --enable-static --disable-shared
 make clean


### PR DESCRIPTION
This behavior doesn't work in Ubuntu 20.04.
Related: #6180