### PR TITLE
pdfium: initial integration

### DIFF
--- a/projects/pdfium/BUILD.gn
+++ b/projects/pdfium/BUILD.gn
@@ -1,0 +1,293 @@
+# Copyright 2018 The PDFium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("../pdfium.gni")
+#import("fuzzers/")
+
+source_set("test_support") {
+  testonly = true
+  sources = [
+    "font_renamer.cpp",
+    "font_renamer.h",
+    "fx_string_testhelpers.cpp",
+    "fx_string_testhelpers.h",
+    "invalid_seekable_read_stream.cpp",
+    "invalid_seekable_read_stream.h",
+    "pseudo_retainable.h",
+    "scoped_set_tz.cpp",
+    "scoped_set_tz.h",
+    "string_write_stream.cpp",
+    "string_write_stream.h",
+    "test_fonts.cpp",
+    "test_fonts.h",
+    "test_loader.cpp",
+    "test_loader.h",
+    "test_support.h",
+    "utils/bitmap_saver.cpp",
+    "utils/bitmap_saver.h",
+    "utils/file_util.cpp",
+    "utils/file_util.h",
+    "utils/hash.cpp",
+    "utils/hash.h",
+  ]
+  data = [ "resources/" ]
+  public_deps = [
+    ":path_service",
+    "//third_party/test_fonts",
+  ]
+  deps = [
+    "../:pdfium_public_headers",
+    "../core/fdrm",
+    "../core/fxcrt",
+    "../core/fxge",
+    "image_diff",
+  ]
+  configs += [
+    "../:pdfium_strict_config",
+    "../:pdfium_noshorten_config",
+  ]
+  visibility = [ "../*" ]
+  if (pdf_enable_v8) {
+    sources += [
+      "v8_initializer.cpp",
+      "v8_initializer.h",
+    ]
+    deps += [
+      "//v8",
+      "//v8:v8_libplatform",
+    ]
+    configs += [ "//v8:external_startup_data" ]
+  }
+}
+
+executable("pdf_cmap_fuzzer") {
+  sources = [
+    "fuzzers/pdf_cmap_fuzzer.cc"
+  ]
+  deps = [
+    "../:freetype_common",
+    "../core/fpdfapi/font",
+    "../core/fxcrt",
+  ]
+  cflags = [ "-fsanitize=fuzzer-no-link" ]
+  ldflags = [ "-fsanitize=fuzzer,address" ]
+}
+
+source_set("fuzzer_helper") {
+  sources = [
+    "fuzzers/pdfium_fuzzer_helper.cc",
+    "fuzzers/pdfium_fuzzer_helper.h",
+  ]
+  deps = [
+    "../:pdfium_public_headers",
+    "../fpdfsdk",
+  ]
+}
+
+executable("pdfium_xfa_fuzzer") {
+  sources = [
+    "fuzzers/pdfium_xfa_fuzzer.cc"
+  ]
+  deps = [
+    ":fuzzer_helper",
+    "../:pdfium_public_headers"
+  ]
+  cflags = [ "-fsanitize=fuzzer-no-link" ]
+  ldflags = [ "-fsanitize=fuzzer,address" ]
+}
+
+executable("pdf_cjs_util_fuzzer") {
+  sources = [
+    "fuzzers/pdf_cjs_util_fuzzer.cc"
+  ]
+  deps = [
+    "../core/fxcrt",
+    "../fpdfsdk",
+    "../fxjs"
+  ]
+  cflags = [ "-fsanitize=fuzzer-no-link" ]
+  ldflags = [ "-fsanitize=fuzzer,address" ]
+}
+
+executable("pdf_formcalc_context_fuzzer") {
+  sources = [ "fuzzers/pdf_formcalc_context_fuzzer.cc" ]
+  deps = [
+    ":fuzzer_helper",
+    "../:pdfium_public_headers",
+    "../core/fxcrt",
+    "../fpdfsdk",
+    "../fpdfsdk/fpdfxfa",
+    "../fxjs",
+    "../xfa/fxfa"
+  ]
+  cflags = [ "-fsanitize=fuzzer-no-link" ]
+  ldflags = [ "-fsanitize=fuzzer,address" ]
+}
+
+executable("pdf_jpx_fuzzer") {
+  sources = [ "fuzzers/pdf_jpx_fuzzer.cc" ]
+  deps = [
+    "../core/fpdfapi/page",
+    "../core/fxcodec",
+    "../core/fxcrt",
+    "../core/fxge",
+  ]
+  cflags = [ "-fsanitize=fuzzer-no-link" ]
+  ldflags = [ "-fsanitize=fuzzer,address" ]
+}
+
+source_set("path_service") {
+  testonly = true
+  sources = [
+    "utils/path_service.cpp",
+    "utils/path_service.h",
+  ]
+  deps = [ "../core/fxcrt" ]
+  configs += [
+    "../:pdfium_strict_config",
+    "../:pdfium_noshorten_config",
+  ]
+  visibility = [ "../*" ]
+}
+
+source_set("test_environments") {
+  testonly = true
+  sources = [
+    "pdf_test_environment.cpp",
+    "pdf_test_environment.h",
+  ]
+  deps = [
+    ":test_support",
+    "../core/fxcrt",
+    "../core/fxge",
+    "//testing/gtest",
+  ]
+  configs += [
+    "../:pdfium_strict_config",
+    "../:pdfium_noshorten_config",
+  ]
+  if (pdf_enable_v8) {
+    sources += [
+      "v8_test_environment.cpp",
+      "v8_test_environment.h",
+    ]
+    deps += [
+      "../fxjs",
+      "//v8",
+      "//v8:v8_libplatform",
+    ]
+    configs += [ "//v8:external_startup_data" ]
+  }
+  if (pdf_enable_xfa) {
+    sources += [
+      "xfa_test_environment.cpp",
+      "xfa_test_environment.h",
+    ]
+    deps += [
+      "../fxjs:gc",
+      "../xfa/fgas/font",
+    ]
+  }
+}
+
+source_set("unit_test_support") {
+  testonly = true
+  sources = []
+  deps = []
+  configs += [
+    "../:pdfium_strict_config",
+    "../:pdfium_noshorten_config",
+  ]
+  public_deps = [
+    ":test_environments",
+    ":test_support",
+  ]
+  if (pdf_enable_v8) {
+    sources += [
+      "fxv8_unittest.cpp",
+      "fxv8_unittest.h",
+    ]
+    deps += [
+      "../fxjs",
+      "//testing/gtest",
+    ]
+    configs += [ "//v8:external_startup_data" ]
+    if (pdf_enable_xfa) {
+      sources += [
+        "fxgc_unittest.cpp",
+        "fxgc_unittest.h",
+      ]
+      deps += [
+        "../fxjs:gc",
+        "//testing/gtest",
+      ]
+    }
+  }
+}
+
+source_set("embedder_test_support") {
+  testonly = true
+  sources = [
+    "embedder_test.cpp",
+    "embedder_test.h",
+    "embedder_test_constants.cpp",
+    "embedder_test_constants.h",
+    "embedder_test_environment.cpp",
+    "embedder_test_environment.h",
+    "embedder_test_mock_delegate.h",
+    "embedder_test_timer_handling_delegate.h",
+    "fake_file_access.cpp",
+    "fake_file_access.h",
+    "range_set.cpp",
+    "range_set.h",
+  ]
+  deps = [
+    "../:pdfium_public_headers",
+    "../core/fdrm",
+    "../core/fxcrt",
+    "../core/fxge",
+    "../third_party:pdfium_base",
+    "//testing/gmock",
+    "//testing/gtest",
+  ]
+  public_deps = [
+    ":test_environments",
+    ":test_support",
+  ]
+  configs += [
+    "../:pdfium_strict_config",
+    "../:pdfium_noshorten_config",
+  ]
+  visibility = [ "../*" ]
+  if (pdf_enable_v8) {
+    sources += [
+      "external_engine_embedder_test.cpp",
+      "external_engine_embedder_test.h",
+      "js_embedder_test.cpp",
+      "js_embedder_test.h",
+    ]
+    deps += [
+      "../fxjs",
+      "//v8",
+      "//v8:v8_libplatform",
+    ]
+    configs += [ "//v8:external_startup_data" ]
+    if (pdf_enable_xfa) {
+      sources += [
+        "xfa_js_embedder_test.cpp",
+        "xfa_js_embedder_test.h",
+      ]
+      deps += [
+        "../fpdfsdk",
+        "../fpdfsdk/fpdfxfa",
+        "../xfa/fxfa",
+        "../xfa/fxfa/parser",
+      ]
+    }
+  }
+}
+
+# Dummy group to keep satisfy references from //build.
+group("test_scripts_shared") {
+}

