### PR TITLE
[clamav] add rust toolchain

### DIFF
--- a/projects/clamav/Dockerfile
+++ b/projects/clamav/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder-rust
 RUN apt-get update && apt-get install -y \
     flex bison \
     python3-dev \


### PR DESCRIPTION
Switch over to the base-builder-rust image to build Rust modules (static libs) in ClamAV