### PR TITLE
Zydis: Enable assertions during fuzzing

### DIFF
--- a/projects/zydis/build.sh
+++ b/projects/zydis/build.sh
@@ -20,6 +20,7 @@ mv $SRC/ZydisFuzz_seed_corpus.zip $OUT/ZydisFuzz_seed_corpus.zip
 mkdir build && cd build
 
 cmake                                   \
+    -DZYAN_FORCE_ASSERTS=ON             \
     -DZYDIS_BUILD_EXAMPLES=OFF          \
     -DZYDIS_BUILD_TOOLS=OFF             \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo   \
@@ -29,7 +30,7 @@ cmake                                   \
     -DCMAKE_CXX_FLAGS="$CXXFLAGS"       \
     ..
 
-make -j8
+make -j$(nproc) VERBOSE=1
 
 $CXX                                    \
     $CXXFLAGS                           \


### PR DESCRIPTION
Now that we've been running in OSS-Fuzz for a while and haven't seen any crashes for quite a bit, we figured that it'd be a good idea to step it up a bit and build with assertions enabled to additionally verify all of our internal assumptions.

In addition to that, this PR also enables more verbose printing during the build to make it easier to see what flags are actually passed in the logs.

Related Zydis PRs: 
- https://github.com/zyantific/zydis/pull/217
- https://github.com/zyantific/zycore-c/pull/29

CC @flobernd