### PR TITLE
ostree: initial integration

### DIFF
--- a/projects/ostree/Dockerfile
+++ b/projects/ostree/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2018 Google Inc.
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/ostree/Dockerfile
+++ b/projects/ostree/Dockerfile
@@ -1,0 +1,38 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y \
+    make \
+    autoconf \
+    pkg-config \
+    automake \
+    software-properties-common \
+    wget \
+    liblzma-dev \
+    libffi-dev \
+    libext2fs-dev \
+    libgpgme-dev libfuse-dev \
+    python3-pip \
+    libtool \
+    bison
+RUN unset CFLAGS CXXFLAGS && pip3 install -U meson ninja
+RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/glib
+RUN git clone https://github.com/ostreedev/ostree && \
+    cd ostree && \
+    git submodule update --init
+COPY build.sh $SRC/
+COPY fuzz*.c $SRC/

--- a/projects/ostree/build.sh
+++ b/projects/ostree/build.sh
@@ -1,0 +1,88 @@
+#!/bin/bash -eu
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Build glib with sanitizer support
+cd glib
+mkdir build
+cd build
+meson --prefix=/usr --buildtype=release -Db_lundef=false -Ddefault_library=static -Dlibmount=disabled
+ninja
+ninja install
+
+# Build libostree
+cd $SRC/ostree
+env NOCONFIGURE=1 ./autogen.sh
+./configure --enable-static --without-selinux
+make V=1
+
+# This needs to be able to fail in case some tests are breaking.
+make check V=1 || true
+
+# Build fuzzers
+cp $SRC/fuzz*.c ./tests/
+
+FUZZ_LIBS="./.libs/libbsdiff.a \
+           ./.libs/libglnx.a \
+           ./.libs/libotutil.a \
+           -L/usr/lib/x86_64-linux-gnu \
+           ./.libs/libostree-1.a \
+           ./.libs/libostreetest.a \
+           ./.libs/libostree-1.a \
+           -l:libgpgme.a \
+           -l:libassuan.a \
+           /usr/lib/x86_64-linux-gnu/libgpg-error.so \
+           -l:liblzma.a \
+           -l:libgio-2.0.a \
+           -lresolv \
+           -l:libgobject-2.0.a \
+           -l:libffi.a \
+           -l:libgmodule-2.0.a \
+           -l:libglib-2.0.a \
+           -lm \
+           -l:libz.a \
+           -l:libselinux.a \
+           -pthread"
+
+FUZZ_INCLUDES="-I./src/libotutil \
+               -I./src/libostree \
+               -I./src/libostree \
+               -I./src/ostree \
+               -I./libglnx \
+               -I/usr/include/gio-unix-2.0 \
+               -I/usr/include/glib-2.0 \
+               -I/usr/lib/x86_64-linux-gnu/glib-2.0/include \
+               -DPKGLIBEXECDIR=\"/usr/local/libexec/libostree\""
+
+FUZZ_DEFINES="-DHAVE_CONFIG_H \
+              -I. \
+              -DDATADIR=\"/usr/local/share\" \
+              -DLIBEXECDIR=\"/usr/local/libexec\" \
+              -DLOCALEDIR=\"/usr/local/share/locale\" \
+              -DSYSCONFDIR=\"/usr/local/etc\" \
+              -DTARGET_PREFIX=\"/usr/local\" \
+              -DOSTREE_COMPILATION \
+              -DG_LOG_DOMAIN=\"OSTree\" \
+              -DOSTREE_GITREV=\"v2022.2-41-gf21944da1cf24cc2bbf1d4dfbd3aaa698d4f0a70\" \
+              -DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_66 \
+              -DSOUP_VERSION_MIN_REQUIRED=SOUP_VERSION_2_40"
+
+FUZZ_WERROR=""
+
+for fuzz in repo bsdiff; do
+  $CC $CFLAGS $FUZZ_DEFINES $FUZZ_INCLUDES -o tests/fuzz-$fuzz.o -c tests/fuzz-$fuzz.c
+  $CC $CFLAGS $LIB_FUZZING_ENGINE $FUZZ_INCLUDES -o $OUT/fuzz-$fuzz  tests/fuzz-$fuzz.o $FUZZ_LIBS
+done

