### PR TITLE
qt: move Qt source clones to subfolder

### DIFF
--- a/projects/qt/Dockerfile
+++ b/projects/qt/Dockerfile
@@ -15,11 +15,18 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
+
 RUN apt-get update && apt-get install -y libssl-dev ninja-build libc6-dev:i386
+
 RUN git clone --depth 1 https://github.com/AFLplusplus/AFLplusplus.git myaflplusplus && \
     cp -r myaflplusplus/dictionaries afldictionaries && \
     cp -r myaflplusplus/testcases afltestcases && \
     rm -rf myaflplusplus
+
+# Simulate a classic Qt folder structure
+RUN mkdir qt
+WORKDIR $SRC/qt
+
 RUN git clone --branch dev --depth 1 git://code.qt.io/qt/qt5.git && \
     cp -r qt5/cmake . && \
     rm -rf qt5


### PR DESCRIPTION
The current Docker image as it is created does not allow the use of external sources to test fixes as the mount will come on top of all the SRC content which has more than just the Qt sources.

This patch changes that and moves the clone to a dedicated folder so it will follow the same structure as the Qt sources and it will possible to mount them again to test fixes.

Fixes #7634