### PR TITLE
[harfbuzz] Build with meson 0.56.0

### DIFF
--- a/projects/harfbuzz/Dockerfile
+++ b/projects/harfbuzz/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y python3-pip ragel pkg-config && \
-    pip3 install meson==0.53.0 ninja
+    pip3 install meson==0.56.0 ninja
 RUN git clone --depth 1 https://github.com/harfbuzz/harfbuzz.git
 WORKDIR harfbuzz
 COPY build.sh $SRC/


### PR DESCRIPTION
Upstream is going to require it soon (https://github.com/harfbuzz/harfbuzz/pull/3302).