### PR TITLE
[aarch64] Add ARM support to GHA CI.

### DIFF
--- a/.github/workflows/project_tests.yml
+++ b/.github/workflows/project_tests.yml
@@ -35,6 +35,9 @@ jobs:
           - engine: libfuzzer
             sanitizer: address
             architecture: i386
+          - engine: libfuzzer
+            sanitizer: address
+            architecture: aarch64
           - engine: none
             sanitizer: address
             architecture: x86_64


### PR DESCRIPTION
This uses emulation and depends on:
https://github.com/google/oss-fuzz/pull/8332
Related: #8164