### PR TITLE
[wget] Fix AFL build

### DIFF
--- a/projects/wget/Dockerfile
+++ b/projects/wget/Dockerfile
@@ -39,12 +39,12 @@ RUN apt-get update && apt-get install -y \
 ENV GNULIB_TOOL $SRC/gnulib/gnulib-tool
 RUN git clone git://git.savannah.gnu.org/gnulib.git
 RUN git clone --depth=1 --recursive https://git.savannah.gnu.org/git/libunistring.git
-RUN git clone --depth=1 --recursive https://gitlab.com/libidn/libidn2.git
+RUN git clone --depth=1 https://gitlab.com/libidn/libidn2.git
 RUN git clone --depth=1 --recursive https://github.com/rockdaboot/libpsl.git
 RUN git clone --depth=1 https://git.lysator.liu.se/nettle/nettle.git
 RUN git clone --depth=1 https://gitlab.com/gnutls/gnutls.git
 
-RUN git clone --recursive https://git.savannah.gnu.org/git/wget.git
+RUN git clone https://git.savannah.gnu.org/git/wget.git
 
 WORKDIR wget
 COPY build.sh $SRC/

--- a/projects/wget/build.sh
+++ b/projects/wget/build.sh
@@ -18,6 +18,7 @@
 export WGET_DEPS_PATH=$SRC/wget_deps
 export PKG_CONFIG_PATH=$WGET_DEPS_PATH/lib64/pkgconfig:$WGET_DEPS_PATH/lib/pkgconfig
 export CPPFLAGS="-I$WGET_DEPS_PATH/include"
+export CFLAGS="$CFLAGS -I$WGET_DEPS_PATH/include -L$WGET_DEPS_PATH/lib"
 export LDFLAGS="-L$WGET_DEPS_PATH/lib"
 export GNULIB_SRCDIR=$SRC/gnulib
 export LLVM_PROFILE_FILE=/tmp/prof.test
@@ -81,15 +82,10 @@ ln -s $WGET_DEPS_PATH/lib64/libhogweed.a $WGET_DEPS_PATH/lib/libhogweed.a
 ln -s $WGET_DEPS_PATH/lib64/libnettle.a  $WGET_DEPS_PATH/lib/libnettle.a
 
 cd $SRC/wget
-./bootstrap
+./bootstrap --skip-po
 autoreconf -fi
 
-export CFLAGS="$CFLAGS -I$WGET_DEPS_PATH/include"
-export CXXFLAGS="$CXXFLAGS -I$WGET_DEPS_PATH/include"
-
 # build and run non-networking tests
-GNUTLS_CFLAGS="-lgnutls" \
-GNUTLS_LIBS="-lgnutls" \
 LIBS="-lgnutls -lhogweed -lnettle -lidn2 -lunistring -lpsl" \
 ./configure -C
 make clean
@@ -97,8 +93,6 @@ make -j$(nproc)
 make -j$(nproc) -C fuzz check
 
 # build for fuzzing
-GNUTLS_CFLAGS="-lgnutls" \
-GNUTLS_LIBS="-lgnutls" \
 LIBS="-lgnutls -lhogweed -lnettle -lidn2 -lunistring -lpsl" \
 ./configure --enable-fuzzing -C
 make clean
@@ -108,7 +102,7 @@ make -j$(nproc) -C src
 # build fuzzers
 cd fuzz
 make -j$(nproc) ../src/libunittest.a
-CXXFLAGS="$CXXFLAGS -L$WGET_DEPS_PATH/lib/" make oss-fuzz
+make oss-fuzz
 
 find . -name '*_fuzzer' -exec cp -v '{}' $OUT ';'
 find . -name '*_fuzzer.dict' -exec cp -v '{}' $OUT ';'


### PR DESCRIPTION
- Fix AFL build by using $CC instead of $CXX
- Avoid 2x indirect git cloning of gnulib submodules
- Smaller cleanups in build.sh