### PR TITLE
[knot-dns] fix build of the gnutls dependency

### DIFF
--- a/projects/knot-dns/Dockerfile
+++ b/projects/knot-dns/Dockerfile
@@ -23,13 +23,15 @@ RUN apt-get update && apt-get install -y \
  bison \
  gettext \
  gperf \
+ gtk-doc-tools \
+ libev-dev \
+ libev4 \
+ libtasn1-bin \
  libtool \
  make \
  pkg-config \
  texinfo \
- wget \
- libev4 \
- libev-dev
+ wget
 
 ENV GNULIB_TOOL $SRC/gnulib/gnulib-tool
 RUN git clone git://git.savannah.gnu.org/gnulib.git


### PR DESCRIPTION
Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=46482

Inspired by https://github.com/google/oss-fuzz/commit/88ca7c42141f6c99f30724d2179bb26b0fa84d0b