### PR TITLE
[git]: Remove git system config and add debug message

### DIFF
--- a/projects/git/build.sh
+++ b/projects/git/build.sh
@@ -44,7 +44,6 @@ zip -j $OUT/fuzz-commit-graph_seed_corpus .git/objects/info/commit-graph
 for fuzzer in $FUZZERS ; do
   cat >$OUT/$fuzzer.options << EOF
 [libfuzzer]
-close_fd_mask = 2
 detect_leaks = 0
 EOF
 done

--- a/projects/git/fuzz-cmd-diff.c
+++ b/projects/git/fuzz-cmd-diff.c
@@ -11,6 +11,7 @@ limitations under the License.
 */
 #include <ftw.h>
 
+#include "config.h"
 #include "builtin.h"
 #include "repository.h"
 #include "fuzz-cmd-base.h"
@@ -30,6 +31,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	char *argv[6];
 	char *data_chunk;
 	char *basedir = "./.git";
+	struct strbuf config = STRBUF_INIT;
 
 	/*
 	 * End this round of fuzzing if the data is not large enough
@@ -42,10 +44,15 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	/*
 	 * Cleanup if needed
 	 */
+	system("ls -lart ./");
+	strbuf_addf(&config, "rm -rf %s", git_system_config());
+	system(config.buf);
 	system("rm -rf ./.git");
 	system("rm -rf ./TEMP-*");
 	system("echo \"TEMP1TEMP1TEMP1TEMP1\" > ./TEMP_1");
 	system("echo \"TEMP1TEMP1TEMP1TEMP1\" > ./TEMP_2");
+	system("ls -lart ./");
+	strbuf_release(&config);
 
 	/*
 	 *  Initialize the repository


### PR DESCRIPTION
Reset git system config for each iteration and print debug message of folder construction.
Allowing error message to display.
