### PR TITLE
[elfutils] drop unused static libraries

### DIFF
--- a/projects/elfutils/build.sh
+++ b/projects/elfutils/build.sh
@@ -82,31 +82,16 @@ fi
 
 ASAN_OPTIONS=detect_leaks=0 make -j$(nproc) V=1
 
-$CC $CFLAGS \
-	-D_GNU_SOURCE -DHAVE_CONFIG_H \
-	-I. -I./lib -I./libelf -I./libebl -I./libdw -I./libdwelf -I./libdwfl -I./libasm \
-	-c "$SRC/fuzz-dwfl-core.c" -o fuzz-dwfl-core.o
-$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz-dwfl-core.o \
-	./libdw/libdw.a ./libelf/libelf.a -l:libz.a \
-	-o "$OUT/fuzz-dwfl-core"
-
-$CC $CFLAGS \
-  -D_GNU_SOURCE -DHAVE_CONFIG_H \
-  -I. -I./lib -I./libelf -I./libebl -I./libdw -I./libdwelf -I./libdwfl -I./libasm \
-  -c "$SRC/fuzz-libelf.c" -o fuzz-libelf.o
-$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz-libelf.o \
-	./libasm/libasm.a ./libebl/libebl.a ./backends/libebl_backends.a ./libcpu/libcpu.a \
-  ./libdw/libdw.a ./libelf/libelf.a ./lib/libeu.a -l:libz.a \
-	-o "$OUT/fuzz-libelf"
-
-$CC $CFLAGS \
-  -D_GNU_SOURCE -DHAVE_CONFIG_H \
-  -I. -I./lib -I./libelf -I./libebl -I./libdw -I./libdwelf -I./libdwfl -I./libasm \
-  -c "$SRC/fuzz-libdwfl.c" -o fuzz-libdwfl.o
-$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz-libdwfl.o \
-	./libasm/libasm.a ./libebl/libebl.a ./backends/libebl_backends.a ./libcpu/libcpu.a \
-  ./libdw/libdw.a ./libelf/libelf.a ./lib/libeu.a -l:libz.a \
-	-o "$OUT/fuzz-libdwfl"
+for f in $SRC/fuzz-*.c; do
+    target=$(basename $f .c)
+    $CC $CFLAGS \
+        -D_GNU_SOURCE -DHAVE_CONFIG_H \
+        -I. -I./lib -I./libelf -I./libebl -I./libdw -I./libdwelf -I./libdwfl -I./libasm \
+        -c "$SRC/$target.c" -o $target.o
+    $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $target.o \
+        ./libdw/libdw.a ./libelf/libelf.a -l:libz.a \
+        -o "$OUT/$target"
+done
 
 # Corpus
 cp "$SRC/fuzz-dwfl-core_seed_corpus.zip" "$OUT"


### PR DESCRIPTION
fuzz-libdwfl and fuzz-libelf have to be linked against libelf and
libdw. The other static libraries just make the fuzz targets
unnecessarily larger. Without those libraries it's also possible to
simplify the build script a bit.