### PR TITLE
Coverage for rust projects with clang 13

### DIFF
--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -102,7 +102,9 @@ then
     # link to C++ from comment in f5098035eb1a14aa966c8651d88ea3d64323823d
     export RUSTFLAGS="$RUSTFLAGS -Zinstrument-coverage -C link-arg=-lc++"
     if [ "$FUZZING_LANGUAGE" = "rust" ]; then
-        # Copy latest llvm-symbolizer in $OUT for stack symbolization.
+        # Copy right llvm coverage tools
+        export CC=clang-13
+        export CXX=clang++-13
         cp /usr/bin/llvm-cov-13 $OUT/llvm-cov
         cp /usr/bin/llvm-profdata-13 $OUT/llvm-profdata
     fi

--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -103,10 +103,8 @@ then
     export RUSTFLAGS="$RUSTFLAGS -Zinstrument-coverage -C link-arg=-lc++"
     if [ "$FUZZING_LANGUAGE" = "rust" ]; then
         # Copy right llvm coverage tools
-        export CC=clang-13
-        export CXX=clang++-13
-        cp /usr/bin/llvm-cov-13 $OUT/llvm-cov
-        cp /usr/bin/llvm-profdata-13 $OUT/llvm-profdata
+        cp $(which llvm-cov) $OUT/
+        cp $(which llvm-profdata) $OUT/
     fi
 fi
 

--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -101,6 +101,11 @@ if [ "$SANITIZER" = "coverage" ]
 then
     # link to C++ from comment in f5098035eb1a14aa966c8651d88ea3d64323823d
     export RUSTFLAGS="$RUSTFLAGS -Zinstrument-coverage -C link-arg=-lc++"
+    if [ "$FUZZING_LANGUAGE" = "rust" ]; then
+        # Copy latest llvm-symbolizer in $OUT for stack symbolization.
+        cp /usr/bin/llvm-cov-13 $OUT/llvm-cov
+        cp /usr/bin/llvm-profdata-13 $OUT/llvm-profdata
+    fi
 fi
 
 # Add Rust libfuzzer flags.

--- a/infra/base-images/base-builder/install_rust.sh
+++ b/infra/base-images/base-builder/install_rust.sh
@@ -23,6 +23,7 @@ rustup component add rust-src --toolchain nightly
 (
 unset CFLAGS
 unset CXXFLAGS
+# so that compile_libfuzzer can copy, without knowing the clang version
 rm /usr/local/lib/clang/*/lib/linux/libclang_rt.fuzzer-*
 /root/checkout_build_install_llvm.sh llvmorg-13.0.0-rc2-g34ff6a75f583
 )

--- a/infra/base-images/base-builder/install_rust.sh
+++ b/infra/base-images/base-builder/install_rust.sh
@@ -23,5 +23,6 @@ rustup component add rust-src --toolchain nightly
 (
 unset CFLAGS
 unset CXXFLAGS
+rm /usr/local/lib/clang/*/lib/linux/libclang_rt.fuzzer-*
 /root/checkout_build_install_llvm.sh llvmorg-13.0.0-rc2-g34ff6a75f583
 )

--- a/infra/base-images/base-builder/install_rust.sh
+++ b/infra/base-images/base-builder/install_rust.sh
@@ -20,4 +20,8 @@ cargo install cargo-fuzz && rm -rf /rust/registry
 # Needed to recompile rust std library for MSAN
 rustup component add rust-src --toolchain nightly
 
+(
+unset CFLAGS
+unset CXXFLAGS
 /root/checkout_build_install_llvm.sh llvmorg-13.0.0-rc2-g34ff6a75f583
+)

--- a/infra/base-images/base-builder/install_rust.sh
+++ b/infra/base-images/base-builder/install_rust.sh
@@ -19,3 +19,9 @@ curl https://sh.rustup.rs | sh -s -- -y --default-toolchain=nightly --profile=mi
 cargo install cargo-fuzz && rm -rf /rust/registry
 # Needed to recompile rust std library for MSAN
 rustup component add rust-src --toolchain nightly
+
+apt-get update && apt-get install -y wget
+wget https://apt.llvm.org/llvm.sh
+chmod +x llvm.sh
+./llvm.sh 13
+apt-get remove -y wget

