### PR TITLE
projects/cosmos-sdk: use main branch

### DIFF
--- a/projects/cosmos-sdk/Dockerfile
+++ b/projects/cosmos-sdk/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
-RUN git clone --single-branch --branch fuzz-packages https://github.com/cosmos/cosmos-sdk
+RUN git clone --depth 1 https://github.com/cosmos/cosmos-sdk
 
 COPY build.sh $SRC
 WORKDIR $SRC/cosmos-sdk


### PR DESCRIPTION
The cosmos-sdk fuzz tests have been merged to the main branch in
https://github.com/cosmos/cosmos-sdk/pull/12152

CC @odeke-em 