### PR TITLE
fluent-bit: added dependency (openssl)

### DIFF
--- a/projects/fluent-bit/Dockerfile
+++ b/projects/fluent-bit/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make cmake flex bison
+RUN apt-get update && apt-get install -y make cmake flex bison libssl-dev
 RUN git clone --depth 1 https://github.com/fluent/fluent-bit/ fluent-bit
 
 WORKDIR $SRC


### PR DESCRIPTION
fluent-bit is transitioning from mbedtls to openssl making the latter mandatory and completely remove the former.
 
Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>