### PR TITLE
libvips: build improvements

### DIFF
--- a/projects/libvips/Dockerfile
+++ b/projects/libvips/Dockerfile
@@ -26,7 +26,6 @@ RUN apt-get update && apt-get install -y \
   libexpat1-dev \
   libffi-dev \
   libfftw3-dev \
-  libgflags-dev \
   libselinux1-dev \
   libtool \
   nasm \


### PR DESCRIPTION
- Remove `libgflags-dev`, no longer needed by libjxl.
- Remove CMake options that are already default.
- Split long build options across multiple lines.
- Use the `RelWithDebInfo` build type for CMake builds.
- Use the `debugoptimized` build type for Meson builds (except for libvips itself).
- Avoid using the bundled lcms2 dependency in libjxl.
- Ensure libjxl builds against the static zlib library.

/cc @jcupitt