### PR TITLE
[libssh2][python3-libraries][django] Run apt-get update

### DIFF
--- a/projects/django/Dockerfile
+++ b/projects/django/Dockerfile
@@ -15,7 +15,8 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get install -y build-essential libncursesw5-dev libreadline-dev libssl-dev libgdbm-dev libc6-dev libsqlite3-dev tk-dev libbz2-dev zlib1g-dev libffi-dev wget
+RUN apt-get update && \
+    apt-get install -y build-essential libncursesw5-dev libreadline-dev libssl-dev libgdbm-dev libc6-dev libsqlite3-dev tk-dev libbz2-dev zlib1g-dev libffi-dev wget
 RUN wget -q https://github.com/python/cpython/archive/v3.8.7.tar.gz
 RUN git clone --depth 1 https://github.com/django/django-fuzzers.git
 RUN git clone --depth 1 https://github.com/django/django.git

--- a/projects/libssh2/build.sh
+++ b/projects/libssh2/build.sh
@@ -15,5 +15,6 @@
 #
 ################################################################################
 
+apt-get update
 # Run the OSS-Fuzz script in the project.
 ./tests/ossfuzz/ossfuzz.sh

--- a/projects/python3-libraries/Dockerfile
+++ b/projects/python3-libraries/Dockerfile
@@ -15,7 +15,8 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get install -y build-essential libncursesw5-dev libreadline-dev libssl-dev libgdbm-dev libc6-dev libsqlite3-dev tk-dev libbz2-dev zlib1g-dev libffi-dev
+RUN apt-get update && \
+    apt-get install -y build-essential libncursesw5-dev libreadline-dev libssl-dev libgdbm-dev libc6-dev libsqlite3-dev tk-dev libbz2-dev zlib1g-dev libffi-dev
 RUN git clone https://github.com/python/cpython.git cpython
 RUN git clone --depth 1 https://github.com/guidovranken/python-library-fuzzers.git
 COPY build.sh $SRC/


### PR DESCRIPTION
Not doing this relies on the base-builder image running apt-get
update "recently" and is a bad assumption.