### PR TITLE
Update Wasmtime's docker image

### DIFF
--- a/projects/wasmtime/Dockerfile
+++ b/projects/wasmtime/Dockerfile
@@ -15,13 +15,16 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder-rust
-RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang
+RUN apt-get update && apt-get install -y make autoconf automake libtool curl \
+  cmake python llvm-dev libclang-dev clang \
+  libgmp-dev
 
 # Install a newer version of OCaml than provided by Ubuntu 16.04 (base version for this image)
 RUN curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh -o install.sh && \
   echo | sh install.sh && \
   opam init --disable-sandboxing --yes && \
-  opam install ocamlbuild --yes
+  opam install ocamlbuild ocamlfind --yes && \
+  CFLAGS= opam install zarith --yes
 
 RUN git clone --depth 1 https://github.com/bytecodealliance/wasm-tools wasm-tools
 


### PR DESCRIPTION
This adds some more ocaml-related dependencies to support fuzzing
against a different spec interpreter recently landed in Wasmtime at
https://github.com/bytecodealliance/wasmtime/pull/3843