### PR TITLE
[ubuntu upgrade] Dont install ninja

### DIFF
--- a/projects/flatbuffers/Dockerfile
+++ b/projects/flatbuffers/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make cmake ninja
+RUN apt-get update && apt-get install -y make cmake
 RUN git clone https://github.com/google/flatbuffers
 
 WORKDIR $SRC/


### PR DESCRIPTION
ninja-build is the intended package name. ninja-build isn't actually
needed for this project anyway.
ninja is not the build tool and isn't available in Ubuntu 20.04.
Removing this to prevent breakage.
Related: #6180