### PR TITLE
infra: simplify afl build and remove non-determinism

### DIFF
--- a/infra/base-images/base-builder/compile_afl
+++ b/infra/base-images/base-builder/compile_afl
@@ -37,6 +37,73 @@ export ASAN_OPTIONS="detect_leaks=0:symbolize=0:detect_odr_violation=0:abort_on_
 # No complain on unknown AFL environment variables
 export AFL_IGNORE_UNKNOWN_ENVS=1
 
+function afl_env1() {
+    export AFL_LLVM_INSTRUMENT=CLASSIC,CTX-2
+    export AFL_ENABLE_CMPLOG=0
+    # we increase the chance for LAF because we do not do CMPLOG with CTX
+    export AFL_LAF_CHANCE=30
+}
+
+function afl_env2() {
+    export AFL_ENABLE_DICTIONARY=1
+}
+
+function afl_env3() {
+    export AFL_LLVM_CMPLOG=1
+    touch "$OUT/afl_cmplog.txt"
+}
+
+function afl_env4() {
+    export AFL_LLVM_LAF_ALL=1
+}
+
+# Make it easy to explicitly explore the various 
+# combinations of AFL environments.
+function afl_set_oss_fuzz_opts() {
+  export AFL_LLVM_MODE_WORKAROUND=0
+  export AFL_ENABLE_DICTIONARY=0
+  export AFL_ENABLE_CMPLOG=1
+  export AFL_LAF_CHANCE=5
+
+  rm -f "$OUT/afl_cmplog.txt"
+
+  opt = $1
+  if [ $opt == "OPT1" ]; then
+    afl_env1
+  elif [ $opt == "OPT2" ]; then
+    afl_env2
+  elif [ $opt == "OPT3" ]; then
+    afl_env1
+    afl_env2
+  elif [ $opt == "OPT4" ]; then
+    afl_env2
+    afl_env3
+  elif [ $opt == "OPT5" ]; then
+    afl_env3    
+  elif [ $opt == "OPT6" ]; then
+    afl_env1
+    afl_env4
+  elif [ $opt == "OPT7" ]; then
+    afl_env1
+    afl_env2
+    afl_env4
+  elif [ $opt == "OPT8" ]; then
+    afl_env2
+    afl_env4
+  elif [ $opt == "OPT9" ]; then
+    afl_env4
+  fi
+
+  # Create a dictionary if one is wanted.
+  test "$AFL_ENABLE_DICTIONARY" = "1" && {
+    export AFL_LLVM_DICT2FILE="$OUT/afl++.dict"
+  }
+}
+
+if [ -z ${AFL_OSSFUZZ_OPT} ]; then
+  afl_set_oss_fuzz_opts ${AFLL_OSSFUZZ_OPT}
+fi
+
 # To analyze build failures and set specific AFL++ settings, set
 # `export AFL_SKIP_OSSFUZZ=1`
 # The 'env|grep' setup ensures we do not trigger the linter.

