### PR TITLE
[MSAN] Enable memory sanitizer build

### DIFF
--- a/projects/cras/build.sh
+++ b/projects/cras/build.sh
@@ -24,9 +24,10 @@
 cd ${SRC}/adhd/cras
 ./git_prepare.sh
 mkdir -p ${WORK}/build && cd ${WORK}/build
+export CARGO_BUILD_TARGET="x86_64-unknown-linux-gnu"
 CFLAGS="${CFLAGS} -DHAVE_FUZZER" ${SRC}/adhd/cras/configure --disable-featured
 make -j$(nproc)
-cp ${WORK}/build/src/server/rust/target/release/libcras_rust.a /usr/local/lib
+cp ${WORK}/build/src/server/rust/target/${CARGO_BUILD_TARGET}/release/libcras_rust.a /usr/local/lib
 
 CRAS_FUZZERS="rclient_message cras_hfp_slc cras_fl_media_fuzzer"
 

--- a/projects/cras/project.yaml
+++ b/projects/cras/project.yaml
@@ -14,6 +14,7 @@ auto_ccs:
   - "hunghsienchen@chromium.org"
   - "htcheong@chromium.org"
   - "jrwu@chromium.org"
+  - "michelleyswang@google.com"
 sanitizers:
   - address
   - memory

--- a/projects/cras/project.yaml
+++ b/projects/cras/project.yaml
@@ -14,5 +14,9 @@ auto_ccs:
   - "hunghsienchen@chromium.org"
   - "htcheong@chromium.org"
   - "jrwu@chromium.org"
-builds_per_day: 2
+sanitizers:
+  - address
+  - memory
+  - undefined
+builds_per_day: 4
 main_repo: 'https://chromium.googlesource.com/chromiumos/third_party/adhd'


### PR DESCRIPTION
- In oss-fuzz, to build with MemorySanitizer, Rust part needs to use

  ```
  CARGO_BUILD_TARGET="x86_64-unknown-linux-gnu"
  ```

  to resolve libc `MemorySanitizer: use-of-uninitialized-value` error
  according to https://github.com/google/oss-fuzz/issues/3469.
 - This change will work after https://crrev.com/c/3788003 get merged
 - Change builds_per_day to 4
 - Add new member to auto_cc