### PR TITLE
Turn off leak detection for binutils

### DIFF
--- a/projects/binutils/build.sh
+++ b/projects/binutils/build.sh
@@ -31,7 +31,7 @@ cd ../
 
 ./configure --disable-gdb --disable-gdbserver --disable-gdbsupport \
 	    --disable-libdecnumber --disable-readline --disable-sim \
-	    --enable-targets=all --disable-werror
+	    --disable-libbacktrace --disable-werror --enable-targets=all
 make MAKEINFO=true && true
 
 # Make fuzzer directory
@@ -139,4 +139,6 @@ cp $OUT/fuzz_readelf_seed_corpus.zip $OUT/fuzz_objcopy_seed_corpus.zip
 # Copy options files
 cp $SRC/fuzz_*.options $OUT/
 cp $OUT/fuzz_objcopy.options $OUT/fuzz_as.options
+cp $OUT/fuzz_objcopy.options $OUT/fuzz_nm.options
+cp $OUT/fuzz_objcopy.options $OUT/fuzz_objdump.options
 cp $OUT/fuzz_objcopy.options $OUT/fuzz_disas_ext-bfd_arch_csky.options


### PR DESCRIPTION
Leaking a small amout of memory in a utility that runs then exits
is totally uninteresting.  Disable leak detection for nm and objdump
in addition to the others.  Also, save some build time by not
compiling libbacktrace which is currently unused by binutils.