### PR TITLE
[tensorflow] Fix libfuzzer-undefined build.

### DIFF
--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -42,6 +42,8 @@ done
 if [ "$SANITIZER" = "undefined" ]
 then
   echo "--linkopt=$(find $(llvm-config --libdir) -name libclang_rt.ubsan_standalone_cxx-x86_64.a | head -1)"
+  sed -i -e 's/"\/\/conditions:default": \[/"\/\/conditions:default": \[\n"-fno-sanitize=undefined",/' third_party/nasm/nasm.BUILD
+  sed -i -e 's/includes/linkopts = \["-fno-sanitize=undefined"\],\nincludes/' third_party/nasm/nasm.BUILD
 fi
 if [ "$SANITIZER" = "address" ]
 then


### PR DESCRIPTION
Hi! Current version of tensorflow cannot be built with `-fsanitize=undefined` because of some ubsan reports in `external/nasm`. Here is a fix, I've checked, it works.