### PR TITLE
Add corpora to the spirv-tools project

### DIFF
--- a/projects/spirv-tools/build.sh
+++ b/projects/spirv-tools/build.sh
@@ -17,9 +17,10 @@
 
 git clone https://github.com/KhronosGroup/SPIRV-Headers external/spirv-headers --depth=1
 git clone https://github.com/protocolbuffers/protobuf   external/protobuf      --branch v3.13.0.1
+git clone https://dawn.googlesource.com/tint --depth=1
 
 mkdir build
-cd build
+pushd build
 
 CMAKE_ARGS="-DSPIRV_BUILD_LIBFUZZER_TARGETS=ON"
 
@@ -31,4 +32,54 @@ fi
 cmake -G Ninja .. ${CMAKE_ARGS}
 ninja
 
-cp test/fuzzers/spvtools_*_fuzzer $OUT
+SPIRV_BINARY_FUZZERS="spvtools_binary_parser_fuzzer\
+ spvtools_dis_fuzzer\
+ spvtools_opt_legalization_fuzzer\
+ spvtools_opt_performance_fuzzer\
+ spvtools_opt_size_fuzzer\
+ spvtools_val_fuzzer"
+
+SPIRV_ASSEMBLY_FUZZERS="spvtools_as_fuzzer"
+
+for fuzzer in $SPIRV_BINARY_FUZZERS $SPIRV_ASSEMBLY_FUZZERS
+do
+  cp test/fuzzers/$fuzzer $OUT
+done
+
+popd
+
+# Generate a corpus of SPIR-V binaries from the SPIR-V assembly files in the
+# SPIRV-Tools and tint repositories.
+mkdir $WORK/tint-binary-corpus
+python3 tint/fuzzers/generate_spirv_corpus.py tint/test $WORK/tint-binary-corpus build/tools/spirv-as
+mkdir $WORK/spirv-binary-corpus-hashed-names
+tint_test_cases=`ls $WORK/tint-binary-corpus/*.spv`
+spirv_tools_test_cases=`find test/fuzzers/corpora -name "*.spv"`
+for f in $tint_test_cases $spirv_tools_test_cases
+do
+  hashed_name=$(sha1sum "$f" | awk '{print $1}')
+  cp $f $WORK/spirv-binary-corpus-hashed-names/$hashed_name
+done
+zip -j "$WORK/spirv_binary_seed_corpus.zip" "$WORK/spirv-binary-corpus-hashed-names"/*
+
+# Supply each of the binary fuzzers with this seed corpus.
+for fuzzer in $SPIRV_BINARY_FUZZERS
+do
+  cp "$WORK/spirv_binary_seed_corpus.zip" "$OUT/${fuzzer}_seed_corpus.zip"
+done
+
+# Generate a corpus of SPIR-V assembly files from the tint repository.
+mkdir $WORK/spirv-assembly-corpus-hashed-names
+for f in `find tint/test -name "*.spvasm"`
+do
+  hashed_name=$(sha1sum "$f" | awk '{print $1}')
+  cp $f $WORK/spirv-assembly-corpus-hashed-names/$hashed_name
+done
+
+zip -j "$WORK/spirv_assembly_seed_corpus.zip" "$WORK/spirv-assembly-corpus-hashed-names"/*
+
+# Supply each of the assembly fuzzers with this seed corpus.
+for fuzzer in $SPIRV_ASSEMBLY_FUZZERS
+do
+  cp "$WORK/spirv_assembly_seed_corpus.zip" "$OUT/${fuzzer}_seed_corpus.zip"
+done


### PR DESCRIPTION
Adds corpora of SPIR-V binary and assembly shaders to the spirv-tools
project, based on shaders in the SPIRV-Tools and tint repositories.