### PR TITLE
Add CuraEngine to OSS-Fuzz

### DIFF
--- a/projects/cura-engine/project.yaml
+++ b/projects/cura-engine/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/Ultimaker/CuraEngine"
+language: c++
+primary_contact: "j.vankessel@ultimaker.com"
+auto_ccs:
+  - "artem.smotrakov@gmail.com"
+sanitizers:
+  - address
+  - undefined
+main_repo: "https://github.com/Ultimaker/CuraEngine.git"


### PR DESCRIPTION
I'd like to add CuraEngine to OSS-Fuzz. CuraEngine is part of Cura which is a popular slicer used for 3D printing.

If the project is accepted, I'll intergate it to OSS-Fuzz. Here is an [approval](https://github.com/Ultimaker/CuraEngine/issues/1603#issuecomment-1069061684) for the `primary_contact`. 