### PR TITLE
Add 32-bit support for ffmpeg fuzzers

### DIFF
--- a/projects/ffmpeg/Dockerfile
+++ b/projects/ffmpeg/Dockerfile
@@ -15,11 +15,17 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
+RUN dpkg --add-architecture i386
 RUN apt-get update && apt-get install -y make autoconf libtool build-essential \
-    libass-dev libfreetype6-dev libsdl1.2-dev \
-    libvdpau-dev libxcb1-dev libxcb-shm0-dev libdrm-dev \
-    pkg-config texinfo libbz2-dev zlib1g-dev yasm cmake mercurial wget \
-    xutils-dev libpciaccess-dev nasm rsync
+		libass-dev:i386 libfreetype6-dev:i386 \
+		libvdpau-dev:i386 libxcb1-dev:i386 libxcb-shm0-dev:i386 libdrm-dev:i386 \
+		texinfo libbz2-dev:i386 lib32z1 zlib1g:i386 zlib1g-dev:i386 yasm cmake mercurial wget \
+		xutils-dev libpciaccess-dev:i386 nasm rsync libvpx-dev:i386 gcc-multilib \
+		libass-dev libfreetype6-dev libsdl1.2-dev \
+		libvdpau-dev libxcb1-dev libxcb-shm0-dev libdrm-dev \
+		pkg-config texinfo libbz2-dev zlib1g zlib1g-dev yasm cmake mercurial wget \
+		xutils-dev libpciaccess-dev nasm rsync libvpx-dev
+
 RUN curl -LO http://mirrors.kernel.org/ubuntu/pool/main/a/automake-1.16/automake_1.16.5-1.3_all.deb && \
     apt install ./automake_1.16.5-1.3_all.deb
 RUN git clone https://git.ffmpeg.org/ffmpeg.git ffmpeg

--- a/projects/ffmpeg/build.sh
+++ b/projects/ffmpeg/build.sh
@@ -16,8 +16,13 @@
 ################################################################################
 
 # Disable UBSan vptr since several targets built with -fno-rtti.
-export CFLAGS="$CFLAGS -fno-sanitize=vptr"
-export CXXFLAGS="$CXXFLAGS -fno-sanitize=vptr"
+if [[ "$ARCHITECTURE" == i386 ]]; then
+	export CFLAGS="$CFLAGS -fno-sanitize=vptr -m32"
+	export CXXFLAGS="$CXXFLAGS -fno-sanitize=vptr -m32"
+else
+	export CFLAGS="$CFLAGS -fno-sanitize=vptr"
+	export CXXFLAGS="$CXXFLAGS -fno-sanitize=vptr"
+fi
 
 # Build dependencies.
 export FFMPEG_DEPS_PATH=$SRC/ffmpeg_deps
@@ -39,7 +44,7 @@ make install
 cd $SRC/fdk-aac
 autoreconf -fiv
 CXXFLAGS="$CXXFLAGS -fno-sanitize=shift-base,signed-integer-overflow" \
-./configure --prefix="$FFMPEG_DEPS_PATH" --disable-shared
+	./configure --prefix="$FFMPEG_DEPS_PATH" --disable-shared
 make clean
 make -j$(nproc) all
 make install
@@ -66,13 +71,24 @@ make -j$(nproc) all
 make install
 
 cd $SRC/libvpx
-LDFLAGS="$CXXFLAGS" ./configure --prefix="$FFMPEG_DEPS_PATH" \
-    --disable-examples --disable-unit-tests \
-    --size-limit=12288x12288 \
-    --extra-cflags="-DVPX_MAX_ALLOCABLE_MEMORY=1073741824"
-make clean
-make -j$(nproc) all
-make install
+if [[ "$ARCHITECTURE" == i386 ]]; then
+	LDFLAGS="$CXXFLAGS" ./configure --prefix="$FFMPEG_DEPS_PATH" \
+		--disable-examples --disable-unit-tests \
+		--size-limit=12288x12288 \
+		--extra-cflags="-DVPX_MAX_ALLOCABLE_MEMORY=1073741824" \
+		--target=x86-linux-gcc
+	make clean
+	make -j$(nproc) all
+	make install
+else
+	LDFLAGS="$CXXFLAGS" ./configure --prefix="$FFMPEG_DEPS_PATH" \
+		--disable-examples --disable-unit-tests \
+		--size-limit=12288x12288 \
+		--extra-cflags="-DVPX_MAX_ALLOCABLE_MEMORY=1073741824"
+	make clean
+	make -j$(nproc) all
+	make install
+fi
 
 cd $SRC/ogg
 ./autogen.sh
