### PR TITLE
istio: switch to standard base-builder-go

### DIFF
--- a/projects/istio/Dockerfile
+++ b/projects/istio/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-go-codeintelligencetesting
+FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN git clone --depth 1 https://github.com/istio/istio
 COPY build.sh $SRC/
 WORKDIR $SRC/istio

--- a/projects/istio/Dockerfile
+++ b/projects/istio/Dockerfile
@@ -14,6 +14,7 @@
 #
 ################################################################################
 
+# Setup the builder for Istio. The standard Go builder is sufficient.
 FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN git clone --depth 1 https://github.com/istio/istio
 COPY build.sh $SRC/


### PR DESCRIPTION
This is required to use the Go 1.18 native fuzzing