### PR TITLE
add new project jwt-verify-lib

### DIFF
--- a/projects/jwt-verify-lib/project.yaml
+++ b/projects/jwt-verify-lib/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://github.com/google/jwt_verify_lib"
+language: c++
+primary_contact: "qiwzhang@google.com"
+auto_ccs:
+- "nareddyt@google.com"
+- "yangshuo@google.com"
+- "taoxuy@google.com"
+main_repo: 'https://github.com/google/jwt_verify_lib.git'


### PR DESCRIPTION
Initial integration steps following https://google.github.io/oss-fuzz/getting-started/accepting-new-projects/. Note this is a Google-owned project that is used in production, primarily via Envoy proxy.