### PR TITLE
Avoid calling strlen on uninitialized data

### DIFF
--- a/projects/inchi/inchi_input_fuzzer.c
+++ b/projects/inchi/inchi_input_fuzzer.c
@@ -40,6 +40,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   inchi_InputINCHI inpInChI;
   inpInChI.szInChI = szINCHISource;
+  inpInChI.szOptions = NULL;
 
   inchi_Output out;
   GetINCHIfromINCHI(&inpInChI, &out);


### PR DESCRIPTION
GetINCHIfromINCHI calls strlen on szOptions, which leads to undefined behavior as it's not a valid null-terminated byte string.
Explicitly NULL out the char* to avoid this.