### PR TITLE
libass: fix build, upgrade Ubuntu, update contacts

### DIFF
--- a/projects/libass/Dockerfile
+++ b/projects/libass/Dockerfile
@@ -14,16 +14,11 @@
 #
 ################################################################################
 
-# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
-# See https://github.com/google/oss-fuzz/issues/6291 for more details.
-FROM gcr.io/oss-fuzz-base/base-builder:xenial
-# Delete line above and uncomment line below to upgrade to 20.04.
-# FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config libfreetype6-dev libfontconfig1-dev python3-pip && \
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config libfontconfig1-dev libfreetype-dev libfribidi-dev python3-pip && \
     pip3 install meson==0.53.0 ninja
 
 RUN git clone --depth 1 https://github.com/libass/libass.git
-RUN git clone --depth 1 https://github.com/behdad/fribidi.git
 RUN git clone --depth 1 https://github.com/harfbuzz/harfbuzz.git
 
 COPY build.sh libass_fuzzer.cc *.dict *.options $SRC/

--- a/projects/libass/build.sh
+++ b/projects/libass/build.sh
@@ -15,10 +15,6 @@
 #
 ################################################################################
 
-cd $SRC/fribidi
-./autogen.sh --disable-docs --enable-static=yes --enable-shared=no --with-pic=yes --prefix=/work/
-make install
-
 cd $SRC/harfbuzz
 
 # setup
@@ -45,10 +41,11 @@ export PKG_CONFIG_PATH=/work/lib/pkgconfig
 ./configure --disable-asm
 make -j$(nproc)
 
-$CXX $CXXFLAGS -std=c++11 -I$SRC/libass -L/work/lib \
+$CXX $CXXFLAGS -std=c++11 -I$SRC/libass \
     $SRC/libass_fuzzer.cc -o $OUT/libass_fuzzer \
     $LIB_FUZZING_ENGINE libass/.libs/libass.a \
-    -Wl,-Bstatic -lfontconfig  -lfribidi -lfreetype -lharfbuzz -lz -lpng12 \
-    -lexpat -Wl,-Bdynamic
+    -Wl,-Bstatic \
+    $(pkg-config --static --libs fontconfig freetype2 fribidi harfbuzz | sed 's/-lm //g') \
+    -Wl,-Bdynamic
 
 cp $SRC/*.dict $SRC/*.options $OUT/

--- a/projects/libass/build.sh
+++ b/projects/libass/build.sh
@@ -33,6 +33,7 @@ CFLAGS="$CFLAGS -fno-sanitize=vptr" \
 CXXFLAGS="$CXXFLAGS -fno-sanitize=vptr" \
 meson --default-library=static --wrap-mode=nodownload \
       -Dfuzzer_ldflags="$(echo $LIB_FUZZING_ENGINE)" \
+      -Dtests=disabled \
       --prefix=/work/ --libdir=lib $build \
   || (cat build/meson-logs/meson-log.txt && false)
 meson install -C $build

--- a/projects/libass/project.yaml
+++ b/projects/libass/project.yaml
@@ -1,10 +1,9 @@
 homepage: "https://github.com/libass/libass"
 language: c++
-primary_contact: "greg@kinoho.net"
+primary_contact: "chortos@inbox.lv"
 auto_ccs:
+  - "greg@kinoho.net"
   - "rodger.combs@gmail.com"
-  - "nfxjfg@gmail.com"
-  - "chortos@inbox.lv"
   - "vabnick@gmail.com"
 sanitizers:
   - address


### PR DESCRIPTION
libass got a new [coverage build failure](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=38511) which I don’t really understand. When I tried to search whether other people had reported similar cases, I stumbled upon https://github.com/google/oss-fuzz/issues/6291 and discovered libass was one of the remaining Ubuntu 16.04 projects. Perhaps the Ubuntu 16.04 environment has gotten somehow borked.

This PR upgrades libass to Ubuntu 20.04 and cleans up the build script. (In particular, this should make future upgrades smoother, hopefully.)

While I was at it, I also updated our contact list:
* One address is removed because the person has severed all contact with the development team and deleted their GitHub account. The bugs.chromium.org/p/oss-fuzz UI also shows they have “never” visited the bug tracker, although I don’t know how reliable this info is.
* Our former primary contact has become inactive, so I’ve swapped their email with my own. I’m one of the currently active core developers, and recent releases have been signed with my PGP key.