### PR TITLE
Undefined name: import sys for line 33

### DIFF
--- a/projects/pyyaml/fuzz_loader.py
+++ b/projects/pyyaml/fuzz_loader.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import atheris
 
 with atheris.instrument_imports():


### PR DESCRIPTION
`sys.argv` is not accessible unless `sys` is imported.