### PR TITLE
sudoers: set optimization flag in LDFLAGS for the object size sanitizer

### DIFF
--- a/projects/sudoers/build.sh
+++ b/projects/sudoers/build.sh
@@ -28,7 +28,11 @@ else
     sanitizer_opts="$SANITIZER_FLAGS"
 fi
 # This is already added by --enable-fuzzer
-CFLAGS="`echo \"$CFLAGS\" | sed \"s/ -fsanitize=fuzzer-no-link//\"`"
+CFLAGS="`echo \"$CFLAGS\" | sed 's/ -fsanitize=fuzzer-no-link//'`"
+
+# Copy optimization flag to LDFLAGS for UBSan object-size check.
+OPTFLAG="`echo \"$CFLAGS\" | sed 's/^.*\(-O[^ ]\).*$/\1/'`"
+export LDFLAGS="${LDFLAGS:-}${LDFLAGS:+ }$OPTFLAG"
 
 # Build sudo with static libs and enable fuzzing targets.
 # All fuzz targets are integrated into the build process.


### PR DESCRIPTION
Sudo does not link executables using CFLAGS, only LDFLAGS.  When building with UBSan, the compiler warns that the object size sanitizer has no effect at -O0 but is explicitly enabled.