### PR TITLE
Update auto-cc for spirv-tools

### DIFF
--- a/projects/spirv-tools/project.yaml
+++ b/projects/spirv-tools/project.yaml
@@ -3,6 +3,7 @@ language: c++
 primary_contact: rharrison@google.com 
 auto_ccs:
   - "afdx@google.com"
+  - "radial-team@google.com"
 sanitizers:
   - address
   - memory


### PR DESCRIPTION
Adds the Radial team to the auto-cc list.