### PR TITLE
projects: libwebsockets: change primary_contact

### DIFF
--- a/projects/libwebsockets/project.yaml
+++ b/projects/libwebsockets/project.yaml
@@ -1,6 +1,6 @@
 homepage: "https://libwebsockets.org"
 language: c
-primary_contact: "andy@warmcat.com"
+primary_contact: "andy.warmcat.com@googlemail.com"
 sanitizers:
   - address
 fuzzing_engines:


### PR DESCRIPTION
Google requires the primary_contact is not the alternate email on a google
account.

https://github.com/google/oss-fuzz/issues/7985