### PR TITLE
Helper fixes for external projects.

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -84,8 +84,8 @@ class Project:
       build_integration_path=constants.DEFAULT_EXTERNAL_BUILD_INTEGRATION_PATH):
     self.is_external = is_external
     if self.is_external:
-      self.name = os.path.basename(os.path.abspath(project_name_or_path))
-      self.path = project_name_or_path
+      self.path = os.path.abspath(project_name_or_path)
+      self.name = os.path.basename(self.path)
       self.build_integration_path = os.path.join(self.path,
                                                  build_integration_path)
     else:
@@ -135,14 +135,16 @@ class Project:
 def main():  # pylint: disable=too-many-branches,too-many-return-statements
   """Gets subcommand from program arguments and does it. Returns 0 on success 1
   on error."""
-  os.chdir(OSS_FUZZ_DIR)
-  if not os.path.exists(BUILD_DIR):
-    os.mkdir(BUILD_DIR)
-
   logging.basicConfig(level=logging.INFO)
 
   parser = get_parser()
   args = parse_args(parser)
+
+  # Note: this has to happen after parse_args above as parse_args needs to know
+  # the original CWD for external projects.
+  os.chdir(OSS_FUZZ_DIR)
+  if not os.path.exists(BUILD_DIR):
+    os.mkdir(BUILD_DIR)
 
   # We have different default values for `sanitizer` depending on the `engine`.
   # Some commands do not have `sanitizer` argument, so `hasattr` is necessary.

--- a/infra/helper_test.py
+++ b/infra/helper_test.py
@@ -165,7 +165,7 @@ class ProjectTest(fake_filesystem_unittest.TestCase):
   def setUp(self):
     self.project_name = 'project'
     self.internal_project = helper.Project(self.project_name)
-    self.external_project_path = os.path.join('path', 'to', self.project_name)
+    self.external_project_path = os.path.join('/path', 'to', self.project_name)
     self.external_project = helper.Project(self.external_project_path,
                                            is_external=True)
     self.setUpPyfakefs()

--- a/infra/templates.py
+++ b/infra/templates.py
@@ -47,7 +47,7 @@ COPY build.sh $SRC/
 """
 
 EXTERNAL_DOCKER_TEMPLATE = """\
-FROM gcr.io/oss-fuzz-base/%(base_builder)s
+FROM gcr.io/oss-fuzz-base/%(base_builder)s:v1
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN COPY . $SRC/%(project_name)s
 WORKDIR %(project_name)s


### PR DESCRIPTION
- Add ":v1" suffix to Dockerfile template.
- Support relative paths for external project directories.