### PR TITLE
file: Add elf and pe seeds

### DIFF
--- a/projects/file/Dockerfile
+++ b/projects/file/Dockerfile
@@ -17,5 +17,9 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool shtool
 RUN git clone --depth 1 https://github.com/file/file.git
+
+ # supplement file's existing test files to get elf + pe coverage
+RUN git clone --depth 1 https://github.com/DavidKorczynski/binary-samples.git
+
 WORKDIR file
 COPY build.sh magic_fuzzer.cc $SRC/

--- a/projects/file/Dockerfile
+++ b/projects/file/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool shtool
 RUN git clone --depth 1 https://github.com/file/file.git
 
- # supplement file's existing test files to get elf + pe coverage
+# Supplement file's existing test files to get elf + pe coverage.
 RUN git clone --depth 1 https://github.com/DavidKorczynski/binary-samples.git
 
 WORKDIR file

--- a/projects/file/build.sh
+++ b/projects/file/build.sh
@@ -25,4 +25,4 @@ $CXX $CXXFLAGS -std=c++11 -Isrc/ \
 
 cp ./magic/magic.mgc $OUT/
 
-zip -j $OUT/magic_fuzzer_seed_corpus.zip ./tests/*.testfile ../binary-samples/{elf,pe}-*
+zip -j $OUT/magic_fuzzer_seed_corpus.zip ./tests/*.testfile $SRC/binary-samples/{elf,pe}-*

--- a/projects/file/build.sh
+++ b/projects/file/build.sh
@@ -25,4 +25,4 @@ $CXX $CXXFLAGS -std=c++11 -Isrc/ \
 
 cp ./magic/magic.mgc $OUT/
 
-zip -j $OUT/magic_fuzzer_seed_corpus.zip ./tests/*.testfile
+zip -j $OUT/magic_fuzzer_seed_corpus.zip ./tests/*.testfile ../binary-samples/{elf,pe}-*


### PR DESCRIPTION
This PR adds elf and pe samples to file's corpus. They are the same ones used in the libdwarf and binutils targets.

Fuzz introspector [shows ](https://storage.googleapis.com/oss-fuzz-introspector/file/inspector-report/20220724/fuzz_report.html#Optimal-target-analysis) the file project doesn't have any coverage of elf files.

This is because the current seed corpus uses file's existing test cases, which don't have any elf (or pe) binaries.