### PR TITLE
A Proof of Error in `python-libnmap-0.7.2`

### DIFF
--- a/infra/experimental/sanitizers/ExecSan/Makefile
+++ b/infra/experimental/sanitizers/ExecSan/Makefile
@@ -13,5 +13,14 @@ target: target.cpp
 test:  all vuln.dict
 	./execSan ./target -dict=vuln.dict
 
+libnmap:  PoEs/python-libnmap-0.7.2/
+	cp ./execSan.cpp ./vuln.dict ./PoEs/python-libnmap-0.7.2/
+	(cd PoEs/python-libnmap-0.7.2/; \
+	docker build . --tag python-libnmap; \
+	docker run -t python-libnmap:latest)
+
+
 clean:
 	rm -f execSan /tmp/tripwire target
+	(cd PoEs/python-libnmap-0.7.2/; \
+	rm -rf execSan.cpp vuln.dict)

--- a/infra/experimental/sanitizers/ExecSan/PoEs/python-libnmap-0.7.2/Dockerfile
+++ b/infra/experimental/sanitizers/ExecSan/PoEs/python-libnmap-0.7.2/Dockerfile
@@ -1,0 +1,36 @@
+# Copyright 2022 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build and run the proof of error in python-libnmap.
+
+FROM gcr.io/oss-fuzz-base/base-clang
+
+RUN apt update && \
+  apt install -y \
+  wget \
+  python3 \
+  python3-pip \
+  nmap && \
+  wget https://github.com/savon-noir/python-libnmap/archive/refs/tags/v0.7.2.tar.gz -O python-libnmap-0.7.2.tar.gz && \
+  tar -xf python-libnmap-0.7.2.tar.gz && \
+  cd python-libnmap-0.7.2 && \
+  pip3 install -e . && \
+  mkdir /CVE
+
+WORKDIR /CVE
+
+COPY . /CVE
+
+CMD ["make", "libnmap"]
+

--- a/infra/experimental/sanitizers/ExecSan/PoEs/python-libnmap-0.7.2/Makefile
+++ b/infra/experimental/sanitizers/ExecSan/PoEs/python-libnmap-0.7.2/Makefile
@@ -1,0 +1,16 @@
+.POSIX:
+CXX     = clang++
+CFLAGS = -std=c++17 -Wall -Wextra -O3 -g3
+
+execSan: execSan.cpp
+	$(CXX) $(CFLAGS) -lpthread -o $@ $^
+
+target: target.cpp
+	$(CXX) $(CFLAGS) -fsanitize=address,fuzzer -o $@ $^
+
+libnmap: clean execSan target
+	$(CXX) $(CFLAGS) -fsanitize=address,fuzzer -o ./target ./target.cpp
+	./execSan ./target
+
+clean:
+	rm -f execSan /tmp/tripwire target

--- a/infra/experimental/sanitizers/ExecSan/PoEs/python-libnmap-0.7.2/libnmap_target.py
+++ b/infra/experimental/sanitizers/ExecSan/PoEs/python-libnmap-0.7.2/libnmap_target.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Invoking the target program under test,with the inputs injected into its parameters."""
+"""Invoking the target with the inputs from fuzzers as its parameters."""
 
 import sys
 

--- a/infra/experimental/sanitizers/ExecSan/PoEs/python-libnmap-0.7.2/libnmap_target.py
+++ b/infra/experimental/sanitizers/ExecSan/PoEs/python-libnmap-0.7.2/libnmap_target.py
@@ -1,0 +1,24 @@
+# Copyright 2022 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Invoking the target program under test,with the inputs injected into its parameters."""
+
+import sys
+
+from libnmap.process import NmapProcess
+
+if __name__ == "__main__":
+  NMAP_OPTIONS = ' -sn -n '
+  TARGETS = ' '.join(sys.argv[1:])
+  nmap_proc = NmapProcess(targets=TARGETS, options=NMAP_OPTIONS, safe_mode=True)
+  nmap_proc.run()

--- a/infra/experimental/sanitizers/ExecSan/PoEs/python-libnmap-0.7.2/target.cpp
+++ b/infra/experimental/sanitizers/ExecSan/PoEs/python-libnmap-0.7.2/target.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Google LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *      http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+/* A wrapper of libnmap_target.py, the target program under test,
+ * inputs will be injected into its shell command as parameters. */
+
+#include <stdlib.h>
+
+#include <iostream>
+#include <string>
+
+extern "C" int LLVMFuzzerTestOneInput(char* data, size_t size) {
+  std::string str(data, size);
+  system(("python3 ./libnmap_target.py " + str).c_str());
+  return 0;
+}

--- a/infra/experimental/sanitizers/ExecSan/README.md
+++ b/infra/experimental/sanitizers/ExecSan/README.md
@@ -34,6 +34,13 @@ which indicates the detection of executing the planted `/tmp/tripwire`.
 which indicates the detection of executing a syntactic erroneous command.
 
 
+### Run Proof of Error in python-libnmap
+```shell
+make libnmap
+```
+Look for the same messages as in Sec. Run test.
+
 ## TODOs
 1. Find real examples of past shell injection vulnerabilities using this.
+  1. [x] `python-libnmap-0.7.2`
 


### PR DESCRIPTION
1. A docker environment to show the proof of the error.
2. wrappers to feed inputs to `python-libnmap-0.7.2`.