### PR TITLE
infra: fix python coverage logic

### DIFF
--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -302,7 +302,7 @@ elif [[ $FUZZING_LANGUAGE == "python" ]]; then
   cd $PYCOVDIR
   python3 /usr/local/bin/python_coverage_runner_help.py combine .coverage_*
   python3 /usr/local/bin/python_coverage_runner_help.py html
-  mv htmlcov $REPORT_ROOT_DIR/
+  mv htmlcov/* $REPORT_PLATFORM_DIR/
 elif [[ $FUZZING_LANGUAGE == "jvm" ]]; then
 
   # From this point on the script does not tolerate any errors.

--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -156,6 +156,11 @@ function run_python_fuzz_target {
   local zipped_sources="$DUMPS_DIR/$target.deps.zip"
   local corpus_real="$CORPUS_DIR/${target}"
   $OUT/$target.pkg $corpus_real -atheris_runs=$(ls -la $corpus_real | wc -l)
+  if (( $? != 0 )); then
+    echo "Error happened getting coverage of $target"
+    echo "This is likely because Atheris did not exit gracefully"
+    return 0
+  fi
   mv .coverage $OUT/.coverage_$target
 }
 


### PR DESCRIPTION
The recently integrated python coverage failed on all projects as far as I can tell. This PR should fix this. Specifically, two fixes:
- coverage reports are put in the right directory (`REPORT_PLATFORM_DIR` instead of `REPORT_ROOT_DIR`)
- in the event a fuzzer fails to generate coverage (e.g. if it exited wrongly) then the coverage logic is discontinued for that particular fuzzer

Ref: https://github.com/google/oss-fuzz/issues/7615
