### PR TITLE
Clean up build infra issues.

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -142,10 +142,6 @@ RUN cd $SRC && \
 COPY precompile_afl /usr/local/bin/
 RUN precompile_afl
 
-RUN git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
-    cd fuzz-introspector && \
-    git checkout 9e3393cd551b65a6bf2de6495013b415f315f74e
-
 COPY precompile_honggfuzz /usr/local/bin/
 RUN precompile_honggfuzz
 

--- a/infra/base-images/base-builder/install_python.sh
+++ b/infra/base-images/base-builder/install_python.sh
@@ -17,5 +17,5 @@
 
 echo "ATHERIS INSTALL"
 unset CFLAGS CXXFLAGS
-pip3 install -v --no-cache-dir atheris>=2.0.6 pyinstaller==4.1
+pip3 install -v --no-cache-dir "atheris>=2.0.6" "pyinstaller==4.1"
 rm -rf /tmp/*

--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -23,7 +23,7 @@ ENV INTROSPECTOR_PATCHES=$introspector
 
 # Install newer cmake.
 ENV CMAKE_VERSION 3.21.1
-RUN apt-get update && apt-get install -y wget sudo git && \
+RUN apt-get update && apt-get install -y wget sudo && \
     wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
     chmod +x cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
     ./cmake-$CMAKE_VERSION-Linux-x86_64.sh --skip-license --prefix="/usr/local" && \
@@ -31,9 +31,11 @@ RUN apt-get update && apt-get install -y wget sudo git && \
     SUDO_FORCE_REMOVE=yes apt-get remove --purge -y wget sudo && \
     rm -rf /usr/local/doc/cmake /usr/local/bin/cmake-gui
 
-RUN git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
+RUN apt-get update && apt-get install -y git && \
+    git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
     cd fuzz-introspector && \
-    git checkout 9e3393cd551b65a6bf2de6495013b415f315f74e
+    git checkout 9e3393cd551b65a6bf2de6495013b415f315f74e && \
+    apt-get remove --purge -y git
 
 COPY checkout_build_install_llvm.sh /root/
 # Keep all steps in the same script to decrease the number of intermediate

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -101,9 +101,9 @@ echo "Using LLVM revision: $LLVM_REVISION"
 if [ -n "$INTROSPECTOR_PATCHES" ]; then
   # For fuzz introspector.
   echo "Applying introspector changes"
-  BBBASE=$PWD
-  cd $LLVM_SRC 
-  cp -rf /fuzz-introspector/llvm/include/llvm/Transforms/Inspector/ ./llvm/include/llvm/Transforms//Inspector
+  OLD_WORKING_DIR=$PWD
+  cd $LLVM_SRC
+  cp -rf /fuzz-introspector/llvm/include/llvm/Transforms/Inspector/ ./llvm/include/llvm/Transforms/Inspector
   cp -rf /fuzz-introspector/llvm/lib/Transforms/Inspector ./llvm/lib/Transforms/Inspector
 
   # LLVM currently does not support dynamically loading LTO passes. Thus,
@@ -113,7 +113,7 @@ if [ -n "$INTROSPECTOR_PATCHES" ]; then
   sed -i 's/using namespace/#include "llvm\/Transforms\/Inspector\/Inspector.h"\nusing namespace/g' ./llvm/lib/Transforms/IPO/PassManagerBuilder.cpp
   echo "add_subdirectory(Inspector)" >> ./llvm/lib/Transforms/CMakeLists.txt
   sed -i 's/Instrumentation/Instrumentation\n  Inspector/g' ./llvm/lib/Transforms/IPO/CMakeLists.txt
-  cd $BBBASE  
+  cd $OLD_WORKING_DIR
 fi
 
 # Build & install.


### PR DESCRIPTION
0. Don't clone fuzz-introspector to /src since it breaks builds.
1. Install packages in python install script properly. Previously
pip install atheris>=2.0.6 was interpreted as "redirect the output
from pip install atheris" to the file "=2.0.6".
3. Clean up some miscellanious issues.