### PR TITLE
[flac] Disable CRC checks in ogg container

### DIFF
--- a/projects/flac/build.sh
+++ b/projects/flac/build.sh
@@ -33,7 +33,7 @@ export CXXFLAGS="$CXXFLAGS -D_GLIBCXX_DEBUG"
 mkdir $SRC/libogg-install
 cd $SRC/ogg
 ./autogen.sh
-./configure --prefix="$SRC/libogg-install"
+./configure --disable-crc --prefix="$SRC/libogg-install"
 make -j$(nproc)
 make install
 


### PR DESCRIPTION
libogg has had a build option to disable crc checking since 2019, but it wasn't used here. This should massively improve fuzzing FLAC-in-ogg