### PR TITLE
[Ubuntu upgrade] Disable MSAN where it doesn't support on Ubuntu 20.04

### DIFF
--- a/projects/assimp/project.yaml
+++ b/projects/assimp/project.yaml
@@ -3,7 +3,8 @@ language: c++
 primary_contact: "kim.kulling@googlemail.com"
 sanitizers:
   - address
-  - memory:
-     experimental: True
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
+#     experimental: True
   - undefined
 main_repo: 'https://github.com/assimp/assimp.git'

--- a/projects/assimp/project.yaml
+++ b/projects/assimp/project.yaml
@@ -3,7 +3,7 @@ language: c++
 primary_contact: "kim.kulling@googlemail.com"
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
 #     experimental: True
   - undefined

--- a/projects/bearssl/project.yaml
+++ b/projects/bearssl/project.yaml
@@ -6,7 +6,7 @@ auto_ccs:
 sanitizers:
  - address
  - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
 architectures:
  - x86_64

--- a/projects/bearssl/project.yaml
+++ b/projects/bearssl/project.yaml
@@ -6,7 +6,8 @@ auto_ccs:
 sanitizers:
  - address
  - undefined
- - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
 architectures:
  - x86_64
  - i386

--- a/projects/bitcoin-core/project.yaml
+++ b/projects/bitcoin-core/project.yaml
@@ -12,7 +12,7 @@ auto_ccs:
 sanitizers:
   - address
   - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
 architectures:
   - x86_64

--- a/projects/bitcoin-core/project.yaml
+++ b/projects/bitcoin-core/project.yaml
@@ -12,7 +12,8 @@ auto_ccs:
 sanitizers:
   - address
   - undefined
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
 architectures:
   - x86_64
   - i386

--- a/projects/bls-signatures/project.yaml
+++ b/projects/bls-signatures/project.yaml
@@ -5,7 +5,7 @@ main_repo: "https://github.com/supranational/blst.git"
 sanitizers:
  - address
  - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
 architectures:
  - x86_64

--- a/projects/bls-signatures/project.yaml
+++ b/projects/bls-signatures/project.yaml
@@ -5,7 +5,8 @@ main_repo: "https://github.com/supranational/blst.git"
 sanitizers:
  - address
  - undefined
- - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
 architectures:
  - x86_64
  - i386

--- a/projects/botan/project.yaml
+++ b/projects/botan/project.yaml
@@ -7,7 +7,7 @@ auto_ccs:
   - "norritt@bytefortress.de"
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
   - undefined
 main_repo: 'https://github.com/randombit/botan.git'

--- a/projects/botan/project.yaml
+++ b/projects/botan/project.yaml
@@ -7,6 +7,7 @@ auto_ccs:
   - "norritt@bytefortress.de"
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
   - undefined
 main_repo: 'https://github.com/randombit/botan.git'

--- a/projects/cel-cpp/project.yaml
+++ b/projects/cel-cpp/project.yaml
@@ -7,5 +7,6 @@ auto_ccs :
 
 sanitizers:
 - address
-- memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# - memory
 main_repo: 'https://github.com/google/cel-cpp'

--- a/projects/cel-cpp/project.yaml
+++ b/projects/cel-cpp/project.yaml
@@ -7,6 +7,6 @@ auto_ccs :
 
 sanitizers:
 - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 # - memory
 main_repo: 'https://github.com/google/cel-cpp'

--- a/projects/cmake/project.yaml
+++ b/projects/cmake/project.yaml
@@ -7,4 +7,5 @@ auto_ccs:
 sanitizers:
   - address
   - undefined
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory

--- a/projects/cmake/project.yaml
+++ b/projects/cmake/project.yaml
@@ -7,5 +7,5 @@ auto_ccs:
 sanitizers:
   - address
   - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory

--- a/projects/cpp-httplib/project.yaml
+++ b/projects/cpp-httplib/project.yaml
@@ -10,5 +10,6 @@ auto_ccs :
 sanitizers:
   - address
   - undefined
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
 main_repo: 'https://github.com/yhirose/cpp-httplib.git'

