### PR TITLE
tpm2-tss: disable policy from fuzz

### DIFF
--- a/projects/tpm2-tss/build.sh
+++ b/projects/tpm2-tss/build.sh
@@ -33,7 +33,8 @@ export GEN_FUZZ=1
   --disable-tcti-swtpm \
   --disable-doxygen-doc \
   --disable-shared \
-  --disable-fapi
+  --disable-fapi \
+  --disable-policy
 
 sed -i 's/@DX_RULES@/# @DX_RULES@/g' Makefile
 make -j $(nproc) fuzz-targets


### PR DESCRIPTION
This way we don't need additional dependencies not needed for fuzz
tests.

Signed-off-by: William Roberts <william.c.roberts@intel.com>