### PR TITLE
qemu: add default fuzzing options

### DIFF
--- a/projects/qemu/default.options
+++ b/projects/qemu/default.options
@@ -1,0 +1,3 @@
+[libfuzzer]
+close_fd_mask=3
+detect_leaks=0


### PR DESCRIPTION
Close fds, and disable leak detection

Signed-off-by: Alexander Bulekov <alxndr@bu.edu>