### PR TITLE
igraph: move libxml2 download to build script

### DIFF
--- a/projects/igraph/Dockerfile
+++ b/projects/igraph/Dockerfile
@@ -18,6 +18,5 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
   pkg-config cmake bison flex
 RUN git clone --branch master  https://github.com/igraph/igraph
-RUN wget https://download.gnome.org/sources/libxml2/2.10/libxml2-2.10.0.tar.xz && tar xf libxml2-2.10.0.tar.xz
 WORKDIR igraph
 RUN cp $SRC/igraph/fuzzing/build.sh $SRC/build.sh


### PR DESCRIPTION
I have moved the libxml2 download to the build script from the Dockerfile, so I can more easily update the version, and related operations would not be split up. Is this okay with you?

See https://github.com/igraph/igraph/commit/5a89bbc76c8016de44fd273d06cce809e2c45316