### PR TITLE
Fix wget

### DIFF
--- a/projects/wget/Dockerfile
+++ b/projects/wget/Dockerfile
@@ -39,9 +39,10 @@ RUN apt-get update && apt-get install -y \
  libtasn1-bin
 
 ENV GNULIB_TOOL $SRC/gnulib/gnulib-tool
+ENV GNULIB_SRCDIR $SRC/gnulib
 RUN git clone git://git.savannah.gnu.org/gnulib.git
-RUN git clone --depth=1 --recursive https://git.savannah.gnu.org/git/libunistring.git
-RUN git clone --depth=1 https://gitlab.com/libidn/libidn2.git
+RUN wget -qO- https://ftp.gnu.org/gnu/libunistring/libunistring-latest.tar.gz | tar -xz -C /src && mv /src/libunistring-* /src/libunistring
+RUN wget -qO- https://ftp.gnu.org/gnu/libidn/libidn2-latest.tar.gz | tar -xz -C /src && mv /src/libidn2-* /src/libidn2
 RUN git clone --depth=1 --recursive https://github.com/rockdaboot/libpsl.git
 RUN git clone --depth=1 https://git.lysator.liu.se/nettle/nettle.git
 RUN git clone --depth=1 https://gitlab.com/gnutls/gnutls.git

--- a/projects/wget/build.sh
+++ b/projects/wget/build.sh
@@ -84,14 +84,14 @@ cd $SRC/wget
 autoreconf -fi
 
 # build and run non-networking tests
-LIBS="-lgnutls -lhogweed -lnettle -lidn2 -lunistring -lpsl" \
+LIBS="-lgnutls -lhogweed -lnettle -lidn2 -lunistring -lpsl -lz" \
 ./configure -C
 make clean
 make -j$(nproc)
 make -j$(nproc) -C fuzz check
 
 # build for fuzzing
-LIBS="-lgnutls -lhogweed -lnettle -lidn2 -lunistring -lpsl" \
+LIBS="-lgnutls -lhogweed -lnettle -lidn2 -lunistring -lpsl -lz" \
 ./configure --enable-fuzzing -C
 make clean
 make -j$(nproc) -C lib

--- a/projects/wget/build.sh
+++ b/projects/wget/build.sh
@@ -24,13 +24,11 @@ export GNULIB_SRCDIR=$SRC/gnulib
 export LLVM_PROFILE_FILE=/tmp/prof.test
 
 cd $SRC/libunistring
-./autogen.sh
 ./configure --enable-static --disable-shared --prefix=$WGET_DEPS_PATH --cache-file ../config.cache
 make -j$(nproc)
 make install
 
 cd $SRC/libidn2
-./bootstrap
 ./configure --enable-static --disable-shared --disable-doc --disable-gcc-warnings --prefix=$WGET_DEPS_PATH --cache-file ../config.cache
 make -j$(nproc)
 make install


### PR DESCRIPTION
- Speed up and stabilize the build by building libunistring and libidn2 from tarball.
- Fix the build by explicitly adding -lz at link time.