### PR TITLE
[Ubuntu upgrade][libspectre] Disable dataflow builds.

### DIFF
--- a/projects/libspectre/project.yaml
+++ b/projects/libspectre/project.yaml
@@ -7,10 +7,8 @@ fuzzing_engines:
   - libfuzzer
   - afl
   - honggfuzz
-  - dataflow
 sanitizers:
   - address
   - undefined
   - memory
-  - dataflow
 main_repo: 'https://gitlab.freedesktop.org/libspectre/libspectre.git'


### PR DESCRIPTION
They aren't really supported anymore and they break in
Ubuntu 20.04.
Related: #6180.