### PR TITLE
Pin base-builder-new to xenial.

### DIFF
--- a/infra/base-images/base-builder-new/Dockerfile
+++ b/infra/base-images/base-builder-new/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-clang
+FROM gcr.io/oss-fuzz-base/base-clang:xenial
 
 RUN dpkg --add-architecture i386 && \
     apt-get update && \


### PR DESCRIPTION
Build is currently breaking:


```
ep #5: [91m+ apt install -y wget binutils libc6-dev libcurl3 libedit2 libgcc-5-dev libpython2.7 libsqlite3-0 libstdc++-5-dev libxml2 pkg-config tzdata zlib1g-dev
Step #5: [0m[91m
Step #5: WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
Step #5: 
Step #5: [0mReading package lists...
Step #5: Building dependency tree...
Step #5: Reading state information...
Step #5: Package libcurl3 is not available, but is referred to by another package.
Step #5: This may mean that the package is missing, has been obsoleted, or
Step #5: is only available from another source
Step #5: However the following packages replace it:
Step #5:   libcurl4:i386 libcurl4
Step #5: 
Step #5: Package libstdc++-5-dev is not available, but is referred to by another package.
Step #5: This may mean that the package is missing, has been obsoleted, or
Step #5: is only available from another source
Step #5: 
Step #5: Package libgcc-5-dev is not available, but is referred to by another package.
Step #5: This may mean that the package is missing, has been obsoleted, or
Step #5: is only available from another source
Step #5: 
Step #5: [91mE: Package 'libcurl3' has no installation candidate
Step #5: E: Package 'libgcc-5-dev' has no installation candidate
Step #5: E: Package 'libstdc++-5-dev' has no installation candidate
Step #5: [0m[91m+ wget https://swift.org/builds/swift-5.3.3-release/ubuntu1604/swift-5.3.3-RELEASE/swift-5.3.3-RELEASE-ubuntu16.04.tar.gz
Step #5: [0m[91m/usr/local/bin/install_swift.sh: line 25: wget: command not found
Step #5: The command '/bin/sh -c install_swift.sh' returned a non-zero code: 127
Finished Step #5
ERROR
ERROR: build step 5 "gcr.io/cloud-builders/docker" failed: step exited with non-zero status: 127
Step #5: [0m
```