### PR TITLE
[libjpeg-turbo] Fuzz multiple code branches

### DIFF
--- a/projects/libjpeg-turbo/Dockerfile
+++ b/projects/libjpeg-turbo/Dockerfile
@@ -1,4 +1,5 @@
 # Copyright 2016 Google Inc.
+# Copyright 2022 D. R. Commander
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +17,13 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make yasm cmake
-RUN git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo
+RUN git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo libjpeg-turbo.main
+RUN git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo -b 2.0.x libjpeg-turbo.2.0.x
+RUN git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo -b dev libjpeg-turbo.dev || /bin/true
 
 RUN git clone --depth 1 https://github.com/libjpeg-turbo/seed-corpora
 RUN cd seed-corpora && zip -r ../decompress_fuzzer_seed_corpus.zip afl-testcases/jpeg* bugs/decompress* $SRC/libjpeg-turbo/testimages/*.jpg
 RUN cd seed-corpora && zip -r ../compress_fuzzer_seed_corpus.zip afl-testcases/bmp afl-testcases/gif* bugs/compress* $SRC/libjpeg-turbo/testimages/*.bmp $SRC/libjpeg-turbo/testimages/*.ppm
 RUN rm -rf seed-corpora
 
-WORKDIR libjpeg-turbo
-RUN cp fuzz/build.sh $SRC/
+COPY build.sh $SRC/

--- a/projects/libjpeg-turbo/build.sh
+++ b/projects/libjpeg-turbo/build.sh
@@ -1,0 +1,31 @@
+# Copyright 2022 D. R. Commander
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+set -e
+set -u
+
+for branch in main 2.0.x dev; do
+	if [ "$branch" = "dev" -a ! -d libjpeg-turbo.$branch ]; then
+		continue
+	fi
+	pushd libjpeg-turbo.$branch
+	if [ "$branch" = "main" ]; then
+		sh fuzz/build.sh
+	else
+		sh fuzz/build.sh _$branch
+	fi
+	popd
+done


### PR DESCRIPTION
libjpeg-turbo uses a stable mainline branch model, so the main branch is
always stable and feeds into the current release series.  The next-gen
evolving release series is developed in the dev branch, and bug fixes
are cherry-picked into stable branches for past release series.

It is desirable to fuzz the dev branch to ensure that bugs are caught
before the evolving code is merged down into main (which generally
occurs in conjunction with a beta release) and also to allow for the
fuzzers themselves to evolve along with the libjpeg-turbo feature set.
It is also desirable to fuzz the stable branch from the most recent
release series (2.0.x at the moment) to ensure that the same quality is
maintained from when that code occupied the main branch.

Note that both the Dockerfile and multi-branch build script included in
this commit accommodate the fact that the dev branch may not exist.  The
dev branch will not exist between the time that the current release
series enters beta and the first feature for the next-gen release series
is developed.

Closes #7479