### PR TITLE
Execsan syntax error (minor fixes)

### DIFF
--- a/infra/experimental/sanitizers/ExecSan/README.md
+++ b/infra/experimental/sanitizers/ExecSan/README.md
@@ -36,4 +36,7 @@ which indicates the detection of executing a syntactic erroneous command.
 
 ## TODOs
 1. Find real examples of past shell injection vulnerabilities using this.
+2. More specific patterns of error messages (to avoid false postives/negatives)
+  * e.g. cache and concatenate the buffer of consecutive `write` syscalls
+  * e.g. define the RegEx of patterns and pattern-match with buffers
 

--- a/infra/experimental/sanitizers/ExecSan/execSan.cpp
+++ b/infra/experimental/sanitizers/ExecSan/execSan.cpp
@@ -101,10 +101,10 @@ const std::map<std::string, std::set<std::string>> kShellSyntaxErrors = {
      }},
     {"dash",
      {
-         ": not found",     // General
-         ": Syntax error",  // Unfinished " or ' or ` or if, leading | or ; or &
-         ": missing ]",     // Unfinished [
-         ": No such file",  // Leading <
+         "not found",     // General
+         "Syntax error",  // Unfinished " or ' or ` or if, leading | or ; or &
+         "missing ]",     // Unfinished [
+         "No such file",  // Leading <
      }},
     {"zsh",
      {

--- a/infra/experimental/sanitizers/ExecSan/target.cpp
+++ b/infra/experimental/sanitizers/ExecSan/target.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
 */
 /* A sample target program under test,
- * the sand program will be injected into its shell command */
+ * /tmp/tripwire or other commands will be injected into its shell command */
 
 #include <stdlib.h>
 #include <string>


### PR DESCRIPTION
1. Some error messages from `dash` mismatches with our pattern:
   1. Our previous pattern (i.e. `: Syntax error`) is designed to reduce false positives, but it relies on `dash` to print out an error message within one `write` syscall. E.g. `sh: 1: Syntax error: "invalid_command" unexpected`.
   2. However, in some cases, `dash` breaks the message into multiple `write` syscalls. E.g. it invokes 2 `writes` whose buffers respectively contain `sh: 1:`, ` Syntax error: "invalid_command" unexpected`.
   3. The PR removes the `: ` prefix in our previous pattern to capture case ii and reduce false negatives. 
4. Fix outdated wording.