### PR TITLE
envoy: add include directory to coverage

### DIFF
--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -124,9 +124,10 @@ then
   # the profiler.
   declare -r REMAP_PATH="${OUT}/proc/self/cwd"
   mkdir -p "${REMAP_PATH}"
-  # For .cc, we only really care about source/ today.
+  # Copy the cc and header files that will be covered.
   rsync -av "${SRC}"/envoy/source "${REMAP_PATH}"
   rsync -av "${SRC}"/envoy/test "${REMAP_PATH}"
+  rsync -av "${SRC}"/envoy/envoy "${REMAP_PATH}"
   # Remove filesystem loop manually.
   rm -rf "${SRC}"/envoy/bazel-envoy/external/envoy
   # Clean up symlinks with a missing referrant.


### PR DESCRIPTION
Adding the envoy include directory which was recently renamed to "include",
in order to fix fuzz coverage step.

This should fix errors we've seen, such as:
```
Step #5: error: /workspace/out/libfuzzer-coverage-x86_64/proc/self/cwd/envoy/config/context_provider.h: No such file or directory
Step #5: warning: The file '/proc/self/cwd/envoy/config/context_provider.h' isn't covered.
```

Signed-off-by: Adi Suissa-Peleg <adip@google.com>