### PR TITLE
infra: enable run_fuzzer to accept multiple options

### DIFF
--- a/infra/base-images/base-runner/run_fuzzer
+++ b/infra/base-images/base-runner/run_fuzzer
@@ -158,7 +158,7 @@ else
     CMD_LINE="$CMD_LINE $CORPUS_DIR"
   fi
 
-  if [ ! -z $CUSTOM_LIBFUZZER_OPTIONS ]; then
+  if [[ ! -z ${CUSTOM_LIBFUZZER_OPTIONS} ]]; then
     CMD_LINE="$CMD_LINE $CUSTOM_LIBFUZZER_OPTIONS"
   fi
 


### PR DESCRIPTION
The current run_fuzzer will fail when multiple libfuzzer options are
specificed in a .options file. Currently, if there are multiple options
then none of the options will be used, but rather an issue about a
"binary operator expected" will occur. One implication of this is that
check_build fails to use it and may, therefore, report erroneously. This
fixes it by enabling the use of zero, one and many libfuzzer options.