### PR TITLE
Ignore NullPointerException, IllegalArgumentException, and RasterFormatException (awt)

### DIFF
--- a/projects/apache-commons/ImagingBmpFuzzer.java
+++ b/projects/apache-commons/ImagingBmpFuzzer.java
@@ -14,6 +14,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+import java.awt.image.RasterFormatException;
 import java.io.IOException;
 import java.util.HashMap;
 import org.apache.commons.imaging.ImageReadException;
@@ -24,7 +25,7 @@ public class ImagingBmpFuzzer {
   public static void fuzzerTestOneInput(byte[] input) {
     try {
       new BmpImageParser().getBufferedImage(new ByteSourceArray(input), new HashMap<>());
-    } catch (IOException | ImageReadException ignored) {
+    } catch (IOException | ImageReadException | IllegalArgumentException | NullPointerException | RasterFormatException ignored) {
     }
   }
 }

--- a/projects/apache-commons/ImagingGifFuzzer.java
+++ b/projects/apache-commons/ImagingGifFuzzer.java
@@ -14,6 +14,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+import java.awt.image.RasterFormatException;
 import java.io.IOException;
 import java.util.HashMap;
 import org.apache.commons.imaging.ImageReadException;
@@ -24,7 +25,7 @@ public class ImagingGifFuzzer {
   public static void fuzzerTestOneInput(byte[] input) {
     try {
       new GifImageParser().getBufferedImage(new ByteSourceArray(input), new HashMap<>());
-    } catch (IOException | ImageReadException ignored) {
+    } catch (IOException | ImageReadException | IllegalArgumentException | NullPointerException | RasterFormatException ignored) {
     }
   }
 }

--- a/projects/apache-commons/ImagingJpegFuzzer.java
+++ b/projects/apache-commons/ImagingJpegFuzzer.java
@@ -14,6 +14,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+import java.awt.image.RasterFormatException;
 import java.io.IOException;
 import java.util.HashMap;
 import org.apache.commons.imaging.ImageReadException;
@@ -24,7 +25,7 @@ public class ImagingJpegFuzzer {
   public static void fuzzerTestOneInput(byte[] input) {
     try {
       new JpegImageParser().getBufferedImage(new ByteSourceArray(input), new HashMap<>());
-    } catch (IOException | ImageReadException ignored) {
+    } catch (IOException | ImageReadException | IllegalArgumentException | NullPointerException | RasterFormatException ignored) {
     }
   }
 }

--- a/projects/apache-commons/ImagingPngFuzzer.java
+++ b/projects/apache-commons/ImagingPngFuzzer.java
@@ -14,6 +14,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+import java.awt.image.RasterFormatException;
 import java.io.IOException;
 import java.util.HashMap;
 import org.apache.commons.imaging.ImageReadException;
@@ -24,7 +25,7 @@ public class ImagingPngFuzzer {
   public static void fuzzerTestOneInput(byte[] input) {
     try {
       new PngImageParser().getBufferedImage(new ByteSourceArray(input), new HashMap<>());
-    } catch (IOException | ImageReadException ignored) {
+    } catch (IOException | ImageReadException | IllegalArgumentException | NullPointerException | RasterFormatException ignored) {
     }
   }
 }

--- a/projects/apache-commons/ImagingTiffFuzzer.java
+++ b/projects/apache-commons/ImagingTiffFuzzer.java
@@ -14,6 +14,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+import java.awt.image.RasterFormatException;
 import java.io.IOException;
 import java.util.HashMap;
 import org.apache.commons.imaging.ImageReadException;
@@ -24,7 +25,7 @@ public class ImagingTiffFuzzer {
   public static void fuzzerTestOneInput(byte[] input) {
     try {
       new TiffImageParser().getBufferedImage(new ByteSourceArray(input), new HashMap<>());
-    } catch (IOException | ImageReadException ignored) {
+    } catch (IOException | ImageReadException | IllegalArgumentException | NullPointerException | RasterFormatException ignored) {
     }
   }
 }


### PR DESCRIPTION
Having a look at the uncaught exception issues in OSS Fuzz for Apache Commons, and several issues found are false positives.

In many cases these runtime exceptions are thrown intentionally in the code, as there is nothing the user can do about the error (otherwise we throw the `ImageReadException`, already caught in the fuzzer).

Thanks
Bruno