--- a/projects/pdfium/Dockerfile
+++ b/projects/pdfium/Dockerfile
@@ -1,0 +1,33 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make cmake
+
+RUN cd $SRC && mkdir dep_tools && \
+    cd dep_tools && \
+    git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+ENV PATH="${PATH}:$SRC/dep_tools/depot_tools/"
+
+RUN cd $SRC && \
+    mkdir repo && cd repo && \
+    gclient config --unmanaged https://pdfium.googlesource.com/pdfium.git && \
+    gclient sync
+
+RUN apt-get update && apt-get install -y sudo
+
+WORKDIR $SRC
+COPY build.sh args.gn OSS_FUZZ_BUILD.gn clang_BUILD.gn *.gni cov_args.gn $SRC/

--- a/projects/pdfium/OSS_FUZZ_BUILD.gn
+++ b/projects/pdfium/OSS_FUZZ_BUILD.gn
@@ -1,0 +1,304 @@
+# Copyright 2018 The PDFium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("../pdfium.gni")
+#import("fuzzers/")
+
+source_set("test_support") {
+  testonly = true
+  sources = [
+    "font_renamer.cpp",
+    "font_renamer.h",
+    "fx_string_testhelpers.cpp",
+    "fx_string_testhelpers.h",
+    "invalid_seekable_read_stream.cpp",
+    "invalid_seekable_read_stream.h",
+    "pseudo_retainable.h",
+    "scoped_set_tz.cpp",
+    "scoped_set_tz.h",
+    "string_write_stream.cpp",
+    "string_write_stream.h",
+    "test_fonts.cpp",
+    "test_fonts.h",
+    "test_loader.cpp",
+    "test_loader.h",
+    "test_support.h",
+    "utils/bitmap_saver.cpp",
+    "utils/bitmap_saver.h",
+    "utils/file_util.cpp",
+    "utils/file_util.h",
+    "utils/hash.cpp",
+    "utils/hash.h",
+  ]
+  data = [ "resources/" ]
+  public_deps = [
+    ":path_service",
+    "//third_party/test_fonts",
+  ]
+  deps = [
+    "../:pdfium_public_headers",
+    "../core/fdrm",
+    "../core/fxcrt",
+    "../core/fxge",
+    "image_diff",
+  ]
+  configs += [
+    "../:pdfium_strict_config",
+    "../:pdfium_noshorten_config",
+  ]
+  visibility = [ "../*" ]
+  if (pdf_enable_v8) {
+    sources += [
+      "v8_initializer.cpp",
+      "v8_initializer.h",
+    ]
+    deps += [
+      "//v8",
+      "//v8:v8_libplatform",
+    ]
+    configs += [ "//v8:external_startup_data" ]
+  }
+}
+
+executable("pdf_cmap_fuzzer") {
+  sources = [
+    "fuzzers/pdf_cmap_fuzzer.cc"
+  ]
+  deps = [
+    "../:freetype_common",
+    "../core/fpdfapi/font",
+    "../core/fxcrt",
+  ]
+  cflags = [ "FUZZCFLAGS" ]
+  ldflags = [ "FUZZLDFLAGS" ]
+}
+
+source_set("fuzzer_helper") {
+  sources = [
+    "fuzzers/pdfium_fuzzer_helper.cc",
+    "fuzzers/pdfium_fuzzer_helper.h",
+  ]
+  deps = [
+    "../:pdfium_public_headers",
+    "../fpdfsdk",
+  ]
+}
+
+executable("pdfium_xfa_fuzzer") {
+  sources = [
+    "fuzzers/pdfium_xfa_fuzzer.cc"
+  ]
+  deps = [
+    ":fuzzer_helper",
+    "../:pdfium_public_headers"
+  ]
+  cflags = [ "-fsanitize=fuzzer-no-link" ]
+  ldflags = [ "-fsanitize=fuzzer,address" ]
+}
+
+executable("pdf_cjs_util_fuzzer") {
+  sources = [
+    "fuzzers/pdf_cjs_util_fuzzer.cc"
+  ]
+  deps = [
+    "../core/fxcrt",
+    "../fpdfsdk",
+    "../fxjs"
+  ]
+  cflags = [ "-fsanitize=fuzzer-no-link" ]
+  ldflags = [ "-fsanitize=fuzzer,address" ]
+}
+
+executable("pdfium_fuzzer") {
+  sources = [
+    "fuzzers/pdfium_fuzzer.cc"
+  ]
+  deps = [
+    ":fuzzer_helper"
+  ]
+  cflags = [ "-fsanitize=fuzzer-no-link" ]
+  ldflags = [ "-fsanitize=fuzzer,address" ]
+}
+
+executable("pdf_formcalc_context_fuzzer") {
+  sources = [ "fuzzers/pdf_formcalc_context_fuzzer.cc" ]
+  deps = [
+    ":fuzzer_helper",
+    "../:pdfium_public_headers",
+    "../core/fxcrt",
+    "../fpdfsdk",
+    "../fpdfsdk/fpdfxfa",
+    "../fxjs",
+    "../xfa/fxfa"
+  ]
+  cflags = [ "-fsanitize=fuzzer-no-link" ]
+  ldflags = [ "-fsanitize=fuzzer,address" ]
+}
+
+executable("pdf_jpx_fuzzer") {
+  sources = [ "fuzzers/pdf_jpx_fuzzer.cc" ]
+  deps = [
+    "../core/fpdfapi/page",
+    "../core/fxcodec",
+    "../core/fxcrt",
+    "../core/fxge",
+  ]
+  cflags = [ "-fsanitize=fuzzer-no-link" ]
+  ldflags = [ "-fsanitize=fuzzer,address" ]
+}
+
+source_set("path_service") {
+  testonly = true
+  sources = [
+    "utils/path_service.cpp",
+    "utils/path_service.h",
+  ]
+  deps = [ "../core/fxcrt" ]
+  configs += [
+    "../:pdfium_strict_config",
+    "../:pdfium_noshorten_config",
+  ]
+  visibility = [ "../*" ]
+}
+
+source_set("test_environments") {
+  testonly = true
+  sources = [
+    "pdf_test_environment.cpp",
+    "pdf_test_environment.h",
+  ]
+  deps = [
+    ":test_support",
+    "../core/fxcrt",
+    "../core/fxge",
+    "//testing/gtest",
+  ]
+  configs += [
+    "../:pdfium_strict_config",
+    "../:pdfium_noshorten_config",
+  ]
+  if (pdf_enable_v8) {
+    sources += [
+      "v8_test_environment.cpp",
+      "v8_test_environment.h",
+    ]
+    deps += [
+      "../fxjs",
+      "//v8",
+      "//v8:v8_libplatform",
+    ]
+    configs += [ "//v8:external_startup_data" ]
+  }
+  if (pdf_enable_xfa) {
+    sources += [
+      "xfa_test_environment.cpp",
+      "xfa_test_environment.h",
+    ]
+    deps += [
+      "../fxjs:gc",
+      "../xfa/fgas/font",
+    ]
+  }
+}
+
+source_set("unit_test_support") {
+  testonly = true
+  sources = []
+  deps = []
+  configs += [
+    "../:pdfium_strict_config",
+    "../:pdfium_noshorten_config",
+  ]
+  public_deps = [
+    ":test_environments",
+    ":test_support",
+  ]
+  if (pdf_enable_v8) {
+    sources += [
+      "fxv8_unittest.cpp",
+      "fxv8_unittest.h",
+    ]
+    deps += [
+      "../fxjs",
+      "//testing/gtest",
+    ]
+    configs += [ "//v8:external_startup_data" ]
+    if (pdf_enable_xfa) {
+      sources += [
+        "fxgc_unittest.cpp",
+        "fxgc_unittest.h",
+      ]
+      deps += [
+        "../fxjs:gc",
+        "//testing/gtest",
+      ]
+    }
+  }
+}
+
+source_set("embedder_test_support") {
+  testonly = true
+  sources = [
+    "embedder_test.cpp",
+    "embedder_test.h",
+    "embedder_test_constants.cpp",
+    "embedder_test_constants.h",
+    "embedder_test_environment.cpp",
+    "embedder_test_environment.h",
+    "embedder_test_mock_delegate.h",
+    "embedder_test_timer_handling_delegate.h",
+    "fake_file_access.cpp",
+    "fake_file_access.h",
+    "range_set.cpp",
+    "range_set.h",
+  ]
+  deps = [
+    "../:pdfium_public_headers",
+    "../core/fdrm",
+    "../core/fxcrt",
+    "../core/fxge",
+    "../third_party:pdfium_base",
+    "//testing/gmock",
+    "//testing/gtest",
+  ]
+  public_deps = [
+    ":test_environments",
+    ":test_support",
+  ]
+  configs += [
+    "../:pdfium_strict_config",
+    "../:pdfium_noshorten_config",
+  ]
+  visibility = [ "../*" ]
+  if (pdf_enable_v8) {
+    sources += [
+      "external_engine_embedder_test.cpp",
+      "external_engine_embedder_test.h",
+      "js_embedder_test.cpp",
+      "js_embedder_test.h",
+    ]
+    deps += [
+      "../fxjs",
+      "//v8",
+      "//v8:v8_libplatform",
+    ]
+    configs += [ "//v8:external_startup_data" ]
+    if (pdf_enable_xfa) {
+      sources += [
+        "xfa_js_embedder_test.cpp",
+        "xfa_js_embedder_test.h",
+      ]
+      deps += [
+        "../fpdfsdk",
+        "../fpdfsdk/fpdfxfa",
+        "../xfa/fxfa",
+        "../xfa/fxfa/parser",
+      ]
+    }
+  }
+}
+
+# Dummy group to keep satisfy references from //build.
+group("test_scripts_shared") {
+}

