### PR TITLE
Fix libarchive build.

### DIFF
--- a/projects/libarchive/build.sh
+++ b/projects/libarchive/build.sh
@@ -24,7 +24,8 @@ cd $SRC/libxml2
     --without-ftp \
     --without-http \
     --without-legacy \
-    --without-python
+    --without-python \
+    --enable-static
 make -j$(nproc)
 make install
 cp .libs/libxml2.a ${DEPS}/


### PR DESCRIPTION
Set --enable-static for libxml2. This was set to false by default in a
recent commit