### PR TITLE
Abstract away duplicate code in prepare_for_fuzzer_build

### DIFF
--- a/infra/cifuzz/continuous_integration.py
+++ b/infra/cifuzz/continuous_integration.py
@@ -231,7 +231,7 @@ class InternalGithub(GithubCiMixin, BaseCi):
     """Builds the fuzzer builder image, checks out the pull request/commit and
     returns the BuildPreparationResult."""
     logging.info('InternalGithub: preparing for fuzzer build.')
-    assert self.config.pr_ref or self.config.commit_sha
+    assert self.config.pr_ref or self.config.git_sha
     # _detect_main_repo builds the image as a side effect.
     inferred_url, image_repo_path = self._detect_main_repo()
     if not inferred_url or not image_repo_path:

--- a/infra/cifuzz/continuous_integration.py
+++ b/infra/cifuzz/continuous_integration.py
@@ -125,6 +125,10 @@ class BaseCi:
       logging.error('Could not detect repo.')
     return inferred_url, image_repo_path
 
+  def _create_repo_manager_for_project_src_path(self):
+    """Returns a repo manager for |project_src_path|."""
+    return repo_manager.RepoManager(self.config.project_src_path)
+
 
 def get_build_command():
   """Returns the command to build the project inside the project builder
@@ -286,7 +290,7 @@ class InternalGeneric(BaseCi):
     if not image_repo_path:
       return get_build_preparation_failure()
 
-    manager = repo_manager.RepoManager(self.config.project_src_path)
+    manager = self._create_repo_manager_for_project_src_path()
     return BuildPreparationResult(success=True,
                                   image_repo_path=image_repo_path,
                                   repo_manager=manager)
@@ -330,7 +334,7 @@ class ExternalGeneric(BaseCi):
 
   def prepare_for_fuzzer_build(self):
     logging.info('ExternalGeneric: preparing for fuzzer build.')
-    manager = repo_manager.RepoManager(self.config.project_src_path)
+    manager = self._create_repo_manager_for_project_src_path()
     return self._build_external_project_docker_image(manager)
 
   def get_build_command(self, host_repo_path, image_repo_path):  # pylint: disable=no-self-use
@@ -348,7 +352,6 @@ class ExternalGithub(GithubCiMixin, BaseCi):
     projects are expected to bring their own source code to CIFuzz. Returns True
     on success."""
     logging.info('ExternalGithub: preparing for fuzzer build.')
-    os.makedirs(self.workspace.repo_storage, exist_ok=True)
     # Checkout before building, so we don't need to rely on copying the source
     # from the image.
     manager = self._clone_repo_and_checkout(self.config.git_url,


### PR DESCRIPTION
Share more code between the 4 implementations of `prepare_for_fuzzer_build`.

This simplifies the code of these implementations, reduces repetition and makes them easier to
understand.

Create helper functions/methods for:
1. Creating a failed `BuildPreparationResult`: `get_build_preparation_failure`
2. Building an external project docker image: `_build_external_project_docker_image` 
3. Cloning a repo and checking out the specified commit/pr: `_clone_repo_and_checkout`
4. Detecting the main repo `_detect_main_repo`
5. Creating a repo manager from an existing checkout: `_create_repo_manager_for_project_src_path`

Change `ExternalGeneric` implementation of `prepare_for_fuzzer_build` to:
1. Call `_create_repo_manager_for_project_src_path`
2. Call `_build_external_project_docker_image`

Change `InternalGeneric` implementation of `prepare_for_fuzzer_build` to:
1. Call `_detect_main_repo`
2. Call `_create_repo_manager_for_project_src_path`

Change `ExternalGithub` implementation of `prepare_for_fuzzer_build` to:
1. Call `_clone_repo_and_checkout`
2. Call `_build_external_project_docker_image`

Change `InternalGithub` implementation of `prepare_for_fuzzer_build` to:
1. Call `_detect_main_repo`
2. Call `_clone_repo_and_checkout`