### PR TITLE
[base-clang] Fix typo in OUR_LLVM_REVISION

### DIFF
--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -70,7 +70,7 @@ cd clang
 LLVM_SRC=$SRC/llvm-project
 
 # For manual bumping.
-OUR_LLVM_REVISION==llvmorg-14-init-11072-gb1bc627e
+OUR_LLVM_REVISION=llvmorg-14-init-11072-gb1bc627e
 
 # To allow for manual downgrades. Set to 0 to use Chrome's clang version (i.e.
 # *not* force a manual downgrade). Set to 1 to force a manual downgrade.


### PR DESCRIPTION
Not sure if this is causing the build failures, but worth a shot?