### PR TITLE
Improve the xpdf pdf fuzzer

### DIFF
--- a/projects/xpdf/Dockerfile
+++ b/projects/xpdf/Dockerfile
@@ -15,7 +15,9 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install software-properties-common -y && apt-get update && apt-get install -y make wget cmake libpng-dev libfreetype-dev zlib1g-dev
+RUN git clone --depth 1 https://gitlab.freedesktop.org/freetype/freetype
+RUN apt-get update
+RUN apt-get install --no-install-recommends -y make wget cmake qtbase5-dev libcups2-dev autoconf automake autotools-dev libtool
 RUN wget https://dl.xpdfreader.com/xpdf-latest.tar.gz
 
 WORKDIR $SRC

--- a/projects/xpdf/build.sh
+++ b/projects/xpdf/build.sh
@@ -20,23 +20,37 @@ tar -zxf xpdf-latest.tar.gz
 dir_name=`tar -tzf xpdf-latest.tar.gz | head -1 | cut -f1 -d"/"`
 cd $dir_name
 
+PREFIX=$WORK/prefix
+mkdir -p $PREFIX
+
+export PKG_CONFIG="`which pkg-config` --static"
+export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig
+export PATH=$PREFIX/bin:$PATH
+pushd $SRC/freetype
+./autogen.sh
+./configure --prefix="$PREFIX" --disable-shared PKG_CONFIG_PATH="$PKG_CONFIG_PATH" --with-png=no --with-zlib=no 
+make -j$(nproc)
+make install
+popd
+
 # Make minor change in the CMakeFiles file.
 sed -i 's/#--- object files needed by XpdfWidget/add_library(testXpdfStatic STATIC $<TARGET_OBJECTS:xpdf_objs>)\n#--- object files needed by XpdfWidget/' ./xpdf/CMakeLists.txt
+sed -i 's/#--- pdftops/add_library(testXpdfWidgetStatic STATIC $<TARGET_OBJECTS:xpdf_widget_objs>\n $<TARGET_OBJECTS:splash_objs>\n $<TARGET_OBJECTS:xpdf_objs>\n ${FREETYPE_LIBRARY}\n ${FREETYPE_OTHER_LIBS})\n#--- pdftops/' ./xpdf/CMakeLists.txt
 
 # Build the project
 mkdir build && cd build
 export LD=$CXX
 cmake ../ -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
-  -DOPI_SUPPORT=ON -DMULTITHREADED=0 -DCMAKE_DISABLE_FIND_PACKAGE_Qt4=1 \
-  -DCMAKE_DISABLE_FIND_PACKAGE_Qt5Widgets=1 -DSPLASH_CMYK=ON
-make -i || true
+  -DOPI_SUPPORT=ON -DSPLASH_CMYK=ON -DMULTITHREADED=ON \
+  -DUSE_EXCEPTIONS=ON -DXPDFWIDGET_PRINTING=ON -DFREETYPE_DIR="$PREFIX"
+make
 
 # Build fuzzers
 for fuzzer in zxdoc pdfload; do
     cp ../../fuzz_$fuzzer.cc .
     $CXX fuzz_$fuzzer.cc -o $OUT/fuzz_$fuzzer $CXXFLAGS $LIB_FUZZING_ENGINE \
-      ./xpdf/libtestXpdfStatic.a ./fofi/libfofi.a ./goo/libgoo.a \
-      -I../ -I../goo -I../fofi -I. -I../xpdf
+      ./xpdf/libtestXpdfStatic.a ./fofi/libfofi.a ./goo/libgoo.a ./splash/libsplash.a ./xpdf/libtestXpdfWidgetStatic.a /work/prefix/lib/libfreetype.a \
+      -I../ -I../goo -I../fofi -I. -I../xpdf -I../splash
 done
 
 # Copy over options files


### PR DESCRIPTION
- Do not fail silently on compilation issues
- Use a static version of freetype
- Render the PDF on a bitmap, to exercise more code paths.
  - I'm planning on adding more outputs (maybe in new fuzzers) for Postscript for example
- Exercise more metadata gathering functions
- Use a stream instead of a file, to speed the fuzzer up
- Allocate the PDFDoc on the stack instead of the heap
- Don't install recommended packages