### PR TITLE
Set flags to use old pass manger

### DIFF
--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -19,7 +19,7 @@ echo "---------------------------------------------------------------"
 
 # This is a temporary fix: fall back to LLVM14's old pass manager
 if [ -n "$OLD_LLVMPASS" ]; then
-          export SANITIZER_FLAGS_introspector=$(echo $SANITIZER_FLAGS_introspector | sed -r 's/-O0/-flegacy-pass-manager/')
+  export SANITIZER_FLAGS_introspector=$(echo $SANITIZER_FLAGS_introspector | sed -r 's/-O0/-flegacy-pass-manager/')
 fi
 
 if [ "$SANITIZER" = "dataflow" ] && [ "$FUZZING_ENGINE" != "dataflow" ]; then

--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -17,6 +17,11 @@
 
 echo "---------------------------------------------------------------"
 
+# This is a temporary fix: fall back to LLVM14's old pass manager
+if [ -n "$OLD_LLVMPASS" ]; then
+          export SANITIZER_FLAGS_introspector=$(echo $SANITIZER_FLAGS_introspector | sed -r 's/-O0/-flegacy-pass-manager/')
+fi
+
 if [ "$SANITIZER" = "dataflow" ] && [ "$FUZZING_ENGINE" != "dataflow" ]; then
   echo "ERROR: 'dataflow' sanitizer can be used with 'dataflow' engine only."
   exit 1

--- a/projects/alembic/Dockerfile
+++ b/projects/alembic/Dockerfile
@@ -27,3 +27,4 @@ RUN git clone -b v2.4.2 --depth 1 https://github.com/AcademySoftwareFoundation/o
 
 COPY build.sh *.h *.cc $SRC/
 WORKDIR $WORK/
+ENV OLD_LLVMPASS 1

--- a/projects/alembic/Dockerfile
+++ b/projects/alembic/Dockerfile
@@ -27,4 +27,5 @@ RUN git clone -b v2.4.2 --depth 1 https://github.com/AcademySoftwareFoundation/o
 
 COPY build.sh *.h *.cc $SRC/
 WORKDIR $WORK/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/alembic/Dockerfile
+++ b/projects/alembic/Dockerfile
@@ -27,5 +27,6 @@ RUN git clone -b v2.4.2 --depth 1 https://github.com/AcademySoftwareFoundation/o
 
 COPY build.sh *.h *.cc $SRC/
 WORKDIR $WORK/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/bearssl/Dockerfile
+++ b/projects/bearssl/Dockerfile
@@ -22,5 +22,6 @@ RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora
 RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/bearssl/Dockerfile
+++ b/projects/bearssl/Dockerfile
@@ -22,3 +22,5 @@ RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora
 RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1
+ENV OLD_LLVMPASS 1

--- a/projects/bearssl/Dockerfile
+++ b/projects/bearssl/Dockerfile
@@ -23,4 +23,3 @@ RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora
 RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 COPY build.sh $SRC/
 ENV OLD_LLVMPASS 1
-ENV OLD_LLVMPASS 1

--- a/projects/bearssl/Dockerfile
+++ b/projects/bearssl/Dockerfile
@@ -22,4 +22,5 @@ RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora
 RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/bls-signatures/Dockerfile
+++ b/projects/bls-signatures/Dockerfile
@@ -25,3 +25,4 @@ RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_
 RUN wget https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz
 RUN wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable.tar.gz
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/bls-signatures/Dockerfile
+++ b/projects/bls-signatures/Dockerfile
@@ -25,5 +25,6 @@ RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_
 RUN wget https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz
 RUN wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable.tar.gz
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/bls-signatures/Dockerfile
+++ b/projects/bls-signatures/Dockerfile
@@ -25,4 +25,5 @@ RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_
 RUN wget https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz
 RUN wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable.tar.gz
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/boost/Dockerfile
+++ b/projects/boost/Dockerfile
@@ -21,4 +21,5 @@ RUN git clone --recursive https://github.com/boostorg/boost.git
 WORKDIR boost
 # Preferably, move boost_regex_fuzzer.cc to the boost repository.
 COPY build.sh *.cc $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/boost/Dockerfile
+++ b/projects/boost/Dockerfile
@@ -21,3 +21,4 @@ RUN git clone --recursive https://github.com/boostorg/boost.git
 WORKDIR boost
 # Preferably, move boost_regex_fuzzer.cc to the boost repository.
 COPY build.sh *.cc $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/boost/Dockerfile
+++ b/projects/boost/Dockerfile
@@ -21,5 +21,6 @@ RUN git clone --recursive https://github.com/boostorg/boost.git
 WORKDIR boost
 # Preferably, move boost_regex_fuzzer.cc to the boost repository.
 COPY build.sh *.cc $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/boringssl/Dockerfile
+++ b/projects/boringssl/Dockerfile
@@ -24,3 +24,4 @@ RUN git clone --depth 1 https://github.com/google/fuzzing.git
 RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
 RUN (mkdir LPM && cd LPM && cmake ../libprotobuf-mutator -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release && ninja)
 COPY *.cc build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/boringssl/Dockerfile
+++ b/projects/boringssl/Dockerfile
@@ -24,4 +24,5 @@ RUN git clone --depth 1 https://github.com/google/fuzzing.git
 RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
 RUN (mkdir LPM && cd LPM && cmake ../libprotobuf-mutator -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release && ninja)
 COPY *.cc build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/boringssl/Dockerfile
+++ b/projects/boringssl/Dockerfile
@@ -24,5 +24,6 @@ RUN git clone --depth 1 https://github.com/google/fuzzing.git
 RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
 RUN (mkdir LPM && cd LPM && cmake ../libprotobuf-mutator -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release && ninja)
 COPY *.cc build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/botan/Dockerfile
