### PR TITLE
grpc: fix build

### DIFF
--- a/projects/grpc/Dockerfile
+++ b/projects/grpc/Dockerfile
@@ -17,11 +17,10 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN apt-get update && apt-get install -y software-properties-common
-RUN add-apt-repository ppa:webupd8team/java
 RUN apt-get update && apt-get -y install  \
 	vim             \
 	build-essential \
-	openjdk-8-jdk   \
+	openjdk-11-jre-headless   \
 	make            \
         curl            \
         autoconf        \
@@ -29,21 +28,18 @@ RUN apt-get update && apt-get -y install  \
         rsync
 
 # Install dependencies
-
 RUN apt-get update && apt-get install -y \
     python-all-dev \
-    python3-all-dev \
-    python-pip
+    python3-all-dev
 
 # Install Python packages from PyPI
-RUN pip install --upgrade pip==10.0.1
-RUN pip install virtualenv
-RUN pip install incremental==16.10.1
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install virtualenv
+RUN python3 -m pip install incremental futures enum34 protobuf six twisted
 
-#========================
-# Bazel installation
+RUN git clone --recursive https://github.com/grpc/grpc grpc && \
+    cd grpc && \
+    git submodule update --init
 
-RUN git clone --recursive https://github.com/grpc/grpc grpc
 WORKDIR $SRC/grpc/
-COPY build.sh $SRC/
+COPY build.sh cmake_fuzz_patch.diff $SRC/

--- a/projects/grpc/Dockerfile
+++ b/projects/grpc/Dockerfile
@@ -42,3 +42,4 @@ RUN git clone --recursive https://github.com/grpc/grpc grpc && \
     git submodule update --init
 
 WORKDIR $SRC/grpc/
+COPY build.sh $SRC/

--- a/projects/grpc/Dockerfile
+++ b/projects/grpc/Dockerfile
@@ -42,4 +42,3 @@ RUN git clone --recursive https://github.com/grpc/grpc grpc && \
     git submodule update --init
 
 WORKDIR $SRC/grpc/
-COPY build.sh cmake_fuzz_patch.diff $SRC/

--- a/projects/grpc/build.sh
+++ b/projects/grpc/build.sh
@@ -111,8 +111,6 @@ for target in "${FUZZER_TARGETS[@]}"; do
   cp "bazel-bin/$fuzzer_name" "$OUT/"
 done
 
-cp ${SRC}/grpc/tools/fuzzer/options/*.options "${OUT}/"
-
 # We don't have a consistent naming convention between fuzzer files and corpus
 # directories so we resort to hard coding zipping corpuses
 zip "${OUT}/json_fuzzer_seed_corpus.zip" test/core/json/corpus/*

--- a/projects/grpc/build.sh
+++ b/projects/grpc/build.sh
@@ -18,10 +18,6 @@
 set -o errexit
 set -o nounset
 
-readonly FUZZER_DICTIONARIES=(
-  test/core/end2end/fuzzers/hpack.dictionary
-)
-
 readonly FUZZER_TARGETS=(
   test/core/json:json_fuzzer
   test/core/uri:uri_fuzzer_test
@@ -33,8 +29,6 @@ readonly FUZZER_TARGETS=(
   test/core/slice:percent_encode_fuzzer
   test/core/transport/chttp2:hpack_parser_fuzzer
   test/core/end2end/fuzzers:client_fuzzer
-  test/core/end2end/fuzzers:server_fuzzer
-  test/core/security:ssl_server_fuzzer
   test/core/security:alts_credentials_fuzzer
 )
 
@@ -67,8 +61,6 @@ fi
 
 tools/bazel build \
   --dynamic_mode=off \
-  --spawn_strategy=standalone \
-  --genrule_strategy=standalone \
   ${NO_VPTR} \
   --strip=never \
   --linkopt=-lc++ \
@@ -77,7 +69,7 @@ tools/bazel build \
   --linkopt=${LIB_FUZZING_ENGINE} \
   ${EXTRA_BAZEL_FLAGS} \
   ${FUZZER_TARGETS[@]} \
-  --verbose_failures
+  --verbose_failures -s
 
 # Profiling with coverage requires that we resolve+copy all Bazel symlinks and
 # also remap everything under proc/self/cwd to correspond to Bazel build paths.
@@ -117,11 +109,6 @@ for target in "${FUZZER_TARGETS[@]}"; do
   fuzzer_name=${target/:/\/}
   echo "Copying fuzzer $fuzzer_name"
   cp "bazel-bin/$fuzzer_name" "$OUT/"
-done
-
-# Copy dictionaries and options files to $OUT/
-for dict in "${FUZZER_DICTIONARIES[@]}"; do
-  cp "${dict}" "${OUT}/"
 done
 
 cp ${SRC}/grpc/tools/fuzzer/options/*.options "${OUT}/"


### PR DESCRIPTION
Grpc has been broken for half a year or so. The reasons being it (1) relied on an old package repository, (2) used deprecated bazel and commands and (3) referred to files in the upstream repo that no longer exists. 