### PR TITLE
[igraph] build libxml2 without ICU

### DIFF
--- a/projects/igraph/Dockerfile
+++ b/projects/igraph/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
-  pkg-config cmake bison flex libz-dev libz-dev:i386 liblzma-dev liblzma-dev:i386
+  pkg-config cmake bison flex
 RUN git clone --depth 1 --branch develop  https://github.com/igraph/igraph
 RUN wget https://download.gnome.org/sources/libxml2/2.9/libxml2-2.9.13.tar.xz && tar xf libxml2-2.9.13.tar.xz
 WORKDIR igraph

--- a/projects/igraph/Dockerfile
+++ b/projects/igraph/Dockerfile
@@ -16,9 +16,8 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
-  pkg-config cmake bison flex libxml2-dev libxml2-dev:i386 libz-dev libz-dev:i386 liblzma-dev liblzma-dev:i386
+  pkg-config cmake bison flex libz-dev libz-dev:i386 liblzma-dev liblzma-dev:i386
 RUN git clone --depth 1 --branch develop  https://github.com/igraph/igraph
-RUN wget https://github.com/unicode-org/icu/releases/download/release-66-1/icu4c-66_1-src.tgz && tar xzvf icu4c-66_1-src.tgz
+RUN wget https://download.gnome.org/sources/libxml2/2.9/libxml2-2.9.13.tar.xz && tar xf libxml2-2.9.13.tar.xz
 WORKDIR igraph
 RUN cp $SRC/igraph/fuzzing/build.sh $SRC/build.sh
-


### PR DESCRIPTION
This is to work around a crash in ICU, see https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=44854 and https://unicode-org.atlassian.net/browse/ICU-21932