### PR TITLE
[selinux] replace PCRE by PCRE2

### DIFF
--- a/projects/selinux/Dockerfile
+++ b/projects/selinux/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && \
 	libcap-dev \
 	libcap-ng-dev \
 	libglib2.0-dev \
-	libpcre3-dev
+	libpcre2-dev
 RUN git clone --depth 1 https://github.com/SELinuxProject/selinux
 WORKDIR selinux
 COPY build.sh $SRC/


### PR DESCRIPTION
The SELinux userspace has been ported to default to build with PCRE2[1].

[1]: https://github.com/SELinuxProject/selinux/commit/4ffe2dfc782465ab3807db49d0f6f67bce9e3e72