### PR TITLE
hunspell: enable msan and use project build script

### DIFF
--- a/projects/hunspell/build.sh
+++ b/projects/hunspell/build.sh
@@ -15,11 +15,4 @@
 #
 ################################################################################
 
-mv -f ./tests/korean.* $OUT/
-mv -f ./tests/utf8_nonbmp.* $OUT/
-
-autoreconf -vfi
-./configure --disable-shared --enable-static
-make clean
-make -j$(nproc) 
-$CXX $CXXFLAGS -o $OUT/fuzzer -I./src/ $LIB_FUZZING_ENGINE ./src/tools/fuzzer.cxx ./src/hunspell/.libs/libhunspell-1.7.a
+$SRC/hunspell/oss-fuzz-build.sh

--- a/projects/hunspell/project.yaml
+++ b/projects/hunspell/project.yaml
@@ -7,10 +7,9 @@ vendor_ccs:
   - "twsmith@mozilla.com"
 sanitizers:
   - address
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
-#  - memory
+  - memory
   - undefined
 architectures:
- - i386
- - x86_64
+  - i386
+  - x86_64
 main_repo: 'https://github.com/hunspell/hunspell.git'


### PR DESCRIPTION
msan works fine, and using a project-side build script makes it more
flexible to extend hunspell's fuzzing