### PR TITLE
[base-builder-swift] Reduce size 1.6GB and misc improvements

### DIFF
--- a/infra/base-images/base-builder/install_swift.sh
+++ b/infra/base-images/base-builder/install_swift.sh
@@ -33,14 +33,14 @@ SWIFT_PACKAGES="wget \
           tzdata \
           zlib1g-dev"
 SWIFT_SYMBOLIZER_PACKAGES="build-essential make cmake ninja-build git python3 g++-multilib binutils-dev zlib1g-dev"
-apt-get update && apt install -y $SWIFT_PACKAGES && \
-  apt install -y $SWIFT_SYMBOLIZER_PACKAGES --no-install-recommends  
+apt-get update && apt-get install -y $SWIFT_PACKAGES && \
+  apt-get install -y $SWIFT_SYMBOLIZER_PACKAGES --no-install-recommends
 
 
 wget https://swift.org/builds/swift-5.4.2-release/ubuntu2004/swift-5.4.2-RELEASE/swift-5.4.2-RELEASE-ubuntu20.04.tar.gz
 tar xzf swift-5.4.2-RELEASE-ubuntu20.04.tar.gz
 cp -r swift-5.4.2-RELEASE-ubuntu20.04/usr/* /usr/
-rm -rf swift-5.4.2-RELEASE-ubuntu20.04.tar.gz
+rm -rf swift-5.4.2-RELEASE-ubuntu20.04.tar.gz swift-5.4.2-RELEASE-ubuntu20.04
 # TODO: Move to a seperate work dir
 git clone https://github.com/llvm/llvm-project.git
 cd llvm-project


### PR DESCRIPTION
1. Reduce image size by 1.6GB by deleting unneeded directory containing
swift tools that were already copied to /usr.
2. Use apt-get instead of apt to avoid warnings.