### PR TITLE
[trafficserver] initial integration

### DIFF
--- a/projects/trafficserver/Dockerfile
+++ b/projects/trafficserver/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y autoconf automake libtool pkg-config libpcre3-dev
+RUN git clone --depth 1 https://github.com/apache/trafficserver
+RUN git clone https://github.com/0x34d/oss-fuzz-bloat
+COPY build.sh $SRC/
+COPY fuzzer/ $SRC/trafficserver/fuzzer/
+WORKDIR $SRC/trafficserver/

--- a/projects/trafficserver/Dockerfile
+++ b/projects/trafficserver/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y autoconf automake libtool pkg-config libpcre3-dev
+RUN apt-get update && apt-get install -y autoconf automake libtool pkg-config libpcre3-dev zlib1g-dev
 RUN git clone --depth 1 https://github.com/apache/trafficserver
 RUN git clone https://github.com/0x34d/oss-fuzz-bloat
 COPY build.sh $SRC/

--- a/projects/trafficserver/build.sh
+++ b/projects/trafficserver/build.sh
@@ -23,4 +23,12 @@ make -j$(nproc)
 
 pushd fuzzer/
 make
+cp FuzzEsi $OUT/FuzzEsi
+cp FuzzHTTP $OUT/FuzzHTTP
 popd
+
+pushd $SRC/oss-fuzz-bloat/trafficserver/
+cp FuzzEsi_seed_corpus.zip $OUT/FuzzEsi_seed_corpus.zip
+cp FuzzHTTP_seed_corpus.zip $OUT/FuzzHTTP_seed_corpus.zip
+popd
+

--- a/projects/trafficserver/build.sh
+++ b/projects/trafficserver/build.sh
@@ -14,12 +14,14 @@
 # limitations under the License.
 #
 ################################################################################
-export CXXFLAGS="$CFLAGS"
-export LDFLAGS="$CFLAGS"
 
 autoreconf -if
 ./configure
 make -j$(nproc)
+
+mkdir $OUT/lib
+cp src/tscore/.libs/libtscore.so* $OUT/lib/.
+cp src/tscpp/util/.libs/libtscpputil.so* $OUT/lib/.
 
 pushd fuzzer/
 make
@@ -31,4 +33,3 @@ pushd $SRC/oss-fuzz-bloat/trafficserver/
 cp FuzzEsi_seed_corpus.zip $OUT/FuzzEsi_seed_corpus.zip
 cp FuzzHTTP_seed_corpus.zip $OUT/FuzzHTTP_seed_corpus.zip
 popd
-

--- a/projects/trafficserver/build.sh
+++ b/projects/trafficserver/build.sh
@@ -21,7 +21,7 @@ make -j$(nproc) --ignore-errors
 pushd fuzzer/
 make
 cp FuzzEsi $OUT/FuzzEsi
-cp FuzzHTTP $OUT/FuzzHTTP
+#cp FuzzHTTP $OUT/FuzzHTTP
 popd
 
 pushd $SRC/oss-fuzz-bloat/trafficserver/

--- a/projects/trafficserver/build.sh
+++ b/projects/trafficserver/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -eu
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+export CXXFLAGS="$CFLAGS"
+export LDFLAGS="$CFLAGS"
+
+autoreconf -if
+./configure
+make -j$(nproc)
+
+pushd fuzzer/
+make
+popd

--- a/projects/trafficserver/build.sh
+++ b/projects/trafficserver/build.sh
@@ -14,14 +14,9 @@
 # limitations under the License.
 #
 ################################################################################
-
 autoreconf -if
-./configure
-make -j$(nproc)
-
-mkdir $OUT/lib
-cp src/tscore/.libs/libtscore.so* $OUT/lib/.
-cp src/tscpp/util/.libs/libtscpputil.so* $OUT/lib/.
+./configure --enable-debug
+make -j$(nproc) --ignore-errors
 
 pushd fuzzer/
 make
@@ -33,3 +28,7 @@ pushd $SRC/oss-fuzz-bloat/trafficserver/
 cp FuzzEsi_seed_corpus.zip $OUT/FuzzEsi_seed_corpus.zip
 cp FuzzHTTP_seed_corpus.zip $OUT/FuzzHTTP_seed_corpus.zip
 popd
