### PR TITLE
ngolo-fuzzing: better exclude pattern

### DIFF
--- a/projects/ngolo-fuzzing/build.sh
+++ b/projects/ngolo-fuzzing/build.sh
@@ -26,7 +26,7 @@ mv $SRC/goroot /root/.go
 compile_package () {
     pkg=$1
     pkg_flat=`echo $pkg | sed 's/\//_/g'`
-    args=`cat $SRC/ngolo-fuzzing/std/exclude.txt | grep $pkg_flat | awk '{print "-exclude", $2}'`
+    args=`cat $SRC/ngolo-fuzzing/std/exclude.txt | grep "$pkg_flat " | awk '{print "-exclude", $2}'`
     ./ngolo-fuzzing $args $pkg fuzz_ng_$pkg_flat
     (
         cd fuzz_ng_$pkg_flat


### PR DESCRIPTION
so that `runtime` gets only patterns from `runtime` and not from `runtime/debug`