### PR TITLE
Separating introspector build schedule from coverage build

### DIFF
--- a/infra/build/functions/project_sync.py
+++ b/infra/build/functions/project_sync.py
@@ -35,6 +35,7 @@ VALID_PROJECT_NAME = re.compile(r'^[a-zA-Z0-9_-]+$')
 DEFAULT_BUILDS_PER_DAY = 1
 MAX_BUILDS_PER_DAY = 4
 COVERAGE_SCHEDULE = '0 6 * * *'
+INTROSPECTOR_SCHEDULE = '0 10 * * *'
 FUZZING_BUILD_TOPIC = 'request-build'
 COVERAGE_BUILD_TOPIC = 'request-coverage-build'
 INTROSPECTOR_BUILD_TOPIC = 'request-introspector-build'
@@ -132,7 +133,8 @@ def sync_projects(cloud_scheduler_client, projects):
       create_scheduler(cloud_scheduler_client, project_name, COVERAGE_SCHEDULE,
                        build_and_run_coverage.COVERAGE_BUILD_TYPE,
                        COVERAGE_BUILD_TOPIC)
-      create_scheduler(cloud_scheduler_client, project_name, COVERAGE_SCHEDULE,
+      create_scheduler(cloud_scheduler_client, project_name,
+                       INTROSPECTOR_SCHEDULE,
                        build_and_run_coverage.INTROSPECTOR_BUILD_TYPE,
                        INTROSPECTOR_BUILD_TOPIC)
     except exceptions.GoogleAPICallError as error:

--- a/infra/build/functions/project_sync_test.py
+++ b/infra/build/functions/project_sync_test.py
@@ -188,7 +188,7 @@ class TestDataSync(unittest.TestCase):
                   'data':
                       b'test1'
               },
-              'schedule': '0 6 * * *'
+              'schedule': '0 10 * * *'
           },
           {
               'name': 'projects/test-project/location/us-central1/jobs/'
@@ -219,7 +219,7 @@ class TestDataSync(unittest.TestCase):
                   'data':
                       b'test2'
               },
-              'schedule': '0 6 * * *'
+              'schedule': '0 10 * * *'
           },
       ], cloud_scheduler_client.schedulers)
 


### PR DESCRIPTION
This gives enough time for coverage build to finish and then interospector can use the coverage report. It eliminates the chance of incomplete reports on introspector when there is no coverage report. Until we implement the method for getting the latest coverage reports from GCB.