### PR TITLE
Add project.yaml for Spicy

### DIFF
--- a/projects/spicy/project.yaml
+++ b/projects/spicy/project.yaml
@@ -1,0 +1,18 @@
+homepage: "https://docs.zeek.org/projects/spicy/en/latest/"
+language: c++
+primary_contact: "security@zeek.org"
+auto_ccs:
+  - "robin@corelight.com"
+  - "johanna@corelight.com"
+  - "tim@corelight.com"
+  - "seth@corelight.com"
+  - "justin@corelight.com"
+  - "vern@corelight.com"
+  - "vlad@es.net"
+  - "benjamin.bannier@corelight.com"
+fuzzing_engines:
+  - libfuzzer
+  - honggfuzz
+sanitizers:
+  - address
+main_repo: 'https://github.com/zeek/spicy'


### PR DESCRIPTION
Hi,

I am one of the maintainers of [Zeek](https://github.com/zeek/zeek), which is already being fuzzed by OSS-Fuzz (https://github.com/google/oss-fuzz/tree/master/projects/zeek).

We created a new subproject, called [Spicy](https://github.com/zeek/spicy), which is a standalone toolchain for generating parsers for network protocols/file formats. Spicy currently is not used by Zeek by default - however it will be in the future.

We would like to add Spicy to OSS-Fuzz, to see if any issues can be found with fuzzing. It would be especially nice if we could do this before it gets used by Zeek by default.

I am submitting a minimal PR to check and make sure that it is OK for us to submit a subproject to OSS fuzz that currently might not have a large user-base yet; the project will immediately have that userbase once it is used by Zeek. Spicy will always be a standalone project that can also be integrated by other software - so it will make sense to fuzz it separately going forward.