### PR TITLE
[infra] Upgrade cmake to latest release (3.24.2)

### DIFF
--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -26,7 +26,7 @@ ENV FUZZINTRO_OUTDIR=$SRC
 ENV FUZZ_INTROSPECTOR=$introspector
 
 # Install newer cmake.
-ENV CMAKE_VERSION 3.21.1
+ENV CMAKE_VERSION 3.24.2
 RUN apt-get update && apt-get install -y wget sudo && \
     wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-$arch.sh && \
     chmod +x cmake-$CMAKE_VERSION-Linux-$arch.sh && \


### PR DESCRIPTION
CMake 3.21.1 is known to cause issues when building Qt.