### PR TITLE
[cryptofuzz] Update

### DIFF
--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -26,8 +26,6 @@ RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora
 RUN git clone --depth 1 https://github.com/openssl/openssl
 RUN git clone --depth 1 https://boringssl.googlesource.com/boringssl
-RUN git clone --depth 1 https://github.com/libressl-portable/portable libressl
-RUN cd $SRC/libressl && ./update.sh
 RUN git clone --depth 1 https://github.com/weidai11/cryptopp/
 RUN git clone --depth 1 git://git.gnupg.org/libgcrypt.git
 RUN wget https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.36.tar.bz2
@@ -37,7 +35,7 @@ RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone --depth 1 https://github.com/wolfSSL/wolfssl.git
 RUN git clone --depth 1 -b development_2.x https://github.com/ARMmbed/mbedtls.git
 RUN hg clone https://hg.mozilla.org/projects/nspr
-#RUN hg clone https://hg.mozilla.org/projects/nss
+RUN hg clone https://hg.mozilla.org/projects/nss
 RUN git clone --depth 1 https://github.com/jedisct1/libsodium.git
 RUN git clone --depth 1 https://github.com/libtom/libtomcrypt.git
 #RUN git clone --depth 1 https://github.com/microsoft/SymCrypt.git

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -192,11 +192,15 @@ make -B -j$(nproc)
 
 if [[ $CFLAGS != *sanitize=memory* && $CFLAGS != *-m32* ]]
 then
+
     # noble-secp256k1
-    cd $SRC/cryptofuzz/modules/noble-secp256k1/
-    export NOBLE_SECP256K1_PATH="$SRC/noble-secp256k1/index.js"
-    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NOBLE_SECP256K1"
-    make -B
+#    cd $SRC/noble-secp256k1/
+#    npm install && npm run build
+#    export NOBLE_SECP256K1_PATH=$(realpath lib/index.js)
+#
+#    cd $SRC/cryptofuzz/modules/noble-secp256k1/
+#    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NOBLE_SECP256K1"
+#    make -B
 
     # noble-bls12-381
     cd $SRC/noble-bls12-381/

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -93,23 +93,26 @@ then
 fi
 
 # Compile NSS
-#if [[ $CFLAGS != *-m32* ]]
-#then
-#    mkdir $SRC/nss-nspr
-#    mv $SRC/nss $SRC/nss-nspr/
-#    mv $SRC/nspr $SRC/nss-nspr/
-#    cd $SRC/nss-nspr/
-#
-#    CXX="$CXX -stdlib=libc++" LDFLAGS="$CFLAGS" nss/build.sh --enable-fips --static --disable-tests --fuzz=oss
-#
-#    export NSS_NSPR_PATH=$(realpath $SRC/nss-nspr/)
-#    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NSS"
-#    export LINK_FLAGS="$LINK_FLAGS -lsqlite3"
-#
-#    # Compile Cryptofuzz NSS module
-#    cd $SRC/cryptofuzz/modules/nss
-#    make -B
-#fi
+if [[ $CFLAGS != *-m32* ]]
+then
+    mkdir $SRC/nss-nspr
+    mv $SRC/nss $SRC/nss-nspr/
+    mv $SRC/nspr $SRC/nss-nspr/
+    cd $SRC/nss-nspr/
+
+    # Prevent compilation error with Clang
+    export CFLAGS="$CFLAGS -Wno-unused-but-set-variable"
+
+    CXX="$CXX -stdlib=libc++" LDFLAGS="$CFLAGS" nss/build.sh --enable-fips --static --disable-tests --fuzz=oss
+
+    export NSS_NSPR_PATH=$(realpath $SRC/nss-nspr/)
+    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NSS"
+    export LINK_FLAGS="$LINK_FLAGS -lsqlite3"
+
+    # Compile Cryptofuzz NSS module
+    cd $SRC/cryptofuzz/modules/nss
+    make -B
+fi
 
 # Compile Monocypher
 cd $SRC/Monocypher/
