### PR TITLE
[kubeedge] Initial integration

### DIFF
--- a/projects/kubeedge/Dockerfile
+++ b/projects/kubeedge/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/kubeedge/kubeedge
+RUN git clone --depth 1 https://github.com/cncf/cncf-fuzzing
+COPY build.sh $SRC/
+WORKDIR $SRC/kubeedge

--- a/projects/kubeedge/build.sh
+++ b/projects/kubeedge/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -eu
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+$SRC/cncf-fuzzing/projects/kubeedge/build.sh

--- a/projects/kubeedge/project.yaml
+++ b/projects/kubeedge/project.yaml
@@ -1,0 +1,14 @@
+homepage: "https://kubeedge.io/en/"
+primary_contact: "linguohui1@huawei.com"
+auto_ccs :
+  - "xufei40@huawei.com"
+  - "wangzefeng@huawei.com"
+vendor_ccs :
+  - "Adam@adalogics.com"
+  - "David@adalogics.com"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+main_repo: 'https://github.com/kubeedge/kubeedge'


### PR DESCRIPTION
KubeEdge is an open source system for extending native containerized application orchestration capabilities to hosts at Edge. It is a CNCF project that is being used by several large and publicly traded companies in China includig Huawei and Raisecom.

A non-exhaustive list of adopters can be found here: https://github.com/kubeedge/kubeedge/blob/master/ADOPTERS.md
CNCF profile: https://www.cncf.io/projects/kubeedge/