### PR TITLE
infra: make per-target coverage reports readable

### DIFF
--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -343,8 +343,8 @@ else
 fi
 
 # Make sure report is readable.
-chmod -R +r $REPORT_ROOT_DIR
-find $REPORT_ROOT_DIR -type d -exec chmod +x {} +
+chmod -R +r $REPORT_ROOT_DIR $REPORT_BY_TARGET_ROOT_DIR
+find $REPORT_ROOT_DIR $REPORT_BY_TARGET_ROOT_DIR -type d -exec chmod +x {} +
 
 if [[ -n $HTTP_PORT ]]; then
   # Serve the report locally.


### PR DESCRIPTION
Similar to the main report make all target reports readable. This is
currently a blocker on fuzz-introspector for running locally.