### PR TITLE
Update upb to +cc protobuf-oss-fuzz and team

### DIFF
--- a/projects/upb/project.yaml
+++ b/projects/upb/project.yaml
@@ -1,7 +1,24 @@
 homepage: "https://github.com/protocolbuffers/upb"
 language: c++
 primary_contact: "haberman@google.com"
-
+auto_ccs:
+- protobuf-oss-fuzz@google.com
+- jgm@google.com
+- jgrimes@google.com
+- kfm@google.com
+- pzd@google.com
+- acozzette@google.com
+- deannagarcia@google.com
+- gberg@google.com
+- jieluo@google.com
+- jorg@google.com
+- mcyoung@google.com
+- mkruskal@google.com
+- salo@google.com
+- sandyzhang@google.com
+- sbenza@google.com
+- shaod@google.com
+- theodorerose@google.com
 sanitizers:
 - address
 - memory


### PR DESCRIPTION
Per
https://google.github.io/oss-fuzz/getting-started/new-project-guide/#primary, Google accounts are needed for full access, which is why individuals are also listed explicitly instead of using groups.