### PR TITLE
java-projects: update maven 3.8.5 to 3.8.6

### DIFF
--- a/projects/apache-commons-codec/Dockerfile
+++ b/projects/apache-commons-codec/Dockerfile
@@ -16,11 +16,11 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 
-RUN curl -L https://dlcdn.apache.org/maven/maven-3/3.8.5/binaries/apache-maven-3.8.5-bin.zip -o maven.zip && \
+RUN curl -L https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \
     rm -rf maven.zip
 
-ENV MVN $SRC/maven/apache-maven-3.8.5/bin/mvn
+ENV MVN $SRC/maven/apache-maven-3.8.6/bin/mvn
 
 RUN git clone --depth 1 https://gitbox.apache.org/repos/asf/commons-codec.git commons-codec
 

--- a/projects/apache-commons-io/Dockerfile
+++ b/projects/apache-commons-io/Dockerfile
@@ -16,11 +16,11 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 
-RUN curl -L https://dlcdn.apache.org/maven/maven-3/3.8.5/binaries/apache-maven-3.8.5-bin.zip -o maven.zip && \
+RUN curl -L https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \
     rm -rf maven.zip
 
-ENV MVN $SRC/maven/apache-maven-3.8.5/bin/mvn
+ENV MVN $SRC/maven/apache-maven-3.8.6/bin/mvn
 
 RUN git clone --depth 1 https://github.com/google/fuzzing && \
     mv fuzzing/dictionaries/xml.dict $SRC/XmlFuzzer.dict && \

--- a/projects/brotli-java/Dockerfile
+++ b/projects/brotli-java/Dockerfile
@@ -16,10 +16,10 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 RUN apt-get update && apt-get install -y make autoconf automake libtool wget
-RUN curl -L https://downloads.apache.org/maven/maven-3/3.8.5/binaries/apache-maven-3.8.5-bin.zip -o maven.zip && \
+RUN curl -L https://downloads.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \
     rm -rf maven.zip
-ENV MVN $SRC/maven/apache-maven-3.8.5/bin/mvn
+ENV MVN $SRC/maven/apache-maven-3.8.6/bin/mvn
 
 RUN git clone --depth 1 https://github.com/google/brotli brotli-java
 WORKDIR brotli-java

--- a/projects/cbor-java/Dockerfile
+++ b/projects/cbor-java/Dockerfile
@@ -16,10 +16,10 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 RUN apt-get update && apt-get install -y make autoconf automake libtool wget
-RUN curl -L https://downloads.apache.org/maven/maven-3/3.8.5/binaries/apache-maven-3.8.5-bin.zip -o maven.zip && \
+RUN curl -L https://downloads.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \
     rm -rf maven.zip
-ENV MVN $SRC/maven/apache-maven-3.8.5/bin/mvn
+ENV MVN $SRC/maven/apache-maven-3.8.6/bin/mvn
 
 RUN git clone --depth 1 https://android.googlesource.com/platform/external/cbor-java cbor-java
 

--- a/projects/gson/Dockerfile
+++ b/projects/gson/Dockerfile
@@ -17,10 +17,10 @@
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 RUN apt-get update && apt-get install -y make autoconf automake libtool wget
 
-RUN curl -L https://downloads.apache.org/maven/maven-3/3.8.5/binaries/apache-maven-3.8.5-bin.zip -o maven.zip && \
+RUN curl -L https://downloads.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \
     rm -rf maven.zip
-ENV MVN $SRC/maven/apache-maven-3.8.5/bin/mvn
+ENV MVN $SRC/maven/apache-maven-3.8.6/bin/mvn
 
 RUN git clone --depth 1 https://github.com/google/gson gson
 WORKDIR gson

--- a/projects/jettison/Dockerfile
+++ b/projects/jettison/Dockerfile
@@ -16,11 +16,11 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 
-RUN curl -L https://dlcdn.apache.org/maven/maven-3/3.8.5/binaries/apache-maven-3.8.5-bin.zip -o maven.zip && \
+RUN curl -L https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \
     rm -rf maven.zip
 
-ENV MVN $SRC/maven/apache-maven-3.8.5/bin/mvn
+ENV MVN $SRC/maven/apache-maven-3.8.6/bin/mvn
 
 RUN git clone --depth 1 https://github.com/google/fuzzing && \
     mv fuzzing/dictionaries/json.dict $SRC/JsonFuzzer.dict && \

--- a/projects/jsign/Dockerfile
+++ b/projects/jsign/Dockerfile
@@ -16,11 +16,11 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 
-RUN curl -L https://dlcdn.apache.org/maven/maven-3/3.8.5/binaries/apache-maven-3.8.5-bin.zip -o maven.zip && \
+RUN curl -L https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \
     rm -rf maven.zip
 
-ENV MVN $SRC/maven/apache-maven-3.8.5/bin/mvn
+ENV MVN $SRC/maven/apache-maven-3.8.6/bin/mvn
 
 RUN git clone --depth 1 https://github.com/ebourg/jsign.git
 

