### PR TITLE
Fuzz introspector build fixes.

### DIFF
--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -216,7 +216,7 @@ if [ "$SANITIZER" = "introspector" ]; then
   fi  
   
   cd $SRC/inspector
-  python3 $SRC/fuzz-introspector/post-processing/main.py --target_dir=$SRC/inspector --git_repo_url=$GIT_REPO --coverage_url=$COVERAGE_URL
+  python3 /fuzz-introspector/post-processing/main.py --target_dir=$SRC/inspector --git_repo_url=$GIT_REPO --coverage_url=$COVERAGE_URL
 
   cp -rf $SRC/inspector $OUT/inspector
 fi

--- a/infra/build/functions/build_and_run_coverage.py
+++ b/infra/build/functions/build_and_run_coverage.py
@@ -34,7 +34,7 @@ ARCHITECTURE = 'x86_64'
 PLATFORM = 'linux'
 
 COVERAGE_BUILD_TYPE = 'coverage'
-INTROSPECTOR_BUILD_TYPE = 'fuzz_introspector'
+INTROSPECTOR_BUILD_TYPE = 'introspector'
 
 # This is needed for ClusterFuzz to pick up the most recent reports data.
 

--- a/infra/build/functions/deploy.sh
+++ b/infra/build/functions/deploy.sh
@@ -106,12 +106,6 @@ deploy_scheduler $BASE_IMAGE_SCHEDULER_JOB \
 				  "$BASE_IMAGE_MESSAGE" \
 				  $PROJECT_ID
 
-deploy_scheduler $UPDATE_BUILD_SCHEDULER_JOB-introspector \
-				 "$UPDATE_BUILD_JOB_SCHEDULE" \
-				 $UPDATE_BUILD_JOB_TOPIC \
-				 "introspector" \
-				 $PROJECT_ID
-
 deploy_cloud_function sync \
 					  sync \
 					  $SYNC_JOB_TOPIC \

--- a/infra/build/functions/project_sync.py
+++ b/infra/build/functions/project_sync.py
@@ -37,6 +37,7 @@ MAX_BUILDS_PER_DAY = 4
 COVERAGE_SCHEDULE = '0 6 * * *'
 FUZZING_BUILD_TOPIC = 'request-build'
 COVERAGE_BUILD_TOPIC = 'request-coverage-build'
+INTROSPECTOR_BUILD_TOPIC = 'request-introspector-build'
 
 ProjectMetadata = namedtuple(
     'ProjectMetadata', 'schedule project_yaml_contents dockerfile_contents')
@@ -95,7 +96,8 @@ def delete_project(cloud_scheduler_client, project):
   """Delete the given project."""
   logging.info('Deleting project %s', project.name)
   for tag in (build_project.FUZZING_BUILD_TYPE,
-              build_and_run_coverage.COVERAGE_BUILD_TYPE):
+              build_and_run_coverage.COVERAGE_BUILD_TYPE,
+              build_and_run_coverage.INTROSPECTOR_BUILD_TYPE):
     try:
       delete_scheduler(cloud_scheduler_client, project.name, tag)
     except exceptions.NotFound:
@@ -128,6 +130,9 @@ def sync_projects(cloud_scheduler_client, projects):
       create_scheduler(cloud_scheduler_client, project_name, COVERAGE_SCHEDULE,
                        build_and_run_coverage.COVERAGE_BUILD_TYPE,
                        COVERAGE_BUILD_TOPIC)
+      create_scheduler(cloud_scheduler_client, project_name, COVERAGE_SCHEDULE,
+                       build_and_run_coverage.INTROSPECTOR_BUILD_TYPE,
+                       INTROSPECTOR_BUILD_TOPIC)
       project_metadata = projects[project_name]
       Project(name=project_name,
               schedule=project_metadata.schedule,

--- a/infra/build/functions/project_sync_test.py
+++ b/infra/build/functions/project_sync_test.py
@@ -93,7 +93,7 @@ class CloudSchedulerClient:
   def update_job(self, job, update_mask):
     """Simulate update jobs."""
     for existing_job in self.schedulers:
-      if existing_job == job:
+      if existing_job == job and 'schedule' in update_mask:
         job['schedule'] = update_mask['schedule']
 
 
@@ -159,6 +159,37 @@ class TestDataSync(unittest.TestCase):
       }, {project.name: project.schedule for project in projects_query})
 
       self.assertCountEqual([
+          {
+              'name': 'projects/test-project/location/us-central1/jobs/'
+                      'test1-scheduler-fuzzing',
+              'pubsub_target': {
+                  'topic_name': 'projects/test-project/topics/request-build',
+                  'data': b'test1'
+              },
+              'schedule': '0 8 * * *'
+          },
+          {
+              'name': 'projects/test-project/location/us-central1/jobs/'
+                      'test1-scheduler-coverage',
+              'pubsub_target': {
+                  'topic_name':
+                      'projects/test-project/topics/request-coverage-build',
+                  'data':
+                      b'test1'
+              },
+              'schedule': '0 6 * * *'
+          },
+          {
+              'name': 'projects/test-project/location/us-central1/jobs/'
+                      'test1-scheduler-introspector',
+              'pubsub_target': {
+                  'topic_name':
+                      'projects/test-project/topics/request-introspector-build',
+                  'data':
+                      b'test1'
+              },
+              'schedule': '0 6 * * *'
+          },
           {
               'name': 'projects/test-project/location/us-central1/jobs/'
                       'test2-scheduler-fuzzing',

--- a/infra/build/functions/project_sync_test.py
+++ b/infra/build/functions/project_sync_test.py
@@ -179,6 +179,17 @@ class TestDataSync(unittest.TestCase):
               },
               'schedule': '0 6 * * *'
           },
+          {
+              'name': 'projects/test-project/location/us-central1/jobs/'
+                      'test2-scheduler-introspector',
+              'pubsub_target': {
+                  'topic_name':
+                      'projects/test-project/topics/request-introspector-build',
+                  'data':
+                      b'test2'
+              },
+              'schedule': '0 6 * * *'
+          },
       ], cloud_scheduler_client.schedulers)
 
   def test_sync_projects_delete(self):


### PR DESCRIPTION
- Point `compile` to the right `fuzz-introspector` location (since it's no longer checked out in $SRC).
- Rename build tag to "introspector" to be more consistent with other
  tags.
- Fix bad merge in deploy.sh script.
- Add introspector setup to project sync.
- Enable more logging for project sync cron.