### PR TITLE
[igraph] install additional dependencies

### DIFF
--- a/projects/igraph/Dockerfile
+++ b/projects/igraph/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
-  pkg-config cmake bison flex
+  pkg-config cmake bison flex libxml2-dev
 RUN git clone --depth 1 --branch develop  https://github.com/igraph/igraph
 WORKDIR igraph
 RUN cp $SRC/igraph/fuzzing/build.sh $SRC/build.sh


### PR DESCRIPTION
This PR ensures that libxml2 is installed, which is a prerequisite to testing igraph's GraphML reader.