### PR TITLE
Update protobuf-python to +cc protobuf team

### DIFF
--- a/projects/protobuf-python/project.yaml
+++ b/projects/protobuf-python/project.yaml
@@ -5,6 +5,26 @@ language: python
 main_repo: https://github.com/protocolbuffers/protobuf
 sanitizers:
 - address
+auto_ccs:
+- buganizer-system+1260285@google.com
+- jgm@google.com
+- jgrimes@google.com
+- pzd@google.com
+- acozzette@google.com
+- deannagarcia@google.com
+- gberg@google.com
+- haberman@google.com
+- jieluo@google.com
+- jorg@google.com
+- mcyoung@google.com
+- mkruskal@google.com
+- salo@google.com
+- sandyzhang@google.com
+- jgm@google.com
+- sbenza@google.com
+- shaod@google.com
+- theodorerose@google.com
+primary_contact: kfm@google.com
 vendor_ccs:
 - david@adalogics.com
 - riccardo.schirone@trailofbits.com


### PR DESCRIPTION
auto_cc individual google accounts and bug component for triage.

Per https://google.github.io/oss-fuzz/getting-started/new-project-guide/#primary, Google accounts are needed for full access, which is why individuals are listed explicitly instead of using groups.

This PR is similar to https://github.com/google/oss-fuzz/pull/8758 which does the same for protobuf-java.