### PR TITLE
[notary] Initial integration

### DIFF
--- a/projects/notary/Dockerfile
+++ b/projects/notary/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/notary/Dockerfile
+++ b/projects/notary/Dockerfile
@@ -16,5 +16,5 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN git clone --depth 1 https://github.com/notaryproject/notary
-COPY build.sh $SRC/
+COPY build.sh fuzz_trustmanager_test.go $SRC/
 WORKDIR $SRC/notary

--- a/projects/notary/Dockerfile
+++ b/projects/notary/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/notaryproject/notary
+COPY build.sh $SRC/
+WORKDIR $SRC/notary

--- a/projects/notary/build.sh
+++ b/projects/notary/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2021 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/notary/build.sh
+++ b/projects/notary/build.sh
@@ -24,4 +24,5 @@ compile_go_fuzzer github.com/theupdateframework/notary/cryptoservice/fuzz Fuzz f
 
 mv $SRC/notary/trustmanager/keys_test.go $SRC/notary/trustmanager/keys_test_fuzz.go
 mv $SRC/notary/trustmanager/keystore_test.go $SRC/notary/trustmanager/keystore_test_fuzz.go
-compile_native_go_fuzzer github.com/theupdateframework/notary/trustmanager FuzzImportKeys FuzzImportKeys
+compile_native_go_fuzzer github.com/theupdateframework/notary/trustmanager FuzzImportKeysSimple FuzzImportKeysSimple
+compile_native_go_fuzzer github.com/theupdateframework/notary/trustmanager FuzzImportKeysStructured FuzzImportKeysStructured

--- a/projects/notary/build.sh
+++ b/projects/notary/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+compile_go_fuzzer github.com/theupdateframework/notary/cryptoservice/fuzz Fuzz fuzz

--- a/projects/notary/build.sh
+++ b/projects/notary/build.sh
@@ -15,4 +15,13 @@
 #
 ################################################################################
 
+sed 's/go 1.17/go 1.19/g' -i $SRC/notary/go.mod
+
+cp $SRC/fuzz_trustmanager_test.go $SRC/notary/trustmanager/
+printf "package trustmanager\nimport _ \"github.com/AdamKorcz/go-118-fuzz-build/testing\"\n" > $SRC/notary/trustmanager/registerfuzzdep.go
+go mod tidy && go mod vendor
 compile_go_fuzzer github.com/theupdateframework/notary/cryptoservice/fuzz Fuzz fuzz
+
+mv $SRC/notary/trustmanager/keys_test.go $SRC/notary/trustmanager/keys_test_fuzz.go
+mv $SRC/notary/trustmanager/keystore_test.go $SRC/notary/trustmanager/keystore_test_fuzz.go
+compile_native_go_fuzzer github.com/theupdateframework/notary/trustmanager FuzzImportKeys FuzzImportKeys

--- a/projects/notary/fuzz_trustmanager_test.go
+++ b/projects/notary/fuzz_trustmanager_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/notary/fuzz_trustmanager_test.go
+++ b/projects/notary/fuzz_trustmanager_test.go
@@ -1,0 +1,40 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package trustmanager
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+var initter sync.Once
+
+func muteLogging() {
+	logrus.SetLevel(logrus.PanicLevel)
+}
+
+func FuzzImportKeys(f *testing.F) {
+	f.Fuzz(func(t *testing.T, from []byte, fallbackRole, fallbackGUN string) {
+		initter.Do(muteLogging)
+		s := NewTestImportStore()
+
+		in := bytes.NewReader(from)
+		ImportKeys(in, []Importer{s}, fallbackRole, fallbackGUN, passphraseRetriever)
+	})
+}

--- a/projects/notary/project.yaml
+++ b/projects/notary/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/notaryproject/notary"
+main_repo: "https://github.com/notaryproject/notary"
+primary_contact: ""
+auto_ccs :
+  - "adam@adalogics.com"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address

--- a/projects/notary/project.yaml
+++ b/projects/notary/project.yaml
@@ -1,8 +1,13 @@
 homepage: "https://github.com/notaryproject/notary"
 main_repo: "https://github.com/notaryproject"
-primary_contact: ""
+primary_contact: "yizha1@microsoft.com"
 auto_ccs :
-  - "adam@adalogics.com"
+  - "vaninrao@amazon.com"
+  - "hbandi@gmail.com"
+  - "shizh@microsoft.com"
+vendor_ccs :
+  - "Adam@adalogics.com"
+  - "David@adalogics.com"
 language: go
 fuzzing_engines:
   - libfuzzer

--- a/projects/notary/project.yaml
+++ b/projects/notary/project.yaml
@@ -1,5 +1,5 @@
 homepage: "https://github.com/notaryproject/notary"
-main_repo: "https://github.com/notaryproject/notary"
+main_repo: "https://github.com/notaryproject"
 primary_contact: ""
 auto_ccs :
   - "adam@adalogics.com"


### PR DESCRIPTION
Notary is an implementation of the TUF specification. It is a tool for publishing and managing trusted collections of content. Publishers can digitally sign collections and consumers can verify the integrity and origin of content.

Initially, Notary was sponsored by Docker who uses Notary for signing and verifying container images. Notary joined the CNCF in 2017 and is today used by companies such as:

- Amazon
- Docker
- Microsoft
______________________________________________________________________

@justincormack @marcofranssen @cyli @toddysm Are you interested in integrating notary into OSS-fuzz for continuous fuzzing?

This PR adds the build files for the cryptoservice fuzzer to be run continuously.

To complete this integration, one or more maintainers email addresses are needed.