### PR TITLE
Pin Wasmtime's OCaml version to 4.11.2

### DIFF
--- a/projects/wasmtime/Dockerfile
+++ b/projects/wasmtime/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool curl \
 # Install a newer version of OCaml than provided by Ubuntu 16.04 (base version for this image)
 RUN curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh -o install.sh && \
   echo | sh install.sh && \
-  opam init --disable-sandboxing --yes && \
+  opam init --disable-sandboxing --yes --compiler=4.11.2 && \
   opam install ocamlbuild ocamlfind --yes && \
   CFLAGS= opam install zarith --yes
 

--- a/projects/wasmtime/differential_spec.options
+++ b/projects/wasmtime/differential_spec.options
@@ -1,5 +1,0 @@
-[asan]
-allow_user_segv_handler=1
-handle_sigill=0
-handle_segv=1
-detect_leaks=0


### PR DESCRIPTION
This commit takes an alternative approach to #7358 where instead of
specifically ignoring leaks we use a build of OCaml that doesn't have
the leak to begin with. It looks like the leak was introduced in the
4.12 -> 4.13 update (and Wasmtime is currently using the latest of
4.13). This should also help improve reproducibility by always using the
same OCaml version on oss-fuzz runs. We're mostly interested in fuzzing
Rust code, not OCaml code, so our goal is to just get a working OCaml
reference somehow.

---

As an aside I apologize for all the issues/PRs related to Wasmtime recently, I didn't mean to be so noisy! We happened to have a lot of stuff happen at once but I hope that this is one of the last changes needed for our ocaml spec interpreter fuzzer.