### PR TITLE
[CIFuzz] remove leading slashes from covered files

### DIFF
--- a/infra/cifuzz/affected_fuzz_targets.py
+++ b/infra/cifuzz/affected_fuzz_targets.py
@@ -90,7 +90,8 @@ def is_fuzz_target_affected(coverage, fuzz_target_path, files_changed):
     return True
 
   covered_files = [
-      os.path.normpath(covered_file) for covered_file in covered_files
+      os.path.normpath(covered_file).lstrip('/')
+      for covered_file in covered_files
   ]
   logging.info('Fuzz target %s is affected by: %s', fuzz_target, covered_files)
   for filename in files_changed:

--- a/infra/cifuzz/affected_fuzz_targets_test.py
+++ b/infra/cifuzz/affected_fuzz_targets_test.py
@@ -106,7 +106,7 @@ class IsFuzzTargetAffected(unittest.TestCase):
       self.assertTrue(
           affected_fuzz_targets.is_fuzz_target_affected(
               coverage, self.fuzz_target_path,
-              ['/src/systemd/src/basic/alloc-util.c']))
+              ['src/systemd/src/basic/alloc-util.c']))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Paths to files changed in PRs are relative so leading slashes should
be removed to make it possible to compare those paths.

Closes https://github.com/google/oss-fuzz/issues/7011