### PR TITLE
Update ownership of Meta projects.

### DIFF
--- a/projects/hermes/project.yaml
+++ b/projects/hermes/project.yaml
@@ -2,7 +2,9 @@ homepage: "https://github.com/facebook/hermes"
 language: c++
 primary_contact: "neildhar@fb.com"
 auto_ccs:
-  - "mhl@fb.com"
+  - "hmf@fb.com"
+  - "yaohway@fb.com"
+  - "axxu@fb.com"
   - "avp@fb.com"
   - "jsx@fb.com"
 vendor_ccs:

--- a/projects/lz4/project.yaml
+++ b/projects/lz4/project.yaml
@@ -6,10 +6,14 @@ auto_ccs:
   - "cyan@fb.com"
   - "terrelln@fb.com"
   - "felixh@fb.com"
-  - "mhl@fb.com"
+  - "hmf@fb.com"
+  - "yaohway@fb.com"
+  - "axxu@fb.com"
   - "embg@fb.com"
   - "yoniko@fb.com"
   - "sangelov@fb.com"
+vendor_ccs:
+  - "oss-fuzz@fb.com"
 fuzzing_engines:
   - libfuzzer
   - afl

--- a/projects/osquery/project.yaml
+++ b/projects/osquery/project.yaml
@@ -7,7 +7,6 @@ auto_ccs:
   - "seph@directionless.org"
   - "alessandro.gario@gmail.com"
   - "tom@ritter.vg"
-  - "mhl@fb.com"
   - "sharvil@sharvilshah.com"
   - "gellerbedoya@gmail.com"
   - "stefano.bonicatti@gmail.com"

--- a/projects/proxygen/project.yaml
+++ b/projects/proxygen/project.yaml
@@ -1,9 +1,10 @@
 homepage: "https://github.com/facebook/proxygen"
 language: c++
-primary_contact: "mhl@fb.com"
+primary_contact: "axxu@fb.com"
 auto_ccs:
-  - "gulshan@fb.com"
-  - "reed@fb.com"
+  - "hmf@fb.com"
+  - "yaohway@fb.com"
+  - "axxu@fb.com"
   - "lniccolini@fb.com"
   - "afrind@fb.com"
   - "subodh@fb.com"

--- a/projects/rocksdb/project.yaml
+++ b/projects/rocksdb/project.yaml
@@ -5,7 +5,9 @@ vendor_ccs:
   - "oss-fuzz@fb.com"
 auto_ccs:
   - "david@adalogics.com"
-  - "mhl@fb.com"
+  - "hmf@fb.com"
+  - "yaohway@fb.com"
+  - "axxu@fb.com"
 sanitizers:
   - "address"
 main_repo: 'https://github.com/facebook/rocksdb'

--- a/projects/zstd/project.yaml
+++ b/projects/zstd/project.yaml
@@ -7,11 +7,15 @@ auto_ccs:
   - "cyan@fb.com"
   - "felixh@fb.com"
   - "dpc@fb.com"
-  - "mhl@fb.com"
+  - "hmf@fb.com"
+  - "yaohway@fb.com"
+  - "axxu@fb.com"
   - "binhvo@fb.com"
   - "embg@fb.com"
   - "yoniko@fb.com"
   - "sangelov@fb.com"
+vendor_ccs:
+  - "oss-fuzz@fb.com"
 fuzzing_engines:
   - libfuzzer
   - afl


### PR DESCRIPTION
I'll no longer be working on fuzzing at Meta, so updating the ownership lists to add more folks from my team.
I added the vendor_cc list where it was missing.
I also removed a few employees that no longer are at Meta from the proxygen project list.