### PR TITLE
nghttp2: update build to fit new fuzzer

### DIFF
--- a/projects/nghttp2/Dockerfile
+++ b/projects/nghttp2/Dockerfile
@@ -15,7 +15,16 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config
+RUN apt-get update && apt-get install -y \
+  make \
+  autoconf \
+  automake \
+  libtool \
+  pkg-config \
+  libcunit1 \
+  libcunit1-doc \
+  libcunit1-dev
+
 RUN git clone --depth 1 https://github.com/nghttp2/nghttp2.git
 WORKDIR nghttp2
 COPY build.sh *.options $SRC/

--- a/projects/nghttp2/build.sh
+++ b/projects/nghttp2/build.sh
@@ -15,18 +15,25 @@
 #
 ################################################################################
 
-autoreconf -i
-./configure --enable-lib-only
-make -j$(nproc) all
+mkdir build
+cd build
+cmake -DENABLE_LIB_ONLY=ON -DENABLE_STATIC_LIB=ON -DHAVE_CUNIT=ON ../
+make
+make check
 
-$CXX $CXXFLAGS -std=c++11 -Ilib/includes \
-    fuzz/fuzz_target.cc -o $OUT/nghttp2_fuzzer \
-    $LIB_FUZZING_ENGINE lib/.libs/libnghttp2.a
+$CXX $CXXFLAGS -std=c++11 -I../lib/includes -Ilib/includes -I../lib/ -I../tests/ \
+    ../fuzz/fuzz_frames.cc -o $OUT/nghttp2_fuzz_frames \
+    tests/CMakeFiles/main.dir/nghttp2_test_helper.c.o \
+    $LIB_FUZZING_ENGINE lib/libnghttp2.a
 
-$CXX $CXXFLAGS -std=c++11 -Ilib/includes \
-    fuzz/fuzz_target_fdp.cc -o $OUT/nghttp2_fuzzer_fdp \
-    $LIB_FUZZING_ENGINE lib/.libs/libnghttp2.a
+$CXX $CXXFLAGS -std=c++11 -I../lib/includes -Ilib/includes -I../lib/ \
+    ../fuzz/fuzz_target.cc -o $OUT/nghttp2_fuzzer \
+    $LIB_FUZZING_ENGINE lib/libnghttp2.a
+
+$CXX $CXXFLAGS -std=c++11 -I../lib/includes -Ilib/includes -I../lib/ \
+    ../fuzz/fuzz_target_fdp.cc -o $OUT/nghttp2_fuzzer_fdp \
+    $LIB_FUZZING_ENGINE lib/libnghttp2.a
 
 cp $SRC/*.options $OUT
 
-zip -j $OUT/nghttp2_fuzzer_seed_corpus.zip fuzz/corpus/*/*
+zip -j $OUT/nghttp2_fuzzer_seed_corpus.zip ../fuzz/corpus/*/*

--- a/projects/nghttp2/build.sh
+++ b/projects/nghttp2/build.sh
@@ -22,7 +22,7 @@ make
 make check
 
 $CXX $CXXFLAGS -std=c++11 -I../lib/includes -Ilib/includes -I../lib/ -I../tests/ \
-    ../fuzz/fuzz_frames.cc -o $OUT/nghttp2_fuzz_frames \
+    ../fuzz/fuzz_frames.cc -o $OUT/nghttp2_fuzzer_frames \
     tests/CMakeFiles/main.dir/nghttp2_test_helper.c.o \
     $LIB_FUZZING_ENGINE lib/libnghttp2.a
 


### PR DESCRIPTION
Keeping this in draft until upstream PR is reviewed, some things will have to change once the upstream PR is merged.