### PR TITLE
Ignore leaks in Wasmtime's differential_spec fuzzer

### DIFF
--- a/projects/wasmtime/Dockerfile
+++ b/projects/wasmtime/Dockerfile
@@ -36,4 +36,4 @@ WORKDIR wasmtime
 
 #RUN git clone --depth 1 https://github.com/bytecodealliance/wasmtime-libfuzzer-corpus wasmtime-libfuzzer-corpus
 
-COPY build.sh default.options $SRC/
+COPY build.sh *.options $SRC/

--- a/projects/wasmtime/build.sh
+++ b/projects/wasmtime/build.sh
@@ -58,7 +58,11 @@ build() {
               $SRC/wasmtime/wasmtime-libfuzzer-corpus/$dst_name/
       fi
 
-      cp $SRC/default.options $OUT/$dst_name.options
+      if [[ -f $SRC/$dst_name.options ]]; then
+        cp $SRC/$dst_name.options $OUT/$dst_name.options
+      else
+        cp $SRC/default.options $OUT/$dst_name.options
+      fi
   done
 }
 

--- a/projects/wasmtime/differential_spec.options
+++ b/projects/wasmtime/differential_spec.options
@@ -1,0 +1,5 @@
+[asan]
+allow_user_segv_handler=1
+handle_sigill=0
+handle_segv=1
+detect_leaks=0


### PR DESCRIPTION
This uses an OCaml backend and we're getting leak messages from OCaml
which we don't have control over so suppress them for now for this
specific fuzzer.