### PR TITLE
native go fuzzing: Remove installation of dependencies

### DIFF
--- a/infra/base-images/base-builder/compile_native_go_fuzzer
+++ b/infra/base-images/base-builder/compile_native_go_fuzzer
@@ -82,9 +82,6 @@ fuzzer_filename=$(grep -r -l  -s "$function" "${abs_file_dir}")
 # Test if file contains a line with "func $function" and "testing.F".
 if [ $(grep -r "func $function" $fuzzer_filename | grep "testing.F" | wc -l) -eq 1 ]
 then
-	# Install more dependencies.
-	gotip get github.com/AdamKorcz/go-118-fuzz-build/utils
-	gotip get google.golang.org/grpc/internal/channelz@v1.42.0
 
 	rewrite_go_fuzz_harness $fuzzer_filename $function
 	build_native_go_fuzzer $fuzzer $function $abs_file_dir


### PR DESCRIPTION
Installing the dependencies in the script does not work with go projects that vendor their dependencies. Removing it for now to get the first set of Kubernetes' fuzzers working here: https://github.com/cncf/cncf-fuzzing/pull/92

Removing it from here means that users have to install them themselves. 

It is a bit annoying to do it manually (for now) but it is necessary at this stage to support vendored projects.