### PR TITLE
cras: Disable featured in configure

### DIFF
--- a/projects/cras/build.sh
+++ b/projects/cras/build.sh
@@ -23,7 +23,7 @@
 
 cd ${SRC}/adhd/cras
 ./git_prepare.sh
-./configure
+./configure --disable-featured
 make -j$(nproc)
 cp ${SRC}/adhd/cras/src/server/rust/target/release/libcras_rust.a /usr/local/lib
 


### PR DESCRIPTION
featured [1] is a ChromeOS specific daemon that's not available in gcr.io/oss-fuzz-base/base-builder-rust.
Disable it to fix the build [2].

[1] https://chromium.googlesource.com/chromiumos/platform2/+/HEAD/featured/
[2] https://crbug.com/oss-fuzz/45744