### PR TITLE
fix openh264 folder rename issue

### DIFF
--- a/projects/openh264/build.sh
+++ b/projects/openh264/build.sh
@@ -27,4 +27,4 @@ else
   ASM_BUILD=Yes
 fi
 make -j$(nproc) ARCH=$ARCHITECTURE USE_ASM=$ASM_BUILD BUILDTYPE=Debug libraries
-$CXX $CXXFLAGS -o $OUT/decoder_fuzzer -I./codec/api/svc -I./codec/console/common/inc -I./codec/common/inc -L. $LIB_FUZZING_ENGINE $SRC/decoder_fuzzer.cpp libopenh264.a
+$CXX $CXXFLAGS -o $OUT/decoder_fuzzer -I./codec/api/wels -I./codec/console/common/inc -I./codec/common/inc -L. $LIB_FUZZING_ENGINE $SRC/decoder_fuzzer.cpp libopenh264.a

--- a/projects/openh264/decoder_fuzzer.cpp
+++ b/projects/openh264/decoder_fuzzer.cpp
@@ -1,3 +1,20 @@
+/*
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+*/
 // TODO: This should be moved to the openh264 repo.
 
 #include <stddef.h>

--- a/projects/openh264/decoder_fuzzer.cpp
+++ b/projects/openh264/decoder_fuzzer.cpp
@@ -18,7 +18,7 @@
 /*
  * To build locally:
  * CC=clang CXX=clang++ CFLAGS="-fsanitize=address,fuzzer-no-link -g" CXXFLAGS="-fsanitize=address,fuzzer-no-link -g" LDFLAGS="-fsanitize=address,fuzzer-no-link" make -j$(nproc) USE_ASM=No BUILDTYPE=Debug libraries
- * clang++ -o decoder_fuzzer -fsanitize=address -g -O1 -I./codec/api/svc -I./codec/console/common/inc -I./codec/common/inc -L. -lFuzzer -lstdc++ decoder_fuzzer.cpp libopenh264.a
+ * clang++ -o decoder_fuzzer -fsanitize=address -g -O1 -I./codec/api/wels -I./codec/console/common/inc -I./codec/common/inc -L. -lFuzzer -lstdc++ decoder_fuzzer.cpp libopenh264.a
  */
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)


### PR DESCRIPTION
att. 
Change the test code to re-enable the fuzzy test for openh264.