### PR TITLE
gson: catch highest level exceptions

### DIFF
--- a/projects/gson/FuzzParse.java
+++ b/projects/gson/FuzzParse.java
@@ -22,6 +22,6 @@ public class FuzzParse {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     try {
       JsonParser.parseString(data.consumeRemainingAsString());
-    } catch (JsonSyntaxException expected) { }
+    } catch (JsonParseException expected) { }
   }
 }

--- a/projects/gson/FuzzReader.java
+++ b/projects/gson/FuzzReader.java
@@ -30,6 +30,6 @@ public class FuzzReader {
       while (reader.peek() != JsonToken.END_DOCUMENT) {
         adapter.read(reader);
       }
-    } catch (JsonSyntaxException | IOException expected) { }
+    } catch (JsonSyntaxException | IllegalStateException | NumberFormatException | IOException expected) { }
   }
 }


### PR DESCRIPTION
This should fix:
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=40795
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=40787

Signed-off-by: David Korczynski <david@adalogics.com>