### PR TITLE
Add two defines to libarchive's build

### DIFF
--- a/projects/libarchive/build.sh
+++ b/projects/libarchive/build.sh
@@ -44,7 +44,7 @@ sed -i 's/-Werror//g' ./CMakeLists.txt
 
 mkdir build2
 cd build2
-cmake ../
+cmake -DCHECK_CRC_ON_SOLID_SKIP=1 -DDONT_FAIL_ON_CRC_ERROR=1 ../
 make -j$(nproc)
 
 # build seed


### PR DESCRIPTION
This should increase coverage by making libarchive ignore some crc computation results.