### PR TITLE
[skia] Add COLRv1 fuzzer from upstream

### DIFF
--- a/projects/skia/Dockerfile
+++ b/projects/skia/Dockerfile
@@ -72,6 +72,8 @@ RUN wget -O $SRC/skia_data/skp_seed_corpus.zip https://storage.googleapis.com/sk
 
 RUN wget -O $SRC/skia_data/skdescriptor_deserialize_seed_corpus.zip https://storage.googleapis.com/skia-fuzzer/oss-fuzz/skdescriptor_deserialize_seed_corpus.zip
 
+RUN wget -O $SRC/skia_data/colrv1_seed_corpus.zip https://storage.googleapis.com/skia-fuzzer/oss-fuzz/colrv1_seed_corpus.zip
+
 COPY image_filter_deserialize_width.options $SRC/skia_data/image_filter_deserialize_width.options
 
 COPY json.dict $SRC/skia_data/json.dict

--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -133,6 +133,7 @@ $SRC/depot_tools/ninja -C out/Fuzz \
   api_skparagraph \
   api_svg_canvas \
   api_triangulation \
+  colrv1 \
   image_decode \
   image_decode_incremental \
   image_filter_deserialize \
@@ -284,3 +285,6 @@ mv out/Fuzz/api_skparagraph $OUT/api_skparagraph
 mv out/Fuzz/api_regionop $OUT/api_regionop
 
 mv out/Fuzz/api_triangulation $OUT/api_triangulation
+
+mv out/Fuzz/colrv1 $OUT/colrv1
+mv ../skia_data/colrv1_seed_corpus.zip $OUT/colrv1_seed_corpus.zip


### PR DESCRIPTION
Add fuzzer for COLRv1 glyph rendering, locally tested to run at >400
runs/s. Corpus file colrv1_seed_corpus.zip uploaded to bucket. The
corpus is mostly identical to the freetype2-testing COLRv1 corpus [2].

Fuzzer code for COLRv1 added in Skia in [1].

[1] https://skia-review.googlesource.com/c/skia/+/571934
[2] https://github.com/freetype/freetype2-testing/tree/master/fuzzing/corpora/colrv1