### PR TITLE
[elfutils] prevent MSan from reporting issues for now

### DIFF
--- a/projects/elfutils/project.yaml
+++ b/projects/elfutils/project.yaml
@@ -9,7 +9,8 @@ fuzzing_engines:
   - honggfuzz
 sanitizers:
   - address
-  - memory
+  - memory:
+     experimental: True
   - undefined
 architectures:
   - x86_64


### PR DESCRIPTION
https://sourceware.org/pipermail/elfutils-devel/2022q1/004784.html

I think it should wait for the other MSan-related PRs to land so that the bogus issues can be closed properly. Though if the flag doesn't affect issues that have already been opened I think it should be good to go.