### PR TITLE
[cifuzz] Small correction to docs

### DIFF
--- a/docs/getting-started/continuous_integration.md
+++ b/docs/getting-started/continuous_integration.md
@@ -100,7 +100,7 @@ to `c++`. This should be the same as the value you set in `project.yaml`. See
 [this explanation]({{ site.baseurl }}//getting-started/new-project-guide/#language)
 for more details.
 
-`fuzz-time`: Determines how long CIFuzz spends fuzzing your project in seconds.
+`fuzz-seconds`: Determines how long CIFuzz spends fuzzing your project in seconds.
 The default is 600 seconds. The GitHub Actions max run time is 21600 seconds (6
 hours). This variable is only meaningful when supplied to the `run_fuzzers`
 action, not the `build_fuzzers` action.


### PR DESCRIPTION
@jonathanmetzman The CIFuzz docs has a section about `fuzz-time` that is not mentioned elsewhere in the docs or the examples.

Should it also be changed for ClusterfuzzLite? https://github.com/google/oss-fuzz/blob/master/docs/clusterfuzzlite/running_clusterfuzzlite.md#configuration-options