### PR TITLE
golang: fix false positive

### DIFF
--- a/projects/golang/h2c_fuzzer.go
+++ b/projects/golang/h2c_fuzzer.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"net/http"
 	"net/textproto"
+	"net/url"
 	"runtime"
 	"strings"
 )
@@ -94,6 +95,7 @@ func FuzzH2c(data []byte) int {
 	w := &FakeHttpWriter{}
 	r := &http.Request{
 		Body: io.NopCloser(bytes.NewReader(data)),
+		URL:  &url.URL{Path: "nil"},
 	}
 	r.Header = headerMap
 	defer catchPanics()


### PR DESCRIPTION
Fixes https://oss-fuzz.com/testcase-detail/5265203150848000 which is a false positive.

Signed-off-by: AdamKorcz <adam@adalogics.com>