### PR TITLE
Use Go 1.18 beta 2 for base-runner to fix coverage reports.

### DIFF
--- a/infra/base-images/base-runner/Dockerfile
+++ b/infra/base-images/base-runner/Dockerfile
@@ -71,7 +71,7 @@ ENV AFL_FUZZER_ARGS="-m none"
 # Download and install the latest stable Go.
 ADD https://storage.googleapis.com/golang/getgo/installer_linux $SRC/
 RUN chmod +x $SRC/installer_linux && \
-    SHELL="bash" $SRC/installer_linux && \
+    SHELL="bash" $SRC/installer_linux -version 1.18beta2 && \
     rm $SRC/installer_linux
 
 # Set up Golang environment variables (copied from /root/.bash_profile).

--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -239,9 +239,7 @@ wait
 
 if [[ $FUZZING_LANGUAGE == "go" ]]; then
   $SYSGOPATH/bin/gocovmerge $DUMPS_DIR/*.profdata > fuzz.cov
-  # TODO(adamkorcz): Once oss-fuzz upgrades go to 1.18, 
-  # use "go" instead of "gotip":
-  gotip tool cover -html=fuzz.cov -o $REPORT_ROOT_DIR/index.html
+  go tool cover -html=fuzz.cov -o $REPORT_ROOT_DIR/index.html
   $SYSGOPATH/bin/gocovsum fuzz.cov > $SUMMARY_FILE
   cp $REPORT_ROOT_DIR/index.html $REPORT_PLATFORM_DIR/index.html
   $SYSGOPATH/bin/pprof-merge $DUMPS_DIR/*.perf.cpu.prof


### PR DESCRIPTION
Fixes #7281.