### PR TITLE
pin the version of protobuf

### DIFF
--- a/infra/build/functions/requirements.txt
+++ b/infra/build/functions/requirements.txt
@@ -28,3 +28,4 @@ google-api-core==1.22.2
 google-api-python-client==1.9.3
 oauth2client==4.1.3
 python-dateutil==2.8.1
+protobuf==3.20.1

--- a/infra/cifuzz/requirements.txt
+++ b/infra/cifuzz/requirements.txt
@@ -1,2 +1,3 @@
 clusterfuzz==2.5.6
 requests==2.25.1
+protobuf==3.20.1


### PR DESCRIPTION
pin the version of `protobuf` to fix infra test errors.