### PR TITLE
Ignore the files generated from the protos in the coverage data.

### DIFF
--- a/projects/swift-protobuf/project.yaml
+++ b/projects/swift-protobuf/project.yaml
@@ -10,4 +10,5 @@ fuzzing_engines:
 sanitizers:
 - address
 - thread
+coverage_extra_args: -ignore-filename-regex=*.pb.swift
 main_repo: 'https://github.com/apple/swift-protobuf.git'


### PR DESCRIPTION
The testing isn't calling all the generated apis, it is focused on ensuring all
the parsing/serialization code paths are covered; so don't count these files in
the stats.