### PR TITLE
tmux: fix coverage

### DIFF
--- a/projects/tmux/Dockerfile
+++ b/projects/tmux/Dockerfile
@@ -16,7 +16,11 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y autoconf automake bison pkg-config \
-    libevent-dev ncurses-dev
+    ncurses-dev libtool
+
+RUN git clone https://github.com/libevent/libevent.git && \
+    cd libevent && ./autogen.sh && ./configure --disable-openssl --disable-shared && \
+    make clean && make all && make install
 
 RUN git clone --depth 1 https://github.com/tmux/tmux.git
 RUN git clone --depth 1 https://github.com/tmux/tmux-fuzzing-corpus.git

--- a/projects/tmux/build.sh
+++ b/projects/tmux/build.sh
@@ -15,12 +15,15 @@
 #
 ################################################################################
 
+# Ensure libevent can be found
+export PKG_CONFIG_PATH="/usr/local/lib/"
+
 ./autogen.sh
 ./configure \
     --enable-fuzzing \
     FUZZING_LIBS="${LIB_FUZZING_ENGINE} -lc++" \
     LIBEVENT_LIBS="-Wl,-Bstatic -levent -Wl,-Bdynamic" \
-    LIBTINFO_LIBS="-Wl,-Bstatic -ltinfo -Wl,-Bdynamic"
+    LIBTINFO_LIBS=" -l:libtinfo.a "
 
 make -j"$(nproc)" check
 find "${SRC}/tmux/fuzz/" -name '*-fuzzer' -exec cp -v '{}' "${OUT}"/ \;
@@ -44,8 +47,3 @@ cat "${SRC}/tmux-fuzzing-corpus/iterm2"/* | \
     split -a5 -db$MAXLEN - iterm2.
 zip -q -j -r "${OUT}/input-fuzzer_seed_corpus.zip" \
     "${WORK}/fuzzing_corpus/"
-
-# Handle libevent not existing on runner.
-mkdir $OUT/lib
-cp /lib/x86_64-linux-gnu/libevent_core* $OUT/lib
-patchelf --set-rpath '$ORIGIN/lib' $OUT/input-fuzzer


### PR DESCRIPTION
Fix coverage issue by compiling libevent from source rather than grabbing from a package and using patchelf to fix up dependencies.

The use of patchelf seems to be causing coverage building issues on several projects. This includes  libbpf https://github.com/google/oss-fuzz/issues/6524#issuecomment-945046006, (potentially) Proxygen https://github.com/google/oss-fuzz/issues/6524 and usbguard https://github.com/google/oss-fuzz/issues/6614