### PR TITLE
initial integration for fuzzing zip4j

### DIFF
--- a/projects/zip4j/Dockerfile
+++ b/projects/zip4j/Dockerfile
@@ -1,0 +1,39 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-jvm
+
+RUN curl -L https://dlcdn.apache.org/maven/maven-3/3.8.5/binaries/apache-maven-3.8.5-bin.zip -o maven.zip && \
+    unzip maven.zip -d $SRC/maven && \
+    rm -rf maven.zip
+
+ENV MVN $SRC/maven/apache-maven-3.8.5/bin/mvn
+
+# Dict
+RUN git clone --depth 1 https://github.com/google/fuzzing && \
+    mv fuzzing/dictionaries/zip.dict $SRC/Zip4jFuzzer.dict && \
+    rm -rf fuzzing
+
+# Seeds
+RUN git clone --depth 1 https://github.com/dvyukov/go-fuzz-corpus && \
+    zip -j $SRC/Zip4jFuzzer_seed_corpus.zip go-fuzz-corpus/zip/corpus/* && \
+    rm -rf go-fuzz-corpus
+
+RUN git clone --depth 1 https://github.com/srikanth-lingala/zip4j.git zip4j
+
+COPY build.sh $SRC/
+COPY Zip4jFuzzer.java $SRC/
+WORKDIR $SRC/zip4j

--- a/projects/zip4j/Zip4jFuzzer.java
+++ b/projects/zip4j/Zip4jFuzzer.java
@@ -1,0 +1,97 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+import java.io.IOException;
+import java.io.ByteArrayInputStream;
+
+import java.util.List;
+
+import net.lingala.zip4j.io.inputstream.ZipInputStream;
+import net.lingala.zip4j.model.LocalFileHeader;
+import net.lingala.zip4j.model.ExtraDataRecord;
+import net.lingala.zip4j.model.AESExtraDataRecord;
+import net.lingala.zip4j.model.enums.CompressionMethod;
+import net.lingala.zip4j.model.enums.EncryptionMethod;
+import net.lingala.zip4j.model.Zip64ExtendedInfo;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+public class Zip4jFuzzer {
+	public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+
+		ZipInputStream v0 = null;
+		LocalFileHeader v1 = null;
+		AESExtraDataRecord v2 = null;
+		CompressionMethod v3 = null;
+		EncryptionMethod v4 = null;
+		List<ExtraDataRecord> v5 = null;
+		Zip64ExtendedInfo v6 = null;
+
+		try {
+			v0 = new ZipInputStream(new ByteArrayInputStream(data.consumeRemainingAsBytes()));
+
+			if (v0 != null) {
+
+				while (true) {
+
+					v1 = v0.getNextEntry();
+					if (v1 ==  null)
+						break;
+					else {
+
+						v1.isDirectory();
+						v1.isEncrypted();
+
+						v2 = v1.getAesExtraDataRecord();
+						if (v2 != null) {
+							v2.getCompressionMethod();
+							v2.getDataSize();
+						}
+
+						v3 = v1.getCompressionMethod();
+						if (v3 != null) {
+							v3.getCode();
+						}
+
+						v4 = v1.getEncryptionMethod();
+						v5 = v1.getExtraDataRecords();
+						if (v5 != null) {
+							for (ExtraDataRecord v7 : v5) {
+								v7.getData();
+								v7.getHeader();
+								v7.getSizeOfData();
+							}
+						}
+
+						v6 = v1.getZip64ExtendedInfo();
+						if (v6 != null) {
+							v6.getCompressedSize();
+							v6.getUncompressedSize();
+						}
+
+					}
+
+				}
+
+			}
+
+		} catch (IOException e) {
+			return;
+		}
+	}
+}

--- a/projects/zip4j/build.sh
+++ b/projects/zip4j/build.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -eu
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+mv $SRC/{*.zip,*.dict} $OUT
+
+MAVEN_ARGS="-Dmaven.test.skip=true -Djavac.src.version=15 -Djavac.target.version=15"
+$MVN package org.apache.maven.plugins:maven-shade-plugin:3.2.4:shade $MAVEN_ARGS
+CURRENT_VERSION=$($MVN org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate \
+ -Dexpression=project.version -q -DforceStdout)
+cp "target/zip4j-$CURRENT_VERSION.jar" $OUT/zip4j.jar
+
+ALL_JARS="zip4j.jar"
+
+# The classpath at build-time includes the project jars in $OUT as well as the
+# Jazzer API.
+BUILD_CLASSPATH=$(echo $ALL_JARS | xargs printf -- "$OUT/%s:"):$JAZZER_API_PATH
+
+# All .jar and .class files lie in the same directory as the fuzzer at runtime.
+RUNTIME_CLASSPATH=$(echo $ALL_JARS | xargs printf -- "\$this_dir/%s:"):\$this_dir
+
+for fuzzer in $(find $SRC -name '*Fuzzer.java'); do
+  fuzzer_basename=$(basename -s .java $fuzzer)
+  javac -cp $BUILD_CLASSPATH $fuzzer
+  cp $SRC/$fuzzer_basename.class $OUT/
+
+  # Create an execution wrapper that executes Jazzer with the correct arguments.
+  echo "#!/bin/sh
+# LLVMFuzzerTestOneInput for fuzzer detection.
+this_dir=\$(dirname \"\$0\")
+LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\":\$this_dir \
+\$this_dir/jazzer_driver --agent_path=\$this_dir/jazzer_agent_deploy.jar \
+--cp=$RUNTIME_CLASSPATH \
+--target_class=$fuzzer_basename \
+--jvm_args=\"-Xmx2048m\" \
+\$@" > $OUT/$fuzzer_basename
+  chmod u+x $OUT/$fuzzer_basename
+done

--- a/projects/zip4j/project.yaml
+++ b/projects/zip4j/project.yaml
@@ -6,4 +6,5 @@ main_repo: https://github.com/srikanth-lingala/zip4j.git
 sanitizers:
 - address
 vendor_ccs:
+- srikanth.mailbox@gmail.com
 - all.u.ever.know@gmail.com

--- a/projects/zip4j/project.yaml
+++ b/projects/zip4j/project.yaml
@@ -1,0 +1,9 @@
+fuzzing_engines:
+- libfuzzer
+homepage: http://www.lingala.net/zip4j.html
+language: jvm
+main_repo: https://github.com/srikanth-lingala/zip4j.git
+sanitizers:
+- address
+vendor_ccs:
+- all.u.ever.know@gmail.com


### PR DESCRIPTION
Adds the [zip4j](https://github.com/srikanth-lingala/zip4j) fuzzer implementation to oss-fuzz. Passed testing on ubuntu 18.04 X64 following this [link](https://google.github.io/oss-fuzz/getting-started/new-project-guide/).