### PR TITLE
[xs] Disable stack-use-after-return detection

### DIFF
--- a/projects/xs/xst.options
+++ b/projects/xs/xst.options
@@ -1,2 +1,4 @@
 [libfuzzer]
 detect_leaks=0
+[asan]
+detect_stack_use_after_return=0


### PR DESCRIPTION
The `detect_stack_use_after_return=1` option in `ASAN_OPTIONS` set by the runner seemed to cause the fuzzer to not pick up any coverage. 

I'm not quite sure why this happens. Any guidance would be appreciated. The fuzzer seems stuck with this flag set:

`python infra/helper.py run_fuzzer --corpus-dir ../corpus_xst_json/ xs xst_jsonparse -- seed=1`

```
INFO: seed corpus: files: 1728 min: 1b max: 131336b total: 336638b rss: 92Mb
#64	pulse  cov: 322 ft: 323 corp: 1/1b exec/s: 32 rss: 92Mb
#128	pulse  cov: 322 ft: 323 corp: 1/1b exec/s: 25 rss: 92Mb
#256	pulse  cov: 322 ft: 324 corp: 2/8b exec/s: 23 rss: 93Mb
#512	pulse  cov: 322 ft: 324 corp: 2/8b exec/s: 22 rss: 93Mb
#1024	pulse  cov: 322 ft: 324 corp: 2/8b exec/s: 22 rss: 93Mb
```

However disabling it seems to make progress, with the same command (note same seed and corpus). After rebuilding image with `detect_stack_use_after_return` disabled:

`python infra/helper.py run_fuzzer --corpus-dir ../corpus_xst_json/ xs xst_jsonparse -- seed=1`

```
INFO: seed corpus: files: 1728 min: 1b max: 131336b total: 336638b rss: 92Mb
#64	pulse  cov: 485 ft: 500 corp: 29/55b exec/s: 32 rss: 93Mb
#128	pulse  cov: 574 ft: 673 corp: 70/239b exec/s: 25 rss: 93Mb
#256	pulse  cov: 749 ft: 1060 corp: 132/707b exec/s: 23 rss: 93Mb
#512	pulse  cov: 834 ft: 1560 corp: 214/1767b exec/s: 22 rss: 93Mb
#1024	pulse  cov: 953 ft: 2344 corp: 353/5213b exec/s: 22 rss: 93Mb
```

Setting `detect_stack_use_after_return=0` fixed it -- local runs picked up coverage with seed corpus, and even a couple of crashes. Until I work around this it would be preferable to gain some coverage, even if we don't detect `stack-use-after-return` for now.