### PR TITLE
[kryo] Fix build in anticipation of a Jazzer breaking change

### DIFF
--- a/projects/kryo/build.sh
+++ b/projects/kryo/build.sh
@@ -45,7 +45,7 @@ LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\":\$this_dir \
 \$this_dir/jazzer_driver --agent_path=\$this_dir/jazzer_agent_deploy.jar \
 --cp=$RUNTIME_CLASSPATH \
 --target_class=$fuzzer_basename \
---jvm_args=\"-Xmx2048m;--enable-preview\" \
+--jvm_args=\"-Xmx2048m:--enable-preview\" \
 \$@" > $OUT/$fuzzer_basename
   chmod +x $OUT/$fuzzer_basename
 done


### PR DESCRIPTION
Jazzer now uses ':' instead of ';' to separate JVM arguments:
https://github.com/CodeIntelligenceTesting/jazzer/commit/24069c388579f54ec9872e61efa44f5e6065f838