### PR TITLE
toml_edit: initial integration

### DIFF
--- a/projects/toml_edit/Dockerfile
+++ b/projects/toml_edit/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN git clone --depth 1 ttps://github.com/ordian/toml_edit toml_edit
+WORKDIR $SRC
+COPY build.sh $SRC/

--- a/projects/toml_edit/Dockerfile
+++ b/projects/toml_edit/Dockerfile
@@ -16,6 +16,6 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-rust
 RUN apt-get update && apt-get install -y make autoconf automake libtool
-RUN git clone --depth 1 ttps://github.com/ordian/toml_edit toml_edit
+RUN git clone --depth 1 https://github.com/ordian/toml_edit toml_edit
 WORKDIR $SRC
 COPY build.sh $SRC/

--- a/projects/toml_edit/build.sh
+++ b/projects/toml_edit/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -eu
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC/toml_edit
+cargo fuzz build -O
+cp fuzz/target/x86_64-unknown-linux-gnu/release/parse_document $OUT/

--- a/projects/toml_edit/project.yaml
+++ b/projects/toml_edit/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/ordian/toml_edit"
+language: rust
+main_repo: "https://github.com/ordian/toml_edit"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+vendor_ccs:
+  - maxnair.dev@gmail.com

--- a/projects/toml_edit/project.yaml
+++ b/projects/toml_edit/project.yaml
@@ -1,6 +1,7 @@
 homepage: "https://github.com/ordian/toml_edit"
 language: rust
 main_repo: "https://github.com/ordian/toml_edit"
+primary_contact: "eopage@gmail.com"
 fuzzing_engines:
   - libfuzzer
 sanitizers:


### PR DESCRIPTION
Hi, [toml_edit](https://github.com/ordian/toml_edit) crate allows you to parse and modify toml documents, while preserving comments, spaces and relative order or items. 
- It has 2 million+ downloads as per [crates.io](https://crates.io/crates/toml_edit).
- It's being used by projects like [cargo](https://github.com/rust-lang/cargo), [diem](https://github.com/diem/diem), [lapce](https://github.com/lapce/lapce), [materialize](https://github.com/MaterializeInc/materialize), [clap](https://github.com/clap-rs/clap), [foundry](https://github.com/foundry-rs/foundry) as per [github's dependent graph](https://github.com/ordian/toml_edit/network/dependents?dependent_type=PACKAGE&package_id=UGFja2FnZS0zMjE3NzcwMjM2) and [crates.io's reverse dependencies](https://crates.io/crates/toml_edit/reverse_dependencies).