### PR TITLE
monero: fix and stabilise coverage build

### DIFF
--- a/projects/monero/Dockerfile
+++ b/projects/monero/Dockerfile
@@ -31,7 +31,10 @@ RUN set -ex && \
         doxygen \
         git \
         curl \
+        libtool \
         libtool-bin \
+        flex \
+        bison \
         autoconf \
         automake \
         bzip2 \


### PR DESCRIPTION
Monero builds hav failed in the last 5 out of 7 days, but a bit
on-and-off. The reason is a missing yacc binary during unbound
compilation, this fixes it.