### PR TITLE
Add ninja-build to freetype2 image.

### DIFF
--- a/projects/freetype2/Dockerfile
+++ b/projects/freetype2/Dockerfile
@@ -22,7 +22,9 @@ RUN apt-get update &&  \
       cmake            \
       libtool          \
       pkg-config       \
-      make
+      make             \
+      ninja-build
+
 
 # Get some files for the seed corpus
 ADD https://github.com/adobe-fonts/adobe-variable-font-prototype/releases/download/1.001/AdobeVFPrototype.otf $SRC/font-corpus/


### PR DESCRIPTION
This will allow the FreeType fuzzer to use ninja for some of the build
steps.