### PR TITLE
Lwan: Use HTTPS protocol in GIT repository URI

### DIFF
--- a/projects/lwan/Dockerfile
+++ b/projects/lwan/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update
 RUN apt-get install -y build-essential cmake git ninja-build zlib1g-dev
 
-RUN git clone --depth 1 git://github.com/lpereira/lwan
+RUN git clone --depth 1 https://github.com/lpereira/lwan.git
 WORKDIR lwan
 
 COPY build.sh $SRC/

--- a/projects/lwan/project.yaml
+++ b/projects/lwan/project.yaml
@@ -3,4 +3,4 @@ language: c++
 primary_contact: "leandro.pereira@gmail.com"
 sanitizers:
   - address
-main_repo: 'git://github.com/lpereira/lwan'
+main_repo: 'https://github.com/lpereira/lwan.git'


### PR DESCRIPTION


GitHub deprecated the unencrypted GIT protocol, so use HTTPS instead.