### PR TITLE
spirv-tools: re-enable honggfuzz

### DIFF
--- a/projects/spirv-tools/project.yaml
+++ b/projects/spirv-tools/project.yaml
@@ -13,6 +13,3 @@ main_repo: 'https://github.com/KhronosGroup/SPIRV-Tools.git'
 architectures:
   - x86_64
   - i386
-fuzzing_engines:
-  - libfuzzer
-  - afl


### PR DESCRIPTION
Now that the CMake files for spirv-tools have been fixed, so that when
LIB_FUZZING_ENGINE is set, it is used as the sole way of specifying
fuzzer-related linker flags, the honggfuzz engine should work. This
change reverts the project to use the default set of fuzzing engines,
which includes honggfuzz.