+
+mkdir $OUT/lib
+cp src/tscore/.libs/libtscore.so* $OUT/lib/.
+cp src/tscpp/util/.libs/libtscpputil.so* $OUT/lib/.

--- a/projects/trafficserver/fuzzer/FuzzEsi.cc
+++ b/projects/trafficserver/fuzzer/FuzzEsi.cc
@@ -1,0 +1,63 @@
+/* Copyright 2022 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <iostream>
+#include <cassert>
+#include <string>
+
+#include "EsiParser.h"
+
+using std::string;
+using namespace EsiLib;
+
+#define kMinInputLength 5
+#define kMaxInputLength 1024
+
+void
+Debug(const char *tag, const char *fmt, ...)
+{
+    return;
+}
+
+void
+Error(const char *fmt, ...)
+{
+    return;
+}
+
+extern "C" int
+LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
+{/*trafficserver/plugins/esi/test/docnode_test.cc*/
+
+    if (Size < kMinInputLength || Size > kMaxInputLength){
+        return 0;
+    }
+
+    EsiParser parser("parser_test", &Debug, &Error);
+
+    bool ret;
+    DocNodeList node_list;
+    string input_data((char *)Data,Size);
+
+    ret = parser.completeParse(node_list, input_data);
+
+    if(ret == true){
+        DocNodeList node_list2;
+        string packed = node_list.pack();
+        node_list2.unpack(packed);
+        node_list2.clear();
+    }
+
+    node_list.clear();
+
+    return ret;
+}

--- a/projects/trafficserver/fuzzer/FuzzHTTP.cc
+++ b/projects/trafficserver/fuzzer/FuzzHTTP.cc
@@ -1,0 +1,64 @@
+/* Copyright 2022 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "HTTP.h"
+#include "HttpCompat.h"
+
+#define kMinInputLength 5
+#define kMaxInputLength 1024
+
+extern int cmd_disable_pfreelist;
+
+extern "C" int
+LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
+{/*trafficserver/proxy/hdrs/unit_tests/test_Hdrs.cc*/
+
+    if (Size < kMinInputLength || Size > kMaxInputLength){
+        return 0;
+    }
+
+    http_init();
+    cmd_disable_pfreelist = true;
+
+    int err = 0;
+    const char *start;
+    const char *end;
+    HTTPHdr hdr;
+    HTTPParser parser;
+
+    http_parser_init(&parser);
+
+    start = (char *)Data;
+    end   = start + Size;
+
+    {
+        hdr.create(HTTP_TYPE_REQUEST);
+        err += hdr.parse_req(&parser, &start, end, true);
+        http_parser_clear(&parser);
+        hdr.destroy();
+    }
+
+    {
+        hdr.create(HTTP_TYPE_RESPONSE);
+        err += hdr.parse_resp(&parser, &start, end, true);
+        http_parser_clear(&parser);
+        hdr.destroy();
+    }
+
+    {
+        hdr.create(HTTP_TYPE_REQUEST,HTTP_2_0);
+        err += hdr.parse_req(&parser, &start, end, true);
+        http_parser_clear(&parser);
+        hdr.destroy();
+    }
+
+    return err;
+}

--- a/projects/trafficserver/fuzzer/Makefile
+++ b/projects/trafficserver/fuzzer/Makefile
@@ -61,8 +61,8 @@ $(TARGET):
 	$(CXX) $(CXXFLAGS) $(AM_CXXFLAGS) $(MACROS) $(EsiINC) -c $(EsiEXE).cc
 	$(CXX) $(CXXFLAGS) $(AM_CXXFLAGS) -o $(EsiEXE) $(EsiEXE).o $(EsiLIB)
 
-	$(CXX) $(CXXFLAGS) $(AM_CXXFLAGS) $(MACROS) $(HttpINC) -c $(HttpEXE).cc
-	$(CXX) $(CXXFLAGS) $(AM_CXXFLAGS) -o $(HttpEXE) $(HttpEXE).o $(CoreLib)
+#$(CXX) $(CXXFLAGS) $(AM_CXXFLAGS) $(MACROS) $(HttpINC) -c $(HttpEXE).cc
+#$(CXX) $(CXXFLAGS) $(AM_CXXFLAGS) -o $(HttpEXE) $(HttpEXE).o $(CoreLib)
 
 clean:
 	rm $(EsiEXE) $(HttpEXE) *.o

