### PR TITLE
[bazel-rules-fuzzing-test] Build with last_green Bazel

### DIFF
--- a/projects/bazel-rules-fuzzing-test-java/build.sh
+++ b/projects/bazel-rules-fuzzing-test-java/build.sh
@@ -24,4 +24,6 @@
 # rules_fuzzing.
 export BAZEL_EXTRA_BUILD_FLAGS="--//fuzzing:cc_engine=@rules_fuzzing_oss_fuzz//:oss_fuzz_engine"
 
+export USE_BAZEL_VERSION="last_green"
+
 bazel_build_fuzz_tests

--- a/projects/bazel-rules-fuzzing-test/build.sh
+++ b/projects/bazel-rules-fuzzing-test/build.sh
@@ -24,4 +24,6 @@
 # rules_fuzzing.
 export BAZEL_EXTRA_BUILD_FLAGS="--//fuzzing:cc_engine=@rules_fuzzing_oss_fuzz//:oss_fuzz_engine"
 
+export USE_BAZEL_VERSION="last_green"
+
 bazel_build_fuzz_tests


### PR DESCRIPTION
This will help rules_fuzzing catch bugs caused by newer versions of
Bazel in its CI runs.

More context at:
https://github.com/bazelbuild/rules_fuzzing/issues/193#issuecomment-1016661774