### PR TITLE
Re-enable MSAN and activate more CF operations

### DIFF
--- a/projects/bearssl/project.yaml
+++ b/projects/bearssl/project.yaml
@@ -6,8 +6,7 @@ auto_ccs:
 sanitizers:
  - address
  - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
-#  - memory
+ - memory
 architectures:
  - x86_64
  - i386

--- a/projects/bitcoin-core/build_cryptofuzz.sh
+++ b/projects/bitcoin-core/build_cryptofuzz.sh
@@ -108,6 +108,8 @@ echo -n 'ECC_PrivateToPublic,' >>extra_options.h
 echo -n 'ECC_ValidatePubkey,' >>extra_options.h
 echo -n 'ECC_Point_Add,' >>extra_options.h
 echo -n 'ECC_Point_Mul,' >>extra_options.h
+echo -n 'ECC_Point_Dbl,' >>extra_options.h
+echo -n 'ECC_Point_Neg,' >>extra_options.h
 echo -n 'ECDSA_Sign,' >>extra_options.h
 echo -n 'ECDSA_Verify,' >>extra_options.h
 echo -n 'ECDSA_Recover,' >>extra_options.h

--- a/projects/bls-signatures/project.yaml
+++ b/projects/bls-signatures/project.yaml
@@ -5,8 +5,7 @@ main_repo: "https://github.com/supranational/blst.git"
 sanitizers:
  - address
  - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
-#  - memory
+ - memory
 architectures:
  - x86_64
  - i386

--- a/projects/libecc/build.sh
+++ b/projects/libecc/build.sh
@@ -54,10 +54,10 @@ python gen_repository.py
 rm extra_options.h
 echo -n '"' >>extra_options.h
 echo -n '--force-module=libecc ' >>extra_options.h
-echo -n '--operations=Digest,HMAC,ECC_PrivateToPublic,ECDSA_Sign,ECDSA_Verify,ECGDSA_Sign,ECGDSA_Verify,ECRDSA_Sign,ECRDSA_Verify,ECC_Point_Add,ECC_Point_Mul,BignumCalc ' >>extra_options.h
+echo -n '--operations=Digest,HMAC,ECC_PrivateToPublic,ECDSA_Sign,ECDSA_Verify,ECGDSA_Sign,ECGDSA_Verify,ECRDSA_Sign,ECRDSA_Verify,ECC_Point_Add,ECC_Point_Mul,ECC_Point_Dbl,ECC_Point_Neg,BignumCalc ' >>extra_options.h
 echo -n '--curves=brainpool224r1,brainpool256r1,brainpool384r1,brainpool512r1,secp192r1,secp224r1,secp256r1,secp384r1,secp521r1,secp256k1 ' >>extra_options.h
 echo -n '--digests=NULL,SHA224,SHA256,SHA3-224,SHA3-256,SHA3-384,SHA3-512,SHA384,SHA512,SHA512-224,SHA512-256,SM3,SHAKE256_114,STREEBOG-256,STREEBOG-512 ' >>extra_options.h
-echo -n '--calcops=Add,AddMod,And,Bit,GCD,InvMod,IsOdd,IsOne,IsZero,LShift1,Mod,Mul,MulMod,NumBits,Or,RShift,Sqr,Sub,SubMod,Xor ' >>extra_options.h
+echo -n '--calcops=Add,AddMod,And,Bit,GCD,InvMod,IsOdd,IsOne,IsZero,LShift1,Mod,Mul,MulMod,NumBits,Or,RShift,Sqr,Sub,SubMod,Xor,LRot,RRot ' >>extra_options.h
 echo -n '"' >>extra_options.h
 cd modules/libecc/
 make -B -j$(nproc)

--- a/projects/libecc/project.yaml
+++ b/projects/libecc/project.yaml
@@ -7,8 +7,7 @@ auto_ccs:
 sanitizers:
  - address
  - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
-#  - memory
+ - memory
 architectures:
  - x86_64
  - i386

--- a/projects/relic/build.sh
+++ b/projects/relic/build.sh
@@ -62,7 +62,7 @@ python gen_repository.py
 rm extra_options.h
 echo -n '"' >>extra_options.h
 echo -n '--force-module=relic ' >>extra_options.h
-echo -n '--operations=BignumCalc,ECC_PrivateToPublic,ECC_ValidatePubkey,ECDSA_Sign,ECDSA_Verify,Digest,HMAC,KDF_X963,SymmetricEncrypt,SymmetricDecrypt,ECC_Point_Add,ECC_Point_Mul ' >>extra_options.h
+echo -n '--operations=BignumCalc,ECC_PrivateToPublic,ECC_ValidatePubkey,ECDSA_Sign,ECDSA_Verify,Digest,HMAC,KDF_X963,SymmetricEncrypt,SymmetricDecrypt,ECC_Point_Add,ECC_Point_Mul,ECC_Point_Dbl,ECC_Point_Neg ' >>extra_options.h
 echo -n '--curves=secp256k1,secp256r1 ' >>extra_options.h
 echo -n '--digests=NULL,SHA224,SHA256,SHA384,SHA512,BLAKE2S160,BLAKE2S256 ' >>extra_options.h
 echo -n '--ciphers=AES_128_CBC,AES_192_CBC,AES_256_CBC ' >>extra_options.h

--- a/projects/relic/project.yaml
+++ b/projects/relic/project.yaml
@@ -7,8 +7,7 @@ auto_ccs:
 sanitizers:
  - address
  - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
-#  - memory
+ - memory
 architectures:
  - x86_64
  - i386


### PR DESCRIPTION
- Due to https://github.com/google/oss-fuzz/issues/6294 these projects had their MSAN builds disabled, presumably because they use Boost, however they only use Boost headers, not the libraries
- Enable some Cryptofuzz operations in projects that support them