### PR TITLE
[honggfuzz]: set test timeout to 5 sec

### DIFF
--- a/infra/base-images/base-runner/run_fuzzer
+++ b/infra/base-images/base-runner/run_fuzzer
@@ -140,7 +140,8 @@ elif [[ "$FUZZING_ENGINE" = honggfuzz ]]; then
   # -P: use persistent mode of fuzzing (i.e. LLVMFuzzerTestOneInput)
   # -f: location of the initial (and destination) file corpus
   # -n: number of fuzzing threads (and processes)
-  CMD_LINE="$OUT/honggfuzz -n 1 --exit_upon_crash -R /tmp/${FUZZER}_honggfuzz.report -W $FUZZER_OUT -v -z -P -f \"$CORPUS_DIR\" $(get_dictionary) $* -- \"$OUT/$FUZZER\""
+  # -t: timeout (seconds)
+  CMD_LINE="$OUT/honggfuzz -n 1 -t 5 --exit_upon_crash -R /tmp/${FUZZER}_honggfuzz.report -W $FUZZER_OUT -v -z -P -f \"$CORPUS_DIR\" $(get_dictionary) $* -- \"$OUT/$FUZZER\""
 
 else
 


### PR DESCRIPTION
When running the `check_build` step on locally built fuzzers, I receive errors of the following form:

```
BAD BUILD: fuzzing /tmp/not-out/tmp79o_9sx8/h2_capture_fuzz_test with honggfuzz failed.
/tmp/not-out/tmp79o_9sx8/honggfuzz -n 1 --exit_upon_crash -R /tmp/h2_capture_fuzz_test_honggfuzz.report -W /tmp/h2_capture_fuzz_test_honggfuzz_address_out -v -z -P -f "/tmp/h2_ca
pture_fuzz_test_corpus" -- "/tmp/not-out/tmp79o_9sx8/h2_capture_fuzz_test"
Persistent signature found in '/tmp/not-out/tmp79o_9sx8/h2_capture_fuzz_test'. Enabling persistent fuzzing mode
Start time:'2021-12-16.23.08.00' bin:'/tmp/not-out/tmp79o_9sx8/h2_capture_fuzz_test', input:'/tmp/h2_capture_fuzz_test_corpus', output:'/tmp/h2_capture_fuzz_test_corpus', persist
ent:true, stdin:false, mutation_rate:5, timeout:1, max_runs:0, threads:1, minimize:false, git_commit:af84d98b2e5ddf1dca6c81a23a8e579e83af7139
[2021-12-16T23:08:00+0000][W][3933] sanitizers_AddFlag():67 The 'ASAN_OPTIONS' envar is already set. Not overriding it!
[2021-12-16T23:08:00+0000][W][3933] sanitizers_AddFlag():67 The 'UBSAN_OPTIONS' envar is already set. Not overriding it!
[2021-12-16T23:08:00+0000][W][3933] sanitizers_AddFlag():67 The 'MSAN_OPTIONS' envar is already set. Not overriding it!
Entering phase 1/3: Dry Run
Launched new fuzzing thread, no. #0
Persistent mode: Launched new persistent pid=3936
[2021-12-16T23:08:02+0000][W][3934] subproc_checkTimeLimit():531 pid=3936 took too much time (limit 1 s). Killing it with SIGKILL
[2021-12-16T23:08:02+0000][W][3934] arch_checkWait():239 Persistent mode: pid=3936 exited with status: SIGNALED, signal: 9 (Killed)
Persistent mode: Launched new persistent pid=3937
[2021-12-16T23:08:03+0000][W][3934] subproc_checkTimeLimit():531 pid=3937 took too much time (limit 1 s). Killing it with SIGKILL
[2021-12-16T23:08:03+0000][W][3934] arch_checkWait():239 Persistent mode: pid=3937 exited with status: SIGNALED, signal: 9 (Killed)
Entering phase 2/3: Switching to the Feedback Driven Mode
Entering phase 3/3: Dynamic Main (Feedback Driven Mode)
Persistent mode: Launched new persistent pid=3938
[2021-12-16T23:08:04+0000][W][3934] subproc_checkTimeLimit():531 pid=3938 took too much time (limit 1 s). Killing it with SIGKILL
[2021-12-16T23:08:04+0000][W][3934] arch_checkWait():239 Persistent mode: pid=3938 exited with status: SIGNALED, signal: 9 (Killed)
Persistent mode: Launched new persistent pid=3939
[2021-12-16T23:08:05+0000][W][3934] subproc_checkTimeLimit():531 pid=3939 took too much time (limit 1 s). Killing it with SIGKILL
[2021-12-16T23:08:05+0000][W][3934] arch_checkWait():239 Persistent mode: pid=3939 exited with status: SIGNALED, signal: 9 (Killed)
```

The current PR increases the test timeout of honggfuzz fuzzers from 1 second to 5 seconds.

Verified that the above error doesn't occur by running the following:
1. `python infra/helper.py build_image base-runner`
2. `python infra/helper.py build_image envoy`
3. `python infra/helper.py build_fuzzers --engine honggfuzz --sanitizer address envoy`
4. `python infra/helper.py check_build --engine honggfuzz --sanitizer address envoy`

Signed-off-by: Adi Suissa-Peleg <adip@google.com>