### PR TITLE
[cryptofuzz] Disable special ECDH

### DIFF
--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -57,6 +57,10 @@ git clone https://github.com/golang/sys.git $GOPATH/src/golang.org/x/sys
 # This enables runtime checks for C++-specific undefined behaviour.
 export CXXFLAGS="$CXXFLAGS -D_GLIBCXX_DEBUG"
 
+# wolfCrypt uses a slightly different ECDH algorithm than Trezor and libsecp256k1.
+# This disables running ECDH in Trezor and libsecp256k1 to prevent mismatches.
+export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_DISABLE_SPECIAL_ECDH"
+
 export CXXFLAGS="$CXXFLAGS -I $SRC/cryptofuzz/fuzzing-headers/include"
 if [[ $CFLAGS = *sanitize=memory* ]]
 then


### PR DESCRIPTION
wolfCrypt uses a a slightly different ECDH algorithm than Trezor and libsecp256k1. This leads to spurious reports like this one https://oss-fuzz.com/testcase-detail/4776022191505408

To prevent these reports, this PR disables running ECDH in libsecp256k1 and Trezor in the `cryptofuzz` project. This is OK because Trezor and libsecp256k1 are tested against each other in the `bitcoin-core` project, so bugs in either library will transpire there.