### PR TITLE
[libfido2] install libpcsclite-dev, seed fuzz_pcsc, and bump libcbor

### DIFF
--- a/projects/libfido2/Dockerfile
+++ b/projects/libfido2/Dockerfile
@@ -16,8 +16,8 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool
-RUN apt-get install -y cmake libudev-dev pkg-config chrpath
-RUN git clone --depth 1 --branch v0.8.0 https://github.com/PJK/libcbor
+RUN apt-get install -y cmake libpcsclite-dev libudev-dev pkg-config chrpath
+RUN git clone --depth 1 --branch v0.9.0 https://github.com/PJK/libcbor
 RUN git clone --depth 1 --branch OpenSSL_1_1_1-stable https://github.com/openssl/openssl
 RUN git clone --depth 1 --branch v1.2.11 https://github.com/madler/zlib
 RUN git clone --depth 1 https://github.com/Yubico/libfido2

--- a/projects/libfido2/build.sh
+++ b/projects/libfido2/build.sh
@@ -77,3 +77,4 @@ tar xzf ${SRC}/corpus.tgz
 (set -e ; cd fuzz_largeblob/corpus ; zip -r ${OUT}/fuzz_largeblob_seed_corpus.zip .)
 (set -e ; cd fuzz_mgmt/corpus      ; zip -r ${OUT}/fuzz_mgmt_seed_corpus.zip .)
 (set -e ; cd fuzz_netlink/corpus   ; zip -r ${OUT}/fuzz_netlink_seed_corpus.zip .)
+(set -e ; cd fuzz_pcsc/corpus      ; zip -r ${OUT}/fuzz_pcsc_seed_corpus.zip .)


### PR DESCRIPTION
Hi,

A new harness (fuzz_pcsc) has been added in libfido2. To build it on Linux, libpcsclite's header files need to be present. Instrumentation of libpcsclite is not needed. This PR adds libpcsclite-dev to the list of packages installed by libfido2's Dockerfile and populates fuzz_pcsc's initial corpus in build.sh. While here, bump libcbor from 0.8.0 to 0.9.0.

Thank you,

-p.