### PR TITLE
added architecture flag to coverage helper command

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -331,6 +331,7 @@ def get_parser():  # pylint: disable=too-many-statements
                                'pass to llvm-cov utility.',
                                nargs='*')
   _add_external_project_args(coverage_parser)
+  _add_architecture_args(coverage_parser)
 
   download_corpora_parser = subparsers.add_parser(
       'download_corpora', help='Download all corpora for a project.')
@@ -912,6 +913,7 @@ def coverage(args):
       'SANITIZER=coverage',
       'HTTP_PORT=%s' % args.port,
       'COVERAGE_EXTRA_ARGS=%s' % ' '.join(args.extra_args),
+      'ARCHITECTURE=' + args.architecture,
   ]
 
   run_args = _env_to_docker_args(env)
@@ -943,7 +945,7 @@ def coverage(args):
   if args.fuzz_target:
     run_args.append(args.fuzz_target)
 
-  result = docker_run(run_args)
+  result = docker_run(run_args, architecture=args.architecture)
   if result:
     logging.info('Successfully generated clang code coverage report.')
   else:


### PR DESCRIPTION
Currently if you make a coverage build for a particular architecture (e.g. aarch64), running the coverage command doesn't work as it assumes `x86_64`. This PR adds the `--architecture` flag present in other commands for parity, allowing to run coverage reports built for the matching architecture. 

Tested by running `build_fuzzers` and then `coverage` works as expected with defaults (x86_64).

Now `build_fuzzers` and then `coverage` also work when `--architecture aarch64` is used.

