### PR TITLE
Disable honggfuzz from the tint build

### DIFF
--- a/projects/tint/project.yaml
+++ b/projects/tint/project.yaml
@@ -11,3 +11,6 @@ main_repo: 'https://dawn.googlesource.com/tint.git'
 architectures:
   - x86_64
   - i386
+fuzzing_engines:
+  - libfuzzer
+  - afl


### PR DESCRIPTION
Currently there are errors building with honggfuzz. This may be because
the tint fuzz targets are not correctly configured - the tint build
system does not use the LIB_FUZZING_ENGINE environment variable and
instead hard codes various fuzzer flags. This will be fixed in due
course, but disabling honggfuzz for now to get the OSS-Fuzz build
working.