### PR TITLE
[libvips] Upgrade to Ubuntu 20.04

### DIFF
--- a/projects/libvips/Dockerfile
+++ b/projects/libvips/Dockerfile
@@ -14,28 +14,24 @@
 #
 ################################################################################
 
-# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
-# See https://github.com/google/oss-fuzz/issues/6291 for more details.
-FROM gcr.io/oss-fuzz-base/base-builder:xenial
-# Delete line above and uncomment line below to upgrade to 20.04.
-# FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y \
-  curl \
   automake \
+  autopoint \
   cmake \
-  nasm \
-  gtk-doc-tools \
+  curl \
+  gettext \
+  glib2.0-dev \
   gobject-introspection \
-  python3-pip \
-  libfftw3-dev \
+  gtk-doc-tools \
+  libbrotli-dev \
   libexpat1-dev \
   libffi-dev \
+  libfftw3-dev \
   libselinux1-dev \
-  glib2.0-dev \
-  autopoint \
-  gettext \
   libtool \
-  glib2.0-dev
+  nasm \
+  python3-pip
 RUN pip3 install meson ninja
 RUN mkdir afl-testcases
 RUN curl https://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz | tar xzC afl-testcases

--- a/projects/libvips/build.sh
+++ b/projects/libvips/build.sh
@@ -164,22 +164,16 @@ cmake -G "Unix Makefiles" \
   -DBUILD_SHARED_LIBS=0 \
   -DBUILD_TESTING=0 \
   -DJPEGXL_STATIC=1 \
+  -DJPEGXL_FORCE_SYSTEM_BROTLI=1 \
   -DJPEGXL_ENABLE_FUZZERS=0 \
   -DJPEGXL_ENABLE_MANPAGES=0 \
   -DJPEGXL_ENABLE_BENCHMARK=0 \
   -DJPEGXL_ENABLE_EXAMPLES=0 \
   -DJPEGXL_ENABLE_SKCMS=0 \
+  -DJPEGXL_ENABLE_SJPEG=0 \
   .
 make -j$(nproc)
 make install
-# libbrotli-dev package is too old in Ubuntu 16.04, use jpeg-xl version
-cp -r third_party/brotli/c/include/brotli $WORK/include
-cp third_party/brotli/*.a $WORK/lib
-cp third_party/brotli/*.pc $WORK/lib/pkgconfig
-# Fix pkg-config files of libbrotli
-sed -i'.bak' "s/-lbrotlienc/&-static/" $WORK/lib/pkgconfig/libbrotlienc.pc
-sed -i'.bak' "s/-lbrotlidec/&-static/" $WORK/lib/pkgconfig/libbrotlidec.pc
-sed -i'.bak' "s/-lbrotlicommon/&-static/" $WORK/lib/pkgconfig/libbrotlicommon.pc
 popd
 
 # libimagequant
@@ -244,15 +238,13 @@ for fuzzer in fuzz/*_fuzzer.cc; do
     $WORK/lib/libjxl.a \
     $WORK/lib/libjxl_threads.a \
     $WORK/lib/libhwy.a \
-    $WORK/lib/libbrotlienc-static.a \
-    $WORK/lib/libbrotlidec-static.a \
-    $WORK/lib/libbrotlicommon-static.a \
     $WORK/lib/libimagequant.a \
     $WORK/lib/libcgif.a \
     $LIB_FUZZING_ENGINE \
     -Wl,-Bstatic \
-    -lfftw3 -lgmodule-2.0 -lgio-2.0 -lgobject-2.0 -lffi -lglib-2.0 -lpcre -lexpat \
-    -lresolv -lsepol -lselinux \
+    -lfftw3 -lexpat -lbrotlienc -lbrotlidec -lbrotlicommon \
+    -lgmodule-2.0 -lgio-2.0 -lgobject-2.0 -lffi -lglib-2.0 \
+    -lresolv -lmount -lblkid -lselinux -lsepol -lpcre \
     -Wl,-Bdynamic -pthread
   ln -sf "seed_corpus.zip" "$OUT/${target}_seed_corpus.zip"
 done


### PR DESCRIPTION
- Use libbrotli from system.
- Build libjxl without sjpeg support.
- Link fuzzers against libmount and libblkid (needed by libgio).
- Sort and remove duplicated apt-get packages.