### PR TITLE
[qt] Clone the latest combination of qtbase and qtsvg which passed upstream CI

### DIFF
--- a/projects/qt/Dockerfile
+++ b/projects/qt/Dockerfile
@@ -20,9 +20,10 @@ RUN git clone --depth 1 https://github.com/AFLplusplus/AFLplusplus.git myaflplus
     cp -r myaflplusplus/dictionaries afldictionaries && \
     cp -r myaflplusplus/testcases afltestcases && \
     rm -rf myaflplusplus
-RUN git clone --branch dev --depth 1 --shallow-submodules \
-        --recurse-submodules=qtbase \
-        --recurse-submodules=qtsvg \
-        git://code.qt.io/qt/qt5.git qt
+RUN git clone --branch dev --depth 1 git://code.qt.io/qt/qt5.git && \
+    cp -r qt5/cmake . && \
+    rm -rf qt5
+RUN git clone --branch dev --depth 1 git://code.qt.io/qt/qtsvg.git
+RUN cmake -DSYNC_TO_MODULE=qtsvg -DSYNC_TO_BRANCH=dev -P cmake/QtSynchronizeRepo.cmake
 RUN git clone --branch dev --depth 1 git://code.qt.io/qt/qtqa.git
 RUN cp qtqa/fuzzing/oss-fuzz/build.sh $SRC/

--- a/projects/qt/Dockerfile
+++ b/projects/qt/Dockerfile
@@ -20,9 +20,13 @@ RUN git clone --depth 1 https://github.com/AFLplusplus/AFLplusplus.git myaflplus
     cp -r myaflplusplus/dictionaries afldictionaries && \
     cp -r myaflplusplus/testcases afltestcases && \
     rm -rf myaflplusplus
-RUN git clone --branch dev --depth 1 git://code.qt.io/qt/qt5.git && \
-    cp -r qt5/cmake . && \
-    rm -rf qt5
+# Still keep the old source checkout until the build script was updated
+RUN git clone --branch dev --depth 1 --shallow-submodules \
+        --recurse-submodules=qtbase \
+        --recurse-submodules=qtsvg \
+        git://code.qt.io/qt/qt5.git qt
+# Prepare new sources using dependencies.yaml
+RUN cp -r qt/cmake .
 RUN git clone --branch dev --depth 1 git://code.qt.io/qt/qtsvg.git
 RUN cmake -DSYNC_TO_MODULE=qtsvg -DSYNC_TO_BRANCH=dev -P cmake/QtSynchronizeRepo.cmake
 RUN git clone --branch dev --depth 1 git://code.qt.io/qt/qtqa.git


### PR DESCRIPTION
The super-repo qt5.git contains the revisions which were last tested successfully with all
submodules together. That is much older.

The super repo can be removed as soon as the build script was updated in upstream repo.