### PR TITLE
fuzztest: integrating the infra

### DIFF
--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -91,7 +91,7 @@ function run_fuzz_target {
   # libFuzzer always finishes merge with an empty output dir.
   # Use 100s timeout instead of 25s as code coverage builds can be very slow.
   local args="-merge=1 -timeout=100 $corpus_dummy $corpus_real"
-
+  echo "E1 $target"
   export LLVM_PROFILE_FILE=$profraw_file
   timeout $TIMEOUT $OUT/$target $args &> $LOGS_DIR/$target.log
   if (( $? != 0 )); then
@@ -100,26 +100,45 @@ function run_fuzz_target {
   fi
 
   rm -rf $corpus_dummy
+  echo "E2 $target"
 
   if (( $(du -c $profraw_file_mask | tail -n 1 | cut -f 1) == 0 )); then
     # Skip fuzz targets that failed to produce profile dumps.
     return 0
   fi
 
+  echo "E3 $target"
   # If necessary translate to latest profraw version.
-  profraw_update.py $OUT/$target $profraw_file_mask $profraw_file_mask
+  if [[ $target == *"GFUZZTEST"* ]]; then
+    echo "--- $OUT/$($target//_GFUZZTEST_/ })"
+    sp=(${target//_GFUZZTEST_/ })
+    echo "-2"
+    echo "TT: ${sp[0]}"
+    echo "-3"
+    #real_target="${sp[0]}"
+    target="${sp[0]}"
+    echo "real target $target"
+    profraw_update.py $OUT/$target $profraw_file_mask $profraw_file_mask
+  else
+    profraw_update.py $OUT/$target $profraw_file_mask $profraw_file_mask
+  fi
+  echo "E4 $target"
   llvm-profdata merge -j=1 -sparse $profraw_file_mask -o $profdata_file
 
   # Delete unnecessary and (potentially) large .profraw files.
   rm $profraw_file_mask
 
+  echo "COVE5 $target"
   shared_libraries=$(coverage_helper shared_libs -build-dir=$OUT -object=$target)
 
+  echo "COVE6"
   llvm-cov export -summary-only -instr-profile=$profdata_file -object=$target \
       $shared_libraries $LLVM_COV_COMMON_ARGS > $FUZZER_STATS_DIR/$target.json
 
+  echo "COVE7"
   # For introspector.
-  llvm-cov show -instr-profile=$profdata_file -object=$target -line-coverage-gt=0 $shared_libraries $BRANCH_COV_ARGS $LLVM_COV_COMMON_ARGS > ${TEXTCOV_REPORT_DIR}/$target.covreport
+  #llvm-cov show -instr-profile=$profdata_file -object=$target -line-coverage-gt=0 $shared_libraries $BRANCH_COV_ARGS $LLVM_COV_COMMON_ARGS > ${TEXTCOV_REPORT_DIR}/$target.covreport
+  echo "COVE8"
 }
 
 function run_go_fuzz_target {
@@ -212,20 +231,25 @@ function generate_html {
   local shared_libraries=$2
   local objects=$3
   local output_dir=$4
-
+  echo "G-1"
   rm -rf "$output_dir"
   mkdir -p "$output_dir/$PLATFORM"
 
+  echo "G-2"
   local llvm_cov_args="-instr-profile=$profdata $objects $LLVM_COV_COMMON_ARGS"
   llvm-cov show -format=html -output-dir=$output_dir -Xdemangler rcfilt $llvm_cov_args
 
+  echo "G-3"
   # Export coverage summary in JSON format.
   local summary_file=$output_dir/$PLATFORM/summary.json
 
+  echo "G-4"
   llvm-cov export -summary-only $llvm_cov_args > $summary_file
+  echo "G-5 $output_dir"
 
-  coverage_helper -v post_process -src-root-dir=/ -summary-file=$summary_file \
-      -output-dir=$output_dir $PATH_EQUIVALENCE_ARGS
+  #coverage_helper -v post_process -src-root-dir=/ -summary-file=$summary_file \
+  #    -output-dir=$output_dir $PATH_EQUIVALENCE_ARGS
+  echo "G-6"
 }
 
 export SYSGOPATH=$GOPATH
@@ -257,7 +281,16 @@ for fuzz_target in $FUZZ_TARGETS; do
     fi
 
     echo "Running $fuzz_target"
-    run_fuzz_target $fuzz_target &
+    run_fuzz_target $fuzz_target
+    if [[ $fuzz_target == *"GFUZZTEST"* ]]; then
+      echo "--- $OUT/$($target//_GFUZZTEST_/ })"
+      sp=(${fuzz_target//_GFUZZTEST_/ })
+      echo "-2"
+      echo "TT: ${sp[0]}"
+      echo "-3"
+      #real_target="${sp[0]}"
+      fuzz_target="${sp[0]}"
+    fi
 
     if [[ -z $objects ]]; then
       # The first object needs to be passed without -object= flag.
@@ -280,7 +313,7 @@ wait
 
 if [[ $FUZZING_LANGUAGE == "go" ]]; then
   $SYSGOPATH/bin/gocovmerge $DUMPS_DIR/*.profdata > fuzz.cov
-  gotoolcover -html=fuzz.cov -o $REPORT_ROOT_DIR/index.html
+  go tool cover -html=fuzz.cov -o $REPORT_ROOT_DIR/index.html
   $SYSGOPATH/bin/gocovsum fuzz.cov > $SUMMARY_FILE
   cp $REPORT_ROOT_DIR/index.html $REPORT_PLATFORM_DIR/index.html
   $SYSGOPATH/bin/pprof-merge $DUMPS_DIR/*.perf.cpu.prof
@@ -313,6 +346,7 @@ elif [[ $FUZZING_LANGUAGE == "python" ]]; then
   mv htmlcov/* $REPORT_PLATFORM_DIR/
 
   # Create an empty summary file for now
+  echo "objects: $objects"
   echo "{}" >> $SUMMARY_FILE
 elif [[ $FUZZING_LANGUAGE == "jvm" ]]; then
 
@@ -362,18 +396,34 @@ else
   set -e
 
   # Merge all dumps from the individual targets.
+  echo "PP-1"
   rm -f $PROFILE_FILE
   llvm-profdata merge -sparse $DUMPS_DIR/*.profdata -o $PROFILE_FILE
+  echo "PP-1.1"
+  echo "objects: $objects"
 
   # TODO(mmoroz): add script from Chromium for rendering directory view reports.
   # The first path in $objects does not have -object= prefix (llvm-cov format).
   shared_libraries=$(coverage_helper shared_libs -build-dir=$OUT -object=$objects)
+  echo "PP-1.2"
   objects="$objects $shared_libraries"
+  echo "PP-2"
 
   generate_html $PROFILE_FILE "$shared_libraries" "$objects" "$REPORT_ROOT_DIR"
+  echo "PP-3"
 
   # Per target reports.
   for fuzz_target in $FUZZ_TARGETS; do
+    if [[ $fuzz_target == *"GFUZZTEST"* ]]; then
+      #echo "--- $OUT/$($fuzz_target//_GFUZZTEST_/ })"
+      sp=(${fuzz_target//_GFUZZTEST_/ })
+      echo "-2"
+      echo "TT: ${sp[0]}"
+      echo "-3"
+      #real_target="${sp[0]}"
+      fuzz_target="${sp[0]}"
+    fi
+
     profdata_path=$DUMPS_DIR/$fuzz_target.profdata
     if [[ ! -f "$profdata_path" ]]; then
       echo "WARNING: $fuzz_target has no profdata generated."
@@ -381,8 +431,11 @@ else
     fi
 
     report_dir=$REPORT_BY_TARGET_ROOT_DIR/$fuzz_target
+    echo "PP-4"
     generate_html $profdata_path "$shared_libraries" "$fuzz_target" "$report_dir"
+    echo "PP-4.1"
   done
+  echo "PP-5"
 fi
 
 # Make sure report is readable.

--- a/projects/fuzztest-example/Dockerfile
+++ b/projects/fuzztest-example/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+#RUN git clone --depth 1 <git_url> fuzztest-example     # or use other version control
+#WORKDIR fuzztest-example
+RUN git clone --depth 1 https://github.com/google/fuzztest fuzztest
+#COPY fuzztest $SRC/fuzztest
+COPY setup_configs.sh fuzztest/bazel/setup_configs.sh
+COPY my_workspace $SRC/my_workspace
+COPY build.sh $SRC/

--- a/projects/fuzztest-example/build.sh
+++ b/projects/fuzztest-example/build.sh
@@ -1,0 +1,76 @@
+#!/bin/bash -eu
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd fuzztest
+cp -rf ../my_workspace .
+cd my_workspace
+
+EXTRA_CONFIGS=libfuzzer \
+    bazel run @com_google_fuzztest//bazel:setup_configs > fuzztest.bazelrc
+
+FUZZ_TEST_BINARIES=$(bazel query 'kind("cc_test", rdeps(..., @com_google_fuzztest//fuzztest:fuzztest_gtest_main))')
+FUZZ_TEST_BINARIES_OUT_PATHS=$(bazel cquery 'kind("cc_test", rdeps(..., @com_google_fuzztest//fuzztest:fuzztest_gtest_main))' --output=files)
+
+echo "Fuzz test binaries:"
+echo ${FUZZ_TEST_BINARIES}
+echo "-----------------------------"
+#echo ${FUZZ_TEST_BINARIES3}
+echo "-----------------------------"
+
+bazel build --subcommands --config=oss-fuzz ${FUZZ_TEST_BINARIES[*]}
+
+echo "Listing tetss:"
+for fuzz_main_file in $FUZZ_TEST_BINARIES_OUT_PATHS; do
+  FUZZ_TESTS=$($fuzz_main_file --list_fuzz_tests)
+  cp ${fuzz_main_file} $OUT/
+
+  fuzz_basename=$(basename $fuzz_main_file)
+  for ft in $FUZZ_TESTS; do
+    echo "-"
+    echo $ft
+    TARGET_FUZZER="${fuzz_basename}_GFUZZTEST_$ft"
+
+    # Write executer script
+    echo "#!/bin/sh
+  # LLVMFuzzerTestOneInput for fuzzer detection.
+  this_dir=\$(dirname \"\$0\")
+  chmod +x \$this_dir/
+  $fuzz_basename --fuzz=$ft -- \$@" > $OUT/$TARGET_FUZZER
+    chmod +x $OUT/$TARGET_FUZZER
+  done
+  echo "------------"
+done
+
+# synchronise coverage directory to bazel generated code.
+if [ "$SANITIZER" = "coverage" ]
+then
+  echo "syncing bazel source files to coverage collection"
+  declare -r REMAP_PATH="${OUT}/proc/self/cwd"
+  mkdir -p "${REMAP_PATH}"
+
+  # Remove symlinks and delete them
+  declare -r RSYNC_FILTER_ARGS=("--include" "*.h" "--include" "*.cc" "--include" \
+    "*.hpp" "--include" "*.cpp" "--include" "*.c" "--include" "*/" "--exclude" "*")
+  rsync -avLk "${RSYNC_FILTER_ARGS[@]}" "${PWD}"/bazel-my_workspace/external "${REMAP_PATH}"
+
+  echo "Deleting symlinks"
+  find . -type l -ls -delete
+  echo "Done symlinks"
+  ls -la 
+
+  rsync -av ${PWD}/ "${REMAP_PATH}"
+fi

--- a/projects/fuzztest-example/my_workspace/.bazelrc
+++ b/projects/fuzztest-example/my_workspace/.bazelrc
@@ -1,0 +1,29 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Force the use of Clang for all builds.
+build --action_env=CC=clang
+build --action_env=CXX=clang++
+
+# Use the C++17 standard.
+build --cxxopt=-std=c++17
+
+# Show everything when running tests.
+test --test_output=streamed
+
+# To create this file, please run:
+#
+#  bazel run @com_google_fuzztest//bazel:setup_configs > fuzztest.bazelrc
+#
+try-import %workspace%/fuzztest.bazelrc

--- a/projects/fuzztest-example/my_workspace/BUILD
+++ b/projects/fuzztest-example/my_workspace/BUILD
@@ -1,0 +1,35 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The Escaping Library example for the FuzzTest Codelab.
+
+package(default_visibility = ["//visibility:private"])
+
+licenses(["notice"])
+
+cc_library(
+    name = "escaping",
+    srcs = ["escaping.cc"],
+    hdrs = ["escaping.h"],
+)
+
+cc_test(
+    name = "escaping_test",
+    srcs = ["escaping_test.cc"],
+    deps = [
+        ":escaping",
+        "@com_google_fuzztest//fuzztest",
+        "@com_google_fuzztest//fuzztest:fuzztest_gtest_main",
+    ],
+)

--- a/projects/fuzztest-example/my_workspace/WORKSPACE
+++ b/projects/fuzztest-example/my_workspace/WORKSPACE
@@ -1,0 +1,74 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+workspace(name = "fuzztest_codelab")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+################################################################################
+# Transitive dependencies (not directly required by the codelab)
+#
+# TODO(b/245360431): Add a function for loading transitive dependencies.
+################################################################################
+
+# Required by com_google_absl.
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
+    ],
+)
+
+# Required by com_google_fuzztest.
+http_archive(
+    name = "com_google_absl",
+    sha256 = "da79745569dd8767ebd8f738fd3eec55ccd23e45b0e680a7b5b6bab7624de77b",
+    strip_prefix = "abseil-cpp-6acb60c161f1203e6eca929b87f2041da7714bfe",
+    url = "https://github.com/abseil/abseil-cpp/archive/6acb60c161f1203e6eca929b87f2041da7714bfe.tar.gz",
+)
+
+# Required by com_google_fuzztest.
+http_archive(
+    name = "com_googlesource_code_re2",
+    sha256 = "f89c61410a072e5cbcf8c27e3a778da7d6fd2f2b5b1445cd4f4508bee946ab0f",
+    strip_prefix = "re2-2022-06-01",
+    url = "https://github.com/google/re2/archive/refs/tags/2022-06-01.tar.gz",
+)
+
+################################################################################
+# Direct dependencies
+################################################################################
+
+http_archive(
+    name = "com_google_googletest",
+    sha256 = "81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2",
+    strip_prefix = "googletest-release-1.12.1",
+    url = "https://github.com/google/googletest/archive/refs/tags/release-1.12.1.tar.gz",
+)
+
+# TODO(fniksic): Replace this with an http_archive after we release FuzzTest.
+FUZZTEST_COMMIT = "62cf00c7341eb05d128d0a3cbce79ac31dbda032"
+
+#http_archive(
+#    name = "com_google_fuzztest",
+#    strip_prefix = "fuzztest-" + FUZZTEST_COMMIT,
+#    url = "https://github.com/google/fuzztest/archive/" + FUZZTEST_COMMIT + ".zip",
+#)
+
+local_repository(
+    name = "com_google_fuzztest",
+    path = "..",
+)

--- a/projects/fuzztest-example/my_workspace/escaping.cc
+++ b/projects/fuzztest-example/my_workspace/escaping.cc
@@ -1,0 +1,72 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "./escaping.h"
+
+namespace codelab {
+
+std::string Escape(std::string_view str) {
+  std::string result;
+  for (size_t i = 0; i < str.size(); ++i) {
+    switch (str[i]) {
+      case '\n':
+        result.push_back('\\');
+        result.push_back('n');
+        break;
+      case '\r':
+        result.push_back('\\');
+        result.push_back('r');
+        break;
+      case '\t':
+        result.push_back('\\');
+        result.push_back('t');
+        break;
+      case '\\':
+        result.push_back('\\');
+        result.push_back('\\');
+        break;
+      default:
+        result.push_back(str[i]);
+        break;
+    }
+  }
+  return result;
+}
+
+std::string Unescape(std::string_view str) {
+  std::string result;
+  for (size_t i = 0; i < str.size(); ++i) {
+    if (str[i] == '\\') {
+      ++i;
+      switch (str[i]) {
+        case 'n':
+          result.push_back('\n');
+          break;
+        case 't':
+          result.push_back('\t');
+          break;
+        case '\\':
+          result.push_back('\\');
+          break;
+        default:
+          break;
+      }
+    } else {
+      result.push_back(str[i]);
+    }
+  }
+  return result;
+}
+
+}  // namespace codelab

--- a/projects/fuzztest-example/my_workspace/escaping.h
+++ b/projects/fuzztest-example/my_workspace/escaping.h
@@ -1,0 +1,33 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FUZZTEST_CODELAB_ESCAPING_H_
+#define FUZZTEST_CODELAB_ESCAPING_H_
+
+#include <string>
+#include <string_view>
+
+namespace codelab {
+
+// Escapes `str`, by replacing special characters, such as '\n' and '\t',
+// with their corresponding C escape sequences, i.e., "\\n" and "\\t".
+std::string Escape(std::string_view str);
+
+// Unescapes `str`, by replacing any occurrence of C escape sequences with their
+// equivalent character. Invalid sequences are ignored.
+std::string Unescape(std::string_view str);
+
+}  // namespace codelab
+
+#endif  // FUZZTEST_CODELAB_ESCAPING_H_

--- a/projects/fuzztest-example/my_workspace/escaping_test.cc
+++ b/projects/fuzztest-example/my_workspace/escaping_test.cc
@@ -1,0 +1,67 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "./escaping.h"
+
+#include "gtest/gtest.h"
+#include "fuzztest/fuzztest.h"
+
+namespace codelab {
+namespace {
+
+TEST(EscapingTest, EscapingEmptyStringReturnsEmptyString) {
+  EXPECT_EQ(Escape(""), "");
+}
+
+TEST(EscapingTest, UnescapingEmptyStringReturnsEmptyString) {
+  EXPECT_EQ(Unescape(""), "");
+}
+
+TEST(EscapingTest, EscapingPlainStringIsReturnedAsIs) {
+  EXPECT_EQ(Escape("plain text"), "plain text");
+}
+
+TEST(EscapingTest, UnescapingPlainStringIsReturnedAsIs) {
+  EXPECT_EQ(Unescape("plain text"), "plain text");
+}
+
+TEST(EscapingTest, EscapingReplacesSpecialCharacters) {
+  EXPECT_EQ(Escape("two\nlines"), "two\\nlines");
+  EXPECT_EQ(Escape("back\\slash"), "back\\\\slash");
+}
+
+TEST(EscapingTest, UnescapingReplacesEscapeSequences) {
+  EXPECT_EQ(Unescape("two\\nlines"), "two\nlines");
+  EXPECT_EQ(Unescape("back\\\\slash"), "back\\slash");
+}
+
+// Comment out the following fuzz tests:
+
+void UnescapingEscapedStringGivesOriginal(std::string_view s) {
+  EXPECT_EQ(s, Unescape(Escape(s)));
+}
+FUZZ_TEST(EscapingTest, UnescapingEscapedStringGivesOriginal);
+
+void EscapingAStringNeverTriggersUndefinedBehavior(std::string_view s) {
+  Escape(s);
+}
+FUZZ_TEST(EscapingTest, EscapingAStringNeverTriggersUndefinedBehavior);
+
+void UnescapingAStringNeverTriggersUndefinedBehavior(std::string_view s) {
+   Unescape(s);
+}
+FUZZ_TEST(EscapingTest, UnescapingAStringNeverTriggersUndefinedBehavior);
+
+}  // namespace
+}  // namespace codelab

--- a/projects/fuzztest-example/project.yaml
+++ b/projects/fuzztest-example/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/google/fuzztest"
+language: c++
+primary_contact: "david@adalogics.com"
+main_repo: "https://github.com/google/fuzztest"
+fuzzing_engines:
+ - libfuzzer

--- a/projects/fuzztest-example/setup_configs.sh
+++ b/projects/fuzztest-example/setup_configs.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+# Script for generating fuzztest.bazelrc.
+
+set -euf -o pipefail
+
+echo "### DO NOT EDIT. Generated file.
+#
+# To regenerate, run the following from your project's workspace:
+#
+#  bazel run @com_google_fuzztest//bazel:setup_configs > fuzztest.bazelrc
+#
+# And don't forget to add the following to your project's .bazelrc:
+#
+#  try-import %workspace%/fuzztest.bazelrc
+"
+
+echo "
+### Common options.
+#
+# Do not use directly.
+
+# Link with Address Sanitizer (ASAN).
+build:fuzztest-common --linkopt=-fsanitize=address
+
+# Standard define for \"ifdef-ing\" any fuzz test specific code.
+build:fuzztest-common --copt=-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+
+# In fuzz tests, we want to catch assertion violations even in optimized builds.
+build:fuzztest-common --copt=-UNDEBUG
+"
+
+echo "
+### FuzzTest build configuration.
+#
+# Use with: --config=fuzztest
+
+build:fuzztest --config=fuzztest-common
+
+# Link statically.
+build:fuzztest --dynamic_mode=off
+
+# We rely on the following flag instead of the compiler provided
+# __has_feature(address_sanitizer) to know that we have an ASAN build even in
+# the uninstrumented runtime.
+build:fuzztest --copt=-DADDRESS_SANITIZER
+"
+
+REPO_NAME="${1}"
+# When used in the fuzztest repo itself.
+if [ ${REPO_NAME} == "@" ]; then
+  FUZZTEST_FILTER="//fuzztest:"
+# When used in client repo.
+elif [ ${REPO_NAME} == "@com_google_fuzztest" ]; then
+  FUZZTEST_FILTER="fuzztest/.*"
+else
+  echo "Unexpected repo name: ${REPO_NAME}"
+  exit 1
+fi
+
+echo "# We apply coverage tracking and ASAN instrumentation to everything but the
+# FuzzTest framework itself (including GoogleTest and GoogleMock).
+build:fuzztest --per_file_copt=+//,-${FUZZTEST_FILTER},-googletest/.*,-googlemock/.*@-fsanitize=address,-fsanitize-coverage=inline-8bit-counters,-fsanitize-coverage=trace-cmp
+"
+
+# Do not use the extra configurations below, unless you know what you're doing.
+
+EXTRA_CONFIGS="${EXTRA_CONFIGS:-none}"
+
+if [[ ${EXTRA_CONFIGS} == *"libfuzzer"* ]]; then
+
+# Find llvm-config.
+LLVM_CONFIG=$(command -v llvm-config    ||
+              command -v llvm-config-15 ||
+              command -v llvm-config-14 ||
+              command -v llvm-config-13 ||
+              command -v llvm-config-12 ||
+              echo "")
+
+if [[ -z "${LLVM_CONFIG}" ]]; then
+  echo "ERROR: Couldn't generate config, because cannot find llvm-config."
+  echo ""
+  echo "Please install clang and llvm, e.g.:"
+  echo ""
+  echo "  sudo apt install clang llvm"
+  exit 1
+fi
+
+echo "
+### libFuzzer compatibility mode.
+#
+# Use with: --config=libfuzzer
+
+build:libfuzzer --config=fuzztest-common
+build:libfuzzer --copt=-DFUZZTEST_COMPATIBILITY_MODE
+build:libfuzzer --copt=-fsanitize=fuzzer-no-link
+build:libfuzzer --per_file_copt=+//,-${FUZZTEST_FILTER},-googletest/.*,-googlemock/.*@-fsanitize=address
+build:libfuzzer --linkopt=$(find $(${LLVM_CONFIG} --libdir) -name libclang_rt.fuzzer_no_main-x86_64.a | head -1)
+"
+
+fi # libFuzzer
+
+echo "
+### oss-fuzz compatibility mode.
+#
+# Use with: --config=oss-fuzz
+build:oss-fuzz --config=fuzztest-common
+build:oss-fuzz --copt=-DFUZZTEST_COMPATIBILITY_MODE
+build:oss-fuzz --dynamic_mode=off
+"
+if [ "$SANITIZER" = "address" ]; then
+  echo "build:oss-fuzz --copt=-fsanitize=fuzzer-no-link"
+  echo "build:oss-fuzz --per_file_copt=+//,-${FUZZTEST_FILTER},-googletest/.*,-googlemock/.*@-fsanitize=address"
+fi
+if [ "$SANITIZER" = "undefined" ]; then
+  echo "build:oss-fuzz --copt=-fsanitize=fuzzer-no-link"
+  echo "build:oss-fuzz --per_file_copt=+//,-${FUZZTEST_FILTER},-googletest/.*,-googlemock/.*@-fsanitize=undefined"
+  echo "build:oss-fuzz --linkopt=$(find $(llvm-config --libdir) -name libclang_rt.ubsan_standalone_cxx-x86_64.a | head -1)"
+fi
+if [ "$SANITIZER" = "coverage" ]; then
+  echo "build:oss-fuzz --per_file_copt=+//,-${FUZZTEST_FILTER},-googletest/.*,-googlemock/.*@-fprofile-instr-generate"
+  echo "build:oss-fuzz --per_file_copt=+//,-${FUZZTEST_FILTER},-googletest/.*,-googlemock/.*@-fcoverage-mapping"
+  echo "build:oss-fuzz --linkopt=-fprofile-instr-generate"
+  echo "build:oss-fuzz --linkopt=-fcoverage-mapping"
+fi
+echo "
+build:oss-fuzz --linkopt=$(find $(${LLVM_CONFIG} --libdir) -name libclang_rt.fuzzer_no_main-x86_64.a | head -1)
+"


### PR DESCRIPTION
This is work in progress. Putting it here so it's easier to keep track and to follow. Will simplify and refine most of this shortly.

Status:
- building and running fuzzers with libfuzzer + sanitizers defined by oss-fuzz works (simplified atm but principle is there)
- coverage is working for the simple project:
![Screenshot from 2022-10-14 01-18-29](https://user-images.githubusercontent.com/657617/195734653-6b4720b2-c52a-45d1-8b80-84a16de5fe10.png)
- keeping some of the files from the fuzztest repo (the example) in here just for convenience.


So far, the main problems have come from invoking the fuzzers as scripts rather than binaries and also code coverage collection in the context of bazel. Atm the code coverage is inspired by Envoy's approach. More changes are needed before this is ready for review. Will make this a PR on the main repo rather than a fork once it's more ready.

Ref: https://github.com/google/oss-fuzz/issues/8678

Signed-off-by: David Korczynski <david@adalogics.com>