### PR TITLE
Fixes ecc-diff-fuzzer with new base-builder

### DIFF
--- a/projects/ecc-diff-fuzzer/Dockerfile
+++ b/projects/ecc-diff-fuzzer/Dockerfile
@@ -14,7 +14,10 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+ENV GOPATH /root/go
+ENV PATH $PATH:/root/.go/bin:$GOPATH/bin
+RUN install_go.sh
 RUN apt-get update && apt-get install -y make cmake bzip2 autoconf automake gettext libtool python curl
 RUN rustup target add i686-unknown-linux-gnu
 #use different package sources for recent npm

--- a/projects/suricata/Dockerfile
+++ b/projects/suricata/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder-rust
 RUN apt-get update && apt-get install -y build-essential autoconf automake libtool make pkg-config  python flex bison zlib1g-dev libpcre3-dev cmake tshark
 
 # TODO libmagic, liblzma and other optional libraries


### PR DESCRIPTION
Needing both rust and golang

Cf https://github.com/google/oss-fuzz/pull/6361#issuecomment-910718334

Same for Suricata needing rust