### PR TITLE
fluxcd: Update Flux Security Team details

### DIFF
--- a/projects/fluxcd/project.yaml
+++ b/projects/fluxcd/project.yaml
@@ -2,9 +2,9 @@ homepage: "https://fluxcd.io/"
 main_repo: "https://github.com/fluxcd/flux2"
 primary_contact: "cncf-flux-security@lists.cncf.io"
 auto_ccs :
-  - "stefan@weave.works"
   - "hidde@weave.works"
-  - "michael@weave.works"
+  - "scott@weave.works"
+  - "paulo.gomes@weave.works"
   - "david@adalogics.com"
   - "adam@adalogics.com"
 language: go


### PR DESCRIPTION
Updating contact details based on current members of the Flux Security Team:
https://github.com/fluxcd/.github/blob/main/SECURITY.md#security-team

cc: @stefanprodan @hiddeco @scottrigby @squaremo