### PR TITLE
Add alper.oss.fuzz@gmail.com to Crossplane auto_ccs

### DIFF
--- a/projects/crossplane/project.yaml
+++ b/projects/crossplane/project.yaml
@@ -4,6 +4,7 @@ primary_contact: "jbw976@gmail.com"
 auto_ccs :
   - "me@muvaf.com"
   - "nicc@rk0n.org"
+  - "alper.oss.fuzz@gmail.com"
 vendor_ccs :
   - "adam@adalogics.com"
 language: go


### PR DESCRIPTION
This PR proposes to add `alper.oss.fuzz@gmail.com` to the `auto_ccs` list for the Crossplane project. I'd like to be able to access the relevant resources/documents on the https://oss-fuzz.com site with the `Sign in with Google` option and authenticate as `alper.oss.fuzz@gmail.com` via SSO. Thank you.

cc. @jbw976