### PR TITLE
Adding lib32stdc++6 to base-runner

### DIFF
--- a/infra/base-images/base-runner/Dockerfile
+++ b/infra/base-images/base-runner/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update && apt-get install -y \
     git \
     lib32gcc1 \
     libc6-i386 \
+    lib32stdc++6 \
     libcap2 \
     python3 \
     python3-pip \


### PR DESCRIPTION
lib32stdc++6 is missing for 32bits target. I tried to understand why target with i386 architecture enabled are passing test_all.py in base-runner, and it seems they do not depend of this library in the final build.
I took as an example https://github.com/google/oss-fuzz/tree/master/projects/openh264, as we can see this target does not have libstdc++.so.6 as a dependency:
```➜  libfuzzer-address-i386 ldd decoder_fuzzer
./decoder_fuzzer: /lib/i386-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by ./decoder_fuzzer)
        linux-gate.so.1 (0xf7eee000)
        libm.so.6 => /lib/i386-linux-gnu/libm.so.6 (0xf7dd2000)
        libpthread.so.0 => /lib/i386-linux-gnu/libpthread.so.0 (0xf7db2000)
        librt.so.1 => /lib/i386-linux-gnu/librt.so.1 (0xf7da8000)
        libdl.so.2 => /lib/i386-linux-gnu/libdl.so.2 (0xf7da3000)
        libgcc_s.so.1 => /lib/i386-linux-gnu/libgcc_s.so.1 (0xf7d85000)
        libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf7ba9000)
        /lib/ld-linux.so.2 (0xf7eef000)
```

However with a target that needs it, we get:
```
root@08fe95743993:/workspace/out/libfuzzer-address-i386# ldd fuzz
        linux-gate.so.1 (0xf7f36000)
        libstdc++.so.6 => not found
        libm.so.6 => /lib32/libm.so.6 (0xf7e29000)
        libpthread.so.0 => /lib32/libpthread.so.0 (0xf7e06000)
        librt.so.1 => /lib32/librt.so.1 (0xf7dfa000)
        libdl.so.2 => /lib32/libdl.so.2 (0xf7df4000)
        libgcc_s.so.1 => /lib32/libgcc_s.so.1 (0xf7dd5000)
        libc.so.6 => /lib32/libc.so.6 (0xf7be9000)
        /lib/ld-linux.so.2 (0xf7f37000)
root@08fe95743993:/workspace/out/libfuzzer-address-i386# ./fuzz
./fuzz: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory
```
The build itself works perfectly fine though, as the package libstdc++-9-dev:i386 is install in the [Dockerfile](https://github.com/google/oss-fuzz/blob/master/projects/openh264/Dockerfile#L19)
