### PR TITLE
wasmtime: update regalloc fuzzer to use regalloc2.

### DIFF
--- a/projects/wasmtime/Dockerfile
+++ b/projects/wasmtime/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.s
 
 RUN git clone --depth 1 https://github.com/bytecodealliance/wasm-tools wasm-tools
 
-RUN git clone --depth 1 https://github.com/bytecodealliance/regalloc.rs regalloc.rs
+RUN git clone --depth 1 https://github.com/bytecodealliance/regalloc2 regalloc2
 
 RUN git clone --depth 1 https://github.com/bytecodealliance/wasmtime wasmtime
 WORKDIR wasmtime

--- a/projects/wasmtime/build.sh
+++ b/projects/wasmtime/build.sh
@@ -30,6 +30,8 @@ build() {
   shift
   fuzz_targets=$1
   shift
+  fuzz_target_path=$1
+  shift
   PROJECT_DIR=$SRC/$project
 
   # ensure we get absolute paths for the coverage report
@@ -41,7 +43,7 @@ build() {
 
   cd $PROJECT_DIR/fuzz && cargo fuzz build --strip-dead-code -O --debug-assertions "$@"
 
-  FUZZ_TARGET_OUTPUT_DIR=$PROJECT_DIR/target/x86_64-unknown-linux-gnu/release
+  FUZZ_TARGET_OUTPUT_DIR=$PROJECT_DIR/$fuzz_target_path/x86_64-unknown-linux-gnu/release
 
   if [ "x$fuzz_targets" = "x" ]; then
       fuzz_targets=$PROJECT_DIR/fuzz/fuzz_targets/*.rs
@@ -69,9 +71,9 @@ build() {
 # Ensure OCaml environment is set up prior to Wasmtime build.
 eval $(opam env)
 
-build wasmtime "" ""
-build wasm-tools wasm-tools- ""
-build regalloc.rs regalloc- bt bt
+build wasmtime "" "" target
+build wasm-tools wasm-tools- "" target
+build regalloc2 regalloc2- ion_checker fuzz/target
 
 # In coverage builds copy the opam header files into the output so coverage can
 # find the source files.


### PR DESCRIPTION
We are currently (bytecodealliance/wasmtime#3989) switching over to a
new register allocator in Cranelift/wasmtime. This PR switches our
fuzzing setup to start fuzzing the new allocator instead of the old one.