+++ b/projects/botan/Dockerfile
@@ -20,4 +20,5 @@ RUN git clone --depth 1 https://github.com/randombit/botan.git botan
 RUN git clone --depth 1 https://github.com/randombit/crypto-corpus.git fuzzer_corpus
 WORKDIR botan
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/botan/Dockerfile
+++ b/projects/botan/Dockerfile
@@ -20,5 +20,6 @@ RUN git clone --depth 1 https://github.com/randombit/botan.git botan
 RUN git clone --depth 1 https://github.com/randombit/crypto-corpus.git fuzzer_corpus
 WORKDIR botan
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/botan/Dockerfile
+++ b/projects/botan/Dockerfile
@@ -20,3 +20,4 @@ RUN git clone --depth 1 https://github.com/randombit/botan.git botan
 RUN git clone --depth 1 https://github.com/randombit/crypto-corpus.git fuzzer_corpus
 WORKDIR botan
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/c-ares/Dockerfile
+++ b/projects/c-ares/Dockerfile
@@ -19,5 +19,6 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/c-ares/c-ares.git
 WORKDIR c-ares
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/c-ares/Dockerfile
+++ b/projects/c-ares/Dockerfile
@@ -19,4 +19,5 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/c-ares/c-ares.git
 WORKDIR c-ares
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/c-ares/Dockerfile
+++ b/projects/c-ares/Dockerfile
@@ -19,3 +19,4 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/c-ares/c-ares.git
 WORKDIR c-ares
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/cel-cpp/Dockerfile
+++ b/projects/cel-cpp/Dockerfile
@@ -26,4 +26,5 @@ RUN cat WORKSPACE >> $SRC/cel-cpp/WORKSPACE
 RUN cat .bazelrc >> $SRC/cel-cpp/.bazelrc
 RUN echo "4.1.0" > $SRC/cel-cpp/.bazelversion
 WORKDIR $SRC/cel-cpp
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/cel-cpp/Dockerfile
+++ b/projects/cel-cpp/Dockerfile
@@ -26,5 +26,6 @@ RUN cat WORKSPACE >> $SRC/cel-cpp/WORKSPACE
 RUN cat .bazelrc >> $SRC/cel-cpp/.bazelrc
 RUN echo "4.1.0" > $SRC/cel-cpp/.bazelversion
 WORKDIR $SRC/cel-cpp
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/cel-cpp/Dockerfile
+++ b/projects/cel-cpp/Dockerfile
@@ -26,3 +26,4 @@ RUN cat WORKSPACE >> $SRC/cel-cpp/WORKSPACE
 RUN cat .bazelrc >> $SRC/cel-cpp/.bazelrc
 RUN echo "4.1.0" > $SRC/cel-cpp/.bazelversion
 WORKDIR $SRC/cel-cpp
+ENV OLD_LLVMPASS 1

--- a/projects/cmake/Dockerfile
+++ b/projects/cmake/Dockerfile
@@ -21,3 +21,4 @@ RUN git clone --depth 1 https://gitlab.kitware.com/cmake/cmake CMake
 RUN git clone --depth 1 https://github.com/strongcourage/fuzzing-corpus
 WORKDIR CMake
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/cmake/Dockerfile
+++ b/projects/cmake/Dockerfile
@@ -21,4 +21,5 @@ RUN git clone --depth 1 https://gitlab.kitware.com/cmake/cmake CMake
 RUN git clone --depth 1 https://github.com/strongcourage/fuzzing-corpus
 WORKDIR CMake
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/cmake/Dockerfile
+++ b/projects/cmake/Dockerfile
@@ -21,5 +21,6 @@ RUN git clone --depth 1 https://gitlab.kitware.com/cmake/cmake CMake
 RUN git clone --depth 1 https://github.com/strongcourage/fuzzing-corpus
 WORKDIR CMake
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/cppcheck/Dockerfile
+++ b/projects/cppcheck/Dockerfile
@@ -21,4 +21,5 @@ RUN git clone https://github.com/danmar/cppcheck.git
 WORKDIR cppcheck
 COPY build.sh $SRC/
 
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/cppcheck/Dockerfile
+++ b/projects/cppcheck/Dockerfile
@@ -21,5 +21,6 @@ RUN git clone https://github.com/danmar/cppcheck.git
 WORKDIR cppcheck
 COPY build.sh $SRC/
 
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/cppcheck/Dockerfile
+++ b/projects/cppcheck/Dockerfile
@@ -21,3 +21,4 @@ RUN git clone https://github.com/danmar/cppcheck.git
 WORKDIR cppcheck
 COPY build.sh $SRC/
 
+ENV OLD_LLVMPASS 1

--- a/projects/cyclonedds/Dockerfile
+++ b/projects/cyclonedds/Dockerfile
@@ -28,5 +28,6 @@ RUN git clone --depth 1 https://github.com/eclipse-cyclonedds/cyclonedds
 
 COPY build.sh $SRC
 WORKDIR $SRC/cyclonedds
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/cyclonedds/Dockerfile
+++ b/projects/cyclonedds/Dockerfile
@@ -28,4 +28,5 @@ RUN git clone --depth 1 https://github.com/eclipse-cyclonedds/cyclonedds
 
 COPY build.sh $SRC
 WORKDIR $SRC/cyclonedds
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/cyclonedds/Dockerfile
+++ b/projects/cyclonedds/Dockerfile
@@ -28,3 +28,4 @@ RUN git clone --depth 1 https://github.com/eclipse-cyclonedds/cyclonedds
 
 COPY build.sh $SRC
 WORKDIR $SRC/cyclonedds
+ENV OLD_LLVMPASS 1

--- a/projects/dart/Dockerfile
+++ b/projects/dart/Dockerfile
@@ -23,5 +23,6 @@ RUN mkdir dart-sdk && cd dart-sdk && fetch dart
 COPY build.sh $SRC
 COPY patch.diff $SRC
 WORKDIR $SRC/dart-sdk/sdk
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/dart/Dockerfile
+++ b/projects/dart/Dockerfile
@@ -23,4 +23,5 @@ RUN mkdir dart-sdk && cd dart-sdk && fetch dart
 COPY build.sh $SRC
 COPY patch.diff $SRC
 WORKDIR $SRC/dart-sdk/sdk
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/dart/Dockerfile
+++ b/projects/dart/Dockerfile
@@ -23,3 +23,4 @@ RUN mkdir dart-sdk && cd dart-sdk && fetch dart
 COPY build.sh $SRC
 COPY patch.diff $SRC
 WORKDIR $SRC/dart-sdk/sdk
+ENV OLD_LLVMPASS 1

