### PR TITLE
docs: remove minijail doc.

### DIFF
--- a/docs/further-reading/fuzzer_environment.md
+++ b/docs/further-reading/fuzzer_environment.md
@@ -9,8 +9,7 @@ permalink: /further-reading/fuzzer-environment/
 # Fuzzer environment on ClusterFuzz
 
 Your fuzz targets will be run on a
-[Google Compute Engine](https://cloud.google.com/compute/) VM (Linux) with some
-[security restrictions](https://github.com/google/oss-fuzz/blob/master/infra/base-images/base-runner/run_minijail).
+[Google Compute Engine](https://cloud.google.com/compute/) VM (Linux).
 
 - TOC
 {:toc}


### PR DESCRIPTION
Minijail is no longer used. Please take a look @jonathanmetzman @oliverchang @inferno-chromium in case I misunderstood.

Solves https://github.com/google/oss-fuzz/issues/6284