### PR TITLE
ghostscript: add tiff fuzzer

### DIFF
--- a/projects/ghostscript/build.sh
+++ b/projects/ghostscript/build.sh
@@ -45,7 +45,7 @@ CPPFLAGS="${CPPFLAGS:-} $CUPS_CFLAGS -DPACIFY_VALGRIND" ./autogen.sh \
   CUPSCONFIG=$CUPSCONFIG \
   --enable-freetype --enable-fontconfig \
   --enable-cups --with-ijs --with-jbig2dec \
-  --with-drivers=pdfwrite,cups,ljet4,laserjet,pxlmono,pxlcolor,pcl3,uniprint,pgmraw,ps2write,png16m
+  --with-drivers=pdfwrite,cups,ljet4,laserjet,pxlmono,pxlcolor,pcl3,uniprint,pgmraw,ps2write,png16m,tiffsep1
 make -j$(nproc) libgs
 
 fuzzers="gstoraster_fuzzer            \
@@ -56,7 +56,8 @@ fuzzers="gstoraster_fuzzer            \
          gs_device_pxlmono_fuzzer     \
          gs_device_pgmraw_fuzzer      \
          gs_device_ps2write_fuzzer    \
-         gs_device_png16m_fuzzer"
+         gs_device_png16m_fuzzer      \
+         gs_device_tiffsep1_fuzzer"
 
 for fuzzer in $fuzzers; do
   $CXX $CXXFLAGS $CUPS_LDFLAGS -std=c++11 -I. -I$SRC \

--- a/projects/ghostscript/gs_device_pdfwrite_fuzzer.cc
+++ b/projects/ghostscript/gs_device_pdfwrite_fuzzer.cc
@@ -15,6 +15,6 @@ limitations under the License.
 #include "gs_fuzzlib.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-	fuzz_gs_device(data, size, 1, "pdfwrite");
+	fuzz_gs_device(data, size, 1, "pdfwrite", "/dev/null");
 	return 0;
 }

--- a/projects/ghostscript/gs_device_pgmraw_fuzzer.cc
+++ b/projects/ghostscript/gs_device_pgmraw_fuzzer.cc
@@ -15,6 +15,6 @@ limitations under the License.
 #include "gs_fuzzlib.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-	fuzz_gs_device(data, size, 1, "pgmraw");
+	fuzz_gs_device(data, size, 1, "pgmraw", "/dev/null");
 	return 0;
 }

--- a/projects/ghostscript/gs_device_png16m_fuzzer.cc
+++ b/projects/ghostscript/gs_device_png16m_fuzzer.cc
@@ -15,6 +15,6 @@ limitations under the License.
 #include "gs_fuzzlib.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-	fuzz_gs_device(data, size, 1, "png16m");
+	fuzz_gs_device(data, size, 1, "png16m", "/dev/null");
 	return 0;
 }

--- a/projects/ghostscript/gs_device_ps2write_fuzzer.cc
+++ b/projects/ghostscript/gs_device_ps2write_fuzzer.cc
@@ -15,6 +15,6 @@ limitations under the License.
 #include "gs_fuzzlib.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-	fuzz_gs_device(data, size, 1, "ps2write");
+	fuzz_gs_device(data, size, 1, "ps2write", "/dev/null");
 	return 0;
 }

--- a/projects/ghostscript/gs_device_tiffsep1_fuzzer.cc
+++ b/projects/ghostscript/gs_device_tiffsep1_fuzzer.cc
@@ -15,6 +15,8 @@ limitations under the License.
 #include "gs_fuzzlib.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-	fuzz_gs_device(data, size, 1, "pxlmono", "/dev/null");
+  char filename[256];
+  sprintf(filename, "/tmp/libfuzzer.%d.tiff", getpid());
+	fuzz_gs_device(data, size, 1, "tiffsep1", filename);
 	return 0;
 }

