### PR TITLE
Dockerfile: drop unused packages

### DIFF
--- a/projects/tpm2-tss/Dockerfile
+++ b/projects/tpm2-tss/Dockerfile
@@ -47,13 +47,7 @@ RUN apt-get update && \
     python-yaml \
     python3-yaml \
     vim-common \
-    python3-pip \
-    libsqlite3-dev \
-    python-cryptography \
-    python3-cryptography \
     acl
-
-RUN pip3 install cpp-coveralls
 
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 100
 RUN update-alternatives --install /usr/bin/scan-build scan-build /usr/bin/scan-build-6.0 100


### PR DESCRIPTION
No need for python stuff and libsqlite, so remove it.

Signed-off-by: William Roberts <william.c.roberts@intel.com>