### PR TITLE
infra: bump Go to 1.19

### DIFF
--- a/infra/base-images/base-builder/install_go.sh
+++ b/infra/base-images/base-builder/install_go.sh
@@ -18,7 +18,7 @@
 cd /tmp
 curl -O https://storage.googleapis.com/golang/getgo/installer_linux
 chmod +x ./installer_linux
-SHELL="bash" ./installer_linux -version=1.18
+SHELL="bash" ./installer_linux -version=1.19
 rm -rf ./installer_linux
 
 echo 'Set "GOPATH=/root/go"'


### PR DESCRIPTION
Most projects have upgraded to 1.19 which is the latest version.

This upgrades Go to 1.19 in the base-image.

Signed-off-by: AdamKorcz <adam@adalogics.com>