### PR TITLE
bluez: refine set up

### DIFF
--- a/projects/bluez/Dockerfile
+++ b/projects/bluez/Dockerfile
@@ -15,8 +15,19 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config libglib2.0-dev libdbus-1-dev  libreadline8 libreadline-dev python-docutils libudev-dev udev libical-dev libdbus-1-dev systemd
+RUN apt-get update && apt-get install -y \
+    make autoconf automake libtool pkg-config \
+    libdbus-1-dev  libreadline8 libreadline-dev \
+    python-docutils libudev-dev udev libical-dev \
+    libdbus-1-dev systemd
+
+RUN pip3 install -U meson ninja
 RUN git clone --depth 1 https://github.com/bluez/bluez bluez
+RUN git clone https://github.com/GNOME/glib  && \
+    cd glib && \
+    meson _build -Db_lundef=false -Ddefault_library=static -Dlibmount=disabled && \
+    ninja -C _build && \
+    ninja -C _build install
 WORKDIR bluez
 COPY build.sh $SRC/
 COPY *.c $SRC/

--- a/projects/bluez/build.sh
+++ b/projects/bluez/build.sh
@@ -20,8 +20,8 @@ autoreconf -f
 ./configure
 make
 
-INCLUDES="-I. -I./src -I./lib -I./gobex -I/usr/include/glib-2.0/ -I/usr/lib/x86_64-linux-gnu/glib-2.0/include/"
-STATIC_LIBS="./src/.libs/libshared-glib.a ./lib/.libs/libbluetooth-internal.a  -l:libical.a -l:libicalss.a -l:libicalvcal.a -l:libdbus-1.a -l:libglib-2.0.a"
+INCLUDES="-I. -I./src -I./lib -I./gobex -I/usr/local/include/glib-2.0/ -I/src/glib/_build/glib/"
+STATIC_LIBS="./src/.libs/libshared-glib.a ./lib/.libs/libbluetooth-internal.a  -l:libical.a -l:libicalss.a -l:libicalvcal.a -l:libdbus-1.a /src/glib/_build/glib/libglib-2.0.a"
 
 $CC $CFLAGS $LIB_FUZZING_ENGINE $INCLUDES \
  $SRC/fuzz_xml.c ./src/bluetoothd-sdp-xml.o -o $OUT/fuzz_xml \

--- a/projects/bluez/fuzz_hci.c
+++ b/projects/bluez/fuzz_hci.c
@@ -33,12 +33,13 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   char *null_terminated = malloc(to_copy+1);
   memcpy(null_terminated, data, to_copy);
   null_terminated[to_copy] = '\0';
-
+/*
   char *tmp = lmp_featurestostr(features, null_terminated, to_copy);
   if (tmp) {
     free(tmp);
   }
-  tmp = NULL;
+*/
+  char *tmp = NULL;
 
   size -= to_copy;
   data += to_copy;


### PR DESCRIPTION
The current coverage of fuzz_hci is blocked. The coverage of the project works, but doesn't show up for fuzz_hci. Am not entirely sure why the reason is, but this commit should fix it.

Signed-off-by: David Korczynski <david@adalogics.com>