### PR TITLE
protobuf-java: update contact information

### DIFF
--- a/projects/protobuf-java/project.yaml
+++ b/projects/protobuf-java/project.yaml
@@ -1,8 +1,12 @@
 homepage: "https://developers.google.com/protocol-buffers/"
 language: jvm
-primary_contact: "acozzette@google.com"
+primary_contact: "kfm@google.com"
 auto_ccs:
   - "meumertzheim@code-intelligence.com"
+  - "acozzette@google.com"
+  - "elharo@google.com"
+  - "pzd@google.com"
+  - "sandyzhang@google.com"
 fuzzing_engines:
   - libfuzzer
 main_repo: "https://github.com/protocolbuffers/protobuf"


### PR DESCRIPTION
This makes kfm@google.com the primary contact and allows access for some
more protobuf team members.