@@ -91,11 +107,11 @@ make install
 cd $SRC/theora
 # theora requires ogg, need to pass its location to the "configure" script.
 CFLAGS="$CFLAGS -fPIC" LDFLAGS="-L$FFMPEG_DEPS_PATH/lib/" \
-    CPPFLAGS="$CXXFLAGS -I$FFMPEG_DEPS_PATH/include/" \
-    LD_LIBRARY_PATH="$FFMPEG_DEPS_PATH/lib/" \
-    ./autogen.sh
+	CPPFLAGS="$CXXFLAGS -I$FFMPEG_DEPS_PATH/include/" \
+	LD_LIBRARY_PATH="$FFMPEG_DEPS_PATH/lib/" \
+	./autogen.sh
 ./configure --with-ogg="$FFMPEG_DEPS_PATH" --prefix="$FFMPEG_DEPS_PATH" \
-    --enable-static --disable-examples
+	--enable-static --disable-examples --disable-asm
 make clean
 make -j$(nproc)
 make install
@@ -109,8 +125,8 @@ make install
 
 cd $SRC/libxml2
 ./autogen.sh --prefix="$FFMPEG_DEPS_PATH" --enable-static \
-    --without-debug --without-ftp --without-http \
-    --without-legacy --without-python
+	--without-debug --without-ftp --without-http \
+	--without-legacy --without-python
 make clean
 make -j$(nproc)
 make install
