### PR TITLE
Add additional maintainer CC to GLib configuration

### DIFF
--- a/projects/glib/project.yaml
+++ b/projects/glib/project.yaml
@@ -5,6 +5,7 @@ auto_ccs:
 - philip.withnall@gmail.com
 - mwl458@gmail.com
 - iain@orangesquash.org.uk
+- slomo@coaxion.net
 sanitizers:
 - address
 - undefined


### PR DESCRIPTION
Add Sebastian Dröge as an additional CC to oss-fuzz issues for GLib. He’s a maintainer (see https://gitlab.gnome.org/GNOME/glib/-/blob/main/docs/CODEOWNERS and https://gitlab.gnome.org/sdroege).