### PR TITLE
infra: allow passing architecture=i386 to CIFuzz

### DIFF
--- a/infra/cifuzz/actions/build_fuzzers/action.yml
+++ b/infra/cifuzz/actions/build_fuzzers/action.yml
@@ -18,6 +18,9 @@ inputs:
   sanitizer:
     description: 'The sanitizer to build the fuzzers with.'
     default: 'address'
+  architecture:
+    description: 'The architecture used to build the fuzzers.'
+    default: 'x86_64'
   project-src-path:
     description: "The path to the project's source code checkout."
     required: false
@@ -38,6 +41,7 @@ runs:
     DRY_RUN: ${{ inputs.dry-run}}
     ALLOWED_BROKEN_TARGETS_PERCENTAGE: ${{ inputs.allowed-broken-targets-percentage}}
     SANITIZER: ${{ inputs.sanitizer }}
+    ARCHITECTURE: ${{ inputs.architecture }}
     PROJECT_SRC_PATH: ${{ inputs.project-src-path }}
     LOW_DISK_SPACE: 'True'
     BAD_BUILD_CHECK: ${{ inputs.bad-build-check }}

--- a/infra/cifuzz/base_runner_utils.py
+++ b/infra/cifuzz/base_runner_utils.py
@@ -27,7 +27,7 @@ def get_env(config, workspace):
   env['OUT'] = workspace.out
   env['CIFUZZ'] = 'True'
   env['FUZZING_ENGINE'] = config_utils.DEFAULT_ENGINE
-  env['ARCHITECTURE'] = config_utils.DEFAULT_ARCHITECTURE
+  env['ARCHITECTURE'] = config.architecture
   # Do this so we don't fail in tests.
   env['FUZZER_ARGS'] = '-rss_limit_mb=2560 -timeout=25'
   return env

--- a/infra/cifuzz/build_fuzzers.py
+++ b/infra/cifuzz/build_fuzzers.py
@@ -80,7 +80,7 @@ class Builder:  # pylint: disable=too-many-instance-attributes
     the fuzzers from that source code. Returns True on success."""
     docker_args, docker_container = docker.get_base_docker_run_args(
         self.workspace, self.config.sanitizer, self.config.language,
-        self.config.docker_in_docker)
+        self.config.architecture, self.config.docker_in_docker)
     if not docker_container:
       docker_args.extend(
           _get_docker_build_fuzzers_args_not_container(self.host_repo_path))

--- a/infra/cifuzz/continuous_integration.py
+++ b/infra/cifuzz/continuous_integration.py
@@ -240,7 +240,7 @@ class InternalGithub(GithubCiMixin, BaseCi):
     bash_command = f'cp -r {image_repo_path} {host_repo_path}'
     docker_args, _ = docker.get_base_docker_run_args(
         self.workspace, self.config.sanitizer, self.config.language,
-        self.config.docker_in_docker)
+        self.config.architecture, self.config.docker_in_docker)
     docker_args.extend([
         docker.get_project_image_name(self.config.oss_fuzz_project_name),
         '/bin/bash', '-c', bash_command

--- a/infra/cifuzz/docker.py
+++ b/infra/cifuzz/docker.py
@@ -28,8 +28,7 @@ PROJECT_TAG_PREFIX = 'gcr.io/oss-fuzz/'
 
 # Default fuzz configuration.
 _DEFAULT_DOCKER_RUN_ARGS = [
-    '-e', 'FUZZING_ENGINE=' + constants.DEFAULT_ENGINE, '-e',
-    'ARCHITECTURE=' + constants.DEFAULT_ARCHITECTURE, '-e', 'CIFUZZ=True'
+    '-e', 'FUZZING_ENGINE=' + constants.DEFAULT_ENGINE, '-e', 'CIFUZZ=True'
 ]
 
 EXTERNAL_PROJECT_IMAGE = 'external-project'
@@ -70,12 +69,14 @@ def delete_images(images):
 def get_base_docker_run_args(workspace,
                              sanitizer=constants.DEFAULT_SANITIZER,
                              language=constants.DEFAULT_LANGUAGE,
+                             architecture=constants.DEFAULT_ARCHITECTURE,
                              docker_in_docker=False):
   """Returns arguments that should be passed to every invocation of 'docker
   run'."""
   docker_args = _DEFAULT_DOCKER_RUN_ARGS.copy()
   env_mapping = {
       'SANITIZER': sanitizer,
+      'ARCHITECTURE': architecture,
       'FUZZING_LANGUAGE': language,
       'OUT': workspace.out
   }