--- a/projects/ghostscript/gs_device_tiffsep1_fuzzer.cc
+++ b/projects/ghostscript/gs_device_tiffsep1_fuzzer.cc
@@ -12,6 +12,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+#include <sys/types.h>
+#include <unistd.h>
+#include <stdio.h>
+
 #include "gs_fuzzlib.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {

--- a/projects/ghostscript/gs_device_tiffsep1_fuzzer.cc
+++ b/projects/ghostscript/gs_device_tiffsep1_fuzzer.cc
@@ -19,8 +19,8 @@ limitations under the License.
 #include "gs_fuzzlib.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-  char filename[256];
-  sprintf(filename, "/tmp/libfuzzer.%d.tiff", getpid());
+	char filename[256];
+	sprintf(filename, "/tmp/libfuzzer.%d.tiff", getpid());
 	fuzz_gs_device(data, size, 1, "tiffsep1", filename);
 	return 0;
 }

--- a/projects/ghostscript/gs_fuzzlib.h
+++ b/projects/ghostscript/gs_fuzzlib.h
@@ -31,7 +31,8 @@ int fuzz_gs_device(
 	const unsigned char *buf,
 	size_t size,
 	int color_scheme,
-	const char *device_target
+	const char *device_target,
+	const char *output_file
 );
 
 #define min(x, y) ((x) < (y) ? (x) : (y))
@@ -61,28 +62,30 @@ int gs_to_raster_fuzz(
 	int color_scheme
 )
 {
-	return fuzz_gs_device(buf, size, color_scheme, "cups");
+	return fuzz_gs_device(buf, size, color_scheme, "cups", "/dev/null");
 }
 
 int fuzz_gs_device(
 	const unsigned char *buf,
 	size_t size,
 	int color_scheme,
-	const char *device_target
+	const char *device_target,
+	const char *output_file,
 )
 {
 	int ret;
 	void *gs = NULL;
 	char color_space[50];
 	char gs_device[50];
+	char gs_o[100];
 	/*
 	 * We are expecting color_scheme to be in the [0:62] interval.
 	 * This corresponds to the color schemes defined here:
 	 * https://github.com/ArtifexSoftware/ghostpdl/blob/8c97d5adce0040ac38a1fb4d7954499c65f582ff/cups/libs/cups/raster.h#L102
 	 */
 	sprintf(color_space, "-dcupsColorSpace=%d", color_scheme);
-
 	sprintf(gs_device, "-sDEVICE=%s", device_target);
+	sprintf(gs_o, "-sOutputFile=%s", output_file)
 	/* Mostly stolen from cups-filters gstoraster. */
 	char *args[] = {
 		"gs",
@@ -100,7 +103,7 @@ int fuzz_gs_device(
 		"-dNOINTERPOLATE",
 		"-dNOMEDIAATTRS",
 		"-sstdout=%%stderr",
-		"-sOutputFile=/dev/null",
+		gs_o,
 		gs_device,
 		"-_",
 	};

--- a/projects/ghostscript/gs_fuzzlib.h
+++ b/projects/ghostscript/gs_fuzzlib.h
@@ -70,7 +70,7 @@ int fuzz_gs_device(
 	size_t size,
 	int color_scheme,
 	const char *device_target,
-	const char *output_file,
+	const char *output_file
 )
 {
 	int ret;
@@ -85,7 +85,7 @@ int fuzz_gs_device(
 	 */
 	sprintf(color_space, "-dcupsColorSpace=%d", color_scheme);
 	sprintf(gs_device, "-sDEVICE=%s", device_target);
-	sprintf(gs_o, "-sOutputFile=%s", output_file)
+	sprintf(gs_o, "-sOutputFile=%s", output_file);
 	/* Mostly stolen from cups-filters gstoraster. */
 	char *args[] = {
 		"gs",


### PR DESCRIPTION
Similar to all other devices with exception it writes to file instead of
/dev/null. This is needed because tiff writing requires seek abilities.