### PR TITLE
Fix zlib - do not exit() from libFuzzer, just return from function

### DIFF
--- a/projects/zlib/compress_fuzzer.c
+++ b/projects/zlib/compress_fuzzer.c
@@ -65,7 +65,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *d, size_t size) {
 
   const int level = d[0] % 10;
   d++,size--;
-  
+
   //https://web.archive.org/web/20200220015003/http://www.onicos.com/staff/iz/formats/gzip.html
   unsigned compression_method = d[0] % 5;
   if (compression_method == 4)  //[4...7] are reserved

--- a/projects/zlib/example_dict_fuzzer.c
+++ b/projects/zlib/example_dict_fuzzer.c
@@ -10,7 +10,7 @@
 #define CHECK_ERR(err, msg) { \
     if (err != Z_OK) { \
         fprintf(stderr, "%s error: %d\n", msg, err); \
-        exit(1); \
+        return 1; \
     } \
 }
 
@@ -24,7 +24,7 @@ static unsigned long dictId; /* Adler32 value of the dictionary */
 /* ===========================================================================
  * Test deflate() with preset dictionary
  */
-void test_dict_deflate(unsigned char **compr, size_t *comprLen)
+int test_dict_deflate(unsigned char **compr, size_t *comprLen)
 {
     z_stream c_stream; /* compression stream */
     int err;
@@ -79,16 +79,17 @@ void test_dict_deflate(unsigned char **compr, size_t *comprLen)
     err = deflate(&c_stream, Z_FINISH);
     if (err != Z_STREAM_END) {
         fprintf(stderr, "deflate dict should report Z_STREAM_END\n");
-        exit(1);
+        return 1;
     }
     err = deflateEnd(&c_stream);
     CHECK_ERR(err, "deflateEnd");
+    return 0;
 }
 
 /* ===========================================================================
  * Test inflate() with a preset dictionary
  */