@@ -95,11 +96,16 @@ def get_base_docker_run_args(workspace,
 def get_base_docker_run_command(workspace,
                                 sanitizer=constants.DEFAULT_SANITIZER,
                                 language=constants.DEFAULT_LANGUAGE,
+                                architecture=constants.DEFAULT_ARCHITECTURE,
                                 docker_in_docker=False):
   """Returns part of the command that should be used everytime 'docker run' is
   invoked."""
   docker_args, docker_container = get_base_docker_run_args(
-      workspace, sanitizer, language, docker_in_docker=docker_in_docker)
+      workspace,
+      sanitizer,
+      language,
+      architecture,
+      docker_in_docker=docker_in_docker)
   command = _DEFAULT_DOCKER_RUN_COMMAND.copy() + docker_args
   return command, docker_container
 

--- a/infra/cifuzz/docker_test.py
+++ b/infra/cifuzz/docker_test.py
@@ -69,11 +69,11 @@ class GetBaseDockerRunArgsTest(unittest.TestCase):
         '-e',
         'FUZZING_ENGINE=libfuzzer',
         '-e',
-        'ARCHITECTURE=x86_64',
-        '-e',
         'CIFUZZ=True',
         '-e',
         f'SANITIZER={SANITIZER}',
+        '-e',
+        'ARCHITECTURE=x86_64',
         '-e',
         f'FUZZING_LANGUAGE={LANGUAGE}',
         '-e',
@@ -91,8 +91,8 @@ class GetBaseDockerRunArgsTest(unittest.TestCase):
         WORKSPACE, SANITIZER, LANGUAGE)
     self.assertEqual(docker_container, None)
     expected_docker_args = [
-        '-e', 'FUZZING_ENGINE=libfuzzer', '-e', 'ARCHITECTURE=x86_64', '-e',
-        'CIFUZZ=True', '-e', f'SANITIZER={SANITIZER}', '-e',
+        '-e', 'FUZZING_ENGINE=libfuzzer', '-e', 'CIFUZZ=True', '-e',
+        f'SANITIZER={SANITIZER}', '-e', 'ARCHITECTURE=x86_64', '-e',
         f'FUZZING_LANGUAGE={LANGUAGE}', '-e', f'OUT={WORKSPACE.out}', '-v',
         f'{WORKSPACE.workspace}:{WORKSPACE.workspace}'
     ]
@@ -111,8 +111,8 @@ class GetBaseDockerRunCommandTest(unittest.TestCase):
     self.assertEqual(docker_container, None)
     expected_docker_command = [
         'docker', 'run', '--rm', '--privileged', '-e',
-        'FUZZING_ENGINE=libfuzzer', '-e', 'ARCHITECTURE=x86_64', '-e',
-        'CIFUZZ=True', '-e', f'SANITIZER={SANITIZER}', '-e',
+        'FUZZING_ENGINE=libfuzzer', '-e', 'CIFUZZ=True', '-e',
+        f'SANITIZER={SANITIZER}', '-e', 'ARCHITECTURE=x86_64', '-e',
         f'FUZZING_LANGUAGE={LANGUAGE}', '-e', f'OUT={WORKSPACE.out}', '-v',
         f'{WORKSPACE.workspace}:{WORKSPACE.workspace}'
     ]


### PR DESCRIPTION
to mostly make sure that fuzz targets are buildable with
architecture=i386. Ideally CIFuzz should also download the
latest builds using the "clusterfuzz-builds-i386" links but
it kind of works even without that.

It was tested in https://github.com/evverx/oss-fuzz/pull/13
by pointing https://github.com/evverx/systemd/pull/110 to
that fork of the oss-fuzz repository. To judge from
https://github.com/evverx/systemd/actions/runs/2406321298 it
seems to be working more or less. The "i386" job failed there
because https://github.com/systemd/systemd/commit/89b6a3f13e5f3b8a375dc82cb2a1c2c204a5067e was reverted there to test "i386" as much as possible.