### PR TITLE
SystemSan: ony report arbitrary file open for writes

### DIFF
--- a/infra/experimental/SystemSan/SystemSan.cpp
+++ b/infra/experimental/SystemSan/SystemSan.cpp
@@ -307,6 +307,10 @@ void inspect_for_corruption(pid_t pid, const user_regs_struct &regs) {
 }
 
 void log_file_open(std::string path, int flags, pid_t pid) {
+  // Report only bugs for files opened to write into them.
+  if ((flags & 3) == O_RDONLY) {
+    return;
+  }
   report_bug(kArbitraryFileOpenError, pid);
   std::cerr << "===File opened: " << path << ", flags = " << flags << ",";
   switch (flags & 3) {


### PR DESCRIPTION
File opens for read only seem so far to be :
- config includers (like yaml fuzzers)
- files parsed under a specific format, which makes it unlikely that an attacker can abuse it to leak some secret.