### PR TITLE
Cover the cases where the project has .yml file instead of .yaml

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -108,6 +108,8 @@ class Project:
       return constants.DEFAULT_LANGUAGE
 
     project_yaml_path = os.path.join(self.path, 'project.yaml')
+    if not os.path.isfile(project_yaml_path):
+      project_yaml_path = os.path.join(self.path, 'project.yml')
     with open(project_yaml_path) as file_handle:
       content = file_handle.read()
       for line in content.splitlines():


### PR DESCRIPTION
Found in one case a project had project.yml instead of project.yaml causing the script to crash.