### PR TITLE
istio: Permanently restrict view access to issues

### DIFF
--- a/projects/istio/project.yaml
+++ b/projects/istio/project.yaml
@@ -11,3 +11,6 @@ fuzzing_engines:
 sanitizers:
   - address
 main_repo: 'https://github.com/istio/istio'
+labels:
+  '*':
+  - Restrict-View-EditIssue


### PR DESCRIPTION
We have been repeatedly burned by https://github.com/google/oss-fuzz/issues/7061, where issues are falsely opened to the public, potentially exposing 0-day exploits. This is an attempt to just make our issues never public. I would prefer other options but it doesn't seem like there are any?