### PR TITLE
Updated fast-dds/build.sh for upcoming refactoring

### DIFF
--- a/projects/fast-dds/build.sh
+++ b/projects/fast-dds/build.sh
@@ -50,4 +50,12 @@ cmake --build . --target install
 mkdir build && cd build
 cmake .. -DBUILD_SHARED_LIBS=OFF
 make -j $(nproc)
-cp src/cpp/fuzz* $OUT/
+cd ..
+
+find build/fuzz -maxdepth 3 -type f -name 'fuzz_*' | while read fuzzer; do
+    cp "$fuzzer" $OUT/
+done
+
+find fuzz/ -type d -name 'fuzz_*_seed_corpus' | while read corpus_dir; do
+  zip -j $OUT/$(basename "$corpus_dir").zip $corpus_dir/*
+done


### PR DESCRIPTION
Updated fast-dds/build.sh for this upcoming refactoring: https://github.com/eProsima/Fast-DDS/pull/2273

This is the first time I update an existing project, so I guess @MiguelCompany or other Fast-DDS maintainers should (1) merge https://github.com/eProsima/Fast-DDS/pull/2273 and ACK before this PR can be accepted.

Signed-off-by: Federico Maggi <fede@maggi.cc>