### PR TITLE
[elfutils] point CIFuzz to evverx/elfutils

### DIFF
--- a/projects/elfutils/Dockerfile
+++ b/projects/elfutils/Dockerfile
@@ -17,6 +17,11 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && \
     apt-get install -y pkg-config make autoconf autopoint zlib1g-dev flex bison gawk
-RUN git clone --depth 1 git://sourceware.org/git/elfutils.git
+RUN bash -x -c "\
+if [[ '$CIFUZZ' == True ]]; then \
+    git clone --depth 1 https://github.com/evverx/elfutils; \
+else \
+    git clone --depth 1 git://sourceware.org/git/elfutils.git; \
+fi"
 WORKDIR elfutils
 COPY build.sh *.c *.zip $SRC/


### PR DESCRIPTION
I created https://github.com/evverx/elfutils where I test elfutils
with gcc/clang, asan/ubsan, LGTM and Coverity. It would be great
if it was possible to test patches with CIFuzz there as well. Judging by
https://github.com/evverx/elfutils/actions/runs/1527662451, it just
falls back to the official repository (which is hosted at https://sourceware.org/git/?p=elfutils.git;a=summary
and where GitHub branches CIFuzz tries to checkout don't exist)
```
Stderr of command "git fetch origin refs/pull/2/merge" is: fatal: couldn't find remote ref refs/pull/2/merge
Can not check out requested state refs/pull/2/merge. Using current repo state
```

It would be even better if instead of hardcoding "evverx/elfutils"
I could pass `${{ github.repository }}` or something like that.

More generally, this PR is an attempt to get around https://github.com/google/oss-fuzz/issues/3731