### PR TITLE
Set ENV in Dockerfile to make it visible to bazel builds

### DIFF
--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -157,8 +157,6 @@ if [ "$SANITIZER" = "introspector" ]; then
 
   ln -sf /usr/local/bin/llvm-ar /usr/bin/ar
   ln -sf /usr/local/bin/llvm-ranlib /usr/bin/ranlib
-
-  export FUZZ_INTROSPECTOR=1
 fi
 
 echo "---------------------------------------------------------------"

--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -21,6 +21,7 @@ FROM gcr.io/oss-fuzz-base/base-image
 ARG introspector
 ENV INTROSPECTOR_PATCHES=$introspector
 ENV FUZZINTRO_OUTDIR=$SRC
+ENV FUZZ_INTROSPECTOR=$introspector
 
 # Install newer cmake.
 ENV CMAKE_VERSION 3.21.1
@@ -35,7 +36,7 @@ RUN apt-get update && apt-get install -y wget sudo && \
 RUN apt-get update && apt-get install -y git && \
     git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
     cd fuzz-introspector && \
-    git checkout 5bc9bc1d0e80d01a7675f2a99e96b2eb8da57bc8 && \
+    git checkout 9868bb88c539b4ba142b07636ea0028069ca2105 && \
     apt-get remove --purge -y git
 
 COPY checkout_build_install_llvm.sh /root/


### PR DESCRIPTION
Had to set it at Dockerfile otherwise bazel builds could not see the environment variable.
Also bumping up introspector.