### PR TITLE
infra: bump introspector and update python compile script

### DIFF
--- a/infra/base-images/base-builder/compile_python_fuzzer
+++ b/infra/base-images/base-builder/compile_python_fuzzer
@@ -44,7 +44,6 @@ if [[ $SANITIZER = *introspector* ]]; then
     ARGS="--fuzzer $fuzzer_path"
     if [ -n "${PYFUZZPACKAGE-}" ]; then
       ARGS="$ARGS --package=${PYFUZZPACKAGE}"
-      ARGS="$ARGS --scan"
     fi
     python /fuzz-introspector/frontends/python/main.py $ARGS
     ls -la ./

--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y wget sudo && \
 RUN apt-get update && apt-get install -y git && \
     git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
     cd fuzz-introspector && \
-    git checkout ff8d2cd46d329a97444ccbc98d393019b188e003 && \
+    git checkout 91b30879ddc8fc308d5c7a2aace6624ea8cae6e1 && \
     git submodule init && \
     git submodule update && \
     apt-get autoremove --purge -y git && \


### PR DESCRIPTION
This is a follow-up to https://github.com/google/oss-fuzz/pull/8952

This bump is needed to have the Python projects work properly. Scan should be done for all projects now, so have switched it on by default in fuzz introspector.

Bump also contains
- Fix for util-linux where per-target coverage report links were broken.
- Reduced logging.

Signed-off-by: David Korczynski <david@adalogics.com>