### PR TITLE
Revert "Fix run_fuzzers_test::CoverageReportIntegrationTest. (#7325)"

### DIFF
--- a/infra/cifuzz/filestore/github_actions/__init__.py
+++ b/infra/cifuzz/filestore/github_actions/__init__.py
@@ -63,7 +63,7 @@ class GithubActionsFilestore(filestore.BaseFilestore):
 
   def __init__(self, config):
     super().__init__(config)
-    self.github_api_http_headers = github_api.get_http_auth_headers()
+    self.github_api_http_headers = github_api.get_http_auth_headers(config)
 
   def _get_artifact_name(self, name):
     """Returns |name| prefixed with |self.ARITFACT_PREFIX| if it isn't already

--- a/infra/cifuzz/filestore/github_actions/github_actions_test.py
+++ b/infra/cifuzz/filestore/github_actions/github_actions_test.py
@@ -39,20 +39,21 @@ class GithubActionsFilestoreTest(fake_filesystem_unittest.TestCase):
   @mock.patch('platform_config.github._get_event_data', return_value={})
   def setUp(self, _):  # pylint: disable=arguments-differ
     test_helpers.patch_environ(self)
+    self.token = 'example githubtoken'
     self.owner = 'exampleowner'
     self.repo = 'examplerepo'
     os.environ['GITHUB_REPOSITORY'] = f'{self.owner}/{self.repo}'
     os.environ['GITHUB_EVENT_PATH'] = '/fake'
     os.environ['CFL_PLATFORM'] = 'github'
     os.environ['GITHUB_WORKSPACE'] = '/workspace'
-    os.environ['ACTIONS_RUNTIME_TOKEN'] = 'githubtoken'
-    self.config = test_helpers.create_run_config()
+    self.config = test_helpers.create_run_config(token=self.token)
     self.local_dir = '/local-dir'
     self.testcase = os.path.join(self.local_dir, 'testcase')
 
   def _get_expected_http_headers(self):
     return {
-        'Authorization': 'Bearer githubtoken',
+        'Authorization': f'token {self.token}',
+        'Accept': 'application/vnd.github.v3+json',
     }
 
   @mock.patch('filestore.github_actions.github_api.list_artifacts')

--- a/infra/cifuzz/filestore/github_actions/github_api.py
+++ b/infra/cifuzz/filestore/github_actions/github_api.py
@@ -35,16 +35,12 @@ _GET_ATTEMPTS = 3
 _GET_BACKOFF = 1
 
 
-def get_http_auth_headers():
+def get_http_auth_headers(config):
   """Returns HTTP headers for authentication to the API."""
-  # Undocumented token used for artifacts auth.
-  token = os.environ.get('ACTIONS_RUNTIME_TOKEN')
-  if not token:
-    return {}
-
-  authorization = f'Bearer {token}'
+  authorization = f'token {config.token}'
   return {
       'Authorization': authorization,
+      'Accept': 'application/vnd.github.v3+json'
   }
 
 

--- a/infra/cifuzz/filestore/github_actions/github_api_test.py
+++ b/infra/cifuzz/filestore/github_actions/github_api_test.py
@@ -31,9 +31,11 @@ class GetHttpAuthHeaders(unittest.TestCase):
 
   def test_get_http_auth_headers(self):
     """Tests that get_http_auth_headers returns the correct result."""
-    test_helpers.patch_environ(self)
-    os.environ['ACTIONS_RUNTIME_TOKEN'] = 'githubtoken'
+    token = 'example githubtoken'
+    run_config = test_helpers.create_run_config(token=token)
     expected_headers = {
-        'Authorization': 'Bearer githubtoken',
+        'Authorization': f'token {token}',
+        'Accept': 'application/vnd.github.v3+json',
     }
-    self.assertEqual(expected_headers, github_api.get_http_auth_headers())
+    self.assertEqual(expected_headers,
+                     github_api.get_http_auth_headers(run_config))


### PR DESCRIPTION
This reverts commit 9553ab10d770ef7aeba47829e3e7dbd71dc6af6c.

The commit does the opposite of what was intended.
Here is CFL with the commit: https://github.com/jonathanmetzman/cifuzz-external-example/runs/5726826920?check_suite_focus=true (bad creds)
Here is CFL in a public repo without the commit (works): https://github.com/jonathanmetzman/cifuzz-external-example/runs/5726869794?check_suite_focus=true
Here I made the repo private and without the commit (works): https://github.com/jonathanmetzman/cifuzz-external-example/runs/5727044959?check_suite_focus=true

Fixes: https://github.com/google/clusterfuzzlite/issues/91