### PR TITLE
[Ubuntu upgrade] Fix projects so they don't break with upgrade.

### DIFF
--- a/projects/bignum-fuzzer/Dockerfile
+++ b/projects/bignum-fuzzer/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y software-properties-common python-software-properties wget curl sudo mercurial autoconf bison texinfo libboost-all-dev cmake
+RUN apt-get update && apt-get install -y software-properties-common curl sudo mercurial autoconf bison texinfo libboost-all-dev cmake wget
 
 RUN wget https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.5.1.tar.gz
 RUN git clone --depth 1 https://github.com/guidovranken/bignum-fuzzer

--- a/projects/clib/Dockerfile
+++ b/projects/clib/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make cmake ninja libcurl4-gnutls-dev -qq
+RUN apt-get update && apt-get install -y make cmake libcurl4-gnutls-dev -qq
 RUN git clone https://github.com/clibs/clib
 WORKDIR $SRC/
 COPY build.sh $SRC/

--- a/projects/containerd/Dockerfile
+++ b/projects/containerd/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y btrfs-progs libc-dev pkg-config libseccomp-dev gcc wget
+RUN apt-get update && apt-get install -y btrfs-progs libc-dev pkg-config libseccomp-dev gcc wget libbtrfs-dev
 RUN git clone --depth 1 https://github.com/containerd/containerd
 COPY build.sh $SRC/
 WORKDIR $SRC/containerd

--- a/projects/cpython3/Dockerfile
+++ b/projects/cpython3/Dockerfile
@@ -1,4 +1,8 @@
-FROM gcr.io/oss-fuzz-base/base-builder
+# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
+# See https://github.com/google/oss-fuzz/issues/6291 for more details.
+FROM gcr.io/oss-fuzz-base/base-builder:xenial
+# Delete line above and uncomment line below to upgrade to 20.04.
+# FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN apt-get update
 RUN apt-get install -y build-essential libncursesw5-dev \

--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && \
     wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add - && \
     apt-add-repository 'deb https://apt.kitware.com/ubuntu/ xenial main' && \
     apt-get update && \
-    apt-get install -y software-properties-common python-software-properties make autoconf automake libtool build-essential cmake mercurial gyp ninja-build zlib1g-dev libsqlite3-dev bison flex texinfo
+    apt-get install -y software-properties-common wget make autoconf automake libtool build-essential cmake mercurial gyp ninja-build zlib1g-dev libsqlite3-dev bison flex texinfo
 
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora

--- a/projects/firefox/Dockerfile
+++ b/projects/firefox/Dockerfile
@@ -15,13 +15,16 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
-  gawk \
-  libstdc++6 \
-  m4 \
-  python \
-  software-properties-common
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+      gawk \
+      libstdc++6 \
+      m4 \
+      python
 
 # This wrapper of cargo seems to interfere with our build system.
 RUN rm -f /usr/local/bin/cargo

--- a/projects/flac/build.sh
+++ b/projects/flac/build.sh
@@ -53,7 +53,7 @@ cd $SRC/fuzzing-headers
 
 # Build fuzzers
 cd $SRC/flac-fuzzers/
-$CXX $CXXFLAGS -I $SRC/flac/include/ -I $SRC/ExoPlayer/extensions/flac/src/main/jni/ -I /usr/lib/jvm/java-8-openjdk-amd64/include/ -I /usr/lib/jvm/java-8-openjdk-amd64/include/linux/ fuzzer_exo.cpp \
+$CXX $CXXFLAGS -I $SRC/flac/include/ -I $SRC/ExoPlayer/extensions/flac/src/main/jni/ -I /usr/lib/jvm/java-11-openjdk-amd64/include/ -I /usr/lib/jvm/java-11-openjdk-amd64/include/linux/ fuzzer_exo.cpp \
     $SRC/flac/src/libFLAC++/.libs/libFLAC++.a $SRC/flac/src/libFLAC/.libs/libFLAC.a $SRC/libogg-install/lib/libogg.a $LIB_FUZZING_ENGINE -o $OUT/fuzzer_exo
 $CXX $CXXFLAGS -I $SRC/flac/include/ fuzzer_decoder.cpp $SRC/flac/src/libFLAC++/.libs/libFLAC++.a $SRC/flac/src/libFLAC/.libs/libFLAC.a $SRC/libogg-install/lib/libogg.a $LIB_FUZZING_ENGINE -o $OUT/fuzzer_decoder
 $CXX $CXXFLAGS -I $SRC/flac/include/ fuzzer_encoder.cpp $SRC/flac/src/libFLAC++/.libs/libFLAC++.a $SRC/flac/src/libFLAC/.libs/libFLAC.a $SRC/libogg-install/lib/libogg.a $LIB_FUZZING_ENGINE -o $OUT/fuzzer_encoder

