### PR TITLE
miniz_oxide: initial integration

### DIFF
--- a/projects/miniz_oxide/Dockerfile
+++ b/projects/miniz_oxide/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN git clone --depth 1 https://github.com/Frommi/miniz_oxide miniz_oxide
+WORKDIR miniz_oxide
+COPY build.sh $SRC/

--- a/projects/miniz_oxide/build.sh
+++ b/projects/miniz_oxide/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -eu
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+./build_orig_miniz.sh
+RUSTFLAGS='-L./bin/' cargo fuzz build -O
+fuzz_release=fuzz/target/x86_64-unknown-linux-gnu/release
+cp $fuzz_release/inflate_nonwrapping $OUT/

--- a/projects/miniz_oxide/project.yaml
+++ b/projects/miniz_oxide/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/Frommi/miniz_oxide"
+language: rust
+main_repo: "https://github.com/Frommi/miniz_oxide"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+vendor_ccs:
+  - maxnair.dev@gmail.com


### PR DESCRIPTION
Hi, [miniz_oxide](https://github.com/Frommi/miniz_oxide) is a pure rust replacement for the [miniz](https://github.com/richgel999/miniz) deflate/zlib encoder/decoder using no unsafe code.
- It has 60 million+ downloads as per [crates.io](https://crates.io/crates/miniz_oxide).
- It is being used by projects like:
  - [backtrace-rs](https://crates.io/crates/backtrace)
  - [flate2](https://crates.io/crates/flate2)
  - [deflate-rs](https://crates.io/crates/deflate)
  - [image-png](https://crates.io/crates/png)