### PR TITLE
[Ubuntu upgrade][infra] Fix issue with write_labels.py

### DIFF
--- a/infra/base-images/base-builder/write_labels.py
+++ b/infra/base-images/base-builder/write_labels.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
/usr/bin/python3 doesn't exist and isn't pythonic. Change shebang
to "/usr/bin/env python3"

Related: #6180