### PR TITLE
fuzz-introspector: bump

### DIFF
--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y wget sudo && \
 RUN apt-get update && apt-get install -y git && \
     git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
     cd fuzz-introspector && \
-    git checkout 80c97c95a26caab0f4ab87c816b3e8f99d9ebbd1 && \
+    git checkout e38fbbff621936c02e81d31cbec0d605d6f0a21e && \
     apt-get remove --purge -y git
 
 COPY checkout_build_install_llvm.sh /root/


### PR DESCRIPTION
This has some improvements related to https://github.com/google/oss-fuzz/issues/7593#issuecomment-1104385015 and also if there is a regression in fuzz-introspector as mentioned here https://github.com/google/oss-fuzz/issues/7601#issuecomment-1105647031 (not sure if it actually is a regression or something else) then the current set up works properly with elfutils locally. Also has improvements in some coverage analysis reporting.