### PR TITLE
lxml: catch highest exception

### DIFF
--- a/projects/lxml/fuzz_html_parse.py
+++ b/projects/lxml/fuzz_html_parse.py
@@ -26,7 +26,7 @@ def TestOneInput(data):
     root = et.HTML(data)
     if root != None:
       et.tostring(root)
-  except et.XMLSyntaxError:
+  except et.LxmlError:
     None
 
 

--- a/projects/lxml/fuzz_sax.py
+++ b/projects/lxml/fuzz_sax.py
@@ -30,7 +30,7 @@ def TestOneInput(data):
 
     handler = sax.ElementTreeContentHandler()
     sax.ElementTreeProducer(parsed, handler).saxify()
-  except et.XMLSyntaxError:
+  except et.LxmlError:
     None
 
 def main():


### PR DESCRIPTION
fuzz_html_parse can also throw SerialisationError:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=46579

Forces the fuzzers to catch highest lxml exception for now.