### PR TITLE
git: fix branch name during diffing

### DIFF
--- a/projects/git/fuzz-cmd-diff.c
+++ b/projects/git/fuzz-cmd-diff.c
@@ -193,7 +193,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	argv[3] = NULL;
 	cmd_diff(3, (const char **)argv, (const char *)"");
 	argv[1] = "--diff-filter=MRC";
-	argv[2] = "HEAD^";
+	argv[2] = "HEAD";
 	argv[3] = NULL;
 	cmd_diff(3, (const char **)argv, (const char *)"");
 	argv[1] = "-R";


### PR DESCRIPTION
Fixes various early exits atm:
- https://storage.cloud.google.com/git-logs.clusterfuzz-external.appspot.com/libFuzzer_git_fuzz-cmd-diff/libfuzzer_asan_git/2022-10-17/05%3A05%3A41%3A777284.log
- https://storage.cloud.google.com/git-logs.clusterfuzz-external.appspot.com/libFuzzer_git_fuzz-cmd-diff/libfuzzer_asan_git/2022-10-17/05%3A05%3A36%3A470438.log