### PR TITLE
rust coverage: broader definition for remaps

### DIFF
--- a/infra/base-images/base-builder/cargo
+++ b/infra/base-images/base-builder/cargo
@@ -39,7 +39,7 @@ then
     while read i; do
         export RUSTFLAGS="$RUSTFLAGS --remap-path-prefix $i=$fuzz_src_abspath/$i"
         # Bash while syntax so that we modify RUSTFLAGS in main shell instead of a subshell.
-    done <<< "$(ls */*.rs | cut -d/ -f1 | uniq)"
+    done <<< "$(find . -name "*.rs" | cut -d/ -f2 | uniq)"
     # we do not want to trigger debug assertions and stops
     export RUSTFLAGS="$RUSTFLAGS -C debug-assertions=no"
     # do not optimize with --release, leading to Malformed instrumentation profile data


### PR DESCRIPTION
As shown by opensk, rust files can be in a deeper directory

Fixes #6571 
cc @kaczmarczyck 

The difference of opensk was that in its fuzz directory, we had `fuzz_helper` with rust files in it, but only in directories one level below