### PR TITLE
[helm] Initial integration

### DIFF
--- a/projects/helm/Dockerfile
+++ b/projects/helm/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/helm/helm
+RUN git clone --depth 1 https://github.com/cncf/cncf-fuzzing
+COPY build.sh $SRC/
+WORKDIR $SRC/helm

--- a/projects/helm/build.sh
+++ b/projects/helm/build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -eu
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+set -o nounset
+set -o pipefail
+set -o errexit
+set -x
+
+mv $SRC/cncf-fuzzing/projects/helm/strvals_fuzzer_test.go \
+   $SRC/helm/pkg/strvals/
+
+mv $SRC/cncf-fuzzing/projects/helm/ignore_fuzzer_test.go \
+   $SRC/helm/internal/ignore/
+
+
+sed 's/go 1.16/go 1.18/g' -i $SRC/helm/go.mod
+
+gotip mod download && gotip mod tidy
+gotip get github.com/AdamKorcz/go-118-fuzz-build/utils
+compile_native_go_fuzzer helm.sh/helm/v3/internal/ignore FuzzIgnoreParse fuzz_ignore_parse
+compile_native_go_fuzzer helm.sh/helm/v3/pkg/strvals FuzzStrvalsParse fuzz_strvals_parse

--- a/projects/helm/project.yaml
+++ b/projects/helm/project.yaml
@@ -1,0 +1,13 @@
+homepage: "https://helm.sh"
+main_repo: "https://github.com/helm/helm"
+primary_contact: "cncf-helm-core-maintainers@lists.cncf.io"
+auto_ccs :
+  - "adam@adalogics.com"
+  - "david@adalogics.com"
+  - "scott@r6by.com"
+  - "matt.farina@gmail.com"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
Adds initial integration of Helm. 

Helm is a graduated CNCF-project [[src](https://www.cncf.io/projects/helm/)] and a widely adopted package manager for Kubernetes.

@scottrigby @mattfarina