### PR TITLE
apr_pool_initialize() pairs with apr_pool_terminate()

### DIFF
--- a/projects/apache-httpd/fuzz_addr_parse.c
+++ b/projects/apache-httpd/fuzz_addr_parse.c
@@ -31,7 +31,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   free(input_string);
   apr_pool_destroy(pool);
-  apr_terminate();
+  apr_pool_terminate();
 
   return 0;
 }

--- a/projects/apache-httpd/fuzz_tokenize.c
+++ b/projects/apache-httpd/fuzz_tokenize.c
@@ -28,7 +28,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   free(arg_str);
   apr_pool_destroy(pool);
-  apr_terminate();
+  apr_pool_terminate();
 
   return 0;
 }


### PR DESCRIPTION
Using apr_terminate() causes leaks (e.g. Issue 37165).