### PR TITLE
infra: fix per-target coverage html generation

### DIFF
--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -387,7 +387,7 @@ else
     fi
 
     report_dir=$REPORT_BY_TARGET_ROOT_DIR/$fuzz_target
-    generate_html $profdata_path "$shared_libraries" "$objects" "$report_dir"
+    generate_html $profdata_path "$shared_libraries" "$fuzz_target" "$report_dir"
   done
 fi
 


### PR DESCRIPTION
When generating coverage reports for single targets we should not
include all fuzz targets (in the $objects var), but only the object
(binary file) for the given target.

Ref: https://github.com/ossf/fuzz-introspector/issues/340

The current set up clutters the per target coverage reports. An example is https://storage.googleapis.com/oss-fuzz-coverage/apache-httpd/reports-by-target/20220629/fuzz_preq/linux/src/report.html which is for the target "fuzz_preq", but as can be seen in the html the coverage report contains source for multiple fuzzers and the `fuzz_preg.c` itself has no coverage (which is the one that should have). This fixes it.