--- a/projects/cpp-httplib/project.yaml
+++ b/projects/cpp-httplib/project.yaml
@@ -10,6 +10,6 @@ auto_ccs :
 sanitizers:
   - address
   - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
 main_repo: 'https://github.com/yhirose/cpp-httplib.git'

--- a/projects/dlplibs/project.yaml
+++ b/projects/dlplibs/project.yaml
@@ -3,6 +3,6 @@ language: c++
 primary_contact: "dtardon@redhat.com"
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 # - memory
   - undefined

--- a/projects/dlplibs/project.yaml
+++ b/projects/dlplibs/project.yaml
@@ -3,5 +3,6 @@ language: c++
 primary_contact: "dtardon@redhat.com"
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# - memory
   - undefined

--- a/projects/easywsclient/project.yaml
+++ b/projects/easywsclient/project.yaml
@@ -3,7 +3,7 @@ language: c++
 primary_contact: "dhbaird@gmail.com"
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
   - undefined
 architectures:

--- a/projects/easywsclient/project.yaml
+++ b/projects/easywsclient/project.yaml
@@ -3,7 +3,8 @@ language: c++
 primary_contact: "dhbaird@gmail.com"
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
   - undefined
 architectures:
   - x86_64

--- a/projects/exprtk/project.yaml
+++ b/projects/exprtk/project.yaml
@@ -10,5 +10,6 @@ fuzzing_engines:
 sanitizers:
     - address
     - undefined
-    - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# - memory
 main_repo: 'https://github.com/ArashPartow/exprtk.git'

--- a/projects/exprtk/project.yaml
+++ b/projects/exprtk/project.yaml
@@ -10,6 +10,6 @@ fuzzing_engines:
 sanitizers:
     - address
     - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 # - memory
 main_repo: 'https://github.com/ArashPartow/exprtk.git'

--- a/projects/file/project.yaml
+++ b/projects/file/project.yaml
@@ -3,7 +3,8 @@ language: c++
 primary_contact: "zoulasc@gmail.com"
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# - memory
   - undefined
 architectures:
   - x86_64

--- a/projects/file/project.yaml
+++ b/projects/file/project.yaml
@@ -3,7 +3,7 @@ language: c++
 primary_contact: "zoulasc@gmail.com"
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 # - memory
   - undefined
 architectures:

--- a/projects/ghostscript/project.yaml
+++ b/projects/ghostscript/project.yaml
@@ -10,6 +10,6 @@ auto_ccs:
   - "kdlee@chromium.org"
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
 main_repo: 'git://git.ghostscript.com/ghostpdl.git'

--- a/projects/ghostscript/project.yaml
+++ b/projects/ghostscript/project.yaml
@@ -10,5 +10,6 @@ auto_ccs:
   - "kdlee@chromium.org"
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
 main_repo: 'git://git.ghostscript.com/ghostpdl.git'

--- a/projects/glib/project.yaml
+++ b/projects/glib/project.yaml
@@ -8,6 +8,7 @@ auto_ccs:
 sanitizers:
 - address
 - undefined
-- memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
 help_url: https://gitlab.gnome.org/GNOME/glib/tree/master/fuzzing#how-to-reproduce-oss-fuzz-bugs-locally
 main_repo: 'https://gitlab.gnome.org/GNOME/glib'

--- a/projects/glib/project.yaml
+++ b/projects/glib/project.yaml
@@ -8,7 +8,7 @@ auto_ccs:
 sanitizers:
 - address
 - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
 help_url: https://gitlab.gnome.org/GNOME/glib/tree/master/fuzzing#how-to-reproduce-oss-fuzz-bugs-locally
 main_repo: 'https://gitlab.gnome.org/GNOME/glib'

--- a/projects/graphicsmagick/project.yaml
+++ b/projects/graphicsmagick/project.yaml
@@ -8,7 +8,7 @@ auto_ccs:
 sanitizers:
     - address
     - memory
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 # - memory
 architectures:
     - x86_64

--- a/projects/graphicsmagick/project.yaml
+++ b/projects/graphicsmagick/project.yaml
@@ -8,7 +8,8 @@ auto_ccs:
 sanitizers:
     - address
     - memory
