### PR TITLE
Fix building postgres project for current master branch

### DIFF
--- a/projects/postgresql/add_fuzzers.diff
+++ b/projects/postgresql/add_fuzzers.diff
@@ -39,8 +39,8 @@ index 0775abe35d..f53b3580b3 100644
 +       {
 +#endif /* FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION */
 +
- 	AssertArg(dbname != NULL);
- 	AssertArg(username != NULL);
+ 	Assert(dbname != NULL);
+ 	Assert(username != NULL);
  
 @@ -4312,6 +4325,11 @@ PostgresMain(const char *dbname, const char *username)
  	if (!ignore_till_sync)

--- a/projects/postgresql/fuzzer/Makefile
+++ b/projects/postgresql/fuzzer/Makefile
@@ -22,7 +22,7 @@ objfiles.txt: Makefile $(SUBDIROBJS) $(OBJS_FUZZERS)
 
 SUBDIRS = ../access ../bootstrap ../catalog ../parser ../commands ../executor ../foreign ../lib ../libpq \
 	../main ../nodes ../optimizer ../partitioning ../port ../postmaster \
-	../regex ../replication ../rewrite \
+	../regex ../replication ../rewrite ../backup \
 	../statistics ../storage ../tcop ../tsearch ../utils $(top_builddir)/src/timezone \
 	../jit
 
@@ -41,13 +41,13 @@ fuzzer: simple_query_fuzzer \
 	protocol_fuzzer
 
 simple_query_fuzzer json_parser_fuzzer: %: %.o fuzzer_initialize.o $(OBJS_FUZZERS)
-	$(CXX) $(CFLAGS) $(call expand_subsys,$^) -o $@ $(LIB_FUZZING_ENGINE)
+	$(CXX) $(CFLAGS) $(call expand_subsys,$^) -o $@ $(LIB_FUZZING_ENGINE) -lz
 
 simple_query_fuzzer.o json_parser_fuzzer.o protocol_fuzzer.o fuzzer_initialize.o: %.o: %.c
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $^ 
 
 protocol_fuzzer: %: %.o $(OBJS_FUZZERS)
-	$(CXX) $(CFLAGS) $(call expand_subsys,$^) -o $@ $(LIB_FUZZING_ENGINE) -Wl,--wrap=exit -Wl,--wrap=pq_getbyte
+	$(CXX) $(CFLAGS) $(call expand_subsys,$^) -o $@ $(LIB_FUZZING_ENGINE) -Wl,--wrap=exit -Wl,--wrap=pq_getbyte  -lz
 
 dbfuzz: dbfuzz.o | submake-libpgport temp-install
 	$(CC) $(CFLAGS) $^ $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@ \

--- a/projects/postgresql/fuzzer/fuzzer_initialize.c
+++ b/projects/postgresql/fuzzer/fuzzer_initialize.c
@@ -86,7 +86,7 @@ int FuzzerInitialize(char *dbname, char ***argv){
   InitProcess();
   BaseInit();
   PG_SETMASK(&UnBlockSig);
-  InitPostgres("dbfuzz", InvalidOid, username, InvalidOid, NULL, false);
+  InitPostgres("dbfuzz", InvalidOid, username, InvalidOid, false, false,  NULL);
  
   SetProcessingMode(NormalProcessing);
 

--- a/projects/postgresql/fuzzer/simple_query_fuzzer.c
+++ b/projects/postgresql/fuzzer/simple_query_fuzzer.c
@@ -79,7 +79,7 @@ exec_simple_query(const char *query_string)
       else
 	oldcontext = MemoryContextSwitchTo(MessageContext);
 
-      querytree_list = pg_analyze_and_rewrite(parsetree, query_string,
+      querytree_list = pg_analyze_and_rewrite_fixedparams(parsetree, query_string,
 					      NULL, 0, NULL);
  
       plantree_list = pg_plan_queries(querytree_list, query_string,
@@ -124,7 +124,6 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
       AbortCurrentTransaction();
  
       PortalErrorCleanup();
-      SPICleanup();
 
       jit_reset_after_error();
 


### PR DESCRIPTION
* `AssertArg` have been replaced with Assert in b1099eca
* `pg_analyze_and_rewrite` was renamed to `pg_analyze_and_rewrite_fixedparams` in 791b1b71
* `SPICleanup` was removed in 2e517818
* Argument list for `InitPostgres` have been changed in b35617de
* `.o` files from `src/backend/backup` is now needed to build some fuzzers
* `libz` is needed to be linked to fuzzers as needed by backup related code: