### PR TITLE
Fix link issue

### DIFF
--- a/projects/msquic/Dockerfile
+++ b/projects/msquic/Dockerfile
@@ -22,8 +22,13 @@ RUN apt-get update && \
     dpkg -i packages-microsoft-prod.deb && \
     add-apt-repository universe && \
     apt-get update -y && \
-    apt-get install -y powershell cmake && \
+    apt-get install -y powershell && \
     rm -rf /var/lib/apt/lists/*
+
+ENV CMAKE_VERSION=3.24.2
+ADD https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz cmake.tar.gz
+RUN tar xvf cmake.tar.gz -C /usr/local --strip 1 \
+    && rm cmake.tar.gz
 
 RUN git clone https://github.com/microsoft/msquic && \
     cd msquic && \

--- a/projects/msquic/build.sh
+++ b/projects/msquic/build.sh
@@ -15,7 +15,7 @@
 #
 ################################################################################
 
-pwsh ./scripts/build.ps1 -Static -DisableTest -DisableTools -DisablePerf -Parallel 1
+pwsh ./scripts/build.ps1 -Static -DisableTools -DisablePerf -Parallel 1
 
 cd $SRC/msquic/src/fuzzing
 


### PR DESCRIPTION
- cmake 3.16 (default version) might not work as expected with -Static option
- Specifying exactly three option `-DisableTest -DisableTools -DisablePerf` doesn't generate libmsquic.a, then link error for fuzzing code