### PR TITLE
libvips: add pdfium to build

### DIFF
--- a/projects/libvips/Dockerfile
+++ b/projects/libvips/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update && apt-get install -y \
 RUN pip3 install meson ninja
 RUN mkdir afl-testcases
 RUN curl https://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz | tar xzC afl-testcases
-mkdir pdfium-latest
+RUN mkdir pdfium-latest
 RUN curl -L https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-linux-x64.tgz | tar xzC pdfium-latest
 RUN git clone --depth 1 https://github.com/libvips/libvips.git
 RUN git clone --depth 1 https://github.com/madler/zlib.git

--- a/projects/libvips/Dockerfile
+++ b/projects/libvips/Dockerfile
@@ -34,7 +34,8 @@ RUN apt-get update && apt-get install -y \
 RUN pip3 install meson ninja
 RUN mkdir afl-testcases
 RUN curl https://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz | tar xzC afl-testcases
-RUN curl https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-linux-x64.tgz | tar xzC pdfium-latest
+mkdir pdfium-latest
+RUN curl -L https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-linux-x64.tgz | tar xzC pdfium-latest
 RUN git clone --depth 1 https://github.com/libvips/libvips.git
 RUN git clone --depth 1 https://github.com/madler/zlib.git
 RUN git clone --depth 1 https://github.com/libexif/libexif.git

--- a/projects/libvips/Dockerfile
+++ b/projects/libvips/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update && apt-get install -y \
 RUN pip3 install meson ninja
 RUN mkdir afl-testcases
 RUN curl https://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz | tar xzC afl-testcases
+RUN curl https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-linux-x64.tgz | tar xzC pdfium-latest
 RUN git clone --depth 1 https://github.com/libvips/libvips.git
 RUN git clone --depth 1 https://github.com/madler/zlib.git
 RUN git clone --depth 1 https://github.com/libexif/libexif.git

--- a/projects/libvips/build.sh
+++ b/projects/libvips/build.sh
@@ -192,8 +192,10 @@ ninja -C build install
 popd
 
 # pdfium doesn't need fuzzing, but we want to fuzz the libvips/pdfium link
