### PR TITLE
olefile: do not fail if tmp file can't be removed

### DIFF
--- a/projects/olefile/fuzz_reader.py
+++ b/projects/olefile/fuzz_reader.py
@@ -30,7 +30,12 @@ def TestOneInput(data):
                 pass
         except (olefile.olefile.OleFileError, IOError) as e:
             pass
-    os.remove(fuzz_olefile)
+    try:
+        # Ensure the file gets closed, however the file should usually be closed
+        # by olefile itself, so ignore FileNotFoundError if raised.
+        os.remove(fuzz_olefile)
+    except FileNotFoundError:
+        pass
 
 
 def main():


### PR DESCRIPTION
Should fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=49945 .