### PR TITLE
Add Code Intelligence go114-fuzz-build fork

### DIFF
--- a/infra/base-images/base-builder/install_go_CodeIntelligenceTesting.sh
+++ b/infra/base-images/base-builder/install_go_CodeIntelligenceTesting.sh
@@ -31,6 +31,6 @@ mv -f /tmp/.go-CodeIntelligenceTesting /root/.go
 # Install go114-fuzz-build with the new Go.
 rm -rf "$GOPATH/"
 mkdir -p "$GOPATH/"
-go install github.com/mdempsky/go114-fuzz-build@latest
+go install github.com/CodeIntelligenceTesting/go114-fuzz-build@latest
 ln -s "$GOPATH/bin/go114-fuzz-build" "$GOPATH/bin/go-fuzz"
 


### PR DESCRIPTION
The patched Go version adds a new runtime function `runtime.LibfuzzerInitializeCounters()` to register 8bit counters when initializing the fuzz target. This is needed to register those counters with libFuzzer and get real edge coverage and is implemented in the provided fork. The change is meant to be a temporary change until the Go patches are accepted upstream. Then, we will create a pull request for go114-fuzz-build