### PR TITLE
Improve xpdf's PDF fuzzer

### DIFF
--- a/projects/xpdf/Dockerfile
+++ b/projects/xpdf/Dockerfile
@@ -15,8 +15,8 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install software-properties-common -y && apt-get update && apt-add-repository ppa:rock-core/qt4 && apt-get install -y make wget cmake libqt4-dev
-RUN wget --no-check-certificate https://dl.xpdfreader.com/xpdf-latest.tar.gz
+RUN apt-get update && apt-get install software-properties-common -y && apt-get update && apt-get install -y make wget cmake libpng-dev libfreetype-dev zlib1g-dev
+RUN wget https://dl.xpdfreader.com/xpdf-latest.tar.gz
 
 WORKDIR $SRC
 COPY fuzz_*.cc $SRC/

--- a/projects/xpdf/build.sh
+++ b/projects/xpdf/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 # Unpack the file and cd into it
-tar -zxvf xpdf-latest.tar.gz
+tar -zxf xpdf-latest.tar.gz
 dir_name=`tar -tzf xpdf-latest.tar.gz | head -1 | cut -f1 -d"/"`
 cd $dir_name
 
@@ -26,7 +26,9 @@ sed -i 's/#--- object files needed by XpdfWidget/add_library(testXpdfStatic STAT
 # Build the project
 mkdir build && cd build
 export LD=$CXX
-cmake ../ -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS"
+cmake ../ -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+  -DOPI_SUPPORT=ON -DMULTITHREADED=0 -DCMAKE_DISABLE_FIND_PACKAGE_Qt4=1 \
+  -DCMAKE_DISABLE_FIND_PACKAGE_Qt5Widgets=1 -DSPLASH_CMYK=ON
 make -i || true
 
 # Build fuzzers

--- a/projects/xpdf/fuzz_pdfload.cc
+++ b/projects/xpdf/fuzz_pdfload.cc
@@ -43,9 +43,32 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         if (doc->isOk() == gTrue)
         {
             doc->getNumPages();
+            doc->getOutline();
+            doc->getStructTreeRoot();
+            doc->getXRef();
+            doc->readMetadata();
+
+            Object info;
+            doc->getDocInfo(&info);
+            if (info.isDict()) {
+              info.getDict();
+            }
+            info.free();
+
             if ((acroForm = doc->getCatalog()->getAcroForm())->isDict()) {
                 acroForm->dictLookup("XFA", &xfa);
                 xfa.free();
+            }
+
+            for (size_t i = 0; i < doc->getNumPages(); i++) {
+              doc->getLinks(i);
+              auto page = doc->getCatalog()->getPage(i);
+              if (!page->isOk()) {
+                continue;
+              }
+              page->getResourceDict();
+              page->getMetadata();
+              page->getResourceDict();
             }
         }
     } catch (...) {


### PR DESCRIPTION
- Check the certificate when downloading the source code archive
- Don't use Qt, since it's only used for the xpdf GUI
- Be less verbose when unpacking the xpdf source code
- Install libpng, freetype and zlib to increase coverage
- Explicitly disable multithreading
- Exercise more codepaths