### PR TITLE
apache-httpd, libyang: fix pcre2 location

### DIFF
--- a/projects/apache-httpd/Dockerfile
+++ b/projects/apache-httpd/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool wget \
                                          uuid-dev pkg-config libtool-bin \
                                          libbsd-dev
 
-RUN svn co svn://vcs.exim.org/pcre2/code/trunk pcre2 && \
+RUN git clone https://github.com/PCRE2Project/pcre2 pcre2 && \
     cd pcre2 && \
     ./autogen.sh && \
     ./configure && \

--- a/projects/libyang/Dockerfile
+++ b/projects/libyang/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y autoconf automake libtool subversion
 RUN git clone https://github.com/CESNET/libyang
 
-RUN svn co svn://vcs.exim.org/pcre2/code/trunk pcre2 && \
+RUN git clone https://github.com/PCRE2Project/pcre2 pcre2 && \
     cd pcre2 && \
     ./autogen.sh && \
     ./configure && \


### PR DESCRIPTION
pcre2 is now on Github. Fixes both builds.