### PR TITLE
Don't use centipede's install script

### DIFF
--- a/infra/base-images/base-builder/precompile_centipede
+++ b/infra/base-images/base-builder/precompile_centipede
@@ -19,7 +19,8 @@ echo -n "Precompiling centipede"
 
 # Build Centipede with bazel.
 cd "$SRC/centipede/"
-./install_dependencies_debian.sh
+apt-get install libssl-dev -y
+unset CXXFLAGS CFLAGS
 echo 'build --cxxopt=-stdlib=libc++ --linkopt=-lc++' >> /tmp/centipede.bazelrc
 bazel --bazelrc=/tmp/centipede.bazelrc build -c opt :all
 
@@ -29,8 +30,7 @@ bazel --bazelrc=/tmp/centipede.bazelrc build -c opt :all
 # data-flow tracing flags, but will still throw errors when they cannot find
 # the corresponding functions.
 # The weak symbols provides fake implementations for intermediate binaries.
-/clang/bin/clang++ "$SRC/centipede/weak_sancov_stubs.cc" -c -o \
-  "$SRC/centipede/weak.o"
+$CXX "$SRC/centipede/weak_sancov_stubs.cc" -c -o "$SRC/centipede/weak.o"
 
 echo 'Removing extra stuff leftover to avoid bloating image.'
 

--- a/projects/envoy/Dockerfile
+++ b/projects/envoy/Dockerfile
@@ -27,7 +27,8 @@ RUN apt-get update && apt-get -y install  \
     libtool         \
     wget            \
     golang          \
-    rsync
+    rsync           \
+    python3
 
 RUN git clone https://github.com/envoyproxy/envoy.git
 WORKDIR $SRC/envoy/

--- a/projects/libraw/Dockerfile
+++ b/projects/libraw/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config
+RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config zlib1g-dev
 RUN git clone --depth 1 https://github.com/libraw/libraw
 WORKDIR libraw
 

--- a/projects/librdkafka/Dockerfile
+++ b/projects/librdkafka/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make cmake flex bison
+RUN apt-get update && apt-get install -y make cmake flex bison zlib1g-dev
 RUN git clone https://github.com/edenhill/librdkafka
 
 WORKDIR $SRC


### PR DESCRIPTION
We can't simply autoremove the packages it installs and it adds 500 MB to the image size.