### PR TITLE
Fix CIFuzz coverage by adding Jinja2 dependency.

### DIFF
--- a/infra/cifuzz/external-actions/build_fuzzers/action.yml
+++ b/infra/cifuzz/external-actions/build_fuzzers/action.yml
@@ -22,19 +22,6 @@ inputs:
     description: "Whether or not OSS-Fuzz's check for bad builds should be done."
     required: false
     default: true
-  storage-repo:
-    description: |
-      The git repo to use for storing certain artifacts from fuzzing.
-    required: false
-  storage-repo-branch:
-    description: |
-      The branch of the git repo to use for storing certain artifacts from
-      fuzzing.
-    required: false
-  storage-repo-branch-coverage:
-    description: |
-      The branch of the git repo to use for storing coverage reports.
-    required: false
   upload-build:
     description: |
       If set, will upload the build.

--- a/infra/cifuzz/external-actions/run_fuzzers/action.yml
+++ b/infra/cifuzz/external-actions/run_fuzzers/action.yml
@@ -40,10 +40,12 @@ inputs:
     description: |
       The branch of the git repo to use for storing certain artifacts from
       fuzzing.
+    default: main
     required: false
   storage-repo-branch-coverage:
     description: |
       The branch of the git repo to use for storing coverage reports.
+    default: gh-pages
     required: false
   report-unreproducible-crashes:
     description: 'If True, then unreproducible crashes will be reported by CIFuzz.'

--- a/infra/cifuzz/requirements.txt
+++ b/infra/cifuzz/requirements.txt
@@ -1,2 +1,3 @@
 clusterfuzz==2.5.5.post1
+Jinja2==3.0.1
 requests==2.25.1


### PR DESCRIPTION
Also clean up the external action definitions:
- Set default values for the storage repo branches.
- Remove storage repo options from build_fuzzers.