### PR TITLE
[php] Disable mbstring fuzzer

### DIFF
--- a/projects/php/Dockerfile
+++ b/projects/php/Dockerfile
@@ -18,6 +18,5 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && \
     apt-get install -y autoconf automake libtool bison re2c pkg-config
 RUN git clone --depth 1 --branch master https://github.com/php/php-src.git php-src
-RUN git clone https://github.com/kkos/oniguruma.git php-src/oniguruma
 WORKDIR php-src
 COPY build.sh *.options $SRC/

--- a/projects/php/build.sh
+++ b/projects/php/build.sh
@@ -15,15 +15,6 @@
 #
 ################################################################################
 
-# build oniguruma and link statically
-pushd oniguruma
-autoreconf -vfi
-./configure
-make -j$(nproc)
-popd
-export ONIG_CFLAGS="-I$PWD/oniguruma/src"
-export ONIG_LIBS="-L$PWD/oniguruma/src/.libs -l:libonig.a"
-
 # PHP's zend_function union is incompatible with the object-size sanitizer
 export CFLAGS="$CFLAGS -fno-sanitize=object-size"
 export CXXFLAGS="$CXXFLAGS -fno-sanitize=object-size"
@@ -45,7 +36,6 @@ fi
     --enable-option-checking=fatal \
     --enable-fuzzer \
     --enable-exif \
-    --enable-mbstring \
     --enable-opcache \
     --without-pcre-jit \
     --disable-phpdbg \
@@ -63,7 +53,6 @@ cp sapi/fuzzer/json.dict $OUT/php-fuzz-json.dict
 
 FUZZERS="php-fuzz-json
 php-fuzz-exif
-php-fuzz-mbstring
 php-fuzz-unserialize
 php-fuzz-unserializehash
 php-fuzz-parser


### PR DESCRIPTION
The mbstring fuzzer is really a fuzzer for the oniguruma library
through the PHP mbregex extension. This was important at the time
as the upstream oniguruma project did not have fuzzing and we were
bundling the library (and thus responsible for security backports).

Nowadays we no longer bundle this library and the upstream project
does their own fuzzing, including integration with oss-fuzz:
https://github.com/google/oss-fuzz/tree/master/projects/oniguruma

I haven't really done anything with reports from this fuzzer in a
long time, as issues get addressed upstream. As such, I think it's
safe to drop it on the PHP side.