### PR TITLE
Add .gitattributes to specify LF as .sh line terminator

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Check out Linux shell scripts with LF (necessary when using Docker setup on Windows)
+*.sh text eol=lf


### PR DESCRIPTION
Resolves partially #7613

Unfortunately this won't cover all Linux shell script files because some seem to have no file extension, e.g. `infra/base-images/base-builder-swift/precompile_swift`.