### PR TITLE
Ensure VLA of zero size is never created in LLVMFuzzerTestOneInput().

### DIFF
--- a/projects/lzo/lzo_compress_target.c
+++ b/projects/lzo/lzo_compress_target.c
@@ -41,7 +41,7 @@ extern int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
      * we must provide a little more output space in case that compression
      * is not possible.
     */
-    unsigned char __LZO_MMODEL in[size];
+    unsigned char __LZO_MMODEL in[size > 0 ? size : 1];
     unsigned char __LZO_MMODEL out[size + size/16 + 64 + 3];
 
     static bool isInit = false;


### PR DESCRIPTION
Some fuzzing drivers invoke this function with zero size, which causes creation of a zero-size VLA (variable-length array). In C99 VLA size must not be zero. Clang started enforcing this in https://github.com/llvm/llvm-project/commit/b2715660ed0f821619f51158fb92cd8bddd105d8 (when compiled with -fsanitize=vla-bound).