### PR TITLE
g-api-auth-library-python: refine set up

### DIFF
--- a/projects/g-api-auth-library-python/build.sh
+++ b/projects/g-api-auth-library-python/build.sh
@@ -19,6 +19,7 @@
 cp tests/data/*.pem $OUT/
 cp tests/data/*.pub $OUT/
 
+pip3 install -r docs/requirements-docs.txt
 pip3 install .
 
 for fuzzer in $(find $SRC -name 'fuzz_*.py'); do


### PR DESCRIPTION
Split the existing fuzzer. This adds significant speedup in one of the
code areas being tested. Also refines the setup to add more code paths
in the encoding logic.