### PR TITLE
[flac] Disable _FORTIFY_SOURCE for all sanitizers

### DIFF
--- a/projects/flac/build.sh
+++ b/projects/flac/build.sh
@@ -27,7 +27,8 @@ then
     export CXXFLAGS="$CXXFLAGS -DMSAN"
 fi
 
-export CXXFLAGS="$CXXFLAGS -D_GLIBCXX_DEBUG"
+export CFLAGS="$CFLAGS -D_FORTIFY_SOURCE=0"
+export CXXFLAGS="$CXXFLAGS -D_FORTIFY_SOURCE=0 -D_GLIBCXX_DEBUG"
 
 # Build libogg
 mkdir $SRC/libogg-install
@@ -42,7 +43,6 @@ cd $SRC/flac/
 ./autogen.sh
 if [[ $CFLAGS = *sanitize=memory* ]]
 then
-    export CFLAGS="$CFLAGS -D_FORTIFY_SOURCE=0"
     LD_LIBRARY_PATH="$SRC/libogg-install/lib" ./configure --with-ogg="$SRC/libogg-install" --enable-static --disable-shared --disable-oggtest --disable-examples --disable-xmms-plugin --disable-asm-optimizations --disable-sse --enable-oss-fuzzers
 else
     LD_LIBRARY_PATH="$SRC/libogg-install/lib" ./configure --with-ogg="$SRC/libogg-install" --enable-static --disable-shared --disable-oggtest --disable-examples --disable-xmms-plugin --enable-oss-fuzzers


### PR DESCRIPTION
Since adding fuzzer_metadata in #7975, there are about ~100 unreproducible crashes each day. I do not encounter these when running that fuzzer on my own device (with the provided images through docker) so I cannot work out what the problem is. However, seeing I had problems with _FORTIFY_SOURCE and MSAN earlier and the combination of _FORTIFY_SOURCE and ASAN can produce weird behaviour, it seems best to force _FORTIFY_SOURCE off for all sanitizers anyway.