### PR TITLE
boringssl: Remove -std=c++11

### DIFF
--- a/projects/boringssl/build.sh
+++ b/projects/boringssl/build.sh
@@ -39,7 +39,7 @@ find . -name "*.a"
 for F in $fuzzerFiles; do
   fuzzerName=$(basename $F .cc)
   echo "Building fuzzer $fuzzerName"
-  $CXX $CXXFLAGS -std=c++11 \
+  $CXX $CXXFLAGS \
       -o $OUT/${fuzzerName} $LIB_FUZZING_ENGINE $F \
       -I $SRC/boringssl/include ./ssl/libssl.a  ./crypto/libcrypto.a
 


### PR DESCRIPTION
BoringSSL is trying to upgrade to C++14. Since that's default for Clang
and GCC for about five years now, just remove the explicit -std flag.
Hopefully that'll save some fuss later on when C++17 is the default
and we want to move there.

https://crbug.com/oss-fuzz/46932