### PR TITLE
gnupg: fix build

### DIFF
--- a/projects/gnupg/Dockerfile
+++ b/projects/gnupg/Dockerfile
@@ -15,7 +15,8 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool gettext bzip2 gnupg bison flex
+RUN apt-get update && apt-get install -y make autoconf automake libtool bzip2 gnupg bison flex gettext
+
 # Install automake 1.16.3 from future. See:
 # * https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=commit;h=6ca540715139899137e1f86c7e1dcbd0288f15b3
 # * https://packages.ubuntu.com/en/hirsute/automake

--- a/projects/gnupg/build.sh
+++ b/projects/gnupg/build.sh
@@ -18,6 +18,7 @@
 #compile and link statically dependencies
 cd ..
 cd libgpg-error
+sed -i 's/0.19/0.20/g' ./po/Makefile.in.in
 ./autogen.sh
 ./configure --disable-doc --enable-static --disable-shared
 make


### PR DESCRIPTION
Ensure the gettext version in `Makefile.in.in` of libgpg-error is valid in the oss-fuzz environment