### PR TITLE
flac: only disable signed integer sanitizing on decoder fuzzers

### DIFF
--- a/projects/flac/build.sh
+++ b/projects/flac/build.sh
@@ -48,10 +48,23 @@ else
 fi
 make -j$(nproc)
 
-# Build fuzzer_exo, copy other fuzzers
+# Copy encoder fuzzers
 cd $SRC/flac/oss-fuzz
-cp fuzzer_encoder fuzzer_encoder_v2 fuzzer_decoder $OUT
+cp fuzzer_encoder fuzzer_encoder_v2 $OUT
+
+# Build libflac again for decoder fuzzers, but now with addition CFLAG
+export CFLAGS="$CFLAGS -DFUZZING_BUILD_MODE_NO_SANITIZE_SIGNED_INTEGER_OVERFLOW"
+
+cd $SRC/flac/
+make clean
+make -j$(nproc)
+
+# Copy decoder fuzzers
+cd $SRC/flac/oss-fuzz
+cp fuzzer_decoder $OUT
 cp fuzzer_*.dict $OUT
 cd $SRC
+
+# Build fuzzer_exo
 $CXX $CXXFLAGS -I $SRC/flac/include/ -I $SRC/ExoPlayer/extensions/flac/src/main/jni/ -I /usr/lib/jvm/java-11-openjdk-amd64/include/ -I /usr/lib/jvm/java-11-openjdk-amd64/include/linux/ fuzzer_exo.cpp \
     $SRC/flac/src/libFLAC++/.libs/libFLAC++.a $SRC/flac/src/libFLAC/.libs/libFLAC.a $SRC/libogg-install/lib/libogg.a $LIB_FUZZING_ENGINE -o $OUT/fuzzer_exo


### PR DESCRIPTION
oss-fuzz has reported numerous signed integer overflow problems in flac that cannot be reasonably fixed. The problem is that flac uses some math that is numerically unstable when fed with random data, and as these are only audio samples, this overflow is not a problem. Therefore, I added `__attribute__((no_sanitize("signed-integer-overflow")))` to a few functions in the flac sources.

However, while a decoder fed with random data has this problem, a decoder that is being used to verify an encoder fed with random data should never overflow. As the same functions are used, the flac sources should be compiled twice: once with the mentioned attributes for the decoder fuzzers, and once without them for the encoder fuzzers.

Note that the define passed in this code is not yet integrated in libflac, but this change should happen first or else the old bugs muted by `__attribute__((no_sanitize("signed-integer-overflow")))` appear again