### PR TITLE
[Clusterfuzzlite] Add missing replace param to upload_corpus()

### DIFF
--- a/infra/cifuzz/filestore/no_filestore/__init__.py
+++ b/infra/cifuzz/filestore/no_filestore/__init__.py
@@ -26,7 +26,7 @@ class NoFilestore(filestore.BaseFilestore):
     """Noop implementation of upload_crashes."""
     logging.info('Not uploading crashes because no Filestore.')
 
-  def upload_corpus(self, name, directory):
+  def upload_corpus(self, name, directory, replace=False):
     """Noop implementation of upload_corpus."""
     logging.info('Not uploading corpus because no Filestore.')
 


### PR DESCRIPTION
I was about to add support for GitLab to Clusterfuzzlite (https://github.com/google/clusterfuzzlite/issues/55) and wanted to start with a minimal example with no filestore, but noticed during CI run that `NoFilestore::upload_corpus()` is missing the `BaseFilestore` interface's `replace` parameter, which makes Clusterfuzzlite throw an exception when using the `NoFilestore`.