### PR TITLE
Remove unnecessary step in fuzz introspector

### DIFF
--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -215,7 +215,6 @@ if [ "$SANITIZER" = "introspector" ]; then
 
   find $SRC/ -name "*.data" -exec cp {} $SRC/inspector/ \;
   find $SRC/ -name "*.data.yaml" -exec cp {} $SRC/inspector/ \;
-  find $SRC/ -name "*branchProfile.yaml" -exec cp {} $SRC/inspector/ \;
   # Move coverage report.
   if [ -d "$OUT/textcov_reports" ]
   then


### PR DESCRIPTION
The explicit copy of branchProfile is not needed, as it is being written into fuzzer profile log.