### PR TITLE
[RawSpeed] Reenable errneously disabled MSan build

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/projects/librawspeed/ @LebedevRI

--- a/projects/librawspeed/project.yaml
+++ b/projects/librawspeed/project.yaml
@@ -4,6 +4,5 @@ primary_contact: "lebedev.ri@gmail.com"
 sanitizers:
 - address
 - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
-# - memory
+- memory
 main_repo: 'https://github.com/darktable-org/rawspeed.git'


### PR DESCRIPTION
I was not notified about that change, which i believe to be errneous.
The fuzzers built here do *not* link to *any* outside libraries.

Refs. https://github.com/google/oss-fuzz/pull/6281
Refs. https://github.com/google/oss-fuzz/issues/6294