### PR TITLE
libavif: go back to using dav1d.cmd to build dav1d

### DIFF
--- a/projects/libavif/build.sh
+++ b/projects/libavif/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 # build dav1d
-cd ext && bash dav1d_oss_fuzz.sh && cd ..
+cd ext && bash dav1d.cmd && cd ..
 
 # build libavif
 mkdir build


### PR DESCRIPTION
It is no longer necessary to use dav1d_oss_fuzz.sh.