### PR TITLE
cloud-hypervisor: Add additional fuzzers

### DIFF
--- a/projects/cloud-hypervisor/build.sh
+++ b/projects/cloud-hypervisor/build.sh
@@ -15,9 +15,13 @@
 ################################################################################
 cd $SRC/cloud-hypervisor
 cargo fuzz build -O
+cp $SRC/cloud-hypervisor/fuzz/target/x86_64-unknown-linux-gnu/release/balloon $OUT/
 cp $SRC/cloud-hypervisor/fuzz/target/x86_64-unknown-linux-gnu/release/block $OUT/
 cp $SRC/cloud-hypervisor/fuzz/target/x86_64-unknown-linux-gnu/release/cmos $OUT/
 cp $SRC/cloud-hypervisor/fuzz/target/x86_64-unknown-linux-gnu/release/http_api $OUT/
+cp $SRC/cloud-hypervisor/fuzz/target/x86_64-unknown-linux-gnu/release/pmem $OUT/
 cp $SRC/cloud-hypervisor/fuzz/target/x86_64-unknown-linux-gnu/release/qcow $OUT/
+cp $SRC/cloud-hypervisor/fuzz/target/x86_64-unknown-linux-gnu/release/rng $OUT/
 cp $SRC/cloud-hypervisor/fuzz/target/x86_64-unknown-linux-gnu/release/serial $OUT/
 cp $SRC/cloud-hypervisor/fuzz/target/x86_64-unknown-linux-gnu/release/vhdx $OUT/
+cp $SRC/cloud-hypervisor/fuzz/target/x86_64-unknown-linux-gnu/release/watchdog $OUT/


### PR DESCRIPTION
New fuzzers since last update: virtio-{balloon, pmem, rng, watchdog}

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
