### PR TITLE
Fix OpenSK build problem

### DIFF
--- a/projects/opensk/Dockerfile
+++ b/projects/opensk/Dockerfile
@@ -14,7 +14,8 @@
 #
 ################################################################################
 FROM gcr.io/oss-fuzz-base/base-builder-rust
-RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang uuid-runtime
+RUN apt-get update && apt-get install -y make autoconf automake libtool curl \
+    cmake python llvm-dev libclang-dev clang uuid-runtime pkg-config libssl-dev
 
 RUN git clone --depth=1 --branch=develop https://github.com/google/OpenSK  && \
     cd OpenSK && \


### PR DESCRIPTION
With a recent push on our develop branch, we now need to install pkg-config and libssl-dev before building. Tested with:
```
python infra/helper.py build_image opensk
python infra/helper.py build_fuzzers --sanitizer address --engine libfuzzer --architecture x86_64 opensk
```