### PR TITLE
[libfido2] re-enable MSAN

### DIFF
--- a/projects/libfido2/project.yaml
+++ b/projects/libfido2/project.yaml
@@ -10,8 +10,7 @@ auto_ccs:
 sanitizers:
     - address
     - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
-#  - memory
+    - memory
 fuzzing_engines:
     - libfuzzer
 main_repo: 'https://github.com/Yubico/libfido2'


### PR DESCRIPTION
The dependencies built without MSAN (chiefly, libudev) aren't used by the fuzz targets, so it seems safe to bring MSAN back. Verified locally with `python infra/helper.py`.