### PR TITLE
infra: let honggfuzz verify crashes

### DIFF
--- a/infra/base-images/base-runner/run_fuzzer
+++ b/infra/base-images/base-runner/run_fuzzer
@@ -141,6 +141,7 @@ elif [[ "$FUZZING_ENGINE" = honggfuzz ]]; then
   # Honggfuzz expects at least 1 file in the input dir.
   echo input > $CORPUS_DIR/input
   # --exit_upon_crash: exit whith a first crash seen
+  # -V: verify crashes
   # -R (report): save report file to this location
   # -W (working dir): where the crashes go
   # -v (verbose): don't use VTE UI, just stderr
@@ -148,7 +149,7 @@ elif [[ "$FUZZING_ENGINE" = honggfuzz ]]; then
   # -P: use persistent mode of fuzzing (i.e. LLVMFuzzerTestOneInput)
   # -f: location of the initial (and destination) file corpus
   # -n: number of fuzzing threads (and processes)
-  CMD_LINE="$OUT/honggfuzz -n 1 --exit_upon_crash -R /tmp/${FUZZER}_honggfuzz.report -W $FUZZER_OUT -v -z -P -f \"$CORPUS_DIR\" $(get_dictionary) $* -- \"$OUT/$FUZZER\""
+  CMD_LINE="$OUT/honggfuzz -n 1 --exit_upon_crash -V -R /tmp/${FUZZER}_honggfuzz.report -W $FUZZER_OUT -v -z -P -f \"$CORPUS_DIR\" $(get_dictionary) $* -- \"$OUT/$FUZZER\""
 
 else
 


### PR DESCRIPTION
to make it easier to catch issues like
https://github.com/google/honggfuzz/issues/465.

With -V when unreproducible crashes are triggered honggfuzz shows something like
```
[2022-06-10T15:21:12+0000][W][2373157] subproc_checkTimeLimit():532 pid=2374490 took too much time (limit 30 s). Killing it with SIGKILL
Sz:280 Tm:30,021,052us (i/b/h/e/p/c) New:0/0/0/0/0/3, Cur:0/0/0/0/0/591
Launching verifier for HASH: 1b859677dd (iteration: 1 out of 5)
[2022-06-10T15:21:13+0000][E][2373157] fuzz_runVerifier():280 Verifier stack mismatch: (original) 1b859677dd != (new) 0
```