### PR TITLE
fix Dockerfile COPY command

### DIFF
--- a/infra/templates.py
+++ b/infra/templates.py
@@ -49,7 +49,7 @@ COPY build.sh $SRC/
 EXTERNAL_DOCKER_TEMPLATE = """\
 FROM gcr.io/oss-fuzz-base/%(base_builder)s:v1
 RUN apt-get update && apt-get install -y make autoconf automake libtool
-RUN COPY . $SRC/%(project_name)s
+COPY . $SRC/%(project_name)s
 WORKDIR %(project_name)s
 COPY .clusterfuzzlite/build.sh $SRC/
 """


### PR DESCRIPTION
Found this incorrect command in the generated Dockerfile when testing clusterfuzzlite