### PR TITLE
Improve e2fsprogs fuzzers 

### DIFF
--- a/projects/e2fsprogs/fuzz/ext2fs_check_directory_fuzzer.cc
+++ b/projects/e2fsprogs/fuzz/ext2fs_check_directory_fuzzer.cc
@@ -30,7 +30,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   ext2_filsys fs;
   errcode_t retval = ext2fs_open(
       fname,
-      0, 0, 0,
+      EXT2_FLAG_IGNORE_CSUM_ERRORS, 0, 0,
       unix_io_manager,
       &fs);
 

--- a/projects/e2fsprogs/fuzz/ext2fs_image_read_write_fuzzer.cc
+++ b/projects/e2fsprogs/fuzz/ext2fs_image_read_write_fuzzer.cc
@@ -36,18 +36,21 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   FuzzedDataProvider stream(data, size);
   const FuzzerType f = stream.ConsumeEnum<FuzzerType>();
-  static const char* fname = "/tmp/ext2_test_file";
+  const int flags = stream.ConsumeIntegral<int>();
+
+  static const char* fname = "ext2_test_file";
 
   // Write our data to a temp file.
   int fd = syscall(SYS_memfd_create, fname, 0);
   std::vector<char> buffer = stream.ConsumeRemainingBytes<char>();
   write(fd, buffer.data(), buffer.size());
-  close(fd);
+
+  std::string fspath("/proc/self/fd" + std::to_string(fd));
 
   ext2_filsys fs;
   errcode_t retval = ext2fs_open(
-      fname,
-      0, 0, 0,
+      fspath.c_str(),
+      flags | EXT2_FLAG_IGNORE_CSUM_ERRORS, 0, 0,
       unix_io_manager,
       &fs);
 
@@ -83,6 +86,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     }
     ext2fs_close(fs);
   }
+  close(fd);
 
   return 0;
 }

--- a/projects/e2fsprogs/fuzz/ext2fs_image_read_write_fuzzer.cc
+++ b/projects/e2fsprogs/fuzz/ext2fs_image_read_write_fuzzer.cc
@@ -45,7 +45,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   std::vector<char> buffer = stream.ConsumeRemainingBytes<char>();
   write(fd, buffer.data(), buffer.size());
 
-  std::string fspath("/proc/self/fd" + std::to_string(fd));
+  std::string fspath("/proc/self/fd/" + std::to_string(fd));
 
   ext2_filsys fs;
   errcode_t retval = ext2fs_open(

--- a/projects/e2fsprogs/fuzz/ext2fs_read_bitmap_fuzzer.cc
+++ b/projects/e2fsprogs/fuzz/ext2fs_read_bitmap_fuzzer.cc
@@ -41,7 +41,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   std::vector<char> buffer = stream.ConsumeRemainingBytes<char>();
   write(fd, buffer.data(), buffer.size());
 
-  std::string fspath("/proc/self/fd" + std::to_string(fd));
+  std::string fspath("/proc/self/fd/" + std::to_string(fd));
 
   ext2_filsys fs;
   errcode_t retval = ext2fs_open(

--- a/projects/e2fsprogs/fuzz/ext2fs_read_bitmap_fuzzer.cc
+++ b/projects/e2fsprogs/fuzz/ext2fs_read_bitmap_fuzzer.cc
@@ -32,18 +32,21 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   FuzzedDataProvider stream(data, size);
   const FuzzerType f = stream.ConsumeEnum<FuzzerType>();
-  static const char* fname = "/tmp/ext2_test_file";
+  const int flags = stream.ConsumeIntegral<int>();
+
+  static const char* fname = "ext2_test_file";
 
   // Write our data to a temp file.
   int fd = syscall(SYS_memfd_create, fname, 0);
   std::vector<char> buffer = stream.ConsumeRemainingBytes<char>();
   write(fd, buffer.data(), buffer.size());
-  close(fd);
+
+  std::string fspath("/proc/self/fd" + std::to_string(fd));
 
   ext2_filsys fs;
   errcode_t retval = ext2fs_open(
-      fname,
-      0, 0, 0,
+      fspath.c_str(),
+      flags | EXT2_FLAG_IGNORE_CSUM_ERRORS, 0, 0,
       unix_io_manager,
       &fs);
 
@@ -63,6 +66,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     }
     ext2fs_close(fs);
   }
+  close(fd);
 
   return 0;
 }


### PR DESCRIPTION
Move fuzzers to properly use memfd_create. memfd_create doesn't create a file on disk that's reference-able. It can only be accessed by /proc/self/fd/, and it will only have a number. The name is purely for debugging purposes and is also not unique.  Closing it also deletes it, so move the close to the end of the test case.

Also disable checksum fatal errors, making fuzzing a bit easier, and specify random open flags per test case. 