--- a/projects/pdfium/args.gn
+++ b/projects/pdfium/args.gn
@@ -1,0 +1,33 @@
+#use_goma = false  # Googlers only. Make sure goma is installed and running first.
+#is_debug = false  # Enable debugging features.
+
+# Set true to enable experimental Skia backend.
+#pdf_use_skia = false
+# Set true to enable experimental Skia backend (paths only).
+#pdf_use_skia_paths = false
+#v8_enable_verify_heap = true
+
+#pdf_enable_xfa = true  # Set false to remove XFA support (implies JS support).
+#pdf_enable_v8 = true  # Set false to remove Javascript support.
+#pdf_is_standalone = true  # Set for a non-embedded build.
+#is_component_build = true # Disable component build (Though it should work)
+#optimize_for_fuzzing = true
+
+#use_libfuzzer = true
+#pdf_enable_xfa = true
+#is_asan=true
+#dcheck_always_on = true
+#use_libfuzzer = true
+dcheck_always_on = true
+v8_enable_verify_heap = true
+#enable_mojom_fuzzer = true
+#enable_nacl = false
+#ffmpeg_branding = "ChromeOS"
+is_asan = true
+is_component_build = false
+is_debug = false
+optimize_for_fuzzing = true
+pdf_enable_xfa = true
+proprietary_codecs = true
+use_goma = false
+use_libfuzzer = true

