### PR TITLE
[lldb-eval] Fix build failure after upgrade to Ubuntu 20.04

### DIFF
--- a/projects/lldb-eval/Dockerfile
+++ b/projects/lldb-eval/Dockerfile
@@ -14,11 +14,7 @@
 #
 ################################################################################
 
-# Using Ubuntu 16.04 because of breakage on Ubuntu 20.04.
-# See https://github.com/google/oss-fuzz/issues/6291 for more details.
-FROM gcr.io/oss-fuzz-base/base-builder:xenial
-# Delete line above and uncomment line below to upgrade to 20.04.
-# FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN apt-get update \
     && apt-get install -y wget git patchelf zlib1g-dev python libtinfo-dev --no-install-recommends

--- a/projects/lldb-eval/build.sh
+++ b/projects/lldb-eval/build.sh
@@ -17,7 +17,7 @@
 
 (
 cd $SRC/
-GITHUB_RELEASE="https://github.com/google/lldb-eval/releases/download/oss-fuzz-llvm-12"
+GITHUB_RELEASE="https://github.com/google/lldb-eval/releases/download/oss-fuzz-ubuntu-20.04"
 
 if [ "$SANITIZER" = "address" ]
 then


### PR DESCRIPTION
An attempt to resolve google/oss-fuzz#6302 and google/lldb-eval#172.

CC: @werat 