--- a/projects/duckdb/Dockerfile
+++ b/projects/duckdb/Dockerfile
@@ -18,3 +18,4 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN git clone --depth=1 https://github.com/duckdb/duckdb duckdb
 WORKDIR duckdb
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/duckdb/Dockerfile
+++ b/projects/duckdb/Dockerfile
@@ -18,4 +18,5 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN git clone --depth=1 https://github.com/duckdb/duckdb duckdb
 WORKDIR duckdb
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/duckdb/Dockerfile
+++ b/projects/duckdb/Dockerfile
@@ -18,5 +18,6 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN git clone --depth=1 https://github.com/duckdb/duckdb duckdb
 WORKDIR duckdb
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/fast-dds/Dockerfile
+++ b/projects/fast-dds/Dockerfile
@@ -23,3 +23,4 @@ RUN git clone --depth 1 https://github.com/eProsima/foonathan_memory_vendor.git
 RUN git clone --depth 1 https://github.com/eProsima/Fast-DDS.git
 COPY build.sh $SRC
 WORKDIR $SRC/Fast-DDS
+ENV OLD_LLVMPASS 1

--- a/projects/fast-dds/Dockerfile
+++ b/projects/fast-dds/Dockerfile
@@ -23,5 +23,6 @@ RUN git clone --depth 1 https://github.com/eProsima/foonathan_memory_vendor.git
 RUN git clone --depth 1 https://github.com/eProsima/Fast-DDS.git
 COPY build.sh $SRC
 WORKDIR $SRC/Fast-DDS
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/fast-dds/Dockerfile
+++ b/projects/fast-dds/Dockerfile
@@ -23,4 +23,5 @@ RUN git clone --depth 1 https://github.com/eProsima/foonathan_memory_vendor.git
 RUN git clone --depth 1 https://github.com/eProsima/Fast-DDS.git
 COPY build.sh $SRC
 WORKDIR $SRC/Fast-DDS
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/firestore/Dockerfile
+++ b/projects/firestore/Dockerfile
@@ -18,3 +18,4 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool wget golang python python-protobuf python-six
 RUN git clone --depth 1 https://github.com/firebase/firebase-ios-sdk.git
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/firestore/Dockerfile
+++ b/projects/firestore/Dockerfile
@@ -18,5 +18,6 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool wget golang python python-protobuf python-six
 RUN git clone --depth 1 https://github.com/firebase/firebase-ios-sdk.git
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/firestore/Dockerfile
+++ b/projects/firestore/Dockerfile
@@ -18,4 +18,5 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool wget golang python python-protobuf python-six
 RUN git clone --depth 1 https://github.com/firebase/firebase-ios-sdk.git
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/flatbuffers/Dockerfile
+++ b/projects/flatbuffers/Dockerfile
@@ -20,4 +20,5 @@ RUN git clone https://github.com/google/flatbuffers
 
 WORKDIR $SRC/
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/flatbuffers/Dockerfile
+++ b/projects/flatbuffers/Dockerfile
@@ -20,3 +20,4 @@ RUN git clone https://github.com/google/flatbuffers
 
 WORKDIR $SRC/
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/flatbuffers/Dockerfile
+++ b/projects/flatbuffers/Dockerfile
@@ -20,5 +20,6 @@ RUN git clone https://github.com/google/flatbuffers
 
 WORKDIR $SRC/
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/git/Dockerfile
+++ b/projects/git/Dockerfile
@@ -26,3 +26,4 @@ RUN git clone https://github.com/git/git git
 WORKDIR git
 RUN git checkout origin/next
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/git/Dockerfile
+++ b/projects/git/Dockerfile
@@ -26,5 +26,6 @@ RUN git clone https://github.com/git/git git
 WORKDIR git
 RUN git checkout origin/next
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/git/Dockerfile
+++ b/projects/git/Dockerfile
@@ -26,4 +26,5 @@ RUN git clone https://github.com/git/git git
 WORKDIR git
 RUN git checkout origin/next
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/gnupg/Dockerfile
+++ b/projects/gnupg/Dockerfile
@@ -35,3 +35,4 @@ WORKDIR gnupg
 COPY fuzzgnupg.diff $SRC/fuzz.diff
 COPY fuzz_* $SRC/
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/gnupg/Dockerfile
+++ b/projects/gnupg/Dockerfile
@@ -35,5 +35,6 @@ WORKDIR gnupg
 COPY fuzzgnupg.diff $SRC/fuzz.diff
 COPY fuzz_* $SRC/
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/gnupg/Dockerfile
+++ b/projects/gnupg/Dockerfile
@@ -35,4 +35,5 @@ WORKDIR gnupg
 COPY fuzzgnupg.diff $SRC/fuzz.diff
 COPY fuzz_* $SRC/
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/gnutls/Dockerfile
+++ b/projects/gnutls/Dockerfile
@@ -47,5 +47,6 @@ RUN git clone --depth=1 --recursive https://gitlab.com/gnutls/gnutls.git
 
 WORKDIR gnutls
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/gnutls/Dockerfile
+++ b/projects/gnutls/Dockerfile
@@ -47,4 +47,5 @@ RUN git clone --depth=1 --recursive https://gitlab.com/gnutls/gnutls.git
 
 WORKDIR gnutls
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/gnutls/Dockerfile
+++ b/projects/gnutls/Dockerfile
@@ -47,3 +47,4 @@ RUN git clone --depth=1 --recursive https://gitlab.com/gnutls/gnutls.git
 
 WORKDIR gnutls
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/grpc-httpjson-transcoding/Dockerfile
+++ b/projects/grpc-httpjson-transcoding/Dockerfile
@@ -21,4 +21,5 @@ RUN apt-get update && apt-get install python -y
 RUN git clone https://github.com/grpc-ecosystem/grpc-httpjson-transcoding.git
 WORKDIR $SRC/grpc-httpjson-transcoding/
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/grpc-httpjson-transcoding/Dockerfile
+++ b/projects/grpc-httpjson-transcoding/Dockerfile
@@ -21,5 +21,6 @@ RUN apt-get update && apt-get install python -y
 RUN git clone https://github.com/grpc-ecosystem/grpc-httpjson-transcoding.git
 WORKDIR $SRC/grpc-httpjson-transcoding/
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/grpc-httpjson-transcoding/Dockerfile
+++ b/projects/grpc-httpjson-transcoding/Dockerfile
@@ -21,3 +21,4 @@ RUN apt-get update && apt-get install python -y
 RUN git clone https://github.com/grpc-ecosystem/grpc-httpjson-transcoding.git
 WORKDIR $SRC/grpc-httpjson-transcoding/
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/hermes/Dockerfile
+++ b/projects/hermes/Dockerfile
@@ -29,5 +29,6 @@ RUN wget https://github.com/unicode-org/icu/archive/refs/tags/cldr/2021-08-25.ta
 RUN git clone https://github.com/facebook/hermes.git
 WORKDIR $SRC
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/hermes/Dockerfile
+++ b/projects/hermes/Dockerfile
@@ -29,3 +29,4 @@ RUN wget https://github.com/unicode-org/icu/archive/refs/tags/cldr/2021-08-25.ta
 RUN git clone https://github.com/facebook/hermes.git
 WORKDIR $SRC
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/hermes/Dockerfile
+++ b/projects/hermes/Dockerfile
@@ -29,4 +29,5 @@ RUN wget https://github.com/unicode-org/icu/archive/refs/tags/cldr/2021-08-25.ta
 RUN git clone https://github.com/facebook/hermes.git
 WORKDIR $SRC
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/janet/Dockerfile
+++ b/projects/janet/Dockerfile
@@ -20,3 +20,4 @@ RUN git clone https://github.com/janet-lang/janet
 
 WORKDIR $SRC
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/janet/Dockerfile
+++ b/projects/janet/Dockerfile
@@ -20,5 +20,6 @@ RUN git clone https://github.com/janet-lang/janet
 
 WORKDIR $SRC
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/janet/Dockerfile
+++ b/projects/janet/Dockerfile
@@ -20,4 +20,5 @@ RUN git clone https://github.com/janet-lang/janet
 
 WORKDIR $SRC
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/json/Dockerfile
+++ b/projects/json/Dockerfile
@@ -20,5 +20,6 @@ RUN apt-get update && apt-get install -y binutils make
 RUN git clone --depth 1 -b develop https://github.com/nlohmann/json.git
 WORKDIR json/
 COPY build.sh *.options parse_afl_fuzzer.dict $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/json/Dockerfile
