### PR TITLE
[Ubuntu upgrade] Pin projects to Xenial where fuzzer build fails.

### DIFF
--- a/projects/bitcoin-core/Dockerfile
+++ b/projects/bitcoin-core/Dockerfile
@@ -14,7 +14,11 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
+# See https://github.com/google/oss-fuzz/issues/6291 for more details.
+FROM gcr.io/oss-fuzz-base/base-builder:xenial
+# Delete line above and uncomment line below to upgrade to 20.04.
+# FROM gcr.io/oss-fuzz-base/base-builder
 
 # Packages taken from:
 # * https://github.com/bitcoin/bitcoin/blob/master/doc/build-unix.md#dependency-build-instructions

--- a/projects/gdal/Dockerfile
+++ b/projects/gdal/Dockerfile
@@ -14,7 +14,11 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
+# See https://github.com/google/oss-fuzz/issues/6291 for more details.
+FROM gcr.io/oss-fuzz-base/base-builder:xenial
+# Delete line above and uncomment line below to upgrade to 20.04.
+# FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && \
     apt-get install -y make autoconf automake libtool g++ curl cmake sqlite3 pkg-config
 

--- a/projects/gnutls/Dockerfile
+++ b/projects/gnutls/Dockerfile
@@ -14,7 +14,11 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
+# See https://github.com/google/oss-fuzz/issues/6291 for more details.
+FROM gcr.io/oss-fuzz-base/base-builder:xenial
+# Delete line above and uncomment line below to upgrade to 20.04.
+# FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y \
  make \
  pkg-config \

--- a/projects/gstreamer/Dockerfile
+++ b/projects/gstreamer/Dockerfile
@@ -14,7 +14,11 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
+# See https://github.com/google/oss-fuzz/issues/6291 for more details.
+FROM gcr.io/oss-fuzz-base/base-builder:xenial
+# Delete line above and uncomment line below to upgrade to 20.04.
+# FROM gcr.io/oss-fuzz-base/base-builder
 # Install the build dependencies
 
 # install the minimum

--- a/projects/hermes/Dockerfile
+++ b/projects/hermes/Dockerfile
@@ -14,7 +14,11 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
+# See https://github.com/google/oss-fuzz/issues/6291 for more details.
+FROM gcr.io/oss-fuzz-base/base-builder:xenial
+# Delete line above and uncomment line below to upgrade to 20.04.
+# FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && \
     apt-get install -y make autoconf automake libtool wget libicu-dev \
     ninja-build python zip libreadline-dev libatomic-ops-dev

--- a/projects/libarchive/Dockerfile
+++ b/projects/libarchive/Dockerfile
@@ -14,7 +14,11 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
+# See https://github.com/google/oss-fuzz/issues/6291 for more details.
+FROM gcr.io/oss-fuzz-base/base-builder:xenial
+# Delete line above and uncomment line below to upgrade to 20.04.
+# FROM gcr.io/oss-fuzz-base/base-builder
 
 # Installing optional libraries can utilize more code path and/or improve
 # performance (avoid calling external programs).

--- a/projects/libass/Dockerfile
+++ b/projects/libass/Dockerfile
@@ -14,7 +14,11 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
+# See https://github.com/google/oss-fuzz/issues/6291 for more details.
+FROM gcr.io/oss-fuzz-base/base-builder:xenial
+# Delete line above and uncomment line below to upgrade to 20.04.
+# FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config libfreetype6-dev libfontconfig1-dev python3-pip && \
     pip3 install meson==0.53.0 ninja
 

--- a/projects/libphonenumber/Dockerfile
+++ b/projects/libphonenumber/Dockerfile
@@ -14,7 +14,11 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
+# See https://github.com/google/oss-fuzz/issues/6291 for more details.
+FROM gcr.io/oss-fuzz-base/base-builder:xenial
+# Delete line above and uncomment line below to upgrade to 20.04.
+# FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y autoconf automake libtool g++ cmake-curses-gui libgtest-dev libre2-dev libicu-dev libboost-dev libboost-thread-dev libboost-system-dev binutils ninja-build liblzma-dev libz-dev pkg-config wget openjdk-8-jdk
 
 WORKDIR $SRC/

--- a/projects/libvips/Dockerfile
+++ b/projects/libvips/Dockerfile
@@ -14,7 +14,11 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
+# See https://github.com/google/oss-fuzz/issues/6291 for more details.
+FROM gcr.io/oss-fuzz-base/base-builder:xenial
+# Delete line above and uncomment line below to upgrade to 20.04.
+# FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y \
   curl \
   automake \

