### PR TITLE
Fuzz JBIG2 code by checking on each object in PDF file

### DIFF
--- a/projects/xpdf/fuzz_pdfload.cc
+++ b/projects/xpdf/fuzz_pdfload.cc
@@ -118,14 +118,15 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
             delete splashOut;
 
-            Object globals;
-            BaseStream *base_str = doc.getBaseStream();
-            if (base_str) {
-              JBIG2Stream *str = new JBIG2Stream(base_str, &globals);
-              str->reset();
-              delete str;
+            XRef *xref = doc.getXRef();
+            int objNums = xref->getNumObjects();
+            Object currentObj;
+            for (int i = 0; i < objNums; ++i) {
+              if (xref->fetch(i, 0, &currentObj)->isStream()){
+                currentObj.getStream()->reset();
+              }
             }
-            globals.free();            
+            currentObj.free();
         }
     } catch (...) {
 


### PR DESCRIPTION
Changing the fuzzer logic to go through each stream in the input file and call reset on it. This allows to actually reach `JBIG2Stream::readTextRegionSeg`