### PR TITLE
[php] Make reports public

### DIFF
--- a/projects/php/project.yaml
+++ b/projects/php/project.yaml
@@ -11,4 +11,5 @@ sanitizers:
 architectures:
  - x86_64
  - i386
+view_restrictions: none
 main_repo: 'https://github.com/php/php-src.git'


### PR DESCRIPTION
We have some fuzzers that are security-critical (json, exif), but
these haven't found anything genuinely new in a long time. It seems
unlikely that they will find something that is not a regression in
a pre-release version (and as such okay to be public).

The other fuzzers are not classified as security-critical by the
the PHP project (unserialize, unserializehash, parser, execute,
function-jit, tracing-jit). The latter three produce the vast
majority of new reports.

I think it would be more valuable to make fuzzing reports public
and have a larger set of people who can work on them.

@smalyshev What do you think about this?