### PR TITLE
ngolo-fuzzing: use latest go from git

### DIFF
--- a/projects/ngolo-fuzzing/Dockerfile
+++ b/projects/ngolo-fuzzing/Dockerfile
@@ -26,6 +26,7 @@ RUN mkdir LPM; \
 
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 
+RUN git clone --depth 1 https://go.googlesource.com/go goroot
 RUN git clone --depth 1 https://github.com/catenacyber/ngolo-fuzzing.git
 
 COPY build.sh $SRC/

--- a/projects/ngolo-fuzzing/build.sh
+++ b/projects/ngolo-fuzzing/build.sh
@@ -15,6 +15,14 @@
 #
 ################################################################################
 
+# compile latest go from git
+(
+cd $SRC/goroot/src
+./make.bash
+)
+rm -Rf /root/.go/
+mv $SRC/goroot /root/.go
+
 compile_package () {
     pkg=$1
     pkg_flat=`echo $pkg | sed 's/\//_/g'`
@@ -35,6 +43,7 @@ compile_package () {
     $CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz_ng_$pkg_flat/ngolofuzz.pb.o fuzz_ng_$pkg_flat//ngolofuzz.o fuzz_ng_$pkg_flat.a  $SRC/LPM/src/libfuzzer/libprotobuf-mutator-libfuzzer.a $SRC/LPM/src/libprotobuf-mutator.a $SRC/LPM/external.protobuf/lib/libprotobuf.a -o $OUT/fuzz_ng_$pkg_flat
 }
 
+# in $SRC/ngolo-fuzzing
 go build
 
 (


### PR DESCRIPTION
So that fixes appear before the next release like https://github.com/golang/go/issues/52035