-    - undefined
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# - memory
 architectures:
     - x86_64
     - i386

--- a/projects/grpc-httpjson-transcoding/project.yaml
+++ b/projects/grpc-httpjson-transcoding/project.yaml
@@ -16,4 +16,5 @@ fuzzing_engines:
 sanitizers:
 - address
 - undefined
-- memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory

--- a/projects/grpc-httpjson-transcoding/project.yaml
+++ b/projects/grpc-httpjson-transcoding/project.yaml
@@ -16,5 +16,5 @@ fuzzing_engines:
 sanitizers:
 - address
 - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory

--- a/projects/http-pattern-matcher/project.yaml
+++ b/projects/http-pattern-matcher/project.yaml
@@ -16,4 +16,5 @@ fuzzing_engines:
 sanitizers:
 - address
 - undefined
-- memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# - memory

--- a/projects/http-pattern-matcher/project.yaml
+++ b/projects/http-pattern-matcher/project.yaml
@@ -16,5 +16,5 @@ fuzzing_engines:
 sanitizers:
 - address
 - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 # - memory

--- a/projects/hunspell/project.yaml
+++ b/projects/hunspell/project.yaml
@@ -8,7 +8,8 @@ vendor_ccs:
   - "twsmith@mozilla.com"
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
   - undefined
 architectures:
  - i386

--- a/projects/hunspell/project.yaml
+++ b/projects/hunspell/project.yaml
@@ -8,7 +8,7 @@ vendor_ccs:
   - "twsmith@mozilla.com"
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
   - undefined
 architectures:

--- a/projects/ibmswtpm2/project.yaml
+++ b/projects/ibmswtpm2/project.yaml
@@ -7,5 +7,6 @@ auto_ccs:
   - "david.wooten@ieee.org"
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
   - undefined

--- a/projects/ibmswtpm2/project.yaml
+++ b/projects/ibmswtpm2/project.yaml
@@ -7,6 +7,6 @@ auto_ccs:
   - "david.wooten@ieee.org"
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
   - undefined

--- a/projects/icu/project.yaml
+++ b/projects/icu/project.yaml
@@ -11,7 +11,7 @@ auto_ccs:
  - ftang@google.com
 sanitizers:
  - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
 
 main_repo: 'https://github.com/unicode-org/icu.git'

--- a/projects/icu/project.yaml
+++ b/projects/icu/project.yaml
@@ -11,6 +11,7 @@ auto_ccs:
  - ftang@google.com
 sanitizers:
  - address
- - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
 
 main_repo: 'https://github.com/unicode-org/icu.git'

--- a/projects/imagemagick/project.yaml
+++ b/projects/imagemagick/project.yaml
@@ -7,7 +7,7 @@ auto_ccs:
   - urban.warrior.fuzz@gmail.com
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 # - memory
   - undefined
 architectures:

--- a/projects/imagemagick/project.yaml
+++ b/projects/imagemagick/project.yaml
@@ -7,7 +7,8 @@ auto_ccs:
   - urban.warrior.fuzz@gmail.com
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# - memory
   - undefined
 architectures:
   - x86_64

--- a/projects/json/project.yaml
+++ b/projects/json/project.yaml
@@ -6,5 +6,6 @@ auto_ccs:
 sanitizers:
  - address
  - undefined
- - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
 main_repo: 'https://github.com/nlohmann/json.git'

--- a/projects/json/project.yaml
+++ b/projects/json/project.yaml
@@ -6,6 +6,6 @@ auto_ccs:
 sanitizers:
  - address
  - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
 main_repo: 'https://github.com/nlohmann/json.git'

--- a/projects/jsoncpp/project.yaml
+++ b/projects/jsoncpp/project.yaml
@@ -6,6 +6,6 @@ auto_ccs:
 sanitizers:
   - address
   - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
 main_repo: 'https://github.com/open-source-parsers/jsoncpp'

--- a/projects/jsoncpp/project.yaml
+++ b/projects/jsoncpp/project.yaml
@@ -6,5 +6,6 @@ auto_ccs:
 sanitizers:
   - address
   - undefined
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
 main_repo: 'https://github.com/open-source-parsers/jsoncpp'

