### PR TITLE
[osquery] Fix build due to new CMake requirements

### DIFF
--- a/projects/osquery/Dockerfile
+++ b/projects/osquery/Dockerfile
@@ -18,6 +18,12 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends python python3 bison flex make wget xz-utils libunwind-dev lsb-release build-essential libssl-dev
 
+# osquery now needs at least version 3.21.4.
+ENV cmakeVer 3.21.4
+RUN wget https://github.com/Kitware/CMake/releases/download/v${cmakeVer}/cmake-${cmakeVer}-Linux-x86_64.tar.gz \
+	&& tar xvf cmake-${cmakeVer}-Linux-x86_64.tar.gz -C /usr/local --strip 1 \
+	&& rm cmake-${cmakeVer}-Linux-x86_64.tar.gz
+
 RUN git clone --depth 1 https://github.com/osquery/osquery osquery
 
 WORKDIR osquery


### PR DESCRIPTION
osquery now requires CMake version 3.21.4 at least, but on the base image
only 3.21.1 is available so the build fails.
Download a CMake prebuilt binary with the correct version.