### PR TITLE
mdbtools: Disable silent rules when configuring

### DIFF
--- a/projects/mdbtools/build.sh
+++ b/projects/mdbtools/build.sh
@@ -17,7 +17,7 @@
 ################################################################################
 
 autoreconf -f -i
-./configure --enable-static --disable-man --disable-glib
+./configure --enable-static --disable-man --disable-glib --disable-silent-rules
 make clean
 
 make


### PR DESCRIPTION
This will assist with debugging a failed CIFuzz action build:

https://github.com/mdbtools/mdbtools/pull/333/checks?check_run_id=3403232791