### PR TITLE
bitcoin-core: Temp workaround for UBSan build failure

### DIFF
--- a/projects/bitcoin-core/build.sh
+++ b/projects/bitcoin-core/build.sh
@@ -37,6 +37,13 @@ fi
 sed -i "s|PROVIDE_FUZZ_MAIN_FUNCTION|NEVER_PROVIDE_MAIN_FOR_OSS_FUZZ|g" "./configure.ac"
 ./autogen.sh
 
+# Temporarily compile with O2 to work around clang-13 (and later) UBSan
+# -fsanitize=vptr,object-size false positive that only happens with -O1
+if [ "$SANITIZER" = "undefined" ]; then
+  export CFLAGS="$CFLAGS -O2"
+  export CXXFLAGS="$CXXFLAGS -O2"
+fi
+
 # OSS-Fuzz will provide CC, CXX, etc. So only set:
 # * --enable-fuzz, see https://github.com/bitcoin/bitcoin/blob/master/doc/fuzzing.md
 # * CONFIG_SITE, see https://github.com/bitcoin/bitcoin/blob/master/depends/README.md


### PR DESCRIPTION
Fix for https://oss-fuzz-build-logs.storage.googleapis.com/log-c7c2bcec-feaf-459d-ae58-143cca72f738.txt

```
Step #40 - "build-check-libfuzzer-undefined-x86_64": BAD BUILD: /tmp/not-out/process_message_getaddr seems to have either startup crash or exit:
Step #40 - "build-check-libfuzzer-undefined-x86_64": /tmp/not-out/process_message_getaddr -rss_limit_mb=2560 -timeout=25 -seed=1337 -runs=4 < /dev/null
Step #40 - "build-check-libfuzzer-undefined-x86_64": init.cpp:476:29: runtime error: member call on address 0x55ec4342a908 which does not point to an object of type 'WalletInitInterface'
Step #40 - "build-check-libfuzzer-undefined-x86_64": 0x55ec4342a908: note: object has invalid vptr
Step #40 - "build-check-libfuzzer-undefined-x86_64":  00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00
Step #40 - "build-check-libfuzzer-undefined-x86_64":               ^~~~~~~~~~~~~~~~~~~~~~~
Step #40 - "build-check-libfuzzer-undefined-x86_64":               invalid vptr