### PR TITLE
[WIP] Add `nix` to the projects (with Ubuntu packages)

### DIFF
--- a/projects/nix/Dockerfile
+++ b/projects/nix/Dockerfile
@@ -1,0 +1,115 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN sed -i -e 's/xenial/focal/g' /etc/apt/sources.list
+
+RUN apt-get update -y && apt-get install -y --reinstall \
+      automake \
+      autoconf \
+      autoconf-archive \
+      build-essential \
+      jq \
+      libtool \
+      make \
+      pkg-config \
+      wget
+
+# Debug helpers.
+RUN apt-get install -y \
+      strace ltrace gdb vim
+
+# `nix` requires `libeditline` to be >= 1.14;
+# While latest version in Ubuntu repositories is 1.12 .
+RUN git clone --branch 1.17.1 https://github.com/troglobit/editline.git \
+      && cd editline \
+      && ./autogen.sh \
+      && ./configure \
+      && make all \
+      && make install \
+      && cd - \
+      && rm -R editline
+
+# Install `libutil`'s dependencies.
+RUN apt-get install -y \
+      libarchive-dev \
+      libboost-all-dev \
+      libbrotli-dev \
+      libcpuid-dev \
+      libssl-dev
+# `libutil`'s transitive dependencies.
+RUN apt-get install -y \
+      libacl1-dev \
+      libbz2-dev \
+      liblz4-dev \
+      libxml2-dev \
+      libzstd-dev
+
+# `libutil` requires `libarchive`, that requires `liblzma`;
+# Sadly, Ubuntu's `libzma.a` is missing some necessary definitions.
+RUN wget https://tukaani.org/xz/xz-5.2.4.tar.gz \
+      && tar xf xz-5.2.4.tar.gz \
+      && cd xz-5.2.4 \
+      && ./configure --enable-shared=no --enable-static \
+      && make \
+      && make install \
+      && cd - \
+      && rm -R xz-5.2.4*
+
+# Install `libstore`'s dependencies.
+RUN apt-get install -y \
+      libsodium-dev \
+      libsqlite3-dev
+# `libstore`'s transitive dependencies.
+RUN apt-get install -y \
+      comerr-dev \
+      libticonv-dev \
+      libidn2-dev \
+      libnghttp2-dev \
+      libpsl-dev \
+      libssh-dev \
+      libunistring-dev \
+      nettle-dev
+
+# `libstore` requires `libcurl`;
+# Sadly, `libcurl` requires `libkrb5`-related static libraries, which are not distributed anymore.
+RUN wget https://curl.se/download/curl-7.68.0.tar.gz \
+      && tar xf curl-7.68.0.tar.gz \
+      && cd curl-7.68.0 \
+      && ./configure --disable-shared --enable-static --disable-ldap --disable-sspi --with-openssl --without-librtmp --without-gnutls \
+      && make \
+      && make install \
+      && cd - \
+      && rm -R curl-7.68.0*
+
+# Install other required dependencies./configure` fails.
+RUN apt-get install -y \
+      libgtest-dev \
+      libseccomp-dev \
+      libstdc++-10-dev
+
+RUN apt autoremove -y \
+      && rm -rf /var/lib/apt/lists/*
+
+# Clone a fork to get the fuzz targets; Will eventually be PRed/merged upstream.
+RUN git clone --depth 1 --branch fuzzing_meson https://github.com/Pamplemousse/nix.git
+
+COPY build.sh $SRC/
+
+# TODO: in the wait of having it integrated upstream.
+COPY local.mk $SRC/nix/fuzz/
+RUN echo "include fuzz/local.mk" >> $SRC/nix/Makefile

--- a/projects/nix/build.sh
+++ b/projects/nix/build.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC/nix
+
+./bootstrap.sh
+
+# `libcurl`'s `./configure` does not detect the entire dependency chain when compiling statically;
+# See: https://github.com/curl/curl/discussions/6324 .
+curl_extra_libs='-lunistring -llzma -licuuc -licudata'
+libcurl_libs="$(pkg-config --static --libs libcurl) $curl_extra_libs"
+
+# `libarchive` is missing dependency flags.
+archive_extra_libs='-llzma -licuuc -licudata'
+libarchive_libs="$(pkg-config --static --libs libarchive) $archive_extra_libs"
+
+libutil_FLAGS="-fsanitize=fuzzer-no-link"
+libstore_FLAGS="-fsanitize=fuzzer-no-link"
+for S in $SANITIZER; do
+  libutil_FLAGS+="-fsanitize=S"
+  libstore_FLAGS+="-fsanitize=S"
+done
+
+LIBARCHIVE_LIBS=$libarchive_libs \
+LIBCURL_LIBS=$libcurl_libs \
+libutil_CXXFLAGS=$libutil_FLAGS \
+libutil_LDFLAGS=$libutil_FLAGS \
+libstore_CXXFLAGS=$libstore_FLAGS \
+libstore_LDFLAGS=$libstore_FLAGS \
+./configure \
+  --enable-shared=no \
+  --enable-gc=no \
+  --prefix=$OUT
+
+make clean
+
+OPTIMIZE=0 ENABLE_S3=0 make -j$(nproc) fuzz/parse_store_path
+mv fuzz/parse_store_path $OUT/
+
+cd -

--- a/projects/nix/local.mk
+++ b/projects/nix/local.mk
@@ -1,0 +1,2 @@
+fuzz/parse_store_path: fuzz/target_parse_store_path.cc src/libstore/libnixstore.a src/libutil/libnixutil.a
+	$(CXX) -v $(CPPFLAGS) $(GLOBAL_CXXFLAGS_PCH) $(GLOBAL_CXXFLAGS) $(LIB_FUZZING_ENGINE) $(nix_CXXFLAGS) -static $^ $(libstore_LDFLAGS_USE) $(libutil_LDFLAGS_USE) -o $@

--- a/projects/nix/project.yaml
+++ b/projects/nix/project.yaml
@@ -1,0 +1,9 @@
+homepage: 'https://nixos.org/'
+language: c++
+primary_contact: 'edolstra@gmail.com'
+# TODO: auto_ccs:
+# See https://nixos.org/community/teams/security.html .
+sanitizers:
+- address
+- undefined
+main_repo: 'https://github.com/nixos/nix'


### PR DESCRIPTION
:warning: This is a **Work-In-Progress** that does not even work (yet?) :warning:

As I am struggling to integrate `nix` to OSS-fuzz, these PR (with google/oss-fuzz#6317) helps to keep track of the progress, and help gather feedback on approaches taken.

### Context

As part of a fellowship, I work on fuzzing [`nix`](github.com/nixos/nix/); More details on https://discourse.nixos.org/t/tweag-fellowship-fuzzing-nix-0 .
One of the "end-goal" of the project is to integrate [`nix`](github.com/nixos/nix/) to OSS-fuzz; This PR is a step in that direction.

### Approach

Unlike google/oss-fuzz#6317 ;

This approach aims to stay close to OSS-fuzz's philosophy:
* use Docker for build-time reproducibility
* compile the fuzzers statically
While still:
* leverage upstream's autotools system:
  - build `nix` libraries without hassle
  - add compilation of fuzz target
  - add extra flags to libraries (relies on nixos/nix#5175) for better fuzzer coverage and sanitization

**Disadvantage**: Doesn't work (yet); Dockerfile and build.sh are non trivial and will be a pain to maintain.

### TODO

* [ ] :warning: correct the runtime `SEGFAULT`...
* [x] apply sanitizers to libraries
* [ ] don't clone a fork:
  - [ ] integrate fuzz targets upstream
  - [ ] integrate `local.mk` upstream
* [ ] compile and test coverage binary(ies)
* [ ] add `auto_ccs` to `projects.yaml` if maintainers are OK
* [x] sign the google-cla thing


cc @regnat