--- a/projects/jul-to-slf4j/Dockerfile
+++ b/projects/jul-to-slf4j/Dockerfile
@@ -16,11 +16,11 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 
-RUN curl -L https://dlcdn.apache.org/maven/maven-3/3.8.5/binaries/apache-maven-3.8.5-bin.zip -o maven.zip && \
+RUN curl -L https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \
     rm -rf maven.zip
 
-ENV MVN $SRC/maven/apache-maven-3.8.5/bin/mvn
+ENV MVN $SRC/maven/apache-maven-3.8.6/bin/mvn
 
 RUN git clone --depth 1 https://github.com/qos-ch/slf4j.git slf4j
 

--- a/projects/jul-to-slf4j/Dockerfile
+++ b/projects/jul-to-slf4j/Dockerfile
@@ -16,11 +16,11 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 
-RUN curl -L https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.zip -o maven.zip && \
+RUN curl -L https://dlcdn.apache.org/maven/maven-3/3.8.5/binaries/apache-maven-3.8.5-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \
     rm -rf maven.zip
 
-ENV MVN $SRC/maven/apache-maven-3.8.6/bin/mvn
+ENV MVN $SRC/maven/apache-maven-3.8.5/bin/mvn
 
 RUN git clone --depth 1 https://github.com/qos-ch/slf4j.git slf4j
 

--- a/projects/slf4j-api/Dockerfile
+++ b/projects/slf4j-api/Dockerfile
@@ -16,11 +16,11 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 
-RUN curl -L https://dlcdn.apache.org/maven/maven-3/3.8.5/binaries/apache-maven-3.8.5-bin.zip -o maven.zip && \
+RUN curl -L https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \
     rm -rf maven.zip
 
-ENV MVN $SRC/maven/apache-maven-3.8.5/bin/mvn
+ENV MVN $SRC/maven/apache-maven-3.8.6/bin/mvn
 
 RUN git clone --depth 1 https://github.com/qos-ch/slf4j.git slf4j
 

--- a/projects/snakeyaml/Dockerfile
+++ b/projects/snakeyaml/Dockerfile
@@ -16,11 +16,11 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 
-RUN curl -L https://dlcdn.apache.org/maven/maven-3/3.8.5/binaries/apache-maven-3.8.5-bin.zip -o maven.zip && \
+RUN curl -L https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \
     rm -rf maven.zip
 
-ENV MVN $SRC/maven/apache-maven-3.8.5/bin/mvn
+ENV MVN $SRC/maven/apache-maven-3.8.6/bin/mvn
 
 RUN git clone --depth 1 https://github.com/google/fuzzing && \
     mv fuzzing/dictionaries/yaml.dict $SRC/YamlFuzzer.dict && \

--- a/projects/stringtemplate4/Dockerfile
+++ b/projects/stringtemplate4/Dockerfile
@@ -17,11 +17,11 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 
-RUN curl -L https://dlcdn.apache.org/maven/maven-3/3.8.5/binaries/apache-maven-3.8.5-bin.zip -o maven.zip && \
+RUN curl -L https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \
     rm -rf maven.zip
 
-ENV MVN $SRC/maven/apache-maven-3.8.5/bin/mvn
+ENV MVN $SRC/maven/apache-maven-3.8.6/bin/mvn
 
 RUN git clone --depth 1 https://github.com/antlr/stringtemplate4.git stringtemplate4
 

--- a/projects/xstream/Dockerfile
+++ b/projects/xstream/Dockerfile
@@ -16,11 +16,11 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 
-RUN curl -L https://dlcdn.apache.org/maven/maven-3/3.8.5/binaries/apache-maven-3.8.5-bin.zip -o maven.zip && \
+RUN curl -L https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \
     rm -rf maven.zip
 
-ENV MVN $SRC/maven/apache-maven-3.8.5/bin/mvn
+ENV MVN $SRC/maven/apache-maven-3.8.6/bin/mvn
 
 RUN git clone --depth 1 https://github.com/google/fuzzing && \
     mv fuzzing/dictionaries/xml.dict $SRC/XmlFuzzer.dict && \

--- a/projects/zip4j/Dockerfile
+++ b/projects/zip4j/Dockerfile
@@ -16,11 +16,11 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 
-RUN curl -L https://dlcdn.apache.org/maven/maven-3/3.8.5/binaries/apache-maven-3.8.5-bin.zip -o maven.zip && \
+RUN curl -L https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \
     rm -rf maven.zip
 
-ENV MVN $SRC/maven/apache-maven-3.8.5/bin/mvn
+ENV MVN $SRC/maven/apache-maven-3.8.6/bin/mvn
 
 # Dict
 RUN git clone --depth 1 https://github.com/google/fuzzing && \


### PR DESCRIPTION
The 3.8.5 is no longer available so project builds are failing for those
in this commit. This fixes it.