### PR TITLE
[dbus-broker] initial integration

### DIFF
--- a/projects/dbus-broker/project.yaml
+++ b/projects/dbus-broker/project.yaml
@@ -1,0 +1,15 @@
+homepage: "https://github.com/bus1/dbus-broker"
+language: c
+primary_contact: "david.rheinsberg@gmail.com"
+builds_per_day: 4
+sanitizers:
+  - address
+  - undefined
+  - memory
+auto_ccs:
+  - evverx@gmail.com
+  - fsumsal@redhat.com
+main_repo: "https://github.com/bus1/dbus-broker"
+architectures:
+  - x86_64
+file_github_issue: True


### PR DESCRIPTION
Prompted by https://github.com/bus1/dbus-broker/issues/291

I have a fuzz target targeting the code parsing DBus messages that can trigger all those crashes but I think it should be added once all shallow issues are gone.

cc @dvdhrm @mrc0mmand