### PR TITLE
bad_example: make fuzz-introspector work and fix build

### DIFF
--- a/projects/bad_example/bad_example_fuzzer.cc
+++ b/projects/bad_example/bad_example_fuzzer.cc
@@ -1,6 +1,17 @@
 // Copyright 2017 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+/* Copyright 2022 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 #include <stddef.h>
 #include <stdint.h>

--- a/projects/bad_example/build.sh
+++ b/projects/bad_example/build.sh
@@ -1,3 +1,18 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
 #!/bin/bash -eu
 
 # Testcase 1. Valid fuzzer build.

--- a/projects/bad_example/build.sh
+++ b/projects/bad_example/build.sh
@@ -22,8 +22,8 @@ $CXX $CXXFLAGS -std=c++11 -I. -DINTENTIONAL_STARTUP_CRASH \
     $LIB_FUZZING_ENGINE ./libz.a
 
 
-# The latest two examples won't work for coverage build, bail out.
-if [[ $SANITIZER = *coverage* ]]; then
+# The latest two examples won't work for coverage or introspector, bail out.
+if [[ $SANITIZER = *coverage* || $SANITIZER = *introspector* ]]; then
   exit 0
 fi
 
@@ -35,7 +35,8 @@ export CFLAGS="-O1"
 export CXXFLAGS_ORIG="$CXXFLAGS"
 export CXXFLAGS="-O1 -stdlib=libc++"
 
-./configure
+# We need to pass static as zlib fails to build shared lib in OSS-Fuzz env.
+./configure --static
 make -j$(nproc) clean
 make -j$(nproc) all
 
@@ -46,7 +47,8 @@ $CXX -fsanitize=$SANITIZER $CXXFLAGS_ORIG -std=c++11 -I. \
 
 # Testcase 4. Completely ignore the flags provided by OSS-Fuzz.
 ################################################################################
-./configure
+# We need to pass static as zlib fails to build shared lib in OSS-Fuzz env.
+./configure --static
 make -j$(nproc) clean
 make -j$(nproc) all
 


### PR DESCRIPTION
Makes fuzz-introspector work with the bad_example project. This was
brought up as an issue on the fuzz-introspector repo.

Ref: https://github.com/ossf/fuzz-introspector/issues/257