### PR TITLE
Pin Go back to 1.17

### DIFF
--- a/infra/base-images/base-builder/install_go.sh
+++ b/infra/base-images/base-builder/install_go.sh
@@ -18,7 +18,7 @@
 cd /tmp
 curl -O https://storage.googleapis.com/golang/getgo/installer_linux
 chmod +x ./installer_linux
-SHELL="bash" ./installer_linux
+SHELL="bash" ./installer_linux -version=1.17
 rm -rf ./installer_linux
 
 echo 'Set "GOPATH=/root/go"'


### PR DESCRIPTION
A bit more work is required to upgrade to Go 1.18.

#7410