### PR TITLE
SysSan: stricter file open detection

### DIFF
--- a/infra/experimental/SystemSan/SystemSan.cpp
+++ b/infra/experimental/SystemSan/SystemSan.cpp
@@ -308,9 +308,15 @@ void inspect_for_arbitrary_file_open(pid_t pid, const user_regs_struct &regs) {
     if (root_dir_end != std::string::npos) {
       path_absolute_topdir = path.substr(0, root_dir_end);
     }
-    struct stat dirstat;
-    if (stat(path_absolute_topdir.c_str(), &dirstat) != 0) {
-      log_file_open(path, regs.rdx);
+    for (size_t i = 1; i < path_absolute_topdir.length(); i++) {
+      // the the path top dir has a non-ascii character
+      if (path_absolute_topdir[i] & 0x80) {
+        struct stat dirstat;
+        if (stat(path_absolute_topdir.c_str(), &dirstat) != 0) {
+          log_file_open(path, regs.rdx);
+        }
+        break;
+      }
     }
   }
 }

--- a/infra/experimental/SystemSan/SystemSan.cpp
+++ b/infra/experimental/SystemSan/SystemSan.cpp
@@ -292,6 +292,15 @@ void log_file_open(std::string path, int flags) {
   std::cerr << "===\n";
 }
 
+bool has_unprintable(const std::string &value) {
+  for (size_t i = 0; i < value.length(); i++) {
+    if (value[i] & 0x80) {
+      return true;
+    }
+  }
+  return false;
+}
+
 void inspect_for_arbitrary_file_open(pid_t pid, const user_regs_struct &regs) {
   // Inspect a PID's register for the sign of arbitrary file open.
   std::string path = read_string(pid, regs.rsi, kRootDirMaxLength);
@@ -308,14 +317,10 @@ void inspect_for_arbitrary_file_open(pid_t pid, const user_regs_struct &regs) {
     if (root_dir_end != std::string::npos) {
       path_absolute_topdir = path.substr(0, root_dir_end);
     }
-    for (size_t i = 1; i < path_absolute_topdir.length(); i++) {
-      // the the path top dir has a non-ascii character
-      if (path_absolute_topdir[i] & 0x80) {
-        struct stat dirstat;
-        if (stat(path_absolute_topdir.c_str(), &dirstat) != 0) {
-          log_file_open(path, regs.rdx);
-        }
-        break;
+    if (has_unprintable(path_absolute_topdir)) {
+      struct stat dirstat;
+      if (stat(path_absolute_topdir.c_str(), &dirstat) != 0) {
+        log_file_open(path, regs.rdx);
       }
     }
   }


### PR DESCRIPTION
cc @oliverchang 

This allows to get rid of false positives such as https://github.com/google/oss-fuzz/blob/master/projects/phmap/phashmap_fuzz.cc#L33 and others which try to scan non-existing directories such as /config