### PR TITLE
Swift ideal integration

### DIFF
--- a/docs/getting-started/new-project-guide/swift.md
+++ b/docs/getting-started/new-project-guide/swift.md
@@ -1,0 +1,80 @@
+---
+layout: default
+title: Integrating a Swift project
+parent: Setting up a new project
+grand_parent: Getting started
+nav_order: 1
+permalink: /getting-started/new-project-guide/swift/
+---
+
+# Integrating a Swift project
+{: .no_toc}
+
+- TOC
+{:toc}
+---
+
+The process of integrating a project written in Swift with OSS-Fuzz is very similar
+to the general
+[Setting up a new project]({{ site.baseurl }}/getting-started/new-project-guide/)
+process. The key specifics of integrating a Swift project are outlined below.
+
+## Project files
+
+First, you need to write a Swift fuzz target that accepts a stream of bytes and
+calls the program API with that. This fuzz target should reside in your project
+repository.
+
+The structure of the project directory in OSS-Fuzz repository doesn't differ for
+projects written in Swift. The project files have the following Swift specific
+aspects.
+
+### project.yaml
+
+The `language` attribute must be specified.
+
+```yaml
+language: swift
+```
+
+The only supported fuzzing engine is `libfuzzer`
+
+The supported sanitizers are and `address`, `thread`, `undefined`, `leaks`
+
+[Example](https://github.com/google/oss-fuzz/blob/2a15c3c88b21f4f1be2a7ff115f72bd7a08e34ac/projects/swift-nio/project.yaml#L9):
+
+```yaml
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+  - thread
+  - undefined
+  - leaks
+```
+
+### Dockerfile
+
+The Dockerfile should start by `FROM gcr.io/oss-fuzz-base/base-builder-swift`
+instead of using the simple base-builder
+
+### build.sh
+
+A `precompile_swift` generates an environment variable `SWIFTFLAGS`
+This can then be used in the building command such as `swift build -c release $SWIFTFLAGS`
+
+
+A usage example from swift-protobuf project is
+
+```sh
+. precompile_swift
+# build project
+cd FuzzTesting
+swift build -c debug $SWIFTFLAGS
+
+(
+cd .build/debug/
+find . -maxdepth 1 -type f -name "*Fuzzer" -executable | while read i; do cp $i $OUT/"$i"-debug; done
+)
+
+```

--- a/docs/getting-started/new-project-guide/swift.md
+++ b/docs/getting-started/new-project-guide/swift.md
@@ -39,7 +39,7 @@ language: swift
 
 The only supported fuzzing engine is `libfuzzer`
 
-The supported sanitizers are and `address`, `thread`, `undefined`, `leaks`
+The supported sanitizers are and `address`, `thread`
 
 [Example](https://github.com/google/oss-fuzz/blob/2a15c3c88b21f4f1be2a7ff115f72bd7a08e34ac/projects/swift-nio/project.yaml#L9):
 
@@ -49,8 +49,6 @@ fuzzing_engines:
 sanitizers:
   - address
   - thread
-  - undefined
-  - leaks
 ```
 
 ### Dockerfile

--- a/infra/base-images/base-builder-swift/Dockerfile
+++ b/infra/base-images/base-builder-swift/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-new:xenial
+FROM gcr.io/oss-fuzz-base/base-builder-new
 
 RUN install_swift.sh
 

--- a/infra/base-images/base-builder-swift/Dockerfile
+++ b/infra/base-images/base-builder-swift/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-new
+FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN install_swift.sh
 

--- a/infra/base-images/base-builder-swift/precompile_swift
+++ b/infra/base-images/base-builder-swift/precompile_swift
@@ -1,3 +1,4 @@
+#!/bin/bash -eu
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,8 +15,17 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-new:xenial
+if [ "$SANITIZER" = "coverage" ]
+then
+    export SWIFTFLAGS="-Xswiftc -parse-as-library -Xswiftc -static-stdlib -Xswiftc -use-ld=/usr/bin/ld --static-swift-stdlib -Xswiftc -profile-generate -Xswiftc -profile-coverage-mapping"
+else
+    export SWIFTFLAGS="-Xswiftc -parse-as-library -Xswiftc -static-stdlib -Xswiftc -use-ld=/usr/bin/ld --static-swift-stdlib -Xswiftc -sanitize=fuzzer,$SANITIZER --sanitize=$SANITIZER"
+fi
 
-RUN install_swift.sh
+for f in $CFLAGS; do
+    export SWIFTFLAGS="$SWIFTFLAGS -Xcc=$f"
+done
 
-COPY precompile_swift /usr/local/bin/
+for f in $CXXFLAGS; do
+    export SWIFTFLAGS="$SWIFTFLAGS -Xcxx=$f"
+done

--- a/infra/base-images/base-builder-swift/precompile_swift
+++ b/infra/base-images/base-builder-swift/precompile_swift
@@ -15,6 +15,8 @@
 #
 ################################################################################
 
+cp /usr/local/bin/llvm-symbolizer-swift $OUT/llvm-symbolizer
+
 export SWIFTFLAGS="-Xswiftc -parse-as-library -Xswiftc -static-stdlib -Xswiftc -use-ld=/usr/bin/ld --static-swift-stdlib"
 if [ "$SANITIZER" = "coverage" ]
 then

--- a/infra/base-images/base-builder-swift/precompile_swift
+++ b/infra/base-images/base-builder-swift/precompile_swift
@@ -15,11 +15,12 @@
 #
 ################################################################################
 
+export SWIFTFLAGS="-Xswiftc -parse-as-library -Xswiftc -static-stdlib -Xswiftc -use-ld=/usr/bin/ld --static-swift-stdlib"
 if [ "$SANITIZER" = "coverage" ]
 then
-    export SWIFTFLAGS="-Xswiftc -parse-as-library -Xswiftc -static-stdlib -Xswiftc -use-ld=/usr/bin/ld --static-swift-stdlib -Xswiftc -profile-generate -Xswiftc -profile-coverage-mapping -Xswiftc -sanitize=fuzzer"
+    export SWIFTFLAGS="$SWIFTFLAGS -Xswiftc -profile-generate -Xswiftc -profile-coverage-mapping -Xswiftc -sanitize=fuzzer"
 else
-    export SWIFTFLAGS="-Xswiftc -parse-as-library -Xswiftc -static-stdlib -Xswiftc -use-ld=/usr/bin/ld --static-swift-stdlib -Xswiftc -sanitize=fuzzer,$SANITIZER --sanitize=$SANITIZER"
+    export SWIFTFLAGS="$SWIFTFLAGS -Xswiftc -sanitize=fuzzer,$SANITIZER --sanitize=$SANITIZER"
 fi
 
 for f in $CFLAGS; do

--- a/infra/base-images/base-builder-swift/precompile_swift
+++ b/infra/base-images/base-builder-swift/precompile_swift
@@ -17,7 +17,7 @@
 
 if [ "$SANITIZER" = "coverage" ]
 then
-    export SWIFTFLAGS="-Xswiftc -parse-as-library -Xswiftc -static-stdlib -Xswiftc -use-ld=/usr/bin/ld --static-swift-stdlib -Xswiftc -profile-generate -Xswiftc -profile-coverage-mapping"
+    export SWIFTFLAGS="-Xswiftc -parse-as-library -Xswiftc -static-stdlib -Xswiftc -use-ld=/usr/bin/ld --static-swift-stdlib -Xswiftc -profile-generate -Xswiftc -profile-coverage-mapping -Xswiftc -sanitize=fuzzer"
 else
     export SWIFTFLAGS="-Xswiftc -parse-as-library -Xswiftc -static-stdlib -Xswiftc -use-ld=/usr/bin/ld --static-swift-stdlib -Xswiftc -sanitize=fuzzer,$SANITIZER --sanitize=$SANITIZER"
 fi

--- a/infra/base-images/base-builder/install_swift.sh
+++ b/infra/base-images/base-builder/install_swift.sh
@@ -56,7 +56,7 @@ cmake -G "Ninja" \
     -DLLVM_BUILD_TESTS=OFF \
     -DLLVM_INCLUDE_TESTS=OFF llvm
 ninja -j$(nproc) llvm-symbolizer
-cp bin/llvm-symbolizer $OUT/
+cp bin/llvm-symbolizer /usr/local/bin/llvm-symbolizer-swift
 
 cd $SRC
 rm -rf llvm-project llvmsymbol.diff

--- a/infra/base-images/base-builder/install_swift.sh
+++ b/infra/base-images/base-builder/install_swift.sh
@@ -16,17 +16,31 @@
 ################################################################################
 
 
-SWIFT_PACKAGES="wget binutils libc6-dev libcurl3 libedit2 libgcc-5-dev libpython2.7 libsqlite3-0 libstdc++-5-dev libxml2 pkg-config tzdata zlib1g-dev"
+SWIFT_PACKAGES="wget \
+          binutils \
+          git \
+          gnupg2 \
+          libc6-dev \
+          libcurl4 \
+          libedit2 \
+          libgcc-9-dev \
+          libpython2.7 \
+          libsqlite3-0 \
+          libstdc++-9-dev \
+          libxml2 \
+          libz3-dev \
+          pkg-config \
+          tzdata \
+          zlib1g-dev"
 SWIFT_SYMBOLIZER_PACKAGES="build-essential make cmake ninja-build git python3 g++-multilib binutils-dev zlib1g-dev"
 apt-get update && apt install -y $SWIFT_PACKAGES && \
   apt install -y $SWIFT_SYMBOLIZER_PACKAGES --no-install-recommends  
 
 
-wget https://swift.org/builds/swift-5.3.3-release/ubuntu1604/swift-5.3.3-RELEASE/swift-5.3.3-RELEASE-ubuntu16.04.tar.gz
-tar xzf swift-5.3.3-RELEASE-ubuntu16.04.tar.gz
-cp -r swift-5.3.3-RELEASE-ubuntu16.04/usr/* /usr/
-rm -rf swift-5.3.3-RELEASE-ubuntu16.04.tar.gz
-
+wget https://swift.org/builds/swift-5.4.2-release/ubuntu2004/swift-5.4.2-RELEASE/swift-5.4.2-RELEASE-ubuntu20.04.tar.gz
+tar xzf swift-5.4.2-RELEASE-ubuntu20.04.tar.gz
+cp -r swift-5.4.2-RELEASE-ubuntu20.04/usr/* /usr/
+rm -rf swift-5.4.2-RELEASE-ubuntu20.04.tar.gz
 # TODO: Move to a seperate work dir
 git clone --depth 1 https://github.com/llvm/llvm-project.git
 cd llvm-project

--- a/infra/base-images/base-builder/llvmsymbol.diff
+++ b/infra/base-images/base-builder/llvmsymbol.diff
@@ -1,8 +1,8 @@
 diff --git a/llvm/lib/DebugInfo/Symbolize/CMakeLists.txt b/llvm/lib/DebugInfo/Symbolize/CMakeLists.txt
-index acfb3bd0e..5c4cf9763 100644
+index acfb3bd0e..a499ee2e0 100644
 --- a/llvm/lib/DebugInfo/Symbolize/CMakeLists.txt
 +++ b/llvm/lib/DebugInfo/Symbolize/CMakeLists.txt
-@@ -12,4 +12,12 @@ add_llvm_component_library(LLVMSymbolize
+@@ -12,4 +12,11 @@ add_llvm_component_library(LLVMSymbolize
    Object
    Support
    Demangle
@@ -10,14 +10,13 @@ index acfb3bd0e..5c4cf9763 100644
 +
 +  LINK_LIBS
 +  /usr/lib/swift_static/linux/libswiftCore.a
-+  /usr/lib/swift_static/linux/libswiftImageInspectionShared.a
 +  /usr/lib/swift_static/linux/libicui18nswift.a
 +  /usr/lib/swift_static/linux/libicuucswift.a
 +  /usr/lib/swift_static/linux/libicudataswift.a
 +  /usr/lib/x86_64-linux-gnu/libstdc++.so.6
 +)
 diff --git a/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp b/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
-index 4c3f3a3767e1..aa7b9f0f5abb 100644
+index fb4875f79..0030769ee 100644
 --- a/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
 +++ b/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
 @@ -36,6 +36,13 @@
@@ -34,7 +33,7 @@ index 4c3f3a3767e1..aa7b9f0f5abb 100644
  namespace llvm {
  namespace symbolize {
  
-@@ -632,6 +639,14 @@ LLVMSymbolizer::DemangleName(const std::string &Name,
+@@ -678,6 +685,14 @@ LLVMSymbolizer::DemangleName(const std::string &Name,
      free(DemangledName);
      return Result;
    }

--- a/infra/build/functions/build_and_run_coverage.py
+++ b/infra/build/functions/build_and_run_coverage.py
@@ -42,7 +42,7 @@ COVERAGE_BUCKET_NAME = 'oss-fuzz-coverage'
 LATEST_REPORT_INFO_CONTENT_TYPE = 'application/json'
 
 # Languages from project.yaml that have code coverage support.
-LANGUAGES_WITH_COVERAGE_SUPPORT = ['c', 'c++', 'go', 'jvm', 'rust']
+LANGUAGES_WITH_COVERAGE_SUPPORT = ['c', 'c++', 'go', 'jvm', 'rust', 'swift']
 
 
 class Bucket:  # pylint: disable=too-few-public-methods

--- a/infra/constants.py
+++ b/infra/constants.py
@@ -30,7 +30,7 @@ LANGUAGES = [
     'rust',
     'swift',
 ]
-LANGUAGES_WITH_COVERAGE_SUPPORT = ['c', 'c++', 'go', 'jvm', 'rust']
+LANGUAGES_WITH_COVERAGE_SUPPORT = ['c', 'c++', 'go', 'jvm', 'rust', 'swift']
 SANITIZERS = [
     'address', 'none', 'memory', 'undefined', 'dataflow', 'thread', 'coverage'
 ]

--- a/projects/grpc-swift/Dockerfile
+++ b/projects/grpc-swift/Dockerfile
@@ -14,11 +14,7 @@
 #
 ################################################################################
 
-# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
-# See https://github.com/google/oss-fuzz/issues/6291 for more details.
-FROM gcr.io/oss-fuzz-base/base-builder-swift:xenial
-# Delete line above and uncomment line below to upgrade to 20.04.
-# FROM gcr.io/oss-fuzz-base/base-builder-swift
+FROM gcr.io/oss-fuzz-base/base-builder-swift
 
 # specific to project
 RUN git clone --depth 1 https://github.com/grpc/grpc-swift

--- a/projects/grpc-swift/build.sh
+++ b/projects/grpc-swift/build.sh
@@ -15,25 +15,16 @@
 #
 ################################################################################
 
+. precompile_swift
 # build project
 cd FuzzTesting
-# Maybe we should have a helper script to set $SWIFT_FLAGS
-# for instance about -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION in -Xcc
-swift build -c debug -Xswiftc -sanitize=fuzzer,address \
-    -Xswiftc -parse-as-library -Xswiftc -static-stdlib \
-    -Xswiftc -use-ld=/usr/bin/ld --static-swift-stdlib \
-    --sanitize=address -Xcc="-fsanitize=fuzzer-no-link,address" \
-    -Xcxx="-fsanitize=fuzzer-no-link,address"
+swift build -c debug $SWIFTFLAGS
 
 (
 cd .build/debug/
 find . -maxdepth 1 -type f -name "*Fuzzer" -executable | while read i; do cp $i $OUT/"$i"-debug; done
 )
-swift build -c release -Xswiftc -sanitize=fuzzer,address \
-    -Xswiftc -parse-as-library -Xswiftc -static-stdlib \
-    -Xswiftc -use-ld=/usr/bin/ld --static-swift-stdlib \
-    --sanitize=address -Xcc="-fsanitize=fuzzer-no-link,address" \
-    -Xcxx="-fsanitize=fuzzer-no-link,address"
+swift build -c release $SWIFTFLAGS
 (
 cd .build/release/
 find . -maxdepth 1 -type f -name "*Fuzzer" -executable | while read i; do cp $i $OUT/"$i"-release; done

--- a/projects/grpc-swift/project.yaml
+++ b/projects/grpc-swift/project.yaml
@@ -9,4 +9,5 @@ fuzzing_engines:
 - libfuzzer
 sanitizers:
 - address
+- thread
 main_repo: 'https://github.com/grpc/grpc-swift'

--- a/projects/swift-nio/Dockerfile
+++ b/projects/swift-nio/Dockerfile
@@ -14,11 +14,7 @@
 #
 ################################################################################
 
-# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
-# See https://github.com/google/oss-fuzz/issues/6291 for more details.
-FROM gcr.io/oss-fuzz-base/base-builder-swift:xenial
-# Delete line above and uncomment line below to upgrade to 20.04.
-# FROM gcr.io/oss-fuzz-base/base-builder-swift
+FROM gcr.io/oss-fuzz-base/base-builder-swift
 
 # specific swift-nio
 RUN git clone --depth 1 https://github.com/google/fuzzing

--- a/projects/swift-nio/build.sh
+++ b/projects/swift-nio/build.sh
@@ -23,14 +23,14 @@ rm -Rf Sources/swift-nio-fuzz
 mkdir Sources/swift-nio-http1-fuzz
 cp $SRC/fuzz_http1.swift Sources/swift-nio-http1-fuzz/main.swift
 cp $SRC/Package.swift Package.swift
-# Maybe we should have a helper script to set $SWIFT_FLAGS
-# for instance about -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION in -Xcc
-swift build -c debug -Xswiftc -sanitize=fuzzer,address -Xswiftc -parse-as-library -Xswiftc -static-stdlib -Xswiftc -use-ld=/usr/bin/ld --static-swift-stdlib  --sanitize=address -Xcc="-fsanitize=fuzzer-no-link,address"
+
+. precompile_swift
+swift build -c debug $SWIFTFLAGS
 (
 cd .build/debug/
 find . -maxdepth 1 -type f -name "*fuzz" -executable | while read i; do cp $i $OUT/"$i"-debug; done
 )
-swift build -c release -Xswiftc -sanitize=fuzzer,address -Xswiftc -parse-as-library -Xswiftc -static-stdlib -Xswiftc -use-ld=/usr/bin/ld --static-swift-stdlib  --sanitize=address -Xcc="-fsanitize=fuzzer-no-link,address"
+swift build -c release $SWIFTFLAGS
 (
 cd .build/release/
 find . -maxdepth 1 -type f -name "*fuzz" -executable | while read i; do cp $i $OUT/"$i"-release; done

--- a/projects/swift-nio/project.yaml
+++ b/projects/swift-nio/project.yaml
@@ -10,4 +10,5 @@ fuzzing_engines:
 - libfuzzer
 sanitizers:
 - address
+- thread
 main_repo: 'https://github.com/apple/swift-nio.git'

--- a/projects/swift-protobuf/Dockerfile
+++ b/projects/swift-protobuf/Dockerfile
@@ -14,11 +14,7 @@
 #
 ################################################################################
 
-# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
-# See https://github.com/google/oss-fuzz/issues/6291 for more details.
-FROM gcr.io/oss-fuzz-base/base-builder-swift:xenial
-# Delete line above and uncomment line below to upgrade to 20.04.
-# FROM gcr.io/oss-fuzz-base/base-builder-swift
+FROM gcr.io/oss-fuzz-base/base-builder-swift
 
 RUN git clone --depth 1 https://github.com/apple/swift-protobuf.git
 COPY build.sh $SRC

--- a/projects/swift-protobuf/build.sh
+++ b/projects/swift-protobuf/build.sh
@@ -15,14 +15,16 @@
 #
 ################################################################################
 
+
+. precompile_swift
 # build project
 cd FuzzTesting
-swift build -c debug -Xswiftc -sanitize=address,fuzzer -Xswiftc -parse-as-library -Xswiftc -static-stdlib -Xswiftc -use-ld=/usr/bin/ld --static-swift-stdlib --sanitize=address
+swift build -c debug $SWIFTFLAGS
 (
 cd .build/debug/
 find . -maxdepth 1 -type f -name "Fuzz*" -executable | while read i; do cp $i $OUT/"$i"_debug; done
 )
-swift build -c release -Xswiftc -sanitize=address,fuzzer -Xswiftc -parse-as-library -Xswiftc -static-stdlib -Xswiftc -use-ld=/usr/bin/ld --static-swift-stdlib --sanitize=address
+swift build -c release $SWIFTFLAGS
 (
 cd .build/release/
 find . -maxdepth 1 -type f -name "Fuzz*" -executable | while read i; do cp $i $OUT/"$i"_release; done

--- a/projects/swift-protobuf/project.yaml
+++ b/projects/swift-protobuf/project.yaml
@@ -9,4 +9,5 @@ fuzzing_engines:
 - libfuzzer
 sanitizers:
 - address
+- thread
 main_repo: 'https://github.com/apple/swift-protobuf.git'


### PR DESCRIPTION
Following @asraa work to split base-builder 🙇 

- Generic script to generate `SWIFTFLAGS` as `RUSTFLAGS` or `CFLAGS`
- Support for thread sanitizer (tested build) (got `error: unsupported option '-sanitize=undefined' for target 'x86_64-unknown-linux-gnu'` for undefined )
- Support for coverage report (tested on swift-protobuf, getting a compiler internal error on grpc-swift)
- Documentation

Am I missing something ?
cc @jonathanmetzman @inferno-chromium 

How should it fit with the ubuntu upgrade ?