### PR TITLE
containerd: don't do shallow clone

### DIFF
--- a/projects/containerd/Dockerfile
+++ b/projects/containerd/Dockerfile
@@ -17,6 +17,8 @@
 FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN apt-get update && apt-get install -y btrfs-progs libc-dev pkg-config libseccomp-dev gcc wget libbtrfs-dev
 RUN git clone --depth 1 https://github.com/containerd/containerd
-RUN git clone --depth 1 https://github.com/AdamKorcz/instrumentation
+RUN git clone https://github.com/AdamKorcz/instrumentation \
+    && cd $SRC/instrumentation \
+    && git checkout cca41747087a403a1dfcbdf064e52d3e073d174f
 COPY build.sh $SRC/
 WORKDIR $SRC/containerd


### PR DESCRIPTION
The repo is very small and Containerd needs to access older, stable versions ad-hoc.

Signed-off-by: AdamKorcz <adam@adalogics.com>