### PR TITLE
Update fluxcd setup and contact details

### DIFF
--- a/projects/fluxcd/Dockerfile
+++ b/projects/fluxcd/Dockerfile
@@ -15,15 +15,14 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
-RUN apt-get update && apt-get install -y wget zlib1g-dev pkg-config
-RUN git clone --depth 1 --branch fuzz1 https://github.com/AdamKorcz/kustomize-controller
-RUN git clone --depth 1 --branch fuzz1 https://github.com/AdamKorcz/pkg
-RUN git clone --depth 1 --branch fuzz1 https://github.com/AdamKorcz/notification-controller
 
-# Go 1.16 is needed to build the notification-controller
-RUN cd /tmp \
-	&& wget https://golang.org/dl/go1.16.8.linux-amd64.tar.gz \
-	&& tar -xf go1.16.8.linux-amd64.tar.gz
+ENV PROJECT_ROOT="${GOPATH:-/root/go}/src/github.com/fluxcd"
+
+RUN mkdir -p "${PROJECT_ROOT}"
+RUN git clone --depth 1 https://github.com/fluxcd/notification-controller \
+		"${PROJECT_ROOT}/notification-controller"
+RUN git clone --depth 1 https://github.com/fluxcd/pkg \
+		"${PROJECT_ROOT}/pkg"
 
 COPY build.sh $SRC/
 WORKDIR $SRC

--- a/projects/fluxcd/build.sh
+++ b/projects/fluxcd/build.sh
@@ -15,44 +15,7 @@
 #
 ################################################################################
 
-# Notification-controller
+PROJECT_ROOT="${GOPATH:-/root/go}/src/github.com/fluxcd"
 
-# The notification-controller needs to be built with go 1.16
-export OLD_PATH=$PATH
-export PATH=/tmp/go/bin:$PATH
-# We are now using go 1.16
-cd $SRC/notification-controller/controllers
-cp ../fuzzing/fuzz.go ./
-rm *_test.go
-compile_go_fuzzer . Fuzz notification_fuzzer
-export PATH=$OLD_PATH
-
-# Kustomize-controller:
-cd $SRC/kustomize-controller
-sed 's/filippo.io\/age v1.0.0-beta7/filippo.io\/age v1.0.0/g' -i go.mod
-mv fuzz/fuzz.go ./controllers/
-cd controllers
-rm ./*_test.go
-compile_go_fuzzer . Fuzz kustomize_fuzzer
-
-# Pkg:
-cd $SRC/pkg
-mv ./fuzz/tls_fuzzer.go runtime/tls/
-mv ./fuzz/conditions_fuzzer.go ./runtime/conditions/
-go mod init pkg
-cd fuzz
-compile_go_fuzzer . FuzzUntar fuzz_untar
-compile_go_fuzzer . FuzzLibGit2Error fuzz_libgit_2_error
-compile_go_fuzzer . FuzzEventInfof fuzz_event_infof
-cd -
-
-cd ./runtime/tls
-compile_go_fuzzer . FuzzTlsConfig fuzz_tls_config
-cd -
-
-cd ./runtime/conditions
-compile_go_fuzzer . FuzzGetterConditions fuzz_getter_conditions
-compile_go_fuzzer . FuzzConditionsMatch fuzz_conditions_match
-compile_go_fuzzer . FuzzPatchApply fuzz_patch_apply
-compile_go_fuzzer . FuzzConditionsUnstructured fuzz_conditions_unstructured
-cd $SRC
+# Build the fuzzers for all cloned sub-projects 
+find "${PROJECT_ROOT}/" -type f -name oss_fuzz_build.sh | bash -e

--- a/projects/fluxcd/project.yaml
+++ b/projects/fluxcd/project.yaml
@@ -1,9 +1,10 @@
 homepage: "https://fluxcd.io/"
 main_repo: "https://github.com/fluxcd/flux2"
-primary_contact: "michael@weave.works"
+primary_contact: "cncf-flux-security@lists.cncf.io"
 auto_ccs :
   - "stefan@weave.works"
   - "hidde@weave.works"
+  - "michael@weave.works"
   - "david@adalogics.com"
   - "adam@adalogics.com"
 language: go


### PR DESCRIPTION
Changes target the official fluxcd repository now that the fuzzing implementation has been merged. It also delegates to each repository the responsibility of its own build/setup via a file called `oss_fuzz_build.sh`.

The primary contact is now the official security contact via cncf.io.