### PR TITLE
grpc-swift needs zlib

### DIFF
--- a/infra/base-images/base-builder-swift/precompile_swift
+++ b/infra/base-images/base-builder-swift/precompile_swift
@@ -23,12 +23,11 @@ then
     export SWIFTFLAGS="$SWIFTFLAGS -Xswiftc -profile-generate -Xswiftc -profile-coverage-mapping -Xswiftc -sanitize=fuzzer"
 else
     export SWIFTFLAGS="$SWIFTFLAGS -Xswiftc -sanitize=fuzzer,$SANITIZER --sanitize=$SANITIZER"
+    for f in $CFLAGS; do
+        export SWIFTFLAGS="$SWIFTFLAGS -Xcc=$f"
+    done
+
+    for f in $CXXFLAGS; do
+        export SWIFTFLAGS="$SWIFTFLAGS -Xcxx=$f"
+    done
 fi
-
-for f in $CFLAGS; do
-    export SWIFTFLAGS="$SWIFTFLAGS -Xcc=$f"
-done
-
-for f in $CXXFLAGS; do
-    export SWIFTFLAGS="$SWIFTFLAGS -Xcxx=$f"
-done

--- a/projects/grpc-swift/Dockerfile
+++ b/projects/grpc-swift/Dockerfile
@@ -17,6 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder-swift
 
 # specific to project
+RUN apt-get update && apt-get install -y zlib1g-dev
 RUN git clone --depth 1 https://github.com/grpc/grpc-swift
 COPY build.sh $SRC
 WORKDIR $SRC/grpc-swift


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=38116

Another fix could be to keep zlib1g-dev after installing swift
```
diff --git a/infra/base-images/base-builder/install_swift.sh b/infra/base-images/base-builder/install_swift.sh
index d88a7b5c..6934f65c 100755
--- a/infra/base-images/base-builder/install_swift.sh
+++ b/infra/base-images/base-builder/install_swift.sh
@@ -62,5 +62,5 @@ cd $SRC
 rm -rf llvm-project llvmsymbol.diff
 
 # TODO: Cleanup packages
-apt-get remove --purge -y wget zlib1g-dev
+apt-get remove --purge -y wget
 apt-get autoremove -y
```