### PR TITLE
gonids: use out dir with env variable

### DIFF
--- a/projects/gonids/build.sh
+++ b/projects/gonids/build.sh
@@ -31,7 +31,7 @@ mv $SRC/goroot /root/.go
 
 compile_go_fuzzer github.com/google/gonids FuzzParseRule fuzz_parserule
 
-base64 /out/fuzz_parserule
+base64 $OUT/fuzz_parserule
 
 cd $SRC
 unzip emerging.rules.zip


### PR DESCRIPTION
Should fix build failure