### PR TITLE
[cryptofuzz] Add mini-gmp

### DIFF
--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -616,6 +616,10 @@ then
     cp $SRC/cryptofuzz-corpora/boringssl_latest.zip $OUT/cryptofuzz-boringssl_seed_corpus.zip
 fi
 
+# Compile Cryptofuzz libgmp mini-gmp module
+cd $SRC/cryptofuzz/modules/libgmp
+make -B -f Makefile-mini-gmp
+
 ##############################################################################
 # Compile BoringSSL (with assembly)
 cd $SRC/boringssl


### PR DESCRIPTION
mini-gmp is an alternative, self-contained version of libgmp (but maintained within the same project).

This builds the OpenSSL-based fuzzers with the regular libgmp, and the BoringSSL-based fuzzers with mini-gmp.