### PR TITLE
Submit itoa and ryu.

### DIFF
--- a/projects/itoa/Dockerfile
+++ b/projects/itoa/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder-rust
 
 RUN git clone --depth 1 https://github.com/dtolnay/itoa
-COPY fuzz $SRC/zip/fuzz
+COPY fuzz $SRC/itoa/fuzz
 WORKDIR $SRC
 
 COPY build.sh $SRC/

--- a/projects/itoa/Dockerfile
+++ b/projects/itoa/Dockerfile
@@ -14,8 +14,10 @@
 #
 ################################################################################
 
-FROM rustlang/rust:nightly
-WORKDIR /itoa
-COPY . .
-RUN cargo install cargo-fuzz
-RUN cargo fuzz run decode -- -runs=0
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+
+RUN git clone --depth 1 https://github.com/dtolnay/itoa
+COPY fuzz $SRC/zip/fuzz
+WORKDIR $SRC
+
+COPY build.sh $SRC/

--- a/projects/itoa/Dockerfile
+++ b/projects/itoa/Dockerfile
@@ -1,0 +1,5 @@
+FROM rustlang/rust:nightly
+WORKDIR /itoa
+COPY . .
+RUN cargo install cargo-fuzz
+RUN cargo fuzz run decode -- -runs=0

--- a/projects/itoa/Dockerfile
+++ b/projects/itoa/Dockerfile
@@ -17,7 +17,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder-rust
 
 RUN git clone --depth 1 https://github.com/dtolnay/itoa
-COPY fuzz $SRC/itoa/fuzz
 WORKDIR $SRC
 
 COPY build.sh $SRC/

--- a/projects/itoa/Dockerfile
+++ b/projects/itoa/Dockerfile
@@ -1,3 +1,19 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
 FROM rustlang/rust:nightly
 WORKDIR /itoa
 COPY . .

--- a/projects/itoa/build.sh
+++ b/projects/itoa/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -eu
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC
+cd itoa
+cargo fuzz build -O
+cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_itoa $OUT/

--- a/projects/itoa/project.yaml
+++ b/projects/itoa/project.yaml
@@ -1,5 +1,6 @@
 homepage: "https://github.com/dtolnay/itoa"
 primary_contact: "dtolnay@gmail.com"
+main_repo: "https://github.com/dtolnay/itoa"
 sanitizers:
   - address
 fuzzing_engines:

--- a/projects/itoa/project.yaml
+++ b/projects/itoa/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/dtolnay/itoa"
+primary_contact: "dtolnay@gmail.com"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+language: rust
+auto_ccs:
+  - "adetaylor@chromium.org"

--- a/projects/ryu/Dockerfile
+++ b/projects/ryu/Dockerfile
@@ -1,0 +1,5 @@
+FROM rustlang/rust:nightly
+WORKDIR /ryu
+COPY . .
+RUN cargo install cargo-fuzz
+RUN cargo fuzz run decode -- -runs=0

--- a/projects/ryu/Dockerfile
+++ b/projects/ryu/Dockerfile
@@ -14,8 +14,10 @@
 #
 ################################################################################
 
-FROM rustlang/rust:nightly
-WORKDIR /ryu
-COPY . .
-RUN cargo install cargo-fuzz
-RUN cargo fuzz run decode -- -runs=0
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+
+RUN git clone --depth 1 https://github.com/dtolnay/ryu
+COPY fuzz $SRC/zip/fuzz
+WORKDIR $SRC
+
+COPY build.sh $SRC/

--- a/projects/ryu/Dockerfile
+++ b/projects/ryu/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder-rust
 
 RUN git clone --depth 1 https://github.com/dtolnay/ryu
-COPY fuzz $SRC/zip/fuzz
+COPY fuzz $SRC/ryu/fuzz
 WORKDIR $SRC
 
 COPY build.sh $SRC/

--- a/projects/ryu/Dockerfile
+++ b/projects/ryu/Dockerfile
@@ -1,3 +1,19 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
 FROM rustlang/rust:nightly
 WORKDIR /ryu
 COPY . .

--- a/projects/ryu/Dockerfile
+++ b/projects/ryu/Dockerfile
@@ -17,7 +17,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder-rust
 
 RUN git clone --depth 1 https://github.com/dtolnay/ryu
-COPY fuzz $SRC/ryu/fuzz
 WORKDIR $SRC
 
 COPY build.sh $SRC/

--- a/projects/ryu/build.sh
+++ b/projects/ryu/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -eu
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC
+cd ryu
+cargo fuzz build -O
+cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_ryu $OUT/

--- a/projects/ryu/project.yaml
+++ b/projects/ryu/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/dtolnay/ryu"
+main_repo: "https://github.com/dtolnay/ryu"
 primary_contact: "dtolnay@gmail.com"
 sanitizers:
   - address

--- a/projects/ryu/project.yaml
+++ b/projects/ryu/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/dtolnay/ryu"
+primary_contact: "dtolnay@gmail.com"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+language: rust
+auto_ccs:
+  - "adetaylor@chromium.org"


### PR DESCRIPTION
These two libraries are used by serde_json which, in turn, is used as the
standard JSON parser in various higher level projects. Both itoa and ryu
contain unsafe code, which this fuzzes.