### PR TITLE
teleport: Add @jentfoo to `auto_ccs`

### DIFF
--- a/projects/teleport/project.yaml
+++ b/projects/teleport/project.yaml
@@ -6,6 +6,7 @@ auto_ccs:
   - "oss-fuzz@goteleport.com"
   - "zac.bergquist@goteleport.com"
   - "jakub.nyckowski@goteleport.com"
+  - "mike.jensen@goteleport.com"
   - "ossfuzz1337@gmail.com"
 fuzzing_engines:
   - libfuzzer


### PR DESCRIPTION
@jentfoo needs access to Teleport's OSS-Fuzz results.