### PR TITLE
libvips: add missing linker flag for sharpyuv

### DIFF
--- a/projects/libvips/build.sh
+++ b/projects/libvips/build.sh
@@ -253,7 +253,7 @@ for fuzzer in fuzz/*_fuzzer.cc; do
     -I/usr/lib/x86_64-linux-gnu/glib-2.0/include \
     $LDFLAGS \
     -lvips -lexif -llcms2 -ljpeg -lpng -lspng -lz \
-    -ltiff -lwebpmux -lwebpdemux -lwebp -lheif -laom \
+    -ltiff -lwebpmux -lwebpdemux -lwebp -lsharpyuv -lheif -laom \
     -ljxl -ljxl_threads -lhwy -limagequant -lcgif -lpdfium \
     $LIB_FUZZING_ENGINE \
     -Wl,-Bstatic \


### PR DESCRIPTION
This is needed after commit https://chromium.googlesource.com/webm/libwebp/+/3fe15b67737d0b4d436b9af484d890f18f59da79, which builds `libsharpyuv` as a separate installable library rather than a convenience one.