### PR TITLE
solidity: Revert to upstream LPM.

### DIFF
--- a/projects/solidity/Dockerfile
+++ b/projects/solidity/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool \
 
 RUN git clone --recursive -b develop https://github.com/ethereum/solidity.git solidity
 RUN git clone --depth 1 https://github.com/ethereum/solidity-fuzzing-corpus.git
-RUN git clone --depth 1 -b add-newline https://github.com/bshastry/libprotobuf-mutator.git
+RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
 # evmone v0.8.2 fixes: https://github.com/ethereum/evmone/issues/373
 RUN git clone --branch="v0.8.2" --recurse-submodules \
     https://github.com/ethereum/evmone.git


### PR DESCRIPTION
Fixes failing build after https://github.com/google/libprotobuf-mutator/pull/207 was merged and source branch deleted.