### PR TITLE
[bitcoin-core] Fix build

### DIFF
--- a/projects/bitcoin-core/Dockerfile
+++ b/projects/bitcoin-core/Dockerfile
@@ -14,22 +14,18 @@
 #
 ################################################################################
 
-# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
-# See https://github.com/google/oss-fuzz/issues/6291 for more details.
-FROM gcr.io/oss-fuzz-base/base-builder:xenial
-# Delete line above and uncomment line below to upgrade to 20.04.
-# FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder
 
 # Packages taken from:
 # * https://github.com/bitcoin/bitcoin/blob/master/doc/build-unix.md#dependency-build-instructions
 # * https://github.com/bitcoin/bitcoin/blob/master/depends/README.md#for-linux-including-i386-arm-cross-compilation
 RUN apt-get update && apt-get install -y \
-  build-essential libtool autotools-dev automake pkg-config bsdmainutils python python3 \
+  build-essential libtool autotools-dev automake pkg-config bsdmainutils python3 \
   make automake cmake curl g++-multilib libtool binutils-gold bsdmainutils pkg-config patch bison \
   wget zip
 
-RUN git clone --depth=1 https://github.com/bitcoin/bitcoin.git bitcoin-core
-RUN git clone --depth=1 https://github.com/bitcoin-core/qa-assets bitcoin-core/assets
+#RUN git clone --depth=1 https://github.com/bitcoin/bitcoin.git bitcoin-core
+#RUN git clone --depth=1 https://github.com/bitcoin-core/qa-assets bitcoin-core/assets
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/bitcoin-core/secp256k1.git
 RUN git clone --depth 1 https://github.com/randombit/botan.git

--- a/projects/bitcoin-core/Dockerfile
+++ b/projects/bitcoin-core/Dockerfile
@@ -24,8 +24,8 @@ RUN apt-get update && apt-get install -y \
   make automake cmake curl g++-multilib libtool binutils-gold bsdmainutils pkg-config patch bison \
   wget zip
 
-#RUN git clone --depth=1 https://github.com/bitcoin/bitcoin.git bitcoin-core
-#RUN git clone --depth=1 https://github.com/bitcoin-core/qa-assets bitcoin-core/assets
+RUN git clone --depth=1 https://github.com/bitcoin/bitcoin.git bitcoin-core
+RUN git clone --depth=1 https://github.com/bitcoin-core/qa-assets bitcoin-core/assets
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/bitcoin-core/secp256k1.git
 RUN git clone --depth 1 https://github.com/randombit/botan.git

