### PR TITLE
cras: Support -DHAVE_FUZZER

### DIFF
--- a/projects/cras/build.sh
+++ b/projects/cras/build.sh
@@ -24,7 +24,7 @@
 cd ${SRC}/adhd/cras
 ./git_prepare.sh
 mkdir -p ${WORK}/build && cd ${WORK}/build
-${SRC}/adhd/cras/configure --disable-featured
+CFLAGS="${CFLAGS} -DHAVE_FUZZER" ${SRC}/adhd/cras/configure --disable-featured
 make -j$(nproc)
 cp ${WORK}/build/src/server/rust/target/release/libcras_rust.a /usr/local/lib
 


### PR DESCRIPTION
To fix https://crbug.com/oss-fuzz/49371,
passing HAVE_FUZZER flag during library build stage.

And by pass DBus usage in https://crrev.com/c/3787999.

BUG=oss-fuzz:49371