### PR TITLE
Pass the correct token for artifacts downloading.

### DIFF
--- a/infra/cifuzz/filestore/github_actions/__init__.py
+++ b/infra/cifuzz/filestore/github_actions/__init__.py
@@ -63,7 +63,7 @@ class GithubActionsFilestore(filestore.BaseFilestore):
 
   def __init__(self, config):
     super().__init__(config)
-    self.github_api_http_headers = github_api.get_http_auth_headers(config)
+    self.github_api_http_headers = github_api.get_http_auth_headers()
 
   def _get_artifact_name(self, name):
     """Returns |name| prefixed with |self.ARITFACT_PREFIX| if it isn't already

--- a/infra/cifuzz/filestore/github_actions/github_actions_test.py
+++ b/infra/cifuzz/filestore/github_actions/github_actions_test.py
@@ -39,21 +39,20 @@ class GithubActionsFilestoreTest(fake_filesystem_unittest.TestCase):
   @mock.patch('platform_config.github._get_event_data', return_value={})
   def setUp(self, _):  # pylint: disable=arguments-differ
     test_helpers.patch_environ(self)
-    self.token = 'example githubtoken'
     self.owner = 'exampleowner'
     self.repo = 'examplerepo'
     os.environ['GITHUB_REPOSITORY'] = f'{self.owner}/{self.repo}'
     os.environ['GITHUB_EVENT_PATH'] = '/fake'
     os.environ['CFL_PLATFORM'] = 'github'
     os.environ['GITHUB_WORKSPACE'] = '/workspace'
-    self.config = test_helpers.create_run_config(token=self.token)
+    os.environ['ACTIONS_RUNTIME_TOKEN'] = 'githubtoken'
+    self.config = test_helpers.create_run_config()
     self.local_dir = '/local-dir'
     self.testcase = os.path.join(self.local_dir, 'testcase')
 
   def _get_expected_http_headers(self):
     return {
-        'Authorization': f'token {self.token}',
-        'Accept': 'application/vnd.github.v3+json',
+        'Authorization': 'Bearer githubtoken',
     }
 
   @mock.patch('filestore.github_actions.github_api.list_artifacts')

--- a/infra/cifuzz/filestore/github_actions/github_api.py
+++ b/infra/cifuzz/filestore/github_actions/github_api.py
@@ -35,12 +35,16 @@ _GET_ATTEMPTS = 3
 _GET_BACKOFF = 1
 
 
-def get_http_auth_headers(config):
+def get_http_auth_headers():
   """Returns HTTP headers for authentication to the API."""
-  authorization = f'token {config.token}'
+  # Undocumented token used for artifacts auth.
+  token = os.environ.get('ACTIONS_RUNTIME_TOKEN')
+  if not token:
+    return {}
+
+  authorization = f'Bearer {token}'
   return {
       'Authorization': authorization,
-      'Accept': 'application/vnd.github.v3+json'
   }
 
 

--- a/infra/cifuzz/filestore/github_actions/github_api_test.py
+++ b/infra/cifuzz/filestore/github_actions/github_api_test.py
@@ -31,11 +31,9 @@ class GetHttpAuthHeaders(unittest.TestCase):
 
   def test_get_http_auth_headers(self):
     """Tests that get_http_auth_headers returns the correct result."""
-    token = 'example githubtoken'
-    run_config = test_helpers.create_run_config(token=token)
+    test_helpers.patch_environ(self)
+    os.environ['ACTIONS_RUNTIME_TOKEN'] = 'githubtoken'
     expected_headers = {
-        'Authorization': f'token {token}',
-        'Accept': 'application/vnd.github.v3+json',
+        'Authorization': 'Bearer githubtoken',
     }
-    self.assertEqual(expected_headers,
-                     github_api.get_http_auth_headers(run_config))
+    self.assertEqual(expected_headers, github_api.get_http_auth_headers())


### PR DESCRIPTION
Discovered as part of #7324. Artifacts downloading from private repos was likely failing. 

The wrong token was being passed. The correct one is [ACTIONS_RUNTIME_TOKEN](https://github.com/actions/toolkit/blob/fcb8c4ca798bd0d81a9b07e2f7dffee8397c4707/packages/artifact/src/internal/config-variables.ts#L34) (which is undocumented).