### PR TITLE
Pin setup gcloud action to v0 because master branch is deprecated.

### DIFF
--- a/.github/workflows/infra_tests.yml
+++ b/.github/workflows/infra_tests.yml
@@ -33,7 +33,7 @@ jobs:
           sudo env "PATH=$PATH" pip install -r infra/build/functions/requirements.txt
           sudo env "PATH=$PATH" pip install -r infra/cifuzz/requirements.txt
 
-      - uses: google-github-actions/setup-gcloud@master
+      - uses: google-github-actions/setup-gcloud@v0
         with:
           version: '298.0.0'
       - run: |


### PR DESCRIPTION
This silences a warning when using the action.