### PR TITLE
bitcoin-core: remove msan getrandom workaround

### DIFF
--- a/projects/bitcoin-core/build.sh
+++ b/projects/bitcoin-core/build.sh
@@ -57,16 +57,6 @@ else
   CONFIG_SITE="$PWD/depends/$BUILD_TRIPLET/share/config.site" ./configure --with-seccomp=no --enable-fuzz SANITIZER_LDFLAGS="$LIB_FUZZING_ENGINE"
 fi
 
-
-if [ "$SANITIZER" = "memory" ]; then
-  # MemorySanitizer (MSAN) does not support tracking memory initialization done by
-  # using the Linux getrandom syscall. Avoid using getrandom by undefining
-  # HAVE_SYS_GETRANDOM. See https://github.com/google/sanitizers/issues/852 for
-  # details.
-  grep -v HAVE_SYS_GETRANDOM src/config/bitcoin-config.h > src/config/bitcoin-config.h.tmp
-  mv src/config/bitcoin-config.h.tmp src/config/bitcoin-config.h
-fi
-
 make -j$(nproc)
 
 WRITE_ALL_FUZZ_TARGETS_AND_ABORT="/tmp/a" "./src/test/fuzz/fuzz" || true


### PR DESCRIPTION
Support for intercepting getrandom has been implemented since [llvm 10.0.0](https://github.com/llvm/llvm-project/commit/ac9ee01fcbfac745aaedca0393a8e1c8a33acd8d), and the referenced issue, https://github.com/google/sanitizers/issues/852, marked as resolved. If this still fails, we should either investigate why this is still broken, or update our documentation.