### PR TITLE
binutils: fix issue when printing program name in bucomm

### DIFF
--- a/projects/binutils/fuzz_objdump.c
+++ b/projects/binutils/fuzz_objdump.c
@@ -30,6 +30,8 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
   fwrite(data, size, 1, fp);
   fclose(fp);
 
+  program_name = filename;
+
   process_links = true;
   do_follow_links = true;
   dump_section_contents = true;


### PR DESCRIPTION
Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=40280