### PR TITLE
[dbus-broker] add build script and fuzz target

### DIFF
--- a/projects/dbus-broker/Dockerfile
+++ b/projects/dbus-broker/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN git clone --depth 1 https://github.com/bus1/dbus-broker
+WORKDIR dbus-broker
+COPY *.c build.sh $SRC/

--- a/projects/dbus-broker/build.sh
+++ b/projects/dbus-broker/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -eu
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+apt-get update -y
+
+if [[ "$ARCHITECTURE" == i386 ]]; then
+    apt-get install -y pkg-config:i386
+else
+    apt-get install -y pkg-config
+fi
+
+pip3 install meson ninja
+
+meson -Db_lundef=false -Dlauncher=false build
+ninja -C ./build -v
+$CC $CFLAGS -c -o fuzz-message.o -Isrc -Isubprojects/libcstdaux-1/src -std=c11 -D_GNU_SOURCE "$SRC/fuzz-message.c"
+$CXX $CXXFLAGS -o "$OUT/fuzz-message" \
+    fuzz-message.o \
+    build/src/libbus-static.a \
+    build/subprojects/libcdvar-1/src/libcdvar-1.a \
+    build/subprojects/libcutf8-1/src/libcutf8-1.a \
+    $LIB_FUZZING_ENGINE

--- a/projects/dbus-broker/fuzz-message.c
+++ b/projects/dbus-broker/fuzz-message.c
@@ -1,0 +1,46 @@
+/*
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+*/
+#include <stddef.h>
+#include <stdint.h>
+
+#include "dbus/message.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+        _c_cleanup_(message_unrefp) Message *message = NULL;
+        MessageHeader *header = (void *)data;
+        int r;
+
+        if (size < sizeof(MessageHeader))
+                return 0;
+
+        r = message_new_incoming(&message, *header);
+        if (r != 0)
+                return 0;
+
+        if (message->n_data > size)
+                return 0;
+
+        memcpy(message->data + sizeof(*header), data + sizeof(*header), message->n_data - sizeof(*header));
+
+        r = message_parse_metadata(message);
+        if (r)
+                return 0;
+
+        message_stitch_sender(message, 1);
+
+        return 0;
+}

--- a/projects/dbus-broker/project.yaml
+++ b/projects/dbus-broker/project.yaml
@@ -12,4 +12,5 @@ auto_ccs:
 main_repo: "https://github.com/bus1/dbus-broker"
 architectures:
   - x86_64
+  - i386
 file_github_issue: True


### PR DESCRIPTION
Now that https://github.com/bus1/dbus-broker/issues/291 is fixed the fuzz target can be rolled out.

@dvdhrm I haven't added the fuzz target yet (but I got it to build on i386 in the meantime :-)). I wonder if it would make sense to add it now or once `dbus-broker` with that commit included is released? Once the fuzz target is public it can be used to get those dbus messages in a couple of seconds or so.