### PR TITLE
Allow searching for the binary to execute in `$PATH`

### DIFF
--- a/infra/experimental/sanitizers/ExecSan/execSan.cpp
+++ b/infra/experimental/sanitizers/ExecSan/execSan.cpp
@@ -135,8 +135,8 @@ pid_t run_child(char **argv) {
       fatal_log("Fork failed: %s", strerror(errno));
     case 0:
       raise(SIGSTOP);
-      execv(argv[0], argv);
-      fatal_log("execv: %s", strerror(errno));
+      execvp(argv[0], argv);
+      fatal_log("execvp: %s", strerror(errno));
   }
   return pid;
 }


### PR DESCRIPTION
Replacing `execv` with `execvp` so that it will search in `$PATH` for the binary in the parameter.
This is useful when the binary to execute is not available in the current directory.
This change should not have any other side-effects.