### PR TITLE
libidn2: Fix build (git-version-gen doesn't handle shallow) and have verbose self checks.

### DIFF
--- a/projects/libidn2/Dockerfile
+++ b/projects/libidn2/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake gettext libtool autopoint pkg-config gengetopt curl gperf rsync wget
 
-RUN git clone --depth=1 --recursive https://gitlab.com/libidn/libidn2.git
+RUN git clone --recursive https://gitlab.com/libidn/libidn2.git
 
 WORKDIR libidn2
 COPY build.sh $SRC/

--- a/projects/libidn2/build.sh
+++ b/projects/libidn2/build.sh
@@ -19,7 +19,7 @@
 # switch off leak detection for ./configure run to detect iconv() correctly
 ASAN_OPTIONS=detect_leaks=0 ./configure --enable-static --disable-shared --disable-doc --disable-gcc-warnings
 make clean
-make -j$(nproc) check
+make -j$(nproc) check VERBOSE=t
 
 cd fuzz
 make oss-fuzz


### PR DESCRIPTION
This should make the libidn2 fussing build again, and also make future debugging of self-check failures easier to perform.