### PR TITLE
git: avoid config commands and use environment variables

### DIFF
--- a/projects/git/fuzz-cmd-base.c
+++ b/projects/git/fuzz-cmd-base.c
@@ -159,7 +159,6 @@ int generate_commit_in_branch(char *data, int size, char *branch_name)
 int reset_git_folder(void)
 {
 	char *argv[6];
-
 	argv[0] = "init";
 	argv[1] = NULL;
 	if (cmd_init_db(1, (const char **)argv, (const char *)""))
@@ -167,6 +166,8 @@ int reset_git_folder(void)
 		return -1;
 	}
 
+  /*
+  printf("R2\n");
 	argv[0] = "config";
 	argv[1] = "--global";
 	argv[2] = "user.name";
@@ -177,6 +178,7 @@ int reset_git_folder(void)
 		return -2;
 	}
 
+  printf("R3\n");
 	argv[0] = "config";
 	argv[1] = "--global";
 	argv[2] = "user.email";
@@ -187,6 +189,7 @@ int reset_git_folder(void)
 		return -3;
 	}
 
+  printf("R4\n");
 	argv[0] = "config";
 	argv[1] = "--global";
 	argv[2] = "safe.directory";
@@ -196,7 +199,7 @@ int reset_git_folder(void)
 	{
 		return -4;
 	}
-
+  */
 	argv[0] = "add";
 	argv[1] = "TEMP_1";
 	argv[2] = "TEMP_2";

--- a/projects/git/fuzz-cmd-diff.c
+++ b/projects/git/fuzz-cmd-diff.c
@@ -57,7 +57,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	/*
 	 * Cleanup if needed
 	 */
-	//generateGitConfig(gitconfig_path);
+	generateGitConfig("/tmp/.my_gitconfig");
 	system("ls -lart ./");
   putenv("GIT_CONFIG_NOSYSTEM=true");
   putenv("GIT_AUTHOR_EMAIL=FUZZ@LOCALHOST");

--- a/projects/git/fuzz-cmd-diff.c
+++ b/projects/git/fuzz-cmd-diff.c
@@ -59,26 +59,18 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     return 0;
   }
 
-  char gitconfig_path[250];
-  snprintf(gitconfig_path, 250,  "/tmp/.my_gitconfig");//, current_dir);
-
 	/*
 	 * Cleanup if needed
 	 */
 	//generateGitConfig(gitconfig_path);
 	system("ls -lart ./");
-	//system("export GIT_CONFIG_SYSTEM=\"./gitconfig\"");
   putenv("GIT_CONFIG_NOSYSTEM=true");
   putenv("GIT_AUTHOR_EMAIL=FUZZ@LOCALHOST");
   putenv("GIT_AUTHOR_NAME=FUZZ");
   putenv("GIT_COMMITTER_NAME=FUZZ");
   putenv("GIT_COMMITTER_EMAIL=FUZZ@LOCALHOST");
 
-  char export_var[300];
-  snprintf(export_var, 300, "GIT_CONFIG_GLOBAL=\"%s\"", gitconfig_path);
-  putenv(export_var);
-  //putenv("GIT_CONFIG_SYSTEM=\"./gitconfig\"");
-	//system("cat $GIT_CONFIG_SYSTEM");
+  putenv("GIT_CONFIG_GLOBAL=/tmp/.my_gitconfig");
 	system("rm -rf ./.git");
 	system("rm -rf ./TEMP-*");
 	system("echo \"TEMP1TEMP1TEMP1TEMP1\" > ./TEMP_1");
@@ -89,7 +81,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	 *  Initialize the repository
 	 */
 	initialize_the_repository();
-	//system("ls -lart ./");
 	if (reset_git_folder())
 	{
 		repo_clear(the_repository);

--- a/projects/git/fuzz-cmd-diff.c
+++ b/projects/git/fuzz-cmd-diff.c
@@ -43,7 +43,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	int no_of_commit;
 	int max_commit_count;
 	char *argv[6];
-  char current_dir[200];
 	char *data_chunk;
 	char *basedir = "./.git";
 
@@ -54,10 +53,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	{
 		return 0;
 	}
-
-  if (getcwd(current_dir, 200) == NULL) {
-    return 0;
-  }
 
 	/*
 	 * Cleanup if needed


### PR DESCRIPTION
This should fix:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=52080

Maintains a bit of debug logic in order to understand the logs from oss-fuzz runtime better.

Signed-off-by: David Korczynski <david@adalogics.com>