### PR TITLE
Detect shell injection based on syntax errors

### DIFF
--- a/infra/experimental/sanitizers/ExecSan/Makefile
+++ b/infra/experimental/sanitizers/ExecSan/Makefile
@@ -2,7 +2,7 @@
 CXX     = clang++
 CFLAGS = -std=c++17 -Wall -Wextra -O3 -g3
 
-all: clean execSan tripwire target
+all: clean execSan target
 
 execSan: execSan.cpp
 	$(CXX) $(CFLAGS) -lpthread -o $@ $^
@@ -14,4 +14,4 @@ test:  all vuln.dict
 	./execSan ./target -dict=vuln.dict
 
 clean:
-	rm -f execSan /tmp/tripwire target 
+	rm -f execSan /tmp/tripwire target

--- a/infra/experimental/sanitizers/ExecSan/README.md
+++ b/infra/experimental/sanitizers/ExecSan/README.md
@@ -35,6 +35,5 @@ which indicates the detection of executing a syntactic erroneous command.
 
 
 ## TODOs
-1. ~~[x] Flag syntax errors of shell commands by hooking write() calls from shell.~~
-2. Find real examples of past shell injection vulnerabilities using this.
+1. Find real examples of past shell injection vulnerabilities using this.
 

--- a/infra/experimental/sanitizers/ExecSan/README.md
+++ b/infra/experimental/sanitizers/ExecSan/README.md
@@ -22,14 +22,19 @@ Note this will overwrite /tmp/tripwire if it exists.
 make test
 ```
 
-Look for the following line:
+Look for one of the following lines:
 
 > ===BUG DETECTED: Shell injection===
 
-which indicates the detection of shell injection.
+which indicates the detection of executing the planted `/tmp/tripwire`.
+
+
+> ===BUG DETECTED: Shell corruption===
+
+which indicates the detection of executing a syntactic erroneous command.
 
 
 ## TODOs
-1. Flag syntax errors of shell commands by hooking write() calls from shell.
+1. ~~[x] Flag syntax errors of shell commands by hooking write() calls from shell.~~
 2. Find real examples of past shell injection vulnerabilities using this.
 

--- a/infra/experimental/sanitizers/ExecSan/execSan.cpp
+++ b/infra/experimental/sanitizers/ExecSan/execSan.cpp
@@ -205,7 +205,8 @@ std::string match_shell(std::string binary_pathname);
 // Identify the exact shell behind sh
 std::string identify_sh(std::string binary_name) {
   char shell_pathname[kShellPathnameLength];
-  if (readlink(binary_name.c_str(), shell_pathname, kShellPathnameLength) == -1) {
+  if (readlink(binary_name.c_str(), shell_pathname, kShellPathnameLength) ==
+      -1) {
     std::cerr << "Cannot query which shell is behind sh: readlink failed\n";
     std::cerr << "Assuming the shell is dash\n";
     return "dash";

--- a/infra/experimental/sanitizers/ExecSan/execSan.cpp
+++ b/infra/experimental/sanitizers/ExecSan/execSan.cpp
@@ -258,11 +258,9 @@ void match_error_pattern(std::string buffer, std::string shell) {
     debug_log("Pattern : %s\n", pattern.c_str());
     debug_log("Found at: %lu\n", buffer.find(pattern));
     if (buffer.find(pattern) != std::string::npos) {
-      printf(
-          "--- Found a sign of shell corruption ---\n"
-          "%s\n"
-          "----------------------------------------\n",
-          buffer.c_str());
+      std::cerr << "--- Found a sign of shell corruption ---\n"
+                << buffer.c_str()
+                << "\n----------------------------------------\n";
       report_bug(kCorruptionError);
     }
   }
@@ -271,7 +269,7 @@ void match_error_pattern(std::string buffer, std::string shell) {
 void inspect_for_corruption(pid_t pid, const user_regs_struct &regs) {
   // Inspect a PID's registers for shell corruption.
   std::string buffer = read_string(pid, regs.rsi, regs.rdx);
-  printf("Write buffer: %s\n", buffer.c_str());
+  debug_log("Write buffer: %s\n", buffer.c_str());
   match_error_pattern(buffer, g_shell_pids[pid]);
 }
 

--- a/infra/experimental/sanitizers/ExecSan/execSan.cpp
+++ b/infra/experimental/sanitizers/ExecSan/execSan.cpp
@@ -76,49 +76,51 @@ constexpr int kShellPathnameLength = 20;
 const std::map<std::string, std::set<std::string>> kShellSyntaxErrors = {
     {"sh",
      {
-         ": command not found",  // General
-         ": syntax error",       // Unfinished " or ' or ` or if, leading | or ;
-         ": missing"             // Unfinished [
-         ": event not found",    // ! leads large numbers
-         ": No such file",       // Leading < or /
+         ": command not found",          // General
+         ": syntax error",               // Unfinished " or ' or ` or if, leading | or ;
+         ": missing `]'",                // Unfinished [
+         ": event not found",            // ! leads large numbers
+         ": No such file or directory",  // Leading < or /
      }},
     {"bash",
      {
-         ": command not found",  // General
-         ": syntax error",       // Unfinished " or ' or ` or if, leading | or ;
-         ": missing"             // Unfinished [
-         ": event not found",    // ! leads large numbers
-         ": No such file",       // Leading < or /
+         ": command not found",          // General
+         ": syntax error",               // Unfinished " or ' or ` or if, leading | or ;
+         ": missing `]'",                // Unfinished [
+         ": event not found",            // ! leads large numbers
+         ": No such file or directory",  // Leading < or /
      }},
     {"csh",
      {
-         ": Command not found",       // General
-         "Unmatched",                 // Unfinished " or ' or `, leading ;
-         ": Missing",                 // Unfinished {
-         "Too many",                  // Unfinished (
-         "No match",                  // Leading [
-         "Invalid null command",      // Leading | or < or >
-         "Missing name for redirect"  // Single < or >
-         ": No match",                // Leading ? or [ or *
-         "Modifier failed",           // Leading ^
-         ": No such job",             // Leading %
-         ": Undefined variable",      // Containing $
-         ": Event not found",         // ! leads large numbers
+         ": Command not found.",         // General
+         ": Missing }.",                 // Unfinished {
+         "Too many ('s.",                // Unfinished (
+         "Invalid null command.",        // Leading | or < or >
+         "Missing name for redirect.",   // Single < or >
+         ": No match.",                  // Leading ? or [ or *
+         "Modifier failed.",             // Leading ^
+         "No previous left hand side.",  // A ^
+         ": No such job.",               // Leading %
+         ": No current job.",            // A %
+         ": Undefined variable.",        // Containing $
+         ": Event not found.",           // ! leads large numbers
+         // TODO: Make this more specific.
+         "Unmatched",                    // Unfinished " or ' or `, leading ;
      }},
     {"dash",
      {
          ": not found",     // General
          ": Syntax error",  // Unfinished " or ' or ` or if, leading | or ; or &
-         ": missing"        // Unfinished [
+         ": missing ]",     // Unfinished [
          ": No such file",  // Leading <
      }},
     {"zsh",
      {
          ": command not found",                // General
          ": syntax error",                     // Unfinished " or ' or `
-         " expected"                           // Unfinished [
+         ": ']' expected",                     // Unfinished [
          ": no such file or directory",        // Leading < or /
-         ": parse error",                      // Leading |, or &
+         ": parse error near",                 // Leading |, or &
          ": no such user or named directory",  // Leading ~
      }},
 };

