### PR TITLE
bitcoin-core: Bump clang to remove one workaround, and add one

### DIFF
--- a/projects/bitcoin-core/Dockerfile
+++ b/projects/bitcoin-core/Dockerfile
@@ -14,9 +14,7 @@
 #
 ################################################################################
 
-# Held back because of github.com/google/oss-fuzz/pull/8313
-# Please fix failure and upgrade.
-FROM gcr.io/oss-fuzz-base/base-builder-rust@sha256:b942129fbed50e87e554a58dbbbbf90382f17c650dc4d4e27b7a9f8e68b1d494
+FROM gcr.io/oss-fuzz-base/base-builder-rust
 
 # Packages taken from:
 # * https://github.com/bitcoin/bitcoin/blob/master/doc/build-unix.md#dependency-build-instructions

--- a/projects/bitcoin-core/build.sh
+++ b/projects/bitcoin-core/build.sh
@@ -38,16 +38,6 @@ fi
 sed -i "s|PROVIDE_FUZZ_MAIN_FUNCTION|NEVER_PROVIDE_MAIN_FOR_OSS_FUZZ|g" "./configure.ac"
 ./autogen.sh
 
-# Temporarily compile with O2 to work around clang-13 (and later) UBSan
-# -fsanitize=vptr,object-size false positive that only happens with -O1
-# Fixed in https://github.com/llvm/llvm-project/commit/bbeaf2aac678
-# However, OSS-Fuzz is stuck on a buggy clang, so the workaround is still
-# needed. See https://github.com/google/oss-fuzz/pull/7140
-if [ "$SANITIZER" = "undefined" ]; then
-  export CFLAGS="$CFLAGS -O2"
-  export CXXFLAGS="$CXXFLAGS -O2"
-fi
-
 # OSS-Fuzz will provide CC, CXX, etc. So only set:
 # * --enable-fuzz, see https://github.com/bitcoin/bitcoin/blob/master/doc/fuzzing.md
 # * CONFIG_SITE, see https://github.com/bitcoin/bitcoin/blob/master/depends/README.md

--- a/projects/bitcoin-core/build_cryptofuzz.sh
+++ b/projects/bitcoin-core/build_cryptofuzz.sh
@@ -95,6 +95,14 @@ export BOTAN_INCLUDE_PATH="$SRC/botan/build/include"
 
 # Build Cryptofuzz
 cd $SRC/cryptofuzz
+( # Temporary workaround for clang-15 bug, see https://github.com/google/oss-fuzz/pull/8313#issuecomment-1223234359
+echo 'ZGlmZiAtLWdpdCBhL211dGF0b3Jwb29sLmggYi9tdXRhdG9ycG9vbC5oCmluZGV4IDIwMDA3YWUu
+LmFiMGVkMjggMTAwNjQ0Ci0tLSBhL211dGF0b3Jwb29sLmgKKysrIGIvbXV0YXRvcnBvb2wuaApA
+QCAtMTAzLDcgKzEwMyw3IEBAIHR5cGVkZWYgc3RydWN0IHsKIH0gRnAxMjsKIGV4dGVybiBNdXRh
+dG9yUG9vbDxGcDEyLCBjcnlwdG9mdXp6Ojpjb25maWc6OmtNdXRhdG9yUG9vbFNpemU+IFBvb2xf
+RnAxMjsKIAotdHlwZWRlZiBzdHJ1Y3QgewordHlwZWRlZiBzdHJ1Y3QgQU5PTl9TVFJVQ1RfYzFm
+NTg0MDFkMGQyNTlhYzM1M2NjYTM2MDdmOGVlZGYgewogICAgIHN0cnVjdCBHMSB7CiAgICAgICAg
+IHN0ZDo6c3RyaW5nIGcxX3g7CiAgICAgICAgIHN0ZDo6c3RyaW5nIGcxX3k7Cg=='|base64 --decode | patch -p 1 ; git diff ) || true
 python gen_repository.py
 rm extra_options.h
 echo -n '"' >>extra_options.h


### PR DESCRIPTION
The added workaround can likely be removed after #8108