### PR TITLE
mergo: initial integration

### DIFF
--- a/projects/mergo/project.yaml
+++ b/projects/mergo/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://github.com/imdario/mergo"
+language: go
+primary_contact: "d@rio.hn"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+main_repo: 'https://github.com/imdario/mergo.git'


### PR DESCRIPTION
imdario/mergo is a merging helper library used by Docker, Kubernetes, Github CLI, etc. According to [Open Source Insights](https://deps.dev/go/github.com%2Fimdario%2Fmergo/v0.3.13/versions), at least 40.000 repositories are using it direct or indirectly.