### PR TITLE
Forseti Config Validator: initial integration

### DIFF
--- a/projects/config-validator/Dockerfile
+++ b/projects/config-validator/Dockerfile
@@ -15,7 +15,11 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
-RUN git clone --depth 1 https://github.com/GoogleCloudPlatform/config-validator
 
-WORKDIR $SRC/config-validator
+# Clone the actual repo with the fuzz target.
+RUN git clone --depth 1 --branch 'fuzz-relative-files' https://github.com/MartinPetkov/config-validator $GOPATH/src/github.com/GoogleCloudPlatform/config-validator
+
 COPY build.sh $SRC/
+
+# Required to avoid 'working directory is not part of a module' error.
+WORKDIR $GOPATH/src/github.com/GoogleCloudPlatform/config-validator

--- a/projects/config-validator/Dockerfile
+++ b/projects/config-validator/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/GoogleCloudPlatform/config-validator
+
+WORKDIR $SRC/config-validator
+COPY build.sh $SRC/

--- a/projects/config-validator/Dockerfile
+++ b/projects/config-validator/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder-go
 
 # Clone the actual repo with the fuzz target.
-RUN git clone --depth 1 --branch 'fuzz-relative-files' https://github.com/MartinPetkov/config-validator $GOPATH/src/github.com/GoogleCloudPlatform/config-validator
+RUN git clone --depth 1 https://github.com/GoogleCloudPlatform/config-validator $GOPATH/src/github.com/GoogleCloudPlatform/config-validator
 
 COPY build.sh $SRC/
 

--- a/projects/config-validator/build.sh
+++ b/projects/config-validator/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+compile_go_fuzzer github.com/GoogleCloudPlatform/config-validator/internal/fuzz Fuzz fuzz_config_validator

--- a/projects/config-validator/build.sh
+++ b/projects/config-validator/build.sh
@@ -22,7 +22,7 @@ cp -a 'test/cf/library' $OUT/validatorfiles
 cp -a 'test/cf/templates' $OUT/validatorfiles
 
 # Copy the corpus.
-zip -jr $OUT/config-validator_seed_corpus.zip internal/fuzz/corpus
+zip -jr $OUT/fuzz_config_validator_seed_corpus.zip internal/fuzz/corpus
 
 # Compile the fuzzer.
 compile_go_fuzzer github.com/GoogleCloudPlatform/config-validator/internal/fuzz Fuzz fuzz_config_validator

--- a/projects/config-validator/build.sh
+++ b/projects/config-validator/build.sh
@@ -15,4 +15,14 @@
 #
 ################################################################################
 
+# Copy the library files needed to initialize the validator.
+mkdir -p $OUT/validatorfiles
+cp -a 'test/cf/constraints' $OUT/validatorfiles
+cp -a 'test/cf/library' $OUT/validatorfiles
+cp -a 'test/cf/templates' $OUT/validatorfiles
+
+# Copy the corpus.
+zip -jr $OUT/config-validator_seed_corpus.zip internal/fuzz/corpus
+
+# Compile the fuzzer.
 compile_go_fuzzer github.com/GoogleCloudPlatform/config-validator/internal/fuzz Fuzz fuzz_config_validator

--- a/projects/config-validator/project.yaml
+++ b/projects/config-validator/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://github.com/GoogleCloudPlatform/config-validator/"
+main_repo: "https://github.com/GoogleCloudPlatform/config-validator/"
+primary_contact: "martin.p.petkov@gmail.com"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address

--- a/projects/config-validator/project.yaml
+++ b/projects/config-validator/project.yaml
@@ -1,8 +1,10 @@
 homepage: "https://github.com/GoogleCloudPlatform/config-validator/"
 main_repo: "https://github.com/GoogleCloudPlatform/config-validator/"
 primary_contact: "martin.p.petkov@gmail.com"
+auto_ccs:
+- morgante.pell@morgante.net
 language: go
 fuzzing_engines:
-  - libfuzzer
+- libfuzzer
 sanitizers:
-  - address
+- address

--- a/projects/config-validator/project.yaml
+++ b/projects/config-validator/project.yaml
@@ -2,7 +2,7 @@ homepage: "https://github.com/GoogleCloudPlatform/config-validator/"
 main_repo: "https://github.com/GoogleCloudPlatform/config-validator/"
 primary_contact: "martin.p.petkov@gmail.com"
 auto_ccs:
-- morgante.pell@morgante.net
+- morgantep@google.com
 language: go
 fuzzing_engines:
 - libfuzzer


### PR DESCRIPTION
I successfully ran the following commands from the [guide](https://google.github.io/oss-fuzz/getting-started/new-project-guide/#testing-locally):

```sh
python infra/helper.py build_image config-validator
python infra/helper.py build_fuzzers --sanitizer address config-validator
python infra/helper.py check_build config-validator
python infra/helper.py run_fuzzer config-validator fuzz_config_validator
```