### PR TITLE
[selinux] add Christian Göttsche's email address

### DIFF
--- a/projects/selinux/project.yaml
+++ b/projects/selinux/project.yaml
@@ -11,4 +11,5 @@ auto_ccs:
   - nicolas.iooss.ossfuzz@gmail.com
   - omosnacek@gmail.com
   - jwcart2@gmail.com
+  - cgzones@googlemail.com
 main_repo: 'https://github.com/SELinuxProject/selinux'


### PR DESCRIPTION
Waiting for https://lore.kernel.org/selinux/CAJ2a_DcbGirAaWFZFuk6z4SsbVpZSY8WfeCDJKkVPWpzE3f1WA@mail.gmail.com/T/#u.

@fishilico @WOnder93 could you take a look? @cgzones added a fuzz target that started finding bugs. I don't think those bugs reports should be hidden from @cgzones :-)