### PR TITLE
[libpsl] Apply xlocale hack to build after 20.04 upgrade.

### DIFF
--- a/projects/libpsl/build.sh
+++ b/projects/libpsl/build.sh
@@ -33,6 +33,10 @@ CPPFLAGS="$CPPFLAGS -fno-sanitize=vptr" \
   --disable-tests --disable-samples --with-data-packaging=static --prefix=$DEPS_PATH
 # ugly hack to avoid build error
 echo '#include <locale.h>' >>i18n/digitlst.h
+
+# Hack so that upgrade to Ubuntu 20.04 works.
+ln -s /usr/include/locale.h /usr/include/xlocale.h
+
 make -j
 make install
 


### PR DESCRIPTION
Related: https://github.com/google/oss-fuzz/issues/6180