### PR TITLE
python-tabulate: avoid any exceptions from json

### DIFF
--- a/projects/python-tabulate/fuzz_tabulate.py
+++ b/projects/python-tabulate/fuzz_tabulate.py
@@ -29,7 +29,7 @@ def TestOneInput(data):
     # Create random dictionary
     try:
         fuzzed_dict = json.loads(fdp.ConsumeString(sys.maxsize))
-    except json.JSONDecodeError:
+    except:
         return
     if type(fuzzed_dict) is not dict:
         return


### PR DESCRIPTION
To avoid e.g. recursion errors as well, since this is irrelevant to python-tabulate.

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=49986