### PR TITLE
compile_native_go_fuzzer: go get fuzz build utils

### DIFF
--- a/infra/base-images/base-builder/compile_native_go_fuzzer
+++ b/infra/base-images/base-builder/compile_native_go_fuzzer
@@ -33,6 +33,7 @@ function rewrite_go_fuzz_harness() {
 	# Import https://github.com/AdamKorcz/go-118-fuzz-build.
 	# This changes the line numbers from the original fuzzer.
 	addimport -path "${fuzzer_fn}"
+	go get github.com/AdamKorcz/go-118-fuzz-build/utils
 }
 
 function build_native_go_fuzzer() {


### PR DESCRIPTION
After adding `github.com/AdamKorcz/go-118-fuzz-build/utils` as an import in the fuzz testing files, we still need to `go get` this package so the module has it available for use.