### PR TITLE
kcodecs: Fix build

### DIFF
--- a/projects/kcodecs/build.sh
+++ b/projects/kcodecs/build.sh
@@ -48,6 +48,7 @@ make sub-corelib sub-rcc -j$(nproc)
 
 cd $SRC
 cd kcodecs
+rm -rf poqm
 cmake . -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$SRC/qtbase
 make -j$(nproc) VERBOSE=1
 


### PR DESCRIPTION
To build translations we need more qt stuff, so just delete translations