### PR TITLE
Enable SK_DEBUG when fuzzing SkSL.

### DIFF
--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -73,28 +73,43 @@ if [ "$CIFUZZ" = "true" ]; then
 fi
 set -u
 
+SKIA_ARGS="skia_build_fuzzers=true
+           skia_enable_fontmgr_custom_directory=false
+           skia_enable_fontmgr_custom_embedded=false
+           skia_enable_fontmgr_custom_empty=true
+           skia_enable_gpu=true
+           skia_enable_skottie=true
+           skia_use_egl=true
+           skia_use_fontconfig=false
+           skia_use_freetype=true
+           skia_use_system_freetype2=false
+           skia_use_wuffs=true
+           skia_use_libfuzzer_defaults=false"
+
 # Even though GPU is "enabled" for all these builds, none really
-# uses the gpu except for api_mock_gpu_canvas
+# uses the gpu except for api_mock_gpu_canvas.
 $SRC/skia/bin/gn gen out/Fuzz\
     --args='cc="'$CC'"
       cxx="'$CXX'"
       '$LIMITED_LINK_POOL'
+      '$SKIA_ARGS'
       is_debug=false
       extra_cflags_c=["'"$CFLAGS_ARR"'"]
       extra_cflags_cc=["'"$CXXFLAGS_ARR"'"]
-      extra_ldflags=["'"$LDFLAGS_ARR"'"]
-      skia_build_fuzzers=true
-      skia_enable_fontmgr_custom_directory=false
-      skia_enable_fontmgr_custom_embedded=false
-      skia_enable_fontmgr_custom_empty=true
-      skia_enable_gpu=true
-      skia_enable_skottie=true
-      skia_use_egl=true
-      skia_use_fontconfig=false
-      skia_use_freetype=true
-      skia_use_system_freetype2=false
-      skia_use_wuffs=true
-      skia_use_libfuzzer_defaults=false'
+      extra_ldflags=["'"$LDFLAGS_ARR"'"]'
+
+# Some fuzz targets benefit from assertions so we enable SK_DEBUG to allow SkASSERT
+# and SkDEBUGCODE to run. We still enable optimization (via is_debug=false) because
+# faster code means more fuzz tests and deeper coverage.
+$SRC/skia/bin/gn gen out/FuzzDebug\
+    --args='cc="'$CC'"
+      cxx="'$CXX'"
+      '$LIMITED_LINK_POOL'
+      '$SKIA_ARGS'
+      is_debug=false
+      extra_cflags_c=["-DSK_DEBUG,'"$CFLAGS_ARR"'"]
+      extra_cflags_cc=["-DSK_DEBUG,'"$CXXFLAGS_ARR"'"]
+      extra_ldflags=["'"$LDFLAGS_ARR"'"]'
 
 $SRC/depot_tools/ninja -C out/Fuzz \
   android_codec \
@@ -126,14 +141,16 @@ $SRC/depot_tools/ninja -C out/Fuzz \
   skjson \
   skottie_json \
   skp \
+  svg_dom \
+  textblob_deserialize \
+  webp_encoder
+
+$SRC/depot_tools/ninja -C out/FuzzDebug \
   skruntimeeffect \
   sksl2glsl \
   sksl2metal \
   sksl2pipeline \
   sksl2spirv \
-  svg_dom \
-  textblob_deserialize \
-  webp_encoder
 
 rm -rf $OUT/data
 mkdir $OUT/data
@@ -225,16 +242,16 @@ mv out/Fuzz/image_decode_incremental $OUT/image_decode_incremental
 mv ../skia_data/image_decode_seed_corpus.zip $OUT/image_decode_incremental_seed_corpus.zip
 
 # These 4 use the same sksl_seed_corpus.
-mv out/Fuzz/sksl2glsl $OUT/sksl2glsl
+mv out/FuzzDebug/sksl2glsl $OUT/sksl2glsl
 cp ../skia_data/sksl_seed_corpus.zip $OUT/sksl2glsl_seed_corpus.zip
 
-mv out/Fuzz/sksl2spirv $OUT/sksl2spirv
+mv out/FuzzDebug/sksl2spirv $OUT/sksl2spirv
 cp ../skia_data/sksl_seed_corpus.zip $OUT/sksl2spirv_seed_corpus.zip
 
-mv out/Fuzz/sksl2metal $OUT/sksl2metal
+mv out/FuzzDebug/sksl2metal $OUT/sksl2metal
 cp ../skia_data/sksl_seed_corpus.zip $OUT/sksl2metal_seed_corpus.zip
 
-mv out/Fuzz/sksl2pipeline $OUT/sksl2pipeline
+mv out/FuzzDebug/sksl2pipeline $OUT/sksl2pipeline
 mv ../skia_data/sksl_seed_corpus.zip $OUT/sksl2pipeline_seed_corpus.zip
 
 mv out/Fuzz/skdescriptor_deserialize $OUT/skdescriptor_deserialize
@@ -243,7 +260,7 @@ mv out/Fuzz/svg_dom $OUT/svg_dom
 mv ../skia_data/svg_dom_seed_corpus.zip $OUT/svg_dom_seed_corpus.zip
 
 
-mv out/Fuzz/skruntimeeffect $OUT/skruntimeeffect
+mv out/FuzzDebug/skruntimeeffect $OUT/skruntimeeffect
 mv ../skia_data/sksl_with_256_padding_seed_corpus.zip $OUT/skruntimeeffect_seed_corpus.zip
 
 mv out/Fuzz/api_create_ddl $OUT/api_create_ddl


### PR DESCRIPTION
This will help us catch more errors. We generally try to fail gracefully in SkSL but hitting an assertion is still a valid fuzzer discovery.