### PR TITLE
Pin Rust toolchain to pre-LLVM-13 version

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -90,10 +90,15 @@ RUN go get -u github.com/mdempsky/go114-fuzz-build && \
 ENV CARGO_HOME=/rust
 ENV RUSTUP_HOME=/rust/rustup
 ENV PATH=$PATH:/rust/bin
-RUN curl https://sh.rustup.rs | sh -s -- -y --default-toolchain=nightly --profile=minimal
+# TODO: the nightly Rust toolchain is now using LLVM 13 as-of
+# rust-lang/rust#87570, but LLVM 13 is incompatible with the tools used in the
+# fuzzing images at this time. For now pin the nightly toolchain to a nightly
+# just before the LLVM 13 nightly, and when fuzzing tooling is otherwise
+# LLVM-13-compatible this should switch back to the nightly channel.
+RUN curl https://sh.rustup.rs | sh -s -- -y --default-toolchain=nightly-2021-08-20 --profile=minimal
 RUN cargo install cargo-fuzz && rm -rf /rust/registry
 # Needed to recompile rust std library for MSAN
-RUN rustup component add rust-src --toolchain nightly
+RUN rustup component add rust-src --toolchain nightly-2021-08-20
 # Set up custom environment variable for source code copy for coverage reports
 ENV OSSFUZZ_RUSTPATH /rust
 

--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -169,7 +169,7 @@ COPY_SOURCES_CMD="cp -rL --parents $SRC $WORK /usr/include /usr/local/include $G
 # Copy rust std lib to its path with a hash
 export rustch=`rustc --version --verbose | grep commit-hash | cut -d' ' -f2`
 mkdir -p /rustc/$rustch/
-cp -r /rust/rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/ /rustc/$rustch/
+cp -r `rustc --print sysroot`/lib/rustlib/src/rust/library/ /rustc/$rustch/
 
 if [ "${BUILD_UID-0}" -ne "0" ]; then
   adduser -u $BUILD_UID --disabled-password --gecos '' builder


### PR DESCRIPTION
Typically Rust projects on oss-fuzz use the nightly channel to get the
latest compiler, but the new LLVM 13-based compiler seems to be
incompatible with the other fuzzing tooling that oss-fuzz is using, so
hold Rust back at LLVM 12 now until oss-fuzz tooling has a chance to
update.