### PR TITLE
Reland "Upload per target coverage report. (#7389)" (#7400)"

### DIFF
--- a/infra/build/functions/build_and_run_coverage.py
+++ b/infra/build/functions/build_and_run_coverage.py
@@ -157,6 +157,7 @@ def get_build_steps(  # pylint: disable=too-many-locals, too-many-arguments
 
   # Upload the report.
   upload_report_url = bucket.get_upload_url('reports')
+  upload_report_by_target_url = bucket.get_upload_url('reports-by-target')
 
   # Delete the existing report as gsutil cannot overwrite it in a useful way due
   # to the lack of `-T` option (it creates a subdir in the destination dir).
@@ -172,6 +173,20 @@ def get_build_steps(  # pylint: disable=too-many-locals, too-many-arguments
           upload_report_url,
       ],
   })
+
+  if project.fuzzing_language in LANGUAGES_WITH_INTROSPECTOR_SUPPORT:
+    build_steps.append(build_lib.gsutil_rm_rf_step(upload_report_by_target_url))
+    build_steps.append({
+        'name':
+            'gcr.io/cloud-builders/gsutil',
+        'args': [
+            '-m',
+            'cp',
+            '-r',
+            os.path.join(build.out, 'report_target'),
+            upload_report_by_target_url,
+        ],
+    })
 
   # Upload the fuzzer stats. Delete the old ones just in case.
   upload_fuzzer_stats_url = bucket.get_upload_url('fuzzer_stats')

--- a/infra/build/functions/test_data/expected_coverage_build_steps.json
+++ b/infra/build/functions/test_data/expected_coverage_build_steps.json
@@ -94,6 +94,24 @@
     ]
   },
   {
+    "args": [
+      "-c",
+      "gsutil -m rm -rf gs://oss-fuzz-coverage/test-project/reports-by-target/20200101 || exit 0"
+    ],
+    "entrypoint": "sh",
+    "name": "gcr.io/cloud-builders/gsutil"
+  },
+  {
+    "args": [
+      "-m",
+      "cp",
+      "-r",
+      "/workspace/out/libfuzzer-coverage-x86_64/report_target",
+      "gs://oss-fuzz-coverage/test-project/reports-by-target/20200101"
+    ],
+    "name": "gcr.io/cloud-builders/gsutil"
+  },
+  {
     "name": "gcr.io/cloud-builders/gsutil",
     "entrypoint": "sh",
     "args": [
@@ -114,16 +132,20 @@
   {
     "name": "gcr.io/cloud-builders/gsutil",
     "entrypoint": "sh",
-    "args": ["-c",
-      "gsutil -m rm -rf gs://oss-fuzz-coverage/test-project/textcov_reports/20200101 || exit 0"]
+    "args": [
+      "-c",
+      "gsutil -m rm -rf gs://oss-fuzz-coverage/test-project/textcov_reports/20200101 || exit 0"
+    ]
   },
   {
     "name": "gcr.io/cloud-builders/gsutil",
-    "args": ["-m",
-            "cp",
-            "-r",
-            "/workspace/out/libfuzzer-coverage-x86_64/textcov_reports",
-            "gs://oss-fuzz-coverage/test-project/textcov_reports/20200101"]
+    "args": [
+      "-m",
+      "cp",
+      "-r",
+      "/workspace/out/libfuzzer-coverage-x86_64/textcov_reports",
+      "gs://oss-fuzz-coverage/test-project/textcov_reports/20200101"
+    ]
   },
   {
     "name": "gcr.io/cloud-builders/gsutil",


### PR DESCRIPTION
Only upload per-target reports for C/C++.

This reverts commit 1ae57df24d9d0146d6a2486bdb6e01ca7157ccef.