### PR TITLE
Update Centipede to fix SegFault

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -134,7 +134,7 @@ RUN precompile_honggfuzz
 RUN cd $SRC && \
     git clone https://github.com/google/centipede.git && \
     cd centipede && \
-    git checkout a976295b2acaff8461a906c461f5bb25dafdf557
+    git checkout 0cb913aa9d77ebd2870aa1036fd8651c2557a9a9
 
 COPY precompile_centipede /usr/local/bin/
 RUN precompile_centipede

--- a/infra/base-images/base-runner/run_fuzzer
+++ b/infra/base-images/base-runner/run_fuzzer
@@ -187,7 +187,7 @@ elif [[ "$FUZZING_ENGINE" = centipede ]]; then
   # --address_space_limit_mb=0: No address space limit.
   # --binary: The target binary under test without sanitizer.
   # --extra_binary: The target binaries under test with sanitizers.
-  CMD_LINE="$OUT/centipede --workdir=\"$OUT/workdir\" --corpus_dir=\"$CORPUS_DIR\" --fork_server=1 --exit_on_crash=1 --timeout=1200 --rss_limit_mb=4096 --address_space_limit_mb=0 $(get_dictionary) --binary=\"$OUT/${FUZZER}\" $(get_extra_binaries) $*"
+  CMD_LINE="$OUT/centipede --workdir=\"$OUT/workdir\" --corpus_dir=\"$CORPUS_DIR\" --fork_server=1 --exit_on_crash=1 --timeout=1200 --rss_limit_mb=4096 --address_space_limit_mb=5120 $(get_dictionary) --binary=\"$OUT/${FUZZER}\" $(get_extra_binaries) $*"
 else
 
   CMD_LINE="$OUT/$FUZZER $FUZZER_ARGS $*"


### PR DESCRIPTION
Update `Centipede` to fix [the SegFault when using `AddressSanitizer` with `address_space_limit_mb`](https://github.com/google/centipede/issues/166).
Also set `address_space_limit_mb` as the issue has been fixed.
