### PR TITLE
swift-protobuf: fix regex for coverage exclusion

### DIFF
--- a/projects/swift-protobuf/project.yaml
+++ b/projects/swift-protobuf/project.yaml
@@ -10,5 +10,5 @@ fuzzing_engines:
 sanitizers:
 - address
 - thread
-coverage_extra_args: -ignore-filename-regex=*.pb.swift
+coverage_extra_args: -ignore-filename-regex=.*.pb.swift
 main_repo: 'https://github.com/apple/swift-protobuf.git'


### PR DESCRIPTION
cc @thomasvl 
We are talking regex, not bash here ;-)