### PR TITLE
profraw: bump up version to 8

### DIFF
--- a/infra/base-images/base-runner/profraw_update.py
+++ b/infra/base-images/base-runner/profraw_update.py
@@ -49,7 +49,8 @@ def upgrade(data, sect_prf_cnts, sect_prf_data):
   if generic_header.version == 5:
     generic_header = generic_header._replace(version=7)
     # Upgrade from version 5 to 7 by adding binaryids field.
-    data = data[:8] + struct.pack('Q', generic_header.version) + struct.pack('Q', 0) + data[16:]
+    data = data[:8] + struct.pack('Q', generic_header.version) + struct.pack(
+        'Q', 0) + data[16:]
   if generic_header.version < 7:
     raise Exception('Unhandled version.')
   if generic_header.version == 7:


### PR DESCRIPTION
following https://reviews.llvm.org/D111123

cc @inferno-chromium @jonathanmetzman 

Should fix the rust and swift coverage builds again.

Let's hope that the profraw format remains more stable now as it had been in the last years