### PR TITLE
Fix 47322: Build failure - use latest freetype release

### DIFF
--- a/projects/ghostscript/Dockerfile
+++ b/projects/ghostscript/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN apt-get update && apt-get install -y autoconf zlibc libtool liblcms2-dev libpng-dev
 RUN git clone --branch branch-2.2 --single-branch --depth 1 https://github.com/apple/cups.git cups
-RUN git clone --branch VER-2-11-1 --single-branch --depth 1 https://git.savannah.gnu.org/git/freetype/freetype2.git freetype
+RUN git clone --branch VER-2-12-1 --single-branch --depth 1 https://git.savannah.gnu.org/git/freetype/freetype2.git freetype
 RUN git clone --single-branch --depth 1 git://git.ghostscript.com/ghostpdl.git ghostpdl
 RUN mkdir ghostpdl/fuzz
 


### PR DESCRIPTION
The latest freetype release adds a new source file, the gs build has been updated to include it, but oss-fuzz was pulling in an old freetype release, so the build failed. We want to use up-to-date code, anyway.