@@ -236,24 +239,24 @@ fi
 #fi
 
 # Compile libgmp
-if [[ $CFLAGS != *sanitize=memory* ]]
+cd $SRC/libgmp/
+autoreconf -ivf
+if [[ $CFLAGS != *-m32* ]]
 then
-    cd $SRC/libgmp/
-    autoreconf -ivf
-    if [[ $CFLAGS != *-m32* ]]
-    then
-        ./configure --enable-maintainer-mode
-    else
-        setarch i386 ./configure --enable-maintainer-mode
-    fi
-    make -j$(nproc)
-    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_LIBGMP"
-    export LIBGMP_INCLUDE_PATH=$(realpath .)
-    export LIBGMP_A_PATH=$(realpath .libs/libgmp.a)
-    # Compile Cryptofuzz libgmp module
-    cd $SRC/cryptofuzz/modules/libgmp
-    make -B
+    ./configure --enable-maintainer-mode --enable-assert
+elif [[ $CFLAGS != *sanitize=memory* ]]
+then
+    ./configure --enable-maintainer-mode --enable-assert --disable-assembly
+else
+    setarch i386 ./configure --enable-maintainer-mode --enable-assert
 fi
+make -j$(nproc)
+export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_LIBGMP"
+export LIBGMP_INCLUDE_PATH=$(realpath .)
+export LIBGMP_A_PATH=$(realpath .libs/libgmp.a)
+# Compile Cryptofuzz libgmp module
+cd $SRC/cryptofuzz/modules/libgmp
+make -B
 
 # Compile mpdecimal
 cd $SRC/
@@ -274,11 +277,11 @@ make -B
 cd $SRC/cityhash
 if [[ $CFLAGS != *-m32* ]]
 then
-    CXXFLAGS="$CXXFLAGS -msse4.2" ./configure --disable-shared >/dev/null 2>&1
+    CXXFLAGS="$CXXFLAGS -msse4.2" ./configure --disable-shared
 else
-    ./configure --disable-shared >/dev/null 2>&1
+    ./configure --disable-shared
 fi
-make -j$(nproc) >/dev/null 2>&1
+make -j$(nproc)
 
 export CXXFLAGS="$CXXFLAGS -I$SRC/cityhash/src"
 export CRYPTOFUZZ_REFERENCE_CITY_O_PATH="$SRC/cityhash/src/city.o"
@@ -288,10 +291,10 @@ export CRYPTOFUZZ_REFERENCE_CITY_O_PATH="$SRC/cityhash/src/city.o"
 cd $SRC/cryptopp
 if [[ $CFLAGS != *sanitize=memory* ]]
 then
-    make libcryptopp.a -j$(nproc) >/dev/null 2>&1
+    make libcryptopp.a -j$(nproc)
 else
     export CXXFLAGS="$CXXFLAGS -DCRYPTOPP_DISABLE_ASM=1"
-    make libcryptopp.a -j$(nproc) >/dev/null 2>&1
+    make libcryptopp.a -j$(nproc)
 fi
 
 export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_CRYPTOPP"
@@ -320,7 +323,7 @@ fi
 mkdir build/
 cd build/
 cmake .. -DENABLE_PROGRAMS=0 -DENABLE_TESTING=0
-make -j$(nproc) >/dev/null 2>&1
+make -j$(nproc)
 export MBEDTLS_LIBMBEDCRYPTO_A_PATH="$SRC/mbedtls/build/library/libmbedcrypto.a"
 export MBEDTLS_INCLUDE_PATH="$SRC/mbedtls/include"
 export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_MBEDTLS"
@@ -360,7 +363,7 @@ then
     else
         ./configure --enable-static --host=i386
     fi
-    make -j$(nproc) >/dev/null 2>&1
+    make -j$(nproc)
     make install
     export LINK_FLAGS="$LINK_FLAGS $SRC/libgpg-error-1.36/src/.libs/libgpg-error.a"
 
@@ -373,7 +376,7 @@ then
     else
         ./configure --enable-static --disable-doc
     fi
