### PR TITLE
[OpenTTD] Add project file

### DIFF
--- a/projects/openttd/project.yaml
+++ b/projects/openttd/project.yaml
@@ -1,0 +1,4 @@
+homepage: "https://www.openttd.org"
+language: c++
+primary_contact: "truebrain@openttd.org"
+main_repo: "https://github.com/OpenTTD/OpenTTD"


### PR DESCRIPTION
Lately I have been running AFL++ over our network handling of [OpenTTD](https://www.openttd.org), all with the goal that remote clients cannot crash servers. Found plenty of small (and bigger) bugs, and hopefully fixed them all. But the amount of fuzzing I can do locally is finite.

Before I start working on the integration with oss-fuzz, I was wondering if you guys accept games like OpenTTD. As far as Open Source games go, we are relatively popular, with thousands of players a month. Having hardening like this would greatly help us, but I can also understand if that is not in line with the idea of oss-fuzz (at least I couldn't find any other games currently in the projects; but maybe we are setting a trend here ;)).

It has to be mentioned that the fuzzing will run at ~50 executions a second on my local machine. It is very slow, as OpenTTD's state is immensely complex. To keep stability at 100%, it needs to fork for every attempt.