### PR TITLE
Add multiple architectures to FFmpeg fuzzer

### DIFF
--- a/projects/ffmpeg/project.yaml
+++ b/projects/ffmpeg/project.yaml
@@ -1,6 +1,9 @@
 homepage: "https://www.ffmpeg.org"
 language: c++
 primary_contact: "ffmpeg-security@ffmpeg.org"
+architectures:
+ - x86_64
+ - i386
 auto_ccs:
  - "michaelni@gmx.at"
  - "michael@niedermayer.cc"


### PR DESCRIPTION
Due to the fact that certain important apps compile FFmpeg as 32-bit code I think fuzzing FFmpeg as i386 would be beneficial because then we can find bugs specific to this architecture as well.