### PR TITLE
[igraph] install additional dependencies

### DIFF
--- a/projects/igraph/Dockerfile
+++ b/projects/igraph/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
-  pkg-config cmake bison flex libxml2-dev libz-dev liblzma-dev
+  pkg-config cmake bison flex libxml2-dev libxml2-dev:i386 libz-dev libz-dev:i386 liblzma-dev liblzma-dev:i386
 RUN git clone --depth 1 --branch develop  https://github.com/igraph/igraph
 RUN wget https://github.com/unicode-org/icu/releases/download/release-66-1/icu4c-66_1-src.tgz && tar xzvf icu4c-66_1-src.tgz
 WORKDIR igraph

--- a/projects/igraph/Dockerfile
+++ b/projects/igraph/Dockerfile
@@ -18,6 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
   pkg-config cmake bison flex libxml2-dev libz-dev liblzma-dev
 RUN git clone --depth 1 --branch develop  https://github.com/igraph/igraph
+RUN wget https://github.com/unicode-org/icu/releases/download/release-66-1/icu4c-66_1-src.tgz && tar xzvf icu4c-66_1-src.tgz
 WORKDIR igraph
 RUN cp $SRC/igraph/fuzzing/build.sh $SRC/build.sh
 

--- a/projects/igraph/Dockerfile
+++ b/projects/igraph/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
-  pkg-config cmake bison flex libxml2-dev
+  pkg-config cmake bison flex libxml2-dev libz-dev liblzma-dev
 RUN git clone --depth 1 --branch develop  https://github.com/igraph/igraph
 WORKDIR igraph
 RUN cp $SRC/igraph/fuzzing/build.sh $SRC/build.sh


### PR DESCRIPTION
This is to finally enable the GraphML reader in igraph, according to the suggestions in #7284