### PR TITLE
Set flags correctly to use old pass manager

### DIFF
--- a/projects/alembic/build.sh
+++ b/projects/alembic/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 mkdir -p $WORK/build_openexr
 mkdir -p $WORK/build_alembic
 

--- a/projects/bearssl/build.sh
+++ b/projects/bearssl/build.sh
@@ -15,6 +15,14 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
+
 # Not using OpenSSL
     export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL"
 

--- a/projects/bls-signatures/build.sh
+++ b/projects/bls-signatures/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL -D_LIBCPP_DEBUG=1"
 if [[ "$SANITIZER" = "memory" ]]
 then

--- a/projects/boost/build.sh
+++ b/projects/boost/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 # Build boost
 CXXFLAGS="$CXXFLAGS -stdlib=libc++ -pthread" LDFLAGS="-stdlib=libc++" \
     ./bootstrap.sh --with-toolset=clang --prefix=/usr;

--- a/projects/boringssl/build.sh
+++ b/projects/boringssl/build.sh
@@ -15,6 +15,14 @@
 # limitations under the License.
 #
 ################################################################################
+
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 mkdir -p $WORK/boringssl
 cd $WORK/boringssl
 

--- a/projects/botan/build.sh
+++ b/projects/botan/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 cd $SRC/botan
 
 ln -s $SRC/fuzzer_corpus .

--- a/projects/c-ares/build.sh
+++ b/projects/c-ares/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 # Build the project.
 ./buildconf
 ./configure --enable-debug

--- a/projects/cel-cpp/build.sh
+++ b/projects/cel-cpp/build.sh
@@ -15,4 +15,11 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 bazel_build_fuzz_tests

--- a/projects/cmake/build.sh
+++ b/projects/cmake/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 # Build CMake.
 mkdir build-dir && cd build-dir
 ../bootstrap && make -j$(nproc)

--- a/projects/cppcheck/build.sh
+++ b/projects/cppcheck/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 # build fuzzer
 
 cd $SRC/cppcheck/oss-fuzz

--- a/projects/cyclonedds/build.sh
+++ b/projects/cyclonedds/build.sh
@@ -15,4 +15,11 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 source fuzz/oss-fuzz-build.sh

--- a/projects/dart/build.sh
+++ b/projects/dart/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 # build project
 git apply ../../patch.diff
 ./tools/build.py --no-goma -j$(nproc) -m debug -a x64 --sanitizer=asan dart_libfuzzer

--- a/projects/duckdb/build.sh
+++ b/projects/duckdb/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 make
 EXTENSION_LIBS=$(find ./build/release/extension/ -name "*.a")
 THIRD_PARTY_LIBS=$(find ./build/release/third_party/ -name "*.a")