--- a/projects/trafficserver/fuzzer/Makefile
+++ b/projects/trafficserver/fuzzer/Makefile
@@ -52,16 +52,17 @@ CoreLib=$(LIB_FUZZING_ENGINE) \
 	$(LIBDIR)/iocore/eventsystem/ -linkevent \
 	$(LIBDIR)/src/records/ -lrecords_p \
 	$(LIBDIR)/mgmt/.libs/ -lmgmt_p \
-	$(LIBDIR)/proxy/shared/ -lUglyLogStubs 
+	$(LIBDIR)/proxy/shared/ -lUglyLogStubs \
+	-Wl,-rpath=lib/
 
 all: $(TARGET)
 
 $(TARGET):
-	$(CXX) $(CFLAGS) $(AM_CXXFLAGS) $(MACROS) $(EsiINC) -c $(EsiEXE).cc
-	$(CXX) $(CFLAGS) $(AM_CXXFLAGS) -o $(EsiEXE) $(EsiEXE).o $(EsiLIB)
+	$(CXX) $(CXXFLAGS) $(AM_CXXFLAGS) $(MACROS) $(EsiINC) -c $(EsiEXE).cc
+	$(CXX) $(CXXFLAGS) $(AM_CXXFLAGS) -o $(EsiEXE) $(EsiEXE).o $(EsiLIB)
 
-	$(CXX) $(CFLAGS) $(AM_CXXFLAGS) $(MACROS) $(HttpINC) -c $(HttpEXE).cc
-	$(CXX) $(CFLAGS) $(AM_CXXFLAGS) -o $(HttpEXE) $(HttpEXE).o $(CoreLib)
+	$(CXX) $(CXXFLAGS) $(AM_CXXFLAGS) $(MACROS) $(HttpINC) -c $(HttpEXE).cc
+	$(CXX) $(CXXFLAGS) $(AM_CXXFLAGS) -o $(HttpEXE) $(HttpEXE).o $(CoreLib)
 
 clean:
 	rm $(EsiEXE) $(HttpEXE) *.o

--- a/projects/trafficserver/fuzzer/Makefile
+++ b/projects/trafficserver/fuzzer/Makefile
@@ -1,0 +1,69 @@
+TARGET=Fuzzing
+
+#Binary
+EsiEXE=FuzzEsi
+HttpEXE=FuzzHTTP
+
+#Flags
+INCDIR=-I..
+LIBDIR=-L..
+MANFLAGS=-DHAVE_CONFIG_H 
+CPPFLAGS=-D_GNU_SOURCE -DOPENSSL_NO_SSL_INTERN -DOPENSSL_API_COMPAT=10002 -DOPENSSL_IS_OPENSSL3
+AM_CFLAGS=-std=gnu99 -g -pipe -Wall -Wno-deprecated-declarations -Qunused-arguments -Wextra -Wno-ignored-qualifiers -Wno-unused-parameter -fno-strict-aliasing -mcx16
+AM_CXXFLAGS=-std=c++17 -g -pipe -Wall -Wno-deprecated-declarations -Qunused-arguments -Wextra -Wno-ignored-qualifiers -Wno-unused-parameter -fno-strict-aliasing -Wno-invalid-offsetof -mcx16
+AM_CPPFLAGS=-Dlinux -D_LARGEFILE64_SOURCE=1 -D_COMPILE64BIT_SOURCE=1 -D_REENTRANT -D__STDC_LIMIT_MACROS=1 -D__STDC_FORMAT_MACROS=1
+MACROS=$(MANFLAGS) $(CPPFLAGS) $(AM_CPPFLAGS)
+
+#EsiEXE
+EsiINC=\
+	$(INCDIR)/include \
+	$(INCDIR)/plugins/esi \
+	$(INCDIR)/plugins/esi/lib \
+	$(INCDIR)/plugins/esi/fetcher 
+
+EsiLIB=$(LIB_FUZZING_ENGINE) \
+	$(LIBDIR)/plugins/esi/.libs/ \
+	$(EsiLib) -lesicore
+
+#HttpEXE
+HttpINC=\
+	$(INCDIR)/include \
+	$(INCDIR)/iocore/aio \
+	$(INCDIR)/iocore/cache \
+	$(INCDIR)/iocore/dns \
+	$(INCDIR)/iocore/eventsystem \
+	$(INCDIR)/iocore/hostdb \
+	$(INCDIR)/iocore/net \
+	$(INCDIR)/iocore/net/quic \
+	$(INCDIR)/iocore/utils \
+	$(INCDIR)/lib \
+	$(INCDIR)/proxy/api \
+	$(INCDIR)/proxy/hdrs \
+	$(INCDIR)/proxy/http
+
+CoreLib=$(LIB_FUZZING_ENGINE) \
+	$(LIBDIR)/lib/yamlcpp \
+	$(LIBDIR)/proxy/hdrs -lhdrs \
+	$(LIBDIR)/proxy/http -lhttp \
+	$(LIBDIR)/src/tscore/.libs/ -ltscore \
+	$(LIBDIR)/src/tscpp/util/.libs/ -ltscpputil \
+	-lpcre -lssl -lcrypto -lresolv \
+	$(LIBDIR)/src/tscpp/util/.libs/ -ltscpputil \
+	$(LIBDIR)/iocore/eventsystem/ -linkevent \
+	$(LIBDIR)/src/records/ -lrecords_p \
+	$(LIBDIR)/mgmt/.libs/ -lmgmt_p \
+	$(LIBDIR)/proxy/shared/ -lUglyLogStubs 
+
+all: $(TARGET)
+
+$(TARGET):
+	$(CXX) $(CFLAGS) $(AM_CXXFLAGS) $(MACROS) $(EsiINC) -c $(EsiEXE).cc
+	$(CXX) $(CFLAGS) $(AM_CXXFLAGS) -o $(EsiEXE) $(EsiEXE).o $(EsiLIB)
+
+	$(CXX) $(CFLAGS) $(AM_CXXFLAGS) $(MACROS) $(HttpINC) -c $(HttpEXE).cc
+	$(CXX) $(CFLAGS) $(AM_CXXFLAGS) -o $(HttpEXE) $(HttpEXE).o $(CoreLib)
+
+clean:
+	rm $(EsiEXE) $(HttpEXE) *.o
+
+.PHONY: all clean

