### PR TITLE
[igraph] enable fuzzing on i386

### DIFF
--- a/projects/igraph/project.yaml
+++ b/projects/igraph/project.yaml
@@ -8,3 +8,6 @@ auto_ccs:
 sanitizers:
   - address
   - undefined
+architectures:
+ - x86_64
+ - i386


### PR DESCRIPTION
igraph builds on 32-bit platforms. Fuzzing on 32-bit may be beneficial as some error-handling code paths, related to hitting limits, are only likely to be covered on 32-bit.