### PR TITLE
[trial-build] Add sleep to avoid rate limiting

### DIFF
--- a/infra/build/functions/trial_build.py
+++ b/infra/build/functions/trial_build.py
@@ -201,6 +201,7 @@ def _do_build_type_builds(args, config, credentials, build_type, projects):
           credentials,
           build_type.type_name,
           extra_tags=['trial-build', f'branch-{args.branch}']))
+      time.sleep(1)  # Avoid going over 75 requests per second limit.
     except Exception as error:  # pylint: disable=broad-except
       # Handle flake.
       print('Failed to start build', project_name, error)


### PR DESCRIPTION
Sleep is appropriate because we're going to wait on builds which take orders of magnitude longer than one second sleeps