### PR TITLE
[libpsl] Fix build

### DIFF
--- a/projects/libpsl/Dockerfile
+++ b/projects/libpsl/Dockerfile
@@ -42,4 +42,4 @@ RUN wget https://github.com/unicode-org/icu/releases/download/release-59-2/icu4c
 RUN git clone --depth=1 --recursive https://github.com/rockdaboot/libpsl.git
 
 WORKDIR libpsl
-COPY build.sh config.site $SRC/
+COPY build.sh config.site md5sum $SRC/

--- a/projects/libpsl/build.sh
+++ b/projects/libpsl/build.sh
@@ -86,7 +86,7 @@ for build in $builds; do
   fi
   # older m4 iconv detection has memleaks, so switch leak detection off
   ASAN_OPTIONS=detect_leaks=0 UBSAN_OPTIONS=detect_leaks=0 \
-    ./configure --enable-static --disable-shared --disable-gtk-doc $BUILD_FLAGS --prefix=$DEPS_PATH
+    ./configure --enable-fuzzing --enable-static --disable-shared --disable-gtk-doc $BUILD_FLAGS --prefix=$DEPS_PATH
   make clean
   make -j
   make -j check

--- a/projects/libpsl/config.site
+++ b/projects/libpsl/config.site
@@ -1,5 +1,5 @@
 if test "$cache_file" = /dev/null; then
   hash=`echo $LIBS $CPPFLAGS CXXFLAGS $CFLAGS $LDFLAGS $build_alias $host_alias $target_alias \
-    | md5sum | cut -d' ' -f1`
+    | $SRC/md5sum`
   cache_file=$SRC/config.cache.$CC.$hash
 fi

--- a/projects/libpsl/md5sum
+++ b/projects/libpsl/md5sum
@@ -1,0 +1,31 @@
+#!/usr/local/bin/python3
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import hashlib
+
+BUFSIZE = 4096
+
+if __name__ == "__main__":
+    sys.stdin  = sys.stdin.detach()
+    m = hashlib.md5()
+    while True:
+        data = sys.stdin.read(BUFSIZE)
+        if not data:
+            break
+        m.update(data)
+
+    print(m.hexdigest())


### PR DESCRIPTION
This PR adds the new `--enable-fuzzing` to the `./configure` command line (without it, the oss-fuzz build breaks).

As a little cleanup I added a python3 script `md5sum` as that is much leaner than adding the coreutils package. `md5sum` is used in `config.site` to speed up the configure run via caching.
