### PR TITLE
igraph: switch to master branch and update libxml2 dependency

### DIFF
--- a/projects/igraph/Dockerfile
+++ b/projects/igraph/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
   pkg-config cmake bison flex
-RUN git clone --depth 1 --branch master  https://github.com/igraph/igraph
+RUN git clone --branch master  https://github.com/igraph/igraph
 RUN wget https://download.gnome.org/sources/libxml2/2.9/libxml2-2.9.14.tar.xz && tar xf libxml2-2.9.14.tar.xz
 WORKDIR igraph
 RUN cp $SRC/igraph/fuzzing/build.sh $SRC/build.sh

--- a/projects/igraph/Dockerfile
+++ b/projects/igraph/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
   pkg-config cmake bison flex
-RUN git clone --depth 1 --branch develop  https://github.com/igraph/igraph
-RUN wget https://download.gnome.org/sources/libxml2/2.9/libxml2-2.9.13.tar.xz && tar xf libxml2-2.9.13.tar.xz
+RUN git clone --depth 1 --branch master  https://github.com/igraph/igraph
+RUN wget https://download.gnome.org/sources/libxml2/2.9/libxml2-2.9.14.tar.xz && tar xf libxml2-2.9.14.tar.xz
 WORKDIR igraph
 RUN cp $SRC/igraph/fuzzing/build.sh $SRC/build.sh


### PR DESCRIPTION
With the release of igraph 0.10, most development will happen on the master branch for a while, so I'd like to switch OSS-fuzz over.