### PR TITLE
[skia] Make swiftshader build less noisy

### DIFF
--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -43,7 +43,9 @@ elif [ $SANITIZER == "thread" ]; then
 else
   exit 1
 fi
-CFLAGS= CXXFLAGS="-stdlib=libc++" cmake .. -GNinja -DCMAKE_MAKE_PROGRAM="$SRC/depot_tools/ninja" -D$CMAKE_SANITIZER=1
+# These deprecated warnings get quite noisy and mask other issues.
+CFLAGS= CXXFLAGS="-stdlib=libc++ -Wno-deprecated-declarations" cmake .. -GNinja \
+  -DCMAKE_MAKE_PROGRAM="$SRC/depot_tools/ninja" -D$CMAKE_SANITIZER=1
 
 $SRC/depot_tools/ninja libGLESv2_deprecated libEGL_deprecated
 # Skia is looking for the names w/o the _deprecated tag. The libraries themselves


### PR DESCRIPTION
These deprecated warnings were making it hard to determine what the actual swiftshader compile error was.

There was an extra copy-assignment constructor that Clang 14 isn't happy about. That should be fixed with https://swiftshader-review.googlesource.com/c/SwiftShader/+/57028

This PR silences the deprecated-declaration warnings, which are not treated as errors, but are noisy.