### PR TITLE
ghostscript: add target for new devices

### DIFF
--- a/projects/ghostscript/build.sh
+++ b/projects/ghostscript/build.sh
@@ -46,11 +46,11 @@ CPPFLAGS="${CPPFLAGS:-} $CUPS_CFLAGS -DPACIFY_VALGRIND" ./autogen.sh \
   CUPSCONFIG=$CUPSCONFIG \
   --enable-freetype --enable-fontconfig \
   --enable-cups --with-ijs --with-jbig2dec \
-  --with-drivers=cups,ljet4,laserjet,pxlmono,pxlcolor,pcl3,uniprint
+  --with-drivers=pdfwrite,cups,ljet4,laserjet,pxlmono,pxlcolor,pcl3,uniprint
 make -j$(nproc) libgs
 
 
-for fuzzer in gstoraster_pdf_fuzzer gstoraster_fuzzer gstoraster_fuzzer_all_colors gstoraster_ps_fuzzer; do
+for fuzzer in gstoraster_pdf_fuzzer gstoraster_fuzzer gstoraster_fuzzer_all_colors gstoraster_ps_fuzzer gstoraster_devices_fuzzer; do
   $CXX $CXXFLAGS $CUPS_LDFLAGS -std=c++11 -I. -I$SRC \
     $SRC/${fuzzer}.cc \
     -o "$OUT/${fuzzer}" \
@@ -83,6 +83,7 @@ done
 
 # Create corpus for gstoraster_fuzzer
 zip -j "$OUT/gstoraster_fuzzer_seed_corpus.zip" "$WORK"/seeds/*
+cp "$OUT/gstoraster_fuzzer_seed_corpus.zip" "$OUT/gstoraster_devices_fuzzer_seed_corpus.zip"
 
 # Copy out options
 cp $SRC/*.options $OUT/

--- a/projects/ghostscript/gstoraster_devices_fuzzer.cc
+++ b/projects/ghostscript/gstoraster_devices_fuzzer.cc
@@ -13,15 +13,10 @@ limitations under the License.
 #include "gstoraster_fuzzlib.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-	if (size == 0) {
-		return 0;
-	}
-	// Modulo the possibilities: https://github.com/ArtifexSoftware/ghostpdl/blob/8c97d5adce0040ac38a1fb4d7954499c65f582ff/cups/libs/cups/raster.h#L102
-	// This enables the fuzzer to explore all color schemes
-	int color_scheme = ((int)data[0] % 63);
-	data++;
-	size--;
-
-	gs_to_raster_fuzz(data, size, color_scheme, "cups");
+	/*
+	 * Fuzz pdfwrite and pxlmono
+	 */
+	gs_to_raster_fuzz(data, size, 1, "pdfwrite");
+	gs_to_raster_fuzz(data, size, 1, "pxlmono");
 	return 0;
 }

--- a/projects/ghostscript/gstoraster_fuzzer.cc
+++ b/projects/ghostscript/gstoraster_fuzzer.cc
@@ -20,6 +20,6 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	/* Tests RGB color scheme */
-	gs_to_raster_fuzz(data, size, 1);
+	gs_to_raster_fuzz(data, size, 1, "cups");
 	return 0;
 }

--- a/projects/ghostscript/gstoraster_fuzzlib.h
+++ b/projects/ghostscript/gstoraster_fuzzlib.h
@@ -48,17 +48,25 @@ static int gs_stdnull(void *inst, const char *buf, int len)
 	return len;
 }
 
-int gs_to_raster_fuzz(const unsigned char *buf, size_t size, int color_scheme)
+int gs_to_raster_fuzz(
+	const unsigned char *buf,
+	size_t size,
+	int color_scheme,
+	const char *device_target
+)
 {
 	int ret;
 	void *gs = NULL;
 	char color_space[50];
+	char gs_device[50];
 	/*
 	 * We are expecting color_scheme to be in the [0:62] interval.
 	 * This corresponds to the color schemes defined here:
 	 * https://github.com/ArtifexSoftware/ghostpdl/blob/8c97d5adce0040ac38a1fb4d7954499c65f582ff/cups/libs/cups/raster.h#L102
 	 */
 	sprintf(color_space, "-dcupsColorSpace=%d", color_scheme);
+
+	sprintf(gs_device, "-sDEVICE=%s", device_target);
 	/* Mostly stolen from cups-filters gstoraster. */
 	char *args[] = {
 		"gs",
@@ -77,7 +85,7 @@ int gs_to_raster_fuzz(const unsigned char *buf, size_t size, int color_scheme)
 		"-dNOMEDIAATTRS",
 		"-sstdout=%%stderr",
 		"-sOutputFile=/dev/null",
-		"-sDEVICE=cups",
+		gs_device,
 		"-_",
 	};
 	int argc = sizeof(args) / sizeof(args[0]);

--- a/projects/ghostscript/gstoraster_pdf_fuzzer.cc
+++ b/projects/ghostscript/gstoraster_pdf_fuzzer.cc
@@ -32,6 +32,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	}
 
 	/* Tests using RGB color scheme */
-	gs_to_raster_fuzz(data, size, 1);
+	gs_to_raster_fuzz(data, size, 1, "cups");
 	return 0;
 }

--- a/projects/ghostscript/gstoraster_ps_fuzzer.cc
+++ b/projects/ghostscript/gstoraster_ps_fuzzer.cc
@@ -40,6 +40,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	data++;
 	size--;
 
-	gs_to_raster_fuzz(data, size, color_scheme);
+	gs_to_raster_fuzz(data, size, color_scheme, "cups");
 	return 0;
 }


### PR DESCRIPTION
Adds ability to target various devices and a fuzzer that targets
pdfwrite and pxlmono devices. The primary device of interest here is
likely pdfwrite as it's more widely used as far as I know.