### PR TITLE
Disable ubsan for gpsd

### DIFF
--- a/projects/gpsd/project.yaml
+++ b/projects/gpsd/project.yaml
@@ -12,5 +12,4 @@ fuzzing_engines:
 sanitizers:
   - address
   - memory
-  - undefined
 main_repo: 'https://gitlab.com/gpsd/gpsd'


### PR DESCRIPTION
The maintainer does not want these reports.

Fixes https://github.com/google/oss-fuzz/issues/8658