### PR TITLE
infra: fuzz-introspector; install matplotlib from binary

### DIFF
--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -211,7 +211,8 @@ if [ "$SANITIZER" = "introspector" ]; then
   unset CFLAGS
   apt-get install -y libjpeg-dev zlib1g-dev
   pip3 install --upgrade setuptools
-  pip3 install cxxfilt pyyaml beautifulsoup4 lxml soupsieve matplotlib
+  pip3 install cxxfilt pyyaml beautifulsoup4 lxml soupsieve
+  pip3 install --prefer-binary matplotlib
   mkdir -p $SRC/inspector
 
   find $SRC/ -name "fuzzerLogFile-*.data" -exec cp {} $SRC/inspector/ \;


### PR DESCRIPTION
This avoids compiling certain parts of matplotlib, which speeds up runtime of fuzz-introspector runs locally by a significant (~5-10min) time.

Ref: https://github.com/ossf/fuzz-introspector/pull/579#issuecomment-1300339783 Ref: https://github.com/ossf/fuzz-introspector/issues/465

Signed-off-by: David Korczynski <david@adalogics.com>