### PR TITLE
[igraph] disable experimental mode for MSAN

### DIFF
--- a/projects/igraph/project.yaml
+++ b/projects/igraph/project.yaml
@@ -9,8 +9,7 @@ auto_ccs:
 sanitizers:
   - address
   - undefined
-  - memory:
-     experimental: True
+  - memory
 architectures:
  - x86_64
  - i386


### PR DESCRIPTION
No problems or false positives with MSAN, disable experimental mode.