+++ b/projects/json/Dockerfile
@@ -20,4 +20,5 @@ RUN apt-get update && apt-get install -y binutils make
 RUN git clone --depth 1 -b develop https://github.com/nlohmann/json.git
 WORKDIR json/
 COPY build.sh *.options parse_afl_fuzzer.dict $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/json/Dockerfile
+++ b/projects/json/Dockerfile
@@ -20,3 +20,4 @@ RUN apt-get update && apt-get install -y binutils make
 RUN git clone --depth 1 -b develop https://github.com/nlohmann/json.git
 WORKDIR json/
 COPY build.sh *.options parse_afl_fuzzer.dict $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/jsoncpp/Dockerfile
+++ b/projects/jsoncpp/Dockerfile
@@ -22,3 +22,4 @@ WORKDIR jsoncpp
 RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
 RUN (mkdir LPM && cd LPM && cmake ../libprotobuf-mutator -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release && ninja)
 COPY build.sh *.proto *.h *.cc $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/jsoncpp/Dockerfile
+++ b/projects/jsoncpp/Dockerfile
@@ -22,5 +22,6 @@ WORKDIR jsoncpp
 RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
 RUN (mkdir LPM && cd LPM && cmake ../libprotobuf-mutator -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release && ninja)
 COPY build.sh *.proto *.h *.cc $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/jsoncpp/Dockerfile
+++ b/projects/jsoncpp/Dockerfile
@@ -22,4 +22,5 @@ WORKDIR jsoncpp
 RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
 RUN (mkdir LPM && cd LPM && cmake ../libprotobuf-mutator -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release && ninja)
 COPY build.sh *.proto *.h *.cc $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/jsonnet/Dockerfile
+++ b/projects/jsonnet/Dockerfile
@@ -21,4 +21,5 @@ WORKDIR $SRC/
 
 COPY build.sh $SRC/
 COPY *.cc $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/jsonnet/Dockerfile
+++ b/projects/jsonnet/Dockerfile
@@ -21,5 +21,6 @@ WORKDIR $SRC/
 
 COPY build.sh $SRC/
 COPY *.cc $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/jsonnet/Dockerfile
+++ b/projects/jsonnet/Dockerfile
@@ -21,3 +21,4 @@ WORKDIR $SRC/
 
 COPY build.sh $SRC/
 COPY *.cc $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/keystone/Dockerfile
+++ b/projects/keystone/Dockerfile
@@ -19,5 +19,6 @@ RUN apt-get update && apt-get install -y make cmake
 RUN git clone --depth 1 https://github.com/keystone-engine/keystone.git
 WORKDIR $SRC
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/keystone/Dockerfile
+++ b/projects/keystone/Dockerfile
@@ -19,3 +19,4 @@ RUN apt-get update && apt-get install -y make cmake
 RUN git clone --depth 1 https://github.com/keystone-engine/keystone.git
 WORKDIR $SRC
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/keystone/Dockerfile
+++ b/projects/keystone/Dockerfile
@@ -19,4 +19,5 @@ RUN apt-get update && apt-get install -y make cmake
 RUN git clone --depth 1 https://github.com/keystone-engine/keystone.git
 WORKDIR $SRC
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/lame/Dockerfile
+++ b/projects/lame/Dockerfile
@@ -25,4 +25,5 @@ RUN mv mpg123* mpg123
 RUN git clone --depth 1 https://github.com/guidovranken/LAME-fuzzers
 RUN svn checkout https://svn.code.sf.net/p/lame/svn/trunk/lame $SRC/lame
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/lame/Dockerfile
+++ b/projects/lame/Dockerfile
@@ -25,5 +25,6 @@ RUN mv mpg123* mpg123
 RUN git clone --depth 1 https://github.com/guidovranken/LAME-fuzzers
 RUN svn checkout https://svn.code.sf.net/p/lame/svn/trunk/lame $SRC/lame
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/lame/Dockerfile
+++ b/projects/lame/Dockerfile
@@ -25,3 +25,4 @@ RUN mv mpg123* mpg123
 RUN git clone --depth 1 https://github.com/guidovranken/LAME-fuzzers
 RUN svn checkout https://svn.code.sf.net/p/lame/svn/trunk/lame $SRC/lame
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/libcoap/Dockerfile
+++ b/projects/libcoap/Dockerfile
@@ -20,3 +20,4 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool \
 RUN git clone --depth 1 https://github.com/obgm/libcoap.git libcoap
 WORKDIR libcoap
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/libcoap/Dockerfile
+++ b/projects/libcoap/Dockerfile
@@ -20,4 +20,5 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool \
 RUN git clone --depth 1 https://github.com/obgm/libcoap.git libcoap
 WORKDIR libcoap
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/libcoap/Dockerfile
+++ b/projects/libcoap/Dockerfile
@@ -20,5 +20,6 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool \
 RUN git clone --depth 1 https://github.com/obgm/libcoap.git libcoap
 WORKDIR libcoap
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/libecc/Dockerfile
+++ b/projects/libecc/Dockerfile
@@ -23,5 +23,6 @@ RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN wget https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz
 RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/libecc/Dockerfile
