### PR TITLE
Use uninstrumented spirv-as for corpus prep

### DIFF
--- a/projects/spirv-tools/project.yaml
+++ b/projects/spirv-tools/project.yaml
@@ -7,7 +7,6 @@ auto_ccs:
   - "stevenperron@google.com"
 sanitizers:
   - address
-  - memory
   - undefined
 main_repo: 'https://github.com/KhronosGroup/SPIRV-Tools.git'
 architectures:


### PR DESCRIPTION
Using an instrumented version of spirv-as for corpus preparation is very
slow, and can also lead to issues where a bug in spirv-as gets picked up
by instrumentation and causes corpus preparation to fail when we would
rather it succeeded despite the bug.