### PR TITLE
neomutt: reorganise build

### DIFF
--- a/projects/neomutt/Dockerfile
+++ b/projects/neomutt/Dockerfile
@@ -15,7 +15,13 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool xsltproc libncursesw5-dev libtinfo5 libxml2-dev libxml2-utils libidn11-dev
-RUN git clone https://github.com/neomutt/neomutt neomutt
+
+RUN	apt-get update && \
+	apt-get install -y libncursesw5-dev libtinfo5 libtool make
+
+RUN git clone --depth 1 --branch oss-fuzz https://github.com/neomutt/neomutt
+RUN git clone --depth 1                   https://github.com/neomutt/corpus-address
+
 WORKDIR neomutt
 COPY build.sh $SRC/
+

--- a/projects/neomutt/build.sh
+++ b/projects/neomutt/build.sh
@@ -15,12 +15,14 @@
 #
 ################################################################################
 
-git checkout fuzzer
 ./configure --fuzzing --disable-doc --disable-nls --disable-idn
 make fuzz
+cp fuzz/address-fuzz $OUT/
 
-cd fuzz
-cp address-fuzz $OUT/
-zip -q -r $OUT/address-fuzz_seed_corpus.zip corpus_address
-cp rfc822_headers_dict.txt $OUT/address-fuzz.dict
+cd $SRC/corpus-address
 cp address-fuzz.options $OUT/
+cp address-fuzz.dict $OUT/
+
+cd corpus
+zip -q -r $OUT/address-fuzz_seed_corpus.zip .
+


### PR DESCRIPTION
## Changes

- Split corpus into new repo:
  https://github.com/neomutt/corpus-address

- Use shallow git clones to save net traffic

- Drop unnecessary installs

- Rename files for consistency

## Testing

I've tested the build locally under Docker, using

```sh
infra/helper.py build_image neomutt
infra/helper.py build_fuzzers --sanitizer address neomutt
infra/helper.py check_build neomutt
infra/helper.py run_fuzzer neomutt address-fuzz
```

---

I've signed the Google CLA.