### PR TITLE
infra: bump fuzz-introspector

### DIFF
--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y wget sudo && \
 RUN apt-get update && apt-get install -y git && \
     git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
     cd fuzz-introspector && \
-    git checkout ff2685a105276c753775395b8d206a033c5dbb89 && \
+    git checkout 566269fdac138a60825270f51df39f515f23679b && \
     apt-get remove --purge -y git
 
 COPY checkout_build_install_llvm.sh /root/

--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y wget sudo && \
 RUN apt-get update && apt-get install -y git && \
     git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
     cd fuzz-introspector && \
-    git checkout 566269fdac138a60825270f51df39f515f23679b && \
+    git checkout fe9f8c94c729527bac96c107defd068960c20216 && \
     apt-get remove --purge -y git
 
 COPY checkout_build_install_llvm.sh /root/


### PR DESCRIPTION
This adds a feature where multiple focus functions are output by fuzz-introspector (https://github.com/ossf/fuzz-introspector/pull/252). 

Can confirm the fuzz-introspector oss-fuzz integration tests (https://github.com/ossf/fuzz-introspector/tree/main/oss_fuzz_integration#testing-before-bumping-oss-fuzz) pass.