### PR TITLE
Modernize a bit the pygments fuzzer

### DIFF
--- a/projects/pygments/fuzz_guesser.py
+++ b/projects/pygments/fuzz_guesser.py
@@ -15,24 +15,20 @@
 # limitations under the License.
 
 import atheris
-with atheris.instrument_imports():
-  import sys
-  import pygments
-  import pygments.lexers
 
-@atheris.instrument_func
+import sys
+import pygments
+import pygments.lexers
+import pygments.util
+
 def TestOneInput(data: bytes) -> int:
   try:
     lexer = pygments.lexers.guess_lexer(str(data))
-  except ValueError:
+  except pygments.util.ClassNotFound:
     return 0
   return 0
 
 
-def main():
-  atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
-  atheris.Fuzz()
-
-
-if __name__ == "__main__":
-  main()
+atheris.instrument_all()
+atheris.Setup(sys.argv, TestOneInput)
+atheris.Fuzz()

--- a/projects/pygments/fuzz_lexers.py
+++ b/projects/pygments/fuzz_lexers.py
@@ -15,11 +15,11 @@
 # limitations under the License.
 
 import atheris
-with atheris.instrument_imports():
-  import sys
-  import pygments
-  import pygments.formatters.html
-  import pygments.lexers
+
+import sys
+import pygments
+import pygments.formatters.html
+import pygments.lexers
 
 formatter = pygments.formatters.html.HtmlFormatter()
 # pygments.LEXERS.values() is a list of tuples like this, with some of then empty:
@@ -36,5 +36,6 @@ def TestOneInput(data: bytes) -> int:
   return 0
 
 
+atheris.instrument_all()
 atheris.Setup(sys.argv, TestOneInput)
 atheris.Fuzz()


### PR DESCRIPTION
- Use atheris.instrument_all(), since pygments uses a custom importer
- Get rid of the useless main(), to make the two fuzzers similar
- Narrow an expected exception type