### PR TITLE
[dbus-broker] use wildcards to link dependencies

### DIFF
--- a/projects/dbus-broker/build.sh
+++ b/projects/dbus-broker/build.sh
@@ -44,10 +44,10 @@ if ! meson -Db_lundef=false -Dlauncher=false build; then
 fi
 
 ninja -C ./build -v
-$CC $CFLAGS -c -o fuzz-message.o -Isrc -Isubprojects/libcstdaux-1/src -std=c11 -D_GNU_SOURCE "$SRC/fuzz-message.c"
+$CC $CFLAGS -c -o fuzz-message.o -Isrc -I subprojects/libcstdaux-*/src -std=c11 -D_GNU_SOURCE "$SRC/fuzz-message.c"
 $CXX $CXXFLAGS -o "$OUT/fuzz-message" \
     fuzz-message.o \
     build/src/libbus-static.a \
-    build/subprojects/libcdvar-1/src/libcdvar-1.a \
-    build/subprojects/libcutf8-1/src/libcutf8-1.a \
+    build/subprojects/libcdvar-*/src/libcdvar-*.a \
+    build/subprojects/libcutf8-*/src/libcutf8-*.a \
     $LIB_FUZZING_ENGINE


### PR DESCRIPTION
to make it possible to update them without having to edit
the build script.