### PR TITLE
uint256: fix failing build

### DIFF
--- a/projects/uint256/Dockerfile
+++ b/projects/uint256/Dockerfile
@@ -16,10 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
 
-RUN go get -u -d github.com/holiman/uint256/...
-
 RUN git clone --depth 1 https://github.com/holiman/uint256.git uint256
-
 RUN cp uint256/oss-fuzz.sh $SRC/build.sh
 
-WORKDIR $SRC/
+WORKDIR $SRC/uint256


### PR DESCRIPTION
Fixes the build issue:
```
New issue 50607 by ClusterFuzz-External: uint256: Fuzzing build failure
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=50607
```
