### PR TITLE
Use $ORIGIN in the rpath linker argument

### DIFF
--- a/projects/ruby/build.sh
+++ b/projects/ruby/build.sh
@@ -57,7 +57,7 @@ ruby gen_init_ruby_load_paths.rb > init_ruby_load_paths.h
 # The -rpath flag helps the dynamic linker to find .so files in /out/lib
 ${CC} ${CFLAGS} fuzz_ruby_gems.c -o $OUT/fuzz_ruby_gems \
     -Wall \
-    -Wl,-rpath,./lib \
+    -Wl,-rpath,'$ORIGIN'/lib \
     -L${RUBY_LIB_DIR} \
     ${RUBY_INCLUDES} \
     ${RUBY_LIBRARIES} \


### PR DESCRIPTION
This will hopefully fix [issue 48193](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=48193). The problem is that it can't find `libruby.so.3.2`, which should be in `$OUT/lib`. I previously used `-rpath` with a relative address, but that won't work if the current directory isn't `$OUT`, which is my best guess as to why the build is failing. If so, `$ORIGIN` should fix it.