### PR TITLE
cairo: update glib source and version

### DIFF
--- a/projects/cairo/Dockerfile
+++ b/projects/cairo/Dockerfile
@@ -18,8 +18,7 @@ RUN apt-get update && apt-get install -y python3-pip gtk-doc-tools libffi-dev au
 RUN pip3 install -U meson==0.56.0 ninja
 
 RUN git clone --depth 1 git://git.sv.nongnu.org/freetype/freetype2.git
-ADD https://ftp.gnome.org/pub/gnome/sources/glib/2.64/glib-2.64.2.tar.xz $SRC
-RUN tar xvJf $SRC/glib-2.64.2.tar.xz
+RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/glib
 RUN git clone --depth 1 https://gitlab.freedesktop.org/cairo/cairo.git && \
     zip -q $SRC/cairo_seed_corpus.zip $SRC/cairo/test/reference/*
 

--- a/projects/cairo/build.sh
+++ b/projects/cairo/build.sh
@@ -28,7 +28,7 @@ rm -rf $BUILD
 mkdir -p $BUILD
 
 # Build glib
-pushd $SRC/glib-2.64.2
+pushd $SRC/glib/
 meson \
     --prefix=$PREFIX \
     --libdir=lib \


### PR DESCRIPTION
Sometimes the current ftp site has timeouts which causes the build
to fail. This switches it to the upstream repo (as oss-fuzz glib
integration itself) to make it more stable.