### PR TITLE
golang: modify h2c fuzzer

### DIFF
--- a/projects/golang/h2c_fuzzer.go
+++ b/projects/golang/h2c_fuzzer.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"net/http"
 	"net/textproto"
+	"net/url"
 	"runtime"
 	"strings"
 )
@@ -97,6 +98,11 @@ func FuzzH2c(data []byte) int {
 		return -1
 	}
 	r.Header = headerMap
+	u, err := url.Parse("http://localhost:8001")
+	if err != nil {
+		return 0
+	}
+	r.URL = u
 	defer catchPanics()
 	h.ServeHTTP(w, r)
 	return 1


### PR DESCRIPTION
The fuzzer triggers this crash, https://oss-fuzz.com/testcase-detail/5149758935400448, which I cannot reproduce locally. This PR is an attempt to fix it.
Signed-off-by: AdamKorcz <adam@adalogics.com>