### PR TITLE
openvpn: disable forward fuzzer

### DIFF
--- a/projects/openvpn/build.sh
+++ b/projects/openvpn/build.sh
@@ -70,7 +70,7 @@ ar r libopenvpn.a *.o
 $CXX $CXXFLAGS -g -c $SRC/fuzz_randomizer.cpp -o $SRC/fuzz_randomizer.o
 
 # Compile the fuzzers
-for fuzzname in dhcp misc base64 proxy buffer route packet_id mroute list verify_cert forward; do
+for fuzzname in dhcp misc base64 proxy buffer route packet_id mroute list verify_cert; do
     $CC -DHAVE_CONFIG_H -I. -I../.. -I../../include -I../../src/compat \
       -DPLUGIN_LIBDIR=\"/usr/local/lib/openvpn/plugins\" -std=c99 $CFLAGS \
       -c $SRC/fuzz_${fuzzname}.c -o $SRC/fuzz_${fuzzname}.o


### PR DESCRIPTION
Changes upstream caused it to fail. This should be refined down the
line.