### PR TITLE
libavif: run dav1d_oss_fuzz.sh to build dav1d

### DIFF
--- a/projects/libavif/build.sh
+++ b/projects/libavif/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 # build dav1d
-cd ext && bash dav1d.cmd && cd ..
+cd ext && bash dav1d_oss_fuzz.sh && cd ..
 
 # build libavif
 mkdir build


### PR DESCRIPTION
Run dav1d_oss_fuzz.sh instead of dav1d.cmd to build dav1d.
dav1d_oss_fuzz.sh is a copy of dav1d.cmd, with the only difference being
that it applies a patch to the dav1d source tree to work around a bug in
Meson's symbols_have_underscore_prefix() function when oss-fuzz
specifies -fprofile-instr-generate in CFLAGS in the coverage build.

Part 2 of the fix for https://crbug.com/oss-fuzz/38512.