### PR TITLE
gnutls: Use default focal image (#6473)

### DIFF
--- a/projects/gnutls/Dockerfile
+++ b/projects/gnutls/Dockerfile
@@ -14,11 +14,7 @@
 #
 ################################################################################
 
-# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
-# See https://github.com/google/oss-fuzz/issues/6291 for more details.
-FROM gcr.io/oss-fuzz-base/base-builder:xenial
-# Delete line above and uncomment line below to upgrade to 20.04.
-# FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y \
  make \
  pkg-config \


### PR DESCRIPTION
The gnutls build should be fixed with:
https://gitlab.com/gnutls/gnutls/-/commit/c3137e17356c798ea4c9327a37c0693a500571ae

I have also confirmed with:
```console
$ python infra/helper.py build_image gnutls
$ python infra/helper.py build_fuzzers --sanitizer coverage gnutls
```

Fixes: #6473