### PR TITLE
binutils: Extending and refining fuzzers

### DIFF
--- a/projects/binutils/fuzz_objcopy.c
+++ b/projects/binutils/fuzz_objcopy.c
@@ -21,6 +21,78 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
 
 static int initialized = 0;
 
+void
+init_objcopy_global_state() {
+  // status is a global variable that is set to 0 initially,
+  // and we should ensure the state is not maintained for each iteration.
+  status = 0;
+  pe_file_alignment = (bfd_vma) -1;
+  pe_heap_commit = (bfd_vma) -1;
+  pe_heap_reserve = (bfd_vma) -1;
+  pe_image_base = (bfd_vma) -1;
+  pe_section_alignment = (bfd_vma) -1;
+  pe_stack_commit = (bfd_vma) -1;
+  pe_stack_reserve = (bfd_vma) -1;
+  pe_subsystem = -1;
+  pe_major_subsystem_version = -1;
+  pe_minor_subsystem_version = -1;
+  section_rename_list = NULL;
+  isympp = NULL;
+  osympp = NULL;
+  copy_byte = -1;
+  interleave = 0;
+  copy_width = 1;
+  keep_section_symbols = false;
+  deterministic = -1;
+  status = 0;
+  merge_notes = false;
+  strip_symbols = STRIP_UNDEF;
+  change_sections = NULL;
+  change_start = 0;
+  set_start_set = false;
+  change_section_address = 0;
+  gap_fill_set = false;
+  gap_fill = 0;
+  pad_to_set = false;
+  pad_to;
+  use_alt_mach_code = 0;
+  add_sections = NULL;
+  update_sections = NULL;
+  dump_sections = NULL;
+  gnu_debuglink_filename = NULL;
+  convert_debugging = false;
+  change_leading_char = false;
+  remove_leading_char = false;
+  wildcard = false;
+  localize_hidden = false;
+  strip_specific_htab = NULL;
+  strip_unneeded_htab = NULL;
+  keep_specific_htab = NULL;
+  localize_specific_htab = NULL;
+  globalize_specific_htab = NULL;
+  keepglobal_specific_htab = NULL;
+  weaken_specific_htab = NULL;
+  redefine_specific_htab = NULL;
+  redefine_specific_reverse_htab = NULL;
+  add_sym_tail = &add_sym_list;
+  add_symbols = 0;
+  strip_specific_buffer = NULL;
+  strip_unneeded_buffer = NULL;
+  keep_specific_buffer = NULL;
+  localize_specific_buffer = NULL;
+  globalize_specific_buffer = NULL;
+  keepglobal_specific_buffer = NULL;
+  weaken_specific_buffer = NULL;
+  weaken = false;
+  keep_file_symbols = false;
+  prefix_symbols_string = 0;
+  prefix_sections_string = 0;
+  prefix_alloc_sections_string = 0;
+  extract_symbol = false;
+
+  create_symbol_htabs();
+}
+
 int
 LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
@@ -43,15 +115,22 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     initialized = 1;
   }
 
+  init_objcopy_global_state();
 
-  create_symbol_htabs();
-
-  char *fakeArgv[4];
+  char *fakeArgv[12];
   fakeArgv[0] = "fuzz_objdump";
-  fakeArgv[1] = filename;
-  fakeArgv[2] = "/tmp/random.out";
-  fakeArgv[3] = NULL;
-  copy_main(3, fakeArgv);
+  fakeArgv[1] = "-S";
+  fakeArgv[2] = "--decompress-debug-sections";
+  fakeArgv[3] = "--extract-dwo";
+  fakeArgv[4] = "--merge-notes";
+  fakeArgv[5] = "--pure";
+  fakeArgv[6] = "--debugging";
+  fakeArgv[7] = "--compress-debug-sections";
+  fakeArgv[8] = "--extract-symbol";
+  fakeArgv[9] = filename;
+  fakeArgv[10] = "/tmp/random.out";
+  fakeArgv[11] = NULL;
+  copy_main(11, fakeArgv);
 
   // Cleanup
   free (strip_specific_buffer);

--- a/projects/binutils/fuzz_objdump.c
+++ b/projects/binutils/fuzz_objdump.c
@@ -38,10 +38,25 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
   dump_section_headers = true;
   dump_private_headers = true;
   dump_ar_hdrs = true;
-  dump_reloc_info = true;
-  dump_dynamic_reloc_info = true;
-  disassemble = true;
+  dump_dwarf_section_info = true;
+  dwarf_select_sections_all ();
+  dump_debugging = true;
+
+  dump_stab_section_info = true;
   disassemble_all = true;
+
+  // These flags contain a large set of calls to bfd_fatal (which calls
+  // exit), so to enable fuzzing of objdump with a fuzzer that lives for
+  // a longer period of time (more than 10 seconds) define
+  // OBJDUMP_SAFE
+#ifndef OBJDUMP_SAFE
+  dump_reloc_info = true;
+  // ctf section and reloc are simply too quick to exit and disrupts
+  // fuzzing too much. Will leave this commented out for now.
+  //dump_dynamic_reloc_info = true;
+  //dump_ctf_section_info = true;
+  disassemble = true;
+#endif
 
   // Main fuzz entrypoint in objdump.c
   display_file(filename, NULL, true);

--- a/projects/binutils/fuzz_readelf.options
+++ b/projects/binutils/fuzz_readelf.options
@@ -1,2 +1,0 @@
-[libfuzzer]
-detect_leaks=0


### PR DESCRIPTION
Improve binutils fuzzing in three ways:
- Extend objdump and objcopy fuzzers. Make a version of objdump fuzzing
that is more stable
- New targetted disassembly fuzzer for mep architecture
- Include more extensive corpus

Signed-off-by: David Korczynski <david@adalogics.com>