### PR TITLE
wasmtime: Try to fix coverage build

### DIFF
--- a/projects/wasmtime/build.sh
+++ b/projects/wasmtime/build.sh
@@ -72,3 +72,10 @@ eval $(opam env)
 build wasmtime "" ""
 build wasm-tools wasm-tools- ""
 build regalloc.rs regalloc- bt bt
+
+# In coverage builds copy the opam header files into the output so coverage can
+# find the source files.
+if [ "$SANITIZER" = "coverage" ]; then
+  cp --recursive --dereference --no-preserve mode,ownership --parents \
+    $HOME/.opam/4.11.2/lib/ocaml $OUT
+fi


### PR DESCRIPTION
Our coverage build for Wasmtime has been broken for a bit so this is a
bit of a shot in the dark to try and fix that. The broken build comes
from OCaml sources not being available and I couldn't figure out how to
get the coverage to not ask for the OCaml sources so this attempts to
copy the OCaml sources to the output directory for the coverage code to
use. We're not really interested in the coverage of OCaml itself, but
this should hopefully serve to appease the coverage gods.