### PR TITLE
Update coredns with additional auto_ccs

### DIFF
--- a/projects/go-coredns/project.yaml
+++ b/projects/go-coredns/project.yaml
@@ -4,6 +4,7 @@ main_repo: 'https://github.com/coredns/coredns.git'
 auto_ccs :
 - "miek@miek.nl"
 - "p.antoine@catenacyber.fr"
+- "yong.tang.github@outlook.com"
 language: go
 fuzzing_engines:
 - libfuzzer


### PR DESCRIPTION
Hi, I am a coredns maintainer (see https://github.com/coredns/coredns/blob/master/CODEOWNERS and https://github.com/yongtang)
and I used to receive oss-fuzz issues through `security@coredns.io`.
Recently I tried to address some of the security issues received, but then I noticed that
I can only access the list with google login. Since security@coredns.io
is a mailing list it will not be possible to login.
So adding my email to this list.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>