### PR TITLE
reenable msan (experimentally) after Ubuntu upgrade

### DIFF
--- a/projects/libreoffice/project.yaml
+++ b/projects/libreoffice/project.yaml
@@ -3,9 +3,8 @@ language: c++
 primary_contact: "caolanm@redhat.com"
 sanitizers:
   - address
-  # Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
-  # - memory
-  #    experimental: True
+  - memory:
+     experimental: True
   - undefined
 fuzzing_engines:
   # see https://github.com/google/oss-fuzz/issues/6233 for missing afl


### PR DESCRIPTION
check_build on new baseline, i.e.

python infra/helper.py build_image libreoffice
python infra/helper.py build_fuzzers --sanitizer memory libreoffice
python infra/helper.py check_build --sanitizer memory libreoffice