--- a/projects/fast-dds/build.sh
+++ b/projects/fast-dds/build.sh
@@ -15,6 +15,12 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
 
 (
 cd ../tinyxml2

--- a/projects/firestore/build.sh
+++ b/projects/firestore/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 cd $WORK
 
 # Disable UBSan vptr since Firestore depends on other libraries that are built

--- a/projects/flatbuffers/build.sh
+++ b/projects/flatbuffers/build.sh
@@ -14,7 +14,14 @@
 # limitations under the License.
 #
 ################################################################################
-  
+
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 cd $SRC/flatbuffers
 mkdir build
 cd build

--- a/projects/git/build.sh
+++ b/projects/git/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 # build fuzzers
 make -j$(nproc) CC=$CC CXX=$CXX CFLAGS="$CFLAGS" FUZZ_CXXFLAGS="$CXXFLAGS" \
   LIB_FUZZING_ENGINE=$LIB_FUZZING_ENGINE fuzz-all

--- a/projects/gnupg/build.sh
+++ b/projects/gnupg/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 #compile and link statically dependencies
 cd ..
 cd libgpg-error

--- a/projects/gnutls/build.sh
+++ b/projects/gnutls/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 export DEPS_PATH=$SRC/deps
 export PKG_CONFIG_PATH=$DEPS_PATH/lib64/pkgconfig:$DEPS_PATH/lib/pkgconfig
 export CPPFLAGS="-I$DEPS_PATH/include"

--- a/projects/grpc-httpjson-transcoding/build.sh
+++ b/projects/grpc-httpjson-transcoding/build.sh
@@ -16,6 +16,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 # This project uses bazel rules_fuzzing.
 
 bazel_build_fuzz_tests

--- a/projects/hermes/build.sh
+++ b/projects/hermes/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 # build ICU for linking statically.
 cd $SRC/icu/source
 ./configure --disable-shared --enable-static --disable-layoutex \

--- a/projects/janet/build.sh
+++ b/projects/janet/build.sh
@@ -14,6 +14,14 @@
 # limitations under the License.
 #
 ################################################################################
+
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 export CFLAGS="$CFLAGS -fPIC"
 cd janet
 make

--- a/projects/json/build.sh
+++ b/projects/json/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 make FUZZER_ENGINE="$LIB_FUZZING_ENGINE" fuzzers -Ctests
 
 FUZZER_FILES=$(find tests/ -maxdepth 1 -executable -type f)

--- a/projects/jsoncpp/build.sh
+++ b/projects/jsoncpp/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 mkdir -p build
 cd build
 cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_CXX_FLAGS="$CXXFLAGS" \

--- a/projects/jsonnet/build.sh
+++ b/projects/jsonnet/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 mkdir jsonnet/build
 pushd jsonnet/build
 cmake -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" \

--- a/projects/keystone/build.sh
+++ b/projects/keystone/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 #builds project
 cd keystone
 mkdir build

--- a/projects/lame/build.sh
+++ b/projects/lame/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 pushd mpg123
 if [[ "$ARCHITECTURE" == "i386" ]]; then
 	./configure --enable-static --with-cpu=$ARCHITECTURE

--- a/projects/libcoap/build.sh
+++ b/projects/libcoap/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 ./autogen.sh && ./configure --disable-doxygen --disable-manpages \
                             --disable-dtls                       \
     && make -j$(nproc)

--- a/projects/libecc/build.sh
+++ b/projects/libecc/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL"
 export LIBFUZZER_LINK="$LIB_FUZZING_ENGINE"
 

--- a/projects/libheif/build.sh
+++ b/projects/libheif/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 # Build dependencies.
 export DEPS_PATH=$SRC/deps
 mkdir -p $DEPS_PATH

--- a/projects/libressl/build.sh
+++ b/projects/libressl/build.sh
@@ -16,6 +16,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 # Install Boost headers
 cd $SRC/
 tar jxf boost_1_74_0.tar.bz2

--- a/projects/libsass/build.sh
+++ b/projects/libsass/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 pushd libsass
 export BUILD='static'
 make -j$(nproc)

--- a/projects/libspectre/build.sh
+++ b/projects/libspectre/build.sh
@@ -14,5 +14,13 @@
 # limitations under the License.
 #
 ################################################################################
+
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 # Run the OSS-Fuzz script in the project
 $SRC/libspectre/test/ossfuzz.sh

--- a/projects/libvips/build.sh
+++ b/projects/libvips/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 export PKG_CONFIG="pkg-config --static"
 export PKG_CONFIG_PATH="$WORK/lib/pkgconfig"
 export CPPFLAGS="-I$WORK/include"

--- a/projects/muduo/build.sh
+++ b/projects/muduo/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 sed -i '34 a $ENV{CXXFLAGS}' CMakeLists.txt
 mkdir -p build-dir && cd build-dir
 cmake -DCMAKE_BUILD_TYPE="release" \

--- a/projects/nettle/build.sh
+++ b/projects/nettle/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 export LINK_FLAGS=""
 
 # Not using OpenSSL

--- a/projects/nss/build.sh
+++ b/projects/nss/build.sh
@@ -15,6 +15,12 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
 
 # Build NSS with fuzzers.
 ./automation/ossfuzz/build.sh

--- a/projects/oatpp/build.sh
+++ b/projects/oatpp/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 mkdir build && cd build
 cmake ../
 make

--- a/projects/openbabel/build.sh
+++ b/projects/openbabel/build.sh
@@ -15,6 +15,12 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
 
 # build project
 mkdir build && cd build

--- a/projects/opencv/build.sh
+++ b/projects/opencv/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 build_dir=$WORK/build-$SANITIZER
 install_dir=$WORK/install-$SANITIZER
 

--- a/projects/opendnp3/build.sh
+++ b/projects/opendnp3/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 # build project
 cmake -DDNP3_FUZZING=ON -DDNP3_STATIC_LIBS=ON .
 make all

--- a/projects/opensc/build.sh
+++ b/projects/opensc/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 ./bootstrap
 # FIXME FUZZING_LIBS="$LIB_FUZZING_ENGINE" fails with some missing C++ library, I don't know how to fix this
 ./configure --disable-optimization --disable-shared --disable-pcsc --enable-ctapi --enable-fuzzing FUZZING_LIBS="$LIB_FUZZING_ENGINE"

--- a/projects/perfetto/build.sh
+++ b/projects/perfetto/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 export CFLAGS="$CFLAGS -Wno-extra-semi-stmt"
 export CXXFLAGS="$CXXFLAGS -Wno-extra-semi-stmt"
 

--- a/projects/piex/build.sh
+++ b/projects/piex/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 git checkout fuzzers
 cd fuzzers
 make

--- a/projects/pistache/build.sh
+++ b/projects/pistache/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 mkdir build && cd build
 meson --default-library=static ../
 ninja

--- a/projects/powerdns/build.sh
+++ b/projects/powerdns/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 # remove dependencies on boost's program_options, we don't need it
 # and it won't link because oss-fuzz adds -stdlib=libc++ to the flags,
 # which would require rebuilding boost

--- a/projects/qpdf/build.sh
+++ b/projects/qpdf/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 # libz
 pushd $SRC/zlib
 ./configure --static --prefix="$WORK"

--- a/projects/relic/build.sh
+++ b/projects/relic/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL"
 export LIBFUZZER_LINK="$LIB_FUZZING_ENGINE"
 

--- a/projects/simd/build.sh
+++ b/projects/simd/build.sh
@@ -15,6 +15,12 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
 
 mkdir build && cd build
 cmake ../prj/cmake \

--- a/projects/spdlog/build.sh
+++ b/projects/spdlog/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 # build project
 cmake . && make -j$(nproc)
 

--- a/projects/spice-usbredir/build.sh
+++ b/projects/spice-usbredir/build.sh
@@ -15,4 +15,11 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 exec ./build-aux/oss-fuzz.sh

--- a/projects/tinygltf/build.sh
+++ b/projects/tinygltf/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 # build project
 cd tests/fuzzer/
 meson build

--- a/projects/usbguard/build.sh
+++ b/projects/usbguard/build.sh
@@ -14,6 +14,14 @@
 # limitations under the License.
 #
 ################################################################################
+
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 # Ensure libqb can be found by pkgconfig
 export PKG_CONFIG_PATH=/usr/lib64/pkgconfig/
 

--- a/projects/wabt/build.sh
+++ b/projects/wabt/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 # build project
 mkdir build
 cd build

--- a/projects/wolfssl/build.sh
+++ b/projects/wolfssl/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 if [[ $CFLAGS != *sanitize=dataflow* ]]
 then
     WOLFCRYPT_CONFIGURE_PARAMS="--enable-static --enable-md2 --enable-md4 --enable-ripemd --enable-blake2 --enable-blake2s --enable-pwdbased --enable-scrypt --enable-hkdf --enable-cmac --enable-arc4 --enable-camellia --enable-aesccm --enable-aesctr --enable-xts --enable-des3 --enable-x963kdf --enable-harden --enable-aescfb --enable-aesofb --enable-aeskeywrap --enable-aessiv --enable-keygen --enable-curve25519 --enable-curve448 --enable-shake256 --disable-crypttests --disable-examples --enable-compkey --enable-ed448 --enable-ed25519 --enable-ecccustcurves --enable-xchacha --enable-cryptocb --enable-eccencrypt --enable-aesgcm-stream --enable-smallstack --enable-ed25519-stream --enable-ed448-stream"

--- a/projects/znc/build.sh
+++ b/projects/znc/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+
 git submodule update --init --recursive
 mkdir build && cd build
 cmake -DBUILD_SHARED_LIBS=OFF \

--- a/projects/zstd/build.sh
+++ b/projects/zstd/build.sh
@@ -15,6 +15,12 @@
 #
 ################################################################################
 
+# this is a temporary fix: this project cannot be built with LLVM14 new pass
+# manager, so have to fall back to old pass manager.
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-O0//')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-O0//')
+export CFLAGS=$(echo "$CFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
+export CXXFLAGS=$(echo "$CXXFLAGS" | sed -e 's/-flto/-flegacy-pass-manager -flto/')
 
 cd tests/fuzz
 


### PR DESCRIPTION
#7788 caused a significant number of projects fail to build with introspector.
This PR sets the flags to use old pass manager and get the projects built.