### PR TITLE
croniter: instrument fuzzing function

### DIFF
--- a/projects/croniter/fuzz_iter.py
+++ b/projects/croniter/fuzz_iter.py
@@ -46,6 +46,7 @@ def TestOneInput(data):
 
 
 def main():
+  atheris.instrument_all()
   atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
   atheris.Fuzz()
 

--- a/projects/croniter/fuzz_iter.py
+++ b/projects/croniter/fuzz_iter.py
@@ -26,6 +26,7 @@ with atheris.instrument_imports():
   )
 
 
+@atheris.instrument_func
 def TestOneInput(data):
   fdp = atheris.FuzzedDataProvider(data)
   base = datetime(2012, 4, 6, 13, 26, 10)


### PR DESCRIPTION
The Croniter build is having some troubles with coverage and I'm not
entirely sure why. It seems like the corpus is not there and I'm not
entirely sure if this has to do with some instrumentation underlyings.
Locally the end-to-end process of running, collecting seeds and
generating coverage works for me. The effort in this PR is to make the
setup similar to pyyalm where the coverage visualisation works -- the
only difference I could spot between fuzzers from the two projects is
that croniter does not have its fuzzer entry function instrumented.