### PR TITLE
update Kubernetes contacts

### DIFF
--- a/projects/kubernetes/project.yaml
+++ b/projects/kubernetes/project.yaml
@@ -3,6 +3,7 @@ primary_contact: "security@kubernetes.io"
 auto_ccs :
   - "adam@adalogics.com"
   - "david@adalogics.com"
+  - "mikedanese@google.com"
   - "tabitha.c.sable@gmail.com"
 fuzzing_engines:
   - libfuzzer

--- a/projects/kubernetes/project.yaml
+++ b/projects/kubernetes/project.yaml
@@ -1,8 +1,9 @@
 homepage: "https://kubernetes.io"
-primary_contact: "mikedanese@google.com"
+primary_contact: "security@kubernetes.io"
 auto_ccs :
   - "adam@adalogics.com"
   - "david@adalogics.com"
+  - "tabitha.c.sable@gmail.com"
 fuzzing_engines:
   - libfuzzer
 sanitizers:


### PR DESCRIPTION
The primary contact for Kubernetes should be the official vulnerability reporting email address, `security@kubernetes.io`.

Adding myself as an auto-CC so that I may view details in my role as SRC member.