### PR TITLE
duckdb: link to any built extensions as well

### DIFF
--- a/projects/duckdb/build.sh
+++ b/projects/duckdb/build.sh
@@ -16,8 +16,9 @@
 ################################################################################
 
 make
+EXTENSION_LIBS=$(find ./build/release/extension/ -name "*.a")
 THIRD_PARTY_LIBS=$(find ./build/release/third_party/ -name "*.a")
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE ./test/ossfuzz/parse_fuzz_test.cpp \
     -o $OUT/parse_fuzz_test -I./ -I./src/include \
     ./build/release/src/libduckdb_static.a \
-    ${THIRD_PARTY_LIBS}
+    ${EXTENSION_LIBS} ${THIRD_PARTY_LIBS}


### PR DESCRIPTION
In duckdb/duckdb#2563 we are moving to bundle any included DuckDB extensions with the main library. As by default the Parquet extension is enabled, this is now resulting in linking errors in CI Fuzz ([relevant CI](https://github.com/duckdb/duckdb/runs/4151827093?check_suite_focus=true)). This PR should fix that by linking to the extension libraries as well.