### PR TITLE
Remove Maven debug logging for Gson build

### DIFF
--- a/projects/gson/build.sh
+++ b/projects/gson/build.sh
@@ -17,7 +17,7 @@
 
 # Skip ProGuard because it is only needed for tests (which are skipped as well) and
 # because it would fail since `jmods` JDK folder is removed from this Docker image
-MAVEN_ARGS="-DskipTests -Dproguard.skip -X"
+MAVEN_ARGS="-DskipTests -Dproguard.skip"
 # Only build 'gson' Maven module
 cd gson
 $MVN --batch-mode --update-snapshots package ${MAVEN_ARGS}


### PR DESCRIPTION
Removes the `-X` flag to avoid debug logging. I assume it was initially added when the Gson build caused issues, but now the build seems to work reliably so debug logging should probably not be necessary anymore.

Could additionally also specify `--no-transfer-progress` to prevent the log output for all the downloaded Maven artifacts during build, if desired.