### PR TITLE
Pass FuzzIntrospector environment variables to bazel builds

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -161,5 +161,6 @@ COPY cargo compile compile_afl compile_dataflow compile_libfuzzer compile_honggf
 
 COPY llvmsymbol.diff $SRC
 COPY detect_repo.py /opt/cifuzz/
+COPY bazel.bazelrc /etc/
 
 CMD ["compile"]

--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -161,6 +161,6 @@ COPY cargo compile compile_afl compile_dataflow compile_libfuzzer compile_honggf
 
 COPY llvmsymbol.diff $SRC
 COPY detect_repo.py /opt/cifuzz/
-COPY bazel.bazelrc /etc/
+COPY bazel.bazelrc /root/.bazelrc
 
 CMD ["compile"]

--- a/infra/base-images/base-builder/bazel.bazelrc
+++ b/infra/base-images/base-builder/bazel.bazelrc
@@ -1,0 +1,20 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+
+# pass variables from environment
+build --action_env=FUZZ_INTROSPECTOR
+build --action_env=FUZZINTRO_OUTDIR

--- a/infra/base-images/base-builder/bazel_build_fuzz_tests
+++ b/infra/base-images/base-builder/bazel_build_fuzz_tests
@@ -54,6 +54,8 @@ declare -r BAZEL_BUILD_FLAGS=(
     "--@rules_fuzzing//fuzzing:cc_engine_sanitizer=none" \
     "--cxxopt=-stdlib=libc++" \
     "--linkopt=-lc++" \
+    "--verbose_failures" \
+    "--spawn_strategy=standalone" \
     "--action_env=CC=${CC}" "--action_env=CXX=${CXX}" \
     ${BAZEL_EXTRA_BUILD_FLAGS[*]}
 )

--- a/projects/abseil-cpp/Dockerfile
+++ b/projects/abseil-cpp/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get --no-install-recommends install -y build-essential
 
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
 RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
-RUN apt-get update && apt-get install -y bazel
+RUN apt-get update && apt-get -o Dpkg::Options::="--force-confold" install -y bazel
 RUN curl -Lo /usr/bin/bazel \
         https://github.com/bazelbuild/bazelisk/releases/download/v1.1.0/bazelisk-linux-amd64 \
         && \

--- a/projects/abseil-cpp/Dockerfile
+++ b/projects/abseil-cpp/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get --no-install-recommends install -y build-essential
 
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
 RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
-RUN apt-get update && apt-get -o Dpkg::Options::="--force-confold" install -y bazel
+RUN apt-get update && apt-get -y bazel
 RUN curl -Lo /usr/bin/bazel \
         https://github.com/bazelbuild/bazelisk/releases/download/v1.1.0/bazelisk-linux-amd64 \
         && \

--- a/projects/abseil-cpp/Dockerfile
+++ b/projects/abseil-cpp/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get --no-install-recommends install -y build-essential
 
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
 RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
-RUN apt-get update && apt-get -y bazel
+RUN apt-get update && apt-get install -y bazel
 RUN curl -Lo /usr/bin/bazel \
         https://github.com/bazelbuild/bazelisk/releases/download/v1.1.0/bazelisk-linux-amd64 \
         && \


### PR DESCRIPTION
There is a need to pass environment variables to fuzz introspector -- like where to store the collected profiles. These changes enable bazel based project to build correctly under fuzz introspector.