### PR TITLE
golang: minor updates

### DIFF
--- a/projects/golang/fuzz_tiff_decode.options
+++ b/projects/golang/fuzz_tiff_decode.options
@@ -1,3 +1,4 @@
 [libfuzzer]
 max_len = 1500000
 len_control = 0
+rss_limit_mb=6000

--- a/projects/golang/h2c_fuzzer.go
+++ b/projects/golang/h2c_fuzzer.go
@@ -67,7 +67,6 @@ func catchPanics() {
 		case error:
 			err = r.(error).Error()
 		}
-		fmt.Println(err)
 		// Very hacky for now, but it rids us of a lot of instantiation
 		if strings.Contains(err, "invalid memory address or nil pointer dereference") {
 			return


### PR DESCRIPTION
The `fuzz_tiff_decode` fuzzer seems to quickly progress to 4000-ish MB so bumping the limit. 

Signed-off-by: AdamKorcz <adam@adalogics.com>