### PR TITLE
projects/cosmos-sdk: change base image to base-builder-go for Go 1.18

### DIFF
--- a/projects/cosmos-sdk/Dockerfile
+++ b/projects/cosmos-sdk/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-go-codeintelligencetesting
+FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN git clone --single-branch --branch fuzz-packages https://github.com/cosmos/cosmos-sdk
 
 COPY build.sh $SRC


### PR DESCRIPTION
cosmos-sdk fuzz tests are being converted to native Go format, but the
base-builder-go-codeintelligencetesting image doesn't have `gotip`.