### PR TITLE
Ignore crc32 in zip files in libarchive

### DIFF
--- a/projects/libarchive/libarchive_fuzzer.cc
+++ b/projects/libarchive/libarchive_fuzzer.cc
@@ -41,6 +41,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len) {
   archive_read_support_filter_all(a);
   archive_read_support_format_all(a);
 
+  archive_read_set_options(a, "zip:ignorecrc32");
+
   Buffer buffer = {buf, len};
   archive_read_open(a, &buffer, NULL, reader_callback, NULL);
 


### PR DESCRIPTION
Taken from https://github.com/libarchive/libarchive/blob/1385cd9c5126d9b681b7396ad2f353779ad143ba/libarchive/test/test_write_format_zip_large.c#L293 while waiting for https://github.com/libarchive/libarchive/issues/1788