+++ b/projects/libecc/Dockerfile
@@ -23,4 +23,5 @@ RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN wget https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz
 RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/libecc/Dockerfile
+++ b/projects/libecc/Dockerfile
@@ -23,3 +23,4 @@ RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN wget https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz
 RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/libheif/Dockerfile
+++ b/projects/libheif/Dockerfile
@@ -54,4 +54,5 @@ RUN git clone \
 WORKDIR libheif
 
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/libheif/Dockerfile
+++ b/projects/libheif/Dockerfile
@@ -54,5 +54,6 @@ RUN git clone \
 WORKDIR libheif
 
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/libheif/Dockerfile
+++ b/projects/libheif/Dockerfile
@@ -54,3 +54,4 @@ RUN git clone \
 WORKDIR libheif
 
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/libressl/Dockerfile
+++ b/projects/libressl/Dockerfile
@@ -24,3 +24,4 @@ RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_
 WORKDIR libressl
 RUN ./update.sh
 COPY build.sh *.options $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/libressl/Dockerfile
+++ b/projects/libressl/Dockerfile
@@ -24,5 +24,6 @@ RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_
 WORKDIR libressl
 RUN ./update.sh
 COPY build.sh *.options $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/libressl/Dockerfile
+++ b/projects/libressl/Dockerfile
@@ -24,4 +24,5 @@ RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_
 WORKDIR libressl
 RUN ./update.sh
 COPY build.sh *.options $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/libsass/Dockerfile
+++ b/projects/libsass/Dockerfile
@@ -20,4 +20,5 @@ RUN git clone --depth 1 https://github.com/sass/libsass.git libsass
 WORKDIR $SRC
 COPY build.sh $SRC/
 COPY data_context_fuzzer.cc $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/libsass/Dockerfile
+++ b/projects/libsass/Dockerfile
@@ -20,3 +20,4 @@ RUN git clone --depth 1 https://github.com/sass/libsass.git libsass
 WORKDIR $SRC
 COPY build.sh $SRC/
 COPY data_context_fuzzer.cc $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/libsass/Dockerfile
+++ b/projects/libsass/Dockerfile
@@ -20,5 +20,6 @@ RUN git clone --depth 1 https://github.com/sass/libsass.git libsass
 WORKDIR $SRC
 COPY build.sh $SRC/
 COPY data_context_fuzzer.cc $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/libspectre/Dockerfile
+++ b/projects/libspectre/Dockerfile
@@ -28,5 +28,6 @@ RUN mv $SRC/libspectre/ghostscript-9.53.3 $SRC/libspectre/ghostscript
 
 WORKDIR $SRC/libspectre/
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/libspectre/Dockerfile
+++ b/projects/libspectre/Dockerfile
@@ -28,4 +28,5 @@ RUN mv $SRC/libspectre/ghostscript-9.53.3 $SRC/libspectre/ghostscript
 
 WORKDIR $SRC/libspectre/
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/libspectre/Dockerfile
+++ b/projects/libspectre/Dockerfile
@@ -28,3 +28,4 @@ RUN mv $SRC/libspectre/ghostscript-9.53.3 $SRC/libspectre/ghostscript
 
 WORKDIR $SRC/libspectre/
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/libvips/Dockerfile
+++ b/projects/libvips/Dockerfile
@@ -53,3 +53,4 @@ RUN git clone --depth 1 https://github.com/dloebl/cgif.git
 
 WORKDIR libvips
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/libvips/Dockerfile
+++ b/projects/libvips/Dockerfile
@@ -53,5 +53,6 @@ RUN git clone --depth 1 https://github.com/dloebl/cgif.git
 
 WORKDIR libvips
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/libvips/Dockerfile
+++ b/projects/libvips/Dockerfile
@@ -53,4 +53,5 @@ RUN git clone --depth 1 https://github.com/dloebl/cgif.git
 
 WORKDIR libvips
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/muduo/Dockerfile
+++ b/projects/muduo/Dockerfile
@@ -19,3 +19,4 @@ RUN apt-get update && apt-get install -y make libboost-dev
 RUN git clone --depth 1 https://github.com/chenshuo/muduo
 WORKDIR muduo
 COPY build.sh muduo_http_fuzzer.cpp $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/muduo/Dockerfile
+++ b/projects/muduo/Dockerfile
@@ -19,5 +19,6 @@ RUN apt-get update && apt-get install -y make libboost-dev
 RUN git clone --depth 1 https://github.com/chenshuo/muduo
 WORKDIR muduo
 COPY build.sh muduo_http_fuzzer.cpp $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/muduo/Dockerfile
+++ b/projects/muduo/Dockerfile
@@ -19,4 +19,5 @@ RUN apt-get update && apt-get install -y make libboost-dev
 RUN git clone --depth 1 https://github.com/chenshuo/muduo
 WORKDIR muduo
 COPY build.sh muduo_http_fuzzer.cpp $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/nettle/Dockerfile
