### PR TITLE
Pin Jazzer to older revision

### DIFF
--- a/infra/base-images/base-builder/install_java.sh
+++ b/infra/base-images/base-builder/install_java.sh
@@ -27,8 +27,9 @@ rm -rf $JAVA_HOME/jmods $JAVA_HOME/lib/src.zip
 # jazzer_api_deploy.jar is required only at build-time, the agent and the
 # drivers are copied to $OUT as they need to be present on the runners.
 cd $SRC/
-git clone --depth=1 https://github.com/CodeIntelligenceTesting/jazzer && \
-cd jazzer
+git clone https://github.com/CodeIntelligenceTesting/jazzer && \
+cd jazzer && \
+git checkout 9076da807d9990a7806836fa5666bc43fb5270ae
 bazel build --java_runtime_version=local_jdk_15 -c opt --cxxopt="-stdlib=libc++" --linkopt=-lc++ \
   //agent:jazzer_agent_deploy.jar //driver:jazzer_driver //driver:jazzer_driver_asan //driver:jazzer_driver_ubsan //agent:jazzer_api_deploy.jar
 cp bazel-bin/agent/jazzer_agent_deploy.jar bazel-bin/driver/jazzer_driver bazel-bin/driver/jazzer_driver_asan bazel-bin/driver/jazzer_driver_ubsan /usr/local/bin/


### PR DESCRIPTION
All latest builds seem to be broken with:

```
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
INFO: Loaded 112 hooks from com.code_intelligence.jazzer.runtime.TraceCmpHooks
INFO: Loaded 4 hooks from com.code_intelligence.jazzer.runtime.TraceDivHooks
INFO: Loaded 2 hooks from com.code_intelligence.jazzer.runtime.TraceIndirHooks
INFO: Loaded 4 hooks from com.code_intelligence.jazzer.runtime.NativeLibHooks
INFO: Loaded 8 hooks from com.code_intelligence.jazzer.sanitizers.Deserialization
INFO: Loaded 5 hooks from com.code_intelligence.jazzer.sanitizers.ExpressionLanguageInjection
INFO: Loaded 70 hooks from com.code_intelligence.jazzer.sanitizers.LdapInjection
INFO: Loaded 46 hooks from com.code_intelligence.jazzer.sanitizers.NamingContextLookup
INFO: Loaded 1 hooks from com.code_intelligence.jazzer.sanitizers.OsCommandInjection
INFO: Loaded 52 hooks from com.code_intelligence.jazzer.sanitizers.ReflectiveCall
INFO: Loaded 8 hooks from com.code_intelligence.jazzer.sanitizers.RegexInjection
Exception in thread "main" java.lang.ExceptionInInitializerError
  at com.code_intelligence.jazzer.sanitizers.RegexRoadblocks.<clinit>(RegexRoadblocks.java:72)
  at java.base/java.lang.Class.forName0(Native Method)
  at java.base/java.lang.Class.forName(Class.java:398)
  at com.code_intelligence.jazzer.instrumentor.Hooks$Companion$HooksLoader.loadHooks(Hooks.kt:66)
  at com.code_intelligence.jazzer.instrumentor.Hooks$Companion$HooksLoader.load(Hooks.kt:48)
  at com.code_intelligence.jazzer.instrumentor.Hooks$Companion.loadHooks(Hooks.kt:42)
  at com.code_intelligence.jazzer.agent.Agent.premain(Agent.kt:137)
  at com.code_intelligence.jazzer.driver.Driver.start(Driver.java:97)
Caused by: java.lang.NumberFormatException: For input string: "./jazzer_driver"
  at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:66)
  at java.base/java.lang.Long.parseLong(Long.java:680)
  at java.base/java.lang.Integer.parseUnsignedInt(Integer.java:835)
  at java.base/java.lang.Integer.parseUnsignedInt(Integer.java:929)
  at com.code_intelligence.jazzer.api.Jazzer.getLibFuzzerSeed(Jazzer.java:635)
  at com.code_intelligence.jazzer.api.Jazzer.<clinit>(Jazzer.java:38)
  ... 8 more
```