-cp pdfium-latest/lib/* $WORK/lib
-cp -r pdfium-latest/include $WORK/include
+pushd $SRC/pdfium-latest
+cp lib/* $WORK/lib
+cp -r include $WORK/include
+popd
 
 # make a pdfium.pc that libvips can use ... the version number just needs to
 # be higher than 4200 to satisfy libvips 

--- a/projects/libvips/build.sh
+++ b/projects/libvips/build.sh
@@ -191,6 +191,26 @@ ninja -C build
 ninja -C build install
 popd
 
+# pdfium doesn't need fuzzing, but we want to fuzz the libvips/pdfium link
+cp pdfium-latest/lib/* $WORK/lib
+cp -r pdfium-latest/include $WORK/include
+
+# make a pdfium.pc that libvips can use ... the version number just needs to
+# be higher than 4200 to satisfy libvips 
+mkdir -p $WORK/lib/pkgconfig \
+cat > $WORK/lib/pkgconfig/pdfium.pc << EOF
+     prefix=$WORK
+     exec_prefix=\${prefix}
+     libdir=\${exec_prefix}/lib
+     includedir=\${prefix}/include
+     Name: pdfium
+     Description: pdfium
+     Version: 4901
+     Requires:
+     Libs: -L\${libdir} -lpdfium
+     Cflags: -I\${includedir}
+EOF
+
 # libvips
 # Disable building man pages, gettext po files, tools, and tests
 sed -i "/subdir('man')/{N;N;N;N;d;}" meson.build

--- a/projects/libvips/build.sh
+++ b/projects/libvips/build.sh
@@ -194,22 +194,22 @@ popd
 # pdfium doesn't need fuzzing, but we want to fuzz the libvips/pdfium link
 pushd $SRC/pdfium-latest
 cp lib/* $WORK/lib
-cp -R include $WORK
+cp -r include/* $WORK/include
 popd
 
 # make a pdfium.pc that libvips can use ... the version number just needs to
 # be higher than 4200 to satisfy libvips
 cat > $WORK/lib/pkgconfig/pdfium.pc << EOF
-prefix=$WORK
-exec_prefix=\${prefix}
-libdir=\${exec_prefix}/lib
-includedir=\${prefix}/include
-Name: pdfium
-Description: pdfium
-Version: 4901
-Requires:
-Libs: -L\${libdir} -lpdfium
-Cflags: -I\${includedir}
+  prefix=$WORK
+  exec_prefix=\${prefix}
+  libdir=\${exec_prefix}/lib
+  includedir=\${prefix}/include
+  Name: pdfium
+  Description: pdfium
+  Version: 4901
+  Requires:
+  Libs: -L\${libdir} -lpdfium
+  Cflags: -I\${includedir}
 EOF
 
 # libvips

--- a/projects/libvips/build.sh
+++ b/projects/libvips/build.sh
@@ -194,23 +194,22 @@ popd
 # pdfium doesn't need fuzzing, but we want to fuzz the libvips/pdfium link
 pushd $SRC/pdfium-latest
 cp lib/* $WORK/lib
-cp -r include $WORK/include
+cp -R include $WORK
 popd
 
 # make a pdfium.pc that libvips can use ... the version number just needs to
-# be higher than 4200 to satisfy libvips 
-mkdir -p $WORK/lib/pkgconfig \
+# be higher than 4200 to satisfy libvips
 cat > $WORK/lib/pkgconfig/pdfium.pc << EOF
-     prefix=$WORK
-     exec_prefix=\${prefix}
-     libdir=\${exec_prefix}/lib
-     includedir=\${prefix}/include
-     Name: pdfium
-     Description: pdfium
-     Version: 4901
-     Requires:
-     Libs: -L\${libdir} -lpdfium
-     Cflags: -I\${includedir}
+prefix=$WORK
+exec_prefix=\${prefix}
+libdir=\${exec_prefix}/lib
+includedir=\${prefix}/include
+Name: pdfium
+Description: pdfium
+Version: 4901
+Requires:
+Libs: -L\${libdir} -lpdfium
+Cflags: -I\${includedir}
 EOF
 
 # libvips
@@ -220,6 +219,10 @@ meson setup build --prefix=$WORK --libdir=lib --default-library=static \
   -Ddeprecated=false -Dintrospection=false -Dmodules=disabled
 ninja -C build
 ninja -C build install
+
+# All shared libraries needed during fuzz target execution should be inside the $OUT/lib directory
+mkdir -p $OUT/lib
+cp $WORK/lib/*.so $OUT/lib
 
 # Merge the seed corpus in a single directory, exclude files larger than 2k
 mkdir -p fuzz/corpus
@@ -238,30 +241,17 @@ for fuzzer in fuzz/*_fuzzer.cc; do
     -I$WORK/include \
     -I/usr/include/glib-2.0 \
     -I/usr/lib/x86_64-linux-gnu/glib-2.0/include \
-    $WORK/lib/libvips.a \
-    $WORK/lib/libexif.a \
-    $WORK/lib/liblcms2.a \
-    $WORK/lib/libjpeg.a \
-    $WORK/lib/libpng.a \
-    $WORK/lib/libspng.a \
-    $WORK/lib/libz.a \
-    $WORK/lib/libwebpmux.a \
-    $WORK/lib/libwebpdemux.a \
-    $WORK/lib/libwebp.a \
-    $WORK/lib/libtiff.a \
-    $WORK/lib/libheif.a \
-    $WORK/lib/libaom.a \
-    $WORK/lib/libjxl.a \
-    $WORK/lib/libjxl_threads.a \
-    $WORK/lib/libhwy.a \
-    $WORK/lib/libimagequant.a \
-    $WORK/lib/libcgif.a \
+    -L$WORK/lib \
+    -lvips -lexif -llcms2 -ljpeg -lpng -lspng -lz \
+    -lwebpmux -lwebpdemux -lwebp -ltiff -lheif -laom \
+    -ljxl -ljxl_threads -lhwy -limagequant -lcgif -lpdfium \
     $LIB_FUZZING_ENGINE \
     -Wl,-Bstatic \
     -lfftw3 -lexpat -lbrotlienc -lbrotlidec -lbrotlicommon \
     -lgio-2.0 -lgmodule-2.0 -lgobject-2.0 -lffi -lglib-2.0 \
     -lresolv -lmount -lblkid -lselinux -lsepol -lpcre \
-    -Wl,-Bdynamic -pthread
+    -Wl,-Bdynamic -pthread \
+    -Wl,-rpath,'$ORIGIN/lib'
   ln -sf "seed_corpus.zip" "$OUT/${target}_seed_corpus.zip"
 done
 


### PR DESCRIPTION
Many Rails users will shortly be switching to libvips pdfium load for
PDF rendering. pdfium is well tested and doesn't need fuzzing itself,
but we do need to fuzz the code that links libvips to pdfium.

This PR adds pdfium nightly builds to the libvips fuzzer.