### PR TITLE
containerd: add some maintainers to auto_ccs

### DIFF
--- a/projects/containerd/project.yaml
+++ b/projects/containerd/project.yaml
@@ -3,6 +3,10 @@ main_repo: "https://github.com/containerd/containerd"
 primary_contact: "security@containerd.io"
 auto_ccs :
   - "adam@adalogics.com"
+  - "samuelkarp@google.com"
+  - "derek@mcgstyle.net"
+  - "estesp@gmail.com"
+  - "mikebrow@gmail.com"
 language: go
 fuzzing_engines:
   - libfuzzer


### PR DESCRIPTION
https://github.com/containerd/project/blob/main/MAINTAINERS

Per https://google.github.io/oss-fuzz/faq/#why-do-you-require-a-google-account-for-authentication, these are all Google accounts.