### PR TITLE
[qt] Explicitly clone qtbase

### DIFF
--- a/projects/qt/Dockerfile
+++ b/projects/qt/Dockerfile
@@ -23,6 +23,7 @@ RUN git clone --depth 1 https://github.com/AFLplusplus/AFLplusplus.git myaflplus
 RUN git clone --branch dev --depth 1 git://code.qt.io/qt/qt5.git && \
     cp -r qt5/cmake . && \
     rm -rf qt5
+RUN git clone --branch dev --depth 5000 git://code.qt.io/qt/qtbase.git
 RUN git clone --branch dev --depth 1 git://code.qt.io/qt/qtsvg.git
 RUN cmake -DSYNC_TO_MODULE=qtsvg -DSYNC_TO_BRANCH=dev -P cmake/QtSynchronizeRepo.cmake
 RUN git clone --branch dev --depth 1 git://code.qt.io/qt/qtqa.git


### PR DESCRIPTION
QtSynchronizeRepo.cmake used to do that when a dependency was
missing but since 8a94d1e it just ignores missing checkouts.

--depth 5000 clones about a year of history and reduces the size
of the repository by over 200MB. Cloning even less history would
further reduce the size by less than 15MB.