### PR TITLE
[grok] disable full codec and shared libs in cmake command

### DIFF
--- a/projects/grok/build.sh
+++ b/projects/grok/build.sh
@@ -17,7 +17,7 @@
 
 mkdir build
 cd build
-cmake ..
+cmake .. -DGRK_BUILD_CODEC=OFF -DBUILD_SHARED_LIBS=OFF -DGRK_BUILD_THIRDPARY=ON
 make clean -s
 make -j$(nproc) -s
 cd ..


### PR DESCRIPTION
I've changed how my cmake options function, so I need to modify the cmake command for the fuzzer.
