### PR TITLE
Avoid using signed url when downloading coverage reports

### DIFF
--- a/infra/build/functions/build_lib.py
+++ b/infra/build/functions/build_lib.py
@@ -206,7 +206,7 @@ def download_coverage_data_steps(project_name, latest, bucket_name, out_dir,
     for target_name in fuzz_targets[i:i + CORPUS_DOWNLOAD_BATCH_SIZE]:
       bucket_path = (f'/{bucket_name}/{project_name}/textcov_reports/'
                      f'{latest}/{target_name}.covreport')
-      url = f'https://storage.googleapis.com{bucket_path}'
+      url = 'https://storage.googleapis.com' + bucket_path
       coverage_data_path = os.path.join(f'{out_dir}/textcov_reports',
                                         target_name + '.covreport')
       download_coverage_args.append('%s %s' % (coverage_data_path, url))
@@ -219,7 +219,7 @@ def download_coverage_data_steps(project_name, latest, bucket_name, out_dir,
 
   steps.append({
       'name': 'gcr.io/oss-fuzz-base/base-runner',
-      'args': ['bash', '-c', (f'ls -lrt {out_dir}/textcov_reports')]
+      'args': ['bash', '-c', f'ls -lrt {out_dir}/textcov_reports']
   })
 
   return steps

--- a/infra/build/functions/build_lib.py
+++ b/infra/build/functions/build_lib.py
@@ -206,16 +206,21 @@ def download_coverage_data_steps(project_name, latest, bucket_name, out_dir,
     for target_name in fuzz_targets[i:i + CORPUS_DOWNLOAD_BATCH_SIZE]:
       bucket_path = (f'/{bucket_name}/{project_name}/textcov_reports/'
                      f'{latest}/{target_name}.covreport')
-      signed_url = get_signed_url(bucket_path, method='GET')
+      url = f'https://storage.googleapis.com{bucket_path}'
       coverage_data_path = os.path.join(f'{out_dir}/textcov_reports',
                                         target_name + '.covreport')
-      download_coverage_args.append('%s %s' % (coverage_data_path, signed_url))
+      download_coverage_args.append('%s %s' % (coverage_data_path, url))
 
     steps.append({
         'name': 'gcr.io/oss-fuzz-base/base-runner',
         'entrypoint': 'download_corpus',
         'args': download_coverage_args
     })
+
+  steps.append({
+      'name': 'gcr.io/oss-fuzz-base/base-runner',
+      'args': ['bash', '-c', (f'ls -lrt {out_dir}/textcov_reports')]
+  })
 
   return steps
 


### PR DESCRIPTION
Introspector build has no need to use signed url to download coverage reports as the coverage bucket is public.