--- a/projects/trafficserver/project.yaml
+++ b/projects/trafficserver/project.yaml
@@ -1,0 +1,14 @@
+homepage: "https://trafficserver.apache.org"
+language: c++
+primary_contact: "security@apache.org"
+auto_ccs:
+  - "ajsinghyadav00@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+sanitizers:
+  - address
+  - memory
+  - undefined
+main_repo: 'https://github.com/apache/trafficserver'

--- a/projects/trafficserver/project.yaml
+++ b/projects/trafficserver/project.yaml
@@ -9,4 +9,6 @@ fuzzing_engines:
   - honggfuzz
 sanitizers:
   - address
+  - memory
+  - undefined
 main_repo: 'https://github.com/apache/trafficserver'

--- a/projects/trafficserver/project.yaml
+++ b/projects/trafficserver/project.yaml
@@ -10,5 +10,4 @@ fuzzing_engines:
 sanitizers:
   - address
   - memory
-  - undefined
 main_repo: 'https://github.com/apache/trafficserver'

--- a/projects/trafficserver/project.yaml
+++ b/projects/trafficserver/project.yaml
@@ -10,4 +10,5 @@ fuzzing_engines:
 sanitizers:
   - address
   - memory
+  - undefined
 main_repo: 'https://github.com/apache/trafficserver'

--- a/projects/trafficserver/project.yaml
+++ b/projects/trafficserver/project.yaml
@@ -1,6 +1,8 @@
 homepage: "https://trafficserver.apache.org"
 language: c++
 primary_contact: "security@apache.org"
+vendor_ccs:
+  - "security@trafficserver.apache.org"
 auto_ccs:
   - "ajsinghyadav00@gmail.com"
 fuzzing_engines:

--- a/projects/trafficserver/project.yaml
+++ b/projects/trafficserver/project.yaml
@@ -9,6 +9,4 @@ fuzzing_engines:
   - honggfuzz
 sanitizers:
   - address
-  - memory
-  - undefined
 main_repo: 'https://github.com/apache/trafficserver'


### PR DESCRIPTION
Hello oss-fuzz Team,
FuzzHTTP is not deployed right now due to broken compile system against coverage and undefined sanitizer.

bug:https://github.com/apache/trafficserver/issues/9158


Signed-off-by: 0x34d <ajsinghyadav00@gmail.com>