### PR TITLE
infra: bump fuzz introspector

### DIFF
--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y wget sudo && \
 RUN apt-get update && apt-get install -y git && \
     git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
     cd fuzz-introspector && \
-    git checkout 91b30879ddc8fc308d5c7a2aace6624ea8cae6e1 && \
+    git checkout ea1c238592431da969dba7aa6846a6ffea59165f && \
     git submodule init && \
     git submodule update && \
     apt-get autoremove --purge -y git && \


### PR DESCRIPTION
This has a fix for coverage urls for per-fuzzer coverage reports: https://github.com/ossf/fuzz-introspector/pull/605

Signed-off-by: David Korczynski <david@adalogics.com>