### PR TITLE
Use the install_dependencies.sh script from the exiv2 repo

### DIFF
--- a/projects/exiv2/Dockerfile
+++ b/projects/exiv2/Dockerfile
@@ -15,8 +15,8 @@
 ################################################################################
 FROM gcr.io/oss-fuzz-base/base-builder
 
-RUN apt-get update && apt-get install -y cmake make ccache python3 libexpat1-dev zlib1g-dev libssh-dev libcurl4-openssl-dev libxml2-utils
 RUN git clone https://github.com/Exiv2/exiv2 exiv2
+RUN ./exiv2/ci/install_dependencies.sh
 WORKDIR exiv2
 
 COPY build.sh $SRC/


### PR DESCRIPTION
Call exiv2's `install_dependencies.sh` script rather than using a hard-coded list of packages. This should make the build less fragile when we add new dependencies to exiv2. (Example: https://github.com/Exiv2/exiv2/pull/2381.)