### PR TITLE
A PoC of `execSan` with `pytorch-lightning-1.5.10`

### DIFF
--- a/infra/experimental/sanitizers/ExecSan/Makefile
+++ b/infra/experimental/sanitizers/ExecSan/Makefile
@@ -13,5 +13,11 @@ target: target.cpp
 test:  all vuln.dict
 	./execSan ./target -dict=vuln.dict
 
+pytorch-lightning-1.5.10:
+	cp execSan.cpp PoEs/pytorch-lightning-1.5.10/; \
+	cd PoEs/pytorch-lightning-1.5.10/; \
+	docker build . --tag execsan_pytorch-lightning; \
+	docker run -t execsan_pytorch-lightning:latest;
+
 clean:
 	rm -f execSan /tmp/tripwire target

--- a/infra/experimental/sanitizers/ExecSan/PoEs/pytorch-lightning-1.5.10/Dockerfile
+++ b/infra/experimental/sanitizers/ExecSan/PoEs/pytorch-lightning-1.5.10/Dockerfile
@@ -1,0 +1,32 @@
+# Copyright 2022 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build and run the proof of error in gerapy.
+
+FROM gcr.io/oss-fuzz-base/base-builder-python
+
+RUN apt update && \
+  apt install -y vim && \
+  git clone \
+    --depth 1 \
+    --branch 1.5.10 \
+    https://github.com/PyTorchLightning/pytorch-lightning.git
+
+COPY ./build.sh $SRC
+RUN  ./build.sh
+
+COPY . $SRC
+RUN make execSan
+
+CMD ["make", "run"]

--- a/infra/experimental/sanitizers/ExecSan/PoEs/pytorch-lightning-1.5.10/Dockerfile
+++ b/infra/experimental/sanitizers/ExecSan/PoEs/pytorch-lightning-1.5.10/Dockerfile
@@ -1,18 +1,18 @@
 # Copyright 2022 Google LLC
-
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Build and run the proof of error in gerapy.
+#
+# Build and run the proof of error in pytorch-lightning.
 
 FROM gcr.io/oss-fuzz-base/base-builder-python
 

--- a/infra/experimental/sanitizers/ExecSan/PoEs/pytorch-lightning-1.5.10/Makefile
+++ b/infra/experimental/sanitizers/ExecSan/PoEs/pytorch-lightning-1.5.10/Makefile
@@ -1,0 +1,12 @@
+.POSIX:
+CXX     = clang++
+CFLAGS = -std=c++17 -Wall -Wextra -O3 -g3
+
+execSan: execSan.cpp
+	$(CXX) $(CFLAGS) -lpthread -o $@ $^
+
+run: clean execSan fuzz_pytorch_lightning.py
+	./execSan ./fuzz_pytorch_lightning.py -dict=vuln.dict
+
+clean:
+	rm -f execSan /tmp/tripwire

--- a/infra/experimental/sanitizers/ExecSan/PoEs/pytorch-lightning-1.5.10/build.sh
+++ b/infra/experimental/sanitizers/ExecSan/PoEs/pytorch-lightning-1.5.10/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -eu
+# Copyright 2022 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Build and install project (using current CFLAGS, CXXFLAGS).
+cd pytorch-lightning
+pip3 install .
+
+# Build fuzzers in $OUT.
+for fuzzer in $(find $SRC -name '*_fuzzer.py'); do
+  compile_python_fuzzer $fuzzer
+done

