### PR TITLE
install go1.17 for KubeEdge when building fuzzers

### DIFF
--- a/projects/kubeedge/Dockerfile
+++ b/projects/kubeedge/Dockerfile
@@ -15,6 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN wget https://go.dev/dl/go1.17.5.linux-amd64.tar.gz --quiet && rm -rf /root/.go && mkdir /root/tmpgo && tar -C /root/tmpgo -xzf go1.17.5.linux-amd64.tar.gz && mv /root/tmpgo/go /root/.go && ldconfig
 RUN git clone --depth 1 https://github.com/kubeedge/kubeedge
 RUN git clone --depth 1 https://github.com/cncf/cncf-fuzzing
 COPY build.sh $SRC/


### PR DESCRIPTION
Signed-off-by: vincentgoat <linguohui1@huawei.com>

install go1.17 for KubeEdge when building fuzzers

Fix issue https://github.com/cncf/cncf-fuzzing/issues/232
cc @AdamKorcz 