### PR TITLE
tint: re-enable honggfuzz

### DIFF
--- a/projects/tint/project.yaml
+++ b/projects/tint/project.yaml
@@ -11,6 +11,3 @@ main_repo: 'https://dawn.googlesource.com/tint.git'
 architectures:
   - x86_64
   - i386
-fuzzing_engines:
-  - libfuzzer
-  - afl


### PR DESCRIPTION
Now that the CMake files for int have been fixed, so that when
LIB_FUZZING_ENGINE is set, it is used as the sole way of specifying
fuzzer-related linker flags, the honggfuzz engine should work. This
change reverts the project to use the default set of fuzzing engines,
which includes honggfuzz.