### PR TITLE
[docs] point to the right systemd branch

### DIFF
--- a/docs/getting-started/continuous_integration.md
+++ b/docs/getting-started/continuous_integration.md
@@ -203,7 +203,7 @@ jobs:
 ```
 
 You can checkout CIFuzz configs for OSS-Fuzz projects. Example -
-[systemd](https://github.com/systemd/systemd/blob/master/.github/workflows/cifuzz.yml),
+[systemd](https://github.com/systemd/systemd/blob/main/.github/workflows/cifuzz.yml),
 [curl](https://github.com/curl/curl/blob/master/.github/workflows/fuzz.yml).
 
 ## Understanding results


### PR DESCRIPTION
GitHub redirects it to the main branch but it keeps saying that
the branch was renamed and it's distracting.