### PR TITLE
[containerd] remove cncf-fuzzing

### DIFF
--- a/projects/containerd/Dockerfile
+++ b/projects/containerd/Dockerfile
@@ -17,6 +17,5 @@
 FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN apt-get update && apt-get install -y btrfs-progs libc-dev pkg-config libseccomp-dev gcc wget libbtrfs-dev
 RUN git clone --depth 1 https://github.com/containerd/containerd
-RUN git clone --depth 1 https://github.com/cncf/cncf-fuzzing
 COPY build.sh $SRC/
 WORKDIR $SRC/containerd

--- a/projects/containerd/build.sh
+++ b/projects/containerd/build.sh
@@ -16,4 +16,3 @@
 ################################################################################
 
 $SRC/containerd/contrib/fuzz/oss_fuzz_build.sh
-$SRC/cncf-fuzzing/projects/containerd/build.sh


### PR DESCRIPTION
The only fuzzer we have there is containerd_import_structured_fuzzer.go
but it is ignored by build.sh since
https://github.com/cncf/cncf-fuzzing/pull/220.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>