### PR TITLE
go-toml: initial integration

### DIFF
--- a/projects/go-toml/Dockerfile
+++ b/projects/go-toml/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN apt-get update && apt-get install -y make autoconf automake libtool vim
-RUN git clone --depth 1 https://github.com/pelletier/go-toml go-toml
+RUN git clone --depth 1 --single-branch --branch v2 https://github.com/pelletier/go-toml go-toml
 COPY build.sh $SRC/
 COPY *.go $SRC/go-toml
 WORKDIR $SRC/go-toml

--- a/projects/go-toml/Dockerfile
+++ b/projects/go-toml/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN apt-get update && apt-get install -y make autoconf automake libtool vim
+RUN git clone --depth 1 https://github.com/pelletier/go-toml go-toml
+COPY build.sh $SRC/
+COPY *.go $SRC/go-toml
+WORKDIR $SRC/go-toml

--- a/projects/go-toml/build.sh
+++ b/projects/go-toml/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+compile_go_fuzzer . FuzzToml fuzz_toml gofuzz

--- a/projects/go-toml/fuzz.go
+++ b/projects/go-toml/fuzz.go
@@ -1,0 +1,20 @@
+package toml
+
+func FuzzToml(data []byte) int {
+	if len(data) >= 10240 {
+		return 0
+	}
+
+	var v interface{}
+	err := Unmarshal(data, &v)
+	if err != nil {
+		return 0
+	}
+
+	_, err = Marshal(v)
+	if err != nil {
+		return 0
+	}
+
+	return 1
+}

--- a/projects/go-toml/fuzz.go
+++ b/projects/go-toml/fuzz.go
@@ -1,10 +1,6 @@
 package toml
 
 func FuzzToml(data []byte) int {
-	if len(data) >= 10240 {
-		return 0
-	}
-
 	var v interface{}
 	err := Unmarshal(data, &v)
 	if err != nil {

--- a/projects/go-toml/project.yaml
+++ b/projects/go-toml/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/pelletier/go-toml"
+language: go
+main_repo: "https://github.com/pelletier/go-toml"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+vendor_ccs:
+  - maxnair.dev@gmail.com

--- a/projects/go-toml/project.yaml
+++ b/projects/go-toml/project.yaml
@@ -1,6 +1,7 @@
 homepage: "https://github.com/pelletier/go-toml"
 language: go
 main_repo: "https://github.com/pelletier/go-toml"
+primary_contact: "pelletier.thomas@gmail.com"
 fuzzing_engines:
   - libfuzzer
 sanitizers:

--- a/projects/guice/build.sh
+++ b/projects/guice/build.sh
@@ -95,6 +95,7 @@ LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\":\$this_dir \
 --cp=$RUNTIME_CLASSPATH \
 --target_class=$fuzzer_basename \
 --jvm_args=\"-Xmx2048m\" \
+--disabled_hooks=\"com.code_intelligence.jazzer.sanitizers.ReflectiveCall\" \
 \$@" > $OUT/$fuzzer_basename
   chmod u+x $OUT/$fuzzer_basename
 done


### PR DESCRIPTION
Hi,
[go-toml](https://github.com/pelletier/go-toml) is Go library for the [TOML](https://toml.io/en/) format. As per github's [network dependents](https://github.com/pelletier/go-toml/network/dependents), it is being used by projects like 
- [vercel/turborepo](https://github.com/vercel/turborepo), 
- [containrrr/watchtower](https://github.com/containrrr/watchtower),
- [cloudflare/cloudflare-go](https://github.com/cloudflare/cloudflare-go),
- [uber/cadence](https://github.com/uber/cadence),
- [hashicorp/terraform-provider-google](https://github.com/hashicorp/terraform-provider-google).

Edit: Also used by projects like
 - [spf13/viper](https://github.com/spf13/viper) 
 - [gohugo](https://gohugo.io/)