### PR TITLE
Fix typos in rust_lang.md and cryptofuzz readme

### DIFF
--- a/docs/getting-started/new-project-guide/rust_lang.md
+++ b/docs/getting-started/new-project-guide/rust_lang.md
@@ -129,7 +129,7 @@ pub mod fuzz_logic {
 and then call the logic within `fuzz_logic` from your fuzzer. 
 
 Furthermore, within your `.toml` files, you can then specify fuzzing-specific
-depedencies by wrapping them as follows:
+dependencies by wrapping them as follows:
 ```
 [target.'cfg(fuzzing)'.dependencies]
 ```

--- a/projects/cryptofuzz/README.md
+++ b/projects/cryptofuzz/README.md
@@ -9,7 +9,7 @@ One method to detect invalid results (point 2) is to assert equivalence between 
 
 Another method is to compare a result against the result of different library, where both results are expected to be the same. If they are not the same, this indicates a bug in at least one library. This second method is what merits the composite setup of the project; adherence to the normative specification of a cryptographic primitive is implicitly asserted under the assumption that at least one implementation gets it right. Because determining which one of libraries gets it wrong cannot be reliably automated, all library maintainers are notified in this event, so that the cause of discrepancy can be resolved collaboratively.
 
-Library builds embedding optimized assembly language code and those using pure C implementations have been assigned seperate fuzzer targets (binaries), because either implementation can have distinct bugs that will not transpire if only the other one is tested.
+Library builds embedding optimized assembly language code and those using pure C implementations have been assigned separate fuzzer targets (binaries), because either implementation can have distinct bugs that will not transpire if only the other one is tested.
 
 OpenSSL, BoringSSL and LibreSSL are assigned separate fuzzing targets because their exported symbols largely overlap and can therefore not be bundled into a single binary.
 


### PR DESCRIPTION
docs/getting-started/new-project-guide/rust_lang.md:132: depedencies ==> dependencies
projects/cryptofuzz/README.md:12: seperate ==> separate
