### PR TITLE
gstreamer: update meson version requirements

### DIFF
--- a/projects/gstreamer/Dockerfile
+++ b/projects/gstreamer/Dockerfile
@@ -31,7 +31,7 @@ RUN git clone --depth 1 https://gitlab.xiph.org/xiph/vorbis.git && \
     make -j$(nproc) && \
     make install
 
-ADD https://ftp.gnome.org/pub/gnome/sources/glib/2.64/glib-2.64.2.tar.xz $SRC
+ADD https://ftp.gnome.org/pub/gnome/sources/glib/2.72/glib-2.72.0.tar.xz $SRC
 
 # Checkout repository
 RUN git clone --depth 1 --recursive https://gitlab.freedesktop.org/gstreamer/gstreamer.git gstreamer

--- a/projects/gstreamer/Dockerfile
+++ b/projects/gstreamer/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
    apt-get install -y make autoconf automake libtool build-essential pkg-config bison flex gettext \
     libffi-dev liblzma-dev libtheora-dev libogg-dev zlib1g-dev libcairo2-dev \
     python3-pip ninja-build && \
-   pip3 install meson==0.59.0
+   pip3 install meson==0.61.3
 
 # We must install libvorbis from scratch as otherwise we will run into
 # undefined functions in Ubuntu 20.04


### PR DESCRIPTION
Fixes build error:

./../src/gstreamer/meson.build:1:0: ERROR: Meson version is 0.59.0 but project requires >= 0.60.0

Requires: https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/1975
Requires: https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/1976
Requires: https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/1984