### PR TITLE
Don't allow libmagic to fork

### DIFF
--- a/projects/file/magic_fuzzer.cc
+++ b/projects/file/magic_fuzzer.cc
@@ -23,7 +23,7 @@
 
 struct Environment {
   Environment(std::string data_dir) {
-    magic = magic_open(MAGIC_COMPRESS|MAGIC_CONTINUE);
+    magic = magic_open(MAGIC_COMPRESS|MAGIC_CONTINUE|MAGIC_NO_COMPRESS_FORK);
     std::string magic_path = data_dir + "/magic";
     if (magic_load(magic, magic_path.c_str())) {
       fprintf(stderr, "error loading magic file: %s\n", magic_error(magic));

--- a/projects/file/magic_fuzzer_fd.cc
+++ b/projects/file/magic_fuzzer_fd.cc
@@ -26,7 +26,7 @@
 
 struct Environment {
   Environment(std::string data_dir) {
-    magic = magic_open(MAGIC_COMPRESS|MAGIC_CONTINUE);
+    magic = magic_open(MAGIC_COMPRESS|MAGIC_CONTINUE|MAGIC_NO_COMPRESS_FORK);
     std::string magic_path = data_dir + "/magic";
     if (magic_load(magic, magic_path.c_str())) {
       fprintf(stderr, "error loading magic file: %s\n", magic_error(magic));


### PR DESCRIPTION
Having libmagic fork and call `exit` in the children angers and saddens oss-fuzz's infra.