### PR TITLE
Add XS fuzzer implementation

### DIFF
--- a/projects/xs/Dockerfile
+++ b/projects/xs/Dockerfile
@@ -1,0 +1,21 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN git clone --depth=1 https://github.com/Moddable-OpenSource/moddable moddable
+WORKDIR moddable
+
+COPY build.sh $SRC/
+COPY xst.options $SRC/

--- a/projects/xs/build.sh
+++ b/projects/xs/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -eu
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+
+export MODDABLE=$PWD
+export ASAN_OPTIONS="detect_leaks=0"
+
+cd "$MODDABLE/xs/makefiles/lin"
+FUZZING=1 OSSFUZZ=1 make debug
+
+cd "$MODDABLE"
+cp ./build/bin/lin/debug/xst $OUT/
+cp $SRC/xst.options $OUT/

--- a/projects/xs/xst.options
+++ b/projects/xs/xst.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+detect_leaks=0


### PR DESCRIPTION
Adds the XS fuzzer implementation to oss-fuzz.  Tested on debian/x86 infrastructure with the steps located at https://google.github.io/oss-fuzz/getting-started/new-project-guide/