### PR TITLE
update afl++ commit id (warning)

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -125,7 +125,7 @@ WORKDIR $SRC
 # TODO: switch to -b stable once we can.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git aflplusplus && \
     cd aflplusplus && \
-    git checkout 4fe572b80f76ff0b0e916b639d1e04d5af48b157
+    git checkout 533e979010ca338df6fc415d87668f8187752915
 
 RUN cd $SRC && \
     curl -L -O https://github.com/google/honggfuzz/archive/oss-fuzz.tar.gz && \


### PR DESCRIPTION
This updates afl++ which has a good efficiency increase.
Caveat: cmplog/redqueen binaries still work with previous afl-fuzz but there might be a slight impact.
The new afl-fuzz however requires that cmplog binaries were made with the current (or future) afl-cc/afl-clang-fast.

So - where does afl-fuzz in clusterfuzz come from? If that is from the oss-fuzz target package then this is fine.
If clusterfuzz uses its own afl-fuzz then this should be a coordinated update.