--- a/projects/jsonnet/project.yaml
+++ b/projects/jsonnet/project.yaml
@@ -7,7 +7,7 @@ auto_ccs:
 
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 # - memory
   - undefined
 

--- a/projects/jsonnet/project.yaml
+++ b/projects/jsonnet/project.yaml
@@ -7,7 +7,8 @@ auto_ccs:
 
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# - memory
   - undefined
 
 labels:

--- a/projects/karchive/project.yaml
+++ b/projects/karchive/project.yaml
@@ -3,7 +3,7 @@ language: c++
 primary_contact: tsdgeos@gmail.com
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
   - undefined
 main_repo: 'https://invent.kde.org/frameworks/karchive.git'

--- a/projects/karchive/project.yaml
+++ b/projects/karchive/project.yaml
@@ -3,6 +3,7 @@ language: c++
 primary_contact: tsdgeos@gmail.com
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
   - undefined
 main_repo: 'https://invent.kde.org/frameworks/karchive.git'

--- a/projects/kcodecs/project.yaml
+++ b/projects/kcodecs/project.yaml
@@ -3,6 +3,7 @@ language: c++
 primary_contact: tsdgeos@gmail.com
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
   - undefined
 main_repo: 'https://invent.kde.org/frameworks/kcodecs.git'

--- a/projects/kcodecs/project.yaml
+++ b/projects/kcodecs/project.yaml
@@ -3,7 +3,7 @@ language: c++
 primary_contact: tsdgeos@gmail.com
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
   - undefined
 main_repo: 'https://invent.kde.org/frameworks/kcodecs.git'

--- a/projects/keystone/project.yaml
+++ b/projects/keystone/project.yaml
@@ -6,6 +6,7 @@ auto_ccs :
   - "stalkr@stalkr.net"
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
   - undefined
 main_repo: 'https://github.com/keystone-engine/keystone.git'

--- a/projects/keystone/project.yaml
+++ b/projects/keystone/project.yaml
@@ -6,7 +6,7 @@ auto_ccs :
   - "stalkr@stalkr.net"
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
   - undefined
 main_repo: 'https://github.com/keystone-engine/keystone.git'

--- a/projects/kimageformats/project.yaml
+++ b/projects/kimageformats/project.yaml
@@ -3,7 +3,7 @@ language: c++
 primary_contact: tsdgeos@gmail.com
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 # - memory
   - undefined
 main_repo: 'https://invent.kde.org/frameworks/kimageformats.git'

--- a/projects/kimageformats/project.yaml
+++ b/projects/kimageformats/project.yaml
@@ -3,6 +3,7 @@ language: c++
 primary_contact: tsdgeos@gmail.com
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# - memory
   - undefined
 main_repo: 'https://invent.kde.org/frameworks/kimageformats.git'

--- a/projects/leveldb/project.yaml
+++ b/projects/leveldb/project.yaml
@@ -6,6 +6,6 @@ auto_ccs :
   - "david@adalogics.com"
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
 main_repo: 'https://github.com/google/leveldb.git'

--- a/projects/leveldb/project.yaml
+++ b/projects/leveldb/project.yaml
@@ -6,5 +6,6 @@ auto_ccs :
   - "david@adalogics.com"
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
 main_repo: 'https://github.com/google/leveldb.git'

--- a/projects/libecc/project.yaml
+++ b/projects/libecc/project.yaml
@@ -7,7 +7,8 @@ auto_ccs:
 sanitizers:
  - address
  - undefined
- - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
 architectures:
  - x86_64
  - i386

--- a/projects/libecc/project.yaml
+++ b/projects/libecc/project.yaml
@@ -7,7 +7,7 @@ auto_ccs:
 sanitizers:
  - address
  - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
 architectures:
  - x86_64

--- a/projects/libevent/project.yaml
+++ b/projects/libevent/project.yaml
@@ -3,7 +3,8 @@ language: c++
 primary_contact: "a3at.mail@gmail.com"
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
   - undefined
 architectures:
   - x86_64

--- a/projects/libevent/project.yaml
+++ b/projects/libevent/project.yaml
@@ -3,7 +3,7 @@ language: c++
 primary_contact: "a3at.mail@gmail.com"
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
   - undefined
 architectures:

