### PR TITLE
u-root: fix auto_ccs contact

### DIFF
--- a/projects/u-root/project.yaml
+++ b/projects/u-root/project.yaml
@@ -2,7 +2,7 @@ homepage: "https://u-root.org/"
 main_repo: "https://github.com/u-root/u-root.git"
 primary_contact: "rminnich@gmail.com"
 auto_ccs:
-  - "fabian.wienand@9elements.com"
+  - "fab.wienand@gmail.com"
 language: go
 architectures:
   - x86_64


### PR DESCRIPTION
Updated my mail in the contacts for u-root, since the login seemingly requires a Gmail address.
Sorry, I got confused not knowing what exactly counts as an alternative e-mail address for a Google account.

Signed-off-by: Fabian Wienand <fabian.wienand@9elements.com>