### PR TITLE
Fix addition of define

### DIFF
--- a/projects/flac/build.sh
+++ b/projects/flac/build.sh
@@ -52,11 +52,10 @@ make -j$(nproc)
 cd $SRC/flac/oss-fuzz
 cp fuzzer_encoder fuzzer_encoder_v2 $OUT
 
-# Build libflac again for decoder fuzzers, but now with addition CFLAG
-export CFLAGS="$CFLAGS -DFUZZING_BUILD_MODE_NO_SANITIZE_SIGNED_INTEGER_OVERFLOW"
-
+# Build libflac again for decoder fuzzers, but now with additional define
 cd $SRC/flac/
-make clean
+echo "#define FUZZING_BUILD_MODE_NO_SANITIZE_SIGNED_INTEGER_OVERFLOW" >> config.h
+
 make -j$(nproc)
 
 # Copy decoder fuzzers


### PR DESCRIPTION
In PR #7687 I tried to add a define by adding it to CFLAGS, but that didn't work without rerunning configure. By adding the define to config.h, rerunning configure is not necessary