### PR TITLE
infra: Remove redundant --cap-add SYS_PTRACE

### DIFF
--- a/infra/cifuzz/docker.py
+++ b/infra/cifuzz/docker.py
@@ -27,8 +27,7 @@ PROJECT_TAG_PREFIX = 'gcr.io/oss-fuzz/'
 
 # Default fuzz configuration.
 _DEFAULT_DOCKER_RUN_ARGS = [
-    '-e',
-    'FUZZING_ENGINE=' + constants.DEFAULT_ENGINE, '-e',
+    '-e', 'FUZZING_ENGINE=' + constants.DEFAULT_ENGINE, '-e',
     'ARCHITECTURE=' + constants.DEFAULT_ARCHITECTURE, '-e', 'CIFUZZ=True'
 ]
 

--- a/infra/cifuzz/docker.py
+++ b/infra/cifuzz/docker.py
@@ -27,7 +27,7 @@ PROJECT_TAG_PREFIX = 'gcr.io/oss-fuzz/'
 
 # Default fuzz configuration.
 _DEFAULT_DOCKER_RUN_ARGS = [
-    '--cap-add', 'SYS_PTRACE', '-e',
+    '-e',
     'FUZZING_ENGINE=' + constants.DEFAULT_ENGINE, '-e',
     'ARCHITECTURE=' + constants.DEFAULT_ARCHITECTURE, '-e', 'CIFUZZ=True'
 ]

--- a/infra/cifuzz/docker_test.py
+++ b/infra/cifuzz/docker_test.py
@@ -91,10 +91,9 @@ class GetBaseDockerRunArgsTest(unittest.TestCase):
         WORKSPACE, SANITIZER, LANGUAGE)
     self.assertEqual(docker_container, None)
     expected_docker_args = [
-        '-e', 'FUZZING_ENGINE=libfuzzer', '-e',
-        'ARCHITECTURE=x86_64', '-e', 'CIFUZZ=True', '-e',
-        f'SANITIZER={SANITIZER}', '-e', f'FUZZING_LANGUAGE={LANGUAGE}', '-e',
-        f'OUT={WORKSPACE.out}', '-v',
+        '-e', 'FUZZING_ENGINE=libfuzzer', '-e', 'ARCHITECTURE=x86_64', '-e',
+        'CIFUZZ=True', '-e', f'SANITIZER={SANITIZER}', '-e',
+        f'FUZZING_LANGUAGE={LANGUAGE}', '-e', f'OUT={WORKSPACE.out}', '-v',
         f'{WORKSPACE.workspace}:{WORKSPACE.workspace}'
     ]
     self.assertEqual(docker_args, expected_docker_args)
@@ -111,8 +110,8 @@ class GetBaseDockerRunCommandTest(unittest.TestCase):
         WORKSPACE, SANITIZER, LANGUAGE)
     self.assertEqual(docker_container, None)
     expected_docker_command = [
-        'docker', 'run', '--rm', '--privileged',
-        '-e', 'FUZZING_ENGINE=libfuzzer', '-e', 'ARCHITECTURE=x86_64', '-e',
+        'docker', 'run', '--rm', '--privileged', '-e',
+        'FUZZING_ENGINE=libfuzzer', '-e', 'ARCHITECTURE=x86_64', '-e',
         'CIFUZZ=True', '-e', f'SANITIZER={SANITIZER}', '-e',
         f'FUZZING_LANGUAGE={LANGUAGE}', '-e', f'OUT={WORKSPACE.out}', '-v',
         f'{WORKSPACE.workspace}:{WORKSPACE.workspace}'

--- a/infra/cifuzz/docker_test.py
+++ b/infra/cifuzz/docker_test.py
@@ -66,8 +66,6 @@ class GetBaseDockerRunArgsTest(unittest.TestCase):
     self.assertEqual(docker_container, CONTAINER_NAME)
     expected_docker_args = []
     expected_docker_args = [
-        '--cap-add',
-        'SYS_PTRACE',
         '-e',
         'FUZZING_ENGINE=libfuzzer',
         '-e',
@@ -93,7 +91,7 @@ class GetBaseDockerRunArgsTest(unittest.TestCase):
         WORKSPACE, SANITIZER, LANGUAGE)
     self.assertEqual(docker_container, None)
     expected_docker_args = [
-        '--cap-add', 'SYS_PTRACE', '-e', 'FUZZING_ENGINE=libfuzzer', '-e',
+        '-e', 'FUZZING_ENGINE=libfuzzer', '-e',
         'ARCHITECTURE=x86_64', '-e', 'CIFUZZ=True', '-e',
         f'SANITIZER={SANITIZER}', '-e', f'FUZZING_LANGUAGE={LANGUAGE}', '-e',
         f'OUT={WORKSPACE.out}', '-v',
@@ -113,7 +111,7 @@ class GetBaseDockerRunCommandTest(unittest.TestCase):
         WORKSPACE, SANITIZER, LANGUAGE)
     self.assertEqual(docker_container, None)
     expected_docker_command = [
-        'docker', 'run', '--rm', '--privileged', '--cap-add', 'SYS_PTRACE',
+        'docker', 'run', '--rm', '--privileged',
         '-e', 'FUZZING_ENGINE=libfuzzer', '-e', 'ARCHITECTURE=x86_64', '-e',
         'CIFUZZ=True', '-e', f'SANITIZER={SANITIZER}', '-e',
         f'FUZZING_LANGUAGE={LANGUAGE}', '-e', f'OUT={WORKSPACE.out}', '-v',

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -647,7 +647,7 @@ def build_fuzzers_impl(  # pylint: disable=too-many-arguments,too-many-locals,to
   if env_to_add:
     env += env_to_add
 
-  command = ['--cap-add', 'SYS_PTRACE'] + _env_to_docker_args(env)
+  command = _env_to_docker_args(env)
   if source_path:
     workdir = _workdir_from_dockerfile(project)
     if mount_path:


### PR DESCRIPTION
This is a follow-up to https://github.com/google/oss-fuzz/commit/14582175d07c8a66adf3f9087a464612f2a3f630#diff-f7cbd58a5ead1f30c3790c91e50ab1667afba5b26d0562a601b9d048c9e5da88, which changed the code to pass `--cap-add SYS_PTRACE` into `docker_run`, which again appends `--privileged`. `--privileged` already covers all capabilities, so there is no need to add specific ones. See https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities . In fact, using both will result in errors on alternative docker implementations:

```
Error: invalid config provided: CapAdd and privileged are mutually exclusive options
