### PR TITLE
[qt] Use own Readme as help_url

### DIFF
--- a/projects/qt/project.yaml
+++ b/projects/qt/project.yaml
@@ -4,7 +4,8 @@ primary_contact: "rlohningqt@gmail.com"
 auto_ccs:
  - "sgaist.qt@gmail.com"
  - "shawn.t.rutledge@gmail.com"
+main_repo: 'git://code.qt.io/qt/qt5.git'
 architectures:
  - x86_64
  - i386
-main_repo: 'git://code.qt.io/qt/qt5.git'
+help_url: "https://code.qt.io/cgit/qt/qtbase.git/plain/tests/libfuzzer/README"


### PR DESCRIPTION
It includes a link to the default page so no information will be lost.