### PR TITLE
tor: Use default focal image

### DIFF
--- a/projects/tor/Dockerfile
+++ b/projects/tor/Dockerfile
@@ -14,11 +14,7 @@
 #
 ##############################################################################
 
-# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
-# See https://github.com/google/oss-fuzz/issues/6291 for more details.
-FROM gcr.io/oss-fuzz-base/base-builder:xenial
-# Delete line above and uncomment line below to upgrade to 20.04.
-# FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y autoconf automake make libtool pkg-config
 RUN git clone --depth 1 https://git.torproject.org/tor.git
 RUN git clone --depth 1 https://git.torproject.org/fuzzing-corpora.git tor-fuzz-corpora

--- a/projects/tor/build.sh
+++ b/projects/tor/build.sh
@@ -67,6 +67,7 @@ export ASAN_OPTIONS=detect_leaks=0
     LDFLAGS="-L${TOR_DEPS}/lib64"
 
 make clean
+make micro-revision.i  # Workaround from https://gitlab.torproject.org/tpo/core/tor/-/issues/29520#note_2749427
 make -j$(nproc) oss-fuzz-fuzzers
 
 TORLIBS="`make show-testing-libs`"


### PR DESCRIPTION
No need to use the EOL xenial image