### PR TITLE
[dbus-broker] fix the alignment check

### DIFF
--- a/projects/dbus-broker/build.sh
+++ b/projects/dbus-broker/build.sh
@@ -46,6 +46,8 @@ if [[ "$SANITIZER" == undefined ]]; then
     UBSAN_FLAGS="-fsanitize=$additional_ubsan_checks -fno-sanitize-recover=$additional_ubsan_checks"
     CFLAGS+=" $UBSAN_FLAGS"
     CXXFLAGS+=" $UBSAN_FLAGS"
+    MESON_CFLAGS+=" $UBSAN_FLAGS"
+    MESON_CXXFLAGS+=" $UBSAN_FLAGS"
 fi
 
 pip3 install meson ninja


### PR DESCRIPTION
It should be passed to meson as well to build `dbus-broker` with the alignment check.