### PR TITLE
llvm: add rust and dlang demanglers to the fuzzers list

### DIFF
--- a/projects/llvm/build.sh
+++ b/projects/llvm/build.sh
@@ -23,6 +23,8 @@ readonly FUZZERS=( \
   clangd-fuzzer \
   llvm-itanium-demangle-fuzzer \
   llvm-microsoft-demangle-fuzzer \
+  llvm-dlang-demangle-fuzzer \
+  llvm-rust-demangle-fuzzer \
   llvm-dwarfdump-fuzzer \
   llvm-isel-fuzzer \
   llvm-special-case-list-fuzzer \


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

Add dlang as https://github.com/llvm/llvm-project/commit/9af467ed8b53adfe1c8d0788d874d7a8c08375de got merged and missing rust fuzzer.