### PR TITLE
docs: remove statement on naming seed with sha1 values

### DIFF
--- a/docs/getting-started/new_project_guide.md
+++ b/docs/getting-started/new_project_guide.md
@@ -416,7 +416,7 @@ target]({{ site.baseurl }}/reference/glossary/#fuzz-target)'s coverage.
 
 To provide a corpus for `my_fuzzer`, put `my_fuzzer_seed_corpus.zip` file next
 to the [fuzz target]({{ site.baseurl }}/reference/glossary/#fuzz-target)'s binary in `$OUT` during the build. Individual files in this
-archive will be used as starting inputs for mutations. The name of each file in the corpus is the sha1 checksum (which you can get using the `sha1sum` or `shasum` command) of its contents. You can store the corpus
+archive will be used as starting inputs for mutations. You can store the corpus
 next to source files, generate during build or fetch it using curl or any other
 tool of your choice.
 (example: [boringssl](https://github.com/google/oss-fuzz/blob/master/projects/boringssl/build.sh#L41)).


### PR DESCRIPTION
As far as I can tell this statement is no longer valid, i.e. the files of seeds do not need to be named with the sha1 of their contents. At least not in the OSS-Fuzz infrastructure, but am not sure if Clusterfuzz does some checking on the names?