### PR TITLE
zeek: Add libfl-dev dependency, remove mobile-ipv6 flag

### DIFF
--- a/projects/zeek/Dockerfile
+++ b/projects/zeek/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ninja-build \
         flex \
         bison \
+        libfl-dev \
         libpcap-dev \
         libssl-dev \
         libmaxminddb-dev \

--- a/projects/zeek/build.sh
+++ b/projects/zeek/build.sh
@@ -20,11 +20,11 @@ CFLAGS="${CFLAGS} -pthread" CXXFLAGS="${CXXFLAGS} -pthread" \
                 --build-type=debug \
                 --generator=Ninja \
                 --enable-fuzzers \
-                --enable-mobile-ipv6 \
                 --disable-python \
                 --disable-zeekctl \
                 --disable-auxtools \
-                --disable-broker-tests
+                --disable-broker-tests \
+		--disable-spicy
 
 cd build
 ninja install


### PR DESCRIPTION
The Zeek project recently added a new dependency, which in turn requires us to actually link against the libraries for `flex`. This PR adds the necessary library to the Dockerfile. It also removes a now-deprecated flag from the build, silencing a warning there.