--- a/projects/libjxl/project.yaml
+++ b/projects/libjxl/project.yaml
@@ -6,6 +6,7 @@ auto_ccs:
   - "veluca@google.com"
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
   - undefined
 main_repo: 'https://github.com/libjxl/libjxl.git'

--- a/projects/libjxl/project.yaml
+++ b/projects/libjxl/project.yaml
@@ -6,7 +6,7 @@ auto_ccs:
   - "veluca@google.com"
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
   - undefined
 main_repo: 'https://github.com/libjxl/libjxl.git'

--- a/projects/librawspeed/project.yaml
+++ b/projects/librawspeed/project.yaml
@@ -4,5 +4,6 @@ primary_contact: "lebedev.ri@gmail.com"
 sanitizers:
 - address
 - undefined
-- memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# - memory
 main_repo: 'https://github.com/darktable-org/rawspeed.git'

--- a/projects/librawspeed/project.yaml
+++ b/projects/librawspeed/project.yaml
@@ -4,6 +4,6 @@ primary_contact: "lebedev.ri@gmail.com"
 sanitizers:
 - address
 - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 # - memory
 main_repo: 'https://github.com/darktable-org/rawspeed.git'

--- a/projects/libreoffice/project.yaml
+++ b/projects/libreoffice/project.yaml
@@ -3,8 +3,9 @@ language: c++
 primary_contact: "caolanm@redhat.com"
 sanitizers:
   - address
-  - memory:
-      experimental: True
+  # Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+  # - memory
+  #    experimental: True
   - undefined
 fuzzing_engines:
   # see https://github.com/google/oss-fuzz/issues/6233 for missing afl

--- a/projects/libreoffice/project.yaml
+++ b/projects/libreoffice/project.yaml
@@ -3,7 +3,7 @@ language: c++
 primary_contact: "caolanm@redhat.com"
 sanitizers:
   - address
-  # Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+  # Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
   # - memory
   #    experimental: True
   - undefined

--- a/projects/libsass/project.yaml
+++ b/projects/libsass/project.yaml
@@ -4,7 +4,8 @@ primary_contact: "xzyfer@gmail.com"
 
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
   - undefined
 
 labels:

--- a/projects/libsass/project.yaml
+++ b/projects/libsass/project.yaml
@@ -4,7 +4,7 @@ primary_contact: "xzyfer@gmail.com"
 
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
   - undefined
 

--- a/projects/libssh/project.yaml
+++ b/projects/libssh/project.yaml
@@ -7,6 +7,7 @@ auto_ccs:
  - "anderson.sasaki@gmail.com"
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
   - undefined
 main_repo: 'https://git.libssh.org/projects/libssh.git'

--- a/projects/libssh/project.yaml
+++ b/projects/libssh/project.yaml
@@ -7,7 +7,7 @@ auto_ccs:
  - "anderson.sasaki@gmail.com"
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
   - undefined
 main_repo: 'https://git.libssh.org/projects/libssh.git'

--- a/projects/libtiff/project.yaml
+++ b/projects/libtiff/project.yaml
@@ -5,7 +5,8 @@ auto_ccs:
   - paul.l.kehrer@gmail.com
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
   - undefined
 architectures:
   - x86_64

--- a/projects/libtiff/project.yaml
+++ b/projects/libtiff/project.yaml
@@ -5,7 +5,7 @@ auto_ccs:
   - paul.l.kehrer@gmail.com
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
   - undefined
 architectures:

--- a/projects/mercurial/project.yaml
+++ b/projects/mercurial/project.yaml
@@ -9,6 +9,6 @@ auto_ccs:
 sanitizers:
   - address
   - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
 coverage_extra_args: -ignore-filename-regex=.*/sanpy/.*

--- a/projects/mercurial/project.yaml
+++ b/projects/mercurial/project.yaml
@@ -9,5 +9,6 @@ auto_ccs:
 sanitizers:
   - address
   - undefined
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
 coverage_extra_args: -ignore-filename-regex=.*/sanpy/.*

