### PR TITLE
git: workaround new requirement to use common-main

### DIFF
--- a/projects/git/build.sh
+++ b/projects/git/build.sh
@@ -16,8 +16,9 @@
 ################################################################################
 
 # build fuzzers
-make -j$(nproc) CC=$CC CXX=$CXX CFLAGS="$CFLAGS" FUZZ_CXXFLAGS="$CXXFLAGS" \
-  LIB_FUZZING_ENGINE=$LIB_FUZZING_ENGINE fuzz-all
+make -j$(nproc) CC=$CC CXX=$CXX CFLAGS="$CFLAGS" \
+  FUZZ_CXXFLAGS="$CXXFLAGS -Wl,--allow-multiple-definition" \
+  LIB_FUZZING_ENGINE="common-main.o $LIB_FUZZING_ENGINE" fuzz-all
 
 FUZZERS="fuzz-pack-headers fuzz-pack-idx fuzz-commit-graph"
 

--- a/projects/git/project.yaml
+++ b/projects/git/project.yaml
@@ -7,3 +7,8 @@ auto_ccs:
   - "jonathantanmy@google.com"
   - "jrn@google.com"
 main_repo: 'https://github.com/git/git'
+
+# Disable honggfuzz due to undiagnosed build failures
+fuzzing_engines:
+  - libfuzzer
+  - afl


### PR DESCRIPTION
Due to upstream changes, the Git fuzzers must now link against
common-main.o; however, this breaks the build in two ways:

1) Linking with common-main.o causes main() to have multiple
definitions, one in common-main.o and one from the fuzzing engine.

2) To avoid #1, the Git Makefile specifically excludes common-main.o
from the fuzzer build rule.

To work around these issues, we can override FUZZ_CXXFLAGS (add
"-Wl,--allow-multiple-definition" to fix #1) and LIB_FUZZING_ENGINE (add
"common-main.o" to fix #2).

Once we can get a Makefile fix into Git's upstream, we can remove the
override for LIB_FUZZING_ENGINE.