### PR TITLE
swift: no explicit linker

### DIFF
--- a/infra/base-images/base-builder-swift/precompile_swift
+++ b/infra/base-images/base-builder-swift/precompile_swift
@@ -17,7 +17,7 @@
 
 cp /usr/local/bin/llvm-symbolizer-swift $OUT/llvm-symbolizer
 
-export SWIFTFLAGS="-Xswiftc -parse-as-library -Xswiftc -static-stdlib -Xswiftc -use-ld=/usr/bin/ld --static-swift-stdlib"
+export SWIFTFLAGS="-Xswiftc -parse-as-library -Xswiftc -static-stdlib --static-swift-stdlib"
 if [ "$SANITIZER" = "coverage" ]
 then
     export SWIFTFLAGS="$SWIFTFLAGS -Xswiftc -profile-generate -Xswiftc -profile-coverage-mapping -Xswiftc -sanitize=fuzzer"


### PR DESCRIPTION
ld.gold is default and works better than ld

cc @jonathanmetzman 
Should fix swift projects builds after clang 14 update
cf https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=38503