### PR TITLE
ngolo-fuzzing: try to get coverage

### DIFF
--- a/projects/ngolo-fuzzing/build.sh
+++ b/projects/ngolo-fuzzing/build.sh
@@ -44,11 +44,17 @@ compile_package () {
     if [ "$SANITIZER" = "coverage" ]
     then
         (
+        if [[ `echo $pkg | grep runtime | wc -l` == '1' ]]; then
+            continue
+        fi
         cd fuzz_ng_$pkg_flat
         compile_go_fuzzer . FuzzNG_unsure fuzz_ngo_$pkg_flat
         )
     else
-        compile_go_fuzzer ./fuzz_ng_$pkg_flat FuzzNG_unsure fuzz_ngo_$pkg_flat
+        (
+        cd fuzz_ng_$pkg_flat
+        compile_go_fuzzer . FuzzNG_unsure fuzz_ngo_$pkg_flat
+        )
         ./go114-fuzz-build/go114-fuzz-build -func FuzzNG_valid -o fuzz_ng_$pkg_flat.a ./fuzz_ng_$pkg_flat
 
         $CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz_ng_$pkg_flat/ngolofuzz.pb.o fuzz_ng_$pkg_flat//ngolofuzz.o fuzz_ng_$pkg_flat.a  $SRC/LPM/src/libfuzzer/libprotobuf-mutator-libfuzzer.a $SRC/LPM/src/libprotobuf-mutator.a $SRC/LPM/external.protobuf/lib/libprotobuf.a -o $OUT/fuzz_ng_$pkg_flat


### PR DESCRIPTION
By removing runtime target which times out the whole coverage