### PR TITLE
[cri-o] Initial integration

### DIFF
--- a/projects/cri-o/Dockerfile
+++ b/projects/cri-o/Dockerfile
@@ -1,0 +1,30 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN apt-get update && apt-get install -y libaio-dev autoconf gettext texinfo \
+	libbtrfs-dev git libassuan-dev libdevmapper-dev libglib2.0-dev libc6-dev \
+	libgpgme-dev libgpg-error-dev libseccomp-dev libsystemd-dev libselinux1-dev \
+	pkg-config go-md2man libudev-dev software-properties-common systemd
+RUN git clone --depth 1 https://github.com/cri-o/cri-o
+RUN git clone --depth 1 https://github.com/cncf/cncf-fuzzing
+COPY build.sh $SRC/
+RUN wget https://sourceware.org/ftp/lvm2/LVM2.2.03.15.tgz \
+    && tar -xvzf ./LVM2.2.03.15.tgz \
+    && cd LVM2.2.03.15 \
+    && ./configure --disable-selinux \
+    && make
+WORKDIR $SRC/cri-o

--- a/projects/cri-o/build.sh
+++ b/projects/cri-o/build.sh
@@ -1,0 +1,18 @@
+#/bin/bash -eu
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+$SRC/cncf-fuzzing/projects/cri-o/build.sh

--- a/projects/cri-o/project.yaml
+++ b/projects/cri-o/project.yaml
@@ -1,0 +1,13 @@
+homepage: "https://cri-o.io/"
+main_repo: "https://github.com/cri-o/cri-o"
+primary_contact: "cncf-crio-security@lists.cncf.io"
+auto_ccs :
+  - "adam@adalogics.com"
+  - "david@adalogics.com"
+  - "pehunt@redhat.com"
+  - "sgrunert@redhat.com"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
This adds initial integration of cri-o. Cri-o is a CNCF-hosted implementation of the Kubernetes Container Runtime Interface and is used as the container runtime on many Kubernetes clusters. cri-o's users include:

* [Red Hat's Openshift Container Platform](https://www.openshift.com/) 
* [SUSE CaaS Platform](https://www.suse.com/products/caas-platform)
* [openSUSE Kubic](https://kubic.opensuse.org)
* [Digital Science](https://www.digital-science.com/) (used by Astra Zeneca, the UK NHS, University of Oxford)
* [HERE Technologies](https://here.com) (handles 100b+ API calls/month)
__________________________________________
@haircommander @saschagrunert for info