### PR TITLE
pest: Add my Google Account email address

### DIFF
--- a/projects/pest/project.yaml
+++ b/projects/pest/project.yaml
@@ -5,6 +5,7 @@ auto_ccs:
   - "cad97@cad97.com"
   - "flying-sheep@web.de"
   - "nbtheduke@gmail.com"
+  - "me@tomtau.be"
 sanitizers:
   - address
 fuzzing_engines:


### PR DESCRIPTION
As with https://github.com/google/oss-fuzz/pull/8090 https://github.com/google/oss-fuzz/pull/8097
I cannot access the pages with oss-fuzz bug reports (e.g. links in https://github.com/pest-parser/pest/issues/674).
I am one of maintainers (you can verify my address by checking the recent pest repository git log entries).