--- a/projects/nettle/Dockerfile
+++ b/projects/nettle/Dockerfile
@@ -14,7 +14,11 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
+# See https://github.com/google/oss-fuzz/issues/6291 for more details.
+FROM gcr.io/oss-fuzz-base/base-builder:xenial
+# Delete line above and uncomment line below to upgrade to 20.04.
+# FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get install -y software-properties-common make autoconf build-essential wget lzip libtool python
 RUN git clone --depth 1 https://git.lysator.liu.se/nettle/nettle
 RUN git clone --depth 1 https://github.com/randombit/botan.git

--- a/projects/osquery/Dockerfile
+++ b/projects/osquery/Dockerfile
@@ -14,7 +14,11 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
+# See https://github.com/google/oss-fuzz/issues/6291 for more details.
+FROM gcr.io/oss-fuzz-base/base-builder:xenial
+# Delete line above and uncomment line below to upgrade to 20.04.
+# FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends python python3 bison flex make wget xz-utils libunwind-dev
 

--- a/projects/proxygen/Dockerfile
+++ b/projects/proxygen/Dockerfile
@@ -14,7 +14,11 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
+# See https://github.com/google/oss-fuzz/issues/6291 for more details.
+FROM gcr.io/oss-fuzz-base/base-builder:xenial
+# Delete line above and uncomment line below to upgrade to 20.04.
+# FROM gcr.io/oss-fuzz-base/base-builder
 
 # Install packages we need to build dependencies
 RUN apt-get update && \

--- a/projects/samba/Dockerfile
+++ b/projects/samba/Dockerfile
@@ -14,7 +14,11 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
+# See https://github.com/google/oss-fuzz/issues/6291 for more details.
+FROM gcr.io/oss-fuzz-base/base-builder:xenial
+# Delete line above and uncomment line below to upgrade to 20.04.
+# FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN git clone https://gitlab.com/samba-team/samba samba
 RUN samba/lib/fuzzing/oss-fuzz/build_image.sh

--- a/projects/thrift/Dockerfile
+++ b/projects/thrift/Dockerfile
@@ -14,7 +14,11 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
+# See https://github.com/google/oss-fuzz/issues/6291 for more details.
+FROM gcr.io/oss-fuzz-base/base-builder:xenial
+# Delete line above and uncomment line below to upgrade to 20.04.
+# FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y libssl-dev pkg-config autoconf automake libtool bison flex libboost-all-dev
 RUN git clone --depth 1 https://github.com/apache/thrift
 WORKDIR $SRC/thrift

--- a/projects/tor/Dockerfile
+++ b/projects/tor/Dockerfile
@@ -14,7 +14,11 @@
 #
 ##############################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
+# See https://github.com/google/oss-fuzz/issues/6291 for more details.
+FROM gcr.io/oss-fuzz-base/base-builder:xenial
+# Delete line above and uncomment line below to upgrade to 20.04.
+# FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y autoconf automake make libtool pkg-config
 RUN git clone --depth 1 https://git.torproject.org/tor.git
 RUN git clone --depth 1 https://git.torproject.org/fuzzing-corpora.git tor-fuzz-corpora

--- a/projects/wasm3/Dockerfile
+++ b/projects/wasm3/Dockerfile
@@ -14,7 +14,11 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
+# See https://github.com/google/oss-fuzz/issues/6291 for more details.
+FROM gcr.io/oss-fuzz-base/base-builder:xenial
+# Delete line above and uncomment line below to upgrade to 20.04.
+# FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make
 RUN git clone --depth 1 https://github.com/wasm3/wasm3
 WORKDIR wasm3

--- a/projects/wget/Dockerfile
+++ b/projects/wget/Dockerfile
@@ -14,7 +14,11 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
+# See https://github.com/google/oss-fuzz/issues/6291 for more details.
+FROM gcr.io/oss-fuzz-base/base-builder:xenial
+# Delete line above and uncomment line below to upgrade to 20.04.
+# FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y \
  make \
  pkg-config \

--- a/projects/wget2/Dockerfile
+++ b/projects/wget2/Dockerfile
@@ -14,7 +14,11 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
+# See https://github.com/google/oss-fuzz/issues/6291 for more details.
+FROM gcr.io/oss-fuzz-base/base-builder:xenial
+# Delete line above and uncomment line below to upgrade to 20.04.
+# FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y \
  make \
  pkg-config \


### PR DESCRIPTION
This does not include coverage build failures.
Related: #6180.