### PR TITLE
serenity: Use in-tree BuildFuzzers.sh script to build fuzz targets

### DIFF
--- a/projects/serenity/Dockerfile
+++ b/projects/serenity/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y build-essential cmake curl e2fsprogs libmpfr-dev libmpc-dev libgmp-dev ninja-build
+RUN apt-get update && apt-get install -y build-essential cmake curl ninja-build
 RUN git clone https://github.com/SerenityOS/serenity
 COPY build.sh $SRC/
 WORKDIR $SRC/serenity/Meta/Lagom

--- a/projects/serenity/build.sh
+++ b/projects/serenity/build.sh
@@ -16,16 +16,5 @@
 ################################################################################
 
 # Now build the content
-mkdir -p build
-cd build
-cmake -GNinja \
-    -DBUILD_LAGOM=ON \
-    -DENABLE_OSS_FUZZ=ON \
-    -DCMAKE_C_COMPILER=$CC \
-    -DCMAKE_CXX_COMPILER=$CXX \
-    -DCMAKE_CXX_FLAGS="$CXXFLAGS -DOSS_FUZZ=ON" \
-    -DLINKER_FLAGS="$LIB_FUZZING_ENGINE" \
-    ..
-ninja
-cp Fuzzers/Fuzz* $OUT/
+./BuildFuzzers.sh --oss-fuzz
 


### PR DESCRIPTION
This replaces the manual CMake invocations, as the project will now
build code generator tools in a first stage build to enable fuzzing
generated code too.

~~Creating as Draft until upstream https://github.com/SerenityOS/serenity/pull/12677 is merged.~~

This PR will fix the serenity build now that 12667 is merged.