### PR TITLE
[trial-builds] Use buildkit caching

### DIFF
--- a/infra/build/functions/build_and_push_test_images.py
+++ b/infra/build/functions/build_and_push_test_images.py
@@ -75,7 +75,8 @@ def gcb_build_and_push_images(test_image_suffix):
     test_images.append(test_image_name)
     directory = os.path.join('infra', 'base-images', base_image)
     step = build_lib.get_docker_build_step([image_name, test_image_name],
-                                           directory)
+                                           directory,
+                                           buildkit_cache_image=test_image_name)
     steps.append(step)
 
   overrides = {'images': test_images}

--- a/infra/build/functions/build_and_push_test_images.py
+++ b/infra/build/functions/build_and_push_test_images.py
@@ -59,8 +59,9 @@ def build_image(image, tags, cache_from_tag):
   for tag in tags:
     command.extend(['--tag', tag])
     path = os.path.join(IMAGES_DIR, image)
-  command.extend(['--build-arg', 'BUILDKIT_INLINE_CACHE=1', '--cache-from',
-                  cache_from_tag])
+  command.extend([
+      '--build-arg', 'BUILDKIT_INLINE_CACHE=1', '--cache-from', cache_from_tag
+  ])
   command.append(path)
   subprocess.run(command, check=True)
   logging.info('Built: %s', image)

--- a/infra/build/functions/build_and_push_test_images.py
+++ b/infra/build/functions/build_and_push_test_images.py
@@ -48,18 +48,19 @@ def build_and_push_image(image, test_image_suffix):
   main_tag = TAG_PREFIX + image
   testing_tag = main_tag + '-' + test_image_suffix
   tags = [main_tag, testing_tag]
-  build_image(image, tags)
+  build_image(image, tags, testing_tag)
   push_image(testing_tag)
 
 
-def build_image(image, tags):
+def build_image(image, tags, cache_from_tag):
   """Builds |image| and tags it with |tags|."""
   logging.info('Building: %s', image)
   command = ['docker', 'build']
   for tag in tags:
     command.extend(['--tag', tag])
     path = os.path.join(IMAGES_DIR, image)
-  command.extend(['--build-arg', 'BUILDKIT_INLINE_CACHE=1'])
+  command.extend(['--build-arg', 'BUILDKIT_INLINE_CACHE=1', '--cache-from',
+                  cache_from_tag])
   command.append(path)
   subprocess.run(command, check=True)
   logging.info('Built: %s', image)

--- a/infra/build/functions/build_lib.py
+++ b/infra/build/functions/build_lib.py
@@ -319,7 +319,7 @@ def get_git_clone_step(repo_url='https://github.com/google/oss-fuzz.git',
   return clone_step
 
 
-def get_docker_build_step(image_names, directory):
+def get_docker_build_step(image_names, directory, buildkit_cache_image=None):
   """Returns the docker build step."""
   assert len(image_names) >= 1
   directory = os.path.join('oss-fuzz', directory)
@@ -327,12 +327,24 @@ def get_docker_build_step(image_names, directory):
   for image_name in image_names:
     args.extend(['--tag', image_name])
 
-  args.append('.')
-  return {
+  step = {
       'name': 'gcr.io/cloud-builders/docker',
       'args': args,
       'dir': directory,
   }
+  # Note that we mutate "args" after making it a value in step.
+
+  if buildkit_cache_image is not None:
+    env = ['DOCKER_BUILDKIT=1']
+    step['env'] = env
+    assert buildkit_cache_image in args
+    additional_args = ['--build-arg', 'BUILDKIT_INLINE_CACHE=1',
+                       '--cache-from', buildkit_cache_image]
+    args.extend(additional_args)
+  args.append('.')
+
+  return step
+
 
 
 def project_image_steps(name,

--- a/infra/build/functions/build_lib.py
+++ b/infra/build/functions/build_lib.py
@@ -338,13 +338,14 @@ def get_docker_build_step(image_names, directory, buildkit_cache_image=None):
     env = ['DOCKER_BUILDKIT=1']
     step['env'] = env
     assert buildkit_cache_image in args
-    additional_args = ['--build-arg', 'BUILDKIT_INLINE_CACHE=1',
-                       '--cache-from', buildkit_cache_image]
+    additional_args = [
+        '--build-arg', 'BUILDKIT_INLINE_CACHE=1', '--cache-from',
+        buildkit_cache_image
+    ]
     args.extend(additional_args)
   args.append('.')
 
   return step
-
 
 
 def project_image_steps(name,


### PR DESCRIPTION
Do this to make trial builds more interactive. By using buildkit caching, we won't need to rebuild every single image when a change is made to the PR.