### PR TITLE
[llvm] Use my commit email address instead of the corp one

### DIFF
--- a/projects/llvm/project.yaml
+++ b/projects/llvm/project.yaml
@@ -3,7 +3,7 @@ language: c++
 primary_contact: "kcc@google.com"
 auto_ccs:
   - "mascasa@google.com"
-  - "jdevlieghere@apple.com"
+  - "jonas@devlieghere.com"
   - "vsk@apple.com"
   - "akilsrin@apple.com"
   - "llvm-bugs@lists.llvm.org"


### PR DESCRIPTION
I lost access to the Google account associated with my corporate e-mail
address. Switch to using the one I use for contributing to LLVM, which I
should've done from the beginning.