### PR TITLE
spdk: remove --without-isal option

### DIFF
--- a/projects/spdk/build.sh
+++ b/projects/spdk/build.sh
@@ -18,7 +18,7 @@
 # Build spdk
 export LDFLAGS="${CFLAGS}"
 ./scripts/pkgdep.sh
-./configure --without-shared --without-isal
+./configure --without-shared
 make -j$(nproc)
 
 # Build fuzzers


### PR DESCRIPTION
Recently, isa-l become a hard dependency in SPDK (dd2c08d2d) and the `--without-isal` option was removed, so we also need to remove it here.