### PR TITLE
elfutils/readelf

### DIFF
--- a/projects/elfutils/Dockerfile
+++ b/projects/elfutils/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf autopoint zlib1g-dev zlib1g-dev:i386 flex bison gawk liblzma-dev liblzma-dev:i386 libbz2-dev libbz2-dev:i386
+RUN git clone --depth 1 -b oss-fuzz https://github.com/izzeem/elfutils elfutils
+WORKDIR elfutils
+COPY build.sh $SRC/

--- a/projects/elfutils/build.sh
+++ b/projects/elfutils/build.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# build elf tooling targets
+autoreconf -i -f
+./configure --enable-maintainer-mode --disable-libdebuginfod --enable-libdebuginfod=dummy --disable-debuginfod --disable-libdebuginfod
+
+cd lib && make libeu.a && cd ..
+cd libdwfl && make libdwfl.a && cd ..
+cd libebl && make libebl.a && cd ..
+cd backends && make libebl_backends.a && cd ..
+cd libcpu && make libcpu.a && cd ..
+cd libdwelf && make libdwelf.a && cd ..
+cd libdw && make libdw.a known-dwarf.h && cd ..
+cd libelf && make libelf.a && cd ..
+cd src && cp readelf.c libreadelf.c && patch libreadelf.c libreadelf.diff && make libreadelf && cd ..
+
+# build fuzzer
+cd fuzz
+
+mv ../src/libreadelf libreadelf.o
+ar -x ../libdw/libdw.a
+ar -x ../libebl/libebl.a
+ar -x ../backends/libebl_backends.a
+ar -x ../libcpu/libcpu.a
+ar -x ../libelf/libelf.a
+ar -x ../lib/libeu.a
+ar -x ../libdwfl/libdwfl.a
+ar -x ../libdwelf/libdwelf.a
+
+$CXX $CXXFLAGS fuzz.cc -o $OUT/testfuzz *.o -lz -ldl -lpthread -lbz2 -llzma $LIB_FUZZING_ENGINE
+
+# build corpus
+zip -j0r $OUT/testfuzz_seed_corpus.zip corpus/*
+

--- a/projects/elfutils/project.yaml
+++ b/projects/elfutils/project.yaml
@@ -1,0 +1,15 @@
+homepage: "https://sourceware.org/elfutils/"
+language: c++
+primary_contact: "izzeem@google.com"
+main_repo: "git://sourceware.org/git/elfutils.git"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+sanitizers:
+  - address
+  - memory
+  - undefined
+architectures:
+  - x86_64
+  - i386

--- a/projects/elfutils/project.yaml
+++ b/projects/elfutils/project.yaml
@@ -12,4 +12,3 @@ sanitizers:
   - undefined
 architectures:
   - x86_64
-  - i386


### PR DESCRIPTION
libelf is used by many distros as the defacto elf parsing library which other applications depend on. elf parsing bugs are usually pretty complex and error prone

i just wrapped readelf as it is a good client of libelf and exercises many of the libraries exported functions

https://packages.debian.org/buster/libelf-dev and https://archlinux.org/packages/core/x86_64/libelf/ as examples
