### PR TITLE
[envoy] Build googletest with sanitizers

### DIFF
--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -70,7 +70,7 @@ declare -r DI="$(
 if [ "$SANITIZER" != "coverage" ]
 then
 # Envoy code. Disable coverage instrumentation
-  echo " --per_file_copt=^.*source/extensions/access_loggers/.*\.cc\$@-fsanitize-coverage=0" 
+  echo " --per_file_copt=^.*source/extensions/access_loggers/.*\.cc\$@-fsanitize-coverage=0"
   echo " --per_file_copt=^.*source/common/protobuf/.*\.cc\$@-fsanitize-coverage=0"
 
 # Envoy test code. Disable coverage instrumentation
@@ -80,7 +80,6 @@ then
   echo " --per_file_copt=^.*antlr4_runtimes.*\.cpp\$@-fsanitize-coverage=0,-fno-sanitize=all"
   echo " --per_file_copt=^.*com_google_protobuf.*\.cc\$@-fsanitize-coverage=0,-fno-sanitize=all"
   echo " --per_file_copt=^.*com_google_absl.*\.cc\$@-fsanitize-coverage=0,-fno-sanitize=all"
-  echo " --per_file_copt=^.*googletest.*\.cc\$@-fsanitize-coverage=0,-fno-sanitize=all"
   echo " --per_file_copt=^.*com_github_grpc_grpc.*\.cc\$@-fsanitize-coverage=0,-fno-sanitize=all"
   echo " --per_file_copt=^.*boringssl.*\.cc\$@-fsanitize-coverage=0,-fno-sanitize=all"
   echo " --per_file_copt=^.*com_googlesource_code_re2.*\.cc\$@-fsanitize-coverage=0,-fno-sanitize=all"
@@ -92,6 +91,10 @@ then
   echo " --per_file_copt=^.*com_github_google_libprotobuf_mutator/.*\.cc\$@-fsanitize-coverage=0,-fno-sanitize=all"
   echo " --per_file_copt=^.*com_googlesource_googleurl/.*\.cc\$@-fsanitize-coverage=0,-fno-sanitize=all"
   echo " --per_file_copt=^.*com_lightstep_tracer_cpp/.*\.cc\$@-fsanitize-coverage=0,-fno-sanitize=all"
+
+# External dependency which needs to be compiled with sanitizers. Disable
+# coverage instrumentation.
+  echo " --per_file_copt=^.*googletest.*\.cc\$@-fsanitize-coverage=0"
 
 # All protobuf code and code in bazel-out
   echo " --per_file_copt=^.*\.pb\.cc\$@-fsanitize-coverage=0,-fno-sanitize=all"


### PR DESCRIPTION
The `check_build` step fails on one of the fuzzers because some of the code is built with sanitizers and some of the libraries without.
This PR builds the googletest dependency with sanitizers.

Signed-off-by: Adi Suissa-Peleg <adip@google.com>