### PR TITLE
Fix build image steps for introspector

### DIFF
--- a/infra/build/functions/base_images.py
+++ b/infra/build/functions/base_images.py
@@ -62,16 +62,6 @@ def _get_introspector_base_images_steps(images, tag_prefix=TAG_PREFIX):
           'https://github.com/google/oss-fuzz.git',
       ],
       'name': 'gcr.io/cloud-builders/git',
-  }, {
-      'name': 'gcr.io/cloud-builders/docker',
-      'args': ['pull', 'gcr.io/oss-fuzz-base/base-clang:introspector'],
-  }, {
-      'name':
-          'gcr.io/cloud-builders/docker',
-      'args': [
-          'tag', 'gcr.io/oss-fuzz-base/base-clang:introspector',
-          'gcr.io/oss-fuzz-base/base-clang:latest'
-      ],
   }]
 
   for base_image in images:
@@ -80,6 +70,15 @@ def _get_introspector_base_images_steps(images, tag_prefix=TAG_PREFIX):
 
     if base_image == 'base-clang':
       args_list.extend(['--build-arg', 'introspector=1'])
+    elif base_image == 'base-builder':
+      steps.append({
+          'name':
+              'gcr.io/cloud-builders/docker',
+          'args': [
+              'tag', 'gcr.io/oss-fuzz-base/base-clang:introspector',
+              'gcr.io/oss-fuzz-base/base-clang:latest'
+          ]
+      })
 
     args_list.extend([
         '-t',


### PR DESCRIPTION
This PR fixes a hidden logical error in building introspector images which were causing base-builder:introspector pick up the latest changes with one day delay wrt base-clang:introspector.

The issue was that `docker 
tag gcr.io/oss-fuzz-base/base-clang:introspector gcr.io/oss-fuzz-base/base-clang:latest` is before building the `clang:introspector`
This causes the `base-builder` to have out-dated fuzzintrospector code!


Build Summary
5 Steps
0: gcr.io/cloud-builders/git
clone https://github.com/google/oss-fuzz.git
1: gcr.io/cloud-builders/docker
pull gcr.io/oss-fuzz-base/base-clang:introspector
**2: gcr.io/cloud-builders/docker
tag gcr.io/oss-fuzz-base/base-clang:introspector gcr.io/oss-fuzz-base/base-clang:latest**
3: gcr.io/cloud-builders/docker
build --build-arg introspector=1 -t gcr.io/oss-fuzz-base/base-clang:introspector .
**4: gcr.io/cloud-builders/docker
build -t gcr.io/oss-fuzz-base/base-builder:introspector .**


Previously I was using `sed` to edit `Dockerfiles` on the fly and use current image.
But when tagging (#7423), it has to be after building the latest base-clang.