### PR TITLE
Add main_repo to coredns

### DIFF
--- a/projects/go-coredns/project.yaml
+++ b/projects/go-coredns/project.yaml
@@ -1,5 +1,6 @@
 homepage: "https://coredns.io"
 primary_contact: "security@coredns.io"
+main_repo: 'https://github.com/coredns/coredns.git'
 auto_ccs :
 - "miek@miek.nl"
 - "p.antoine@catenacyber.fr"


### PR DESCRIPTION
Currently oss-fuzz uses go-coredns as the project name. However,
there is no main_repo in project file, and it looks like
the OSSF's scoreboard will not be able to find the coredns project
from oss-fuzz.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>