### PR TITLE
[linkerd2] Initial integration

### DIFF
--- a/projects/linkerd2/Dockerfile
+++ b/projects/linkerd2/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2021 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/linkerd/linkerd2
+COPY build.sh fuzzers.go $SRC/
+WORKDIR $SRC/linkerd2

--- a/projects/linkerd2/build.sh
+++ b/projects/linkerd2/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -eu
+# Copyright 2020 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+mkdir $SRC/linkerd2/test/fuzzing
+
+mv $SRC/fuzzers.go $SRC/linkerd2/test/fuzzing/
+
+compile_go_fuzzer github.com/linkerd/linkerd2/test/fuzzing FuzzParseContainerOpaquePorts FuzzParseContainerOpaquePorts
+compile_go_fuzzer github.com/linkerd/linkerd2/test/fuzzing FuzzParsePorts FuzzParsePorts
+compile_go_fuzzer github.com/linkerd/linkerd2/test/fuzzing FuzzHealthCheck FuzzHealthCheck

--- a/projects/linkerd2/fuzzers.go
+++ b/projects/linkerd2/fuzzers.go
@@ -1,0 +1,49 @@
+package fuzzing
+
+import (
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	"github.com/linkerd/linkerd2/pkg/healthcheck"
+	"github.com/linkerd/linkerd2/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func FuzzParsePorts(data []byte) int {
+	_, _ = util.ParsePorts(string(data))
+	return 1
+}
+
+func FuzzParseContainerOpaquePorts(data []byte) int {
+	f := fuzz.NewConsumer(data)
+
+	qtyOfContainers, err := f.GetInt()
+	if err != nil {
+		return 0
+	}
+
+	containers := make([]corev1.Container, 0)
+	for i := 0; i < qtyOfContainers%20; i++ {
+		newContainer := corev1.Container{}
+		err = f.GenerateStruct(&newContainer)
+		if err != nil {
+			return 0
+		}
+		containers = append(containers, newContainer)
+	}
+	override, err := f.GetString()
+	if err != nil {
+		return 0
+	}
+	_ = util.ParseContainerOpaquePorts(override, containers)
+	return 1
+}
+
+func FuzzHealthCheck(data []byte) int {
+	f := fuzz.NewConsumer(data)
+	options := &healthcheck.Options{}
+	err := f.GenerateStruct(options)
+	if err != nil {
+		return 0
+	}
+	_ = healthcheck.NewHealthChecker([]healthcheck.CategoryID{healthcheck.KubernetesAPIChecks}, options)
+	return 1
+}

--- a/projects/linkerd2/project.yaml
+++ b/projects/linkerd2/project.yaml
@@ -1,0 +1,13 @@
+homepage: "https://linkerd.io/"
+main_repo: "https://github.com/linkerd/linkerd2"
+primary_contact: "ver@buoyant.io"
+auto_ccs :
+  - "adam@adalogics.com"
+  - "david@adalogics.com"
+  - "eliza@buoyant.io"
+  - "kevinl@buoyant.io"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
Linkerd2 is security-first service mesh for Kubernetes used by companies like Godaddy, HP, Walmart and Expedia [[https://linkerd.io](https://linkerd.io)]

The project graduated the CNCF in july this year [[https://linkerd.io/2021/07/28/announcing-cncf-graduation/](https://linkerd.io/2021/07/28/announcing-cncf-graduation/)] 

This PR adds the projects main repo.