--- a/projects/pdfium/build.sh
+++ b/projects/pdfium/build.sh
@@ -1,0 +1,61 @@
+#!/bin/bash -eu
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd repo/pdfium
+
+# Disable trying to install snapcraft because this won't work in the Docker images
+sed -i 's/snapcraft/snapcraftnonexisting/g' ./build/install-build-deps.sh
+build/install-build-deps.sh
+
+# Quick hack which should probably go in the base images
+cp ./third_party/llvm-build/Release+Asserts/bin/llvm-readelf /usr/local/bin/llvm-readelf
+
+cp $SRC/clang_BUILD.gn build/config/clang/BUILD.gn
+cp $SRC/clang.gni build/config/clang/clang.gni
+
+# Copy over libclang_rt.fuzzer
+# This is hopefully a temporary hack. Hack is needed because the pdfium build
+# forces(?) the use of clang downloaded as a third party. This should be fixed,
+# however, such that we use the $CC and $CXX from oss-fuzz, in order to compile
+# with honggfuzz and afl++
+# NB: This is not needed anymore because we now use clang.gni and clang/BUILD.gn above.
+#cp /usr/local/lib/clang/14.0.0/lib/linux/libclang_rt.fuzzer-x86_64.a ./third_party/llvm-build/Release+Asserts/lib/clang/15.0.0/lib/linux/libclang_rt.fuzzer-x86_64.a
+
+# Copy our fuzzer updated BUILD.gn
+cp $SRC/OSS_FUZZ_BUILD.gn testing/BUILD.gn
+
+# Create appropriate flags depending on state
+if [ $SANITIZER == "address" ]; then
+  sed -i 's/FUZZCFLAGS/-fsanitize=fuzzer-no-link,address/g' ./testing/BUILD.gn
+  sed -i 's/FUZZLDFLAGS/-fsanitize=fuzzer/g' ./testing/BUILD.gn
+elif [ $SANITIZER == "coverage" ]; then
+  sed -i 's/FUZZCFLAGS/-fprofile-instr-generate\", \"-fcoverage-mapping/g' ./testing/BUILD.gn
+  sed -i 's/FUZZLDFLAGS/-fsanitize=fuzzer/g' ./testing/BUILD.gn
+fi
+
+# Generate configs for fuzzers
+mkdir -p out/fuzzers
+if [ $SANITIZER == "address" ]; then
+  cp $SRC/args.gn out/fuzzers/args.gn
+elif [ $SANITIZER == "coverage" ]; then
+  cp $SRC/cov_args.gn out/fuzzers/args.gn
+fi
+gn gen out/fuzzers
+
+ninja -v -C out/fuzzers/ pdf_cmap_fuzzer
+#ninja -v -C out/fuzzers/ pdf_cmap_fuzzer
+cp out/fuzzers/pdf_cmap_fuzzer $OUT/pdf_cmap_fuzzer

