### PR TITLE
libigl: fix build following upstream major update

### DIFF
--- a/projects/libigl/Dockerfile
+++ b/projects/libigl/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make
+RUN apt-get update && apt-get install -y make libgmp-dev libmpfr-dev
 RUN git clone --depth 1 https://github.com/libigl/libigl
 WORKDIR $SRC/libigl
 COPY igl_fuzzer.cpp \

--- a/projects/libigl/build.sh
+++ b/projects/libigl/build.sh
@@ -16,16 +16,20 @@
 ################################################################################
 
 mkdir build-dir && cd build-dir
-cmake -DLIBIGL_WITH_OPENGL=OFF \
-      -DLIBIGL_WITH_OPENGL_GLFW=OFF \
-      -DLIBIGL_WITH_OPENGL_GLFW_IMGUI=OFF \
-      -DLIBIGL_WITH_COMISO=OFF \
-      -DLIBIGL_WITH_EMBREE=OFF \
-      -DLIBIGL_WITH_PNG=OFF \
-      -DLIBIGL_WITH_TETGEN=OFF \
-      -DLIBIGL_WITH_TRIANGLE=OFF \
-      -DLIBIGL_WITH_PREDICATES=OFF \
-      -DLIBIGL_WITH_XML=OFF \
+cmake -DLIBIGL_OPENGL=OFF \
+      -DLIBIGL_GLFW=OFF \
+      -DLIBIGL_IMGUI=OFF \
+      -DLIBIGL_COMISO=OFF \
+      -DLIBIGL_EMBREE=OFF \
+      -DLIBIGL_PNG=OFF \
+      -DLIBIGL_COPYLEFT_CORE=OFF \
+      -DLIBIGL_COPYLEFT_CGAL=OFF \
+      -DLIBIGL_COPYLEFT_TETGEN=OFF \
+      -DLIBIGL_COPYLEFT_COMISO=OFF \
+      -DLIBIGL_RESTRICTED_TRIANGLE=OFF \
+      -DLIBIGL_PREDICATES=OFF \
+      -DLIBIGL_XML=OFF \
+      -DLIBIGL_RESTRICTED_MATLAB=OFF \
       -DLIBIGL_BUILD_TESTS=OFF \
       ..
 make -j$(nproc)
@@ -36,4 +40,4 @@ $CXX $CXXFLAGS -DIGL_STATIC_LIBRARY \
      -isystem /src/libigl/cmake/../external/eigen \
      -c $SRC/igl_fuzzer.cpp -o fuzzer.o
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzzer.o   \
-     -o $OUT/igl_fuzzer $SRC/libigl/build-dir/libigl.a
+     -o $OUT/igl_fuzzer $SRC/libigl/build-dir/lib/libigl.a


### PR DESCRIPTION
libigl introduced breaking changes in
https://github.com/libigl/libigl/pull/1805 This fixes the OSS-Fuzz set
up.