### PR TITLE
[mapserver] Disable memory sanitizer

### DIFF
--- a/projects/mapserver/project.yaml
+++ b/projects/mapserver/project.yaml
@@ -8,12 +8,4 @@ vendor_ccs:
   - "sdlime@gmail.com"
 auto_ccs:
   - "ajsinghyadav00@gmail.com"
-fuzzing_engines:
-  - libfuzzer
-  - afl
-  - honggfuzz
-sanitizers:
-  - address
-  - memory
-  - undefined
 main_repo: 'https://github.com/MapServer/MapServer'


### PR DESCRIPTION
It causes false positives due to a number of mapserver dependencies not being rebuilt with it.
Also rely on default settings for the sanitizers and fuzzing_engines section