--- a/projects/pdfium/clang.gni
+++ b/projects/pdfium/clang.gni
@@ -1,0 +1,19 @@
+# Copyright 2014 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/toolchain/toolchain.gni")
+
+#default_clang_base_path = "//third_party/llvm-build/Release+Asserts"
+default_clang_base_path = "/usr/local/"
+
+declare_args() {
+  # Indicates if the build should use the Chrome-specific plugins for enforcing
+  # coding guidelines, etc. Only used when compiling with Chrome's Clang, not
+  # Chrome OS's.
+  clang_use_chrome_plugins = false
+  #    is_clang && !is_nacl && current_os != "zos" &&
+  #    default_toolchain != "//build/toolchain/cros:target"
+
+  clang_base_path = default_clang_base_path
+}

--- a/projects/pdfium/clang_BUILD.gn
+++ b/projects/pdfium/clang_BUILD.gn
@@ -1,0 +1,57 @@
+# Copyright (c) 2013 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("clang.gni")
+
+config("find_bad_constructs") {
+  if (clang_use_chrome_plugins) {
+    cflags = []
+
+    # The plugin is built directly into clang, so there's no need to load it
+    # dynamically.
+    cflags += [
+      "-Xclang",
+      "-add-plugin",
+      "-Xclang",
+      "find-bad-constructs",
+
+      # TODO(danakj): Enable this.
+      #"-Xclang",
+      #"-plugin-arg-find-bad-constructs",
+      # "-Xclang",
+      # "raw-ref-template-as-trivial-member",
+    ]
+
+    if (is_linux || is_chromeos || is_android || is_fuchsia) {
+      cflags += [
+        "-Xclang",
+        "-plugin-arg-find-bad-constructs",
+        "-Xclang",
+        "check-ipc",
+      ]
+    }
+  }
+}
+
+# Enables some extra Clang-specific warnings. Some third-party code won't
+# compile with these so may want to remove this config.
+config("extra_warnings") {
+  cflags = [
+    "-Wheader-hygiene",
+
+    # Warns when a const char[] is converted to bool.
+    "-Wstring-conversion",
+
+    "-Wtautological-overlap-compare",
+    "-Wno-unknown-warning-option",
+  ]
+}
+
+group("llvm-symbolizer_data") {
+  if (is_win) {
+    data = [ "$clang_base_path/bin/llvm-symbolizer.exe" ]
+  } else {
+    data = [ "$clang_base_path/bin/llvm-symbolizer" ]
+  }
+}

