### PR TITLE
apache-httpd: fix build by updating patch to mainstream

### DIFF
--- a/projects/apache-httpd/Dockerfile
+++ b/projects/apache-httpd/Dockerfile
@@ -32,4 +32,4 @@ RUN git clone --depth=1 https://github.com/apache/httpd
 WORKDIR httpd
 COPY build.sh $SRC/
 COPY fuzz_*.c $SRC/
-COPY patches.diff $SRC/
+#COPY patches.diff $SRC/

--- a/projects/apache-httpd/build.sh
+++ b/projects/apache-httpd/build.sh
@@ -19,7 +19,11 @@ unset CPP
 unset CXX
 export LDFLAGS="-l:libbsd.a"
 
-git apply  --ignore-space-change --ignore-whitespace $SRC/patches.diff
+# We used to patch out assert statements. But since https://github.com/apache/httpd/commit/a6e5a92b0d0e74ead5a43f20f81f5cf880ea4fb8
+# This does not seem to be relevant anymore.
+# I will keep the lines and let the fuzzers runs for a while, then remove the patch entirely
+# if it proves no longer needed.
+#git apply  --ignore-space-change --ignore-whitespace $SRC/patches.diff
 
 # Download apr and place in httpd srclib folder. Apr-2.0 includes apr-utils
 svn checkout https://svn.apache.org/repos/asf/apr/apr/trunk/ srclib/apr


### PR DESCRIPTION
Fix build of apache-httpd because patches no longer apply. We now avoid using patches that made the parser cleanly return instead of hitting asserts following https://github.com/apache/httpd/commit/a6e5a92b0d0e74ead5a43f20f81f5cf880ea4fb8

CC @ylavic 