### PR TITLE
native go fuzzing: Restrict fuzzer lookup to `*.go`

### DIFF
--- a/infra/base-images/base-builder/compile_native_go_fuzzer
+++ b/infra/base-images/base-builder/compile_native_go_fuzzer
@@ -77,7 +77,7 @@ tags="-tags gofuzz"
 abs_file_dir=$(go list $tags -f {{.Dir}} $path)
 
 # TODO(adamkorcz): Get rid of "-r" flag here.
-fuzzer_filename=$(grep -r -l  -s "$function" "${abs_file_dir}")
+fuzzer_filename=$(grep -r -l --include='*.go' -s "$function" "${abs_file_dir}")
 
 # Test if file contains a line with "func $function" and "testing.F".
 if [ $(grep -r "func $function" $fuzzer_filename | grep "testing.F" | wc -l) -eq 1 ]


### PR DESCRIPTION
Projects containing words starting with Fuzz in non-go files break `compile_native_go_fuzzer` with the error:

`sed: -e expression #1, char 15: unknown option to 's'`