### PR TITLE
Remove centipede's .git

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -134,7 +134,8 @@ RUN precompile_honggfuzz
 RUN cd $SRC && \
     git clone https://github.com/google/centipede.git && \
     cd centipede && \
-    git checkout baa82e7189677bb9086beb5d9b5e58018d991607
+    git checkout baa82e7189677bb9086beb5d9b5e58018d991607 && \
+    rm -rf .git
 
 COPY precompile_centipede /usr/local/bin/
 RUN precompile_centipede


### PR DESCRIPTION
It takes up space, is uneeded and causes irrelevant data to be displayed in revisions.