### PR TITLE
libidn: fix build.

### DIFF
--- a/projects/libidn/Dockerfile
+++ b/projects/libidn/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y \
  libtool \
  gettext gengetopt curl gperf wget
 
-RUN git clone --depth=1 https://git.savannah.gnu.org/git/libidn.git
+RUN git clone https://git.savannah.gnu.org/git/libidn.git
 
 WORKDIR libidn
 COPY build.sh $SRC/

--- a/projects/libidn/build.sh
+++ b/projects/libidn/build.sh
@@ -18,7 +18,7 @@
 # avoid iconv() memleak on Ubuntu 16.04 image (breaks test suite)
 export ASAN_OPTIONS=detect_leaks=0
 
-./bootstrap
+./bootstrap --skip-po
 ./configure --enable-static --disable-doc
 make -j
 make -j check


### PR DESCRIPTION
This should fix the failing build -- it actually was broken before, but we recently added a self-check to check for this kind of failure (version number errors) and it broke the fuzz build.  I also dropped download of *.po files on every bootstrap...