--- a/projects/ostree/fuzz-bsdiff.c
+++ b/projects/ostree/fuzz-bsdiff.c
@@ -1,0 +1,71 @@
+/* Copyright 2022 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "config.h"
+
+#include "libglnx.h"
+#include "bsdiff/bsdiff.h"
+#include "bsdiff/bspatch.h"
+#include <glib.h>
+#include <stdlib.h>
+#include <gio/gio.h>
+#include <string.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
+
+static int
+bzdiff_write (struct bsdiff_stream* stream, const void* buffer, int size)
+{
+  GOutputStream *out = stream->opaque;
+  if (! g_output_stream_write (out,
+                               buffer,
+                               size,
+                               NULL,
+                               NULL)) {
+    return -1;
+  }
+
+  return 0;
+}
+
+
+int
+LLVMFuzzerTestOneInput (const uint8_t *data,
+                        size_t         size)
+{
+#define NEW_SIZE (512+24)
+
+  struct bsdiff_stream bsdiff_stream;
+  struct bspatch_stream bspatch_stream;
+  int i;
+  g_autofree guint8 *old = g_new (guint8, size);
+  g_autofree guint8 *new = g_new (guint8, NEW_SIZE);
+  g_autofree guint8 *new_generated = g_new0 (guint8, NEW_SIZE);
+  g_autoptr(GOutputStream) out = g_memory_output_stream_new_resizable ();
+  g_autoptr(GInputStream) in = NULL;
+
+  new[0] = 'A';
+  for (i = 0; i < size; i++) {
+    old[i] = data[i];
+  }
+  for (i = 0; i < NEW_SIZE; i++) {
+    new[i] = i;
+  }
+
+  bsdiff_stream.malloc = malloc;
+  bsdiff_stream.free = free;
+  bsdiff_stream.write = bzdiff_write;
+  bsdiff_stream.opaque = out;
+  bsdiff (old, size, new, NEW_SIZE, &bsdiff_stream);
+
+  return 0;
+}

--- a/projects/ostree/fuzz-repo.c
+++ b/projects/ostree/fuzz-repo.c
@@ -1,0 +1,103 @@
+/* Copyright 2022 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "config.h"
+
+#include "libglnx.h"
+#include "bsdiff/bsdiff.h"
+#include "bsdiff/bspatch.h"
+#include <glib.h>
+#include <stdlib.h>
+#include <gio/gio.h>
+#include <glib-object.h>
+#include <libglnx.h>
+#include <locale.h>
+
+#include "ostree-autocleanups.h"
+#include "ostree-types.h"
+
+#include <string.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
+
+typedef struct
+{
+  GLnxTmpDir tmpdir;
+} Fixture;
+
+
+int
+setup (Fixture       *fixture,
+       gconstpointer  test_data)
+{
+  g_autoptr(GError) error = NULL;
+  if (! glnx_mkdtemp ("test-repo-XXXXXX", 0700, &fixture->tmpdir, &error)) {
+    return 1;
+  }
+  return 0;
+}
+
+void
+teardown (Fixture       *fixture,
+          gconstpointer  test_data)
+{
+ 
+  (void) glnx_tmpdir_delete (&fixture->tmpdir, NULL, NULL);
+}
+
+void
+payload (Fixture         *fixture,
+         const uint8_t   *data,
+         size_t           size)
+{
+  g_autoptr (GKeyFile) config = NULL;
+  g_autoptr(GError) error = NULL;
+  guint64 bytes = 0;
+
+  g_autoptr(OstreeRepo) repo = ostree_repo_create_at (fixture->tmpdir.fd,
+                                                      ".",
+                                                      OSTREE_REPO_MODE_ARCHIVE,
+                                                      NULL,
+                                                      NULL,
+                                                      &error);
+
+  config = ostree_repo_copy_config (repo);
+
+  g_key_file_remove_key (config, "core", "min-free-space-size", NULL);
+  
+  char *m1 = malloc(size+1);
+  memcpy(m1, data, size);
+  m1[size] = '\0';
+
+  g_key_file_set_string (config, m1, m1, m1);
+
+  ostree_repo_write_config (repo, config, &error);
+  ostree_repo_reload_config (repo, NULL, &error);
+  ostree_repo_get_min_free_space_bytes (repo, &bytes, &error);
+
+  free(m1);
+}
+
+int
+LLVMFuzzerTestOneInput (const uint8_t *data,
+                       size_t          size)
+{
+  Fixture ft;
+  g_auto(GLnxTmpDir) ret_tmpdir = { 0, };
+  ft.tmpdir = ret_tmpdir;
+  if (setup(&ft, NULL) == 1) {
+    return 0;
+  }
+
+  payload(&ft, data, size);
+  teardown(&ft, NULL);
+  return 0;
+}

--- a/projects/ostree/project.yaml
+++ b/projects/ostree/project.yaml
@@ -1,0 +1,4 @@
+homepage: "https://github.com/ostreedev/ostree"
+main_repo: 'https://github.com/ostreedev/ostree'
+language: c
+primary_contact: "david@adalogics.com"

--- a/projects/ostree/project.yaml
+++ b/projects/ostree/project.yaml
@@ -1,4 +1,6 @@
 homepage: "https://github.com/ostreedev/ostree"
 main_repo: 'https://github.com/ostreedev/ostree'
 language: c
-primary_contact: "david@adalogics.com"
+primary_contact: "walters@verbum.org"
+auto_ccs:
+  - "david@adalogics.com"

--- a/projects/ostree/project.yaml
+++ b/projects/ostree/project.yaml
@@ -3,4 +3,5 @@ main_repo: 'https://github.com/ostreedev/ostree'
 language: c
 primary_contact: "walters@verbum.org"
 auto_ccs:
+  - "dbn@endlessos.org"
   - "david@adalogics.com"


### PR DESCRIPTION
ostree, aka libostree, is a library for committing and downloading
bootable filesytem trees.

Ostree is used by https://github.com/containers/image which is a library
that's used by https://github.com/cri-o/cri-o which is an implementation
of the Kubernetes container runtime interface
(https://kubernetes.io/blog/2016/12/container-runtime-interface-cri-in-kubernetes/).

In this sense, ostree is library that's used by many Kubernetes
deployments to manage their container runtime.

Integrating this as it's a dependency to Kubernetes components that is
written in C.