### PR TITLE
[Ubuntu upgade][lldb-eval] Install python to partially fix build

### DIFF
--- a/projects/lldb-eval/Dockerfile
+++ b/projects/lldb-eval/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN apt-get update \
-    && apt-get install -y wget git patchelf zlib1g-dev libtinfo-dev --no-install-recommends
+    && apt-get install -y wget git patchelf zlib1g-dev python libtinfo-dev --no-install-recommends
 
 RUN git clone --depth 1 https://github.com/google/lldb-eval
 


### PR DESCRIPTION
There are still other issues preventing lldb-eval from building.
related: #6180.