### PR TITLE
Add myself to auto_ccs and remove usage of EXT2_FLAG_NOFREE_ON_ERROR

### DIFF
--- a/projects/e2fsprogs/fuzz/ext2fs_image_read_write_fuzzer.cc
+++ b/projects/e2fsprogs/fuzz/ext2fs_image_read_write_fuzzer.cc
@@ -36,7 +36,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   FuzzedDataProvider stream(data, size);
   const FuzzerType f = stream.ConsumeEnum<FuzzerType>();
-  const int flags = stream.ConsumeIntegral<int>();
+  int flags = stream.ConsumeIntegral<int>();
+  flags &= (~EXT2_FLAG_NOFREE_ON_ERROR); // Unset EXT2_FLAG_NOFREE_ON_ERROR
 
   static const char* fname = "ext2_test_file";
 

--- a/projects/e2fsprogs/fuzz/ext2fs_read_bitmap_fuzzer.cc
+++ b/projects/e2fsprogs/fuzz/ext2fs_read_bitmap_fuzzer.cc
@@ -32,7 +32,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   FuzzedDataProvider stream(data, size);
   const FuzzerType f = stream.ConsumeEnum<FuzzerType>();
-  const int flags = stream.ConsumeIntegral<int>();
+  int flags = stream.ConsumeIntegral<int>();
+  flags &= (~EXT2_FLAG_NOFREE_ON_ERROR); // Unset EXT2_FLAG_NOFREE_ON_ERROR
 
   static const char* fname = "ext2_test_file";
 

--- a/projects/e2fsprogs/project.yaml
+++ b/projects/e2fsprogs/project.yaml
@@ -4,4 +4,5 @@ primary_contact: "tytso@mit.edu"
 auto_ccs:
   - "theodore.tso@gmail.com"
   - "tytso@google.com"
+  - "mxms@google.com"
 main_repo: 'https://github.com/tytso/e2fsprogs'


### PR DESCRIPTION
Add myself to auto_ccs and remove usage of EXT2_FLAG_NOFREE_ON_ERROR.

EXT2_FLAG_NOFREE_ON_ERROR leads to lots of memory leaks. Not necessary to file issues for these. 