### PR TITLE
infra: fix fuzz-introspector linker flags

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -83,7 +83,7 @@ ENV SANITIZER_FLAGS_dataflow "-fsanitize=dataflow"
 
 ENV SANITIZER_FLAGS_thread "-fsanitize=thread"
 
-ENV SANITIZER_FLAGS_introspector "-flegacy-pass-manager -flto -fno-inline-functions -Wl,-fuse-ld=gold,-flto -Wno-unused-command-line-argument"
+ENV SANITIZER_FLAGS_introspector "-flegacy-pass-manager -flto -fno-inline-functions -fuse-ld=gold -Wno-unused-command-line-argument"
 
 # Do not use any sanitizers in the coverage build.
 ENV SANITIZER_FLAGS_coverage ""


### PR DESCRIPTION
Moves -fuse-ld=gold to compile flags and removes -flto from linker
flags.

Should fix a number of the projects
https://github.com/google/oss-fuzz/issues/7540#issuecomment-1101823684

Ref:
https://github.com/google/oss-fuzz/issues/7540#issuecomment-1101868436

Ref:
https://github.com/google/oss-fuzz/issues/7540#issuecomment-1101882757