### PR TITLE
Add abartlet's primary e-mail to Samba project

### DIFF
--- a/projects/samba/project.yaml
+++ b/projects/samba/project.yaml
@@ -4,6 +4,7 @@ language: c
 primary_contact: "douglas.bagnall@catalyst.net.nz"
 auto_ccs:
   - "abartlet+google@catalyst.net.nz"
+  - "abartlet@samba.org"
   - "cryptomilk@gmail.com"
   - "lockyergw@gmail.com"
   - "jra@google.com"


### PR DESCRIPTION
Add primary email for Andrew Bartlett to the Samba Project to allow GitHub authentication