### PR TITLE
dump config.log when configure fails

### DIFF
--- a/projects/openssh/build.sh
+++ b/projects/openssh/build.sh
@@ -24,11 +24,16 @@ sed -i 's|\(usleep.*\)|// \1|' ssh-agent.c
 # Build project
 autoreconf
 env
-env CFLAGS="" ./configure \
-	--without-zlib-version-check \
-	--with-cflags="-DWITH_XMSS=1" \
-	--with-cflags-after="$CFLAGS" \
-	--with-ldflags-after="-g $CFLAGS"
+if ! env CFLAGS="" ./configure \
+    --without-zlib-version-check \
+    --with-cflags="-DWITH_XMSS=1" \
+    --with-cflags-after="$CFLAGS" \
+    --with-ldflags-after="-g $CFLAGS" ; then
+	echo "------ config.log:" 1>&2
+	cat config.log
+	echo "ERROR: configure failed" 1>&2
+	exit 1
+fi
 make -j$(nproc) all
 
 # Build fuzzers


### PR DESCRIPTION
Motivated by https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=41899 which I'm unable to reproduce locally, but would have also saved time for previous failures at configure time, e.g. https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=41424