### PR TITLE
[njs] Build pcre2 dependency manually and enable MSan.

### DIFF
--- a/projects/njs/Dockerfile
+++ b/projects/njs/Dockerfile
@@ -16,9 +16,9 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
-    mercurial libpcre3-dev subversion
+    mercurial git libpcre2-dev
 RUN hg clone http://hg.nginx.org/njs
-RUN svn co svn://vcs.exim.org/pcre/code/trunk pcre
+RUN git clone --branch pcre2-10.39 https://github.com/PhilipHazel/pcre2 pcre2
 
 WORKDIR njs
 COPY build.sh $SRC/

--- a/projects/njs/build.sh
+++ b/projects/njs/build.sh
@@ -16,11 +16,14 @@
 ################################################################################
 
 # Build pcre dependency to be linked statically.
-pushd $SRC/pcre
+pushd $SRC/pcre2
 ./autogen.sh
 CFLAGS="$CFLAGS -fno-use-cxa-atexit" CXXFLAGS="$CXXFLAGS -fno-use-cxa-atexit" ./configure
 make -j$(nproc) clean
 make -j$(nproc) all
+make install
+sed -i "s/\$libS\$libR \(-lpcre2-8$\)/\$libS\$libR -Wl,-Bstatic \1 -Wl,-Bdynamic/" /usr/local/bin/pcre2-config
+#sed -i "s/libS=/libS=-L\${exec_prefix}\/lib/" /usr/local/bin/pcre2-config
 popd
 
 # build project
@@ -35,7 +38,7 @@ SEED_CORPUS_PATH=$OUT/njs_process_script_fuzzer_seed_corpus
 mkdir -p $SEED_CORPUS_PATH
 
 set +x
-cat src/test/njs_interactive_test.c src/test/njs_unit_test.c \
+cat src/test/njs_unit_test.c \
     | egrep -o '".*"' | awk '{print substr($0,2,length($0)-2)}' | sort | uniq \
     | while IFS= read -r line; do
       echo $line > $SEED_CORPUS_PATH/$(echo $line | sha1sum | awk '{ print $1 }');

--- a/projects/njs/project.yaml
+++ b/projects/njs/project.yaml
@@ -6,8 +6,7 @@ auto_ccs:
  - "devrep@nginx.com"
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
-#  - memory
+  - memory
   - undefined
-coverage_extra_args: -ignore-filename-regex=.*/pcre/.*
+coverage_extra_args: -ignore-filename-regex=.*/pcre2/.*
 main_repo: 'https://github.com/nginx/njs.git'


### PR DESCRIPTION
PCRE2 support was added recently for NJS http://hg.nginx.org/njs/rev/728c3741f556.

This pull request replaces PCRE with PCRE2. 
It also fixed MSAN issue.