### PR TITLE
logback: update fuzz target to ignore class injection

### DIFF
--- a/projects/logback/JoranFuzzer.java
+++ b/projects/logback/JoranFuzzer.java
@@ -22,7 +22,14 @@ public class JoranFuzzer {
     }
 
     public static void fuzzerTestOneInput(FuzzedDataProvider data) {
-        InputStream xmlcontent = new ByteArrayInputStream(data.consumeString(1000).getBytes());
+        String content = data.consumeString(1000);
+
+        // https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47102
+        if (content.contains("class=\"")) {
+            return;
+        }
+
+        InputStream xmlcontent = new ByteArrayInputStream(content.getBytes());
         try {
             configurator.doConfigure(xmlcontent);
             logger.debug(data.consumeRemainingAsString());


### PR DESCRIPTION
Ignoring class injection as it is an expected behavior: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47102