### PR TITLE
openssl: Don't find sh scripts in fuzz directory

### DIFF
--- a/projects/openssl/build.sh
+++ b/projects/openssl/build.sh
@@ -25,7 +25,7 @@ fi
 
 make -j$(nproc) LDCMD="$CXX $CXXFLAGS"
 
-fuzzers=$(find fuzz -executable -type f '!' -name \*.py '!' -name \*-test '!' -name \*.pl)
+fuzzers=$(find fuzz -executable -type f '!' -name \*.py '!' -name \*-test '!' -name \*.pl '!' -name \*.sh)
 for f in $fuzzers; do
 	fuzzer=$(basename $f)
 	cp $f $OUT/


### PR DESCRIPTION
As part of https://github.com/openssl/openssl/pull/18355 "Add Reproducible Error Injection"
I want to add an executable testrun.sh script to the fuzz directory.
Ideally I would like to set the executable bit on that file,
but unfortunately this confuses the CIFuzz build.

This excludes *.sh from the find command in build.sh