### PR TITLE
pyjwt: catch PyJWTError exceptions

### DIFF
--- a/projects/pyjwt/fuzz_jwt.py
+++ b/projects/pyjwt/fuzz_jwt.py
@@ -44,8 +44,11 @@ def test_roundtrip(data):
         return
 
     key = "fuzzing"
-    jwt_message = jwt.encode(payload, key, algorithm="HS256")
-    decoded_payload = jwt.decode(jwt_message, key, algorithms=["HS256"])
+    try:
+        jwt_message = jwt.encode(payload, key, algorithm="HS256")
+        decoded_payload = jwt.decode(jwt_message, key, algorithms=["HS256"])
+    except jwt.exceptions.PyJWTError:
+        return
     assert decoded_payload == payload 
 
 


### PR DESCRIPTION
jwt functions like jwt.decode could raise PyJWTError exceptions (e.g. ExpiredSignatureError if the token is expired)

Fix error handling for issue:
- 50696 (https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=50696)