--- a/projects/git/Dockerfile
+++ b/projects/git/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
         cvs cvsps gettext libcgi-pm-perl libcurl4-gnutls-dev \
         libdbd-sqlite3-perl liberror-perl libexpat1-dev libhttp-date-perl \
         libio-pty-perl libmailtools-perl libpcre2-dev libpcre3-dev libsvn-perl \
-        libtime-modules-perl libyaml-perl libz-dev python subversion tcl unzip \
+        perl-modules libyaml-perl libz-dev python subversion tcl unzip \
         asciidoc docbook-xsl xmlto libssl-dev zip
 RUN git clone https://github.com/git/git git
 WORKDIR git

--- a/projects/gnutls/build.sh
+++ b/projects/gnutls/build.sh
@@ -16,9 +16,9 @@
 ################################################################################
 
 export DEPS_PATH=$SRC/deps
-export PKG_CONFIG_PATH=$DEPS_PATH/lib/pkgconfig
+export PKG_CONFIG_PATH=$DEPS_PATH/lib64/pkgconfig:$DEPS_PATH/lib/pkgconfig
 export CPPFLAGS="-I$DEPS_PATH/include"
-export LDFLAGS="-L$DEPS_PATH/lib"
+export LDFLAGS="-L$DEPS_PATH/lib -L$DEPS_PATH/lib64"
 export GNULIB_SRCDIR=$SRC/gnulib
 
 cd $SRC/libunistring

--- a/projects/grpc/Dockerfile
+++ b/projects/grpc/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 
-RUN apt-get update && apt-get install -y software-properties-common python-software-properties
+RUN apt-get update && apt-get install -y software-properties-common
 RUN add-apt-repository ppa:webupd8team/java
 RUN apt-get update && apt-get -y install  \
 	vim             \

--- a/projects/janus-gateway/Dockerfile
+++ b/projects/janus-gateway/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
 	gtk-doc-tools \
 	libconfig-dev \
 	libglib2.0-dev \
-	libgnutls-dev \
+	libgnutls28-dev \
 	libini-config-dev \
 	libjansson-dev \
 	libnice-dev \

--- a/projects/knot-dns/build.sh
+++ b/projects/knot-dns/build.sh
@@ -20,7 +20,7 @@
 # Cribbed from projects/wget2, thanks rockdaboot@gmail.com
 
 export DEPS_PATH=$SRC/knot_deps
-export PKG_CONFIG_PATH=$DEPS_PATH/lib/pkgconfig
+export PKG_CONFIG_PATH=$DEPS_PATH/lib64/pkgconfig:$DEPS_PATH/lib/pkgconfig
 export CPPFLAGS="-I$DEPS_PATH/include"
 export LDFLAGS="-L$DEPS_PATH/lib"
 export GNULIB_SRCDIR=$SRC/gnulib

--- a/projects/liblouis/Dockerfile
+++ b/projects/liblouis/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
-  pkg-config zlib1g-dev pciutils-dev libpci-dev
+  pkg-config zlib1g-dev libpci-dev
 RUN git clone --depth 1 https://github.com/liblouis/liblouis
 WORKDIR liblouis
 COPY build.sh $SRC/

