### PR TITLE
[Ubuntu upgrade] Install python in projects that need it: oak, cel-cpp

### DIFF
--- a/projects/cel-cpp/Dockerfile
+++ b/projects/cel-cpp/Dockerfile
@@ -16,6 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 
+RUN apt-get update && apt-get install python -y
 RUN git clone --depth 1 https://github.com/google/cel-cpp/
 COPY build.sh $SRC/
 RUN mkdir $SRC/cel-cpp/fuzz/

--- a/projects/oak/Dockerfile
+++ b/projects/oak/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get --yes update \
    && apt-get install --no-install-recommends --yes \
    libssl-dev \
    pkg-config \
+   python \
    && apt-get clean \
    && rm --recursive --force /var/lib/apt/lists/*
 


### PR DESCRIPTION
When base-builder upgrades to 20.04, python wont be in and
base-builder these projects will fail unless they install it.
Until then, this change should be a noop.

Related: #6180