### PR TITLE
Revert "Pin Jazzer to older revision. (#7484)"

### DIFF
--- a/infra/base-images/base-builder/install_java.sh
+++ b/infra/base-images/base-builder/install_java.sh
@@ -27,9 +27,8 @@ rm -rf $JAVA_HOME/jmods $JAVA_HOME/lib/src.zip
 # jazzer_api_deploy.jar is required only at build-time, the agent and the
 # drivers are copied to $OUT as they need to be present on the runners.
 cd $SRC/
-git clone https://github.com/CodeIntelligenceTesting/jazzer && \
-cd jazzer && \
-git checkout 2b9e71a2e6ddeb37b18806d055e556b903c94ef3
+git clone --depth=1 https://github.com/CodeIntelligenceTesting/jazzer && \
+cd jazzer
 bazel build --java_runtime_version=local_jdk_15 -c opt --cxxopt="-stdlib=libc++" --linkopt=-lc++ \
   //agent:jazzer_agent_deploy.jar //driver:jazzer_driver //driver:jazzer_driver_asan //driver:jazzer_driver_ubsan //agent:jazzer_api_deploy.jar
 cp bazel-bin/agent/jazzer_agent_deploy.jar bazel-bin/driver/jazzer_driver bazel-bin/driver/jazzer_driver_asan bazel-bin/driver/jazzer_driver_ubsan /usr/local/bin/


### PR DESCRIPTION
Fixes #7483.

The missing target has been added back in https://github.com/CodeIntelligenceTesting/jazzer/pull/372, which also adds a CI check for OSS-Fuzz compatibility.

@oliverchang 