### PR TITLE
nettle: Avoid calling realpath on non-existing path

### DIFF
--- a/projects/nettle/build.sh
+++ b/projects/nettle/build.sh
@@ -56,7 +56,7 @@ then
         cp -R $SRC/nettle $SRC/nettle-with-libgmp/
         cd $SRC/nettle-with-libgmp/
         bash .bootstrap
-        export NETTLE_LIBDIR=`realpath ../nettle-with-libgmp-install/lib`
+        export NETTLE_LIBDIR=`realpath ../nettle-with-libgmp-install`/lib
         if [[ $CFLAGS != *sanitize=memory* ]]
         then
             ./configure --disable-documentation --disable-openssl --prefix=`realpath ../nettle-with-libgmp-install` --libdir="$NETTLE_LIBDIR"
@@ -115,7 +115,7 @@ fi
     cp -R $SRC/nettle $SRC/nettle-with-mini-gmp/
     cd $SRC/nettle-with-mini-gmp/
     bash .bootstrap
-    export NETTLE_LIBDIR=`realpath ../nettle-with-libgmp-install/lib`
+    export NETTLE_LIBDIR=`realpath ../nettle-with-mini-gmp-install`/lib
     if [[ $CFLAGS != *sanitize=memory* ]]
     then
         ./configure --enable-mini-gmp --disable-documentation --disable-openssl --prefix=`realpath ../nettle-with-mini-gmp-install` --libdir="$NETTLE_LIBDIR"


### PR DESCRIPTION
This is a fix-up of commit f369375419035b9a8cbb2a488a76b78525e2978c.
During simplification I misused realpath: after a clean checkout,
PREFIX/lib would not exist yet and thus realpath fails.

Sorry about that; now I have properly checked it with:
```console
$ python infra/helper.py build_fuzzers --sanitizer coverage nettle
```