### PR TITLE
Adds Elango Cheran (ICU team member at Google) to the auto_ccs list of

### DIFF
--- a/projects/icu/project.yaml
+++ b/projects/icu/project.yaml
@@ -1,5 +1,6 @@
-homepage: "http://site.icu-project.org/"
+homepage: "https://icu.unicode.org"
 language: c++
+primary_contact: "nrunge@google.com"
 auto_ccs:
  - icu-security@unicode.org
  - andy.heninger@gmail.com
@@ -9,6 +10,7 @@ auto_ccs:
  - srl295@gmail.com
  - nrunge@google.com
  - ftang@google.com
+ - elango@unicode.org
 sanitizers:
  - address
 # Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294


### PR DESCRIPTION
the Fuzzer ICU project.
