### PR TITLE
[systemd] turn on i386

### DIFF
--- a/projects/systemd/project.yaml
+++ b/projects/systemd/project.yaml
@@ -23,4 +23,7 @@ auto_ccs:
   - daan.j.demeyer@gmail.com
   - luca.boccassi@gmail.com
 main_repo: 'https://github.com/systemd/systemd'
+architectures:
+  - x86_64
+  - i386
 file_github_issue: True


### PR DESCRIPTION
https://github.com/systemd/systemd/issues/23532

Since this stuff is fragile I think it would be great if CIFuzz supported i386.