+++ b/projects/nettle/Dockerfile
@@ -23,3 +23,4 @@ RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora
 RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 RUN wget https://gmplib.org/download/gmp/gmp-6.2.0.tar.lz
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/nettle/Dockerfile
+++ b/projects/nettle/Dockerfile
@@ -23,4 +23,5 @@ RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora
 RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 RUN wget https://gmplib.org/download/gmp/gmp-6.2.0.tar.lz
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/nettle/Dockerfile
+++ b/projects/nettle/Dockerfile
@@ -23,5 +23,6 @@ RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora
 RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 RUN wget https://gmplib.org/download/gmp/gmp-6.2.0.tar.lz
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/nss/Dockerfile
+++ b/projects/nss/Dockerfile
@@ -23,5 +23,6 @@ RUN git clone --depth 1 https://github.com/mozilla/nss-fuzzing-corpus.git nss-co
 
 WORKDIR nss
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/nss/Dockerfile
+++ b/projects/nss/Dockerfile
@@ -23,3 +23,4 @@ RUN git clone --depth 1 https://github.com/mozilla/nss-fuzzing-corpus.git nss-co
 
 WORKDIR nss
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/nss/Dockerfile
+++ b/projects/nss/Dockerfile
@@ -23,4 +23,5 @@ RUN git clone --depth 1 https://github.com/mozilla/nss-fuzzing-corpus.git nss-co
 
 WORKDIR nss
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/oatpp/Dockerfile
+++ b/projects/oatpp/Dockerfile
@@ -19,5 +19,6 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/oatpp/oatpp.git oatpp 
 WORKDIR oatpp
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/oatpp/Dockerfile
+++ b/projects/oatpp/Dockerfile
@@ -19,3 +19,4 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/oatpp/oatpp.git oatpp 
 WORKDIR oatpp
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/oatpp/Dockerfile
+++ b/projects/oatpp/Dockerfile
@@ -19,4 +19,5 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/oatpp/oatpp.git oatpp 
 WORKDIR oatpp
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/openbabel/Dockerfile
+++ b/projects/openbabel/Dockerfile
@@ -19,5 +19,6 @@ RUN apt-get update && apt install -y cmake
 RUN git clone --depth 1 https://github.com/openbabel/openbabel.git
 COPY build.sh $SRC
 WORKDIR $SRC/openbabel
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/openbabel/Dockerfile
+++ b/projects/openbabel/Dockerfile
@@ -19,4 +19,5 @@ RUN apt-get update && apt install -y cmake
 RUN git clone --depth 1 https://github.com/openbabel/openbabel.git
 COPY build.sh $SRC
 WORKDIR $SRC/openbabel
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/openbabel/Dockerfile
+++ b/projects/openbabel/Dockerfile
@@ -19,3 +19,4 @@ RUN apt-get update && apt install -y cmake
 RUN git clone --depth 1 https://github.com/openbabel/openbabel.git
 COPY build.sh $SRC
 WORKDIR $SRC/openbabel
+ENV OLD_LLVMPASS 1

--- a/projects/opencv/Dockerfile
+++ b/projects/opencv/Dockerfile
@@ -21,5 +21,6 @@ WORKDIR opencv/
 
 COPY build.sh $SRC/
 COPY *.cc *.h $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/opencv/Dockerfile
+++ b/projects/opencv/Dockerfile
@@ -21,4 +21,5 @@ WORKDIR opencv/
 
 COPY build.sh $SRC/
 COPY *.cc *.h $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/opencv/Dockerfile
+++ b/projects/opencv/Dockerfile
@@ -21,3 +21,4 @@ WORKDIR opencv/
 
 COPY build.sh $SRC/
 COPY *.cc *.h $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/opendnp3/Dockerfile
+++ b/projects/opendnp3/Dockerfile
@@ -20,3 +20,4 @@ RUN apt-get update && apt-get install -y make wget tshark
 RUN git clone --recursive -b release --depth 1 https://github.com/dnp3/opendnp3.git opendnp3
 WORKDIR opendnp3
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/opendnp3/Dockerfile
+++ b/projects/opendnp3/Dockerfile
@@ -20,5 +20,6 @@ RUN apt-get update && apt-get install -y make wget tshark
 RUN git clone --recursive -b release --depth 1 https://github.com/dnp3/opendnp3.git opendnp3
 WORKDIR opendnp3
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/opendnp3/Dockerfile
+++ b/projects/opendnp3/Dockerfile
@@ -20,4 +20,5 @@ RUN apt-get update && apt-get install -y make wget tshark
 RUN git clone --recursive -b release --depth 1 https://github.com/dnp3/opendnp3.git opendnp3
 WORKDIR opendnp3
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/opensc/Dockerfile
+++ b/projects/opensc/Dockerfile
@@ -19,3 +19,4 @@ RUN apt-get update && apt-get install -y pcscd libccid libpcsclite-dev libssl-de
 RUN git clone --depth 1 --single-branch --branch master https://github.com/OpenSC/OpenSC opensc
 WORKDIR opensc
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/opensc/Dockerfile
+++ b/projects/opensc/Dockerfile
@@ -19,5 +19,6 @@ RUN apt-get update && apt-get install -y pcscd libccid libpcsclite-dev libssl-de
 RUN git clone --depth 1 --single-branch --branch master https://github.com/OpenSC/OpenSC opensc
 WORKDIR opensc
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/opensc/Dockerfile
+++ b/projects/opensc/Dockerfile
@@ -19,4 +19,5 @@ RUN apt-get update && apt-get install -y pcscd libccid libpcsclite-dev libssl-de
 RUN git clone --depth 1 --single-branch --branch master https://github.com/OpenSC/OpenSC opensc
 WORKDIR opensc
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/perfetto/Dockerfile
+++ b/projects/perfetto/Dockerfile
@@ -25,3 +25,4 @@ RUN $SRC/perfetto/infra/oss-fuzz/init_container
 
 WORKDIR $SRC/perfetto
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/perfetto/Dockerfile
+++ b/projects/perfetto/Dockerfile
@@ -25,5 +25,6 @@ RUN $SRC/perfetto/infra/oss-fuzz/init_container
 
 WORKDIR $SRC/perfetto
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/perfetto/Dockerfile
+++ b/projects/perfetto/Dockerfile
@@ -25,4 +25,5 @@ RUN $SRC/perfetto/infra/oss-fuzz/init_container
 
 WORKDIR $SRC/perfetto
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/piex/Dockerfile
+++ b/projects/piex/Dockerfile
@@ -19,3 +19,4 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone https://github.com/guidovranken/piex.git piex
 WORKDIR piex
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/piex/Dockerfile
+++ b/projects/piex/Dockerfile
@@ -19,5 +19,6 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone https://github.com/guidovranken/piex.git piex
 WORKDIR piex
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/piex/Dockerfile
+++ b/projects/piex/Dockerfile
@@ -19,4 +19,5 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone https://github.com/guidovranken/piex.git piex
 WORKDIR piex
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/pistache/Dockerfile
+++ b/projects/pistache/Dockerfile
@@ -20,3 +20,4 @@ RUN pip3 install meson==0.53.0 ninja
 RUN git clone --depth 1 https://github.com/pistacheio/pistache pistache
 WORKDIR pistache
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/pistache/Dockerfile
+++ b/projects/pistache/Dockerfile
@@ -20,4 +20,5 @@ RUN pip3 install meson==0.53.0 ninja
 RUN git clone --depth 1 https://github.com/pistacheio/pistache pistache
 WORKDIR pistache
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/pistache/Dockerfile
+++ b/projects/pistache/Dockerfile
@@ -20,5 +20,6 @@ RUN pip3 install meson==0.53.0 ninja
 RUN git clone --depth 1 https://github.com/pistacheio/pistache pistache
 WORKDIR pistache
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/powerdns/Dockerfile
+++ b/projects/powerdns/Dockerfile
@@ -30,3 +30,4 @@ WORKDIR pdns
 
 # copy build script and other fuzzer files in src dir
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/powerdns/Dockerfile
+++ b/projects/powerdns/Dockerfile
@@ -30,5 +30,6 @@ WORKDIR pdns
 
 # copy build script and other fuzzer files in src dir
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/powerdns/Dockerfile
+++ b/projects/powerdns/Dockerfile
@@ -30,4 +30,5 @@ WORKDIR pdns
 
 # copy build script and other fuzzer files in src dir
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/proj4/Dockerfile
+++ b/projects/proj4/Dockerfile
@@ -27,5 +27,6 @@ RUN git clone --depth 1 https://gitlab.com/libtiff/libtiff.git proj/libtiff
 WORKDIR proj
 
 RUN cp test/fuzzers/build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/proj4/Dockerfile
