### PR TITLE
[libfido2] place libpcsclite.so in ${OUT}/lib

### DIFF
--- a/projects/libfido2/build.sh
+++ b/projects/libfido2/build.sh
@@ -60,6 +60,13 @@ for lib in `ls ${WORK}/lib/lib*.so*`; do
     cp ${lib} ${OUT}/lib;
 done
 
+# Place libpcsclite in ${OUT}; needed by fuzz_pcsc
+if [ -x fuzz/fuzz_pcsc ]; then
+    for lib in `ldd fuzz/fuzz_pcsc | awk '/libpcsclite.so.*=>/ { print $3 }'`; do
+        cp ${lib} ${OUT}/lib;
+    done
+fi
+
 # Fixup rpath in the fuzzers so they use our libs
 for f in `ls fuzz/fuzz_*`; do
     cp ${f} ${OUT}/


### PR DESCRIPTION
Hi,

The fuzz_pcsc harness requires libpcsclite.so on the filesystem at runtime. This was missed in #7379.

Thank you,

-p.