### PR TITLE
json-java: initial integration

### DIFF
--- a/projects/json-java/Dockerfile
+++ b/projects/json-java/Dockerfile
@@ -1,0 +1,28 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-jvm
+
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN curl -L https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip -o maven.zip && \
+    unzip maven.zip -d $SRC/maven && \
+    rm -rf maven.zip
+
+ENV MVN $SRC/maven/apache-maven-3.6.3/bin/mvn
+RUN git clone --depth 1 https://github.com/stleary/JSON-java json-java
+WORKDIR json-java
+COPY build.sh $SRC/
+COPY *.java $SRC/

--- a/projects/json-java/JsonJavaFuzzer.java
+++ b/projects/json-java/JsonJavaFuzzer.java
@@ -1,0 +1,28 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+import org.json.JSONObject;
+import org.json.JSONException;
+
+public class JsonJavaFuzzer {
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+
+    try {
+    JSONObject jo = new JSONObject(data.consumeRemainingAsString());
+    } catch(JSONException e) {}
+  }
+}

--- a/projects/json-java/JsonJavaFuzzer.java
+++ b/projects/json-java/JsonJavaFuzzer.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 //
 ////////////////////////////////////////////////////////////////////////////////
+
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 
 import org.json.JSONObject;
@@ -20,9 +21,8 @@ import org.json.JSONException;
 
 public class JsonJavaFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
-
     try {
-    JSONObject jo = new JSONObject(data.consumeRemainingAsString());
+      JSONObject jo = new JSONObject(data.consumeRemainingAsString());
     } catch(JSONException e) {}
   }
 }

--- a/projects/json-java/build.sh
+++ b/projects/json-java/build.sh
@@ -1,0 +1,44 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+cd src/main/java
+
+javac org/json/*.java
+jar cf $OUT/json-java.jar org/json/*.class
+
+ALL_JARS="json-java.jar"
+BUILD_CLASSPATH=$(echo $ALL_JARS | xargs printf -- "$OUT/%s:"):$JAZZER_API_PATH
+RUNTIME_CLASSPATH=$(echo $ALL_JARS | xargs printf -- "\$this_dir/%s:"):.:\$this_dir
+
+# Let's try and build a simple fuzzer.
+for fuzzer in $(find $SRC -name '*Fuzzer.java'); do
+  fuzzer_basename=$(basename -s .java $fuzzer)
+  javac -cp $BUILD_CLASSPATH $fuzzer
+  cp $SRC/$fuzzer_basename.class $OUT/
+
+# Create an execution wrapper that executes Jazzer with the correct arguments.
+  echo "#!/bin/sh
+# LLVMFuzzerTestOneInput for fuzzer detection.
+this_dir=\$(dirname \"\$0\")
+LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\":\$this_dir \
+\$this_dir/jazzer_driver --agent_path=\$this_dir/jazzer_agent_deploy.jar \
+--cp=$RUNTIME_CLASSPATH \
+--target_class=$fuzzer_basename \
+--jvm_args=\"-Xmx2048m\" \
+\$@" > $OUT/$fuzzer_basename
+  chmod u+x $OUT/$fuzzer_basename
+done
+

--- a/projects/json-java/project.yaml
+++ b/projects/json-java/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/stleary/JSON-java"
+language: jvm
+primary_contact: "someone@json-java.com"
+main_repo: "https://github.com/stleary/JSON-java"
+auto_ccs:
+  - "david@adalogics.com"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address

--- a/projects/json-java/project.yaml
+++ b/projects/json-java/project.yaml
@@ -1,6 +1,6 @@
 homepage: "https://github.com/stleary/JSON-java"
 language: jvm
-primary_contact: "someone@json-java.com"
+primary_contact: "jsonjava060@gmail.com"
 main_repo: "https://github.com/stleary/JSON-java"
 auto_ccs:
   - "david@adalogics.com"


### PR DESCRIPTION
Initial integration of JSON-java. 

The JSON-java package is used by ~4400 repositories in Maven https://mvnrepository.com/artifact/org.json/json and is the 4th most used json library in Java following jackson, gson and fastjson https://mvnrepository.com/open-source/json-libraries - on Maven the releases of JSON-java date back to 2007. 

The repositories on Maven that uses this parser are listed here https://mvnrepository.com/artifact/org.json/json/usages?p=1 and includes various Google repositories. 

@inferno-chromium @jonathanmetzman @oliverchang this one is ready for review! 