-    make -j$(nproc) >/dev/null 2>&1
+    make -j$(nproc)
 
     export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_LIBGCRYPT"
     export LIBGCRYPT_A_PATH="$SRC/libgcrypt/src/.libs/libgcrypt.a"
@@ -393,7 +396,7 @@ then
 else
     ./configure --disable-asm
 fi
-make -j$(nproc) >/dev/null 2>&1
+make -j$(nproc)
 
 export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_LIBSODIUM"
 export LIBSODIUM_A_PATH="$SRC/libsodium/src/libsodium/.libs/libsodium.a"
@@ -407,8 +410,8 @@ if [[ $CFLAGS != *sanitize=memory* && $CFLAGS != *-m32* ]]
 then
     # Compile EverCrypt (with assembly)
     cd $SRC/evercrypt/dist
-    make -C portable -j$(nproc) libevercrypt.a >/dev/null 2>&1
-    make -C kremlin/kremlib/dist/minimal -j$(nproc) >/dev/null 2>&1
+    make -C portable -j$(nproc) libevercrypt.a
+    make -C kremlin/kremlib/dist/minimal -j$(nproc)
 
     export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_EVERCRYPT"
     export EVERCRYPT_A_PATH="$SRC/evercrypt/dist/portable/libevercrypt.a"
@@ -449,27 +452,27 @@ then
     make -B
 fi
 
