### PR TITLE
pigweed: Fix coverage build failure

### DIFF
--- a/projects/pigweed/build.sh
+++ b/projects/pigweed/build.sh
@@ -67,6 +67,7 @@ EXTRA_CXXFLAGS="-Wno-unused-command-line-argument"
 
 # Disable UBSan vptr since target built with -fno-rtti.
 EXTRA_CXXFLAGS+=" -fno-sanitize=vptr"
+EXTRA_CXXFLAGS+=" -fcoverage-compilation-dir=$PW_ROOT"
 
 # Build!
 CXXFLAGS="$CXXFLAGS $EXTRA_CXXFLAGS" LDFLAGS="$CXXFLAGS" \


### PR DESCRIPTION
Use correct compilation directory in the coverage mapping.

Bug: https://crbug.com/oss-fuzz/38518