### PR TITLE
libavif: install nasm as a Linux package

### DIFF
--- a/projects/libavif/Dockerfile
+++ b/projects/libavif/Dockerfile
@@ -16,14 +16,10 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y curl python3-pip python3-setuptools python3-wheel cmake git && \
+    apt-get install --no-install-recommends -y curl python3-pip python3-setuptools python3-wheel cmake git nasm && \
     pip3 install meson ninja
 
 RUN git clone --depth 1 https://github.com/AOMediaCodec/libavif.git libavif
 WORKDIR libavif
-
-RUN curl -L https://download.videolan.org/contrib/nasm/nasm-2.14.tar.gz | tar xvz
-RUN cd nasm-2.14 && ./configure && make -j2 && ln -s `pwd`/nasm /usr/bin/nasm && cd ..
-RUN nasm --version
 
 COPY build.sh avif_decode_seed_corpus.zip $SRC/


### PR DESCRIPTION
Install nasm as a Linux package rather than download and build it from
source code. This is what projects/dav1d/Dockerfile does.