### PR TITLE
[build] Don't assume textcov reports exist for non-C/C++ projects

### DIFF
--- a/infra/build/functions/build_and_run_coverage.py
+++ b/infra/build/functions/build_and_run_coverage.py
@@ -189,21 +189,21 @@ def get_build_steps(  # pylint: disable=too-many-locals, too-many-arguments
       ],
   })
 
-  # Upload the text coverage reports. Delete the old ones just in case.
-  upload_textcov_reports_url = bucket.get_upload_url('textcov_reports')
+  if project.language.lower() in {'c': 'c++'}:
+    # Upload the text coverage reports. Delete the old ones just in case.
+    upload_textcov_reports_url = bucket.get_upload_url('textcov_reports')
 
-  build_steps.append(build_lib.gsutil_rm_rf_step(upload_textcov_reports_url))
-  build_steps.append({
-      'name':
-          'gcr.io/cloud-builders/gsutil',
-      'args': [
-          '-m',
-          'cp',
-          '-r',
-          os.path.join(build.out, 'textcov_reports'),
-          upload_textcov_reports_url,
-      ],
-  })
+    build_steps.append(build_lib.gsutil_rm_rf_step(upload_textcov_reports_url))
+    build_steps.append({
+        'name': 'gcr.io/cloud-builders/gsutil',
+        'args': [
+            '-m',
+            'cp',
+            '-r',
+            os.path.join(build.out, 'textcov_reports'),
+            upload_textcov_reports_url,
+        ],
+    })
 
   # Upload the fuzzer logs. Delete the old ones just in case
   upload_fuzzer_logs_url = bucket.get_upload_url('logs')

--- a/infra/build/functions/build_and_run_coverage.py
+++ b/infra/build/functions/build_and_run_coverage.py
@@ -189,13 +189,14 @@ def get_build_steps(  # pylint: disable=too-many-locals, too-many-arguments
       ],
   })
 
-  if project.language.lower() in {'c': 'c++'}:
+  if project.fuzzing_language in LANGUAGES_WITH_INTROSPECTOR_SUPPORT:
     # Upload the text coverage reports. Delete the old ones just in case.
     upload_textcov_reports_url = bucket.get_upload_url('textcov_reports')
 
     build_steps.append(build_lib.gsutil_rm_rf_step(upload_textcov_reports_url))
     build_steps.append({
-        'name': 'gcr.io/cloud-builders/gsutil',
+        'name':
+            'gcr.io/cloud-builders/gsutil',
         'args': [
             '-m',
             'cp',


### PR DESCRIPTION
Fixes https://github.com/google/oss-fuzz/issues/7225