### PR TITLE
Increasing Envoy per-CPU memory

### DIFF
--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -93,7 +93,7 @@ fi
 )"
 
 
-# The machine hasssuming we have ~32 cores and ~28.8 GiB RAM. By limiting the
+# Asssuming we have ~32 cores and ~28.8 GiB RAM. By limiting the
 # number of CPUs (--local_cpu_resources) we limit the per-CPU mem-usage.
 # Benchmark about 3.6 GB per CPU (8 threads for 28.8 GB RAM)
 # TODO(asraa): Remove deprecation warnings when Envoy and deps moves to C++17


### PR DESCRIPTION
Increasing the per-CPU memory for an Envoy worker to allow the fuzz tests to build.

Signed-off-by: Adi Suissa-Peleg <adip@google.com>