### PR TITLE
fuzz-introspector: force use of llvm-nm

### DIFF
--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -149,13 +149,16 @@ fi
 if [ "$SANITIZER" = "introspector" ]; then
   export LDFLAGS="-fuse-ld=gold"
   export AR=llvm-ar
+  export NM=llvm-nm
   export RANLIB=llvm-ranlib
 
   # Move ar and ranlib
   mv /usr/bin/ar /usr/bin/old-ar
+  mv /usr/bin/nm /usr/bin/old-nm
   mv /usr/bin/ranlib /usr/bin/old-ranlib
 
   ln -sf /usr/local/bin/llvm-ar /usr/bin/ar
+  ln -sf /usr/local/bin/llvm-nm /usr/bin/nm
   ln -sf /usr/local/bin/llvm-ranlib /usr/bin/ranlib
 fi
 

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -225,6 +225,7 @@ mv \
   /usr/local/bin/llvm-config \
   /usr/local/bin/llvm-cov \
   /usr/local/bin/llvm-objcopy \
+  /usr/local/bin/llvm-nm \
   /usr/local/bin/llvm-profdata \
   /usr/local/bin/llvm-ranlib \
   /usr/local/bin/llvm-symbolizer \


### PR DESCRIPTION
This fixes various current build failures across projects that use nm as
part of their build process.

Fixes include jansson and apache-httpd, and probably other projects too.