### PR TITLE
fuzz-introspector: bump

### DIFF
--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y wget sudo && \
 RUN apt-get update && apt-get install -y git && \
     git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
     cd fuzz-introspector && \
-    git checkout 8d3d770d998c2463dc27a607b2afe569cd020ac6 && \
+    git checkout ff2685a105276c753775395b8d206a033c5dbb89 && \
     apt-get remove --purge -y git
 
 COPY checkout_build_install_llvm.sh /root/


### PR DESCRIPTION
Changes:
- coverage fix https://github.com/ossf/fuzz-introspector/issues/249
- UI updates to make the function table smaller by default, but add a button for enabling the user to specify which columns to display https://github.com/ossf/fuzz-introspector/issues/239 
- fixed a bug in navigating calltree: https://github.com/ossf/fuzz-introspector/issues/232

This has been tested on several projects, including jsoncpp and htslib.