### PR TITLE
nDPI: add some missing (optional) dependencies

### DIFF
--- a/projects/ndpi/Dockerfile
+++ b/projects/ndpi/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake autogen pkg-config libtool flex bison cmake
+RUN apt-get update && apt-get install -y make autoconf automake autogen pkg-config libtool flex bison cmake libnuma-dev libgcrypt20-dev libpcre2-dev
 RUN git clone --depth 1 https://github.com/json-c/json-c.git json-c
 RUN git clone --depth 1 https://github.com/ntop/nDPI.git ndpi
 ADD https://www.tcpdump.org/release/libpcap-1.9.1.tar.gz libpcap-1.9.1.tar.gz


### PR DESCRIPTION
Enable fuzzing of QUIC traffic.