### PR TITLE
Setting a shorter timeout for introspector builds temporarily

### DIFF
--- a/infra/build/functions/build_project.py
+++ b/infra/build/functions/build_project.py
@@ -510,9 +510,13 @@ def run_build(oss_fuzz_project,
     options = DEFAULT_GCB_OPTIONS
 
   tags = [oss_fuzz_project + '-' + build_type, build_type, oss_fuzz_project]
+  timeout_value = build_lib.BUILD_TIMEOUT
+  # TODO (navidem): this is temporary until I fix shorter failing projects
+  if build_type == 'introspector':
+    timeout_value /= 4
   build_body = {
       'steps': build_steps,
-      'timeout': str(build_lib.BUILD_TIMEOUT) + 's',
+      'timeout': str(timeout_value) + 's',
       'options': options,
       'logsBucket': GCB_LOGS_BUCKET,
       'tags': tags,


### PR DESCRIPTION
To address issues like #7228 where introspector builds are taking too long.
This is temporary until we fix other fast failing builds.