### PR TITLE
Envoy: overriding CC and CXX when building in oss-fuzz

### DIFF
--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -22,6 +22,12 @@ declare -r FUZZ_TARGET_QUERY='
 declare -r OSS_FUZZ_TARGETS="$(bazel query "${FUZZ_TARGET_QUERY}" | sed 's/$/_oss_fuzz/')"
 
 declare -r EXTRA_BAZEL_FLAGS="$(
+if [ -n "$CC" ]; then
+  echo "--action_env=CC=${CC}"
+fi
+if [ -n "$CXX" ]; then
+  echo "--action_env=CXX=${CXX}"
+fi
 if [ "$SANITIZER" = "undefined" ]
 then
   # Bazel uses clang to link binary, which does not link clang_rt ubsan library for C++ automatically.

--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -28,7 +28,13 @@ fi
 if [ -n "$CXX" ]; then
   echo "--action_env=CXX=${CXX}"
 fi
-if [ "$SANITIZER" = "address" ]
+if [ "$SANITIZER" = "undefined" ]
+then
+  # Bazel uses clang to link binary, which does not link clang_rt ubsan library for C++ automatically.
+  # See issue: https://github.com/bazelbuild/bazel/issues/8777
+  echo "--linkopt=$(find $(llvm-config --libdir) -name libclang_rt.ubsan_standalone_cxx-x86_64.a | head -1)"
+  echo "--linkopt=-fsanitize=undefined"
+elif [ "$SANITIZER" = "address" ]
 then
   echo "--copt=-D__SANITIZE_ADDRESS__" "--copt=-DADDRESS_SANITIZER=1" "--linkopt=-fsanitize=address"
 fi

--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -28,12 +28,7 @@ fi
 if [ -n "$CXX" ]; then
   echo "--action_env=CXX=${CXX}"
 fi
-if [ "$SANITIZER" = "undefined" ]
-then
-  # Bazel uses clang to link binary, which does not link clang_rt ubsan library for C++ automatically.
-  # See issue: https://github.com/bazelbuild/bazel/issues/8777
-  echo "--linkopt=\"$(find $(llvm-config --libdir) -name libclang_rt.ubsan_standalone_cxx-x86_64.a | head -1)\""
-elif [ "$SANITIZER" = "address" ]
+if [ "$SANITIZER" = "address" ]
 then
   echo "--copt=-D__SANITIZE_ADDRESS__" "--copt=-DADDRESS_SANITIZER=1" "--linkopt=-fsanitize=address"
 fi


### PR DESCRIPTION
Envoy's PR [18732](https://github.com/envoyproxy/envoy/pull/18732/files) set the clang/clang++ compilers when using the `clang` build config.
This prevents the underlying oss-fuzz infra from using other types of compilers (e.g., afl++), and we get the following linking error:
```
Step #3 - "compile-afl-address-x86_64": ld.lld: error: undefined symbol: __afl_manual_init
Step #3 - "compile-afl-address-x86_64": >>> referenced by aflpp_driver.c:258
Step #3 - "compile-afl-address-x86_64": >>>               aflpp_driver.o:(main) in archive external/rules_fuzzing_oss_fuzz/oss_fuzz_engine.a
Step #3 - "compile-afl-address-x86_64": >>> referenced by aflpp_driver.c:273
Step #3 - "compile-afl-address-x86_64": >>>               aflpp_driver.o:(main) in archive external/rules_fuzzing_oss_fuzz/oss_fuzz_engine.a
Step #3 - "compile-afl-address-x86_64": >>> referenced by aflpp_driver.c:281
Step #3 - "compile-afl-address-x86_64": >>>               aflpp_driver.o:(main) in archive external/rules_fuzzing_oss_fuzz/oss_fuzz_engine.a
Step #3 - "compile-afl-address-x86_64": 
```

This PR overrides the CC and CXX env vars if they are defined by the underlying environment.

Also removing `linkopt` workaround for ubsan build, as it conflicts with clang 14.

Signed-off-by: Adi Suissa-Peleg <adip@google.com>