### PR TITLE
[clusterfuzzlite] Don't use cifuzz term in image name

### DIFF
--- a/infra/cifuzz/cloudbuild.yaml
+++ b/infra/cifuzz/cloudbuild.yaml
@@ -1,3 +1,4 @@
+# TODO(metzman): Get rid of cifuzz-build-fuzzers and cifuzz-run-fuzzers.
 steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
@@ -16,6 +17,8 @@ steps:
   - gcr.io/oss-fuzz-base/cifuzz-build-fuzzers
   - '-t'
   - gcr.io/oss-fuzz-base/cifuzz-build-fuzzers:v1
+  - '-t'
+  - gcr.io/oss-fuzz-base/clusterfuzzlite-build-fuzzers:v1
   - '-f'
   - infra/build_fuzzers.Dockerfile
   - infra
@@ -26,6 +29,8 @@ steps:
   - gcr.io/oss-fuzz-base/cifuzz-run-fuzzers
   - '-t'
   - gcr.io/oss-fuzz-base/cifuzz-run-fuzzers:v1
+  - '-t'
+  - gcr.io/oss-fuzz-base/clusterfuzzlite-build-fuzzers:v1
   - '-f'
   - infra/run_fuzzers.Dockerfile
   - infra
@@ -36,4 +41,8 @@ images:
 - gcr.io/oss-fuzz-base/cifuzz-run-fuzzers:v1
 - gcr.io/oss-fuzz-base/cifuzz-build-fuzzers
 - gcr.io/oss-fuzz-base/cifuzz-build-fuzzers:v1
+- gcr.io/oss-fuzz-base/clusterfuzzlite-build-fuzzers
+- gcr.io/oss-fuzz-base/clusterfuzzlite-build-fuzzers:v1
+- gcr.io/oss-fuzz-base/clusterfuzzlite-run-fuzzers
+- gcr.io/oss-fuzz-base/clusterfuzzlite-run-fuzzers:v1
 timeout: 1800s


### PR DESCRIPTION
Make images that dont reference cifuzz but which reference
clusterfuzzlite instead.