### PR TITLE
infra: add handling for a wildcard label applying to all fuzz targets in a project

### DIFF
--- a/infra/base-images/base-builder/write_labels.py
+++ b/infra/base-images/base-builder/write_labels.py
@@ -29,6 +29,9 @@ def main():
   out = sys.argv[2]
 
   for target_name, labels in labels_by_target.items():
+    # Skip over wildcard value applying to all fuzz targets
+    if target_name == '*':
+      continue
     with open(os.path.join(out, target_name + '.labels'), 'w') as file_handle:
       file_handle.write('\n'.join(labels))
 


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Joint with https://github.com/google/clusterfuzz/pull/2571 that pulls the wildcard label field into a project labels at setup.

Part of https://github.com/google/oss-fuzz/issues/7318