--- a/projects/myanmar-tools/project.yaml
+++ b/projects/myanmar-tools/project.yaml
@@ -5,7 +5,7 @@ auto_ccs:
   - "ccornelius@google.com"
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 # - memory
 coverage_extra_args: -ignore-filename-regex=.*/\.hunter/.*
 main_repo: 'https://github.com/google/myanmar-tools.git'

--- a/projects/myanmar-tools/project.yaml
+++ b/projects/myanmar-tools/project.yaml
@@ -5,6 +5,7 @@ auto_ccs:
   - "ccornelius@google.com"
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# - memory
 coverage_extra_args: -ignore-filename-regex=.*/\.hunter/.*
 main_repo: 'https://github.com/google/myanmar-tools.git'

--- a/projects/nettle/project.yaml
+++ b/projects/nettle/project.yaml
@@ -6,7 +6,7 @@ auto_ccs:
 sanitizers:
  - address
  - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 # - memory
 architectures:
  - x86_64

--- a/projects/nettle/project.yaml
+++ b/projects/nettle/project.yaml
@@ -6,7 +6,8 @@ auto_ccs:
 sanitizers:
  - address
  - undefined
- - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# - memory
 architectures:
  - x86_64
  - i386

--- a/projects/ninja/project.yaml
+++ b/projects/ninja/project.yaml
@@ -6,6 +6,6 @@ auto_ccs:
 sanitizers:
   - address
   - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
 main_repo: "https://github.com/ninja-build/ninja"

--- a/projects/ninja/project.yaml
+++ b/projects/ninja/project.yaml
@@ -6,5 +6,6 @@ auto_ccs:
 sanitizers:
   - address
   - undefined
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
 main_repo: "https://github.com/ninja-build/ninja"

--- a/projects/njs/project.yaml
+++ b/projects/njs/project.yaml
@@ -6,7 +6,8 @@ auto_ccs:
  - "devrep@nginx.com"
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
   - undefined
 coverage_extra_args: -ignore-filename-regex=.*/pcre/.*
 main_repo: 'https://github.com/nginx/njs.git'

--- a/projects/njs/project.yaml
+++ b/projects/njs/project.yaml
@@ -6,7 +6,7 @@ auto_ccs:
  - "devrep@nginx.com"
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
   - undefined
 coverage_extra_args: -ignore-filename-regex=.*/pcre/.*

--- a/projects/opencv/project.yaml
+++ b/projects/opencv/project.yaml
@@ -12,7 +12,8 @@ auto_ccs:
 sanitizers:
   - address
   - undefined
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
 
 labels:
   imdecode_fuzzer:

--- a/projects/opencv/project.yaml
+++ b/projects/opencv/project.yaml
@@ -12,7 +12,7 @@ auto_ccs:
 sanitizers:
   - address
   - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
 
 labels:

--- a/projects/opendnp3/project.yaml
+++ b/projects/opendnp3/project.yaml
@@ -7,7 +7,7 @@ auto_ccs :
 
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
   - undefined
 main_repo: 'https://github.com/dnp3/opendnp3.git'

--- a/projects/opendnp3/project.yaml
+++ b/projects/opendnp3/project.yaml
@@ -7,6 +7,7 @@ auto_ccs :
 
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
   - undefined
 main_repo: 'https://github.com/dnp3/opendnp3.git'

--- a/projects/poppler/project.yaml
+++ b/projects/poppler/project.yaml
@@ -3,7 +3,8 @@ language: c++
 primary_contact: tsdgeos@gmail.com
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
   - undefined
 auto_ccs:
   - jonathan@titanous.com

--- a/projects/poppler/project.yaml
+++ b/projects/poppler/project.yaml
@@ -3,7 +3,7 @@ language: c++
 primary_contact: tsdgeos@gmail.com
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
   - undefined
 auto_ccs:

--- a/projects/protobuf-c/project.yaml
+++ b/projects/protobuf-c/project.yaml
@@ -5,7 +5,8 @@ auto_ccs:
   - "ilya.lipnitskiy@gmail.com"
 sanitizers:
  - address
- - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
 architectures:
  - x86_64
  - i386

