### PR TITLE
[libbpf] use --disable-libdebuginfod while building libelf

### DIFF
--- a/projects/libbpf/Dockerfile
+++ b/projects/libbpf/Dockerfile
@@ -20,7 +20,6 @@ RUN sed -i -e '/^#\s*deb-src.*\smain\s\+restricted/s/^#//' /etc/apt/sources.list
     # libelf build dependencies \
     apt-get build-dep -y --no-install-recommends libelf-dev && \
     apt-get install -y --no-install-recommends pkg-config && \
-    apt-get install -y --no-install-recommends libcurl4-gnutls-dev && \
     # libbpf build dependencies \
     apt-get install -y --no-install-recommends libz-dev
 RUN git clone --depth 1 https://github.com/libbpf/libbpf

--- a/projects/libbpf/build.sh
+++ b/projects/libbpf/build.sh
@@ -76,7 +76,7 @@ sed -i 's/^\(ZDEFS_LDFLAGS=\).*/\1/' configure.ac &&
 
 
 autoreconf -i -f &&
-./configure --enable-maintainer-mode --disable-debuginfod CC="$CC" CFLAGS="-Wno-error $CFLAGS" CXX="$CXX" CXXFLAGS="-Wno-error $CXXFLAGS" LDFLAGS="$CFLAGS" &&
+./configure --enable-maintainer-mode --disable-debuginfod --disable-libdebuginfod CC="$CC" CFLAGS="-Wno-error $CFLAGS" CXX="$CXX" CXXFLAGS="-Wno-error $CXXFLAGS" LDFLAGS="$CFLAGS" &&
 make -C config -j$(nproc) V=1 &&
 make -C lib -j$(nproc) V=1 &&
 make -C libelf -j$(nproc) V=1


### PR DESCRIPTION
Looks like --disable-libdebuginfod works now so it seems
it can safely be used instead of installing libcurl and
letting ./configure find and ignore it.