### PR TITLE
infra: base-builder: compile: wrap find names in quotes

### DIFF
--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -220,8 +220,8 @@ if [ "$SANITIZER" = "introspector" ]; then
   # Move coverage report.
   if [ -d "$OUT/textcov_reports" ]
   then
-    find $OUT/textcov_reports/ -name *.covreport -exec cp {} $SRC/inspector/ \;
-    find $OUT/textcov_reports/ -name *.json -exec cp {} $SRC/inspector/ \;
+    find $OUT/textcov_reports/ -name "*.covreport" -exec cp {} $SRC/inspector/ \;
+    find $OUT/textcov_reports/ -name "*.json" -exec cp {} $SRC/inspector/ \;
   fi
 
   cd $SRC/inspector


### PR DESCRIPTION
Wrap wildcards in quotes as otherwise the script will autocomplete if there is a e.g. .json file in the current directory. This causes the wrong files to be moved, which means `all_cov.json` will not be moved to the introspector folder and thus wrong (no) coverage data will be used.

This error happens in e.g. g-api-auth-library-python