### PR TITLE
Envoy: disable AFL engine

### DIFF
--- a/projects/envoy/project.yaml
+++ b/projects/envoy/project.yaml
@@ -25,3 +25,6 @@ auto_ccs:
   - "dasfuzzer@x41-dsec.de"
 coverage_extra_args: -ignore-filename-regex=.*\.cache.*envoy_deps_cache.*
 main_repo: 'https://github.com/envoyproxy/envoy.git'
+fuzzing_engines:
+  - libfuzzer
+  - honggfuzz


### PR DESCRIPTION
Using AFL leads to out-of-space on the device.
Possible solution suggested in: https://github.com/bazelbuild/rules_fuzzing/issues/185

This PR disables AFL until we get this sorted out.

Signed-off-by: Adi Suissa-Peleg <adip@google.com>