--- a/infra/experimental/sanitizers/ExecSan/execSan.cpp
+++ b/infra/experimental/sanitizers/ExecSan/execSan.cpp
@@ -70,10 +70,7 @@ const std::string kCorruptionError = "Shell corruption";
 // The PID of the root process we're fuzzing.
 pid_t g_root_pid;
 // Assuming the longest pathname is "/bin/bash".
-constexpr int kShellPathnameLength = 10;
-// Assuming the syntax error pattern is
-// within the first 100 chars of the write buffer.
-constexpr int kErrorMessageLength = 100;
+constexpr int kShellPathnameLength = 20;
 
 // Syntax error messages of each shell.
 const std::map<std::string, std::set<std::string>> kShellSyntaxErrors = {

--- a/infra/experimental/sanitizers/ExecSan/execSan.cpp
+++ b/infra/experimental/sanitizers/ExecSan/execSan.cpp
@@ -78,10 +78,10 @@ constexpr int kFileStdOutLength = 100;
 const std::map<std::string, std::set<std::string>> kShellSyntaxErrors = {
     {"bash",
      {
-         ": command not found",          // General
-         ": syntax error",               // Unfinished " or ' or ` or if, leading | or ;
-         ": missing `]'",                // Unfinished [
-         ": event not found",            // ! leads large numbers
+         ": command not found",  // General
+         ": syntax error",       // Unfinished " or ' or ` or if, leading | or ;
+         ": missing `]'",        // Unfinished [
+         ": event not found",    // ! leads large numbers
          ": No such file or directory",  // Leading < or /
      }},
     {"csh",
@@ -99,7 +99,7 @@ const std::map<std::string, std::set<std::string>> kShellSyntaxErrors = {
          ": Undefined variable.",        // Containing $
          ": Event not found.",           // ! leads large numbers
          // TODO: Make this more specific.
-         "Unmatched",                    // Unfinished " or ' or `, leading ;
+         "Unmatched",  // Unfinished " or ' or `, leading ;
      }},
     {"dash",
      {
@@ -216,7 +216,8 @@ std::string identify_sh(std::string binary_name) {
   }
   std::string file_stdout(file_stdout_raw);
 
-  std::string binary_pathname = file_stdout.substr(file_stdout.find_last_of(" ") + 1, kShellPathnameLength);
+  std::string binary_pathname = file_stdout.substr(
+      file_stdout.find_last_of(" ") + 1, kShellPathnameLength);
   debug_log("sh links to %s\n", binary_pathname.c_str());
 
   return match_shell(binary_pathname);
@@ -227,11 +228,12 @@ std::string match_shell(std::string binary_pathname) {
   if (!binary_pathname.length()) {
     return "";
   }
-  for (const auto& item : kShellSyntaxErrors) {
+  for (const auto &item : kShellSyntaxErrors) {
     std::string known_shell = item.first;
     std::string binary_name = binary_pathname.substr(
         binary_pathname.find_last_of("/") + 1, known_shell.length());
-    debug_log("Binary is %s (%lu)\n", binary_name.c_str(), binary_name.length());
+    debug_log("Binary is %s (%lu)\n", binary_name.c_str(),
+              binary_name.length());
     if (!binary_name.compare(0, 2, "sh")) {
       debug_log("Matched sh: Needs to identify which specific shell it is.\n");
       return identify_sh(binary_pathname);
@@ -252,7 +254,7 @@ std::string get_shell(pid_t pid, const user_regs_struct &regs) {
 
 void match_error_pattern(std::string buffer, std::string shell) {
   auto error_patterns = kShellSyntaxErrors.at(shell);
-  for (const auto& pattern : error_patterns) {
+  for (const auto &pattern : error_patterns) {
     debug_log("Pattern : %s\n", pattern.c_str());
     debug_log("Found at: %lu\n", buffer.find(pattern));
     if (buffer.find(pattern) != std::string::npos) {

--- a/infra/experimental/sanitizers/ExecSan/execSan.cpp
+++ b/infra/experimental/sanitizers/ExecSan/execSan.cpp
@@ -17,45 +17,46 @@
 
 /* C standard library */
 #include <errno.h>
+#include <signal.h>
 #include <stdio.h>
 #include <string.h>
-#include <signal.h>
 
 /* POSIX */
-#include <unistd.h>
 #include <sys/stat.h>
 #include <sys/user.h>
 #include <sys/wait.h>
+#include <unistd.h>
 
 /* Linux */
-#include <syscall.h>
 #include <sys/ptrace.h>
+#include <syscall.h>
 
 #include <fstream>
-#include <string>
+#include <iostream>
 #include <map>
-#include <vector>
 #include <set>
 #include <sstream>
-#include <iostream>
+#include <string>
+#include <vector>
 
 #define DEBUG_LOGS 0
 
 #if DEBUG_LOGS
-#define debug_log(...) \
-  do { \
-    fprintf(stderr, __VA_ARGS__); fflush(stdout); \
-    fputc('\n', stderr); \
+#define debug_log(...)            \
+  do {                            \
+    fprintf(stderr, __VA_ARGS__); \
+    fflush(stdout);               \
+    fputc('\n', stderr);          \
   } while (0)
 #else
 #define debug_log(...)
 #endif
 
-#define fatal_log(...) \
-  do { \
+#define fatal_log(...)            \
+  do {                            \
     fprintf(stderr, __VA_ARGS__); \
-    fputc('\n', stderr); \
-    exit(EXIT_FAILURE); \
+    fputc('\n', stderr);          \
+    exit(EXIT_FAILURE);           \
   } while (0)
 
 // The magic string that we'll use to detect full control over the command
@@ -76,63 +77,53 @@ constexpr int kErrorMessageLength = 100;
 
 // Syntax error messages of each shell.
 const std::map<std::string, std::set<std::string>> kShellSyntaxErrors = {
-  {
-    "sh",
-    {
-      ": command not found",  // General
-      ": syntax error",       // Unfinished " or ' or ` or if, leading | or ;
-      ": missing"             // Unfinished [
-      ": event not found",    // ! leads large numbers
-      ": No such file",       // Leading < or /
-    }
-  },
-  {
-    "bash",
-    {
-      ": command not found",  // General
-      ": syntax error",       // Unfinished " or ' or ` or if, leading | or ;
-      ": missing"             // Unfinished [
-      ": event not found",    // ! leads large numbers
-      ": No such file",       // Leading < or /
-    }
-  },
-  {
-    "csh",
-    {
-      ": Command not found",        // General
-      "Unmatched",                  // Unfinished " or ' or `, leading ;
-      ": Missing",                  // Unfinished {
-      "Too many",                   // Unfinished (
-      "No match",                   // Leading [
-      "Invalid null command",       // Leading | or < or >
-      "Missing name for redirect"   // Single < or >
-      ": No match",                 // Leading ? or [ or *
-      "Modifier failed",            // Leading ^
-      ": No such job",              // Leading %
-      ": Undefined variable",       // Containing $
-      ": Event not found",          // ! leads large numbers
-    }
-  },
-  {
-    "dash",
-    {
-      ": not found",     // General
-      ": Syntax error",  // Unfinished " or ' or ` or if, leading | or ; or &
-      ": missing"        // Unfinished [
-      ": No such file",  // Leading <
-    }
-  },
-  {
-    "zsh",
-    {
-      ": command not found",               // General
-      ": syntax error",                    // Unfinished " or ' or `
-      " expected"                          // Unfinished [
-      ": no such file or directory",       // Leading < or /
-      ": parse error",                     // Leading |, or &
-      ": no such user or named directory", // Leading ~
-    }
-  },
+    {"sh",
+     {
+         ": command not found",  // General
+         ": syntax error",       // Unfinished " or ' or ` or if, leading | or ;
+         ": missing"             // Unfinished [
+         ": event not found",    // ! leads large numbers
+         ": No such file",       // Leading < or /
+     }},
+    {"bash",
+     {
+         ": command not found",  // General
+         ": syntax error",       // Unfinished " or ' or ` or if, leading | or ;
+         ": missing"             // Unfinished [
+         ": event not found",    // ! leads large numbers
+         ": No such file",       // Leading < or /
+     }},
+    {"csh",
+     {
+         ": Command not found",       // General
+         "Unmatched",                 // Unfinished " or ' or `, leading ;
+         ": Missing",                 // Unfinished {
+         "Too many",                  // Unfinished (
+         "No match",                  // Leading [
+         "Invalid null command",      // Leading | or < or >
+         "Missing name for redirect"  // Single < or >
+         ": No match",                // Leading ? or [ or *
+         "Modifier failed",           // Leading ^
+         ": No such job",             // Leading %
+         ": Undefined variable",      // Containing $
+         ": Event not found",         // ! leads large numbers
+     }},
+    {"dash",
+     {
+         ": not found",     // General
+         ": Syntax error",  // Unfinished " or ' or ` or if, leading | or ; or &
+         ": missing"        // Unfinished [
+         ": No such file",  // Leading <
+     }},
+    {"zsh",
+     {
+         ": command not found",                // General
+         ": syntax error",                     // Unfinished " or ' or `
+         " expected"                           // Unfinished [
+         ": no such file or directory",        // Leading < or /
+         ": parse error",                      // Leading |, or &
+         ": no such user or named directory",  // Leading ~
+     }},
 };
 
 // Shells used by Processes.
@@ -159,7 +150,8 @@ pid_t run_child(char **argv) {
   return pid;
 }
 
-std::vector<std::byte> read_memory(pid_t pid, unsigned long long address, size_t size) {
+std::vector<std::byte> read_memory(pid_t pid, unsigned long long address,
+                                   size_t size) {
   std::vector<std::byte> memory;
 
   for (size_t i = 0; i < size; i += sizeof(long)) {
@@ -168,8 +160,8 @@ std::vector<std::byte> read_memory(pid_t pid, unsigned long long address, size_t
       return memory;
     }
 
-    std::byte *word_bytes = reinterpret_cast<std::byte*>(&word);
-    memory.insert(memory.end(), word_bytes, word_bytes+sizeof(long));
+    std::byte *word_bytes = reinterpret_cast<std::byte *>(&word);
+    memory.insert(memory.end(), word_bytes, word_bytes + sizeof(long));
   }
 
   return memory;
@@ -182,8 +174,8 @@ std::string read_string(pid_t pid, unsigned long reg, unsigned long length) {
     return "";
   }
 
-  std::string content(reinterpret_cast<char*>(
-        memory.data()), std::min(memory.size(), length));
+  std::string content(reinterpret_cast<char *>(memory.data()),
+                      std::min(memory.size(), length));
   return content;
 }
 
@@ -221,9 +213,11 @@ std::string get_pathname(pid_t pid, const user_regs_struct &regs) {
 
 std::string match_shell(std::string binary_pathname) {
   // Identify the name of the shell used in the pathname.
-  for (auto it = kShellSyntaxErrors.begin(); it != kShellSyntaxErrors.end(); ++it) {
+  for (auto it = kShellSyntaxErrors.begin(); it != kShellSyntaxErrors.end();
+       ++it) {
     std::string known_shell = it->first;
-    std::string binary_name = binary_pathname.substr(binary_pathname.find_last_of("/") + 1, known_shell.length());
+    std::string binary_name = binary_pathname.substr(
+        binary_pathname.find_last_of("/") + 1, known_shell.length());
     if (binary_name == known_shell) {
       debug_log("Matched %s\n", binary_name.c_str());
       return known_shell;
@@ -243,14 +237,16 @@ std::string get_shell(pid_t pid, const user_regs_struct &regs) {
 
 void match_error_pattern(std::string buffer, std::string shell) {
   auto error_patterns = kShellSyntaxErrors.at(shell);
-  for(auto it = error_patterns.begin(); it != error_patterns.end(); ++it) {
+  for (auto it = error_patterns.begin(); it != error_patterns.end(); ++it) {
     debug_log("Pattern : %s\n", it->c_str());
     debug_log("Found at: %lu\n", buffer.find(*it));
-    if(buffer.find(*it) != std::string::npos) {
+    if (buffer.find(*it) != std::string::npos) {
       buffer = buffer.substr(0, buffer.find("\n"));
-      printf("--- Found a sign of shell corruption ---\n"
-             "%s\n"
-             "----------------------------------------\n", buffer.c_str());
+      printf(
+          "--- Found a sign of shell corruption ---\n"
+          "%s\n"
+          "----------------------------------------\n",
+          buffer.c_str());
       report_bug(kCorruptionError);
     }
   }
@@ -289,7 +285,7 @@ void trace(std::map<pid_t, Tracee> pids) {
       debug_log("finished waiting %d", pid);
 
       if (WIFEXITED(status) || WIFSIGNALED(status)) {
-        debug_log("%d exited", pid); 
+        debug_log("%d exited", pid);
         it = pids.erase(it);
         // Remove pid from the watchlist when it exits
         g_shell_pids.erase(pid);
@@ -297,7 +293,8 @@ void trace(std::map<pid_t, Tracee> pids) {
       }
 
       // ptrace sets 0x80 for syscalls (with PTRACE_O_TRACESYSGOOD set).
-      bool is_syscall = WIFSTOPPED(status) && WSTOPSIG(status) == (SIGTRAP | 0x80);
+      bool is_syscall =
+          WIFSTOPPED(status) && WSTOPSIG(status) == (SIGTRAP | 0x80);
       int sig = 0;
       if (!is_syscall) {
         // Handle generic signal.
@@ -310,10 +307,10 @@ void trace(std::map<pid_t, Tracee> pids) {
         debug_log("forwarding signal %d to %d", sig, pid);
       }
 
-      if (WIFSTOPPED(status) && 
-          (status>>8 == (SIGTRAP | (PTRACE_EVENT_CLONE<<8)) ||
-           status>>8 == (SIGTRAP | (PTRACE_EVENT_FORK<<8)) ||
-           status>>8 == (SIGTRAP | (PTRACE_EVENT_VFORK<<8)))) {
+      if (WIFSTOPPED(status) &&
+          (status >> 8 == (SIGTRAP | (PTRACE_EVENT_CLONE << 8)) ||
+           status >> 8 == (SIGTRAP | (PTRACE_EVENT_FORK << 8)) ||
+           status >> 8 == (SIGTRAP | (PTRACE_EVENT_VFORK << 8)))) {
         long new_pid;
         if (ptrace(PTRACE_GETEVENTMSG, pid, 0, &new_pid) == -1) {
           debug_log("ptrace(PTRACE_GETEVENTMSG, %d): %s", pid, strerror(errno));
@@ -340,8 +337,10 @@ void trace(std::map<pid_t, Tracee> pids) {
             }
           }
 
-          if (regs.orig_rax == __NR_write && g_shell_pids.find(pid) != g_shell_pids.end()) {
-            debug_log("Inspecting the `write` buffer of shell process %d.", pid);
+          if (regs.orig_rax == __NR_write &&
+              g_shell_pids.find(pid) != g_shell_pids.end()) {
+            debug_log("Inspecting the `write` buffer of shell process %d.",
+                      pid);
             inspect_for_corruption(pid, regs);
           }
         }
@@ -382,11 +381,8 @@ int main(int argc, char **argv) {
 
   pid_t pid = run_child(argv + 1);
 
-  long options = 
-    PTRACE_O_TRACESYSGOOD
-    | PTRACE_O_TRACEFORK
-    | PTRACE_O_TRACEVFORK
-    | PTRACE_O_TRACECLONE;
+  long options = PTRACE_O_TRACESYSGOOD | PTRACE_O_TRACEFORK |
+                 PTRACE_O_TRACEVFORK | PTRACE_O_TRACECLONE;
 
   if (ptrace(PTRACE_SEIZE, pid, nullptr, options) == -1) {
     fatal_log("ptrace(PTRACE_SEIZE): %s", strerror(errno));

--- a/infra/experimental/sanitizers/ExecSan/execSan.cpp
+++ b/infra/experimental/sanitizers/ExecSan/execSan.cpp
@@ -201,9 +201,7 @@ void inspect_for_injection(pid_t pid, const user_regs_struct &regs) {
 
 std::string get_pathname(pid_t pid, const user_regs_struct &regs) {
   // Parse the pathname from the memory specified in the RDI register.
-  std::string raw_content = read_string(pid, regs.rdi, kShellPathnameLength);
-
-  std::string pathname = raw_content.substr(0, raw_content.find(" "));
+  std::string pathname = read_string(pid, regs.rdi, kShellPathnameLength);
   debug_log("Pathname is %s (len %lu)\n", pathname.c_str(), pathname.length());
   return pathname;
 }
@@ -250,7 +248,7 @@ void match_error_pattern(std::string buffer, std::string shell) {
 
 void inspect_for_corruption(pid_t pid, const user_regs_struct &regs) {
   // Inspect a PID's registers for shell corruption.
-  std::string buffer = read_string(pid, regs.rsi, kErrorMessageLength);
+  std::string buffer = read_string(pid, regs.rsi, regs.rdx);
   debug_log("Write buffer: %s\n", buffer.c_str());
   match_error_pattern(buffer, g_shell_pids[pid]);
 }

--- a/infra/experimental/sanitizers/ExecSan/execSan.cpp
+++ b/infra/experimental/sanitizers/ExecSan/execSan.cpp
@@ -256,7 +256,6 @@ void match_error_pattern(std::string buffer, std::string shell) {
     debug_log("Pattern : %s\n", pattern.c_str());
     debug_log("Found at: %lu\n", buffer.find(pattern));
     if (buffer.find(pattern) != std::string::npos) {
-      buffer = buffer.substr(0, buffer.find("\n"));
       printf(
           "--- Found a sign of shell corruption ---\n"
           "%s\n"


### PR DESCRIPTION
Inspect the buffer of the `write` syscalls after `execve` for syntax errors, which is an indicator of potential shell injection