### PR TITLE
[elfutils] turn off FORTIFY_SOURCE with MSan

### DIFF
--- a/projects/elfutils/build.sh
+++ b/projects/elfutils/build.sh
@@ -72,6 +72,11 @@ if [[ "$SANITIZER" == undefined ]]; then
     sed -i 's/\(check_undefined_val\)=[0-9]/\1=1/' configure.ac
 fi
 
+if [[ "$SANITIZER" == memory ]]; then
+    CFLAGS+=" -U_FORTIFY_SOURCE"
+    CXXFLAGS+=" -U_FORTIFY_SOURCE"
+fi
+
 autoreconf -i -f
 if ! ./configure --enable-maintainer-mode --disable-debuginfod --disable-libdebuginfod \
             --without-bzlib --without-lzma --without-zstd \


### PR DESCRIPTION
Closes:

https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=45647
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=45676
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=45706

It was tested in https://github.com/evverx/elfutils/pull/73
with CFLite. Combined with https://github.com/google/oss-fuzz/pull/7401
it fixes all the issues MSan has reported.