### PR TITLE
Restore machine type for base images.

### DIFF
--- a/infra/build/functions/base_images.py
+++ b/infra/build/functions/base_images.py
@@ -101,7 +101,9 @@ def run_build(steps, images, tags=None, build_version=MAJOR_TAG):
   credentials, _ = google.auth.default()
   body_overrides = {
       'images': images + [f'{image}:{build_version}' for image in images],
-      'options': {'machineType': 'E2_HIGHCPU_32'},
+      'options': {
+          'machineType': 'E2_HIGHCPU_32'
+      },
   }
   return build_lib.run_build(steps,
                              credentials,

--- a/infra/build/functions/base_images.py
+++ b/infra/build/functions/base_images.py
@@ -100,7 +100,8 @@ def run_build(steps, images, tags=None, build_version=MAJOR_TAG):
   """Execute the retrieved build steps in gcb."""
   credentials, _ = google.auth.default()
   body_overrides = {
-      'images': images + [f'{image}:{build_version}' for image in images]
+      'images': images + [f'{image}:{build_version}' for image in images],
+      'options': {'machineType': 'E2_HIGHCPU_32'},
   }
   return build_lib.run_build(steps,
                              credentials,


### PR DESCRIPTION
This was removed when moving project builds to private pools.