### PR TITLE
Update proto dep to v2 api

### DIFF
--- a/projects/cel-go/fuzz_eval.go
+++ b/projects/cel-go/fuzz_eval.go
@@ -1,7 +1,7 @@
 package cel
 
 import (
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/google/cel-go/checker/decls"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"


### PR DESCRIPTION
With the most recent update to cel-go, the legacy proto package has been completely replaced
by the v2 proto API. This change updates the import to reflect code present in the cel-go vendor
directory.