### PR TITLE
[skia] Compile Vulkan Swiftshader instead of OpenGL ES

### DIFF
--- a/projects/skia/Dockerfile
+++ b/projects/skia/Dockerfile
@@ -16,8 +16,8 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 
-# Mesa and libz/zlib needed to build swiftshader
-RUN apt-get update && apt-get install -y python wget libglu1-mesa-dev cmake lib32z1-dev zlib1g-dev libxext-dev
+# Mesa,libz/zlib, and xcb needed to build swiftshader
+RUN apt-get update && apt-get install -y python wget libglu1-mesa-dev cmake lib32z1-dev zlib1g-dev libxext-dev libxcb-shm0-dev
 
 RUN git clone 'https://chromium.googlesource.com/chromium/tools/depot_tools.git' --depth 1
 ENV PATH="${SRC}/depot_tools:${PATH}"

--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -15,57 +15,15 @@
 #
 ################################################################################
 
-# Build SwiftShader
-pushd third_party/externals/swiftshader/
-export SWIFTSHADER_INCLUDE_PATH=$PWD/include
-# SwiftShader already has a build/ directory, use something else
-rm -rf build_swiftshader
-mkdir build_swiftshader
-
-cd build_swiftshader
-if [ $SANITIZER == "address" ]; then
-  CMAKE_SANITIZER="SWIFTSHADER_ASAN"
-elif [ $SANITIZER == "memory" ]; then
-  CMAKE_SANITIZER="SWIFTSHADER_MSAN"
-  # oss-fuzz will patch the rpath for this after compilation and linking,
-  # so we only need to set this to appease the Swiftshader build rules check.
-  export SWIFTSHADER_MSAN_INSTRUMENTED_LIBCXX_PATH="/does/not/matter"
-elif [ $SANITIZER == "undefined" ]; then
-  # The current SwiftShader build needs -fno-sanitize=vptr, but it cannot be
-  # specified here since -fsanitize=undefined will always come after any
-  # user specified flags passed to cmake. SwiftShader does not need to be
-  # built with the undefined sanitizer in order to fuzz Skia, so don't.
-  CMAKE_SANITIZER="SWIFTSHADER_UBSAN_DISABLED"
-elif [ $SANITIZER == "coverage" ]; then
-  CMAKE_SANITIZER="SWIFTSHADER_EMIT_COVERAGE"
-elif [ $SANITIZER == "thread" ]; then
-  CMAKE_SANITIZER="SWIFTSHADER_UBSAN_DISABLED"
-else
-  exit 1
-fi
-# These deprecated warnings get quite noisy and mask other issues.
-CFLAGS= CXXFLAGS="-stdlib=libc++ -Wno-deprecated-declarations" cmake .. -GNinja \
-  -DCMAKE_MAKE_PROGRAM="$SRC/depot_tools/ninja" -D$CMAKE_SANITIZER=1
-
-$SRC/depot_tools/ninja libGLESv2_deprecated libEGL_deprecated
-# Skia is looking for the names w/o the _deprecated tag. The libraries themselves
-# are looking for the _deprecated suffix, so we copy them both ways into the out
-# directory.
-cp libEGL_deprecated.so $OUT/libEGL.so
-cp libGLESv2_deprecated.so $OUT/libGLESv2.so
-mv libGLESv2_deprecated.so libEGL_deprecated.so $OUT
-export SWIFTSHADER_LIB_PATH=$OUT
-
-popd
 # These are any clang warnings we need to silence.
 DISABLE="-Wno-zero-as-null-pointer-constant -Wno-unused-template
          -Wno-cast-qual"
 # Disable UBSan vptr since target built with -fno-rtti.
-export CFLAGS="$CFLAGS $DISABLE -I$SWIFTSHADER_INCLUDE_PATH -DGR_EGL_TRY_GLES3_THEN_GLES2\
+export CFLAGS="$CFLAGS $DISABLE -DGR_EGL_TRY_GLES3_THEN_GLES2\
  -fno-sanitize=vptr -DSK_BUILD_FOR_LIBFUZZER"
