### PR TITLE
Changes to apache-commons-configuration and new fuzz targets for httpmime

### DIFF
--- a/projects/apache-commons-configuration/INIConfigurationReadFuzzer.java
+++ b/projects/apache-commons-configuration/INIConfigurationReadFuzzer.java
@@ -1,3 +1,19 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 
 import java.io.InputStream;

--- a/projects/apache-commons-configuration/INIConfigurationWriteFuzzer.java
+++ b/projects/apache-commons-configuration/INIConfigurationWriteFuzzer.java
@@ -1,3 +1,19 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 
 import java.io.InputStream;

--- a/projects/apache-commons-configuration/JSONConfigurationReadFuzzer.java
+++ b/projects/apache-commons-configuration/JSONConfigurationReadFuzzer.java
@@ -1,3 +1,19 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 
 import java.io.InputStream;
@@ -15,6 +31,8 @@ public class JSONConfigurationReadFuzzer {
 
         // Create needed objects
         final JSONConfiguration jsonConfig = new JSONConfiguration();
+        jsonConfig.setLogger(null); // disable logger
+
         final InputStream inputStream = new ByteArrayInputStream(byteArray);
         final InputStreamReader reader;
 

--- a/projects/apache-commons-configuration/JSONConfigurationWriteFuzzer.java
+++ b/projects/apache-commons-configuration/JSONConfigurationWriteFuzzer.java
@@ -1,3 +1,19 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 
 import java.io.InputStream;
@@ -17,6 +33,8 @@ public class JSONConfigurationWriteFuzzer {
 
         // Create needed objects
         JSONConfiguration jsonConfig = new JSONConfiguration();
+        jsonConfig.setLogger(null); // disable logger
+
         InputStream inputStream = new ByteArrayInputStream(byteArray);
         InputStreamReader reader;
         StringWriter writer = new StringWriter();

--- a/projects/apache-commons-configuration/XMLConfigurationWriteFuzzer.java
+++ b/projects/apache-commons-configuration/XMLConfigurationWriteFuzzer.java
@@ -19,12 +19,13 @@ import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.StringWriter;
 
 import org.apache.commons.configuration2.XMLConfiguration;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.configuration2.io.FileHandler;
 
-public class XMLConfigurationLoadFuzzer {
+public class XMLConfigurationWriteFuzzer {
     public static void fuzzerTestOneInput(FuzzedDataProvider data) {
         // Create needed objects
         final File tempFile;
@@ -45,14 +46,15 @@ public class XMLConfigurationLoadFuzzer {
         }
 
         final XMLConfiguration xmlConfig = new XMLConfiguration();
-        xmlConfig.setLogger(null); // disable logger
+        xmlConfig.setLogger(null); // disable the logger
 
         final FileHandler fileHandler = new FileHandler(xmlConfig);
         fileHandler.setPath(absoluteFilepath);
 
         try {
             fileHandler.load();
-        } catch (ConfigurationException ignored) {
+            xmlConfig.write(new StringWriter());
+        } catch (ConfigurationException | IOException ignored) {
             // expected Exceptions get ignored
         } finally {
             tempFile.delete();

--- a/projects/apache-commons-configuration/YAMLConfigurationReadFuzzer.java
+++ b/projects/apache-commons-configuration/YAMLConfigurationReadFuzzer.java
@@ -1,22 +1,59 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 
-import java.io.InputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
 import org.apache.commons.configuration2.YAMLConfiguration;
 import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.yaml.snakeyaml.LoaderOptions;
 
 public class YAMLConfigurationReadFuzzer {
-    public static void fuzzerTestOneInput(byte[] data) {
-        // Create needed objects
-        YAMLConfiguration yamlConfig = new YAMLConfiguration();
-        InputStream inputStream = new ByteArrayInputStream(data);
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        // Create helper objects from fuzzer data
+        final boolean useLoaderOptions = data.consumeBoolean();
 
+        // Create needed objects
+        final YAMLConfiguration yamlConfig = new YAMLConfiguration();
+        yamlConfig.setLogger(null); // disable logging
+
+        // the actual fuzzing starts here
         try {
-            yamlConfig.read(inputStream);
+            if (useLoaderOptions) {
+                final LoaderOptions loaderOptions = createLoaderOptions(data);
+                yamlConfig.read(new ByteArrayInputStream(data.consumeBytes(Integer.MAX_VALUE)), loaderOptions);
+            } else {
+                yamlConfig.read(new ByteArrayInputStream(data.consumeBytes(Integer.MAX_VALUE)));
+            }
         } catch (ConfigurationException ignored) {
             // expected Exceptions get ignored
         }
+    }
+
+    private static LoaderOptions createLoaderOptions(FuzzedDataProvider data) {
+        LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setAllowDuplicateKeys(data.consumeBoolean());
+        loaderOptions.setWrappedToRootException(data.consumeBoolean());
+        loaderOptions.setAllowRecursiveKeys(data.consumeBoolean());
+        loaderOptions.setProcessComments(data.consumeBoolean());
+        loaderOptions.setEnumCaseSensitive(data.consumeBoolean());
+
+        return loaderOptions;
     }
 }

--- a/projects/apache-commons-configuration/YAMLConfigurationWriteFuzzer.java
+++ b/projects/apache-commons-configuration/YAMLConfigurationWriteFuzzer.java
@@ -1,25 +1,62 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 
-import java.io.InputStream;
 import java.io.ByteArrayInputStream;
-import java.io.StringWriter;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
 
 import org.apache.commons.configuration2.YAMLConfiguration;
 import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.yaml.snakeyaml.LoaderOptions;
 
 public class YAMLConfigurationWriteFuzzer {
-    public static void fuzzerTestOneInput(byte[] data) {
-        // Create needed objects
-        YAMLConfiguration yamlConfig = new YAMLConfiguration();
-        InputStream inputStream = new ByteArrayInputStream(data);
-        StringWriter writer = new StringWriter();
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        // Create helper objects from fuzzer data
+        final boolean useLoaderOptions = data.consumeBoolean();
 
+        // Create needed objects
+        final YAMLConfiguration yamlConfig = new YAMLConfiguration();
+        yamlConfig.setLogger(null); // disable logging
+
+        // the actual fuzzing starts here
         try {
-            yamlConfig.read(inputStream);
-            yamlConfig.write(writer);
+            if (useLoaderOptions) {
+                final LoaderOptions loaderOptions = createLoaderOptions(data);
+                yamlConfig.read(new ByteArrayInputStream(data.consumeBytes(Integer.MAX_VALUE)), loaderOptions);
+            } else {
+                yamlConfig.read(new ByteArrayInputStream(data.consumeBytes(Integer.MAX_VALUE)));
+            }
+
+            yamlConfig.write(new StringWriter());
         } catch (IOException | ConfigurationException ignored) {
             // expected Exceptions get ignored
         }
+    }
+
+    private static LoaderOptions createLoaderOptions(FuzzedDataProvider data) {
+        LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setAllowDuplicateKeys(data.consumeBoolean());
+        loaderOptions.setWrappedToRootException(data.consumeBoolean());
+        loaderOptions.setAllowRecursiveKeys(data.consumeBoolean());
+        loaderOptions.setProcessComments(data.consumeBoolean());
+        loaderOptions.setEnumCaseSensitive(data.consumeBoolean());
+
+        return loaderOptions;
     }
 }

--- a/projects/httpcomponents-client/ByteArrayBodyWriteToFuzzer.java
+++ b/projects/httpcomponents-client/ByteArrayBodyWriteToFuzzer.java
@@ -1,0 +1,53 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.apache.hc.client5.http.entity.mime.ByteArrayBody;
+import org.apache.hc.core5.http.ContentType;
+
+public class ByteArrayBodyWriteToFuzzer {
+    private static final int FILENAME_MAX_LENGTH = 255;
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        // Create objects from fuzzer input
+        final ContentType contentType = data.pickValue(contentTypes);
+        final String filename = data.consumeString(FILENAME_MAX_LENGTH);
+        final byte[] byteArray = data.consumeBytes(Integer.MAX_VALUE);
+
+        // Actual fuzzing begins here
+        try {
+            final ByteArrayBody byteArrayBody = new ByteArrayBody(byteArray, contentType, filename);
+            byteArrayBody.writeTo(new ByteArrayOutputStream());
+        } catch (IOException ignored) {
+            // ignore expected exceptions
+        }
+    }
+
+    private static final ContentType[] contentTypes = {ContentType.APPLICATION_ATOM_XML,
+        ContentType.APPLICATION_FORM_URLENCODED, ContentType.APPLICATION_JSON, ContentType.APPLICATION_NDJSON,
+        ContentType.APPLICATION_OCTET_STREAM, ContentType.APPLICATION_PDF, ContentType.APPLICATION_PROBLEM_JSON,
+        ContentType.APPLICATION_PROBLEM_XML, ContentType.APPLICATION_RSS_XML, ContentType.APPLICATION_SOAP_XML,
+        ContentType.APPLICATION_SVG_XML, ContentType.APPLICATION_XHTML_XML, ContentType.APPLICATION_XML,
+        ContentType.DEFAULT_BINARY, ContentType.DEFAULT_TEXT, ContentType.IMAGE_BMP, ContentType.IMAGE_GIF,
+        ContentType.IMAGE_JPEG, ContentType.IMAGE_PNG, ContentType.IMAGE_SVG, ContentType.IMAGE_TIFF,
+        ContentType.IMAGE_WEBP, ContentType.MULTIPART_FORM_DATA, ContentType.MULTIPART_MIXED,
+        ContentType.MULTIPART_RELATED, ContentType.TEXT_EVENT_STREAM, ContentType.TEXT_HTML, ContentType.TEXT_MARKDOWN,
+        ContentType.TEXT_PLAIN, ContentType.TEXT_XML, ContentType.WILDCARD};
+}

--- a/projects/httpcomponents-client/Dockerfile
+++ b/projects/httpcomponents-client/Dockerfile
@@ -29,4 +29,4 @@ RUN git clone --depth 1 https://github.com/apache/httpcomponents-core
 RUN git clone --depth 1 https://github.com/qos-ch/slf4j
 
 COPY build.sh $SRC/
-COPY HttpFuzzer.java $SRC/
+COPY *Fuzzer.java $SRC/

--- a/projects/httpcomponents-client/FileBodyWriteToFuzzer.java
+++ b/projects/httpcomponents-client/FileBodyWriteToFuzzer.java
@@ -1,0 +1,74 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import org.apache.hc.client5.http.entity.mime.FileBody;
+import org.apache.hc.core5.http.ContentType;
+
+public class FileBodyWriteToFuzzer {
+    private static final int FILENAME_MAX_LENGTH = 255;
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        // Create objects from fuzzer input
+        final ContentType contentType = data.pickValue(contentTypes);
+        final String filename = data.consumeString(FILENAME_MAX_LENGTH);
+        final String fileContent = data.consumeRemainingAsString();
+
+        // Create needed objects
+        final File tempFile;
+        try {
+            tempFile = File.createTempFile("FileBody", ".bin");
+        } catch (IOException ioe) {
+            return;
+        }
+
+        try {
+            final FileWriter fileWriter = new FileWriter(tempFile);
+            fileWriter.write(fileContent);
+            fileWriter.close();
+        } catch (IOException ioe) {
+            tempFile.delete();
+            return;
+        }
+
+        // Actual fuzzing begins here
+        try {
+            final FileBody fileBody = new FileBody(tempFile, contentType, filename);
+            fileBody.writeTo(new ByteArrayOutputStream());
+        } catch (IOException ignored) {
+            // ignore expected exceptions
+        } finally {
+            tempFile.delete();
+        }
+    }
+
+    private static final ContentType[] contentTypes = {ContentType.APPLICATION_ATOM_XML,
+        ContentType.APPLICATION_FORM_URLENCODED, ContentType.APPLICATION_JSON, ContentType.APPLICATION_NDJSON,
+        ContentType.APPLICATION_OCTET_STREAM, ContentType.APPLICATION_PDF, ContentType.APPLICATION_PROBLEM_JSON,
+        ContentType.APPLICATION_PROBLEM_XML, ContentType.APPLICATION_RSS_XML, ContentType.APPLICATION_SOAP_XML,
+        ContentType.APPLICATION_SVG_XML, ContentType.APPLICATION_XHTML_XML, ContentType.APPLICATION_XML,
+        ContentType.DEFAULT_BINARY, ContentType.DEFAULT_TEXT, ContentType.IMAGE_BMP, ContentType.IMAGE_GIF,
+        ContentType.IMAGE_JPEG, ContentType.IMAGE_PNG, ContentType.IMAGE_SVG, ContentType.IMAGE_TIFF,
+        ContentType.IMAGE_WEBP, ContentType.MULTIPART_FORM_DATA, ContentType.MULTIPART_MIXED,
+        ContentType.MULTIPART_RELATED, ContentType.TEXT_EVENT_STREAM, ContentType.TEXT_HTML, ContentType.TEXT_MARKDOWN,
+        ContentType.TEXT_PLAIN, ContentType.TEXT_XML, ContentType.WILDCARD};
+}

--- a/projects/httpcomponents-client/FormBodyPartBuilderBuildFuzzer.java
+++ b/projects/httpcomponents-client/FormBodyPartBuilderBuildFuzzer.java
@@ -1,0 +1,105 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.hc.client5.http.entity.mime.ByteArrayBody;
+import org.apache.hc.client5.http.entity.mime.ContentBody;
+import org.apache.hc.client5.http.entity.mime.FileBody;
+import org.apache.hc.client5.http.entity.mime.FormBodyPartBuilder;
+import org.apache.hc.client5.http.entity.mime.InputStreamBody;
+import org.apache.hc.client5.http.entity.mime.StringBody;
+import org.apache.hc.core5.http.ContentType;
+
+public class FormBodyPartBuilderBuildFuzzer {
+    private static final int builderNameLength = 255;
+    private static final int fieldNameLength = 255;
+    private static final int fieldValueLength = 500;
+    private static final int bodyContentSize = 2 * fieldValueLength;
+
+    private enum BodyType { ByteArray, File, InputStream, String }
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        final String builderName = data.consumeString(builderNameLength);
+        final ContentBody contentBody;
+        try {
+            contentBody = generateContentBody(data);
+        } catch (IOException ioe) {
+            // preparations failed ; exit early
+            return;
+        };
+
+        try {
+            final FormBodyPartBuilder builder = FormBodyPartBuilder.create(builderName, contentBody);
+
+            while (data.remainingBytes() > 0) {
+                builder.addField(data.consumeString(fieldNameLength), data.consumeString(fieldValueLength));
+            }
+
+            builder.build();
+        } catch (IllegalStateException ignored) {
+            // ignore expected exceptions
+        }
+    }
+
+    private static ContentBody generateContentBody(FuzzedDataProvider data) throws IOException {
+        final BodyType choice = data.pickValue(BodyType.values());
+        final ContentBody contentBody;
+        switch (choice) {
+            case ByteArray:
+                contentBody =
+                    new ByteArrayBody(data.consumeBytes(bodyContentSize), data.consumeString(fieldNameLength));
+                break;
+
+            case File:
+                final File tempFile = File.createTempFile("FileBody", ".bin");
+
+                try {
+                    final FileWriter fileWriter = new FileWriter(tempFile);
+                    fileWriter.write(data.consumeString(bodyContentSize));
+                    fileWriter.close();
+                } catch (IOException ioe) {
+                    tempFile.delete();
+                    throw ioe;
+                }
+
+                contentBody = new FileBody(tempFile);
+                tempFile.delete();
+                break;
+
+            case InputStream:
+                final InputStream inputStream = new ByteArrayInputStream(data.consumeBytes(bodyContentSize));
+                contentBody = new InputStreamBody(inputStream, data.consumeString(fieldNameLength));
+                break;
+
+            case String:
+                contentBody = new StringBody(data.consumeString(bodyContentSize), ContentType.DEFAULT_BINARY);
+                break;
+
+            default: // should never be reached
+                contentBody = null;
+                break;
+        }
+
+        return contentBody;
+    }
+}

--- a/projects/httpcomponents-client/HttpFuzzer.java
+++ b/projects/httpcomponents-client/HttpFuzzer.java
@@ -1,3 +1,19 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 
 import java.util.ArrayList;

--- a/projects/httpcomponents-client/InputStreamBodyWriteToFuzzer.java
+++ b/projects/httpcomponents-client/InputStreamBodyWriteToFuzzer.java
@@ -1,0 +1,56 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.hc.client5.http.entity.mime.InputStreamBody;
+import org.apache.hc.core5.http.ContentType;
+
+public class InputStreamBodyWriteToFuzzer {
+    private static final int FILENAME_MAX_LENGTH = 255;
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        // Create objects from fuzzer input
+        final ContentType contentType = data.pickValue(contentTypes);
+        final String filename = data.consumeString(FILENAME_MAX_LENGTH);
+        final long contentLength = data.consumeLong();
+        final InputStream inputStream = new ByteArrayInputStream(data.consumeBytes(Integer.MAX_VALUE));
+
+        try {
+            final InputStreamBody inputStreamBody =
+                new InputStreamBody(inputStream, contentType, filename, contentLength);
+            inputStreamBody.writeTo(new ByteArrayOutputStream());
+        } catch (IOException ignored) {
+            // ignore expected exceptions
+        }
+    }
+
+    private static final ContentType[] contentTypes = {ContentType.APPLICATION_ATOM_XML,
+        ContentType.APPLICATION_FORM_URLENCODED, ContentType.APPLICATION_JSON, ContentType.APPLICATION_NDJSON,
+        ContentType.APPLICATION_OCTET_STREAM, ContentType.APPLICATION_PDF, ContentType.APPLICATION_PROBLEM_JSON,
+        ContentType.APPLICATION_PROBLEM_XML, ContentType.APPLICATION_RSS_XML, ContentType.APPLICATION_SOAP_XML,
+        ContentType.APPLICATION_SVG_XML, ContentType.APPLICATION_XHTML_XML, ContentType.APPLICATION_XML,
+        ContentType.DEFAULT_BINARY, ContentType.DEFAULT_TEXT, ContentType.IMAGE_BMP, ContentType.IMAGE_GIF,
+        ContentType.IMAGE_JPEG, ContentType.IMAGE_PNG, ContentType.IMAGE_SVG, ContentType.IMAGE_TIFF,
+        ContentType.IMAGE_WEBP, ContentType.MULTIPART_FORM_DATA, ContentType.MULTIPART_MIXED,
+        ContentType.MULTIPART_RELATED, ContentType.TEXT_EVENT_STREAM, ContentType.TEXT_HTML, ContentType.TEXT_MARKDOWN,
+        ContentType.TEXT_PLAIN, ContentType.TEXT_XML, ContentType.WILDCARD};
+}

--- a/projects/httpcomponents-client/StringBodyWriteToFuzzer.java
+++ b/projects/httpcomponents-client/StringBodyWriteToFuzzer.java
@@ -1,0 +1,50 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.apache.hc.client5.http.entity.mime.StringBody;
+import org.apache.hc.core5.http.ContentType;
+
+public class StringBodyWriteToFuzzer {
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        // Create objects from fuzzer input
+        final ContentType contentType = data.pickValue(contentTypes);
+        final String stringData = data.consumeRemainingAsString();
+
+        // Actual fuzzing begins here
+        try {
+            final StringBody stringBody = new StringBody(stringData, contentType);
+            stringBody.writeTo(new ByteArrayOutputStream());
+        } catch (IOException ignored) {
+            // ignore expected exceptions
+        }
+    }
+
+    private static final ContentType[] contentTypes = {ContentType.APPLICATION_ATOM_XML,
+        ContentType.APPLICATION_FORM_URLENCODED, ContentType.APPLICATION_JSON, ContentType.APPLICATION_NDJSON,
+        ContentType.APPLICATION_OCTET_STREAM, ContentType.APPLICATION_PDF, ContentType.APPLICATION_PROBLEM_JSON,
+        ContentType.APPLICATION_PROBLEM_XML, ContentType.APPLICATION_RSS_XML, ContentType.APPLICATION_SOAP_XML,
+        ContentType.APPLICATION_SVG_XML, ContentType.APPLICATION_XHTML_XML, ContentType.APPLICATION_XML,
+        ContentType.DEFAULT_BINARY, ContentType.DEFAULT_TEXT, ContentType.IMAGE_BMP, ContentType.IMAGE_GIF,
+        ContentType.IMAGE_JPEG, ContentType.IMAGE_PNG, ContentType.IMAGE_SVG, ContentType.IMAGE_TIFF,
+        ContentType.IMAGE_WEBP, ContentType.MULTIPART_FORM_DATA, ContentType.MULTIPART_MIXED,
+        ContentType.MULTIPART_RELATED, ContentType.TEXT_EVENT_STREAM, ContentType.TEXT_HTML, ContentType.TEXT_MARKDOWN,
+        ContentType.TEXT_PLAIN, ContentType.TEXT_XML, ContentType.WILDCARD};
+}

--- a/projects/httpcomponents-client/build.sh
+++ b/projects/httpcomponents-client/build.sh
@@ -47,7 +47,7 @@ RUNTIME_CLASSPATH=$(echo $ALL_JARS | xargs printf -- "\$this_dir/%s:"):\$this_di
 for fuzzer in $(find $SRC -name '*Fuzzer.java'); do
   fuzzer_basename=$(basename -s .java $fuzzer)
   javac -cp $BUILD_CLASSPATH $fuzzer
-  cp $SRC/$fuzzer_basename.class $OUT/
+  cp $SRC/$fuzzer_basename*.class $OUT/
 
   # Create an execution wrapper that executes Jazzer with the correct arguments.
   echo "#!/bin/sh

--- a/projects/httpcomponents-client/project.yaml
+++ b/projects/httpcomponents-client/project.yaml
@@ -11,3 +11,4 @@ vendor_ccs:
 - yakdan@code-intelligence.com
 - glendowne@code-intelligence.com
 - hlin@code-intelligence.com
+- yoshi.weber@gmail.com


### PR DESCRIPTION
Disclaimer: this PR includes changes to 2 different projects because I opened my PRs to the same Code Intelligence branch by mistake and nobody noticed until after the merge.

In genereal, I added missing copyright headers.

`commons-configuration`:

- removed logging
- improved temporary file creation and deletion
- added fuzz target for `XMLConfiguration.write`
- added option to fuzz multiple overloaded `YAMLConfiguration.read` methods

`httpmime`:
new fuzz targets for:
- `ByteArrayBody.writeTo`
- `FileBody.writeTo`
- `InputStreamBody.writeTo`
- `StringBody.writeTo`
- `FormBodyPartBuilder.build`