### PR TITLE
Samba builds now expect Ubuntu 20.04

### DIFF
--- a/projects/samba/Dockerfile
+++ b/projects/samba/Dockerfile
@@ -14,11 +14,7 @@
 #
 ################################################################################
 
-# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
-# See https://github.com/google/oss-fuzz/issues/6291 for more details.
-FROM gcr.io/oss-fuzz-base/base-builder:xenial
-# Delete line above and uncomment line below to upgrade to 20.04.
-# FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN git clone https://gitlab.com/samba-team/samba samba
 RUN samba/lib/fuzzing/oss-fuzz/build_image.sh


### PR DESCRIPTION
Per #6302 and https://github.com/google/oss-fuzz/issues/6301#issuecomment-911705365 Samba needed, and now did upgrade the build scripts to run on Ubuntu 20.04.

See https://github.com/samba-team/samba/commit/4366c3bb71fe9c083dedeae8798547b64a64d2b4