### PR TITLE
Change label prefix for protobuf projects

### DIFF
--- a/projects/protobuf-java/project.yaml
+++ b/projects/protobuf-java/project.yaml
@@ -31,4 +31,4 @@ sanitizers:
 - address
 labels:
   "*":
-    - ossfuzz-bugz-1260285
+    - protobuf-ossfuzz-bugz-1260285

--- a/projects/protobuf-python/project.yaml
+++ b/projects/protobuf-python/project.yaml
@@ -33,4 +33,4 @@ vendor_ccs:
 - facundo.tuesca@trailofbits.com
 labels:
   "*":
-    - ossfuzz-bugz-1260285
+    - protobuf-ossfuzz-bugz-1260285

--- a/projects/upb/project.yaml
+++ b/projects/upb/project.yaml
@@ -28,4 +28,4 @@ sanitizers:
 main_repo: 'https://github.com/protocolbuffers/upb.git'
 labels:
   "*":
-    - ossfuzz-bugz-1260285
+    - protobuf-ossfuzz-bugz-1260285


### PR DESCRIPTION
Avoid clashing with labels used by envoy in https://github.com/google/oss-fuzz/blob/master/projects/envoy/project.yaml.