### PR TITLE
freeradius: fix build

### DIFF
--- a/projects/freeradius/Dockerfile
+++ b/projects/freeradius/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt install -y libtalloc-dev libkqueue-dev
+RUN apt-get update && apt install -y libtalloc-dev libkqueue-dev libunwind-dev
 
 # OpenSSL 1.1
 ARG OPENSSL_VERSION=1.1.1g

--- a/projects/freeradius/build.sh
+++ b/projects/freeradius/build.sh
@@ -38,6 +38,7 @@ ls ./build/bin/local/fuzzer_* | while read i; do
     copy_lib ${i} libfreeradius
     copy_lib ${i} talloc
     copy_lib ${i} kqueue
+    copy_lib ${i} libunwind
     cp ${i} $OUT/
 done
 cp -r /usr/local/share/freeradius/dictionary $OUT/dict


### PR DESCRIPTION
This was fairly tedious to debug, the issues boiled down to the call to `ac_fn_c_try_link` here:
https://github.com/FreeRADIUS/freeradius-server/blob/288880a63b510fe83c215f8e54648625500b9ac7/configure#L8247 
resulted in the following errors:
```
$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5   
/usr/bin/ld: /usr/local/lib/clang/14.0.0/lib/linux/libclang_rt.asan-x86_64.a(sanitizer_unwind_linux_libcdep.cpp.o): in function `__sanitizer::BufferedStackTrace::UnwindSlow(unsigned long, unsigned int)':                                                       
/src/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_unwind_linux_libcdep.cpp:130: undefined reference to `_Unwind_Backtrace'
/usr/bin/ld: /usr/local/lib/clang/14.0.0/lib/linux/libclang_rt.asan-x86_64.a(sanitizer_unwind_linux_libcdep.cpp.o): in function `__sanitizer::(anonymous namespace)::Unwind_Trace(_Unwind_Context*, void*)':
/src/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_unwind_linux_libcdep.cpp:69: undefined reference to `_Unwind_GetIP'
/usr/bin/ld: /usr/local/lib/clang/14.0.0/lib/linux/libclang_rt.asan-x86_64.a(sanitizer_unwind_linux_libcdep.cpp.o): in function `__sanitizer::BufferedStackTrace::UnwindSlow(unsigned long, void*, unsigned int)':                                             
/src/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_unwind_linux_libcdep.cpp:130: undefined reference to `_Unwind_Backtrace'
```