### PR TITLE
[base-runner] no longer fail silently in test_one.py

### DIFF
--- a/infra/base-images/base-runner/test_one.py
+++ b/infra/base-images/base-runner/test_one.py
@@ -25,7 +25,11 @@ def test_one(fuzz_target):
   """Does bad_build_check on one fuzz target. Returns True on success."""
   with test_all.use_different_out_dir():
     fuzz_target_path = os.path.join(os.environ['OUT'], fuzz_target)
-    return test_all.do_bad_build_check(fuzz_target_path).returncode == 0
+    result = test_all.do_bad_build_check(fuzz_target_path)
+    if result.returncode != 0:
+      sys.stdout.buffer.write(result.stdout + result.stderr + b'\n')
+      return False
+    return True
 
 
 def main():


### PR DESCRIPTION
It should make it easier to figure out why exactly
`./infra/helper.py check_build project fuzz-target` fails
by turning
```
INFO: performing bad build checks for /tmp/not-out/tmpa4lph9dr/fuzz-bus-message
ERROR:root:Check build failed.
```
into something like
```
INFO: performing bad build checks for /tmp/not-out/tmpa4lph9dr/fuzz-bus-message
BAD BUILD: /tmp/not-out/tmpa4lph9dr/fuzz-bus-message seems to have either startup crash or exit:
/tmp/not-out/tmpa4lph9dr/fuzz-bus-message -rss_limit_mb=2560 -timeout=25 -seed=1337 -runs=4 < /dev/null
/tmp/not-out/tmpa4lph9dr/fuzz-bus-message: error while loading shared libraries: libcap.so.2: cannot open shared object file: No such file or directory

ERROR:root:Check build failed.
```