### PR TITLE
[elfutils] build zlib with MSan

### DIFF
--- a/projects/elfutils/build.sh
+++ b/projects/elfutils/build.sh
@@ -87,12 +87,39 @@ fi
 
 ASAN_OPTIONS=detect_leaks=0 make -j$(nproc) V=1
 
+# External dependencies used by the fuzz targets have to be built
+# with MSan explicitly to avoid bogus "security" bug reports like
+# https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=45630,
+# https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=45631 and
+# https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=45633
+zlib="-l:libz.a"
+if [[ "$SANITIZER" == memory ]]; then
+    git clone https://github.com/madler/zlib
+    pushd zlib
+    git checkout v1.2.11
+    if ! ./configure --static; then
+        cat configure.log
+        exit 1
+    fi
+    make -j$(nproc) V=1
+    popd
+    zlib=zlib/libz.a
+fi
+
+# When new fuzz targets are added it usually makes sense to notify the maintainers of
+# the elfutils project using the mailing list: elfutils-devel@sourceware.org. There
+# fuzz targets can be reviewed properly (to make sure they don't fail to compile
+# with -Werror for example), their names can be chosen accordingly (so as not to spam
+# the mailing list with bogus bug reports that are opened and closed once they are renamed)
+# and so on. Also since a lot of bug reports coming out of the blue aren't exactly helpful
+# fuzz targets should probably be added one at a time to make it easier to keep track
+# of them.
 $CC $CFLAGS \
 	-D_GNU_SOURCE -DHAVE_CONFIG_H \
 	-I. -I./lib -I./libelf -I./libebl -I./libdw -I./libdwelf -I./libdwfl -I./libasm \
 	-c "$SRC/fuzz-dwfl-core.c" -o fuzz-dwfl-core.o
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz-dwfl-core.o \
-	./libdw/libdw.a ./libelf/libelf.a -l:libz.a \
+	./libdw/libdw.a ./libelf/libelf.a "$zlib" \
 	-o "$OUT/fuzz-dwfl-core"
 
 $CC $CFLAGS \
@@ -101,7 +128,7 @@ $CC $CFLAGS \
   -c "$SRC/fuzz-libelf.c" -o fuzz-libelf.o
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz-libelf.o \
 	./libasm/libasm.a ./libebl/libebl.a ./backends/libebl_backends.a ./libcpu/libcpu.a \
-  ./libdw/libdw.a ./libelf/libelf.a ./lib/libeu.a -l:libz.a \
+  ./libdw/libdw.a ./libelf/libelf.a ./lib/libeu.a "$zlib" \
 	-o "$OUT/fuzz-libelf"
 
 $CC $CFLAGS \
@@ -110,7 +137,7 @@ $CC $CFLAGS \
   -c "$SRC/fuzz-libdwfl.c" -o fuzz-libdwfl.o
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz-libdwfl.o \
 	./libasm/libasm.a ./libebl/libebl.a ./backends/libebl_backends.a ./libcpu/libcpu.a \
-  ./libdw/libdw.a ./libelf/libelf.a ./lib/libeu.a -l:libz.a \
+  ./libdw/libdw.a ./libelf/libelf.a ./lib/libeu.a "$zlib" \
 	-o "$OUT/fuzz-libdwfl"
 
 # Corpus


### PR DESCRIPTION
Unlike fuzz-dwfl-core, the new fuzz targets actually use zlib so
instead of just linking against zlib to make them compile they
should use the library instrumented with MSan. Without it OSS-Fuzz
reports bogus issues like https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=45630
and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=45631.

To hopefully make it easier to figure out how to add new fuzz targets
going forward I also added the following comment to the build script
```
When new fuzz targets are added it usually makes sense to notify the maintainers of
the elfutils project using the mailing list: elfutils-devel@sourceware.org. There
fuzz targets can be reviewed properly (to make sure they don't fail to compile with -Werror
for example), their names can be chosen accordingly (so as not to spam the mailing
list with bogus bug reports that are opened and closed once they are renamed) and so
on. Also since a lot of bug reports coming out of the blue aren't exactly helpful
fuzz targets should probably be added one at a time to make it easier to keep track
of them.
```

It's a follow-up to https://github.com/google/oss-fuzz/pull/7395
and https://github.com/google/oss-fuzz/pull/7393.