### PR TITLE
envoy: Limiting number of targets in CI

### DIFF
--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -19,7 +19,15 @@ declare -r FUZZ_TARGET_QUERY='
   let all_fuzz_tests = attr(tags, "fuzz_target", "...") in
   $all_fuzz_tests - attr(tags, "no_fuzz", $all_fuzz_tests)
 '
-declare -r OSS_FUZZ_TARGETS="$(bazel query "${FUZZ_TARGET_QUERY}" | sed 's/$/_oss_fuzz/')"
+
+if [ -n "${OSS_FUZZ_CI-}" ]
+then
+  # CI has fewer resources so restricting to a small number of fuzz targets.
+  # Choosing the header_parser, header_map_impl, and utility.
+  declare -r OSS_FUZZ_TARGETS="$(bazel query "${FUZZ_TARGET_QUERY}" | grep ':header\|http:utility' | sed 's/$/_oss_fuzz/')"
+else
+  declare -r OSS_FUZZ_TARGETS="$(bazel query "${FUZZ_TARGET_QUERY}" | sed 's/$/_oss_fuzz/')"
+fi
 
 declare -r EXTRA_BAZEL_FLAGS="$(
 if [ -n "$CC" ]; then


### PR DESCRIPTION
Limiting the number of fuzz targets when running under CI.
This PR addresses comments from #7770.

Signed-off-by: Adi Suissa-Peleg <adip@google.com>