### PR TITLE
[systemd] turn MSAn on

### DIFF
--- a/projects/systemd/project.yaml
+++ b/projects/systemd/project.yaml
@@ -5,8 +5,7 @@ builds_per_day: 4
 sanitizers:
   - address
   - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
-#  - memory
+  - memory
 auto_ccs:
   - jonathan@titanous.com
   - zbyszek@in.waw.pl


### PR DESCRIPTION
Apparently the dependencies aren't used at runtime by the
fuzz targets so it seems it should be safe to bring MSAn back.
I'd keep https://github.com/systemd/systemd/issues/20542 open though
(at least until the dependencies are either linked properly or
maybe even removed somehow).