+++ b/projects/proj4/Dockerfile
@@ -27,3 +27,4 @@ RUN git clone --depth 1 https://gitlab.com/libtiff/libtiff.git proj/libtiff
 WORKDIR proj
 
 RUN cp test/fuzzers/build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/proj4/Dockerfile
+++ b/projects/proj4/Dockerfile
@@ -27,4 +27,5 @@ RUN git clone --depth 1 https://gitlab.com/libtiff/libtiff.git proj/libtiff
 WORKDIR proj
 
 RUN cp test/fuzzers/build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/qpdf/Dockerfile
+++ b/projects/qpdf/Dockerfile
@@ -21,4 +21,5 @@ RUN git clone --depth 1 https://github.com/madler/zlib.git zlib
 RUN git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo libjpeg-turbo
 WORKDIR qpdf
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/qpdf/Dockerfile
+++ b/projects/qpdf/Dockerfile
@@ -21,5 +21,6 @@ RUN git clone --depth 1 https://github.com/madler/zlib.git zlib
 RUN git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo libjpeg-turbo
 WORKDIR qpdf
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/qpdf/Dockerfile
+++ b/projects/qpdf/Dockerfile
@@ -21,3 +21,4 @@ RUN git clone --depth 1 https://github.com/madler/zlib.git zlib
 RUN git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo libjpeg-turbo
 WORKDIR qpdf
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/relic/Dockerfile
+++ b/projects/relic/Dockerfile
@@ -21,3 +21,4 @@ RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/relic/Dockerfile
+++ b/projects/relic/Dockerfile
@@ -21,4 +21,5 @@ RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/relic/Dockerfile
+++ b/projects/relic/Dockerfile
@@ -21,5 +21,6 @@ RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/simd/Dockerfile
+++ b/projects/simd/Dockerfile
@@ -19,4 +19,5 @@ RUN apt-get update && apt-get install -y make
 RUN git clone --depth 1 https://github.com/ermig1979/Simd
 WORKDIR Simd
 COPY build.sh simd_load_fuzzer.cpp $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/simd/Dockerfile
+++ b/projects/simd/Dockerfile
@@ -19,3 +19,4 @@ RUN apt-get update && apt-get install -y make
 RUN git clone --depth 1 https://github.com/ermig1979/Simd
 WORKDIR Simd
 COPY build.sh simd_load_fuzzer.cpp $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/simd/Dockerfile
+++ b/projects/simd/Dockerfile
@@ -19,5 +19,6 @@ RUN apt-get update && apt-get install -y make
 RUN git clone --depth 1 https://github.com/ermig1979/Simd
 WORKDIR Simd
 COPY build.sh simd_load_fuzzer.cpp $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/spdlog/Dockerfile