--- a/infra/base-images/base-builder/install_rust.sh
+++ b/infra/base-images/base-builder/install_rust.sh
@@ -20,8 +20,4 @@ cargo install cargo-fuzz && rm -rf /rust/registry
 # Needed to recompile rust std library for MSAN
 rustup component add rust-src --toolchain nightly
 
-apt-get update && apt-get install -y wget
-wget https://apt.llvm.org/llvm.sh
-chmod +x llvm.sh
-./llvm.sh 13
-apt-get remove -y wget
+/root/checkout_build_install_llvm.sh llvmorg-13.0.0-rc2-g34ff6a75f583

--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -32,7 +32,6 @@ COPY checkout_build_install_llvm.sh /root/
 # Keep all steps in the same script to decrease the number of intermediate
 # layes in docker file.
 RUN /root/checkout_build_install_llvm.sh
-RUN rm /root/checkout_build_install_llvm.sh
 
 # Setup the environment.
 ENV CC "clang"

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -75,6 +75,10 @@ OUR_LLVM_REVISION=llvmorg-12-init-17251-g6de48655
 # To allow for manual downgrades. Set to 0 to use Chrome's clang version (i.e.
 # *not* force a manual downgrade). Set to 1 to force a manual downgrade.
 FORCE_OUR_REVISION=0
+if [ $# -eq 1 ] ; then
+  OUR_LLVM_REVISION=$1
+  FORCE_OUR_REVISION=1
+fi
 LLVM_REVISION=$(grep -Po "CLANG_REVISION = '\K([^']+)" scripts/update.py)
 
 clone_with_retries https://github.com/llvm/llvm-project.git $LLVM_SRC

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -190,8 +190,10 @@ cp -r $LLVM_SRC/compiler-rt/lib/fuzzer $SRC/libfuzzer
 # Cleanup
 rm -rf $LLVM_SRC
 rm -rf $SRC/chromium_tools
-apt-get remove --purge -y $LLVM_DEP_PACKAGES
-apt-get autoremove -y
+if [ $# -eq 0 ] ; then
+  apt-get remove --purge -y $LLVM_DEP_PACKAGES
+  apt-get autoremove -y
+fi
 
 # Delete unneeded parts of LLVM to reduce image size.
 # See https://github.com/google/oss-fuzz/issues/5170

--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -16,12 +16,18 @@
 ################################################################################
 cd $OUT
 
+# copy version/language-specific coverage tools if any
+cp $OUT/llvm-cov /usr/local/bin || true
+cp $OUT/llvm-profdata /usr/local/bin || true
+
 if (( $# > 0 )); then
   FUZZ_TARGETS="$@"
 else
   FUZZ_TARGETS="$(find . -maxdepth 1 -type f -executable -printf '%P\n' | \
       grep -v -x -F \
       -e 'llvm-symbolizer' \
+      -e 'llvm-cov' \
+      -e 'llvm-profdata' \
       -e 'jazzer_agent_deploy.jar' \
       -e 'jazzer_driver' \
       -e 'jazzer_driver_with_sanitizer')"

--- a/projects/suricata/project.yaml
+++ b/projects/suricata/project.yaml
@@ -1,5 +1,5 @@
 homepage: "https://suricata-ids.org"
-language: c++
+language: rust
 primary_contact: "vjulien@openinfosecfoundation.org"
 auto_ccs:
 - "jish@openinfosecfoundation.org"


### PR DESCRIPTION
Fixes #6268

As discussed in https://reviews.llvm.org/D104556 since clang supports only one version of profraw files at a time, we need for llvm-based languages such as rust and swift, to use the right version of clang

For rust, this is now clang 13, (as clang 14 introduced some changes)

- install_rust.sh now installs clang , using checkout_build_install_llvm.sh by giving it an argument of the revision to build (we need also clang13 on the building side and not only llvm-profdata-13, so that multiple languages project produce consistent profraw file)
- `compile` script now copies llvm-profdata and llvm-covin $OUT if needed (as is done for llvm-symbolizer)
- `coverage` script takes specific `llvm-profdata` if any

The same change likely needs to be done for swift, but with clang 12 I guess.