### PR TITLE
tink: fix coverage

### DIFF
--- a/projects/tink/Dockerfile
+++ b/projects/tink/Dockerfile
@@ -18,8 +18,10 @@ FROM gcr.io/oss-fuzz-base/base-builder
 FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN apt-get update && apt-get install -y make pkg-config
 RUN git clone --depth 1 https://github.com/google/tink
+
+RUN mkdir $SRC/tink/cc/fuzzing
+COPY fuzzing_CMake $SRC/tink/cc/fuzzing/CMakeLists.txt
+COPY tink_encrypt_decrypt_fuzzer.cc $SRC/tink/cc/fuzzing/tink_encrypt_decrypt_fuzzer.cc
+COPY build.sh $SRC/
+
 WORKDIR tink
-COPY fuzzing_CMake \
-     build.sh \
-     tink_encrypt_decrypt_fuzzer.cc \
-     $SRC/

--- a/projects/tink/build.sh
+++ b/projects/tink/build.sh
@@ -15,9 +15,13 @@
 #
 ################################################################################
 
-mkdir ./cc/fuzzing 
-cp $SRC/tink_encrypt_decrypt_fuzzer.cc ./cc/fuzzing/
-cp $SRC/fuzzing_CMake ./cc/fuzzing/CMakeLists.txt
 cd cc/fuzzing && cmake .
 make -j$(nproc)
 mv tink_encrypt_fuzzer $OUT/
+
+# Hack to get coverage to work. We need this due to /src/tink/cc/fuzzing/tink/__include_alias/tink
+# being an symbolic link. Instead, we exchange it with the actual contents.
+rm /src/tink/cc/fuzzing/tink/__include_alias/tink
+mkdir /src/tinktmp
+cp -rf /src/tink/cc/ /src/tinktmp/tink
+cp -rf /src/tinktmp/tink/ /src/tink/cc/fuzzing/tink/__include_alias/tink


### PR DESCRIPTION
There is an issue with the existing coverage due to symbolic links. This fixes it