### PR TITLE
[h3] Add @nrabinowitz to the list of H3 maintainers

### DIFF
--- a/projects/h3/project.yaml
+++ b/projects/h3/project.yaml
@@ -6,6 +6,7 @@ auto_ccs:
   - "h3-dev@googlegroups.com"
   - "isv.damocles@gmail.com"
   - "ajfriend@gmail.com"
+  - "nick.rabinowitz@gmail.com"
 sanitizers:
   - address
   - undefined


### PR DESCRIPTION
Adds [nrabinowitz](https://github.com/nrabinowitz) to the list of maintainers for https://github.com/uber/h3

cc @isaacbrodsky