### PR TITLE
Add `architecture` to `run_fuzzer_parser`'s namespace

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -292,6 +292,7 @@ def get_parser():  # pylint: disable=too-many-statements
 
   run_fuzzer_parser = subparsers.add_parser(
       'run_fuzzer', help='Run a fuzzer in the emulated fuzzing environment.')
+  _add_architecture_args(run_fuzzer_parser)
   _add_engine_args(run_fuzzer_parser)
   _add_sanitizer_args(run_fuzzer_parser)
   _add_environment_args(run_fuzzer_parser)


### PR DESCRIPTION
To fix the following error:
```
Traceback (most recent call last):
  File "/path/to/oss-fuzz/infra/helper.py", line 1178, in <module>
    sys.exit(main())
  File "/path/to/oss-fuzz/infra/helper.py", line 174, in main
    result = run_fuzzer(args)
  File "/path/to/oss-fuzz/infra/helper.py", line 972, in run_fuzzer
    return docker_run(run_args, architecture=args.architecture)
AttributeError: 'Namespace' object has no attribute 'architecture'
```