### PR TITLE
wasmtime: Shrink size of compiled fuzzers

### DIFF
--- a/projects/wasmtime/build.sh
+++ b/projects/wasmtime/build.sh
@@ -39,7 +39,7 @@ build() {
     export RUSTFLAGS="$RUSTFLAGS --remap-path-prefix $i=$crate_src_abspath/$i"
   done <<< "$(find . -name "*.rs" | cut -d/ -f2 | uniq)"
 
-  cd $PROJECT_DIR/fuzz && cargo fuzz build -O --debug-assertions "$@"
+  cd $PROJECT_DIR/fuzz && cargo fuzz build --strip-dead-code -O --debug-assertions "$@"
 
   FUZZ_TARGET_OUTPUT_DIR=$PROJECT_DIR/target/x86_64-unknown-linux-gnu/release
 


### PR DESCRIPTION
It looks like Wasmtime's fuzzers are failing to run due to them being to
large, so this is a quick band-aid fix to reduce the size of the
binaries. It looks like Rust's `cargo fuzz` tool by default links in
dead code for code coverage purposes (ish, I'm not 100% sure on this),
so the size of fuzzers are reduced by stripping dead code. In a local
build this reduces the size of Wasmtime's output directory from 6.8G to
3.4G and should buy us some time to implement deeper fixes (such as
having one shared library that all of the fuzzers call into instead of
duplicating statically-linked Wasmtime amongst all the fuzzer binaries).