### PR TITLE
[llvm] Add clang-pseudo fuzzer

### DIFF
--- a/projects/llvm/build.sh
+++ b/projects/llvm/build.sh
@@ -33,6 +33,7 @@ else
     clang-format-fuzzer \
     clang-objc-fuzzer \
     clangd-fuzzer \
+    clang-pseudo-fuzzer \
     llvm-itanium-demangle-fuzzer \
     llvm-microsoft-demangle-fuzzer \
     llvm-dwarfdump-fuzzer \


### PR DESCRIPTION
clang-pseudo-fuzzer fuzzes clang-pseudo, which is a heuristic parser
based on clang's lexer.
This is a new effort and we'd like to keep it fuzz-clean from the beginning.