+++ b/projects/spdlog/Dockerfile
@@ -22,4 +22,5 @@ RUN zip spdlog_fuzzer_seed_corpus.zip spdlog/example/*
 WORKDIR spdlog
 COPY build.sh spdlog_fuzzer.dict $SRC/
 COPY fuzz/* $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/spdlog/Dockerfile
+++ b/projects/spdlog/Dockerfile
@@ -22,5 +22,6 @@ RUN zip spdlog_fuzzer_seed_corpus.zip spdlog/example/*
 WORKDIR spdlog
 COPY build.sh spdlog_fuzzer.dict $SRC/
 COPY fuzz/* $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/spdlog/Dockerfile
+++ b/projects/spdlog/Dockerfile
@@ -22,3 +22,4 @@ RUN zip spdlog_fuzzer_seed_corpus.zip spdlog/example/*
 WORKDIR spdlog
 COPY build.sh spdlog_fuzzer.dict $SRC/
 COPY fuzz/* $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/spice-usbredir/Dockerfile
+++ b/projects/spice-usbredir/Dockerfile
@@ -29,4 +29,5 @@ RUN git clone --depth 1 https://gitlab.freedesktop.org/spice/usbredir.git $SRC/s
 
 WORKDIR $SRC/spice-usbredir
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/spice-usbredir/Dockerfile
+++ b/projects/spice-usbredir/Dockerfile
@@ -29,5 +29,6 @@ RUN git clone --depth 1 https://gitlab.freedesktop.org/spice/usbredir.git $SRC/s
 
 WORKDIR $SRC/spice-usbredir
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/spice-usbredir/Dockerfile
+++ b/projects/spice-usbredir/Dockerfile
@@ -29,3 +29,4 @@ RUN git clone --depth 1 https://gitlab.freedesktop.org/spice/usbredir.git $SRC/s
 
 WORKDIR $SRC/spice-usbredir
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/tinygltf/Dockerfile
+++ b/projects/tinygltf/Dockerfile
@@ -19,3 +19,4 @@ RUN pip3 install meson ninja
 RUN git clone --depth 1 https://github.com/syoyo/tinygltf.git
 WORKDIR $SRC/tinygltf
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/tinygltf/Dockerfile
+++ b/projects/tinygltf/Dockerfile
@@ -19,5 +19,6 @@ RUN pip3 install meson ninja
 RUN git clone --depth 1 https://github.com/syoyo/tinygltf.git
 WORKDIR $SRC/tinygltf
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/tinygltf/Dockerfile
+++ b/projects/tinygltf/Dockerfile
@@ -19,4 +19,5 @@ RUN pip3 install meson ninja
 RUN git clone --depth 1 https://github.com/syoyo/tinygltf.git
 WORKDIR $SRC/tinygltf
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/usbguard/Dockerfile
+++ b/projects/usbguard/Dockerfile
@@ -42,3 +42,4 @@ RUN git clone --recurse-submodules --depth 1 \
   https://github.com/USBGuard/usbguard usbguard
 WORKDIR usbguard
 COPY build.sh $SRC
+ENV OLD_LLVMPASS 1

--- a/projects/usbguard/Dockerfile
+++ b/projects/usbguard/Dockerfile
@@ -42,4 +42,5 @@ RUN git clone --recurse-submodules --depth 1 \
   https://github.com/USBGuard/usbguard usbguard
 WORKDIR usbguard
 COPY build.sh $SRC
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/usbguard/Dockerfile
+++ b/projects/usbguard/Dockerfile
@@ -42,5 +42,6 @@ RUN git clone --recurse-submodules --depth 1 \
   https://github.com/USBGuard/usbguard usbguard
 WORKDIR usbguard
 COPY build.sh $SRC
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/valijson/Dockerfile
+++ b/projects/valijson/Dockerfile
@@ -21,5 +21,6 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool \
 RUN git clone --depth 1 https://github.com/tristanpenman/valijson
 WORKDIR valijson
 RUN cp $SRC/valijson/tests/fuzzing/oss-fuzz-build.sh $SRC/build.sh
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/valijson/Dockerfile
+++ b/projects/valijson/Dockerfile
@@ -21,4 +21,5 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool \
 RUN git clone --depth 1 https://github.com/tristanpenman/valijson
 WORKDIR valijson
 RUN cp $SRC/valijson/tests/fuzzing/oss-fuzz-build.sh $SRC/build.sh
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/valijson/Dockerfile
+++ b/projects/valijson/Dockerfile
@@ -21,3 +21,4 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool \
 RUN git clone --depth 1 https://github.com/tristanpenman/valijson
 WORKDIR valijson
 RUN cp $SRC/valijson/tests/fuzzing/oss-fuzz-build.sh $SRC/build.sh
+ENV OLD_LLVMPASS 1

--- a/projects/wabt/Dockerfile
+++ b/projects/wabt/Dockerfile
@@ -21,3 +21,4 @@ WORKDIR wabt
 RUN git submodule init
 RUN git submodule update
 COPY build.sh wasm2wat_fuzzer.cc $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/wabt/Dockerfile
+++ b/projects/wabt/Dockerfile
@@ -21,4 +21,5 @@ WORKDIR wabt
 RUN git submodule init
 RUN git submodule update
 COPY build.sh wasm2wat_fuzzer.cc $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/wabt/Dockerfile
+++ b/projects/wabt/Dockerfile
@@ -21,5 +21,6 @@ WORKDIR wabt
 RUN git submodule init
 RUN git submodule update
 COPY build.sh wasm2wat_fuzzer.cc $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/wolfssl/Dockerfile
+++ b/projects/wolfssl/Dockerfile
@@ -60,5 +60,6 @@ RUN gsutil cp gs://libressl-backup.clusterfuzz-external.appspot.com/corpus/libFu
 WORKDIR wolfssl
 
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/wolfssl/Dockerfile
+++ b/projects/wolfssl/Dockerfile
@@ -60,4 +60,5 @@ RUN gsutil cp gs://libressl-backup.clusterfuzz-external.appspot.com/corpus/libFu
 WORKDIR wolfssl
 
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/wolfssl/Dockerfile
+++ b/projects/wolfssl/Dockerfile
@@ -60,3 +60,4 @@ RUN gsutil cp gs://libressl-backup.clusterfuzz-external.appspot.com/corpus/libFu
 WORKDIR wolfssl
 
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/znc/Dockerfile
+++ b/projects/znc/Dockerfile
@@ -19,5 +19,6 @@ RUN apt-get update && apt-get install -y make
 RUN git clone --depth 1 https://github.com/znc/znc
 WORKDIR $SRC/znc
 COPY build.sh msg_parse_fuzzer.cpp $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/znc/Dockerfile
+++ b/projects/znc/Dockerfile
@@ -19,3 +19,4 @@ RUN apt-get update && apt-get install -y make
 RUN git clone --depth 1 https://github.com/znc/znc
 WORKDIR $SRC/znc
 COPY build.sh msg_parse_fuzzer.cpp $SRC/
+ENV OLD_LLVMPASS 1

--- a/projects/znc/Dockerfile
+++ b/projects/znc/Dockerfile
@@ -19,4 +19,5 @@ RUN apt-get update && apt-get install -y make
 RUN git clone --depth 1 https://github.com/znc/znc
 WORKDIR $SRC/znc
 COPY build.sh msg_parse_fuzzer.cpp $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/zstd/Dockerfile
+++ b/projects/zstd/Dockerfile
@@ -20,5 +20,6 @@ RUN apt-get update && apt-get install -y make python wget
 RUN git clone --depth 1 https://github.com/facebook/zstd
 WORKDIR zstd
 COPY build.sh $SRC/
-# To use LLVM old pass manager.
+# This is to fix Fuzz Introspector build by using LLVM old pass manager
+# re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1

--- a/projects/zstd/Dockerfile
+++ b/projects/zstd/Dockerfile
@@ -20,4 +20,5 @@ RUN apt-get update && apt-get install -y make python wget
 RUN git clone --depth 1 https://github.com/facebook/zstd
 WORKDIR zstd
 COPY build.sh $SRC/
+# To use LLVM old pass manager.
 ENV OLD_LLVMPASS 1

--- a/projects/zstd/Dockerfile
+++ b/projects/zstd/Dockerfile
@@ -20,3 +20,4 @@ RUN apt-get update && apt-get install -y make python wget
 RUN git clone --depth 1 https://github.com/facebook/zstd
 WORKDIR zstd
 COPY build.sh $SRC/
+ENV OLD_LLVMPASS 1


### PR DESCRIPTION
https://github.com/google/oss-fuzz/pull/7788 caused a significant number of projects fail to build with introspector.
This PR sets the flags to use old pass manager and get the projects built.