### PR TITLE
[jaeger] Initial integration

### DIFF
--- a/projects/jaeger/Dockerfile
+++ b/projects/jaeger/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/jaegertracing/jaeger
+COPY build.sh json_fuzzer.go thrift_fuzzer.go $SRC/
+WORKDIR $SRC/jaeger

--- a/projects/jaeger/build.sh
+++ b/projects/jaeger/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cp $SRC/json_fuzzer.go $SRC/jaeger/cmd/collector/app/zipkin/
+cp $SRC/thrift_fuzzer.go $SRC/jaeger/model/converter/thrift/zipkin/
+
+compile_go_fuzzer github.com/jaegertracing/jaeger/cmd/collector/app/zipkin Fuzz json_fuzzer
+compile_go_fuzzer github.com/jaegertracing/jaeger/model/converter/thrift/zipkin Fuzz thrift_fuzzer

--- a/projects/jaeger/json_fuzzer.go
+++ b/projects/jaeger/json_fuzzer.go
@@ -1,0 +1,24 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package zipkin
+
+func Fuzz(fuzz []byte) int {
+	_, err := DeserializeJSON(fuzz)
+	if err != nil {
+		return 0
+	}
+	return 1
+}

--- a/projects/jaeger/project.yaml
+++ b/projects/jaeger/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://www.jaegertracing.io"
+main_repo: "https://github.com/jaegertracing/jaeger"
+primary_contact: ""
+auto_ccs :
+  - "adam@adalogics.com"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address

--- a/projects/jaeger/thrift_fuzzer.go
+++ b/projects/jaeger/thrift_fuzzer.go
@@ -1,0 +1,25 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package zipkin
+
+func Fuzz(fuzz []byte) int {
+	spans, err := DeserializeThrift(fuzz)
+	if err != nil {
+		return 0
+	}
+	SerializeThrift(spans)
+	return 1
+}


### PR DESCRIPTION
@pavolloffay @yurishkuro @jpkrohling - Are you interested in running the fuzzers from https://github.com/jaegertracing/jaeger/pull/1925 continuously? This PR adds the json fuzzer, the thrift fuzzer and the build files to run them through OSS-fuzz.
 
 To complete the integration, a maintainers email address is needed.