### PR TITLE
lcms: fix fuzz introspector builds

### DIFF
--- a/projects/lcms/build.sh
+++ b/projects/lcms/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 # build the target.
-./configure
+./configure --enable-shared=no
 make -j$(nproc) all
 
 # build your fuzzer(s)


### PR DESCRIPTION
Current build fails because of the use of linking to dynamically shared libaries in examples of lcms. This conflicts with fuzz introspector and I assume this is because the creation of the dynamically shared libraries makes the lto-compiled objects into binary executables. This fixes it by forcing static linking for all compiled examples in the lcms build process.

I would like to contribute fuzzers to lcms and also use fuzz introspector to assess the current state of lcms fuzzing. This fix is related to that.