### PR TITLE
dng_sdk: extend with more seeds

### DIFF
--- a/projects/dng_sdk/Dockerfile
+++ b/projects/dng_sdk/Dockerfile
@@ -20,6 +20,8 @@ RUN git clone https://android.googlesource.com/platform/external/dng_sdk/
 
 # For seed corpus
 RUN git clone --depth=1 https://github.com/ianare/exif-samples exif-samples
+RUN git clone --depth=1 https://github.com/image-rs/image-tiff image-tiff
+RUN git clone --depth=1 https://github.com/yigolden/TiffLibrary TiffLibrary
 
 COPY build.sh $SRC/
 COPY *_fuzzer.cpp $SRC/

--- a/projects/dng_sdk/build.sh
+++ b/projects/dng_sdk/build.sh
@@ -15,6 +15,7 @@
 #
 ################################################################################
 
+
 # compile source
 cd ./source
 rm dng_xmp*
@@ -51,7 +52,9 @@ $CXX $CXXFLAGS $LIB_FUZZING_ENGINE -DqDNGValidateTarget \
 # Create seed corpus and distribute to fuzzers
 mkdir $SRC/seed_corpus
 cp $SRC/dng_sdk/fuzzer/seeds/CVE_2020_9589/*.dng $SRC/seed_corpus/
-find $SRC/exif-samples/ -name "*.jpg" -exec cp {} $SRC/seed_corpus/ \;
+find $SRC/image-tiff/ -regextype sed -regex ".*\.\(pbm\|pgm\|tif\|tiff\|png\|ppm\|jpg\|exif\)" -exec cp {} $SRC/seed_corpus/ \;
+find $SRC/TiffLibrary/ -regextype sed -regex ".*\.\(pbm\|pgm\|tif\|tiff\|png\|ppm\|jpg\|exif\)" -exec cp {} $SRC/seed_corpus/ \;
+find $SRC/exif-samples/ -regextype sed -regex ".*\.\(pbm\|pgm\|tif\|tiff\|png\|ppm\|jpg\|exif\)" -exec cp {} $SRC/seed_corpus/ \;
 
 # Download a compressed JPEG
 wget https://upload.wikimedia.org/wikipedia/commons/b/b2/JPEG_compression_Example.jpg -O $SRC/seed_corpus/compressed_JPEG.jpg


### PR DESCRIPTION
Currently execution is scarce in areas where image-specific data is
considered. This PR tries to overcome that by including more seeds
in the corpus, with the hope that these images contain examples of
the given data.

Signed-off-by: David Korczynski <david@adalogics.com>