### PR TITLE
Remove a Harfbuzz CC email

### DIFF
--- a/projects/harfbuzz/project.yaml
+++ b/projects/harfbuzz/project.yaml
@@ -11,7 +11,6 @@ auto_ccs:
   - "dr.khaled.hosny@gmail.com"
   - "jfkthame@gmail.com"
   - "cchapman@adobe.com"
-  - "ariza@typekit.com"
   - "qxliu@google.com"
   - "ckitagawa@google.com"
   - "drott@chromium.org"


### PR DESCRIPTION
Remove ariza@typekit.com as adding the email address to issues seems to
create bounces on the bug tracker.