### PR TITLE
ghostscript: add pdfwrite options fuzzer

### DIFF
--- a/projects/ghostscript/build.sh
+++ b/projects/ghostscript/build.sh
@@ -48,22 +48,23 @@ CPPFLAGS="${CPPFLAGS:-} $CUPS_CFLAGS -DPACIFY_VALGRIND" ./autogen.sh \
   --with-drivers=pdfwrite,cups,ljet4,laserjet,pxlmono,pxlcolor,pcl3,uniprint,pgmraw,ps2write,png16m,tiffsep1,faxg3,psdcmyk,eps2write,bmpmono,xpswrite
 make -j$(nproc) libgs
 
-fuzzers="gstoraster_fuzzer            \
-         gstoraster_fuzzer_all_colors \
-         gstoraster_ps_fuzzer         \
-         gstoraster_pdf_fuzzer        \
-         gs_device_pdfwrite_fuzzer    \
-         gs_device_pxlmono_fuzzer     \
-         gs_device_pgmraw_fuzzer      \
-         gs_device_ps2write_fuzzer    \
-         gs_device_png16m_fuzzer      \
-         gs_device_psdcmyk_fuzzer     \
-         gs_device_eps2write_fuzzer   \
-         gs_device_faxg3_fuzzer       \
-         gs_device_bmpmono_fuzzer     \
-         gs_device_xpswrite_fuzzer     \
-         gs_device_pxlcolor_fuzzer     \
-         gs_device_tiffsep1_fuzzer"
+fuzzers="gstoraster_fuzzer                \
+         gstoraster_fuzzer_all_colors     \
+         gstoraster_ps_fuzzer             \
+         gstoraster_pdf_fuzzer            \
+         gs_device_pdfwrite_fuzzer        \
+         gs_device_pxlmono_fuzzer         \
+         gs_device_pgmraw_fuzzer          \
+         gs_device_ps2write_fuzzer        \
+         gs_device_png16m_fuzzer          \
+         gs_device_psdcmyk_fuzzer         \
+         gs_device_eps2write_fuzzer       \
+         gs_device_faxg3_fuzzer           \
+         gs_device_bmpmono_fuzzer         \
+         gs_device_xpswrite_fuzzer        \
+         gs_device_pxlcolor_fuzzer        \
+         gs_device_tiffsep1_fuzzer        \
+         gs_device_pdfwrite_opts_fuzzer"
 
 for fuzzer in $fuzzers; do
   $CXX $CXXFLAGS $CUPS_LDFLAGS -std=c++11 -I. -I$SRC \
