### PR TITLE
infra: enable argument passing to compile_python_fuzzer

### DIFF
--- a/infra/base-images/base-builder/compile_python_fuzzer
+++ b/infra/base-images/base-builder/compile_python_fuzzer
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/bash -eux
 # Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,8 @@
 ################################################################################
 
 fuzzer_path=$1
+shift 1
+
 fuzzer_basename=$(basename -s .py $fuzzer_path)
 fuzzer_package=${fuzzer_basename}.pkg
 
@@ -48,7 +50,7 @@ fi
 rm -rf $PYFUZZ_WORKPATH
 mkdir $PYFUZZ_WORKPATH $FUZZ_WORKPATH
 
-pyinstaller --distpath $OUT --workpath=$FUZZ_WORKPATH --onefile --name $fuzzer_package $fuzzer_path
+pyinstaller --distpath $OUT --workpath=$FUZZ_WORKPATH --onefile --name $fuzzer_package "$@" $fuzzer_path
 
 # In coverage mode save source files of dependencies in pyinstalled binary
 if [[ $SANITIZER = *coverage* ]]; then

--- a/infra/base-images/base-builder/python_coverage_helper.py
+++ b/infra/base-images/base-builder/python_coverage_helper.py
@@ -48,6 +48,8 @@ def get_all_files_from_toc(toc_file, file_path_set):
           if len(egg_path_split) != 2:
             continue
           egg_path = egg_path_split[0] + '.egg'
+          if not os.path.isfile(egg_path):
+            continue
 
           print('Unzipping contents of %s' % egg_path)
 

--- a/projects/django/build.sh
+++ b/projects/django/build.sh
@@ -23,27 +23,5 @@ export DJANGO_SETTINGS_MODULE=fuzzer_project.settings
 
 # Build fuzzers into $OUT. These could be detected in other ways.
 for fuzzer in $(find $SRC -name '*_fuzzer.py'); do
-
-  fuzzer_basename=$(basename -s .py $fuzzer)
-  fuzzer_package=${fuzzer_basename}.pkg
-
-  # To avoid issues with Python version conflicts, or changes in environment
-  # over time on the OSS-Fuzz bots, we use pyinstaller to create a standalone
-  # package. Though not necessarily required for reproducing issues, this is
-  # required to keep fuzzers working properly in OSS-Fuzz.
-  pyinstaller --distpath $OUT --onefile --add-data django/conf/locale/en/LC_MESSAGES:django/conf/locale/en/LC_MESSAGES --name $fuzzer_package $fuzzer
-
-  # Create execution wrapper. Atheris requires that certain libraries are
-  # preloaded, so this is also done here to ensure compatibility and simplify
-  # test case reproduction. Since this helper script is what OSS-Fuzz will
-  # actually execute, it is also always required.
-  # NOTE: If you are fuzzing python-only code and do not have native C/C++
-  # extensions, then remove the LD_PRELOAD line below as preloading sanitizer
-  # library is not required and can lead to unexpected startup crashes.
-  echo "#!/bin/sh
-# LLVMFuzzerTestOneInput for fuzzer detection.
-this_dir=\$(dirname \"\$0\")
-ASAN_OPTIONS=\$ASAN_OPTIONS:symbolize=1:external_symbolizer_path=\$this_dir/llvm-symbolizer:detect_leaks=0 \
-\$this_dir/$fuzzer_package \$@" > $OUT/$fuzzer_basename
-  chmod +x $OUT/$fuzzer_basename
+  compile_python_fuzzer $fuzzer --add-data django/conf/locale/en/LC_MESSAGES:django/conf/locale/en/LC_MESSAGES
 done


### PR DESCRIPTION
Enable passing arguments to pyinstaller. This is used by, e.g. Django.

Ref:
https://github.com/google/oss-fuzz/commit/0cb820e5af64f279f66d0c0d3c93b7437ecabe91#commitcomment-72063587