### PR TITLE
infra: Only pull images corresponding to project language

### DIFF
--- a/infra/helper_test.py
+++ b/infra/helper_test.py
@@ -59,9 +59,9 @@ class BuildImageImplTest(unittest.TestCase):
   def test_pull(self, mock_pull_images, _):
     """Tests that pull=True is handled properly."""
     image_name = 'base-image'
-    self.assertTrue(
-        helper.build_image_impl(helper.Project(image_name), pull=True))
-    mock_pull_images.assert_called_with()
+    project = helper.Project(image_name, is_external=True)
+    self.assertTrue(helper.build_image_impl(project, pull=True))
+    mock_pull_images.assert_called_with('c++')
 
   @mock.patch('helper.docker_build')
   def test_base_image(self, mock_docker_build):


### PR DESCRIPTION
infra/helper.py build_image foobar should, when asked to pull base
images, only pull the generic images as well as the base-builder for the
language declared in foobar.