### PR TITLE
Add project.yaml for Dfinity's IC & Candid

### DIFF
--- a/projects/dfinity/project.yaml
+++ b/projects/dfinity/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://dfinity.org/"
+language: rust
+primary_contact: "venkkatesh.sekar@dfinity.org"
+auto_ccs :
+  - "raghav.sundaravaradan@dfinity.org"
+  - "robin.kunzler@dfinity.org"
+  - "andrew.lee@dfinity.org"
+main_repo: "https://github.com/dfinity/ic"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer


### PR DESCRIPTION
Hi, 

I'm one of the security engineers working on the Internet Computer project (https://dfinity.org/). I would like to add our codebase to Google's OSS fuzz infrastructure and utilize fuzzing to discover bugs within our rust codebase. We would also like to fuzz projects outside our main repo as well, including Candid (https://github.com/dfinity/candid).

This PR adds the initial project.yaml for the project.