--- a/projects/protobuf-c/project.yaml
+++ b/projects/protobuf-c/project.yaml
@@ -5,7 +5,7 @@ auto_ccs:
   - "ilya.lipnitskiy@gmail.com"
 sanitizers:
  - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
 architectures:
  - x86_64

--- a/projects/qpdf/project.yaml
+++ b/projects/qpdf/project.yaml
@@ -4,5 +4,6 @@ primary_contact: "qberkenbilt@gmail.com"
 sanitizers:
   - address
   - undefined
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
 main_repo: 'https://github.com/qpdf/qpdf.git'

--- a/projects/qpdf/project.yaml
+++ b/projects/qpdf/project.yaml
@@ -4,6 +4,6 @@ primary_contact: "qberkenbilt@gmail.com"
 sanitizers:
   - address
   - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
 main_repo: 'https://github.com/qpdf/qpdf.git'

--- a/projects/re2/project.yaml
+++ b/projects/re2/project.yaml
@@ -3,7 +3,8 @@ language: c++
 primary_contact: "junyer@google.com"
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
   - undefined
 architectures:
   - x86_64

--- a/projects/re2/project.yaml
+++ b/projects/re2/project.yaml
@@ -3,7 +3,7 @@ language: c++
 primary_contact: "junyer@google.com"
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
   - undefined
 architectures:

--- a/projects/relic/project.yaml
+++ b/projects/relic/project.yaml
@@ -7,7 +7,8 @@ auto_ccs:
 sanitizers:
  - address
  - undefined
- - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
 architectures:
  - x86_64
  - i386

--- a/projects/relic/project.yaml
+++ b/projects/relic/project.yaml
@@ -7,7 +7,7 @@ auto_ccs:
 sanitizers:
  - address
  - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
 architectures:
  - x86_64

--- a/projects/sentencepiece/project.yaml
+++ b/projects/sentencepiece/project.yaml
@@ -3,7 +3,8 @@ language: c++
 primary_contact: "taku@google.com"
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
   - undefined
 architectures:
   - x86_64

--- a/projects/sentencepiece/project.yaml
+++ b/projects/sentencepiece/project.yaml
@@ -3,7 +3,7 @@ language: c++
 primary_contact: "taku@google.com"
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
   - undefined
 architectures:

--- a/projects/skia/project.yaml
+++ b/projects/skia/project.yaml
@@ -14,7 +14,7 @@ vendor_ccs:
 sanitizers:
  - address
  - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 # - memory
 help_url: "https://skia.org/dev/testing/fuzz"
 builds_per_day: 4

--- a/projects/skia/project.yaml
+++ b/projects/skia/project.yaml
@@ -14,7 +14,8 @@ vendor_ccs:
 sanitizers:
  - address
  - undefined
- - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# - memory
 help_url: "https://skia.org/dev/testing/fuzz"
 builds_per_day: 4
 main_repo: 'https://skia.googlesource.com/skia.git'

--- a/projects/spdlog/project.yaml
+++ b/projects/spdlog/project.yaml
@@ -3,7 +3,7 @@ language: c++
 primary_contact: "gmelman1@gmail.com"
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 # - memory
   - undefined
 main_repo: 'https://github.com/gabime/spdlog.git'

--- a/projects/spdlog/project.yaml
+++ b/projects/spdlog/project.yaml
@@ -3,6 +3,7 @@ language: c++
 primary_contact: "gmelman1@gmail.com"
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# - memory
   - undefined
 main_repo: 'https://github.com/gabime/spdlog.git'

--- a/projects/spice-usbredir/project.yaml
+++ b/projects/spice-usbredir/project.yaml
@@ -5,7 +5,7 @@ auto_ccs:
   - "imsnah@gmail.com"
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
   - undefined
 main_repo: "https://gitlab.freedesktop.org/spice/usbredir.git"

--- a/projects/spice-usbredir/project.yaml
+++ b/projects/spice-usbredir/project.yaml
@@ -5,6 +5,7 @@ auto_ccs:
   - "imsnah@gmail.com"
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
   - undefined
 main_repo: "https://gitlab.freedesktop.org/spice/usbredir.git"

