### PR TITLE
[Ubuntu upgrade][rnp] Make build work on Ubuntu 20.04.

### DIFF
--- a/projects/rnp/Dockerfile
+++ b/projects/rnp/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get install -y \
     zlib1g-dev \
     libjson-c-dev \
     build-essential \
-    python-minimal \
+    python \
     wget
 
 RUN git clone --depth 1 https://github.com/rnpgp/rnp.git rnp

--- a/projects/rnp/build.sh
+++ b/projects/rnp/build.sh
@@ -62,4 +62,4 @@ done
 mkdir -p "${OUT}/lib"
 cp src/lib/librnp.so.0 "${OUT}/lib/"
 cp /usr/lib/libbotan-2.so.16 "${OUT}/lib/"
-cp /lib/x86_64-linux-gnu/libjson-c.so.2 "${OUT}/lib/"
+cp /lib/x86_64-linux-gnu/libjson-c.so.* "${OUT}/lib/"


### PR DESCRIPTION
Copy all versions of the libjson shared object and install python
instead of python-minimal.

Related #6180.