### PR TITLE
g-api-auth-library-python: embed .pem files in pyinstalled exec

### DIFF
--- a/projects/g-api-auth-library-python/build.sh
+++ b/projects/g-api-auth-library-python/build.sh
@@ -15,13 +15,10 @@
 #
 ################################################################################
 
-# Copy cryptographic test data
-cp tests/data/*.pem $OUT/
-cp tests/data/*.pub $OUT/
-
 pip3 install -r docs/requirements-docs.txt
 pip3 install .
 
+# Embed certificates and private key too
 for fuzzer in $(find $SRC -name 'fuzz_*.py'); do
-  compile_python_fuzzer $fuzzer
+  compile_python_fuzzer $fuzzer --add-data "$PWD/tests/data/privatekey.pem:." --add-data "$PWD/tests/data/public_cert.pem:."
 done

--- a/projects/g-api-auth-library-python/fuzz_jwt.py
+++ b/projects/g-api-auth-library-python/fuzz_jwt.py
@@ -13,15 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import atheris
+import os
 import sys
+import atheris
 
 from google.auth import jwt
 from google.auth import crypt
 
+bundle_dir = getattr(sys, '_MEIPASS', os.path.abspath(os.path.dirname(__file__)))
+path_to_public_cert = os.path.abspath(os.path.join(bundle_dir, 'public_cert.pem'))
 
-if os.path.isfile("public_cert.pem"):
-  with open("public_cert.pem", "rb") as fh:
+if os.path.isfile(path_to_public_cert):
+  with open(path_to_public_cert, "rb") as fh:
     PUBLIC_CERT_BYTES = fh.read()
 else:
   raise Exception("Could not find public cert")

--- a/projects/g-api-auth-library-python/fuzz_jwt_roundtrip.py
+++ b/projects/g-api-auth-library-python/fuzz_jwt_roundtrip.py
@@ -13,21 +13,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import atheris
+import os
 import sys
+import atheris
+
+bundle_dir = getattr(sys, '_MEIPASS', os.path.abspath(os.path.dirname(__file__)))
+path_to_public_cert = os.path.abspath(os.path.join(bundle_dir, 'public_cert.pem'))
+path_to_private_key = os.path.abspath(os.path.join(bundle_dir, 'privatekey.pem'))
 
 # We instrument all imports below
 from google.auth import jwt
 from google.auth import crypt
 
-if os.path.isfile("privatekey.pem"):
-  with open("privatekey.pem", "rb") as fh:
+if os.path.isfile(path_to_private_key):
+  with open(path_to_private_key, "rb") as fh:
     PRIVATE_KEY_BYTES = fh.read()
 else:
   raise Exception("Could not find private key")
 
-if os.path.isfile("public_cert.pem"):
-  with open("public_cert.pem", "rb") as fh:
+if os.path.isfile(path_to_public_cert):
+  with open(path_to_public_cert, "rb") as fh:
     PUBLIC_CERT_BYTES = fh.read()
 else:
   raise Exception("Could not find public cert")


### PR DESCRIPTION
This fixes:
https://github.com/google/oss-fuzz/issues/8030#issuecomment-1194645711