--- a/projects/libpsl/build.sh
+++ b/projects/libpsl/build.sh
@@ -33,6 +33,10 @@ CPPFLAGS="$CPPFLAGS -fno-sanitize=vptr" \
   --disable-tests --disable-samples --with-data-packaging=static --prefix=$DEPS_PATH
 # ugly hack to avoid build error
 echo '#include <locale.h>' >>i18n/digitlst.h
+
+# Hack so that upgrade to Ubuntu 20.04 works.
+ln -s /usr/include/locale.h /usr/include/xlocale.h
+
 make -j
 make install
 

--- a/projects/librawspeed/Dockerfile
+++ b/projects/librawspeed/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && \
     apt-get install -y apt-transport-https ca-certificates gnupg software-properties-common wget && \
     wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add - && \
-    apt-add-repository 'deb https://apt.kitware.com/ubuntu/ xenial main' && \
+    apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main' && \
     apt-get update && apt-get install -y cmake make
 RUN git clone --depth 1 https://github.com/darktable-org/rawspeed.git librawspeed
 WORKDIR librawspeed

--- a/projects/libtpms/Dockerfile
+++ b/projects/libtpms/Dockerfile
@@ -19,7 +19,7 @@ RUN \
         apt-get update && \
         apt-get install -y \
         make autoconf automake libtool \
-        libstdc++-5-dev \
+        libstdc++-9-dev \
         libssl-dev libseccomp-dev pkg-config
 RUN git clone --depth 1 https://github.com/stefanberger/libtpms libtpms
 WORKDIR libtpms

--- a/projects/libvips/Dockerfile
+++ b/projects/libvips/Dockerfile
@@ -31,6 +31,10 @@ RUN apt-get update && apt-get install -y \
   libexpat1-dev \
   libffi-dev \
   libselinux1-dev \
+  glib2.0-dev \
+  autopoint \
+  gettext \
+  libtool \
   glib2.0-dev
 RUN pip3 install meson ninja
 RUN mkdir afl-testcases
@@ -43,7 +47,7 @@ RUN git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo
 RUN git clone --depth 1 https://github.com/glennrp/libpng.git
 RUN git clone --depth 1 https://github.com/randy408/libspng.git
 RUN git clone --depth 1 https://chromium.googlesource.com/webm/libwebp
-RUN git clone --depth 1 https://gitlab.com/libtiff/libtiff 
+RUN git clone --depth 1 https://gitlab.com/libtiff/libtiff
 RUN git clone --depth 1 https://aomedia.googlesource.com/aom
 RUN git clone --depth 1 https://github.com/strukturag/libheif
 RUN git clone --depth 1 --recursive https://github.com/libjxl/libjxl.git

--- a/projects/lldb-eval/Dockerfile
+++ b/projects/lldb-eval/Dockerfile
@@ -14,7 +14,11 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
+# See https://github.com/google/oss-fuzz/issues/6291 for more details.
+FROM gcr.io/oss-fuzz-base/base-builder:xenial
+# Delete line above and uncomment line below to upgrade to 20.04.
+# FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN apt-get update \
     && apt-get install -y wget git patchelf zlib1g-dev python libtinfo-dev --no-install-recommends

--- a/projects/openh264/Dockerfile
+++ b/projects/openh264/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && \
-    apt-get install -y libstdc++-5-dev libstdc++-5-dev:i386 nasm subversion
+    apt-get install -y libstdc++-9-dev libstdc++-9-dev:i386 nasm subversion
 RUN git clone --depth 1 https://github.com/cisco/openh264.git openh264
 WORKDIR openh264
 COPY build.sh decoder_fuzzer.cpp $SRC/

--- a/projects/openssh/Dockerfile
+++ b/projects/openssh/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool
-RUN apt-get install -y libz-dev libssl1.0.0 libssl-dev libedit-dev zip
+RUN apt-get install -y libz-dev libssl1.1 libssl-dev libedit-dev zip
 RUN git clone --depth 1 https://github.com/openssh/openssh-portable openssh
 RUN git clone --depth 1 https://github.com/djmdjm/openssh-fuzz-cases
 WORKDIR openssh

