### PR TITLE
Add skia-bugs-central@skia-public.iam.gserviceaccount.com to auto_ccs

### DIFF
--- a/projects/skia/project.yaml
+++ b/projects/skia/project.yaml
@@ -9,6 +9,7 @@ auto_ccs:
   - "ethannicholas@google.com"
   - "egdaniel@google.com"
   - "skia-gpu-wrangler@google.com"
+  - "skia-bugs-central@skia-public.iam.gserviceaccount.com"
 vendor_ccs:
   - "lsalzman@mozilla.com"
   - "twsmith@mozilla.com"


### PR DESCRIPTION
So that this service account has view access.
@oliverchang Is that the best way to give this service account access to skia bugs?