### PR TITLE
simd: force use of a single CPU during compilation

### DIFF
--- a/projects/simd/build.sh
+++ b/projects/simd/build.sh
@@ -19,7 +19,9 @@
 mkdir build && cd build
 cmake ../prj/cmake \
 	-DCMAKE_BUILD_TYPE="Release"
-make -j$(nproc)
+
+# Force simd to only use a single core, as otherwise memory will be exhausted
+make -j1
 
 $CXX $CXXFLAGS -I/src/Simd/src -O3 -DNDEBUG -fPIC \
         -c $SRC/simd_load_fuzzer.cpp -o simd_load_fuzzer.o \

--- a/projects/simd/project.yaml
+++ b/projects/simd/project.yaml
@@ -6,5 +6,4 @@ auto_ccs:
 sanitizers:
   - address
   - undefined
-  - memory
 main_repo: 'https://github.com/ermig1979/Simd'


### PR DESCRIPTION
should fix build failure