### PR TITLE
[flac] Add fuzzer_reencoder

### DIFF
--- a/projects/flac/build.sh
+++ b/projects/flac/build.sh
@@ -61,7 +61,7 @@ make -j$(nproc)
 
 # Copy decoder fuzzers
 cd $SRC/flac/oss-fuzz
-cp fuzzer_decoder fuzzer_seek fuzzer_metadata $OUT
+cp fuzzer_decoder fuzzer_seek fuzzer_metadata fuzzer_reencoder $OUT
 cp fuzzer_*.dict $OUT
 cd $SRC
 


### PR DESCRIPTION
This PR adds to the flac fuzzer build script to include fuzzer_reencoder, which is a fuzzer for which the fuzz input is first decoded and then re-encoded. Additional coverage beyond what is currently achieved is fuzzing of metadata input to the encoder (which is copied from the decoded fuzz input) and the use of very large empty inputs