### PR TITLE
Install python in projects that depend on it.

### DIFF
--- a/projects/bitcoin-core/Dockerfile
+++ b/projects/bitcoin-core/Dockerfile
@@ -20,7 +20,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 # * https://github.com/bitcoin/bitcoin/blob/master/doc/build-unix.md#dependency-build-instructions
 # * https://github.com/bitcoin/bitcoin/blob/master/depends/README.md#for-linux-including-i386-arm-cross-compilation
 RUN apt-get update && apt-get install -y \
-  build-essential libtool autotools-dev automake pkg-config bsdmainutils python3 \
+  build-essential libtool autotools-dev automake pkg-config bsdmainutils python python3 \
   make automake cmake curl g++-multilib libtool binutils-gold bsdmainutils pkg-config patch bison \
   wget zip
 

--- a/projects/boost/Dockerfile
+++ b/projects/boost/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y g++
+RUN apt-get update && apt-get install -y g++ python
 
 RUN git clone --recursive https://github.com/boostorg/boost.git
 WORKDIR boost

--- a/projects/grpc-httpjson-transcoding/Dockerfile
+++ b/projects/grpc-httpjson-transcoding/Dockerfile
@@ -17,6 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER nareddyt@google.com
 
+RUN apt-get update && apt-get install python -y
 RUN git clone https://github.com/grpc-ecosystem/grpc-httpjson-transcoding.git
 WORKDIR $SRC/grpc-httpjson-transcoding/
 COPY build.sh $SRC/

--- a/projects/http-pattern-matcher/Dockerfile
+++ b/projects/http-pattern-matcher/Dockerfile
@@ -17,6 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER nareddyt@google.com
 
+RUN apt-get update && apt-get install python -y
 RUN git clone https://github.com/google/http_pattern_matcher.git
 WORKDIR $SRC/http_pattern_matcher/
 COPY build.sh $SRC/

--- a/projects/libcacard/Dockerfile
+++ b/projects/libcacard/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y pkg-config libglib2.0-dev gyp libsqlite3-dev mercurial python3-pip
+RUN apt-get update && apt-get install -y pkg-config libglib2.0-dev gyp libsqlite3-dev mercurial python3-pip python
 # Because Ubuntu has really ancient meson out there
 RUN pip3 install meson ninja
 

--- a/projects/nettle/Dockerfile
+++ b/projects/nettle/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get install -y software-properties-common python-software-properties make autoconf build-essential wget lzip libtool
+RUN apt-get install -y software-properties-common make autoconf build-essential wget lzip libtool python
 RUN git clone --depth 1 https://git.lysator.liu.se/nettle/nettle
 RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz

--- a/projects/nss/Dockerfile
+++ b/projects/nss/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make mercurial zlib1g-dev gyp ninja-build libssl-dev
+RUN apt-get update && apt-get install -y make mercurial zlib1g-dev gyp ninja-build libssl-dev python
 
 RUN hg clone https://hg.mozilla.org/projects/nspr nspr
 RUN hg clone https://hg.mozilla.org/projects/nss nss

--- a/projects/pffft/Dockerfile
+++ b/projects/pffft/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y mercurial python-numpy
+RUN apt-get update && apt-get install -y mercurial python-numpy python
 RUN git clone https://bitbucket.org/jpommier/pffft $SRC/pffft
 WORKDIR pffft
 COPY build.sh $SRC

--- a/projects/tcmalloc/Dockerfile
+++ b/projects/tcmalloc/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool
-RUN git clone --depth 1 https://github.com/google/tcmalloc tcmalloc   
+RUN apt-get update && apt-get install -y make autoconf automake libtool python
+RUN git clone --depth 1 https://github.com/google/tcmalloc tcmalloc
 WORKDIR tcmalloc
 COPY build.sh $SRC/

--- a/projects/upb/Dockerfile
+++ b/projects/upb/Dockerfile
@@ -15,6 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install python -y
 RUN git clone --depth 1 https://github.com/protocolbuffers/upb.git upb
 WORKDIR upb
 COPY build.sh $SRC/


### PR DESCRIPTION
When we upgrade to 20.04, python wont be in base-builder and
these projects will fail unless they install it.
Until then, this change should be a noop.

Related: #6180