### PR TITLE
mosh: fix code coverage

### DIFF
--- a/projects/mosh/Dockerfile
+++ b/projects/mosh/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y autoconf automake protobuf-compiler \
-    libprotobuf-dev pkg-config zlib1g-dev libncurses5-dev libssl-dev clang
+    libprotobuf-dev pkg-config zlib1g-dev libncurses5-dev libssl-dev clang lcov
 RUN git clone --depth 1 https://github.com/mobile-shell/mosh.git
 WORKDIR mosh
 COPY build.sh $SRC/


### PR DESCRIPTION
Update Mosh’s `build.sh` to pass appropriate configure options when coverage is requested, as well as to pass `CXXFLAGS` through to the actual build. These fix ClusterFuzz code coverage reports.

Along the way, enable verbose build rules, since they’re useful for debugging build failures.