### PR TITLE
binutils: align fuzzers with upstream

### DIFF
--- a/projects/binutils/fuzz_disas_ext.c
+++ b/projects/binutils/fuzz_disas_ext.c
@@ -34,6 +34,15 @@ typedef struct
   size_t pos;
 } SFILE;
 
+static int
+fuzz_disasm_null_styled_printf (void *stream,
+             enum disassembler_style style,
+             const char *format, ...)
+{
+  return 0;
+}
+
+
 static int objdump_sprintf (void *vf, const char *format, ...)
 {
   SFILE *f = (SFILE *) vf;
@@ -65,7 +74,7 @@ disassemble_architecture(int arch, const uint8_t *Data, size_t Size, int big) {
   struct disassemble_info disasm_info;
   SFILE s;
 
-  init_disassemble_info (&disasm_info, stdout, (fprintf_ftype) fprintf, NULL);
+  init_disassemble_info (&disasm_info, stdout, (fprintf_ftype) fprintf, fuzz_disasm_null_styled_printf);
   disasm_info.fprintf_func = objdump_sprintf;
   disasm_info.print_address_func = generic_print_address;
   disasm_info.display_endian = disasm_info.endian = BFD_ENDIAN_LITTLE;

--- a/projects/binutils/fuzz_disas_ext.c
+++ b/projects/binutils/fuzz_disas_ext.c
@@ -65,7 +65,7 @@ disassemble_architecture(int arch, const uint8_t *Data, size_t Size, int big) {
   struct disassemble_info disasm_info;
   SFILE s;
 
-  init_disassemble_info (&disasm_info, stdout, (fprintf_ftype) fprintf);
+  init_disassemble_info (&disasm_info, stdout, (fprintf_ftype) fprintf, NULL);
   disasm_info.fprintf_func = objdump_sprintf;
   disasm_info.print_address_func = generic_print_address;
   disasm_info.display_endian = disasm_info.endian = BFD_ENDIAN_LITTLE;
@@ -74,6 +74,7 @@ disassemble_architecture(int arch, const uint8_t *Data, size_t Size, int big) {
   disasm_info.buffer_length = Size-10;
   disasm_info.insn_info_valid = 0;
   disasm_info.disassembler_options = options;
+  disasm_info.created_styled_output = false;
 
   if (arch == bfd_arch_arm) {
     disasm_info.private_data = private_data;

--- a/projects/binutils/fuzz_disassemble.c
+++ b/projects/binutils/fuzz_disassemble.c
@@ -60,7 +60,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         return 0;
     }
 
-    init_disassemble_info (&disasm_info, stdout, (fprintf_ftype) fprintf);
+    init_disassemble_info (&disasm_info, stdout, (fprintf_ftype) fprintf, NULL);
     disasm_info.fprintf_func = objdump_sprintf;
     disasm_info.print_address_func = generic_print_address;
     disasm_info.display_endian = disasm_info.endian = BFD_ENDIAN_LITTLE;
@@ -68,6 +68,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     disasm_info.buffer_vma = 0x1000;
     disasm_info.buffer_length = Size-10;
     disasm_info.insn_info_valid = 0;
+    disasm_info.created_styled_output = false;
     s.buffer = AssemblyText;
     s.pos = 0;
     disasm_info.stream = &s;

--- a/projects/binutils/fuzz_disassemble.c
+++ b/projects/binutils/fuzz_disassemble.c
@@ -28,6 +28,14 @@ typedef struct
     size_t pos;
 } SFILE;
 
+static int
+fuzz_disasm_null_styled_printf (void *stream,
+			       enum disassembler_style style,
+			       const char *format, ...)
+{
+  return 0;
+}
+
 static int objdump_sprintf (void *vf, const char *format, ...)
 {
     SFILE *f = (SFILE *) vf;
@@ -60,7 +68,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         return 0;
     }
 
-    init_disassemble_info (&disasm_info, stdout, (fprintf_ftype) fprintf, NULL);
+    init_disassemble_info (&disasm_info, stdout, (fprintf_ftype) fprintf, fuzz_disasm_null_styled_printf);
     disasm_info.fprintf_func = objdump_sprintf;
     disasm_info.print_address_func = generic_print_address;
     disasm_info.display_endian = disasm_info.endian = BFD_ENDIAN_LITTLE;


### PR DESCRIPTION
Upstream changed init_disassemble_info

Ref:
https://github.com/bminor/binutils-gdb/commit/60a3da00bd5407f07d64dff82a4dae98230dfaac