### PR TITLE
dropbear: fix broken build

### DIFF
--- a/projects/dropbear/Dockerfile
+++ b/projects/dropbear/Dockerfile
@@ -16,7 +16,6 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y libz-dev autoconf mercurial
-RUN hg clone https://hg.ucc.asn.au/dropbear-fuzzcorpus dropbear-corpus
 RUN git clone https://github.com/mkj/dropbear dropbear
 WORKDIR dropbear
 COPY build.sh *.options $SRC/

--- a/projects/dropbear/build.sh
+++ b/projects/dropbear/build.sh
@@ -27,9 +27,6 @@ make -j$(nproc) fuzz-targets FUZZLIB=$LIB_FUZZING_ENGINE
 
 TARGETS="$(make list-fuzz-targets)"
 
-make -C $SRC/dropbear-corpus
 
 cp -v $TARGETS $OUT/
 cp -v *.options $OUT/
-cp -v $SRC/dropbear-corpus/*.zip $OUT/
-cp -v $SRC/dropbear-corpus/*.dict $OUT/


### PR DESCRIPTION
The corpus repository seems to not be available anymore which breaks the whole build.

Signed-off-by: AdamKorcz <adam@adalogics.com>