### PR TITLE
fix(xs): Add Raphael to oss-fuzz perms

### DIFF
--- a/projects/xs/project.yaml
+++ b/projects/xs/project.yaml
@@ -4,6 +4,7 @@ primary_contact: "peter.hoddie@gmail.com"
 auto_ccs:
   - peter@moddable.com
   - ari@agoric.com
+  - raphael@agoric.com
 sanitizers:
   - address
 main_repo: 'https://github.com/Moddable-OpenSource/moddable.git'


### PR DESCRIPTION
This PR adds Raphael to the oss-fuzz perms for XS

CC: @raphdev