@@ -121,30 +137,66 @@ rm $FFMPEG_DEPS_PATH/lib/*.so.*
 
 # Build ffmpeg.
 cd $SRC/ffmpeg
-PKG_CONFIG_PATH="$FFMPEG_DEPS_PATH/lib/pkgconfig" ./configure \
-    --cc=$CC --cxx=$CXX --ld="$CXX $CXXFLAGS -std=c++11" \
-    --extra-cflags="-I$FFMPEG_DEPS_PATH/include" \
-    --extra-ldflags="-L$FFMPEG_DEPS_PATH/lib" \
-    --prefix="$FFMPEG_DEPS_PATH" \
-    --pkg-config-flags="--static" \
-    --enable-ossfuzz \
-    --libfuzzer=$LIB_FUZZING_ENGINE \
-    --optflags=-O1 \
-    --enable-gpl \
-    --enable-libass \
-    --enable-libfdk-aac \
-    --enable-libfreetype \
-    --enable-libopus \
-    --enable-libtheora \
-    --enable-libvorbis \
-    --enable-libvpx \
-    --enable-libxml2 \
-    --enable-nonfree \
-    --disable-muxers \
-    --disable-protocols \
-    --disable-demuxer=rtp,rtsp,sdp \
-    --disable-devices \
-    --disable-shared
+if [[ "$ARCHITECTURE" == i386 ]]; then
+	PKG_CONFIG_PATH="$FFMPEG_DEPS_PATH/lib/pkgconfig" ./configure \
+		--cc=$CC --cxx=$CXX --ld="$CXX $CXXFLAGS -std=c++11" \
+		--extra-cflags="-I$FFMPEG_DEPS_PATH/include" \
+		--extra-ldflags="-L$FFMPEG_DEPS_PATH/lib" \
+		--prefix="$FFMPEG_DEPS_PATH" \
+		--pkg-config-flags="--static" \
+		--enable-ossfuzz \
+		--libfuzzer=$LIB_FUZZING_ENGINE \
+		--optflags=-O1 \
+		--enable-gpl \
+		--enable-nonfree \
+		--enable-libass \
+		--enable-libfdk-aac \
+		--enable-libfreetype \
+		--enable-libopus \
+		--enable-libtheora \
+		--enable-libvorbis \
+		--enable-libvpx \
+		--enable-libxml2 \
+		--enable-nonfree \
+		--disable-muxers \
+		--disable-protocols \
+		--disable-demuxer=rtp,rtsp,sdp \
+		--disable-devices \
+		--disable-shared \
+		--arch="i386" \
+		--cpu="i386" \
+		--disable-inline-asm \
+		--disable-asm \
+		--disable-neon \
+		;
+else
+	PKG_CONFIG_PATH="$FFMPEG_DEPS_PATH/lib/pkgconfig" ./configure \
+		--cc=$CC --cxx=$CXX --ld="$CXX $CXXFLAGS -std=c++11" \
+		--extra-cflags="-I$FFMPEG_DEPS_PATH/include" \
+		--extra-ldflags="-L$FFMPEG_DEPS_PATH/lib" \
+		--prefix="$FFMPEG_DEPS_PATH" \
+		--pkg-config-flags="--static" \
+		--enable-ossfuzz \
+		--libfuzzer=$LIB_FUZZING_ENGINE \
+		--optflags=-O1 \
+		--enable-gpl \
+		--enable-nonfree \
+		--enable-libass \
+		--enable-libfdk-aac \
+		--enable-libfreetype \
+		--enable-libopus \
+		--enable-libtheora \
+		--enable-libvorbis \
+		--enable-libvpx \
+		--enable-libxml2 \
+		--enable-nonfree \
+		--disable-muxers \
+		--disable-protocols \
+		--disable-demuxer=rtp,rtsp,sdp \
+		--disable-devices \
+		--disable-shared \
+		;
+fi
 make clean
 make -j$(nproc) install
 
@@ -164,43 +216,43 @@ FUZZ_TARGET_SOURCE=$SRC/ffmpeg/tools/target_dec_fuzzer.c
 export TEMP_VAR_CODEC="AV_CODEC_ID_H264"
 export TEMP_VAR_CODEC_TYPE="VIDEO"
 
-CONDITIONALS=`grep 'BSF 1$' config_components.h | sed 's/#define CONFIG_\(.*\)_BSF 1/\1/'`
+CONDITIONALS=$(grep 'BSF 1$' config_components.h | sed 's/#define CONFIG_\(.*\)_BSF 1/\1/')
 if [ -n "${OSS_FUZZ_CI-}" ]; then
-  # When running in CI, check the first targets only to save time and disk space
-  CONDITIONALS=( ${CONDITIONALS[@]:0:2} )
+	# When running in CI, check the first targets only to save time and disk space
+	CONDITIONALS=(${CONDITIONALS[@]:0:2})
 fi
-for c in $CONDITIONALS ; do
-  fuzzer_name=ffmpeg_BSF_${c}_fuzzer
-  symbol=`echo $c | sed "s/.*/\L\0/"`
-  echo -en "[libfuzzer]\nmax_len = 1000000\n" > $OUT/${fuzzer_name}.options
-  make tools/target_bsf_${symbol}_fuzzer
-  mv tools/target_bsf_${symbol}_fuzzer $OUT/${fuzzer_name}
+for c in $CONDITIONALS; do
+	fuzzer_name=ffmpeg_BSF_${c}_fuzzer
+	symbol=$(echo $c | sed "s/.*/\L\0/")
+	echo -en "[libfuzzer]\nmax_len = 1000000\n" >$OUT/${fuzzer_name}.options
+	make tools/target_bsf_${symbol}_fuzzer
+	mv tools/target_bsf_${symbol}_fuzzer $OUT/${fuzzer_name}
 done
 
 # Build fuzzers for decoders.
-CONDITIONALS=`grep 'DECODER 1$' config_components.h | sed 's/#define CONFIG_\(.*\)_DECODER 1/\1/'`
+CONDITIONALS=$(grep 'DECODER 1$' config_components.h | sed 's/#define CONFIG_\(.*\)_DECODER 1/\1/')
 if [ -n "${OSS_FUZZ_CI-}" ]; then
-  # When running in CI, check the first targets only to save time and disk space
-  CONDITIONALS=( ${CONDITIONALS[@]:0:2} )
+	# When running in CI, check the first targets only to save time and disk space
+	CONDITIONALS=(${CONDITIONALS[@]:0:2})
 fi
