### PR TITLE
lcms: extend fuzzing suite

### DIFF
--- a/projects/lcms/build.sh
+++ b/projects/lcms/build.sh
@@ -20,7 +20,13 @@
 make -j$(nproc) all
 
 # build your fuzzer(s)
-FUZZERS="cmsIT8_load_fuzzer cms_transform_fuzzer cms_overwrite_transform_fuzzer cms_transform_all_fuzzer cms_profile_fuzzer"
+FUZZERS="cmsIT8_load_fuzzer            \
+        cms_transform_fuzzer           \
+        cms_overwrite_transform_fuzzer \
+        cms_transform_all_fuzzer       \
+        cms_profile_fuzzer             \
+        cms_transform_extended_fuzzer"
+
 for F in $FUZZERS; do
     $CC $CFLAGS -c -Iinclude \
         $SRC/$F.c -o $SRC/$F.o
@@ -31,5 +37,6 @@ done
 
 cp $SRC/icc.dict $SRC/*.options $OUT/
 cp $SRC/icc.dict $OUT/cms_transform_all_fuzzer.dict
+cp $SRC/icc.dict $OUT/cms_transform_extended_fuzzer.dict
 cp $SRC/seed_corpus.zip $OUT/cms_transform_fuzzer_seed_corpus.zip
 cp $SRC/seed_corpus.zip $OUT/cms_profile_fuzzer_seed_corpus.zip

--- a/projects/lcms/cms_transform_extended_fuzzer.c
+++ b/projects/lcms/cms_transform_extended_fuzzer.c
@@ -73,9 +73,9 @@ run_test(const uint8_t *data,
   }
 
   // Create the transform
-  cmsContext Plugin = cmsCreateContext(NULL, NULL);
+  cmsContext ctx = cmsCreateContext(NULL, NULL);
   cmsHTRANSFORM hTransform = cmsCreateTransformTHR(
-    Plugin,
+    ctx,
     srcProfile,
     srcFormat,
     dstProfile,

--- a/projects/lcms/cms_transform_extended_fuzzer.c
+++ b/projects/lcms/cms_transform_extended_fuzzer.c
@@ -1,0 +1,135 @@
+/* Copyright 2022 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <stdint.h>
+#include "lcms2.h"
+
+// An extended cmsDoTransform fuzzer. The idea is to include a range of
+// input/output source formats.
+
+void
+run_test(const uint8_t *data,
+         size_t size,
+         uint32_t intent,
+         uint32_t flags, int dstVal) {
+  if (size < 2) {
+    return;
+  }
+
+  cmsHPROFILE srcProfile = cmsOpenProfileFromMem(data, size);
+  if (!srcProfile) return;
+
+  // Select dstProfile and dstFormat
+  cmsHPROFILE dstProfile;
+  uint32_t dstFormat;
+  if (dstVal == 1) {
+    dstProfile = cmsCreateLab4Profile(NULL);
+    dstFormat = TYPE_Lab_8;
+  }
+  else if (dstVal == 2) {
+    dstProfile = cmsCreateLab2Profile(NULL);
+    dstFormat = TYPE_LabV2_8;
+  }
+  else if (dstVal == 3) {
+    cmsToneCurve* gamma18;
+    gamma18 = cmsBuildGamma(0, 1.8);
+    dstProfile = cmsCreateGrayProfile(NULL, gamma18);
+    cmsFreeToneCurve(gamma18);
+    dstFormat = TYPE_GRAY_FLT | EXTRA_SH(1);
+  }
+  else if (dstVal == 4) {
+    dstProfile = cmsCreateXYZProfile();
+    dstFormat = TYPE_XYZ_16;
+  }
+  else {
+    dstProfile = cmsCreate_sRGBProfile();
+    dstFormat = TYPE_RGB_8;
+  }
+
+  if (!dstProfile) {
+    cmsCloseProfile(srcProfile);
+    return;
+  }
+
+  // Extract srcFormat from the random src profile
+  cmsColorSpaceSignature srcCS = cmsGetColorSpace(srcProfile);
+  cmsUInt32Number nSrcComponents = cmsChannelsOf(srcCS);
+  cmsUInt32Number srcFormat;
+  if (srcCS == cmsSigLabData) {
+    srcFormat =
+        COLORSPACE_SH(PT_Lab) | CHANNELS_SH(nSrcComponents) | BYTES_SH(0);
+  } else {
+    srcFormat =
+        COLORSPACE_SH(PT_ANY) | CHANNELS_SH(nSrcComponents) | BYTES_SH(1);
+  }
+
+  // Create the transform
+  cmsContext Plugin = cmsCreateContext(NULL, NULL);
+  cmsHTRANSFORM hTransform = cmsCreateTransformTHR(
+    Plugin,
+    srcProfile,
+    srcFormat,
+    dstProfile,
+    dstFormat,
+    intent,
+    flags);
+
+  cmsCloseProfile(srcProfile);
+  cmsCloseProfile(dstProfile);
+  if (!hTransform) return;
+
+
+  // Do transformation.
+  // The output buffer type depends on the dstFormat
+  // The input buffer type depends on the srcFormat.
+  if (T_BYTES(srcFormat) == 0) {  // 0 means double
+    uint8_t output[4];
+    double input[nSrcComponents];
+    for (uint32_t i = 0; i < nSrcComponents; i++) input[i] = 0.5f;
+    cmsDoTransform(hTransform, input, output, 1);
+  } 
+  else {
+    uint8_t input[nSrcComponents];
+    for (uint32_t i = 0; i < nSrcComponents; i++) input[i] = 128;
+
+    if (dstFormat == TYPE_XYZ_16) {
+      cmsCIEXYZ output_XYZ = { 0, 0, 0 };
+      cmsDoTransform(hTransform, input, &output_XYZ, 1);
+    }
+    else {
+      uint8_t output[4];
+      cmsDoTransform(hTransform, input, output, 1);
+    }
+  }
+  cmsDeleteTransform(hTransform);
+}
+
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  if (size < 8) {
+    return 0;
+  }
+
+  uint32_t flags         = *((const uint32_t *)data+0);
+  uint32_t intent        = *((const uint32_t *)data+1) % 16;
+  data += 8;
+  size -= 8;
+
+  // Transform using various output formats.
+  run_test(data, size, intent, flags, 0);
+  run_test(data, size, intent, flags, 1);
+  run_test(data, size, intent, flags, 2);
+  run_test(data, size, intent, flags, 3);
+  run_test(data, size, intent, flags, 4);
+
+  return 0;
+}


### PR DESCRIPTION
Add a fuzzer that target various output formats when transforming. There
are more oppournities to extend this further but will let this fuzzer
run for a while to see how it goes.