### PR TITLE
libvips: add gflags dependency for libjxl

### DIFF
--- a/projects/libvips/Dockerfile
+++ b/projects/libvips/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update && apt-get install -y \
   libexpat1-dev \
   libffi-dev \
   libfftw3-dev \
+  libgflags-dev \
   libselinux1-dev \
   libtool \
   nasm \


### PR DESCRIPTION
This will fix the failing build.

Required since https://github.com/libjxl/libjxl/pull/1039

As fixed for libjxl via https://github.com/google/oss-fuzz/pull/7063