### PR TITLE
fuzz-introspector: remove use of LDFLAGS

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -83,7 +83,7 @@ ENV SANITIZER_FLAGS_dataflow "-fsanitize=dataflow"
 
 ENV SANITIZER_FLAGS_thread "-fsanitize=thread"
 
-ENV SANITIZER_FLAGS_introspector "-flegacy-pass-manager -flto -fno-inline-functions -Wl,-fuse-ld=gold,-flto"
+ENV SANITIZER_FLAGS_introspector "-flegacy-pass-manager -flto -fno-inline-functions -Wl,-fuse-ld=gold,-flto -Wno-unused-command-line-argument"
 
 # Do not use any sanitizers in the coverage build.
 ENV SANITIZER_FLAGS_coverage ""

--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -83,7 +83,7 @@ ENV SANITIZER_FLAGS_dataflow "-fsanitize=dataflow"
 
 ENV SANITIZER_FLAGS_thread "-fsanitize=thread"
 
-ENV SANITIZER_FLAGS_introspector "-flegacy-pass-manager -flto -fno-inline-functions"
+ENV SANITIZER_FLAGS_introspector "-flegacy-pass-manager -flto -fno-inline-functions -Wl,-fuse-ld=gold,-flto"
 
 # Do not use any sanitizers in the coverage build.
 ENV SANITIZER_FLAGS_coverage ""

--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -147,7 +147,6 @@ if [ "$FUZZING_LANGUAGE" = "jvm" ]; then
 fi
 
 if [ "$SANITIZER" = "introspector" ]; then
-  export LDFLAGS="-fuse-ld=gold -flto"
   export AR=llvm-ar
   export NM=llvm-nm
   export RANLIB=llvm-ranlib


### PR DESCRIPTION
The use of LDFLAGS does not really follow the policy of OSS-Fuzz. This
moves the linker flags into the sanitizer flags.

Ref:
https://github.com/google/oss-fuzz/issues/7540#issuecomment-1094500094