### PR TITLE
[lxc] move apt-gets and pips to the lxc repository

### DIFF
--- a/projects/lxc/Dockerfile
+++ b/projects/lxc/Dockerfile
@@ -15,8 +15,6 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && \
-    apt-get install -y pkgconf make libtool automake autoconf
 RUN git clone --depth 1 https://github.com/lxc/lxc
 WORKDIR lxc
 COPY build.sh $SRC/


### PR DESCRIPTION
By analogy with 8d762775ac3c04f1 it should make it easier
to change the build script when new build dependencies like
meson are introduced.

lxc is switching to meson in https://github.com/lxc/lxc/pull/4142
so it's expected that it should fail to build on OSS-Fuzz.

cc @brauner 