### PR TITLE
suricata: uses better dictionaries

### DIFF
--- a/projects/suricata/build.sh
+++ b/projects/suricata/build.sh
@@ -86,6 +86,15 @@ cp src/fuzz_* $OUT/
 
 echo \"SMB\" > $OUT/fuzz_applayerparserparse_smb.dict
 
+echo "\"FPC0\"" > $OUT/fuzz_sigpcap_aware.dict
+echo "\"FPC0\"" > $OUT/fuzz_predefpcap_aware.dict
+
+git grep tag rust | grep '"' | cut -d '"' -f2 | sort | uniq | awk 'length($0) > 2' | awk '{print "\""$0"\""}' > generic.dict
+cat generic.dict >> $OUT/fuzz_siginit.dict
+cat generic.dict >> $OUT/fuzz_applayerparserparse.dict
+cat generic.dict >> $OUT/fuzz_sigpcap.dict
+cat generic.dict >> $OUT/fuzz_sigpcap_aware.dict
+
 # build corpuses
 # default configuration file
 zip -r $OUT/fuzz_confyamlloadstring_seed_corpus.zip suricata.yaml
@@ -126,7 +135,6 @@ echo -ne '\0' >> corpus/$i; python3 $SRC/fuzzpcap/tcptofpc.py $t/*.pcap >> corpu
 done
 set -x
 zip -q -r $OUT/fuzz_sigpcap_aware_seed_corpus.zip corpus
-echo "\"FPC0\"" > $OUT/fuzz_sigpcap_aware.dict
 rm -Rf corpus
 mkdir corpus
 set +x
@@ -136,4 +144,3 @@ python3 $SRC/fuzzpcap/tcptofpc.py $t/*.pcap >> corpus/$i || rm corpus/$i; i=$((i
 done
 set -x
 zip -q -r $OUT/fuzz_predefpcap_aware_seed_corpus.zip corpus
-echo "\"FPC0\"" > $OUT/fuzz_predefpcap_aware.dict


### PR DESCRIPTION
cc @inferno-chromium @jonathanmetzman 

In facts, I would like the fuzzing engines to automatically get these words for the dictionaries.
That is when the rust function `tag` (from nom crate) is called, the first string should be provided as a feedback to the fuzzing engine so that it can put it in the dictionary.
This way, the dictionaries entries will be automatically used by the relevant fuzz targets.
With this precomputed generic dictionary, I do not know which patterns are useful for which targets (like `bitstring_overflow` is useful for `fuzz_siginit` but `EPRT` is useful for `fuzz_sigpcap` or ftp targets)

Is there a way to do that ?

PS : I do not have control over the rust function `tag` from nom crate which ends up comparing the chars one by one cf `let pos = self.iter().zip(t.iter()).position(|(a, b)| a != b);` in https://docs.rs/nom/5.1.2/src/nom/traits.rs.html#656-709
