### PR TITLE
infra: use only valid targets for python coverage

### DIFF
--- a/infra/base-images/base-builder/compile_python_fuzzer
+++ b/infra/base-images/base-builder/compile_python_fuzzer
@@ -52,6 +52,11 @@ mkdir $PYFUZZ_WORKPATH $FUZZ_WORKPATH
 
 pyinstaller --distpath $OUT --workpath=$FUZZ_WORKPATH --onefile --name $fuzzer_package "$@" $fuzzer_path
 
+# Disable executable bit from package as OSS-Fuzz uses executable bits to
+# identify fuzz targets. We re-enable the executable bit in wrapper script
+# below.
+chmod -x $OUT/$fuzzer_package
+
 # In coverage mode save source files of dependencies in pyinstalled binary
 if [[ $SANITIZER = *coverage* ]]; then
   rm -rf /medio/
@@ -64,6 +69,7 @@ fi
 echo "#!/bin/sh
 # LLVMFuzzerTestOneInput for fuzzer detection.
 this_dir=\$(dirname \"\$0\")
+chmod +x \$this_dir/$fuzzer_package
 LD_PRELOAD=\$this_dir/sanitizer_with_fuzzer.so \
 ASAN_OPTIONS=\$ASAN_OPTIONS:symbolize=1:external_symbolizer_path=\$this_dir/llvm-symbolizer:detect_leaks=0 \
 \$this_dir/$fuzzer_package \$@" > $OUT/$fuzzer_basename

--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -26,18 +26,6 @@ else
       -e 'jazzer_driver' \
       -e 'jazzer_driver_with_sanitizer' \
       -e 'sanitizer_with_fuzzer.so')"
-  if [[ $FUZZING_LANGUAGE == "python" ]]; then
-    # In python we want to exclude all .pkg binaries. We avoid using
-    # the grep above because technically fuzzer binaries can be labelled
-    # .pkg in other languages.
-    FUZZ_TARGETS_NEW=""
-    for fuzz_target in $FUZZ_TARGETS; do
-      if ! [[ $fuzz_target == *".pkg"* ]]; then
-        FUZZ_TARGETS_NEW="$fuzz_target $FUZZ_TARGETS_NEW"
-      fi
-    done
-    FUZZ_TARGETS=$FUZZ_TARGETS_NEW
-  fi
 fi
 
 COVERAGE_OUTPUT_DIR=${COVERAGE_OUTPUT_DIR:-$OUT}
@@ -172,7 +160,7 @@ function run_python_fuzz_target {
   echo "{}" > "$FUZZER_STATS_DIR/$target.json"
 
   # Run fuzzer
-  $OUT/$target.pkg $corpus_real -atheris_runs=$(ls -la $corpus_real | wc -l) > $LOGS_DIR/$target.log 2>&1
+  $OUT/$target $corpus_real -atheris_runs=$(ls -la $corpus_real | wc -l) > $LOGS_DIR/$target.log 2>&1
   if (( $? != 0 )); then
     echo "Error happened getting coverage of $target"
     echo "This is likely because Atheris did not exit gracefully"

--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -24,7 +24,20 @@ else
       -e 'llvm-symbolizer' \
       -e 'jazzer_agent_deploy.jar' \
       -e 'jazzer_driver' \
-      -e 'jazzer_driver_with_sanitizer')"
+      -e 'jazzer_driver_with_sanitizer' \
+      -e 'sanitizer_with_fuzzer.so')"
+  if [[ $FUZZING_LANGUAGE == "python" ]]; then
+    # In python we want to exclude all .pkg binaries. We avoid using
+    # the grep above because technically fuzzer binaries can be labelled
+    # .pkg in other languages.
+    FUZZ_TARGETS_NEW=""
+    for fuzz_target in $FUZZ_TARGETS; do
+      if ! [[ $fuzz_target == *".pkg"* ]]; then
+        FUZZ_TARGETS_NEW="$fuzz_target $FUZZ_TARGETS_NEW"
+      fi
+    done
+    FUZZ_TARGETS=$FUZZ_TARGETS_NEW
+  fi
 fi
 
 COVERAGE_OUTPUT_DIR=${COVERAGE_OUTPUT_DIR:-$OUT}
@@ -297,7 +310,8 @@ elif [[ $FUZZING_LANGUAGE == "python" ]]; then
   PYCOVDIR=/pycovdir/
   mkdir $PYCOVDIR
   for fuzzer in $FUZZ_TARGETS; do
-    unzip $OUT/$fuzzer.deps.zip
+    fuzzer_deps=${fuzzer}.pkg.deps.zip
+    unzip $OUT/${fuzzer_deps}
     rsync -r ./medio /pythoncovmergedfiles/medio
     rm -rf ./medio
 


### PR DESCRIPTION
Some python coverage reports gets clobbered because non-fuzz targets are
included in FUZZ_TARGETS. The problem is we use a wrapper script to call into python
packages where a package is an executable generated by pyinstaller, and both the script
and the package is executable. Thus, there are two executables per fuzzer -- we should only
have one and it should be the wrapper script. This PR fixes it.