--- a/infra/base-images/base-builder/compile_afl
+++ b/infra/base-images/base-builder/compile_afl
@@ -69,6 +69,7 @@ function afl_set_oss_fuzz_opts() {
   rm -f "$OUT/afl_cmplog.txt"
 
   opt=$1
+  echo "Using AFL option $opt"
   if [ $opt == "OPT1" ]; then
     afl_env1
   elif [ $opt == "OPT2" ]; then
@@ -94,69 +95,69 @@ function afl_set_oss_fuzz_opts() {
   elif [ $opt == "OPT9" ]; then
     afl_env4
   fi
-
-  # Create a dictionary if one is wanted.
-  test "$AFL_ENABLE_DICTIONARY" = "1" && {
-    export AFL_LLVM_DICT2FILE="$OUT/afl++.dict"
-  }
 }
 
 if [[ ! -z ${AFL_OSSFUZZ_OPT} ]]; then
   afl_set_oss_fuzz_opts ${AFL_OSSFUZZ_OPT}
-fi
-
-# To analyze build failures and set specific AFL++ settings, set
-# `export AFL_SKIP_OSSFUZZ=1`
-# The 'env|grep' setup ensures we do not trigger the linter.
-env | egrep -q '^AFL_SKIP_OSSFUZZ=' || {
-
-  # The variables need to be set to "1" here - or before running this script.
-  # AFL++ configuration options.
-  export AFL_LLVM_MODE_WORKAROUND=0
-  export AFL_ENABLE_DICTIONARY=0
-  export AFL_ENABLE_CMPLOG=1
-  export AFL_LAF_CHANCE=5
-
-  #
-  # AFL++ compile option roulette. It is OK if they all happen together.
-  #
-
-  # 20% chance for CTX-2 coverage instrumentation (Caller conTeXt sensitive
-  # edge coverage).
-  test $(($RANDOM % 100)) -lt 20 && {
-    export AFL_LLVM_INSTRUMENT=CLASSIC,CTX-2
-    export AFL_ENABLE_CMPLOG=0
-    # we increase the chance for LAF because we do not do CMPLOG with CTX
-    export AFL_LAF_CHANCE=30
-  }
-
-  # 40% chance to create a dictionary.
-  test $(($RANDOM % 100)) -lt 40 && {
-    export AFL_ENABLE_DICTIONARY=1
-  }
-
-  # 60% chance to perform CMPLOG/REDQUEEN.
-  rm -f "$OUT/afl_cmplog.txt"
-  test "$AFL_ENABLE_CMPLOG" = "1" -a $(($RANDOM % 100)) -lt 60 && {
-    export AFL_LLVM_CMPLOG=1
-    touch "$OUT/afl_cmplog.txt"
-  }
-
-  # chance to perform COMPCOV/LAF_INTEL - if CMPLOG is not enabled.
-  test $(($RANDOM % 100)) -lt $AFL_LAF_CHANCE -a "$AFL_ENABLE_CMPLOG" = "0" && {
-    export AFL_LLVM_LAF_ALL=1
-  }
-
-  #
-  # End of AFL++ compile option roulette
-  #
 
   # Create a dictionary if one is wanted.
   test "$AFL_ENABLE_DICTIONARY" = "1" && {
     export AFL_LLVM_DICT2FILE="$OUT/afl++.dict"
   }
+else
+  # To analyze build failures and set specific AFL++ settings, set
+  # `export AFL_SKIP_OSSFUZZ=1`
+  # The 'env|grep' setup ensures we do not trigger the linter.
+  env | egrep -q '^AFL_SKIP_OSSFUZZ=' || {
 
-}
+    # The variables need to be set to "1" here - or before running this script.
+    # AFL++ configuration options.
+    export AFL_LLVM_MODE_WORKAROUND=0
+    export AFL_ENABLE_DICTIONARY=0
+    export AFL_ENABLE_CMPLOG=1
+    export AFL_LAF_CHANCE=5
+
+    #
+    # AFL++ compile option roulette. It is OK if they all happen together.
+    #
+
+    # 20% chance for CTX-2 coverage instrumentation (Caller conTeXt sensitive
+    # edge coverage).
+    test $(($RANDOM % 100)) -lt 20 && {
+      export AFL_LLVM_INSTRUMENT=CLASSIC,CTX-2
+      export AFL_ENABLE_CMPLOG=0
+      # we increase the chance for LAF because we do not do CMPLOG with CTX
+      export AFL_LAF_CHANCE=30
+    }
+
+    # 40% chance to create a dictionary.
+    test $(($RANDOM % 100)) -lt 40 && {
+      export AFL_ENABLE_DICTIONARY=1
+    }
+
+    # 60% chance to perform CMPLOG/REDQUEEN.
+    rm -f "$OUT/afl_cmplog.txt"
+    test "$AFL_ENABLE_CMPLOG" = "1" -a $(($RANDOM % 100)) -lt 60 && {
+      export AFL_LLVM_CMPLOG=1
+      touch "$OUT/afl_cmplog.txt"
+    }
+
+    # chance to perform COMPCOV/LAF_INTEL - if CMPLOG is not enabled.
+    test $(($RANDOM % 100)) -lt $AFL_LAF_CHANCE -a "$AFL_ENABLE_CMPLOG" = "0" && {
+      export AFL_LLVM_LAF_ALL=1
+    }
+
+    #
+    # End of AFL++ compile option roulette
+    #
+
+    # Create a dictionary if one is wanted.
+    test "$AFL_ENABLE_DICTIONARY" = "1" && {
+      export AFL_LLVM_DICT2FILE="$OUT/afl++.dict"
+    }
+
+  }
+fi
 
 # In case afl-clang-fast ever breaks, this is a workaround:
 test "$AFL_LLVM_MODE_WORKAROUND" = "1" && {

--- a/infra/base-images/base-builder/compile_afl
+++ b/infra/base-images/base-builder/compile_afl
@@ -58,7 +58,8 @@ function afl_env4() {
 }
 
 # Make it easy to explicitly explore the various 
-# combinations of AFL environments.
+# combinations of AFL environments. This should exhibit the possible
+# builds from the roulette below. 
 function afl_set_oss_fuzz_opts() {
   export AFL_LLVM_MODE_WORKAROUND=0
   export AFL_ENABLE_DICTIONARY=0
@@ -67,7 +68,7 @@ function afl_set_oss_fuzz_opts() {
 
   rm -f "$OUT/afl_cmplog.txt"
 
-  opt = $1
+  opt=$1
   if [ $opt == "OPT1" ]; then
     afl_env1
   elif [ $opt == "OPT2" ]; then
@@ -100,8 +101,8 @@ function afl_set_oss_fuzz_opts() {
   }
 }
 
-if [ -z ${AFL_OSSFUZZ_OPT} ]; then
-  afl_set_oss_fuzz_opts ${AFLL_OSSFUZZ_OPT}
+if [[ ! -z ${AFL_OSSFUZZ_OPT} ]]; then
+  afl_set_oss_fuzz_opts ${AFL_OSSFUZZ_OPT}
 fi
 
 # To analyze build failures and set specific AFL++ settings, set


### PR DESCRIPTION
This is part of an effort to avoid running into build issues and also make testing build issues easier. The general idea is to push out non-determinism from the build scripts and make the set of available AFL builds explicit as "option 1, option 2, ..." . 

Specifically, this idea is to push $RANDOM out from compile_afl (e.g. https://github.com/google/oss-fuzz/blob/9d0a2b953a9ae4e8c6a853dcbd7053081b12a322/infra/base-images/base-builder/compile_afl#L58) and substitute the roulette with a fixed and verbose set of options that is controlled by the `build` command then we avoid the non-determinism.

The current option for controlling AFL builds with  `AFL_SKIP_OSSFUZZ` works fine in principle and for reproducing a set up it is good in that one can copy and paste environment variables. However, I would probably prefer an approach that hides fuzzer-specific environment variables from the user as much as possible, e.g. instead of having the user set specific env vars just "pick option 1". 

In terms of the roulette, I then I think there's an argument to move the non-determinism in selecting which AFL build to use over to Clusterfuzz.

We could also use it in the CI to test various different builds easily. In a sense, this also follows the OSS-Fuzz approach more closely in that normally in the CI we test for all possible settings, but only at the fuzzer + sanitizer abstraction. With the addition of AFL++ we have a third dimention: fuzzer + sanitzer + fuzzer settings. One could argue the CI should follow.

What do you think about the idea of removing non-determinism from compile_afl? I can refine the code accordingly. 