-for c in $CONDITIONALS ; do
-  fuzzer_name=ffmpeg_AV_CODEC_ID_${c}_fuzzer
-  symbol=`echo $c | sed "s/.*/\L\0/"`
-  echo -en "[libfuzzer]\nmax_len = 1000000\n" > $OUT/${fuzzer_name}.options
-  make tools/target_dec_${symbol}_fuzzer
-  mv tools/target_dec_${symbol}_fuzzer $OUT/${fuzzer_name}
+for c in $CONDITIONALS; do
+	fuzzer_name=ffmpeg_AV_CODEC_ID_${c}_fuzzer
+	symbol=$(echo $c | sed "s/.*/\L\0/")
+	echo -en "[libfuzzer]\nmax_len = 1000000\n" >$OUT/${fuzzer_name}.options
+	make tools/target_dec_${symbol}_fuzzer
+	mv tools/target_dec_${symbol}_fuzzer $OUT/${fuzzer_name}
 done
 
 # Build fuzzer for demuxer
 fuzzer_name=ffmpeg_DEMUXER_fuzzer
-echo -en "[libfuzzer]\nmax_len = 1000000\n" > $OUT/${fuzzer_name}.options
+echo -en "[libfuzzer]\nmax_len = 1000000\n" >$OUT/${fuzzer_name}.options
 make tools/target_dem_fuzzer
 mv tools/target_dem_fuzzer $OUT/${fuzzer_name}
 
 # We do not need raw reference files for the muxer
-rm `find fate-suite -name '*.s16'`
-rm `find fate-suite -name '*.dec'`
-rm `find fate-suite -name '*.pcm'`
+rm $(find fate-suite -name '*.s16')
+rm $(find fate-suite -name '*.dec')
+rm $(find fate-suite -name '*.pcm')
 
 zip -r $OUT/${fuzzer_name}_seed_corpus.zip fate-suite
 zip -r $OUT/ffmpeg_AV_CODEC_ID_HEVC_fuzzer_seed_corpus.zip fate-suite/hevc fate-suite/hevc-conformance
@@ -211,46 +263,86 @@ make tools/target_io_dem_fuzzer
 mv tools/target_io_dem_fuzzer $OUT/${fuzzer_name}
 
 #Build fuzzers for individual demuxers
