### PR TITLE
libwebp: add libsharpyuv to link line

### DIFF
--- a/projects/libwebp/build.sh
+++ b/projects/libwebp/build.sh
@@ -39,6 +39,7 @@ webp_libs=(
   src/mux/.libs/libwebpmux.a
   src/.libs/libwebp.a
   imageio/.libs/libimageio_util.a
+  sharpyuv/.libs/libsharpyuv.a
 )
 webp_c_fuzzers=(
   advanced_api_fuzzer


### PR DESCRIPTION
Fixes build after:
a3b68c19 Build libsharpyuv as a full installable library.

Bug: oss-fuzz:49778