--- a/projects/pdfium/cov_args.gn
+++ b/projects/pdfium/cov_args.gn
@@ -1,0 +1,34 @@
+#use_goma = false  # Googlers only. Make sure goma is installed and running first.
+#is_debug = false  # Enable debugging features.
+
+# Set true to enable experimental Skia backend.
+#pdf_use_skia = false
+# Set true to enable experimental Skia backend (paths only).
+#pdf_use_skia_paths = false
+#v8_enable_verify_heap = true
+
+#pdf_enable_xfa = true  # Set false to remove XFA support (implies JS support).
+#pdf_enable_v8 = true  # Set false to remove Javascript support.
+#pdf_is_standalone = true  # Set for a non-embedded build.
+#is_component_build = true # Disable component build (Though it should work)
+#optimize_for_fuzzing = true
+
+#use_libfuzzer = true
+#pdf_enable_xfa = true
+#is_asan=true
+#dcheck_always_on = true
+#use_libfuzzer = true
+dcheck_always_on = true
+v8_enable_verify_heap = true
+#enable_mojom_fuzzer = true
+#enable_nacl = false
+#ffmpeg_branding = "ChromeOS"
+#is_asan = true
+is_component_build = false
+is_debug = true
+#optimize_for_fuzzing = true
+pdf_enable_xfa = true
+proprietary_codecs = true
+use_goma = false
+use_libfuzzer = true
+use_clang_coverage = true