-PKG_CONFIG_PATH="$FFMPEG_DEPS_PATH/lib/pkgconfig" ./configure \
-    --cc=$CC --cxx=$CXX --ld="$CXX $CXXFLAGS -std=c++11" \
-    --extra-cflags="-I$FFMPEG_DEPS_PATH/include" \
-    --extra-ldflags="-L$FFMPEG_DEPS_PATH/lib" \
-    --prefix="$FFMPEG_DEPS_PATH" \
-    --pkg-config-flags="--static" \
-    --enable-ossfuzz \
-    --libfuzzer=$LIB_FUZZING_ENGINE \
-    --optflags=-O1 \
-    --enable-gpl \
-    --enable-libxml2 \
-    --disable-muxers \
-    --disable-protocols \
-    --disable-devices \
-    --disable-shared \
-    --disable-encoders \
-    --disable-filters \
-    --disable-muxers  \
-    --disable-parsers  \
-    --disable-decoders  \
-    --disable-hwaccels  \
-    --disable-bsfs  \
-    --disable-vaapi  \
-    --disable-vdpau    \
-    --disable-crystalhd  \
-    --disable-v4l2_m2m  \
-    --disable-cuda_llvm  \
-    --enable-demuxers \
-    --disable-demuxer=rtp,rtsp,sdp \
-
-CONDITIONALS=`grep 'DEMUXER 1$' config_components.h | sed 's/#define CONFIG_\(.*\)_DEMUXER 1/\1/'`
-if [ -n "${OSS_FUZZ_CI-}" ]; then
-  # When running in CI, check the first targets only to save time and disk space
-  CONDITIONALS=( ${CONDITIONALS[@]:0:2} )
+if [[ "$ARCHITECTURE" == i386 ]]; then
+	PKG_CONFIG_PATH="$FFMPEG_DEPS_PATH/lib/pkgconfig" ./configure \
+		--cc=$CC --cxx=$CXX --ld="$CXX $CXXFLAGS -std=c++11" \
+		--extra-cflags="-I$FFMPEG_DEPS_PATH/include" \
+		--extra-ldflags="-L$FFMPEG_DEPS_PATH/lib" \
+		--prefix="$FFMPEG_DEPS_PATH" \
+		--pkg-config-flags="--static" \
+		--enable-ossfuzz \
+		--libfuzzer=$LIB_FUZZING_ENGINE \
+		--optflags=-O1 \
+		--enable-gpl \
+		--enable-libxml2 \
+		--disable-muxers \
+		--disable-protocols \
+		--disable-devices \
+		--disable-shared \
+		--disable-encoders \
+		--disable-filters \
+		--disable-muxers \
+		--disable-parsers \
+		--disable-decoders \
+		--disable-hwaccels \
+		--disable-bsfs \
+		--disable-vaapi \
+		--disable-vdpau \
+		--disable-crystalhd \
+		--disable-v4l2_m2m \
+		--disable-cuda_llvm \
+		--enable-demuxers \
+		--disable-demuxer=rtp,rtsp,sdp \
+		--arch="i386" \
+		--cpu="i386" \
+		--disable-inline-asm \
+		--disable-asm \
+		--disable-neon \
+		;
+else
+	PKG_CONFIG_PATH="$FFMPEG_DEPS_PATH/lib/pkgconfig" ./configure \
+		--cc=$CC --cxx=$CXX --ld="$CXX $CXXFLAGS -std=c++11" \
+		--extra-cflags="-I$FFMPEG_DEPS_PATH/include" \
+		--extra-ldflags="-L$FFMPEG_DEPS_PATH/lib" \
+		--prefix="$FFMPEG_DEPS_PATH" \
+		--pkg-config-flags="--static" \
+		--enable-ossfuzz \
+		--libfuzzer=$LIB_FUZZING_ENGINE \
+		--optflags=-O1 \
+		--enable-gpl \
+		--enable-libxml2 \
+		--disable-muxers \
+		--disable-protocols \
+		--disable-devices \
+		--disable-shared \
+		--disable-encoders \
+		--disable-filters \
+		--disable-muxers \
+		--disable-parsers \
+		--disable-decoders \
+		--disable-hwaccels \
+		--disable-bsfs \
+		--disable-vaapi \
+		--disable-vdpau \
+		--disable-crystalhd \
+		--disable-v4l2_m2m \
+		--disable-cuda_llvm \
+		--enable-demuxers \
+		--disable-demuxer=rtp,rtsp,sdp \
+		;
 fi
-for c in $CONDITIONALS ; do
-  fuzzer_name=ffmpeg_dem_${c}_fuzzer
-  symbol=`echo $c | sed "s/.*/\L\0/"`
-  make tools/target_dem_${symbol}_fuzzer
-  mv tools/target_dem_${symbol}_fuzzer $OUT/${fuzzer_name}
+
+CONDITIONALS=$(grep 'DEMUXER 1$' config_components.h | sed 's/#define CONFIG_\(.*\)_DEMUXER 1/\1/')
+if [ -n "${OSS_FUZZ_CI-}" ]; then
+	# When running in CI, check the first targets only to save time and disk space
+	CONDITIONALS=(${CONDITIONALS[@]:0:2})
+fi
+
+for c in $CONDITIONALS; do
+	fuzzer_name=ffmpeg_dem_${c}_fuzzer
+	symbol=$(echo $c | sed "s/.*/\L\0/")
+	make tools/target_dem_${symbol}_fuzzer
+	mv tools/target_dem_${symbol}_fuzzer $OUT/${fuzzer_name}
 done
 
 # Find relevant corpus in test samples and archive them for every fuzzer.

--- a/projects/ffmpeg/project.yaml
+++ b/projects/ffmpeg/project.yaml
@@ -1,6 +1,9 @@
 homepage: "https://www.ffmpeg.org"
 language: c++
 primary_contact: "ffmpeg-security@ffmpeg.org"
+architectures:
+ - x86_64
+ - i386
 auto_ccs:
  - "michaelni@gmx.at"
  - "michael@niedermayer.cc"


### PR DESCRIPTION
Due to the fact that certain important apps compile FFmpeg as 32-bit code I think fuzzing FFmpeg as i386 would be beneficial because then we can find bugs specific to this architecture as well. build_fuzzers runs successfully on my set-up.