### PR TITLE
oak: fix path

### DIFF
--- a/projects/oak/build.sh
+++ b/projects/oak/build.sh
@@ -27,7 +27,7 @@ fi
 
 cargo fuzz build --release
 
-FUZZ_TARGET_OUTPUT_DIR=fuzz/target/x86_64-unknown-linux-gnu/release
+FUZZ_TARGET_OUTPUT_DIR=../target/x86_64-unknown-linux-gnu/release
 for f in fuzz/fuzz_targets/*.rs
 do
     FUZZ_TARGET_NAME=$(basename ${f%.*})

--- a/projects/oak/project.yaml
+++ b/projects/oak/project.yaml
@@ -9,7 +9,7 @@ auto_ccs:
   - "ivanpetrov@google.com"
   - "razieh@google.com"
 sanitizers:
-  - address
+  - coverage
 fuzzing_engines:
   - libfuzzer
 main_repo: 'https://github.com/project-oak/oak'

--- a/projects/oak/project.yaml
+++ b/projects/oak/project.yaml
@@ -9,7 +9,7 @@ auto_ccs:
   - "ivanpetrov@google.com"
   - "razieh@google.com"
 sanitizers:
-  - coverage
+  - address
 fuzzing_engines:
   - libfuzzer
 main_repo: 'https://github.com/project-oak/oak'


### PR DESCRIPTION
- Update paths in build.sh following the changes in https://github.com/project-oak/oak/pull/2361.
- Changes sanitizers in project.yaml to `coverage`. The CI fails (possibly due to OOM error) for `address` and `undefined` sanitizers, even though the builds pass locally.