### PR TITLE
fluxcd: Revert to base-builder-go to fix build

### DIFF
--- a/projects/fluxcd/Dockerfile
+++ b/projects/fluxcd/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-go-codeintelligencetesting
+FROM gcr.io/oss-fuzz-base/base-builder-go
 
 ENV PROJECT_ROOT="${GOPATH:-/root/go}/src/github.com/fluxcd"
 


### PR DESCRIPTION
The project recently started moving into Go fuzz native, and using the codeintelligencetesting variant is causing the error below:
`/usr/local/bin/compile_native_go_fuzzer: line 35: addimport: command not found`

Once that is fixed by reinstalling `addimport`, the resulting fuzzers error with:
`ERROR: no interesting inputs were found`

This PR reverts https://github.com/google/oss-fuzz/pull/7683 for fluxcd which fixes the issue.