--- a/projects/tcmalloc/project.yaml
+++ b/projects/tcmalloc/project.yaml
@@ -6,5 +6,5 @@ auto_ccs:
  - "david@adalogics.com"
 sanitizers:
  - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 # - memory

--- a/projects/tcmalloc/project.yaml
+++ b/projects/tcmalloc/project.yaml
@@ -2,8 +2,9 @@ homepage: "tcmalloc"
 language: c++
 primary_contact: "ckennelly@google.com"
 main_repo: "https://github.com/google/tcmalloc"
-auto_ccs: 
+auto_ccs:
  - "david@adalogics.com"
 sanitizers:
  - address
- - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# - memory

--- a/projects/unrar/project.yaml
+++ b/projects/unrar/project.yaml
@@ -5,7 +5,7 @@ auto_ccs:
   - "vakh@chromium.org"
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
   - undefined
 main_repo: 'https://github.com/aawc/unrar.git'

--- a/projects/unrar/project.yaml
+++ b/projects/unrar/project.yaml
@@ -5,6 +5,7 @@ auto_ccs:
   - "vakh@chromium.org"
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
   - undefined
 main_repo: 'https://github.com/aawc/unrar.git'

--- a/projects/uriparser/project.yaml
+++ b/projects/uriparser/project.yaml
@@ -3,7 +3,7 @@ language: c++
 primary_contact: "webmaster@hartwork.org"
 sanitizers:
  - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
  - undefined
 architectures:

--- a/projects/uriparser/project.yaml
+++ b/projects/uriparser/project.yaml
@@ -3,7 +3,8 @@ language: c++
 primary_contact: "webmaster@hartwork.org"
 sanitizers:
  - address
- - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
  - undefined
 architectures:
   - x86_64

--- a/projects/usbguard/project.yaml
+++ b/projects/usbguard/project.yaml
@@ -4,7 +4,7 @@ primary_contact: "rsroka@redhat.com"
 sanitizers:
  - address
  - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
 auto_ccs:
  - "alakatos@redhat.com"

--- a/projects/usbguard/project.yaml
+++ b/projects/usbguard/project.yaml
@@ -4,7 +4,8 @@ primary_contact: "rsroka@redhat.com"
 sanitizers:
  - address
  - undefined
- - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
 auto_ccs:
  - "alakatos@redhat.com"
  - "allenwebb@google.com"

--- a/projects/uwebsockets/project.yaml
+++ b/projects/uwebsockets/project.yaml
@@ -4,7 +4,7 @@ primary_contact: "alexhultman@gmail.com"
 builds_per_day: 4
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
   - undefined
 main_repo: 'https://github.com/uNetworking/uWebSockets.git'

--- a/projects/uwebsockets/project.yaml
+++ b/projects/uwebsockets/project.yaml
@@ -4,6 +4,7 @@ primary_contact: "alexhultman@gmail.com"
 builds_per_day: 4
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
   - undefined
 main_repo: 'https://github.com/uNetworking/uWebSockets.git'

--- a/projects/znc/project.yaml
+++ b/projects/znc/project.yaml
@@ -7,5 +7,6 @@ auto_ccs:
 sanitizers:
   - address
   - undefined
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
 main_repo: "https://github.com/znc/znc"

--- a/projects/znc/project.yaml
+++ b/projects/znc/project.yaml
@@ -7,6 +7,6 @@ auto_ccs:
 sanitizers:
   - address
   - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
 main_repo: "https://github.com/znc/znc"

--- a/projects/zopfli/project.yaml
+++ b/projects/zopfli/project.yaml
@@ -3,6 +3,7 @@ language: c++
 primary_contact: "lode@google.com"
 sanitizers:
   - address
-  - memory
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+#  - memory
   - undefined
 main_repo: 'https://github.com/google/zopfli'

--- a/projects/zopfli/project.yaml
+++ b/projects/zopfli/project.yaml
@@ -3,7 +3,7 @@ language: c++
 primary_contact: "lode@google.com"
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6180
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
   - undefined
 main_repo: 'https://github.com/google/zopfli'


### PR DESCRIPTION
These projects were tested and it was found that their use
of MSAN does not work on Ubuntu 20.04. Therefore their use of
MSAN is being disabled.

Related: #6180