-void test_dict_inflate(unsigned char *compr, size_t comprLen) {
+int test_dict_inflate(unsigned char *compr, size_t comprLen) {
   int err;
   z_stream d_stream; /* decompression stream */
   unsigned char *uncompr;
@@ -114,7 +115,7 @@ void test_dict_inflate(unsigned char *compr, size_t comprLen) {
     if (err == Z_NEED_DICT) {
       if (d_stream.adler != dictId) {
         fprintf(stderr, "unexpected dictionary");
-        exit(1);
+        return 1;
       }
       err = inflateSetDictionary(
           &d_stream, (const unsigned char *)data, dictionaryLen);
@@ -127,10 +128,11 @@ void test_dict_inflate(unsigned char *compr, size_t comprLen) {
 
   if (memcmp(uncompr, data, dataLen)) {
     fprintf(stderr, "bad inflate with dict\n");
-    exit(1);
+    return 1;
   }
 
   free(uncompr);
+  return 0;
 }
 
 int LLVMFuzzerTestOneInput(const uint8_t *d, size_t size) {

--- a/projects/zlib/example_dict_fuzzer.c
+++ b/projects/zlib/example_dict_fuzzer.c
@@ -10,7 +10,7 @@
 #define CHECK_ERR(err, msg) { \
     if (err != Z_OK) { \
         fprintf(stderr, "%s error: %d\n", msg, err); \
-        return 1; \
+        return 0; \
     } \
 }
 
@@ -79,7 +79,7 @@ int test_dict_deflate(unsigned char **compr, size_t *comprLen)
     err = deflate(&c_stream, Z_FINISH);
     if (err != Z_STREAM_END) {
         fprintf(stderr, "deflate dict should report Z_STREAM_END\n");
-        return 1;
+        return 0;
     }
     err = deflateEnd(&c_stream);
     CHECK_ERR(err, "deflateEnd");
@@ -115,7 +115,7 @@ int test_dict_inflate(unsigned char *compr, size_t comprLen) {
     if (err == Z_NEED_DICT) {
       if (d_stream.adler != dictId) {
         fprintf(stderr, "unexpected dictionary");
-        return 1;
+        return 0;
       }
       err = inflateSetDictionary(
           &d_stream, (const unsigned char *)data, dictionaryLen);
@@ -128,7 +128,7 @@ int test_dict_inflate(unsigned char *compr, size_t comprLen) {
 
   if (memcmp(uncompr, data, dataLen)) {
     fprintf(stderr, "bad inflate with dict\n");
-    return 1;
+    return 0;
   }
 
   free(uncompr);

--- a/projects/zlib/example_flush_fuzzer.c
+++ b/projects/zlib/example_flush_fuzzer.c
@@ -10,7 +10,7 @@
 #define CHECK_ERR(err, msg) { \
     if (err != Z_OK) { \
         fprintf(stderr, "%s error: %d\n", msg, err); \
-        exit(1); \
+        return 1; \
     } \
 }
 
@@ -22,7 +22,7 @@ static free_func zfree = NULL;
 /* ===========================================================================
  * Test deflate() with full flush
  */
-void test_flush(unsigned char *compr, z_size_t *comprLen) {
+int test_flush(unsigned char *compr, z_size_t *comprLen) {
   z_stream c_stream; /* compression stream */
   int err;
   unsigned int len = dataLen;
@@ -52,12 +52,14 @@ void test_flush(unsigned char *compr, z_size_t *comprLen) {
   CHECK_ERR(err, "deflateEnd");
 
   *comprLen = (z_size_t)c_stream.total_out;
+
+  return 0;
 }
 
 /* ===========================================================================
  * Test inflateSync()
  */
-void test_sync(unsigned char *compr, size_t comprLen, unsigned char *uncompr,
+int test_sync(unsigned char *compr, size_t comprLen, unsigned char *uncompr,
                size_t uncomprLen) {
   int err;
   z_stream d_stream; /* decompression stream */
@@ -86,10 +88,11 @@ void test_sync(unsigned char *compr, size_t comprLen, unsigned char *uncompr,
   if (err != Z_DATA_ERROR) {
     fprintf(stderr, "inflate should report DATA_ERROR\n");
     /* Because of incorrect adler32 */
-    exit(1);
+    return 1;
   }
   err = inflateEnd(&d_stream);
   CHECK_ERR(err, "inflateEnd");
+  return 0;
 }
 
 int LLVMFuzzerTestOneInput(const uint8_t *d, size_t size) {

--- a/projects/zlib/example_flush_fuzzer.c
+++ b/projects/zlib/example_flush_fuzzer.c
@@ -10,7 +10,7 @@
 #define CHECK_ERR(err, msg) { \
     if (err != Z_OK) { \
         fprintf(stderr, "%s error: %d\n", msg, err); \
-        return 1; \
+        return 0; \
     } \
 }
 
@@ -88,7 +88,7 @@ int test_sync(unsigned char *compr, size_t comprLen, unsigned char *uncompr,
   if (err != Z_DATA_ERROR) {
     fprintf(stderr, "inflate should report DATA_ERROR\n");
     /* Because of incorrect adler32 */
-    return 1;
+    return 0;
   }
   err = inflateEnd(&d_stream);
   CHECK_ERR(err, "inflateEnd");

--- a/projects/zlib/example_large_fuzzer.c
+++ b/projects/zlib/example_large_fuzzer.c
@@ -10,7 +10,7 @@
 #define CHECK_ERR(err, msg) { \
     if (err != Z_OK) { \
         fprintf(stderr, "%s error: %d\n", msg, err); \
-        exit(1); \
+        return 1; \
     } \
 }
 
@@ -23,7 +23,7 @@ static unsigned int diff;
 /* ===========================================================================
  * Test deflate() with large buffers and dynamic change of compression level
  */
-void test_large_deflate(unsigned char *compr, size_t comprLen,
+int test_large_deflate(unsigned char *compr, size_t comprLen,
                         unsigned char *uncompr, size_t uncomprLen) {
   z_stream c_stream; /* compression stream */
   int err;
@@ -47,7 +47,7 @@ void test_large_deflate(unsigned char *compr, size_t comprLen,
   CHECK_ERR(err, "deflate large 1");
   if (c_stream.avail_in != 0) {
     fprintf(stderr, "deflate not greedy\n");
-    exit(1);
+    return 1;
   }
 
   /* Feed in already compressed data and switch to no compression: */
@@ -68,16 +68,17 @@ void test_large_deflate(unsigned char *compr, size_t comprLen,
   err = deflate(&c_stream, Z_FINISH);
   if (err != Z_STREAM_END) {
     fprintf(stderr, "deflate large should report Z_STREAM_END\n");
-    exit(1);
+    return 1;
   }
   err = deflateEnd(&c_stream);
   CHECK_ERR(err, "deflateEnd");
+  return 0;
 }
 
 /* ===========================================================================
  * Test inflate() with large buffers
  */
-void test_large_inflate(unsigned char *compr, size_t comprLen,
+int test_large_inflate(unsigned char *compr, size_t comprLen,
                         unsigned char *uncompr, size_t uncomprLen) {
   int err;
   z_stream d_stream; /* decompression stream */
@@ -106,8 +107,9 @@ void test_large_inflate(unsigned char *compr, size_t comprLen,
 
   if (d_stream.total_out != 2 * uncomprLen + diff) {
     fprintf(stderr, "bad large inflate: %zu\n", d_stream.total_out);
-    exit(1);
+    return 1;
   }
+  return 0;
 }
 
 int LLVMFuzzerTestOneInput(const uint8_t *d, size_t size) {

--- a/projects/zlib/example_large_fuzzer.c
+++ b/projects/zlib/example_large_fuzzer.c
@@ -10,7 +10,7 @@
 #define CHECK_ERR(err, msg) { \
     if (err != Z_OK) { \
         fprintf(stderr, "%s error: %d\n", msg, err); \
-        return 1; \
+        return 0; \
     } \
 }
 
@@ -47,7 +47,7 @@ int test_large_deflate(unsigned char *compr, size_t comprLen,
   CHECK_ERR(err, "deflate large 1");
   if (c_stream.avail_in != 0) {
     fprintf(stderr, "deflate not greedy\n");
-    return 1;
+    return 0;
   }
 
   /* Feed in already compressed data and switch to no compression: */
@@ -68,7 +68,7 @@ int test_large_deflate(unsigned char *compr, size_t comprLen,
   err = deflate(&c_stream, Z_FINISH);
   if (err != Z_STREAM_END) {
     fprintf(stderr, "deflate large should report Z_STREAM_END\n");
-    return 1;
+    return 0;
   }
   err = deflateEnd(&c_stream);
   CHECK_ERR(err, "deflateEnd");
@@ -107,7 +107,7 @@ int test_large_inflate(unsigned char *compr, size_t comprLen,
 
   if (d_stream.total_out != 2 * uncomprLen + diff) {
     fprintf(stderr, "bad large inflate: %zu\n", d_stream.total_out);
-    return 1;
+    return 0;
   }
   return 0;
 }

--- a/projects/zlib/example_small_fuzzer.c
+++ b/projects/zlib/example_small_fuzzer.c
@@ -10,7 +10,7 @@
 #define CHECK_ERR(err, msg) { \
     if (err != Z_OK) { \
         fprintf(stderr, "%s error: %d\n", msg, err); \
-        return 1; \
+        return 0; \
     } \
 }
 
@@ -88,7 +88,7 @@ int test_inflate(unsigned char *compr, size_t comprLen, unsigned char *uncompr,
 
   if (memcmp(uncompr, data, dataLen)) {
     fprintf(stderr, "bad inflate\n");
-    return 1;
+    return 0;
   }
   return 0;
 }

--- a/projects/zlib/example_small_fuzzer.c
+++ b/projects/zlib/example_small_fuzzer.c
@@ -10,7 +10,7 @@
 #define CHECK_ERR(err, msg) { \
     if (err != Z_OK) { \
         fprintf(stderr, "%s error: %d\n", msg, err); \
-        exit(1); \
+        return 1; \
     } \
 }
 
@@ -22,7 +22,7 @@ static free_func zfree = NULL;
 /* ===========================================================================
  * Test deflate() with small buffers
  */
-void test_deflate(unsigned char *compr, size_t comprLen) {
+int test_deflate(unsigned char *compr, size_t comprLen) {
   z_stream c_stream; /* compression stream */
   int err;
   unsigned long len = dataLen;
@@ -53,12 +53,13 @@ void test_deflate(unsigned char *compr, size_t comprLen) {
 
   err = deflateEnd(&c_stream);
   CHECK_ERR(err, "deflateEnd");
+  return 0;
 }
 
 /* ===========================================================================
  * Test inflate() with small buffers
  */
-void test_inflate(unsigned char *compr, size_t comprLen, unsigned char *uncompr,
+int test_inflate(unsigned char *compr, size_t comprLen, unsigned char *uncompr,
                   size_t uncomprLen) {
   int err;
   z_stream d_stream; /* decompression stream */
@@ -87,8 +88,9 @@ void test_inflate(unsigned char *compr, size_t comprLen, unsigned char *uncompr,
 
   if (memcmp(uncompr, data, dataLen)) {
     fprintf(stderr, "bad inflate\n");
-    exit(1);
+    return 1;
   }
+  return 0;
 }
 
 int LLVMFuzzerTestOneInput(const uint8_t *d, size_t size) {

--- a/projects/zlib/minigzip_fuzzer.c
+++ b/projects/zlib/minigzip_fuzzer.c
@@ -252,30 +252,30 @@ const char *gzerror(gzFile gz, int *err)
 
 static char *prog;
 
-void error            (const char *msg);
-void gz_compress      (FILE   *in, gzFile out);
+int error            (const char *msg);
+int gz_compress      (FILE   *in, gzFile out);
 #ifdef USE_MMAP
 int  gz_compress_mmap (FILE   *in, gzFile out);
 #endif
 void gz_uncompress    (gzFile in, FILE   *out);
-void file_compress    (char  *file, char *mode);
-void file_uncompress  (char  *file);
+int file_compress    (char  *file, char *mode);
+int file_uncompress  (char  *file);
 int  main             (int argc, char *argv[]);
 
 /* ===========================================================================
- * Display error message and exit
+ * Display error message and return
  */
-void error(const char *msg)
+int error(const char *msg)
 {
     fprintf(stderr, "%s: %s\n", prog, msg);
-    exit(1);
+    return 1;
 }
 
 /* ===========================================================================
  * Compress input to output then close both files.
  */
 
-void gz_compress(FILE   *in, gzFile out)
+int gz_compress(FILE   *in, gzFile out)
 {
     char buf[BUFLEN];
     int len;
@@ -294,7 +294,7 @@ void gz_compress(FILE   *in, gzFile out)
         len = (int)fread(buf, 1, sizeof(buf), in);
         if (ferror(in)) {
             perror("fread");
-            exit(1);
+            return 1;
         }
         if (len == 0) break;
 
@@ -302,6 +302,7 @@ void gz_compress(FILE   *in, gzFile out)
     }
     fclose(in);
     if (gzclose(out) != Z_OK) error("failed gzclose");
+    return 0;
 }
 
 #ifdef USE_MMAP /* MMAP version, Miguel Albrecht <malbrech@eso.org> */
@@ -367,7 +368,7 @@ void gz_uncompress(gzFile in, FILE   *out)
  * Compress the given file: create a corresponding .gz file and remove the
  * original.
  */
-void file_compress(char  *file, char  *mode)
+int file_compress(char  *file, char  *mode)
 {
     char outfile[MAX_NAME_LEN];
     FILE  *in;
@@ -375,7 +376,7 @@ void file_compress(char  *file, char  *mode)
 
     if (strlen(file) + strlen(GZ_SUFFIX) >= sizeof(outfile)) {
         fprintf(stderr, "%s: filename too long\n", prog);
-        exit(1);
+        return 1;
     }
 
     snprintf(outfile, sizeof(outfile), "%s%s", file, GZ_SUFFIX);
@@ -383,23 +384,24 @@ void file_compress(char  *file, char  *mode)
     in = fopen(file, "rb");
     if (in == NULL) {
         perror(file);
-        exit(1);
+        return 1;
     }
     out = gzopen(outfile, mode);
     if (out == NULL) {
         fprintf(stderr, "%s: can't gzopen %s\n", prog, outfile);
-        exit(1);
+        return 1;
     }
     gz_compress(in, out);
 
     unlink(file);
+    return 0;
 }
 
 
 /* ===========================================================================
  * Uncompress the given file and remove the original.
  */
-void file_uncompress(char  *file)
+int file_uncompress(char  *file)
 {
     char buf[MAX_NAME_LEN];
     char *infile, *outfile;
@@ -409,7 +411,7 @@ void file_uncompress(char  *file)
 
     if (len + strlen(GZ_SUFFIX) >= sizeof(buf)) {
         fprintf(stderr, "%s: filename too long\n", prog);
-        exit(1);
+        return 1;
     }
 
     snprintf(buf, sizeof(buf), "%s", file);
@@ -426,17 +428,18 @@ void file_uncompress(char  *file)
     in = gzopen(infile, "rb");
     if (in == NULL) {
         fprintf(stderr, "%s: can't gzopen %s\n", prog, infile);
-        exit(1);
+        return 1;
     }
     out = fopen(outfile, "wb");
     if (out == NULL) {
         perror(file);
-        exit(1);
+        return 1;
     }
 
     gz_uncompress(in, out);
 
     unlink(infile);
+    return 0;
 }
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataLen) {
@@ -490,7 +493,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataLen) {
   in = fopen(inFileName, "rb");
   if (in == NULL) {
     perror(inFileName);
-    exit(1);
+    return 1;
   }
 
   memset(buf, 0, sizeof(buf));
@@ -498,7 +501,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataLen) {
     int len = (int)fread(buf, 1, sizeof(buf), in);
     if (ferror(in)) {
       perror("fread");
-      exit(1);
+      return 1;
     }
     if (len == 0)
       break;

--- a/projects/zlib/minigzip_fuzzer.c
+++ b/projects/zlib/minigzip_fuzzer.c
@@ -268,7 +268,7 @@ int  main             (int argc, char *argv[]);
 int error(const char *msg)
 {
     fprintf(stderr, "%s: %s\n", prog, msg);
-    return 1;
+    return 0;
 }
 
 /* ===========================================================================
@@ -294,7 +294,7 @@ int gz_compress(FILE   *in, gzFile out)
         len = (int)fread(buf, 1, sizeof(buf), in);
         if (ferror(in)) {
             perror("fread");
-            return 1;
+            return 0;
         }
         if (len == 0) break;
 
@@ -376,7 +376,7 @@ int file_compress(char  *file, char  *mode)
 
     if (strlen(file) + strlen(GZ_SUFFIX) >= sizeof(outfile)) {
         fprintf(stderr, "%s: filename too long\n", prog);
-        return 1;
+        return 0;
     }
 
     snprintf(outfile, sizeof(outfile), "%s%s", file, GZ_SUFFIX);
@@ -384,12 +384,12 @@ int file_compress(char  *file, char  *mode)
     in = fopen(file, "rb");
     if (in == NULL) {
         perror(file);
-        return 1;
+        return 0;
     }
     out = gzopen(outfile, mode);
     if (out == NULL) {
         fprintf(stderr, "%s: can't gzopen %s\n", prog, outfile);
-        return 1;
+        return 0;
     }
     gz_compress(in, out);
 
@@ -411,7 +411,7 @@ int file_uncompress(char  *file)
 
     if (len + strlen(GZ_SUFFIX) >= sizeof(buf)) {
         fprintf(stderr, "%s: filename too long\n", prog);
-        return 1;
+        return 0;
     }
 
     snprintf(buf, sizeof(buf), "%s", file);
@@ -428,12 +428,12 @@ int file_uncompress(char  *file)
     in = gzopen(infile, "rb");
     if (in == NULL) {
         fprintf(stderr, "%s: can't gzopen %s\n", prog, infile);
-        return 1;
+        return 0;
     }
     out = fopen(outfile, "wb");
     if (out == NULL) {
         perror(file);
-        return 1;
+        return 0;
     }
 
     gz_uncompress(in, out);
@@ -493,7 +493,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataLen) {
   in = fopen(inFileName, "rb");
   if (in == NULL) {
     perror(inFileName);
-    return 1;
+    return 0;
   }
 
   memset(buf, 0, sizeof(buf));
@@ -501,7 +501,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataLen) {
     int len = (int)fread(buf, 1, sizeof(buf), in);
     if (ferror(in)) {
       perror("fread");
-      return 1;
+      return 0;
     }
     if (len == 0)
       break;


### PR DESCRIPTION
When running libFuzzer without fork mode, zlib targets just exit fuzzing on malformed seeds.