### PR TITLE
[orbit] Suppress stdout output for fuzzers in projects/orbit

### DIFF
--- a/projects/orbit/Dockerfile
+++ b/projects/orbit/Dockerfile
@@ -23,6 +23,7 @@ RUN mkdir -p $SRC/orbit && tar -xzf $SRC/main.tar.gz \
   -C $SRC/orbit/ --strip-components 1; rm -f $SRC/main.tar.gz
 WORKDIR $SRC/orbit
 COPY build.sh $SRC/
+COPY default.options $SRC/
 
 # That's a hack. The service needs to have a more recent kernel than what the
 # container provides. But this code is not going to be called from the fuzz-

--- a/projects/orbit/build.sh
+++ b/projects/orbit/build.sh
@@ -49,6 +49,8 @@ function copy_fuzzer {
   cp -v "$1" "$OUT/"
   patchelf --set-rpath '$ORIGIN/lib' "$OUT/$(basename "$1")"
 
+  cp -v "$SRC/default.options" "$OUT/$(basename "$1").options"
+
   ldd "$1" | grep '=>' | cut -d ' ' -f 3 | while read lib; do
     if [[ -f $lib ]]; then
       cp -v "$lib" "$OUT/lib/"

--- a/projects/orbit/default.options
+++ b/projects/orbit/default.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+close_fd_mask=1


### PR DESCRIPTION
We recently added a new fuzzer that prints a lot to stdout due to
how error messages are handled. With this change we suppress this
output.

The understanding is that useful output from asan, etc. goes to
stderr, which we do not suppress.