### PR TITLE
execSan: Don't exit on reporting a bug.

### DIFF
--- a/infra/experimental/sanitizers/ExecSan/execSan.cpp
+++ b/infra/experimental/sanitizers/ExecSan/execSan.cpp
@@ -178,7 +178,6 @@ void report_bug(std::string bug_type) {
   // Note: this may not be reliable or consistent if shell injection happens
   // in an async way.
   kill(g_root_pid, SIGABRT);
-  _exit(0);
 }
 
 void inspect_for_injection(pid_t pid, const user_regs_struct &regs) {


### PR DESCRIPTION
This causes race conditions with stacktrace printing and does not return
the same exit code as the child process.

Just send the SIGABRT and let our tracing handle the exit.