### PR TITLE
[dbus-broker] turn on the alignment check

### DIFF
--- a/projects/dbus-broker/build.sh
+++ b/projects/dbus-broker/build.sh
@@ -23,6 +23,13 @@ else
     apt-get install -y pkg-config
 fi
 
+if [[ "$SANITIZER" == undefined ]]; then
+    additional_ubsan_checks=alignment
+    UBSAN_FLAGS="-fsanitize=$additional_ubsan_checks -fno-sanitize-recover=$additional_ubsan_checks"
+    CFLAGS+=" $UBSAN_FLAGS"
+    CXXFLAGS+=" $UBSAN_FLAGS"
+fi
+
 pip3 install meson ninja
 
 meson -Db_lundef=false -Dlauncher=false build


### PR DESCRIPTION
By analogy with https://github.com/google/oss-fuzz/commit/8747524f04b1b906d4a21a6ade87f7803b3f9b8c
it should help to somewhat cover architectures where unaligned access
can either crash code or be too expensive in terms of performance.