### PR TITLE
fix: XS coverage builds, and add dictionaries and corpus seeds

### DIFF
--- a/projects/xs/Dockerfile
+++ b/projects/xs/Dockerfile
@@ -14,9 +14,20 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 
+#Apache-2.0 license
+RUN git clone --depth 1 https://github.com/dvyukov/go-fuzz-corpus && \
+    zip -q $SRC/xst_jsonparse_seed_corpus.zip go-fuzz-corpus/json/corpus/*
+
+#Apache-2.0 license
+RUN git clone --depth 1 https://github.com/google/fuzzing && \
+    cat fuzzing/dictionaries/json.dict > $SRC/xst_jsonparse.dict && \
+    cat fuzzing/dictionaries/js.dict > $SRC/xst.dict
+
+#Apache-2.0 license, MIT license, BSD license
+RUN git clone --depth 1 https://github.com/tc39/test262-parser-tests && \
+	zip -q $SRC/xst_seed_corpus.zip test262-parser-tests/pass-explicit/*
+
 RUN git clone --depth=1 https://github.com/Moddable-OpenSource/moddable moddable
 WORKDIR moddable
 
-COPY target.c $SRC/
-COPY build.sh $SRC/
-COPY xst.options $SRC/
+COPY target.c build.sh xst.options $SRC/

--- a/projects/xs/build.sh
+++ b/projects/xs/build.sh
@@ -13,6 +13,9 @@
 #
 ################################################################################
 
+# Copy seed corpus and dictionary.
+mv $SRC/{*.zip,*.dict} $OUT
+
 
 export MODDABLE=$PWD
 export ASAN_OPTIONS="detect_leaks=0"
@@ -22,23 +25,30 @@ FUZZ_TARGETS=(
   xst_jsonparse
 )
 
-# Build a wrapper binary for each target to set environment variables.
-for FUZZ_TARGET in ${FUZZ_TARGETS[@]}
-do
-  $CC $CFLAGS -O0 \
-    -DFUZZ_TARGET=$FUZZ_TARGET \
-    $SRC/target.c -o $OUT/$FUZZ_TARGET
-done
+REALBIN_PATH=$OUT
+if [ "$SANITIZER" = "coverage" ]
+then
+  echo "this is a coverage build"
+else
+  # Stash actual binaries in subdirectory so they aren't picked up by target discovery
+  mkdir -p $OUT/real
+  REALBIN_PATH=$OUT/real
 
-# Stash actual binaries in subdirectory so they aren't picked up by target discovery
-mkdir -p $OUT/real
+  # Build a wrapper binary for each target to set environment variables.
+  for FUZZ_TARGET in ${FUZZ_TARGETS[@]}
+  do
+    $CC $CFLAGS -O0 \
+      -DFUZZ_TARGET=$FUZZ_TARGET \
+      $SRC/target.c -o $OUT/$FUZZ_TARGET
+  done
+fi
 
 # build main target
 cd "$MODDABLE/xs/makefiles/lin"
 FUZZING=1 OSSFUZZ=1 make debug
 
 cd "$MODDABLE"
-cp ./build/bin/lin/debug/xst $OUT/real/xst
+cp ./build/bin/lin/debug/xst $REALBIN_PATH/xst
 cp $SRC/xst.options $OUT/
 
 # build jsonparse target
@@ -47,6 +57,6 @@ make -f xst.mk clean
 FUZZING=1 OSSFUZZ=1 OSSFUZZ_JSONPARSE=1 make debug
 
 cd "$MODDABLE"
-cp ./build/bin/lin/debug/xst $OUT/real/xst_jsonparse
+cp ./build/bin/lin/debug/xst $REALBIN_PATH/xst_jsonparse
 
 cp $SRC/xst.options $OUT/xst_jsonparse.options

--- a/projects/xs/target.c
+++ b/projects/xs/target.c
@@ -1,19 +1,20 @@
 /*
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-################################################################################
-*/
+ ********************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ********************************************************************************
+ */
 
 #include <limits.h>
 #include <stdio.h>


### PR DESCRIPTION
In this PR:

* Fixes coverage builds for all xs targets: fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=48453, failing due to new wrappers
* xst: Introduces seed corpus for js, seeded from test262 parser tests, dictionary for javascript
* xst_jsonparse: Introduces seed corpus for json; dictionary for json
* Comments are fixed in target.c

Tested with:
```
python infra/helper.py build_image --pull xs 

python infra/helper.py build_fuzzers --sanitizer address xs

python infra/helper.py check_build xs

mkdir -p /tmp/corpus1
mkdir -p /tmp/corpus2

python infra/helper.py run_fuzzer --corpus-dir=/tmp/corpus1 xs xst

python infra/helper.py run_fuzzer --corpus-dir=/tmp/corpus2 xs xst_jsonparse

python infra/helper.py build_fuzzers --sanitizer coverage xs

python infra/helper.py coverage xs --fuzz-target xst --corpus-dir=/tmp/corpus1

python infra/helper.py coverage xs --fuzz-target xst_jsonparse --corpus-dir=/tmp/corpus2
```
Both coverage reports succeed, with fuzzers recognizing seed corpus and dictionaries, and builds / check_builds succeed