### PR TITLE
[util-linux] file issues on GitHub as well 

### DIFF
--- a/projects/util-linux/project.yaml
+++ b/projects/util-linux/project.yaml
@@ -9,7 +9,6 @@ auto_ccs:
   - "kerolasa@gmail.com"
 architectures:
   - x86_64
-  - i386
 sanitizers:
   - address
   - undefined

--- a/projects/util-linux/project.yaml
+++ b/projects/util-linux/project.yaml
@@ -15,3 +15,4 @@ sanitizers:
   - undefined
   - memory
 main_repo: 'https://github.com/util-linux/util-linux'
+file_github_issue: True


### PR DESCRIPTION
to make it easier to keep track or them and turn off i386 for now to let it compile everywhere else until https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=51067 is fixed.