### PR TITLE
libass: release library memory on shutdown

### DIFF
--- a/projects/libass/libass_fuzzer.cc
+++ b/projects/libass/libass_fuzzer.cc
@@ -1,3 +1,21 @@
+/*
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+*/
+
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -12,29 +30,35 @@ void msg_callback(int level, const char *fmt, va_list va, void *data) {
 static const int kFrameWidth = 1280;
 static const int kFrameHeight = 720;
 
-static bool init(int frame_w, int frame_h) {
-  ass_library = ass_library_init();
-  if (!ass_library) {
-    printf("ass_library_init failed!\n");
-    exit(1);
+struct init {
+  init(int frame_w, int frame_h) {
+    ass_library = ass_library_init();
+    if (!ass_library) {
+      printf("ass_library_init failed!\n");
+      exit(1);
+    }
+
+    ass_set_message_cb(ass_library, msg_callback, NULL);
+
+    ass_renderer = ass_renderer_init(ass_library);
+    if (!ass_renderer) {
+      printf("ass_renderer_init failed!\n");
+      exit(1);
+    }
+
+    ass_set_frame_size(ass_renderer, frame_w, frame_h);
+    ass_set_fonts(ass_renderer, nullptr, "sans-serif",
+                  ASS_FONTPROVIDER_AUTODETECT, nullptr, 1);
   }
 
-  ass_set_message_cb(ass_library, msg_callback, NULL);
-
-  ass_renderer = ass_renderer_init(ass_library);
-  if (!ass_renderer) {
-    printf("ass_renderer_init failed!\n");
-    exit(1);
+  ~init() {
+    ass_renderer_done(ass_renderer);
+    ass_library_done(ass_library);
   }
-
-  ass_set_frame_size(ass_renderer, frame_w, frame_h);
-  ass_set_fonts(ass_renderer, nullptr, "sans-serif",
-                ASS_FONTPROVIDER_AUTODETECT, nullptr, 1);
-  return true;
-}
+};
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-  static bool initialized = init(kFrameWidth, kFrameHeight);
+  static init initialized(kFrameWidth, kFrameHeight);
 
   ASS_Track *track = ass_read_memory(ass_library, (char *)data, size, nullptr);
   if (!track) return 0;


### PR DESCRIPTION
AddressSanitizer/LeakSanitizer has begun to report partial leaks due to the library being initialized but never finalized. It’s not clear why only part of the memory is reported and why this hasn’t happened before now, but this is a somewhat legitimate report, so add finalization calls to release all memory.

The libFuzzer API provides no shutdown cleanup hook, so use a static variable with a C++ destructor.

Fixes https://github.com/google/oss-fuzz/issues/6440.

Review with “hide whitespace changes” to minimize the diff.