### PR TITLE
Opt out of allstar binary artifacts check

### DIFF
--- a/.allstar/binary_artifacts.yaml
+++ b/.allstar/binary_artifacts.yaml
@@ -1,0 +1,3 @@
+# Exemption reason: This repo uses binary artifacts for integration tests.
+optConfig:
+  optOut: true


### PR DESCRIPTION
These binaries are necessary and are only run during testing.
Fixes https://github.com/google/oss-fuzz/issues/7802