### PR TITLE
spdk: upgrade pip

### DIFF
--- a/projects/spdk/Dockerfile
+++ b/projects/spdk/Dockerfile
@@ -16,6 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make curl yasm autoconf libtool meson nasm
+RUN pip3 install --upgrade pip
 RUN git clone --depth 1 https://github.com/spdk/spdk && \
     cd spdk && \
     git submodule update --init


### PR DESCRIPTION
For some reason, there's a local python3 installation on the
oss-fuzz-base image with a pretty old pip version, 19.2.3, which doesn't
have up-to-date wheel platform tags, so, when installing SPDK
dependencies, it tries to compile them instead of using the wheels. The
compilation fails on the grpcio package for some reason.

So, to resolve this, upgrade the local pip version when building the
SPDK image, so that it's able to fetch the pre-compiled packages.  This
is a workaround for #7914.