--- a/projects/bitcoin-core/build_cryptofuzz.sh
+++ b/projects/bitcoin-core/build_cryptofuzz.sh
@@ -38,6 +38,10 @@ function build_libsecp256k1() {
     if test -f "Makefile"; then
         # Remove old configuration if it exists
         make clean
+
+        # Prevent the error:
+        # "configuration mismatch, invalid ECMULT_WINDOW_SIZE. Try deleting ecmult_static_pre_g.h before the build."
+        rm -f src/ecmult_static_pre_g.h
     fi
 
     SECP256K1_CONFIGURE_PARAMS="
@@ -128,14 +132,18 @@ cd ../trezor/
 make -B -j$(nproc)
 cd ../botan/
 make -B -j$(nproc)
-cd ../schnorr_fun/
-export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_SCHNORR_FUN"
-if [[ $CFLAGS != *-m32* ]]
-then
-    make
-else
-    make -f Makefile.i386
-fi
+
+# schnorr_fun is currently disabled because it was causing build failures
+# See: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=37524
+#cd ../schnorr_fun/
+#export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_SCHNORR_FUN"
+#if [[ $CFLAGS != *-m32* ]]
+#then
+#    make
+#else
+#    make -f Makefile.i386
+#fi
+
 cd ../../
 
 # Build with 3 configurations of libsecp256k1
@@ -152,11 +160,12 @@ rm cryptofuzz
 make
 cp cryptofuzz $OUT/cryptofuzz-bitcoin-cryptography-w15-p4
 
-build_libsecp256k1 "--with-ecmult-window=24" "--with-ecmult-gen-precision=8"
-cd $SRC/cryptofuzz/
-rm cryptofuzz
-make
-cp cryptofuzz $OUT/cryptofuzz-bitcoin-cryptography-w24-p8
+# Disabled because it makes Clang crash
+#build_libsecp256k1 "--with-ecmult-window=24" "--with-ecmult-gen-precision=8"
+#cd $SRC/cryptofuzz/
+#rm cryptofuzz
+#make
+#cp cryptofuzz $OUT/cryptofuzz-bitcoin-cryptography-w24-p8
 
 # Convert Wycheproof test vectors to Cryptofuzz corpus format
 mkdir $SRC/corpus-cryptofuzz-wycheproof/
@@ -166,4 +175,4 @@ zip -j cryptofuzz-bitcoin-cryptography_seed_corpus.zip $SRC/corpus-cryptofuzz-wy
 # Use them as the seed corpus for each of the fuzzers
 cp cryptofuzz-bitcoin-cryptography_seed_corpus.zip $OUT/cryptofuzz-bitcoin-cryptography-w2-p2_seed_corpus.zip
 cp cryptofuzz-bitcoin-cryptography_seed_corpus.zip $OUT/cryptofuzz-bitcoin-cryptography-w15-p4_seed_corpus.zip
-cp cryptofuzz-bitcoin-cryptography_seed_corpus.zip $OUT/cryptofuzz-bitcoin-cryptography-w24-p8_seed_corpus.zip
+#cp cryptofuzz-bitcoin-cryptography_seed_corpus.zip $OUT/cryptofuzz-bitcoin-cryptography-w24-p8_seed_corpus.zip

--- a/projects/bitcoin-core/build_cryptofuzz.sh
+++ b/projects/bitcoin-core/build_cryptofuzz.sh
@@ -160,12 +160,11 @@ rm cryptofuzz
 make
 cp cryptofuzz $OUT/cryptofuzz-bitcoin-cryptography-w15-p4
 
-# Disabled because it makes Clang crash
-#build_libsecp256k1 "--with-ecmult-window=24" "--with-ecmult-gen-precision=8"
-#cd $SRC/cryptofuzz/
-#rm cryptofuzz
-#make
-#cp cryptofuzz $OUT/cryptofuzz-bitcoin-cryptography-w24-p8
+build_libsecp256k1 "--with-ecmult-window=20" "--with-ecmult-gen-precision=8"
+cd $SRC/cryptofuzz/
+rm cryptofuzz
+make
+cp cryptofuzz $OUT/cryptofuzz-bitcoin-cryptography-w20-p8
 
 # Convert Wycheproof test vectors to Cryptofuzz corpus format
 mkdir $SRC/corpus-cryptofuzz-wycheproof/
@@ -175,4 +174,4 @@ zip -j cryptofuzz-bitcoin-cryptography_seed_corpus.zip $SRC/corpus-cryptofuzz-wy
 # Use them as the seed corpus for each of the fuzzers
 cp cryptofuzz-bitcoin-cryptography_seed_corpus.zip $OUT/cryptofuzz-bitcoin-cryptography-w2-p2_seed_corpus.zip
 cp cryptofuzz-bitcoin-cryptography_seed_corpus.zip $OUT/cryptofuzz-bitcoin-cryptography-w15-p4_seed_corpus.zip
-#cp cryptofuzz-bitcoin-cryptography_seed_corpus.zip $OUT/cryptofuzz-bitcoin-cryptography-w24-p8_seed_corpus.zip
+cp cryptofuzz-bitcoin-cryptography_seed_corpus.zip $OUT/cryptofuzz-bitcoin-cryptography-w20-p8_seed_corpus.zip

--- a/projects/bitcoin-core/project.yaml
+++ b/projects/bitcoin-core/project.yaml
@@ -12,8 +12,7 @@ auto_ccs:
 sanitizers:
   - address
   - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
-#  - memory
+  - memory
 architectures:
   - x86_64
   - i386


### PR DESCRIPTION
## Disable schorr_fun Cryptofuzz modulle

Because compiling Rust library is not possible currently:

- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=37524
- https://github.com/google/oss-fuzz/issues/6268

## Disabling w24-p8 libsecp256k1 build (`--with-ecmult-window=24 --with-ecmult-gen-precision=8`) because Clang crashes

(not applicable anymore).

## Other changes

I applied the changes proposed here: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=37524#c4