### PR TITLE
iniconfig: fix fuzzer

### DIFF
--- a/projects/iniconfig/fuzz_parse.py
+++ b/projects/iniconfig/fuzz_parse.py
@@ -21,13 +21,12 @@ import iniconfig
 
 def TestOneInput(data):
     """Simple fuzzer that targets parse routine"""
-    with open("example.ini", "wb") as f:
-        f.write(data)
+    fdp = atheris.FuzzedDataProvider(data)
     try:
-        ini = iniconfig.IniConfig("example.ini")
-    except (iniconfig.ParseError, UnicodeDecodeError) as e:
+        ini = iniconfig.IniConfig(None, fdp.ConsumeUnicodeNoSurrogates(sys.maxsize))
+    except iniconfig.ParseError:
         pass
-    os.remove("example.ini")
+
 
 def main():
     atheris.instrument_all()


### PR DESCRIPTION
The file operations had issues with file not found. This will trigger the same parsing routines but without file operations.

Fixes: https://github.com/pytest-dev/iniconfig/issues/41