### PR TITLE
[cryptsetup] Initial integration for cryptsetup

### DIFF
--- a/projects/cryptsetup/Dockerfile
+++ b/projects/cryptsetup/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN git clone --depth 1 https://gitlab.com/cryptsetup/cryptsetup.git
+
+COPY build.sh $SRC/

--- a/projects/cryptsetup/build.sh
+++ b/projects/cryptsetup/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+./cryptsetup/tests/fuzz/oss-fuzz-build.sh

--- a/projects/cryptsetup/project.yaml
+++ b/projects/cryptsetup/project.yaml
@@ -1,0 +1,14 @@
+homepage: "https://gitlab.com/cryptsetup/cryptsetup"
+language: c
+primary_contact: "gmazyland@gmail.com"
+auto_ccs:
+  - okozina@redhat.com
+  - vtrefny@redhat.com
+  - daniel.zatovic@gmail.com
+sanitizers:
+  - address
+  - memory
+  - undefined
+architectures:
+  - x86_64
+main_repo: "https://gitlab.com/cryptsetup/cryptsetup.git"


### PR DESCRIPTION
This patch adds fuzzers built for the upstream cryptsetup project.

Initially, we try to fuzz LUKS2 on-disk format using various binary and JSON header modification methods.
This produces basic coverage on on-disk header parsing code.

Fuzzers for other formats like LUKS1 will be added later.

Currently, we enable only binary fuzzer and plain JSON mutator with a pre-generated corpus from previous experiments.

Changes based on Daniel Zatovic's work.
