### PR TITLE
[dbus] add project.yaml

### DIFF
--- a/projects/dbus/project.yaml
+++ b/projects/dbus/project.yaml
@@ -1,0 +1,14 @@
+homepage: "https://www.freedesktop.org/wiki/Software/dbus"
+language: c
+primary_contact: ""
+builds_per_day: 4
+sanitizers:
+  - address
+  - undefined
+  - memory
+auto_ccs:
+  - evverx@gmail.com
+main_repo: "https://gitlab.freedesktop.org/dbus/dbus.git"
+architectures:
+  - x86_64
+  - i386


### PR DESCRIPTION
It's a follow-up to https://seclists.org/oss-sec/2022/q4/7

dbus is the reference implementation of D-Bus, a message bus for communication between applications and system services: https://www.freedesktop.org/wiki/Software/dbus/. It's used by default on at least Debian and Ubuntu and among other things it's also a recommended systemd runtime dependency. Combined with https://github.com/google/oss-fuzz/pull/7860 it should hopefully fully cover the most popular system dbus daemons. The dbus project also provides the libdbus library used by a lot of projects directly or via various bindings so it should help to cover them too.