### PR TITLE
Add oss-fuzz@ruby-lang.org to ruby

### DIFF
--- a/projects/ruby/project.yaml
+++ b/projects/ruby/project.yaml
@@ -9,4 +9,5 @@ auto_ccs:
   - "y.endoh@gmail.com"
   - "john@hawthorn.email"
   - "kevinbackhouse@github.com"
+  - "oss-fuzz@ruby-lang.org"
 main_repo: "https://github.com/ruby/ruby"


### PR DESCRIPTION
We'd like to receive notification from oss-fuzz by our dedicated mail alias.