### PR TITLE
tint: pass LIB_FUZZING_ENGINE more elegantly

### DIFF
--- a/projects/tint/build.sh
+++ b/projects/tint/build.sh
@@ -25,7 +25,7 @@ pushd out/Debug
 # when building tint.
 CFLAGS="$CFLAGS -fno-sanitize=vptr" \
 CXXFLAGS="$CXXFLAGS -fno-sanitize=vptr" \
-cmake -GNinja ../.. -DTINT_BUILD_FUZZERS=ON -DTINT_BUILD_SPIRV_TOOLS_FUZZER=ON -DTINT_BUILD_TESTS=OFF
+cmake -GNinja ../.. -DTINT_BUILD_FUZZERS=ON -DTINT_BUILD_SPIRV_TOOLS_FUZZER=ON -DTINT_BUILD_TESTS=OFF -DTINT_LIB_FUZZING_ENGINE_LINK_OPTIONS=$LIB_FUZZING_ENGINE
 
 SPIRV_FUZZERS="tint_spv_reader_fuzzer\
  tint_spv_reader_msl_writer_fuzzer\


### PR DESCRIPTION
The LIB_FUZZING_ENGINE environment variable is now passed to tint's
CMake command as an option, rather than having the environment variable
be queried in the project's CMake files.