### PR TITLE
Removes DFSan for libteken

### DIFF
--- a/projects/libteken/project.yaml
+++ b/projects/libteken/project.yaml
@@ -9,3 +9,4 @@ sanitizers:
   - address
   - undefined
   - memory
+main_repo: 'http://svn.freebsd.org/base/head/sys/teken/'

--- a/projects/libteken/project.yaml
+++ b/projects/libteken/project.yaml
@@ -5,9 +5,7 @@ fuzzing_engines:
   - libfuzzer
   - afl
   - honggfuzz
-  - dataflow
 sanitizers:
   - address
   - undefined
   - memory
-  - dataflow


### PR DESCRIPTION
It does not seem relevant and makes the build fail

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=38471