### PR TITLE
ngolo-fuzzing: use DNDEBUG for libprotobufmutator fuzzer

### DIFF
--- a/projects/ngolo-fuzzing/build.sh
+++ b/projects/ngolo-fuzzing/build.sh
@@ -33,7 +33,7 @@ compile_package () {
         $SRC/LPM/external.protobuf/bin/protoc --go_out=./ ngolofuzz.proto
         mkdir cpp
         $SRC/LPM/external.protobuf/bin/protoc --cpp_out=./cpp ngolofuzz.proto
-        $CXX -stdlib=libc++ -c -I . -I $SRC/LPM/external.protobuf/include cpp/ngolofuzz.pb.cc
+        $CXX -DNDEBUG -stdlib=libc++ -c -I . -I $SRC/LPM/external.protobuf/include cpp/ngolofuzz.pb.cc
         $CXX $CXXFLAGS -c -Icpp -I $SRC/libprotobuf-mutator/ -I $SRC/LPM/external.protobuf/include $SRC/ngolo-fuzzing/lpm/ngolofuzz.cc
     )
     if [ "$SANITIZER" = "coverage" ]


### PR DESCRIPTION
cc @DavidKorczynski whose tip I found

Should fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47582&q=label%3AProj-ngolo-fuzzing