### PR TITLE
cilium: change base image

### DIFF
--- a/projects/cilium/Dockerfile
+++ b/projects/cilium/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-go-codeintelligencetesting
+FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN apt-get update && apt-get install -y wget
 RUN wget https://raw.githubusercontent.com/google/AFL/master/dictionaries/json.dict -O $OUT/fuzz.dict
 


### PR DESCRIPTION
Ciliums fuzzers break with the testing image. Changing to get them running.

Signed-off-by: AdamKorcz <adam@adalogics.com>