### PR TITLE
[CFL] Give docker images unique names to support parallel fuzzing

### DIFF
--- a/infra/cifuzz/continuous_integration_test.py
+++ b/infra/cifuzz/continuous_integration_test.py
@@ -18,6 +18,7 @@ import unittest
 from unittest import mock
 
 import continuous_integration
+import docker
 
 # pylint: disable=wrong-import-position,import-error
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -79,7 +80,7 @@ class BuildExternalProjetDockerImage(unittest.TestCase):
         project_src, build_integration_path)
 
     mock_docker_build.assert_called_with([
-        '-t', 'external-project', '-f',
+        '-t', docker.EXTERNAL_PROJECT_IMAGE, '-f',
         os.path.join('.clusterfuzzlite', 'Dockerfile'), project_src
     ])
 

--- a/infra/cifuzz/docker.py
+++ b/infra/cifuzz/docker.py
@@ -34,6 +34,7 @@ _DEFAULT_DOCKER_RUN_ARGS = [
 
 UNIQUE_ID_SUFFIX = '-' + uuid.uuid4().hex
 
+# TODO(metzman): Make run_fuzzers able to delete this image.
 EXTERNAL_PROJECT_IMAGE = 'external-cfl-project' + UNIQUE_ID_SUFFIX
 
 _DEFAULT_DOCKER_RUN_COMMAND = [

--- a/infra/cifuzz/docker.py
+++ b/infra/cifuzz/docker.py
@@ -55,9 +55,10 @@ def get_docker_env_vars(env_mapping):
 
 def get_project_image_name(project):
   """Returns the name of the project builder image for |project_name|."""
-  # TODO(ochang): We may need unique names to support parallel fuzzing for
-  # CIFuzz (like CFL supports). Don't do this for now because no one has asked
-  # for it and build_specified_commit would need to be modified to support this.
+  # TODO(jonathanmetzman): We may need unique names to support parallel fuzzing
+  # for CIFuzz (like CFL supports). Don't do this for now because no one has
+  # asked for it and build_specified_commit would need to be modified to support
+  # this.
   if project:
     return PROJECT_TAG_PREFIX + project
 

--- a/infra/cifuzz/docker.py
+++ b/infra/cifuzz/docker.py
@@ -57,7 +57,7 @@ def get_project_image_name(project):
   """Returns the name of the project builder image for |project_name|."""
   # TODO(ochang): We may need unique names to support parallel fuzzing.
   if project:
-    return PROJECT_TAG_PREFIX + project + UNIQUE_ID_SUFFIX
+    return PROJECT_TAG_PREFIX + project
 
   return EXTERNAL_PROJECT_IMAGE
 

--- a/infra/cifuzz/docker.py
+++ b/infra/cifuzz/docker.py
@@ -15,6 +15,7 @@
 import logging
 import os
 import sys
+import uuid
 
 # pylint: disable=wrong-import-position,import-error
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -31,7 +32,9 @@ _DEFAULT_DOCKER_RUN_ARGS = [
     '-e', 'FUZZING_ENGINE=' + constants.DEFAULT_ENGINE, '-e', 'CIFUZZ=True'
 ]
 
-EXTERNAL_PROJECT_IMAGE = 'external-project'
+UNIQUE_ID_SUFFIX = '-' + uuid.uuid4().hex
+
+PROJECT_IMAGE = 'external-project' + UNIQUE_ID_SUFFIX
 
 _DEFAULT_DOCKER_RUN_COMMAND = [
     'docker',
@@ -54,7 +57,7 @@ def get_project_image_name(project):
   """Returns the name of the project builder image for |project_name|."""
   # TODO(ochang): We may need unique names to support parallel fuzzing.
   if project:
-    return PROJECT_TAG_PREFIX + project
+    return PROJECT_TAG_PREFIX + project + UNIQUE_ID_SUFFIX
 
   return EXTERNAL_PROJECT_IMAGE
 

--- a/infra/cifuzz/docker.py
+++ b/infra/cifuzz/docker.py
@@ -34,7 +34,7 @@ _DEFAULT_DOCKER_RUN_ARGS = [
 
 UNIQUE_ID_SUFFIX = '-' + uuid.uuid4().hex
 
-PROJECT_IMAGE = 'external-project' + UNIQUE_ID_SUFFIX
+EXTERNAL_PROJECT_IMAGE = 'external-cfl-project' + UNIQUE_ID_SUFFIX
 
 _DEFAULT_DOCKER_RUN_COMMAND = [
     'docker',

--- a/infra/cifuzz/docker.py
+++ b/infra/cifuzz/docker.py
@@ -55,7 +55,9 @@ def get_docker_env_vars(env_mapping):
 
 def get_project_image_name(project):
   """Returns the name of the project builder image for |project_name|."""
-  # TODO(ochang): We may need unique names to support parallel fuzzing.
+  # TODO(ochang): We may need unique names to support parallel fuzzing for
+  # CIFuzz (like CFL supports). Don't do this for now because no one has asked
+  # for it and build_specified_commit would need to be modified to support this.
   if project:
     return PROJECT_TAG_PREFIX + project
 

--- a/infra/cifuzz/docker_test.py
+++ b/infra/cifuzz/docker_test.py
@@ -35,7 +35,7 @@ class GetProjectImageTest(unittest.TestCase):
     """Tests that get_project_image_name works as intended."""
     project = 'my-project'
     self.assertEqual(docker.get_project_image_name(project),
-                     'gcr.io/oss-fuzz/my-project')
+                     'gcr.io/oss-fuzz/my-project' + docker.UNIQUE_ID_SUFFIX)
 
 
 class GetDeleteImagesTest(unittest.TestCase):

--- a/infra/cifuzz/docker_test.py
+++ b/infra/cifuzz/docker_test.py
@@ -35,7 +35,7 @@ class GetProjectImageTest(unittest.TestCase):
     """Tests that get_project_image_name works as intended."""
     project = 'my-project'
     self.assertEqual(docker.get_project_image_name(project),
-                     'gcr.io/oss-fuzz/my-project' + docker.UNIQUE_ID_SUFFIX)
+                     'gcr.io/oss-fuzz/my-project')
 
 
 class GetDeleteImagesTest(unittest.TestCase):


### PR DESCRIPTION
Unintended consequences of this are it will make debugging harder and it will make it harder to delete these images from disk.
Fixes #7897