### PR TITLE
libvips: remove libjxl dependency

### DIFF
--- a/projects/libvips/Dockerfile
+++ b/projects/libvips/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get update && apt-get install -y \
   curl \
   gettext \
   glib2.0-dev \
-  libbrotli-dev \
   libexpat1-dev \
   libffi-dev \
   libfftw3-dev \
@@ -46,7 +45,6 @@ RUN git clone --depth 1 https://chromium.googlesource.com/webm/libwebp
 RUN git clone --depth 1 https://gitlab.com/libtiff/libtiff.git
 RUN git clone --depth 1 https://aomedia.googlesource.com/aom
 RUN git clone --depth 1 https://github.com/strukturag/libheif.git
-RUN git clone --depth 1 --recursive https://github.com/libjxl/libjxl.git
 RUN git clone --depth 1 https://github.com/lovell/libimagequant.git
 RUN git clone --depth 1 https://github.com/dloebl/cgif.git
 

--- a/projects/libvips/build.sh
+++ b/projects/libvips/build.sh
@@ -158,33 +158,6 @@ make -j$(nproc)
 make install
 popd
 
-# jpeg-xl (libjxl)
-pushd $SRC/libjxl
-# Ensure libvips finds JxlEncoderInitBasicInfo
-sed -i '/^Libs.private:/ s/$/ -lc++/' lib/jxl/libjxl.pc.in
-# CMake ignores the CPPFLAGS env, so prepend it to -DCMAKE_C{XX,}_FLAGS instead
-cmake \
-  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-  -DCMAKE_C_FLAGS="$CPPFLAGS $CFLAGS" \
-  -DCMAKE_CXX_FLAGS="$CPPFLAGS $CXXFLAGS" \
-  -DCMAKE_INSTALL_PREFIX=$WORK \
-  -DZLIB_ROOT=$WORK \
-  -DBUILD_SHARED_LIBS=0 \
-  -DBUILD_TESTING=0 \
-  -DJPEGXL_FORCE_SYSTEM_LCMS2=1 \
-  -DJPEGXL_FORCE_SYSTEM_BROTLI=1 \
-  -DJPEGXL_ENABLE_FUZZERS=0 \
-  -DJPEGXL_ENABLE_TOOLS=0 \
-  -DJPEGXL_ENABLE_MANPAGES=0 \
-  -DJPEGXL_ENABLE_BENCHMARK=0 \
-  -DJPEGXL_ENABLE_EXAMPLES=0 \
-  -DJPEGXL_ENABLE_SKCMS=0 \
-  -DJPEGXL_ENABLE_SJPEG=0 \
-  .
-make -j$(nproc)
-make install
-popd
-
 # libimagequant
 pushd $SRC/libimagequant
 meson setup build --prefix=$WORK --libdir=lib --default-library=static --buildtype=debugoptimized
@@ -252,10 +225,10 @@ for fuzzer in fuzz/*_fuzzer.cc; do
     $LDFLAGS \
     -lvips -lexif -llcms2 -ljpeg -lpng -lspng -lz \
     -ltiff -lwebpmux -lwebpdemux -lwebp -lsharpyuv -lheif -laom \
-    -ljxl -ljxl_threads -lhwy -limagequant -lcgif -lpdfium \
+    -limagequant -lcgif -lpdfium \
     $LIB_FUZZING_ENGINE \
     -Wl,-Bstatic \
-    -lfftw3 -lexpat -lbrotlienc -lbrotlidec -lbrotlicommon \
+    -lfftw3 -lexpat \
     -lgio-2.0 -lgmodule-2.0 -lgobject-2.0 -lffi -lglib-2.0 \
     -lresolv -lmount -lblkid -lselinux -lsepol -lpcre \
     -Wl,-Bdynamic -pthread \

--- a/projects/libvips/project.yaml
+++ b/projects/libvips/project.yaml
@@ -4,6 +4,4 @@ primary_contact: "jcupitt@gmail.com"
 auto_ccs:
   - "kleisauke@gmail.com"
   - "lovell.fuller@gmail.com"
-  - "jon.sneyers@gmail.com"
-  - "eustas@google.com"
 main_repo: 'https://github.com/libvips/libvips'


### PR DESCRIPTION
The image formats we've selected to fuzz test libvips with are typically those likely to originate from untrusted sources, and this very much includes the web.

libjxl was added as a dependency of libvips around 18 months ago in anticipation the JPEG-XL format being adopted for the web. A year ago we added a couple of the libjxl maintainers to help triage OSS-Fuzz issues as its inclusion generated a relatively large number of new problems, including one that was later issued a CVE.

https://bugs.chromium.org/p/oss-fuzz/issues/list?q=libvips%20libjxl&can=1

The libvips maintainers would love for JPEG-XL to succeed as a format and we hope to add libjxl back soon, but for now we would like to remove it to help reduce the support overhead.

/cc @jcupitt 