-#if [[ $CFLAGS != *-m32* ]]
-#then
-#    # Compile Cryptofuzz (NSS-based)
-#    cd $SRC/cryptofuzz
-#    LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL $INCLUDE_PATH_FLAGS" make -B -j$(nproc)
-#
-#    # Generate dictionary
-#    ./generate_dict
-#
-#    # Copy fuzzer
-#    cp $SRC/cryptofuzz/cryptofuzz $OUT/cryptofuzz-nss
-#    # Copy dictionary
-#    cp $SRC/cryptofuzz/cryptofuzz-dict.txt $OUT/cryptofuzz-nss.dict
-#    # Copy seed corpus
-#    cp $SRC/cryptofuzz-corpora/libressl_latest.zip $OUT/cryptofuzz-nss_seed_corpus.zip
-#
-#    rm $SRC/cryptofuzz/modules/nss/module.a
-#
-#    CXXFLAGS=${CXXFLAGS//"-DCRYPTOFUZZ_NSS"/}
-#    LINK_FLAGS=${LINK_FLAGS//"-lsqlite3"/}
-#fi
+if [[ $CFLAGS != *-m32* ]]
+then
+    # Compile Cryptofuzz (NSS-based)
+    cd $SRC/cryptofuzz
+    LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL $INCLUDE_PATH_FLAGS" make -B -j$(nproc)
+
+    # Generate dictionary
+    ./generate_dict
+
+    # Copy fuzzer
+    cp $SRC/cryptofuzz/cryptofuzz $OUT/cryptofuzz-nss
+    # Copy dictionary
+    cp $SRC/cryptofuzz/cryptofuzz-dict.txt $OUT/cryptofuzz-nss.dict
+    # Copy seed corpus
+    cp $SRC/cryptofuzz-corpora/libressl_latest.zip $OUT/cryptofuzz-nss_seed_corpus.zip
+
+    rm $SRC/cryptofuzz/modules/nss/module.a
+
+    CXXFLAGS=${CXXFLAGS//"-DCRYPTOFUZZ_NSS"/}
+    LINK_FLAGS=${LINK_FLAGS//"-lsqlite3"/}
+fi
 
 if [[ $CFLAGS != *sanitize=memory* ]]
 then
@@ -501,7 +504,7 @@ then
 fi
 
 ./configure $WOLFCRYPT_CONFIGURE_PARAMS
-make -j$(nproc) >/dev/null 2>&1
+make -j$(nproc)
 
 export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_WOLFCRYPT"
 export WOLFCRYPT_LIBWOLFSSL_A_PATH="$SRC/wolfssl/src/.libs/libwolfssl.a"
@@ -510,69 +513,6 @@ export WOLFCRYPT_INCLUDE_PATH="$SRC/wolfssl"
 # Compile Cryptofuzz wolfcrypt (without assembly) module
 cd $SRC/cryptofuzz/modules/wolfcrypt
 make -B
-
-
-##############################################################################
-if [[ $CFLAGS != *sanitize=memory* ]]
-then
-    # Compile LibreSSL (with assembly)
-    cd $SRC/libressl
-    rm -rf build ; mkdir build
-    cd build
-    if [[ $CFLAGS != *-m32* ]]
-    then
-        cmake -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DCMAKE_C_FLAGS="$CFLAGS" ..
-    else
-        setarch i386 cmake -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DCMAKE_C_FLAGS="$CFLAGS" ..
-    fi
-    make -j$(nproc) crypto >/dev/null 2>&1
-
-    # Compile Cryptofuzz LibreSSL (with assembly) module
-    cd $SRC/cryptofuzz/modules/openssl
-    OPENSSL_INCLUDE_PATH="$SRC/libressl/include" OPENSSL_LIBCRYPTO_A_PATH="$SRC/libressl/build/crypto/libcrypto.a" CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_LIBRESSL" make -B
-
-    # Compile Cryptofuzz
-    cd $SRC/cryptofuzz
-    LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/libressl/include -DCRYPTOFUZZ_LIBRESSL $INCLUDE_PATH_FLAGS" make -B -j$(nproc) >/dev/null 2>&1
-
-    # Generate dictionary
-    ./generate_dict
-
-    # Copy fuzzer
-    cp $SRC/cryptofuzz/cryptofuzz $OUT/cryptofuzz-libressl
-    # Copy dictionary
-    cp $SRC/cryptofuzz/cryptofuzz-dict.txt $OUT/cryptofuzz-libressl.dict
-    # Copy seed corpus
-    cp $SRC/cryptofuzz-corpora/libressl_latest.zip $OUT/cryptofuzz-libressl_seed_corpus.zip
-fi
-
-if [[ $CFLAGS != *-m32* ]]
-then
-    # Compile LibreSSL (without assembly)
-    cd $SRC/libressl
-    rm -rf build ; mkdir build
-    cd build
-    cmake -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DCMAKE_C_FLAGS="$CFLAGS" -DENABLE_ASM=OFF ..
-    make -j$(nproc) crypto >/dev/null 2>&1
-
-    # Compile Cryptofuzz LibreSSL (without assembly) module
-    cd $SRC/cryptofuzz/modules/openssl
-    OPENSSL_INCLUDE_PATH="$SRC/libressl/include" OPENSSL_LIBCRYPTO_A_PATH="$SRC/libressl/build/crypto/libcrypto.a" CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_LIBRESSL" make -B
-
-    # Compile Cryptofuzz
-    cd $SRC/cryptofuzz
-    LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/libressl/include -DCRYPTOFUZZ_LIBRESSL $INCLUDE_PATH_FLAGS" make -B -j$(nproc) >/dev/null 2>&1
-
-    # Generate dictionary
-    ./generate_dict
-
-    # Copy fuzzer
-    cp $SRC/cryptofuzz/cryptofuzz $OUT/cryptofuzz-libressl-noasm
-    # Copy dictionary
-    cp $SRC/cryptofuzz/cryptofuzz-dict.txt $OUT/cryptofuzz-libressl-noasm.dict
-    # Copy seed corpus
-    cp $SRC/cryptofuzz-corpora/libressl_latest.zip $OUT/cryptofuzz-libressl-noasm_seed_corpus.zip
-fi
 
 # OpenSSL can currently not be used together with wolfCrypt due to symbol collisions
 export SAVE_CXXFLAGS="$CXXFLAGS"
@@ -589,7 +529,7 @@ then
     else
         setarch i386 ./config --debug enable-md2 enable-rc5
     fi
-    make -j$(nproc) >/dev/null 2>&1
+    make -j$(nproc)
 
     # Compile Cryptofuzz OpenSSL (with assembly) module
     cd $SRC/cryptofuzz/modules/openssl
@@ -597,7 +537,7 @@ then
 
     # Compile Cryptofuzz
     cd $SRC/cryptofuzz
-    LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl/include $INCLUDE_PATH_FLAGS" make -B -j$(nproc) >/dev/null 2>&1
+    LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl/include $INCLUDE_PATH_FLAGS" make -B -j$(nproc)
 
     # Generate dictionary
     ./generate_dict
@@ -620,7 +560,7 @@ else
     setarch i386 ./config --debug no-asm enable-md2 enable-rc5
 fi
 make clean
-make -j$(nproc) >/dev/null 2>&1
+make -j$(nproc)
 
 # Compile Cryptofuzz OpenSSL (without assembly) module
 cd $SRC/cryptofuzz/modules/openssl
@@ -628,7 +568,7 @@ OPENSSL_INCLUDE_PATH="$SRC/openssl/include" OPENSSL_LIBCRYPTO_A_PATH="$SRC/opens
 
 # Compile Cryptofuzz
 cd $SRC/cryptofuzz
-LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl/include $INCLUDE_PATH_FLAGS" make -B -j$(nproc) >/dev/null 2>&1
+LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl/include $INCLUDE_PATH_FLAGS" make -B -j$(nproc)
 
 # Generate dictionary
 ./generate_dict
@@ -655,7 +595,7 @@ then
     else
         cmake -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DCMAKE_C_FLAGS="$CFLAGS" -DBORINGSSL_ALLOW_CXX_RUNTIME=1 ..
     fi
-    make -j$(nproc) crypto >/dev/null 2>&1
+    make -j$(nproc) crypto
 
     # Compile Cryptofuzz BoringSSL (with assembly) module
     cd $SRC/cryptofuzz/modules/openssl
@@ -663,7 +603,7 @@ then
 
     # Compile Cryptofuzz
     cd $SRC/cryptofuzz
-    LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl/include $INCLUDE_PATH_FLAGS" make -B -j$(nproc) >/dev/null 2>&1
+    LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl/include $INCLUDE_PATH_FLAGS" make -B -j$(nproc)
 
     # Generate dictionary
     ./generate_dict
@@ -682,7 +622,7 @@ cd $SRC/boringssl
 rm -rf build ; mkdir build
 cd build
 cmake -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DCMAKE_C_FLAGS="$CFLAGS" -DBORINGSSL_ALLOW_CXX_RUNTIME=1 -DOPENSSL_NO_ASM=1 ..
-make -j$(nproc) crypto >/dev/null 2>&1
+make -j$(nproc) crypto
 
 # Compile Cryptofuzz BoringSSL (with assembly) module
 cd $SRC/cryptofuzz/modules/openssl
@@ -690,7 +630,7 @@ OPENSSL_INCLUDE_PATH="$SRC/boringssl/include" OPENSSL_LIBCRYPTO_A_PATH="$SRC/bor
 
 # Compile Cryptofuzz
 cd $SRC/cryptofuzz
-LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl/include $INCLUDE_PATH_FLAGS" make -B -j$(nproc) >/dev/null 2>&1
+LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -I $SRC/openssl/include $INCLUDE_PATH_FLAGS" make -B -j$(nproc)
 
 # Generate dictionary
 ./generate_dict
@@ -701,4 +641,3 @@ cp $SRC/cryptofuzz/cryptofuzz $OUT/cryptofuzz-boringssl-noasm
 cp $SRC/cryptofuzz/cryptofuzz-dict.txt $OUT/cryptofuzz-boringssl-noasm.dict
 # Copy seed corpus
 cp $SRC/cryptofuzz-corpora/boringssl_latest.zip $OUT/cryptofuzz-boringssl-noasm_seed_corpus.zip
-


### PR DESCRIPTION
- Enable Mozilla NSS fuzzer again
- Enable libgmp debug asserts
- Build libgmp with MSAN
- Remove LibreSSL (moved to the 'libressl' project some time ago)
- Don't pipe output to /dev/null (this was necessary for some previous version of the OSS-Fuzz build system)