### PR TITLE
[Rolling out Centipede] Project 6 - 10

### DIFF
--- a/projects/abseil-cpp/project.yaml
+++ b/projects/abseil-cpp/project.yaml
@@ -2,3 +2,8 @@ homepage: "abseil.io"
 language: c++
 primary_contact: "abseil-io@googlegroups.com"
 main_repo: 'https://github.com/abseil/abseil-cpp.git'
+fuzzing_engines:
+ - afl
+ - honggfuzz
+ - libfuzzer
+ - centipede

--- a/projects/alembic/project.yaml
+++ b/projects/alembic/project.yaml
@@ -4,3 +4,8 @@ primary_contact: "miller.lucas@gmail.com"
 sanitizers:
   - address
 main_repo: 'https://github.com/alembic/alembic'
+fuzzing_engines:
+ - afl
+ - honggfuzz
+ - libfuzzer
+ - centipede

--- a/projects/arduinojson/project.yaml
+++ b/projects/arduinojson/project.yaml
@@ -9,3 +9,8 @@ architectures:
   - x86_64
   - i386
 main_repo: 'https://github.com/bblanchon/ArduinoJson.git'
+fuzzing_engines:
+ - afl
+ - honggfuzz
+ - libfuzzer
+ - centipede

--- a/projects/aspell/project.yaml
+++ b/projects/aspell/project.yaml
@@ -10,3 +10,8 @@ sanitizers:
   - memory:
       experimental: true
 main_repo: 'https://github.com/gnuaspell/aspell.git'
+fuzzing_engines:
+ - afl
+ - honggfuzz
+ - libfuzzer
+ - centipede

--- a/projects/skcms/project.yaml
+++ b/projects/skcms/project.yaml
@@ -13,3 +13,8 @@ architectures:
   - x86_64
   - i386
 main_repo: 'https://skia.googlesource.com/skcms.git'
+fuzzing_engines:
+ - afl
+ - honggfuzz
+ - libfuzzer
+ - centipede


### PR DESCRIPTION
Continuing #8690.

Given that `Centipede` passed CI tests of the 5 projects in #8690, we will gradually roll it out to let more real-world fuzzing targets benefit from it.
The second round contains the following 5 projects, **some of which are not from Google** (unlike round 1):

1. `skcms`,
2. `abseil-cpp`,
3. `alembic`,
4. `arduinojson`,
5. `aspell`.

Projects are selected because:
1. They are `C++` projects.

There will be another round (of 10 projects) as soon as we can confirm that Centipede works fine in this round.