### PR TITLE
Fix builds after Jazzer breaking change

### DIFF
--- a/docs/getting-started/new-project-guide/jvm_lang.md
+++ b/docs/getting-started/new-project-guide/jvm_lang.md
@@ -138,7 +138,7 @@ LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\":\$this_dir \
 \$this_dir/jazzer_driver --agent_path=\$this_dir/jazzer_agent_deploy.jar \
 --cp=$RUNTIME_CLASSPATH \
 --target_class=$fuzzer_basename \
---jvm_args=\"-Xmx2048m;-Djava.awt.headless=true\" \
+--jvm_args=\"-Xmx2048m:-Djava.awt.headless=true\" \
 \$@" > $OUT/$fuzzer_basename
   chmod +x $OUT/$fuzzer_basename
 done

--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -152,7 +152,7 @@ function run_java_fuzz_target {
   # Use 100s timeout instead of 25s as code coverage builds can be very slow.
   local jacoco_args="destfile=$exec_file,classdumpdir=$class_dump_dir,excludes=com.code_intelligence.jazzer.*"
   local args="-merge=1 -timeout=100 --nohooks \
-      --additional_jvm_args=-javaagent:/opt/jacoco-agent.jar=$jacoco_args \
+      --additional_jvm_args=-javaagent\\:/opt/jacoco-agent.jar=$jacoco_args \
       $corpus_dummy $corpus_real"
 
   timeout $TIMEOUT $OUT/$target $args &> $LOGS_DIR/$target.log

--- a/projects/apache-commons/build.sh
+++ b/projects/apache-commons/build.sh
@@ -59,7 +59,7 @@ LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\":\$this_dir \
 \$this_dir/jazzer_driver --agent_path=\$this_dir/jazzer_agent_deploy.jar \
 --cp=$RUNTIME_CLASSPATH \
 --target_class=$fuzzer_basename \
---jvm_args=\"-Xmx2048m;-Djava.awt.headless=true\" \
+--jvm_args=\"-Xmx2048m:-Djava.awt.headless=true\" \
 \$@" > $OUT/$fuzzer_basename
     chmod +x $OUT/$fuzzer_basename
   done

--- a/projects/zxing/build.sh
+++ b/projects/zxing/build.sh
@@ -47,7 +47,7 @@ LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\":\$this_dir \
 \$this_dir/jazzer_driver --agent_path=\$this_dir/jazzer_agent_deploy.jar \
 --cp=$RUNTIME_CLASSPATH \
 --target_class=$fuzzer_basename \
---jvm_args=\"-Xmx2048m;-Djava.awt.headless=true\" \
+--jvm_args=\"-Xmx2048m:-Djava.awt.headless=true\" \
 \$@" > $OUT/$fuzzer_basename
   chmod u+x $OUT/$fuzzer_basename
 done


### PR DESCRIPTION
Follow-up to f043a72a0e632455f9939383efd60c131973c570, which became necessary due to
https://github.com/CodeIntelligenceTesting/jazzer/commit/24069c388579f54ec9872e61efa44f5e6065f838