### PR TITLE
Revert "[aarch64] Add ARM support to GHA CI. (#8333)"

### DIFF
--- a/.github/workflows/project_tests.yml
+++ b/.github/workflows/project_tests.yml
@@ -35,9 +35,6 @@ jobs:
           - engine: libfuzzer
             sanitizer: address
             architecture: i386
-          - engine: libfuzzer
-            sanitizer: address
-            architecture: aarch64
           - engine: none
             sanitizer: address
             architecture: x86_64


### PR DESCRIPTION
This reverts commit 5ccb903f178c42392090d729f3888926293edae8.