### PR TITLE
[elfutils] bring MSan back

### DIFF
--- a/projects/elfutils/project.yaml
+++ b/projects/elfutils/project.yaml
@@ -9,8 +9,7 @@ fuzzing_engines:
   - honggfuzz
 sanitizers:
   - address
-  - memory:
-     experimental: True
+  - memory
   - undefined
 architectures:
   - x86_64


### PR DESCRIPTION
Now that all the false positives are gone and MSan reports real
issues like https://sourceware.org/bugzilla/show_bug.cgi?id=29000
confirmed by Valgrind it should be safe to bring MSan back.

It reverts https://github.com/google/oss-fuzz/commit/6e6d6068aee8552ff62053b338767a572cf2dc40