### PR TITLE
[elfutils] turn on the alignment check

### DIFF
--- a/projects/elfutils/build.sh
+++ b/projects/elfutils/build.sh
@@ -38,7 +38,7 @@
 set -eux
 
 SANITIZER=${SANITIZER:-address}
-flags="-O1 -fno-omit-frame-pointer -gline-tables-only -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=$SANITIZER -fsanitize=fuzzer-no-link"
+flags="-O1 -fno-omit-frame-pointer -g -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=$SANITIZER -fsanitize=fuzzer-no-link"
 
 export CC=${CC:-clang}
 export CFLAGS=${CFLAGS:-$flags}

--- a/projects/elfutils/build.sh
+++ b/projects/elfutils/build.sh
@@ -61,6 +61,17 @@ find -name Makefile.am | xargs sed -i 's/,--no-undefined//'
 # https://clang.llvm.org/docs/AddressSanitizer.html#usage
 sed -i 's/^\(ZDEFS_LDFLAGS=\).*/\1/' configure.ac
 
+if [[ "$SANITIZER" == undefined ]]; then
+    additional_ubsan_checks=alignment
+    UBSAN_FLAGS="-fsanitize=$additional_ubsan_checks -fno-sanitize-recover=$additional_ubsan_checks"
+    CFLAGS="$CFLAGS $UBSAN_FLAGS"
+    CXXFLAGS="$CXXFLAGS $UBSAN_FLAGS"
+
+    # That's basicaly what --enable-sanitize-undefined does to turn off unaligned access
+    # elfutils heavily relies on on i386/x86_64 but without changing compiler flags along the way
+    sed -i 's/\(check_undefined_val\)=[0-9]/\1=1/' configure.ac
+fi
+
 autoreconf -i -f
 if ! ./configure --enable-maintainer-mode --disable-debuginfod --disable-libdebuginfod \
             --without-bzlib --without-lzma --without-zstd \


### PR DESCRIPTION
Unaligned access can crash code on some architectures like SPARC for example. The latest example (unrelated to elfutils) would be https://github.com/systemd/systemd/issues/21935 (which UBSan could have easily prevented and which led to rolling out the check in the systemd project among other things).

It should probably be merged once https://sourceware.org/bugzilla/show_bug.cgi?id=28720 is closed.