### PR TITLE
qemu: limit input size to avoid timeouts

### DIFF
--- a/projects/qemu/default.options
+++ b/projects/qemu/default.options
@@ -1,3 +1,4 @@
 [libfuzzer]
 close_fd_mask=3
 detect_leaks=0
+max_len=8192


### PR DESCRIPTION
QEMU coverage builds have been failing for a long time. Maybe this is
occuring due to the inputs being too large and timing out. Limit the
input size, in an attempt to fix this.

Signed-off-by: Alexander Bulekov <alxndr@bu.edu>