-export CXXFLAGS="$CXXFLAGS $DISABLE -I$SWIFTSHADER_INCLUDE_PATH -DGR_EGL_TRY_GLES3_THEN_GLES2\
+export CXXFLAGS="$CXXFLAGS $DISABLE -DGR_EGL_TRY_GLES3_THEN_GLES2\
  -fno-sanitize=vptr -DSK_BUILD_FOR_LIBFUZZER"
-export LDFLAGS="$LIB_FUZZING_ENGINE $CXXFLAGS -L$SWIFTSHADER_LIB_PATH"
+export LDFLAGS="$LIB_FUZZING_ENGINE $CXXFLAGS"
 
 # This splits a space separated list into a quoted, comma separated list for gn.
 export CFLAGS_ARR=`echo $CFLAGS | sed -e "s/\s/\",\"/g"`
@@ -74,13 +32,8 @@ export LDFLAGS_ARR=`echo $LDFLAGS | sed -e "s/\s/\",\"/g"`
 
 $SRC/skia/bin/fetch-gn
 
-set +u
+# Prevent OOMs caused by linking too many things at once.
 LIMITED_LINK_POOL="link_pool_depth=1"
-if [ "$CIFUZZ" = "true" ]; then
-  echo "Not restricting linking because on CIFuzz"
-  LIMITED_LINK_POOL=""
-fi
-set -u
 
 SKIA_ARGS="skia_build_fuzzers=true
            skia_enable_fontmgr_custom_directory=false

--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -15,7 +15,8 @@
 #
 ################################################################################
 
-# Build SwiftShader
+# Build SwiftShader so we can compile in our GPU code and test it in an
+# an environment that does not have a real GPU.
 pushd third_party/externals/swiftshader/
 export SWIFTSHADER_INCLUDE_PATH=$PWD/include
 # SwiftShader already has a build/ directory, use something else
@@ -45,15 +46,11 @@ else
 fi
 # These deprecated warnings get quite noisy and mask other issues.
 CFLAGS= CXXFLAGS="-stdlib=libc++ -Wno-deprecated-declarations" cmake .. -GNinja \
-  -DCMAKE_MAKE_PROGRAM="$SRC/depot_tools/ninja" -D$CMAKE_SANITIZER=1
+  -DCMAKE_MAKE_PROGRAM="$SRC/depot_tools/ninja" -D$CMAKE_SANITIZER=1 -DSWIFTSHADER_WARNINGS_AS_ERRORS=FALSE
 
-$SRC/depot_tools/ninja libGLESv2_deprecated libEGL_deprecated
-# Skia is looking for the names w/o the _deprecated tag. The libraries themselves
-# are looking for the _deprecated suffix, so we copy them both ways into the out
-# directory.
-cp libEGL_deprecated.so $OUT/libEGL.so
-cp libGLESv2_deprecated.so $OUT/libGLESv2.so
-mv libGLESv2_deprecated.so libEGL_deprecated.so $OUT
+# Swiftshader only supports Vulkan, so we will build our fuzzers with Vulkan too.
+$SRC/depot_tools/ninja libvk_swiftshader.so
+mv libvk_swiftshader.so $OUT
 export SWIFTSHADER_LIB_PATH=$OUT
 
 popd
@@ -61,9 +58,10 @@ popd
 DISABLE="-Wno-zero-as-null-pointer-constant -Wno-unused-template
          -Wno-cast-qual"
 # Disable UBSan vptr since target built with -fno-rtti.
-export CFLAGS="$CFLAGS $DISABLE -I$SWIFTSHADER_INCLUDE_PATH -DGR_EGL_TRY_GLES3_THEN_GLES2\
+export CFLAGS="$CFLAGS $DISABLE -I$SWIFTSHADER_INCLUDE_PATH \
+ -DSK_GPU_TOOLS_VK_LIBRARY_NAME=libvk_swiftshader.so \
  -fno-sanitize=vptr -DSK_BUILD_FOR_LIBFUZZER"
