### PR TITLE
jsonschema: refine build to enable coverage

### DIFF
--- a/projects/jsonschema/build.sh
+++ b/projects/jsonschema/build.sh
@@ -19,16 +19,5 @@ pip3 install .
 
 # Build fuzzers in $OUT.
 for fuzzer in $(find $SRC -name 'fuzz_*.py'); do
-  fuzzer_basename=$(basename -s .py $fuzzer)
-  fuzzer_package=${fuzzer_basename}.pkg
-  pyinstaller --distpath $OUT --onefile --name $fuzzer_package $fuzzer
-
-  # Create execution wrapper.
-  echo "#!/bin/sh
-# LLVMFuzzerTestOneInput for fuzzer detection.
-this_dir=\$(dirname \"\$0\")
-LD_PRELOAD=\$this_dir/sanitizer_with_fuzzer.so \
-ASAN_OPTIONS=\$ASAN_OPTIONS:symbolize=1:external_symbolizer_path=\$this_dir/llvm-symbolizer:detect_leaks=0 \
-\$this_dir/$fuzzer_package \$@" > $OUT/$fuzzer_basename
-  chmod +x $OUT/$fuzzer_basename
+  compile_python_fuzzer $fuzzer
 done


### PR DESCRIPTION
This follows https://github.com/python-jsonschema/jsonschema/pull/965

coverage is only enabled when using `compile_python_fuzzer`