### PR TITLE
grpc-gateway: refactor

### DIFF
--- a/projects/grpc-gateway/build.sh
+++ b/projects/grpc-gateway/build.sh
@@ -15,10 +15,4 @@
 #
 ################################################################################
 
-if [ "$SANITIZER" = "coverage" ]
-then
-	git clone https://github.com/grpc-ecosystem/grpc-gateway.git
-	compile_go_fuzzer github.com/grpc-ecosystem/grpc-gateway/v2/internal/httprule Fuzz fuzz gofuzz
-else
-	compile_go_fuzzer github.com/grpc-ecosystem/grpc-gateway/v2/internal/httprule Fuzz fuzz gofuzz
-fi
+compile_go_fuzzer github.com/grpc-ecosystem/grpc-gateway/v2/internal/httprule Fuzz fuzz gofuzz


### PR DESCRIPTION
The removed logic is not needed anymore. The build script is simplified in this PR to build the fuzzer with fewer lines of code. 