### PR TITLE
Print sanitizer stacktrace for execSan bugs.

### DIFF
--- a/infra/experimental/sanitizers/ExecSan/Makefile
+++ b/infra/experimental/sanitizers/ExecSan/Makefile
@@ -8,7 +8,7 @@ execSan: execSan.cpp
 	$(CXX) $(CFLAGS) -lpthread -o $@ $^
 
 target: target.cpp
-	$(CXX) $(CFLAGS) -fsanitize=fuzzer -o $@ $^
+	$(CXX) $(CFLAGS) -fsanitize=address,fuzzer -o $@ $^
 
 test:  all vuln.dict
 	./execSan ./target -dict=vuln.dict


### PR DESCRIPTION
Send SIGABRT to the root process being fuzzed to generate a stacktrace.

Also distinguish between syscall enter and exit.