### PR TITLE
janus-gateway: disable memory sanitizer

### DIFF
--- a/projects/janus-gateway/project.yaml
+++ b/projects/janus-gateway/project.yaml
@@ -5,7 +5,8 @@ auto_ccs:
   - "lminiero@gmail.com"
 sanitizers:
   - address
-  - memory
   - undefined
+# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
+#  - memory
 coverage_extra_args: -ignore-filename-regex=.*glib.* -ignore-filename-regex=.*log.c
 main_repo: 'https://github.com/meetecho/janus-gateway.git'


### PR DESCRIPTION
Disable the memory sanitizer in janus-gateway due to [glib not supporting](https://github.com/google/oss-fuzz/blob/master/projects/glib/project.yaml#L12) the sanitizer in oss-fuzz after the upgrade to Ubuntu 20.04.

Please close the monorail issues:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=38786
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=38819
And the related oss-fuzz reports:
https://oss-fuzz.com/testcase-detail/4853666004205568
https://oss-fuzz.com/testcase-detail/6197317464621056