### PR TITLE
[freetype2] Add MemorySanitizer

### DIFF
--- a/projects/freetype2/project.yaml
+++ b/projects/freetype2/project.yaml
@@ -16,4 +16,5 @@ vendor_ccs:
 sanitizers:
   - address
   - undefined
+  - memory
 main_repo: 'https://github.com/freetype/freetype2-testing.git'


### PR DESCRIPTION
The upstream freetype-testing project now pulls llvm-project and builds
libcxx and libcxx-abi and statically links against them to support the
use of C++ in the fuzzer driver.