### PR TITLE
Update project.yaml

### DIFF
--- a/projects/protobuf-java/project.yaml
+++ b/projects/protobuf-java/project.yaml
@@ -9,6 +9,8 @@ auto_ccs:
   - "sandyzhang@google.com"
   - "norbert.schneider@code-intelligence.com"
   - "hlin@code-intelligence.com"
+  - "protobuf-core@google.com"
+  - "woops-core@google.com"
 fuzzing_engines:
   - libfuzzer
 main_repo: "https://github.com/protocolbuffers/protobuf"


### PR DESCRIPTION
Add protobuf-core@ and woops-core@ to project.yaml.

Individual protobuf team members can probably be removed once we've confirmed whether groups can auth.