### PR TITLE
ghostscript: extend with eps2write device fuzzer

### DIFF
--- a/projects/ghostscript/build.sh
+++ b/projects/ghostscript/build.sh
@@ -45,7 +45,7 @@ CPPFLAGS="${CPPFLAGS:-} $CUPS_CFLAGS -DPACIFY_VALGRIND" ./autogen.sh \
   CUPSCONFIG=$CUPSCONFIG \
   --enable-freetype --enable-fontconfig \
   --enable-cups --with-ijs --with-jbig2dec \
-  --with-drivers=pdfwrite,cups,ljet4,laserjet,pxlmono,pxlcolor,pcl3,uniprint,pgmraw,ps2write,png16m,tiffsep1,faxg3,psdcmyk
+  --with-drivers=pdfwrite,cups,ljet4,laserjet,pxlmono,pxlcolor,pcl3,uniprint,pgmraw,ps2write,png16m,tiffsep1,faxg3,psdcmyk,eps2write
 make -j$(nproc) libgs
 
 fuzzers="gstoraster_fuzzer            \
@@ -58,9 +58,11 @@ fuzzers="gstoraster_fuzzer            \
          gs_device_ps2write_fuzzer    \
          gs_device_png16m_fuzzer      \
          gs_device_psdcmyk_fuzzer     \
+         gs_device_eps2write_fuzzer   \
          gs_device_faxg3_fuzzer       \
          gs_device_tiffsep1_fuzzer"
 
+fuzzers="gs_device_eps2write_fuzzer gs_device_eps2write_fuzzer"
 for fuzzer in $fuzzers; do
   $CXX $CXXFLAGS $CUPS_LDFLAGS -std=c++11 -I. -I$SRC \
     $SRC/${fuzzer}.cc \
@@ -96,6 +98,7 @@ done
 zip -j "$OUT/gstoraster_fuzzer_seed_corpus.zip" "$WORK"/seeds/*
 cp "$OUT/gstoraster_fuzzer_seed_corpus.zip" "$OUT/gs_device_pdfwrite_fuzzer_seed_corpus.zip"
 cp "$OUT/gstoraster_fuzzer_seed_corpus.zip" "$OUT/gs_device_pxlmono_fuzzer_seed_corpus.zip"
+cp "$OUT/gstoraster_fuzzer_seed_corpus.zip" "$OUT/gs_device_eps2write_fuzzer_seed_corpus.zip"
 
 # Copy out options
 cp $SRC/*.options $OUT/

--- a/projects/ghostscript/build.sh
+++ b/projects/ghostscript/build.sh
@@ -62,7 +62,6 @@ fuzzers="gstoraster_fuzzer            \
          gs_device_faxg3_fuzzer       \
          gs_device_tiffsep1_fuzzer"
 
-fuzzers="gs_device_eps2write_fuzzer gs_device_eps2write_fuzzer"
 for fuzzer in $fuzzers; do
   $CXX $CXXFLAGS $CUPS_LDFLAGS -std=c++11 -I. -I$SRC \
     $SRC/${fuzzer}.cc \

--- a/projects/ghostscript/gs_device_eps2write_fuzzer.cc
+++ b/projects/ghostscript/gs_device_eps2write_fuzzer.cc
@@ -1,0 +1,20 @@
+/* Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "gs_fuzzlib.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+	fuzz_gs_device(data, size, 1, "eps2write", "/dev/null");
+	return 0;
+}


### PR DESCRIPTION
eps2write is one of the high-level devices currently not targeted by the
fuzzing suite. This adds a fuzzer for this high-level device.