### PR TITLE
opensk: do not specify nightly

### DIFF
--- a/projects/opensk/build.sh
+++ b/projects/opensk/build.sh
@@ -17,6 +17,10 @@
 
 FUZZ_TARGET_OUTPUT_DIR=fuzz/target/x86_64-unknown-linux-gnu/release
 
+# do not use override toolchain
+# cf https://rust-lang.github.io/rustup/overrides.html
+export RUSTUP_TOOLCHAIN=nightly
+
 build_and_copy() {
   pushd "$1"
   cargo fuzz build --release --debug-assertions

--- a/projects/opensk/build.sh
+++ b/projects/opensk/build.sh
@@ -19,7 +19,7 @@ FUZZ_TARGET_OUTPUT_DIR=fuzz/target/x86_64-unknown-linux-gnu/release
 
 build_and_copy() {
   pushd "$1"
-  cargo +nightly fuzz build --release --debug-assertions
+  cargo fuzz build --release --debug-assertions
   for f in fuzz/fuzz_targets/*.rs
   do
     cp ${FUZZ_TARGET_OUTPUT_DIR}/$(basename ${f%.*}) $OUT/


### PR DESCRIPTION
so that coverage works because we use the cargo wrapper
which looks for fuzz build argument at the beginning

cc @kaczmarczyck 