### PR TITLE
infra: fix python coverage

### DIFF
--- a/infra/base-images/base-builder/compile_python_fuzzer
+++ b/infra/base-images/base-builder/compile_python_fuzzer
@@ -26,7 +26,7 @@ FUZZ_WORKPATH=$PYFUZZ_WORKPATH/$fuzzer_basename
 
 # In coverage mode prepend coverage logic to the fuzzer source
 if [[ $SANITIZER = *coverage* ]]; then
-  cat <<EOF >> coverage_wrapper.py
+  cat <<EOF > coverage_wrapper.py
 ###### Coverage stub
 import atexit
 import coverage


### PR DESCRIPTION
The current implementation will append rather than overwrite
coverage_wrapper.py which holds the coverage stub. The effect of the
appending is that the coverage_wrapper.py will include X amount of
coverage stubs when a project has X amount of fuzzers. We just need a
single coverage stub at the top of each fuzzer. This ensure we only add
a single coverage stub.