--- a/projects/openvpn/fuzz_crypto.c
+++ b/projects/openvpn/fuzz_crypto.c
@@ -61,7 +61,7 @@ static int init_frame(struct frame *frame) {
 }
 
 int LLVMFuzzerInitialize(int *argc, char ***argv) {
-  CRYPTO_malloc_init();
+  OPENSSL_malloc_init();
   SSL_library_init();
   ERR_load_crypto_strings();
 

--- a/projects/openvpn/fuzz_proxy.c
+++ b/projects/openvpn/fuzz_proxy.c
@@ -22,7 +22,7 @@ limitations under the License.
 
 int LLVMFuzzerInitialize(int *argc, char ***argv)
 {
-    CRYPTO_malloc_init();
+    OPENSSL_malloc_init();
     SSL_library_init();
     ERR_load_crypto_strings();
 

--- a/projects/openvpn/fuzz_verify_cert.c
+++ b/projects/openvpn/fuzz_verify_cert.c
@@ -40,7 +40,7 @@ static int parse_x509(const uint8_t *data, size_t size, X509 **out) {
 
 
 int LLVMFuzzerInitialize(int *argc, char ***argv) {
-  CRYPTO_malloc_init();
+  OPENSSL_malloc_init();
   SSL_library_init();
   ERR_load_crypto_strings();
 

--- a/projects/openvswitch/Dockerfile
+++ b/projects/openvswitch/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake \
     libtool python python3-pip \
-    libz-dev libssl-dev libssl1.0.0 wget
+    libz-dev libssl-dev libssl1.1 wget
 RUN pip3 install six
 RUN git clone --depth 1 https://github.com/openvswitch/ovs.git openvswitch
 RUN git clone --depth 1 https://github.com/openvswitch/ovs-fuzzing-corpus.git \

--- a/projects/openweave/Dockerfile
+++ b/projects/openweave/Dockerfile
@@ -14,11 +14,15 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y python-pip python-setuptools bridge-utils \
+# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
+# See https://github.com/google/oss-fuzz/issues/6291 for more details.
+FROM gcr.io/oss-fuzz-base/base-builder:xenial
+# Delete line above and uncomment line below to upgrade to 20.04.
+# FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y python3-pip python-setuptools bridge-utils \
   libglib2.0-dev libdbus-1-dev libudev-dev \
   libical-dev libreadline-dev udev \
-  libtool autoconf automake
+  libtool autoconf automake systemd
 RUN pip3 install --user google-cloud googleapis-common-protos grpcio protobuf pycryptodomex
 RUN cpan -i Text::Template
 RUN git clone --depth 1 https://github.com/openweave/openweave-core

--- a/projects/powerdns/Dockerfile
+++ b/projects/powerdns/Dockerfile
@@ -20,7 +20,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 # maintainer for this file
 
 # install required packages to build your project
-RUN add-apt-repository -y ppa:savoury1/boost-defaults-1.71 && apt-get update && apt-get install -y autoconf automake bison dh-autoreconf flex boost1.71-dev libluajit-5.1-dev libedit-dev libprotobuf-dev libssl-dev libtool make pkg-config protobuf-compiler ragel
+RUN apt-get update && apt-get install -y autoconf automake bison dh-autoreconf flex boost1.71-all-dev libluajit-5.1-dev libedit-dev libprotobuf-dev libssl-dev libtool make pkg-config protobuf-compiler ragel
 
 # checkout all sources needed to build your project
 RUN git clone https://github.com/PowerDNS/pdns.git pdns

--- a/projects/skia/Dockerfile
+++ b/projects/skia/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 
 # Mesa and libz/zlib needed to build swiftshader
-RUN apt-get update && apt-get install -y python wget libglu1-mesa-dev cmake lib32z1-dev zlib1g-dev
+RUN apt-get update && apt-get install -y python wget libglu1-mesa-dev cmake lib32z1-dev zlib1g-dev libxext-dev
 
 RUN git clone 'https://chromium.googlesource.com/chromium/tools/depot_tools.git' --depth 1
 ENV PATH="${SRC}/depot_tools:${PATH}"

--- a/projects/tmux/build.sh
+++ b/projects/tmux/build.sh
@@ -44,3 +44,8 @@ cat "${SRC}/tmux-fuzzing-corpus/iterm2"/* | \
     split -a5 -db$MAXLEN - iterm2.
 zip -q -j -r "${OUT}/input-fuzzer_seed_corpus.zip" \
     "${WORK}/fuzzing_corpus/"
+
+# Handle libevent not existing on runner.
+mkdir $OUT/lib
+cp /lib/x86_64-linux-gnu/libevent_core* $OUT/lib
+patchelf --set-rpath '$ORIGIN/lib' $OUT/input-fuzzer

--- a/projects/tpm2/Dockerfile
+++ b/projects/tpm2/Dockerfile
@@ -5,7 +5,7 @@
 # Defines a docker image that can build fuzzers.
 #
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make libssl-dev binutils libgcc-5-dev
+RUN apt-get update && apt-get install -y make libssl-dev binutils libgcc-9-dev
 RUN git clone --depth 1 https://chromium.googlesource.com/chromiumos/third_party/tpm2
 WORKDIR tpm2
 RUN cp /src/tpm2/fuzz/build.sh /src/

--- a/projects/usbguard/build.sh
+++ b/projects/usbguard/build.sh
@@ -81,3 +81,10 @@ if [[ ! -d "$SRC/usbguard/src/Tests/Fuzzers/$corpus_dir" ]] ; then
   cp -R "$SRC/usbguard/src/Tests/USB/data" "${corpus_dir}"
   zip -r "${zip_name}" "${corpus_dir}"
 fi
+
+# Ubuntu 20.04 doesn't have a static libqb.
+mkdir -p $OUT/lib
+cp /lib/x86_64-linux-gnu/libqb* $OUT/lib
+patchelf --set-rpath '$ORIGIN/lib' $OUT/fuzzer-uevent
+patchelf --set-rpath '$ORIGIN/lib' $OUT/fuzzer-usb-descriptor
+patchelf --set-rpath '$ORIGIN/lib' $OUT/fuzzer-rules

--- a/projects/wget/build.sh
+++ b/projects/wget/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 export WGET_DEPS_PATH=$SRC/wget_deps
-export PKG_CONFIG_PATH=$WGET_DEPS_PATH/lib/pkgconfig
+export PKG_CONFIG_PATH=$WGET_DEPS_PATH/lib64/pkgconfig:$WGET_DEPS_PATH/lib/pkgconfig
 export CPPFLAGS="-I$WGET_DEPS_PATH/include"
 export LDFLAGS="-L$WGET_DEPS_PATH/lib"
 export GNULIB_SRCDIR=$SRC/gnulib

--- a/projects/wget2/build.sh
+++ b/projects/wget2/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 export WGET2_DEPS_PATH=$SRC/wget2_deps
-export PKG_CONFIG_PATH=$WGET2_DEPS_PATH/lib/pkgconfig
+export PKG_CONFIG_PATH=$WGET2_DEPS_PATH/lib64/pkgconfig:$WGET2_DEPS_PATH/lib/pkgconfig
 export CPPFLAGS="-I$WGET2_DEPS_PATH/include"
 export LDFLAGS="-L$WGET2_DEPS_PATH/lib"
 export GNULIB_SRCDIR=$SRC/gnulib

--- a/projects/xpdf/Dockerfile
+++ b/projects/xpdf/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make wget cmake libqt4-dev
+RUN apt-get update && apt-get install software-properties-common -y && apt-get update && apt-add-repository ppa:rock-core/qt4 && apt-get install -y make wget cmake libqt4-dev
 RUN wget --no-check-certificate https://dl.xpdfreader.com/xpdf-latest.tar.gz
 
 WORKDIR $SRC


### PR DESCRIPTION
Fix projects so they don't break with upgrade.
These fixes are likely not backwards compatible and will fail on
Ubuntu 16.04.
Related: #6180