### PR TITLE
flask: extend fuzzing

### DIFF
--- a/projects/flask/fuzz_env_jinja_lexer.py
+++ b/projects/flask/fuzz_env_jinja_lexer.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 import sys
 import atheris
+import traceback
 
 with atheris.instrument_imports():
     import jinja2
@@ -26,9 +27,16 @@ def TestOneInput(data):
     env = jinja2.Environment()
     try:
         v1 = env.from_string(original)
-    except jinja2.TemplateSyntaxError:
+        v1.render()
+    except (jinja2.TemplateSyntaxError, jinja2.UndefinedError, RecursionError, MemoryError) as e:
         return
-    v1.render()
+    except Exception as e2:
+        # avoid raising anything that is raise by jinjas "handle_exception"
+        tb = traceback.format_exc()
+        if "handle_exception" in str(tb):
+            pass
+        else:
+            raise e2
 
     # Hit tokernizer directly
     env.lexer.tokenize(original)

--- a/projects/flask/fuzz_jinja_compile_expr.py
+++ b/projects/flask/fuzz_jinja_compile_expr.py
@@ -29,6 +29,8 @@ def TestOneInput(data):
       return
     except RecursionError:
       return
+    except MemoryError:
+      return
     return
 
 def main():

--- a/projects/flask/fuzz_werkzeug_http.py
+++ b/projects/flask/fuzz_werkzeug_http.py
@@ -34,7 +34,7 @@ def TestOneInput(data):
       # https://github.com/pallets/werkzeug/blob/main/src/werkzeug/datastructures.py#L2580
       # https://github.com/pallets/werkzeug/blob/main/src/werkzeug/datastructures.py#L2596
       pass
-    else;
+    else:
       raise e
 
 

--- a/projects/flask/fuzz_werkzeug_http.py
+++ b/projects/flask/fuzz_werkzeug_http.py
@@ -22,12 +22,20 @@ with atheris.instrument_imports():
 
 def TestOneInput(data):
   fdp = atheris.FuzzedDataProvider(data)
-  whttp.parse_content_range_header(fdp.ConsumeUnicode(100))
-  whttp.parse_range_header(fdp.ConsumeUnicode(100))
-  whttp.parse_set_header(fdp.ConsumeUnicode(100))
-  whttp.parse_etags(fdp.ConsumeUnicode(100))
-  whttp.parse_if_range_header(fdp.ConsumeUnicode(100))
-  whttp.parse_dict_header(fdp.ConsumeUnicode(100))
+  try:
+    whttp.parse_content_range_header(fdp.ConsumeUnicode(100))
+    whttp.parse_range_header(fdp.ConsumeUnicode(100))
+    whttp.parse_set_header(fdp.ConsumeUnicode(100))
+    whttp.parse_etags(fdp.ConsumeUnicode(100))
+    whttp.parse_if_range_header(fdp.ConsumeUnicode(100))
+    whttp.parse_dict_header(fdp.ConsumeUnicode(100))
+  except ValueError as e:
+    if "Bad range provided" in str(e):
+      # https://github.com/pallets/werkzeug/blob/main/src/werkzeug/datastructures.py#L2580
+      # https://github.com/pallets/werkzeug/blob/main/src/werkzeug/datastructures.py#L2596
+      pass
+    else;
+      raise e
 
 
 def main():


### PR DESCRIPTION
Extends fuzzing by catching more exceptions that seem to be irrelevant. This closes various issues found and lets the fuzzers focus more on flask/jinja/werkzeug specific code.