### PR TITLE
[cloud-hypervisor] Add @likebreath to auto_ccs list

### DIFF
--- a/projects/cloud-hypervisor/project.yaml
+++ b/projects/cloud-hypervisor/project.yaml
@@ -6,7 +6,7 @@ auto_ccs:
   - "Henry.Wang@arm.com"
   - "robert.bradford@intel.com"
   - "samuel.e.ortiz@protonmail.com"
-
+  - "chen.bo@intel.com"
 sanitizers:
   - address
 fuzzing_engines:


### PR DESCRIPTION
I am one of the main contributors/committers to the Cloud Hypervisor (CH) project, and would like to have access to the ClusterFuzz website interface for the statistics of fuzzing CH.

\cc @rbradford @sboeuf

Signed-off-by: Bo Chen <chen.bo@intel.com>