### PR TITLE
go-containerregistry: intitial integration

### DIFF
--- a/projects/go-containerregistry/Dockerfile
+++ b/projects/go-containerregistry/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/google/go-containerregistry
+WORKDIR $SRC/go-containerregistry
+COPY build.sh fuzz.go $SRC/

--- a/projects/go-containerregistry/build.sh
+++ b/projects/go-containerregistry/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+cp $SRC/fuzz.go $SRC/go-containerregistry/pkg/name/
+compile_go_fuzzer github.com/google/go-containerregistry/pkg/name FuzzParseReference fuzz_parse_reference

--- a/projects/go-containerregistry/fuzz.go
+++ b/projects/go-containerregistry/fuzz.go
@@ -1,0 +1,20 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package name
+
+func FuzzParseReference(data []byte) int {
+	_, _ = ParseReference(string(data))
+	return 1
+}

--- a/projects/go-containerregistry/project.yaml
+++ b/projects/go-containerregistry/project.yaml
@@ -1,0 +1,11 @@
+homepage: "https://github.com/google/go-containerregistry"
+language: go
+primary_contact: "jason@chainguard.dev"
+main_repo: "https://github.com/google/go-containerregistry"
+vendor_ccs:
+  - "adam@adalogics.com"
+  - "david@adalogics.com"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
go-containerregistry is a golang library for working with container registries. It is used by several projects already integrated in OSS-Fuzz like [Istio](https://github.com/istio/istio/blob/master/pkg/wasm/cache.go#L32) and [Crossplane](https://github.com/crossplane/crossplane/blob/dd87bfb23c83442fb72d0c3c0e20d5979d9d3a92/internal/xpkg/fetch.go#L28-L32).

__________________________________________________________

@imjasonh Do you prefer integrating with OSS-Fuzz instead of merging https://github.com/google/go-containerregistry/pull/1421? If so, here is the PR for that

Signed-off-by: AdamKorcz <adam@adalogics.com>