### PR TITLE
[base-clang] Change OUR_LLVM_REVISION

### DIFF
--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -70,7 +70,7 @@ cd clang
 LLVM_SRC=$SRC/llvm-project
 
 # For manual bumping.
-OUR_LLVM_REVISION==llvmorg-14-init-11072-gb1bc627e
+OUR_LLVM_REVISION=c12c7a84b03b98445ca9011ccbce12030c7b72e3
 
 # To allow for manual downgrades. Set to 0 to use Chrome's clang version (i.e.
 # *not* force a manual downgrade). Set to 1 to force a manual downgrade.

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -70,7 +70,7 @@ cd clang
 LLVM_SRC=$SRC/llvm-project
 
 # For manual bumping.
-OUR_LLVM_REVISION=c12c7a84b03b98445ca9011ccbce12030c7b72e3
+OUR_LLVM_REVISION=llvmorg-14-init-8033-gabb2a91b
 
 # To allow for manual downgrades. Set to 0 to use Chrome's clang version (i.e.
 # *not* force a manual downgrade). Set to 1 to force a manual downgrade.


### PR DESCRIPTION
`=llvmorg-14-init-11072-gb1bc627e` corresponds to commit b1bc627e7e9965e6ec15e106ee4b2c21f6c36923, which includes commit 89eb85ac6eaab6431ef72ef705d560c72c5ed71f3 (the commit causing afl++ compile failures).

Thus, set it to `llvmorg-14-init-8033-gabb2a91b`, which compiles afl++ still fine.

For reference:

* https://chromium.googlesource.com/chromium/src/tools/clang/+log/refs/heads/main/scripts/update.py