### PR TITLE
Update email to use google email (not an alias email)

### DIFF
--- a/projects/go-coredns/project.yaml
+++ b/projects/go-coredns/project.yaml
@@ -4,7 +4,7 @@ main_repo: 'https://github.com/coredns/coredns.git'
 auto_ccs :
 - "miek@miek.nl"
 - "p.antoine@catenacyber.fr"
-- "yong.tang.github@outlook.com"
+- "yong.tang.github@gmail.com"
 language: go
 fuzzing_engines:
 - libfuzzer


### PR DESCRIPTION
I noticed that an alternate email alias in google account does not work
https://github.com/google/oss-fuzz/blob/master/docs/faq.md#why-do-you-require-a-google-account-for-authentication
For that the email has been updated to use the main google email instead.

cc @DavidKorczynski

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>