--- a/projects/pdfium/project.yaml
+++ b/projects/pdfium/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://pdfium.googlesource.com/pdfium"
+primary_contact: "david@adalogics.com"
+language: c++
+fuzzing_engines:
+- libfuzzer
+- honggfuzz
+sanitizers:
+- address
+main_repo: 'https://pdfium.googlesource.com/pdfium'

--- a/projects/pdfium/t.sh
+++ b/projects/pdfium/t.sh
@@ -1,0 +1,7 @@
+# temporary script for quick shorthands inside oss-fuzz docker env.
+rm -rf ./out/fuzzers7/
+mkdir -p out/fuzzers7
+cp $SRC/args.gn ./out/fuzzers7/args.gn
+gn gen out/fuzzers7/
+ninja -C out/fuzzers7 pdf_formcalc_context_fuzzer
+


### PR DESCRIPTION
This is very raw at the moment. Below indicates what works/does not
work. Follow up is needed and will return to this a bit later. One problem
that should be addressed is how/whether to compile by way of `gn` in the oss-fuzz environment.

What works:
- compiling pdfium fuzzers with OSS-Fuzz clang, i.e. libfuzzer engine, and running of these fuzzers.

What does not work
- coverage: compiles, runs, but fails with:
```
Running pdf_cmap_fuzzer
[2022-07-19 12:55:12,467 INFO] Finding shared libraries for targets (if
any).
[2022-07-19 12:55:12,473 INFO] Finished finding shared libraries for
targets.
error: ../../third_party/abseil-cpp/absl/synchronization/mutex.cc: No
such file or directory
warning: Could not read coverage for '_ZN4absl9ConditionC2Ev'.
[2022-07-19 12:55:13,081 INFO] Finding shared libraries for targets (if
any).
[2022-07-19 12:55:13,086 INFO] Finished finding shared libraries for
targets.
[0;31merror: ../../core/fdrm/fx_crypt.cpp: No such file or directory
[0m[0;31mwarning: The file '../../core/fdrm/fx_crypt.cpp' isn't covered.
[0m[0;31merror: ../../core/fdrm/fx_crypt_aes.cpp: No such file or
directory
...
[0m[0;31mwarning: The file '../../third_party/zlib/zutil.c' isn't covered.
[0m[0;31merror: ../../third_party/zlib/zutil.h: No such file or directory
[0m[0;31mwarning: The file '../../third_party/zlib/zutil.h' isn't covered.
[0m[2022-07-19 12:55:13,644 ERROR] Default coverage report dir does not exist: /out/report/coverage.
Traceback (most recent call last):
  File "/opt/code_coverage/coverage_utils.py", line 829, in <module>
    sys.exit(Main())
  File "/opt/code_coverage/coverage_utils.py", line 823, in Main
    return _CmdPostProcess(args)
  File "/opt/code_coverage/coverage_utils.py", line 780, in _CmdPostProcess
    processor.PrepareHtmlReport()
  File "/opt/code_coverage/coverage_utils.py", line 572, in PrepareHtmlReport
    self.RenameDefaultCoverageDirectory()
  File "/opt/code_coverage/coverage_utils.py", line 556, in RenameDefaultCoverageDirectory
    MergeTwoDirectories(default_report_subdir_path, self.report_root_dir)
  File "/opt/code_coverage/coverage_utils.py", line 727, in MergeTwoDirectories
    for filename in os.listdir(src_dir_path):
FileNotFoundError: [Errno 2] No such file or directory: '/out/report/coverage'
ERROR:root:Failed to generate clang code coverage report.
```
- fuzzers dependent on v8. They compile but fail a DCHECK in v8
GetPlatform.
- pdfium_fuzzer. It compiles but throws an error when run.
- compiling with AFL++.