### PR TITLE
infra: fuzz-introspector updates and bump

### DIFF
--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -217,7 +217,7 @@ if [ "$SANITIZER" = "introspector" ]; then
   
   cd $SRC/inspector
   python3 /fuzz-introspector/post-processing/main.py correlate --binaries_dir=$OUT/
-  python3 /fuzz-introspector/post-processing/main.py report --target_dir=$SRC/inspector --git_repo_url=$GIT_REPO --coverage_url=$COVERAGE_URL --correlation_file=exe_to_fuzz_introspector_logs.yaml
+  python3 /fuzz-introspector/post-processing/main.py report --target_dir=$SRC/inspector --coverage_url=$COVERAGE_URL --correlation_file=exe_to_fuzz_introspector_logs.yaml
 
   cp -rf $SRC/inspector $OUT/inspector
 fi

--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y wget sudo && \
 RUN apt-get update && apt-get install -y git && \
     git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
     cd fuzz-introspector && \
-    git checkout 652a582e347f6f5bfd1451115849ce1c71bb9160 && \
+    git checkout a5b53ca79684f206832fe3388164f66611405bfc && \
     apt-get remove --purge -y git
 
 COPY checkout_build_install_llvm.sh /root/

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -641,7 +641,6 @@ def build_fuzzers_impl(  # pylint: disable=too-many-arguments,too-many-locals,to
       'FUZZING_ENGINE=' + engine,
       'SANITIZER=' + sanitizer,
       'ARCHITECTURE=' + architecture,
-      'GIT_REPO=',  # TODO(navidem): load from main_repo in project.yaml.
   ]
 
   _add_oss_fuzz_ci_if_needed(env)

--- a/projects/fluent-bit/build.sh
+++ b/projects/fluent-bit/build.sh
@@ -14,6 +14,14 @@
 # limitations under the License.
 #
 ################################################################################
+
+# For fuzz-introspector, cxclude all functions in the fluent-bit/lib/ directory
+export FUZZ_INTROSPECTOR_CONFIG=$SRC/fuzz_introspector_exclusion.config
+cat > $FUZZ_INTROSPECTOR_CONFIG <<EOF
+FILES_TO_AVOID
+fluent-bit/lib
+EOF
+
 cd fluent-bit
 sed -i 's/malloc(/fuzz_malloc(/g' ./lib/msgpack-c/src/zone.c
 sed -i 's/struct msgpack_zone_chunk {/void *fuzz_malloc(size_t size) {if (size > 0xa00000) return NULL;\nreturn malloc(size);}\nstruct msgpack_zone_chunk {/g' ./lib/msgpack-c/src/zone.c

--- a/projects/libarchive/build.sh
+++ b/projects/libarchive/build.sh
@@ -15,6 +15,14 @@
 #
 ################################################################################
 
+# For fuzz-introspector. This is to exclude all libxml2 code from the
+# fuzz-introspector reports.
+export FUZZ_INTROSPECTOR_CONFIG=$SRC/fuzz_introspector_exclusion.config
+cat > $FUZZ_INTROSPECTOR_CONFIG <<EOF
+FILES_TO_AVOID
+libxml2
+EOF
+
 # compile libxml2 from source so we can statically link
 DEPS=/deps
 mkdir ${DEPS}


### PR DESCRIPTION
- removes use of `git_repo_url` from fuzz-introspector
- adds examples of fuzz-introspector configs for excluding project-specific code from analysis
- bumps fuzz-introspector

This supersedes https://github.com/google/oss-fuzz/pull/7494