-export CXXFLAGS="$CXXFLAGS $DISABLE -I$SWIFTSHADER_INCLUDE_PATH -DGR_EGL_TRY_GLES3_THEN_GLES2\
+export CXXFLAGS="$CXXFLAGS $DISABLE -I$SWIFTSHADER_INCLUDE_PATH \
  -fno-sanitize=vptr -DSK_BUILD_FOR_LIBFUZZER"
 export LDFLAGS="$LIB_FUZZING_ENGINE $CXXFLAGS -L$SWIFTSHADER_LIB_PATH"
 
@@ -74,13 +72,8 @@ export LDFLAGS_ARR=`echo $LDFLAGS | sed -e "s/\s/\",\"/g"`
 
 $SRC/skia/bin/fetch-gn
 
-set +u
+# Avoid OOMs on the CI due to lower memory constraints
 LIMITED_LINK_POOL="link_pool_depth=1"
-if [ "$CIFUZZ" = "true" ]; then
-  echo "Not restricting linking because on CIFuzz"
-  LIMITED_LINK_POOL=""
-fi
-set -u
 
 SKIA_ARGS="skia_build_fuzzers=true
            skia_enable_fontmgr_custom_directory=false
@@ -88,7 +81,7 @@ SKIA_ARGS="skia_build_fuzzers=true
            skia_enable_fontmgr_custom_empty=true
            skia_enable_gpu=true
            skia_enable_skottie=true
-           skia_use_egl=true
+           skia_use_vulkan=true
            skia_use_fontconfig=false
            skia_use_freetype=true
            skia_use_system_freetype2=false

--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -82,6 +82,8 @@ SKIA_ARGS="skia_build_fuzzers=true
            skia_enable_gpu=true
            skia_enable_skottie=true
            skia_use_vulkan=true
+           skia_use_egl=false
+           skia_use_gl=false
            skia_use_fontconfig=false
            skia_use_freetype=true
            skia_use_system_freetype2=false


### PR DESCRIPTION
Addresses https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=44132

The legacy OpenGL ES targets were removed in https://swiftshader.googlesource.com/SwiftShader.git/+/4625f84e8d56feaf9ba0122f49a04f9cccbad909

I experimented with removing the swiftshader build entirely and the skia fuzzers appear to still compile, link, and run locally, but that did not translate to actually running the fuzzers in the runtime container.

Using the Vulkan endpoints, just like we do in [Skia proper](https://skia-review.googlesource.com/c/skia/+/437149), is a better solution.

Procedure for testing this locally (and iterating):
  1. In oss-fuzz checkout, run `python infra/helper.py shell skia` to pull up local interactive version of Dockerfuzzer build image.
  2. Run `compile` in fuzzer shell. Stop after the swiftshader compiles and is copied into /out with Ctrl + C.
  3. Comment out the [swiftshader compilation part ](https://github.com/google/oss-fuzz/pull/7214/files#diff-76f13875e33875cdd372f1f0933206be599cd87952f1bd1eaa57ca928ee9e3e1R49-R53) (no need to re-do this when modifying Skia code).
     `apt-get install nano -y`
     `nano ../build.sh`
  4. Make change to Skia repo using normal methods.
  5. Run the following in the Skia repo
     `git diff origin main > foo.patch`
     Copy the patch into the Docker shell using Ctrl+C and nano.
  6. Apply the patch inside the Docker shell
     `git apply foo.patch`
     and re-compile (which should skip right to building the fuzzer libs)
     `compile`
  7. Repeat 4-7 or make small changes directly in the Docker shell via nano.
  8. When compilation and link succeeds, run `ldd /out/api_mock_gpu_canvas` to verify GL and friends were not dynamically linked.