### PR TITLE
Add drubery@chromium.org as auto_cc for unrar

### DIFF
--- a/projects/unrar/project.yaml
+++ b/projects/unrar/project.yaml
@@ -3,6 +3,7 @@ language: c++
 primary_contact: "roshal@rarlab.com"
 auto_ccs:
   - "vakh@chromium.org"
+  - "drubery@chromium.org"
 sanitizers:
   - address
   - memory


### PR DESCRIPTION
I'm working on moving the fuzzing for unrar from OSS-Fuzz to the Chromium repo (https://crrev.com/c/3939973), and need to copy the existing corpus between repos. https://google.github.io/oss-fuzz/advanced-topics/corpora/#obtain-access indicates that I need auto_cc access in order to do this.