### PR TITLE
Move protobuf python to upb

### DIFF
--- a/projects/protobuf-python/Dockerfile
+++ b/projects/protobuf-python/Dockerfile
@@ -15,8 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder-python
-RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config
 RUN curl -L -O https://raw.githubusercontent.com/protobuf-c/protobuf-c/39cd58f5ff06048574ed5ce17ee602dc84006162/t/test-full.proto
 RUN git clone --depth 1 --recursive https://github.com/protocolbuffers/protobuf.git
-WORKDIR $SRC
+RUN cd protobuf && bazel build --nobuild //:protoc @upb//python/dist:binary_wheel
 COPY build.sh fuzz_* $SRC/

--- a/projects/protobuf-python/Dockerfile
+++ b/projects/protobuf-python/Dockerfile
@@ -16,6 +16,6 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-python
 RUN curl -L -O https://raw.githubusercontent.com/protobuf-c/protobuf-c/39cd58f5ff06048574ed5ce17ee602dc84006162/t/test-full.proto
-RUN git clone --depth 1 --recursive https://github.com/protocolbuffers/protobuf.git
+RUN git clone https://github.com/protocolbuffers/protobuf.git
 RUN cd protobuf && bazel build --nobuild //:protoc @upb//python/dist:binary_wheel
 COPY build.sh fuzz_* $SRC/

--- a/projects/protobuf-python/build.sh
+++ b/projects/protobuf-python/build.sh
@@ -32,10 +32,6 @@ mkdir $SRC/wheels
 find -L bazel-out -name 'protobuf*.whl' -exec mv '{}' $SRC/wheels ';'
 pip3 install -vvv --no-index --find-links $SRC/wheels protobuf
 
-# Make sure we're using the default upb implementation.
-# This will give a warning if something went wrong.
-export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=upb
-
 # Compile test protos with protoc.
 cd $SRC/
 $PROTOC --python_out=. --proto_path=. test-full.proto

--- a/projects/protobuf-python/build.sh
+++ b/projects/protobuf-python/build.sh
@@ -15,21 +15,30 @@
 #
 ################################################################################
 
+BAZEL_FLAGS="-c dbg"
+if [[ $CFLAGS = *sanitize=address* ]]
+then
+    BAZEL_FLAGS="$BAZEL_FLAGS --config=asan"
+fi
+
 # Build protoc with default options.
 unset CFLAGS CXXFLAGS
-mkdir $SRC/protobuf-install/
-cmake $SRC/protobuf -Dprotobuf_BUILD_TESTS=OFF
-make -j$(nproc)
-make install
-ldconfig
+cd $SRC/protobuf
+bazel build $BAZEL_FLAGS //:protoc @upb//python/dist:binary_wheel
+PROTOC=$(realpath bazel-bin/protoc)
 
-cd $SRC/protobuf/python
-python3 setup.py build
-pip3 install .
+# Install the protobuf python runtime.
+mkdir $SRC/wheels
+find -L bazel-out -name 'protobuf*.whl' -exec mv '{}' $SRC/wheels ';'
+pip3 install -vvv --no-index --find-links $SRC/wheels protobuf
+
+# Make sure we're using the default upb implementation.
+# This will give a warning if something went wrong.
+export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=upb
 
 # Compile test protos with protoc.
 cd $SRC/
-protoc --python_out=. --proto_path=. test-full.proto
+$PROTOC --python_out=. --proto_path=. test-full.proto
 
 # Build fuzzers in $OUT.
 for fuzzer in $(find $SRC -name 'fuzz_*.py'); do


### PR DESCRIPTION
We currently have 3 implementations of protobuf-python (pure python, C++, and upb).  upb has been the default implementation since 21.x though, and we should be fuzzing against that one.  The other two will eventually be turned down.