### PR TITLE
[CIFuzz] Fix affected fuzz targets.

### DIFF
--- a/infra/cifuzz/CHANGELOG
+++ b/infra/cifuzz/CHANGELOG
@@ -1,0 +1,3 @@
+	Next Release:
+
+	Improve detection of changed files better by fixing https://github.com/google/oss-fuzz/issues/7011

--- a/infra/cifuzz/affected_fuzz_targets.py
+++ b/infra/cifuzz/affected_fuzz_targets.py
@@ -89,6 +89,9 @@ def is_fuzz_target_affected(coverage, fuzz_target_path, files_changed):
                  fuzz_target)
     return True
 
+  covered_files = [
+      os.path.normpath(covered_file) for covered_file in covered_files
+  ]
   logging.info('Fuzz target %s is affected by: %s', fuzz_target, covered_files)
   for filename in files_changed:
     if filename in covered_files:


### PR DESCRIPTION
Fixes affected fuzz targets by normalizing path names.
Fixes: https://github.com/google/oss-fuzz/issues/7011