@@ -88,6 +89,17 @@ for f in examples/ridt91.eps examples/snowflak.ps $SRC/pdf_seeds/pdf.pdf; do
   cp "$f" "$WORK/all_color_seeds/$s"
 done
 zip -j "$OUT/gstoraster_fuzzer_all_colors_seed_corpus.zip" "$WORK"/all_color_seeds/*
+
+# Do the same thing with pdfwrites opt fuzzer, but multiple bytes
+mkdir -p "$WORK/gs_device_pdfwrite_opts_fuzzer_seeds"
+for f in examples/ridt91.eps examples/snowflak.ps $SRC/pdf_seeds/pdf.pdf; do
+  # Prepend the number of bytes used for picking options in the opts fuzzer
+  printf "\x01\x01" | cat - "$f" > tmp_file.txt
+  mv tmp_file.txt $f
+  s=$(sha1sum "$f" | awk '{print $1}')
+  cp "$f" "$WORK/gs_device_pdfwrite_opts_fuzzer_seeds/$s"
+done
+zip -j "$OUT/gs_device_pdfwrite_opts_fuzzer_seed_corpus.zip" "$WORK"/gs_device_pdfwrite_opts_fuzzer_seeds/*
 
 # Create seeds for gstoraster_fuzzer
 mkdir -p "$WORK/seeds"

--- a/projects/ghostscript/gs_device_bmpmono_fuzzer.cc
+++ b/projects/ghostscript/gs_device_bmpmono_fuzzer.cc
@@ -15,6 +15,6 @@ limitations under the License.
 #include "gs_fuzzlib.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-	fuzz_gs_device(data, size, 1, "bmpmono", "/dev/null");
+	fuzz_gs_device(data, size, 1, "bmpmono", "/dev/null", 0);
 	return 0;
 }

--- a/projects/ghostscript/gs_device_eps2write_fuzzer.cc
+++ b/projects/ghostscript/gs_device_eps2write_fuzzer.cc
@@ -15,6 +15,6 @@ limitations under the License.
 #include "gs_fuzzlib.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-	fuzz_gs_device(data, size, 1, "eps2write", "/dev/null");
+	fuzz_gs_device(data, size, 1, "eps2write", "/dev/null", 0);
 	return 0;
 }

--- a/projects/ghostscript/gs_device_faxg3_fuzzer.cc
+++ b/projects/ghostscript/gs_device_faxg3_fuzzer.cc
@@ -15,6 +15,6 @@ limitations under the License.
 #include "gs_fuzzlib.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-	fuzz_gs_device(data, size, 1, "faxg3", "/dev/null");
+	fuzz_gs_device(data, size, 1, "faxg3", "/dev/null", 0);
 	return 0;
 }

--- a/projects/ghostscript/gs_device_pdfwrite_opts_fuzzer.cc
+++ b/projects/ghostscript/gs_device_pdfwrite_opts_fuzzer.cc
@@ -15,6 +15,6 @@ limitations under the License.
 #include "gs_fuzzlib.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-	fuzz_gs_device(data, size, 1, "pdfwrite", "/dev/null", 0);
+	fuzz_gs_device(data, size, 1, "pdfwrite", "/dev/null", 1);
 	return 0;
 }

--- a/projects/ghostscript/gs_device_pdfwrite_opts_fuzzer.cc
+++ b/projects/ghostscript/gs_device_pdfwrite_opts_fuzzer.cc
@@ -15,6 +15,11 @@ limitations under the License.
 #include "gs_fuzzlib.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-	fuzz_gs_device(data, size, 1, "pdfwrite", "/dev/null", 1);
+	if (size < 2) {
+		return 0;
+	}
+	int color_scheme = ((int)data[0] % 63);
+	int do_interpolation = ((int)data[1] % 2);
+	fuzz_gs_device(data, size, color_scheme, "pdfwrite", "/dev/null", do_interpolation);
 	return 0;
 }

--- a/projects/ghostscript/gs_device_pdfwrite_opts_fuzzer.cc
+++ b/projects/ghostscript/gs_device_pdfwrite_opts_fuzzer.cc
@@ -20,6 +20,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	}
 	int color_scheme = ((int)data[0] % 63);
 	int do_interpolation = ((int)data[1] % 2);
+  data += 2;
+  size -= 2;
 	fuzz_gs_device(data, size, color_scheme, "pdfwrite", "/dev/null", do_interpolation);
 	return 0;
 }

--- a/projects/ghostscript/gs_device_pgmraw_fuzzer.cc
+++ b/projects/ghostscript/gs_device_pgmraw_fuzzer.cc
@@ -15,6 +15,6 @@ limitations under the License.
 #include "gs_fuzzlib.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-	fuzz_gs_device(data, size, 1, "pgmraw", "/dev/null");
+	fuzz_gs_device(data, size, 1, "pgmraw", "/dev/null", 0);
 	return 0;
 }

--- a/projects/ghostscript/gs_device_png16m_fuzzer.cc
+++ b/projects/ghostscript/gs_device_png16m_fuzzer.cc
@@ -15,6 +15,6 @@ limitations under the License.
 #include "gs_fuzzlib.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-	fuzz_gs_device(data, size, 1, "png16m", "/dev/null");
+	fuzz_gs_device(data, size, 1, "png16m", "/dev/null", 0);
 	return 0;
 }

--- a/projects/ghostscript/gs_device_ps2write_fuzzer.cc
+++ b/projects/ghostscript/gs_device_ps2write_fuzzer.cc
@@ -15,6 +15,6 @@ limitations under the License.
 #include "gs_fuzzlib.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-	fuzz_gs_device(data, size, 1, "ps2write", "/dev/null");
+	fuzz_gs_device(data, size, 1, "ps2write", "/dev/null", 0);
 	return 0;
 }

--- a/projects/ghostscript/gs_device_psdcmyk_fuzzer.cc
+++ b/projects/ghostscript/gs_device_psdcmyk_fuzzer.cc
@@ -15,6 +15,6 @@ limitations under the License.
 #include "gs_fuzzlib.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-	fuzz_gs_device(data, size, 1, "psdcmyk", "/dev/null");
+	fuzz_gs_device(data, size, 1, "psdcmyk", "/dev/null", 0);
 	return 0;
 }

--- a/projects/ghostscript/gs_device_pxlcolor_fuzzer.cc
+++ b/projects/ghostscript/gs_device_pxlcolor_fuzzer.cc
@@ -15,6 +15,6 @@ limitations under the License.
 #include "gs_fuzzlib.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-	fuzz_gs_device(data, size, 1, "pxlcolor", "/dev/null");
+	fuzz_gs_device(data, size, 1, "pxlcolor", "/dev/null", 0);
 	return 0;
 }

--- a/projects/ghostscript/gs_device_pxlmono_fuzzer.cc
+++ b/projects/ghostscript/gs_device_pxlmono_fuzzer.cc
@@ -15,6 +15,6 @@ limitations under the License.
 #include "gs_fuzzlib.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-	fuzz_gs_device(data, size, 1, "pxlmono", "/dev/null");
+	fuzz_gs_device(data, size, 1, "pxlmono", "/dev/null", 0);
 	return 0;
 }

--- a/projects/ghostscript/gs_device_tiffsep1_fuzzer.cc
+++ b/projects/ghostscript/gs_device_tiffsep1_fuzzer.cc
@@ -21,6 +21,6 @@ limitations under the License.
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	char filename[256];
 	sprintf(filename, "/tmp/libfuzzer.%d.tiff", getpid());
-	fuzz_gs_device(data, size, 1, "tiffsep1", filename);
+	fuzz_gs_device(data, size, 1, "tiffsep1", filename, 0);
 	return 0;
 }

--- a/projects/ghostscript/gs_device_xpswrite_fuzzer.cc
+++ b/projects/ghostscript/gs_device_xpswrite_fuzzer.cc
@@ -15,6 +15,6 @@ limitations under the License.
 #include "gs_fuzzlib.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-	fuzz_gs_device(data, size, 1, "xpswrite", "/dev/null");
+	fuzz_gs_device(data, size, 1, "xpswrite", "/dev/null", 0);
 	return 0;
 }

--- a/projects/ghostscript/gs_fuzzlib.h
+++ b/projects/ghostscript/gs_fuzzlib.h
@@ -32,7 +32,8 @@ int fuzz_gs_device(
 	size_t size,
 	int color_scheme,
 	const char *device_target,
-	const char *output_file
+	const char *output_file,
+	int do_interpolation
 );
 
 #define min(x, y) ((x) < (y) ? (x) : (y))
@@ -62,7 +63,7 @@ int gs_to_raster_fuzz(
 	int color_scheme
 )
 {
-	return fuzz_gs_device(buf, size, color_scheme, "cups", "/dev/null");
+	return fuzz_gs_device(buf, size, color_scheme, "cups", "/dev/null", 0);
 }
 
 int fuzz_gs_device(
@@ -70,7 +71,8 @@ int fuzz_gs_device(
 	size_t size,
 	int color_scheme,
 	const char *device_target,
-	const char *output_file
+	const char *output_file,
+	int do_interpolation
 )
 {
 	int ret;
@@ -78,6 +80,7 @@ int fuzz_gs_device(
 	char color_space[50];
 	char gs_device[50];
 	char gs_o[100];
+	char opt_interpolation[50];
 	/*
 	 * We are expecting color_scheme to be in the [0:62] interval.
 	 * This corresponds to the color schemes defined here:
@@ -86,6 +89,12 @@ int fuzz_gs_device(
 	sprintf(color_space, "-dcupsColorSpace=%d", color_scheme);
 	sprintf(gs_device, "-sDEVICE=%s", device_target);
 	sprintf(gs_o, "-sOutputFile=%s", output_file);
+	if (do_interpolation) {
+		sprintf(opt_interpolation, "-dDOINTERPOLATE");
+	}
+	else {
+		sprintf(opt_interpolation, "-dNOINTERPOLATE");
+	}
 	/* Mostly stolen from cups-filters gstoraster. */
 	char *args[] = {
 		"gs",
@@ -100,7 +109,7 @@ int fuzz_gs_device(
 		"-dSAFER",
 		"-dNOPAUSE",
 		"-dBATCH",
-		"-dNOINTERPOLATE",
+		opt_interpolation,
 		"-dNOMEDIAATTRS",
 		"-sstdout=%%stderr",
 		gs_o,


### PR DESCRIPTION
Fuzzer that will randomise more options for the ghostscript. First try this out with interpolation, where the goal is to increase coverage of base/gxiscale.c

Signed-off-by: David Korczynski <david@adalogics.com>