### PR TITLE
spidermonkey: fix build by avoiding eternal loop

### DIFF
--- a/projects/spidermonkey/build.sh
+++ b/projects/spidermonkey/build.sh
@@ -22,7 +22,9 @@ rustup default nightly
 # Install dependencies.
 export MOZBUILD_STATE_PATH=/root/.mozbuild
 export SHELL=/bin/bash
-../../mach --no-interactive bootstrap --application-choice browser
+cd ../../
+./mach --no-interactive bootstrap --application-choice browser
+cd js/src/
 
 autoconf2.13
 


### PR DESCRIPTION
An eternal loop exists here https://github.com/mozilla/gecko-dev/blob/78963fe42f8d5f582f84da84a5e78377b6c1fc32/python/mozboot/mozboot/bootstrap.py#L527-L558 which is triggered in the current build set up. This fixes it.