### PR TITLE
libvips: enable the SSSE3 target

### DIFF
--- a/projects/libvips/build.sh
+++ b/projects/libvips/build.sh
@@ -162,13 +162,8 @@ popd
 pushd $SRC/libjxl
 # Ensure libvips finds JxlEncoderInitBasicInfo
 sed -i '/^Libs.private:/ s/$/ -lc++/' lib/jxl/libjxl.pc.in
-# FIXME: Remove the `-DHWY_DISABLED_TARGETS=HWY_SSSE3` workaround, see:
-# https://github.com/libjxl/libjxl/issues/858
-extra_libjxl_flags='-DHWY_DISABLED_TARGETS=HWY_SSSE3'
 cmake \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-  -DCMAKE_C_FLAGS="$CPPFLAGS $CFLAGS $extra_libjxl_flags" \
-  -DCMAKE_CXX_FLAGS="$CPPFLAGS $CXXFLAGS $extra_libjxl_flags" \
   -DCMAKE_INSTALL_PREFIX=$WORK \
   -DZLIB_ROOT=$WORK \
   -DBUILD_SHARED_LIBS=0 \

--- a/projects/libvips/build.sh
+++ b/projects/libvips/build.sh
@@ -162,8 +162,11 @@ popd
 pushd $SRC/libjxl
 # Ensure libvips finds JxlEncoderInitBasicInfo
 sed -i '/^Libs.private:/ s/$/ -lc++/' lib/jxl/libjxl.pc.in
+# CMake ignores the CPPFLAGS env, so prepend it to -DCMAKE_C{XX,}_FLAGS instead
 cmake \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DCMAKE_C_FLAGS="$CPPFLAGS $CFLAGS" \
+  -DCMAKE_CXX_FLAGS="$CPPFLAGS $CXXFLAGS" \
   -DCMAKE_INSTALL_PREFIX=$WORK \
   -DZLIB_ROOT=$WORK \
   -DBUILD_SHARED_LIBS=0 \


### PR DESCRIPTION
This reverts commit https://github.com/google/oss-fuzz/commit/912251824c51541ec0bc2085612e5463e1e68429, which was introduced in PR https://github.com/google/oss-fuzz/pull/6845.

See: https://github.com/libjxl/libjxl/issues/858#issuecomment-1200389177.