### PR TITLE
projects: add uint256

### DIFF
--- a/projects/uint256/Dockerfile
+++ b/projects/uint256/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN go get -u -d github.com/holiman/uint256/...
+
+RUN git clone --depth 1 https://github.com/holiman/uint256.git uint256
+
+RUN cp $GOPATH/src/github.com/ethereum/uint256/oss-fuzz.sh $SRC/build.sh
+
+WORKDIR $SRC/

--- a/projects/uint256/Dockerfile
+++ b/projects/uint256/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder-go
 
 RUN go get -u -d github.com/holiman/uint256/...
 

--- a/projects/uint256/Dockerfile
+++ b/projects/uint256/Dockerfile
@@ -20,6 +20,6 @@ RUN go get -u -d github.com/holiman/uint256/...
 
 RUN git clone --depth 1 https://github.com/holiman/uint256.git uint256
 
-RUN cp $GOPATH/src/github.com/ethereum/uint256/oss-fuzz.sh $SRC/build.sh
+RUN cp uint256/oss-fuzz.sh $SRC/build.sh
 
 WORKDIR $SRC/

--- a/projects/uint256/project.yaml
+++ b/projects/uint256/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/holiman/uint256"
+language: go
+primary_contact: "martin.swende@ethereum.org"
+auto_ccs:
+  - "pawel@ethereum.org"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+main_repo: 'https://github.com/holiman/uint256.git'


### PR DESCRIPTION
This PR adds https://github.com/holiman/uint256 to oss-fuzz.

`uint256` is a 256-bit math library in golang, and is used primarily within the Ethereum ecosystem, by projects such as [go-ethereum](https://github.com/ethereum/go-ethereum) and [erigon](https://github.com/ledgerwatch/erigon)