### PR TITLE
Fix OpenSK build problem (nightly version)

### DIFF
--- a/projects/opensk/build.sh
+++ b/projects/opensk/build.sh
@@ -19,7 +19,7 @@ FUZZ_TARGET_OUTPUT_DIR=fuzz/target/x86_64-unknown-linux-gnu/release
 
 # do not use override toolchain
 # cf https://rust-lang.github.io/rustup/overrides.html
-export RUSTUP_TOOLCHAIN=nightly
+export RUSTUP_TOOLCHAIN=nightly-2021-03-25
 
 build_and_copy() {
   pushd "$1"

--- a/projects/opensk/build.sh
+++ b/projects/opensk/build.sh
@@ -19,7 +19,7 @@ FUZZ_TARGET_OUTPUT_DIR=fuzz/target/x86_64-unknown-linux-gnu/release
 
 # do not use override toolchain
 # cf https://rust-lang.github.io/rustup/overrides.html
-export RUSTUP_TOOLCHAIN=nightly-2021-03-25
+export RUSTUP_TOOLCHAIN=nightly-2021-11-01
 
 build_and_copy() {
   pushd "$1"


### PR DESCRIPTION
The bug occured first in our [GitHub workflow](https://github.com/google/OpenSK/pull/424), and was then [automatically reported](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=43876). OpenSK pins the nightly for its builds, and that is necessary for the build script here as well.