### PR TITLE
Small change to maintain the existing corpus

### DIFF
--- a/projects/e2fsprogs/fuzz/ext2fs_image_read_write_fuzzer.cc
+++ b/projects/e2fsprogs/fuzz/ext2fs_image_read_write_fuzzer.cc
@@ -36,6 +36,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   FuzzedDataProvider stream(data, size);
   const FuzzerType f = stream.ConsumeEnum<FuzzerType>();
+  (void) stream.ConsumeIntegral<int>();
+  // Keep this here to not spoil the corpus or reproducers
 
   static const char* fname = "ext2_test_file";
 

--- a/projects/e2fsprogs/fuzz/ext2fs_read_bitmap_fuzzer.cc
+++ b/projects/e2fsprogs/fuzz/ext2fs_read_bitmap_fuzzer.cc
@@ -32,6 +32,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   FuzzedDataProvider stream(data, size);
   const FuzzerType f = stream.ConsumeEnum<FuzzerType>();
+  (void) stream.ConsumeIntegral<int>();
 
   static const char* fname = "ext2_test_file";
 


### PR DESCRIPTION
Keep the consumeInt such that the existing corpus still works exactly. This also ensures that open bugs still repro with the latest fuzzers.