--- a/infra/experimental/sanitizers/ExecSan/PoEs/pytorch-lightning-1.5.10/build.sh
+++ b/infra/experimental/sanitizers/ExecSan/PoEs/pytorch-lightning-1.5.10/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2022 Google Inc.
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/experimental/sanitizers/ExecSan/PoEs/pytorch-lightning-1.5.10/fuzz_pytorch_lightning.py
+++ b/infra/experimental/sanitizers/ExecSan/PoEs/pytorch-lightning-1.5.10/fuzz_pytorch_lightning.py
@@ -24,8 +24,6 @@ we show a way to achieve the same exploit with an arbitrary env variable.
 """
 
 import os
-import random
-import string
 import sys
 import atheris
 
@@ -34,21 +32,10 @@ with atheris.instrument_imports():
   from pytorch_lightning.utilities.argparse import parse_env_variables
 
 
-def random_env_name(length):
-  """Generate a valid random name of environment variables"""
-  valid_env_head_chars = string.ascii_uppercase + string.ascii_lowercase + '_'
-  valid_env_tail_chars = valid_env_head_chars + string.digits
-
-  env_head = random.choice(valid_env_head_chars)
-  env_tail = ''.join(random.choice(valid_env_tail_chars) \
-                     for _ in range(random.randint(0, length)))
-  return env_head + env_tail
-
-
 def prepare_fuzzing_input(data):
   """Prepare the data needed by the exploit with input data from fuzzers."""
   data = data.replace(b'\0', b'')
-  env_name = random_env_name(len(data))
+  env_name = 'AN_ARBITRARY_ENV_NAME'
   return data, env_name
 
 

--- a/infra/experimental/sanitizers/ExecSan/PoEs/pytorch-lightning-1.5.10/fuzz_pytorch_lightning.py
+++ b/infra/experimental/sanitizers/ExecSan/PoEs/pytorch-lightning-1.5.10/fuzz_pytorch_lightning.py
@@ -1,0 +1,79 @@
+#!/usr/local/bin/python3
+
+# Copyright 2022 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+"""Exploit pytorch lightning with fuzzer's input as a random env variable.
+
+This PoC is extended from a report in GitHub Advisory Database:
+https://github.com/advisories/GHSA-r5qj-cvf9-p85h
+The original report documents an exploit using a specific environment variable,
+we show a way to achieve the same exploit with an arbitrary env variable.
+"""
+
+
+import os
+import random
+import string
+import sys
+import atheris
+
+with atheris.instrument_imports():
+  from pytorch_lightning import Trainer
+  from pytorch_lightning.utilities.argparse import parse_env_variables
+
+
+def random_env_name(length):
+  """Generate a valid random name of environment variables"""
+  valid_env_head_chars = string.ascii_uppercase + string.ascii_lowercase + '_'
+  valid_env_tail_chars = valid_env_head_chars + string.digits
+
+  env_head = random.choice(valid_env_head_chars)
+  env_tail = ''.join(random.choice(valid_env_tail_chars) \
+                     for _ in range(random.randint(0, length)))
+  return env_head + env_tail
+
+
+def prepare_fuzzing_input(data):
+  """Prepare the data needed by the exploit with input data from fuzzers."""
+  data = data.replace(b'\0', b'')
+  env_name = random_env_name(len(data))
+  return data, env_name
+
+
+def exploit_target(env_value, env_name):
+  """This target is based on a snippet from
+  the official documentation of `parse_env_variables`:
+  https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.utilities.argparse.html
+  It might not be the most realistic example,
+  but serves as a PoC to show that execSan works for Python"""
+  os.environb[env_name.encode()] = env_value
+  parse_env_variables(Trainer, template=env_name)
+
+
+def TestOneInput(data):  # pylint: disable=invalid-name
+  """Exploit the target only with input data from fuzzers"""
+  env_value, env_name = prepare_fuzzing_input(data)
+  exploit_target(env_value, env_name)
+
+
+def main():
+  """Fuzz target with atheris"""
+  atheris.Setup(sys.argv, TestOneInput)
+  atheris.Fuzz()
+
+
+if __name__ == "__main__":
+  main()

--- a/infra/experimental/sanitizers/ExecSan/PoEs/pytorch-lightning-1.5.10/fuzz_pytorch_lightning.py
+++ b/infra/experimental/sanitizers/ExecSan/PoEs/pytorch-lightning-1.5.10/fuzz_pytorch_lightning.py
@@ -1,6 +1,6 @@
 #!/usr/local/bin/python3
-
-# Copyright 2022 Google Inc.
+#
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ https://github.com/advisories/GHSA-r5qj-cvf9-p85h
 The original report documents an exploit using a specific environment variable,
 we show a way to achieve the same exploit with an arbitrary env variable.
 """
-
 
 import os
 import random
@@ -54,26 +53,26 @@ def prepare_fuzzing_input(data):
 
 
 def exploit_target(env_value, env_name):
-  """This target is based on a snippet from
-  the official documentation of `parse_env_variables`:
-  https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.utilities.argparse.html
+  """This target is based on a snippet from the official documentation of
+  `parse_env_variables`:
+  https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.utilities.argparse.html  # pylint: disable=line-too-long
   It might not be the most realistic example,
-  but serves as a PoC to show that execSan works for Python"""
+  but serves as a PoC to show that execSan works for Python."""
   os.environb[env_name.encode()] = env_value
   parse_env_variables(Trainer, template=env_name)
 
 
 def TestOneInput(data):  # pylint: disable=invalid-name
-  """Exploit the target only with input data from fuzzers"""
+  """Exploit the target only with input data from fuzzers."""
   env_value, env_name = prepare_fuzzing_input(data)
   exploit_target(env_value, env_name)
 
 
 def main():
-  """Fuzz target with atheris"""
+  """Fuzz target with atheris."""
   atheris.Setup(sys.argv, TestOneInput)
   atheris.Fuzz()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
   main()

--- a/infra/experimental/sanitizers/ExecSan/PoEs/pytorch-lightning-1.5.10/vuln.dict
+++ b/infra/experimental/sanitizers/ExecSan/PoEs/pytorch-lightning-1.5.10/vuln.dict
@@ -1,0 +1,1 @@
+"os.system('/tmp/tripwire')"


### PR DESCRIPTION
Show `execSan` can spot a shell injection error in `pytorch-lightning-1.5.10`.
This PoC is extended from [a report in GitHub Advisory Database](https://github.com/advisories/GHSA-r5qj-cvf9-p85h):
The original report documents an exploit using a specific environment variable,
we show a way to achieve the same exploit with an arbitrary env variable.