### PR TITLE
[openssh] Turn off toolchain hardening flags in configure

### DIFF
--- a/projects/openssh/build.sh
+++ b/projects/openssh/build.sh
@@ -25,6 +25,7 @@ sed -i 's|\(usleep.*\)|// \1|' ssh-agent.c
 autoreconf
 env
 if ! env CFLAGS="" ./configure \
+    --without-hardening \
     --without-zlib-version-check \
     --with-cflags="-DWITH_XMSS=1" \
     --with-cflags-after="$CFLAGS" \


### PR DESCRIPTION
These seem to clash with the oss-fuzz environment leading to weird
crashes like monorail #50678

@daztucker 