### PR TITLE
Initial integration of Junrar

### DIFF
--- a/projects/junrar/Dockerfile
+++ b/projects/junrar/Dockerfile
@@ -1,0 +1,38 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-jvm
+
+RUN curl -L https://services.gradle.org/distributions/gradle-7.4.2-bin.zip -o gradle.zip && \
+    unzip gradle.zip -d $SRC/gradle && \
+    rm -rf gradle.zip
+
+ENV GRADLE_HOME $SRC/gradle/gradle-7.4.2
+ENV PATH $GRADLE_HOME/bin:$PATH
+
+# Dict
+# no existing rar.dict found on web, build rar dict manually later
+
+# Seeds
+RUN git clone --depth 1 https://github.com/strongcourage/fuzzing-corpus.git && \
+    zip -j $SRC/JunrarFuzzer_seed_corpus.zip fuzzing-corpus/rar/* && \
+    rm -rf fuzzing-corpus
+
+RUN git clone --depth 1 https://github.com/junrar/junrar.git junrar
+
+COPY build.sh $SRC/
+COPY JunrarFuzzer.java $SRC/
+WORKDIR $SRC/junrar

--- a/projects/junrar/JunrarFuzzer.java
+++ b/projects/junrar/JunrarFuzzer.java
@@ -1,0 +1,84 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.ByteArrayInputStream;
+
+import com.github.junrar.Archive;
+import com.github.junrar.rarfile.FileHeader;
+import com.github.junrar.exception.RarException;
+import com.github.junrar.io.SeekableReadOnlyByteChannel;
+import com.github.junrar.rarfile.MainHeader;
+import com.github.junrar.volume.Volume;
+
+public class JunrarFuzzer {
+	public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+
+		try {
+			InputStream inputStream = new ByteArrayInputStream(data.consumeRemainingAsBytes());
+			Archive v0 = null;
+			FileHeader v1 = null;
+			SeekableReadOnlyByteChannel v2 = null;
+			MainHeader v3 = null;
+			Volume v4 = null;
+
+			v0 = new Archive(inputStream);
+			v2 = v0.getChannel();
+			if (v2 != null) {
+				v2.getPosition();
+			}
+
+			v0.getFileHeaders();
+			v0.getHeaders();
+
+			v3 = v0.getMainHeader();
+			if (v3 != null) {
+				v3.getEncryptVersion();
+				v3.isEncrypted();
+				//v3.print();
+			}
+
+			v4 = v0.getVolume();
+			if (v4 != null) {
+				v4.getChannel();
+				v4.getLength();
+			}
+
+			v0.isEncrypted();
+
+			while (true) {
+				v1 = v0.nextFileHeader();
+				if (v1 == null) {
+					break;
+				}
+
+				v1.getCTime();
+				v1.hasVolumeNumber();
+				v1.isSubBlock();
+
+				v0.extractFile(v1, OutputStream.nullOutputStream()); 
+			}
+
+		} catch (IOException e1) {
+		} catch (RarException e2) {
+			return;
+		}
+	}
+}

--- a/projects/junrar/build.sh
+++ b/projects/junrar/build.sh
@@ -1,0 +1,53 @@
+#!/bin/bash -eu
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+mv $SRC/*.zip $OUT
+#mv $SRC/{*.zip,*.dict} $OUT
+
+./gradlew build
+CURRENT_VERSION=$(./gradlew properties --no-daemon --console=plain -q | grep "^version:" | awk '{printf $2}')
+cp "build/libs/junrar-$CURRENT_VERSION-sources.jar" $OUT/junrar.jar
+
+curl -L https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.jar -o $OUT/slf4j-api.jar
+curl -L https://repo1.maven.org/maven2/org/slf4j/slf4j-simple/1.7.36/slf4j-simple-1.7.36.jar -o $OUT/slf4j-simple.jar
+
+ALL_JARS="junrar.jar slf4j-api.jar slf4j-simple.jar"
+
+# The classpath at build-time includes the project jars in $OUT as well as the
+# Jazzer API.
+BUILD_CLASSPATH=$(echo $ALL_JARS | xargs printf -- "$OUT/%s:"):$JAZZER_API_PATH
+
+# All .jar and .class files lie in the same directory as the fuzzer at runtime.
+RUNTIME_CLASSPATH=$(echo $ALL_JARS | xargs printf -- "\$this_dir/%s:"):\$this_dir
+
+for fuzzer in $(find $SRC -name '*Fuzzer.java'); do
+  fuzzer_basename=$(basename -s .java $fuzzer)
+  javac -cp $BUILD_CLASSPATH $fuzzer
+  cp $SRC/$fuzzer_basename.class $OUT/
+
+  # Create an execution wrapper that executes Jazzer with the correct arguments.
+  echo "#!/bin/sh
+# LLVMFuzzerTestOneInput for fuzzer detection.
+this_dir=\$(dirname \"\$0\")
+LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\":\$this_dir \
+\$this_dir/jazzer_driver --agent_path=\$this_dir/jazzer_agent_deploy.jar \
+--cp=$RUNTIME_CLASSPATH \
+--target_class=$fuzzer_basename \
+--jvm_args=\"-Xmx2048m\" \
+\$@" > $OUT/$fuzzer_basename
+  chmod u+x $OUT/$fuzzer_basename
+done

--- a/projects/junrar/project.yaml
+++ b/projects/junrar/project.yaml
@@ -1,0 +1,9 @@
+fuzzing_engines:
+- libfuzzer
+homepage: https://github.com/junrar/junrar
+language: jvm
+main_repo: https://github.com/junrar/junrar.git
+sanitizers:
+- address
+vendor_ccs:
+- all.u.ever.know@gmail.com


### PR DESCRIPTION
Adds the [junrar](https://github.com/junrar/junrar) fuzzer implementation to oss-fuzz. Passed testing on ubuntu 18.04 X64 following this [link](https://google.github.io/oss-fuzz/getting-started/new-project-guide/).