### PR TITLE
fix build failure, monorail issue 41424

### DIFF
--- a/projects/openssh/build.sh
+++ b/projects/openssh/build.sh
@@ -25,6 +25,7 @@ sed -i 's|\(usleep.*\)|// \1|' ssh-agent.c
 autoreconf
 env
 env CFLAGS="" ./configure \
+	--without-zlib-version-check \
 	--with-cflags="-DWITH_XMSS=1" \
 	--with-cflags-after="$CFLAGS" \
 	--with-ldflags-after="-g $CFLAGS"


### PR DESCRIPTION
a configure test program was segfaulting when trying to parse
ZLIB_VERSION. We don't need to perform this check in configure, since
the zlib included in the clusterfuzz OS images is recent.