### PR TITLE
Fix urllib3 install procedure

### DIFF
--- a/projects/urllib3/build.sh
+++ b/projects/urllib3/build.sh
@@ -15,7 +15,7 @@
 #
 ################################################################################
 
-pip install .
+python3 -m pip install .
 
 # Build fuzzers in $OUT.
 for fuzzer in $(find $SRC -name 'fuzz_*.py'); do

--- a/projects/urllib3/build.sh
+++ b/projects/urllib3/build.sh
@@ -15,7 +15,7 @@
 #
 ################################################################################
 
-python3 setup.py install
+pip install .
 
 # Build fuzzers in $OUT.
 for fuzzer in $(find $SRC -name 'fuzz_*.py'); do


### PR DESCRIPTION
We switched from setuptools to Flit, and running setup.py is deprecated anyway.