### PR TITLE
lzo: unpoison the working buffer

### DIFF
--- a/projects/lzo/all_lzo_compress.cc
+++ b/projects/lzo/all_lzo_compress.cc
@@ -202,6 +202,10 @@ void FuzzLzoAlgorithm(const LzoAlgorithm& algorithm,
   std::unique_ptr<uint8_t[]> compressed_buffer(
       new uint8_t[algorithm.GetMaxCompressedSize(input_buffer.size())]);
 
+#if MEMORY_SANITIZER
+  __msan_unpoison(working_buffer.get(), algorithm.working_memory_size);
+#endif
+
   lzo_uint compressed_size;
   if (algorithm.compress_fn(input_buffer.data(), input_buffer.size(),
                             compressed_buffer.get(), &compressed_size,


### PR DESCRIPTION
The compression function appears to account for the possibility that the
buffer contains random values, but msan does not realize that.

Initializing the buffer would be another option, but mere unpoisoning
maintains the ability to detect flaws in the way that the library
handles such uninitialized buffers. (Although, arguably, perhaps this
would be better served by separate fuzzing, which would also make such
findings more reproducible.)

This fixes b/154387018.