### PR TITLE
burntsushi-toml: Fixes out-of-memory crash

### DIFF
--- a/projects/burntsushi-toml/fuzz.go
+++ b/projects/burntsushi-toml/fuzz.go
@@ -3,6 +3,11 @@ package toml
 import "bytes"
 
 func FuzzToml(data []byte) int {
+
+	if len(data) >= 10240 {
+		return 0
+	}
+
 	buf := make([]byte, 0, 2048)
 
 	var m interface{}


### PR DESCRIPTION
Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=50415
- Adds early return on too big fuzz test case 