### PR TITLE
fuzz-introspector: add -lto to ldflags

### DIFF
--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -147,7 +147,7 @@ if [ "$FUZZING_LANGUAGE" = "jvm" ]; then
 fi
 
 if [ "$SANITIZER" = "introspector" ]; then
-  export LDFLAGS="-fuse-ld=gold"
+  export LDFLAGS="-fuse-ld=gold -flto"
   export AR=llvm-ar
   export RANLIB=llvm-ranlib
 


### PR DESCRIPTION
This solves build issues for several projects, including hiredis. 