### PR TITLE
libdwarf: add seeds and cleanup fuzzers to only used public headers

### DIFF
--- a/projects/libdwarf/Dockerfile
+++ b/projects/libdwarf/Dockerfile
@@ -17,6 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/davea42/libdwarf-code libdwarf
+RUN git clone --depth=1 https://github.com/DavidKorczynski/binary-samples $SRC/binary-samples
 WORKDIR libdwarf
 COPY build.sh $SRC/
 COPY fuzz*.c $SRC/

--- a/projects/libdwarf/build.sh
+++ b/projects/libdwarf/build.sh
@@ -15,13 +15,23 @@
 #
 ################################################################################
 
-export CFLAGS="${CFLAGS} -g"
-export CXXFLAGS="${CXXFLAGS} -g"
+export CFLAGS="${CFLAGS} -g -Werror"
+export CXXFLAGS="${CXXFLAGS} -g -Werror"
 
 mkdir build
 cd build
 cmake ../
 make
+
+# Build corpus for fuzzing
+mkdir $SRC/corp
+cp $SRC/binary-samples/elf* $SRC/corp
+cp $SRC/binary-samples/Mach* $SRC/corp
+cp $SRC/binary-samples/pe* $SRC/corp
+cp $SRC/binary-samples/lib* $SRC/corp
+
+zip -r -j $OUT/fuzz_init_path_seed_corpus.zip $SRC/corp
+cp $OUT/fuzz_init_path_seed_corpus.zip $OUT/fuzz_init_binary_seed_corpus.zip
 
 for fuzzName in init_path init_binary; do
   $CC $CFLAGS $LIB_FUZZING_ENGINE -I../src/lib/libdwarf/ \

--- a/projects/libdwarf/fuzz_init_binary.c
+++ b/projects/libdwarf/fuzz_init_binary.c
@@ -18,11 +18,11 @@ limitations under the License.
 #include <fcntl.h>
 #include <unistd.h>
 
+/*
+ * Libdwarf library callers can only use these headers.
+ */
 #include "dwarf.h"
 #include "libdwarf.h"
-#include "libdwarf_private.h"
-#include "dwarf_alloc.h"
-
 
 /*
  * A fuzzer that simulates a small part of the simplereader.c example.

--- a/projects/libdwarf/fuzz_init_path.c
+++ b/projects/libdwarf/fuzz_init_path.c
@@ -16,11 +16,11 @@ limitations under the License.
 #include <sys/types.h>
 #include <unistd.h>
 
+/*
+ * Libdwarf library callers can only use these headers.
+ */
 #include "dwarf.h"
 #include "libdwarf.h"
-#include "libdwarf_private.h"
-#include "dwarf_alloc.h"
-
 
 /*
  * A fuzzer that simulates a small part of the simplereader.c example.


### PR DESCRIPTION
Thanks to David Anderson for letting me know about header file inclusion in libdwarf