### PR TITLE
Enable support for gnu-tar archive in libarchive

### DIFF
--- a/projects/libarchive/libarchive_fuzzer.cc
+++ b/projects/libarchive/libarchive_fuzzer.cc
@@ -27,6 +27,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len) {
   archive_read_support_format_all(a);
   archive_read_support_format_empty(a);
   archive_read_support_format_raw(a);
+  archive_read_support_format_gnutar(a);
 
   if (ARCHIVE_OK != archive_read_set_options(a, "zip:ignorecrc32,tar:read_concatenated_archives,tar:mac-ext")) {
     return 0;


### PR DESCRIPTION
archive_read_support_format_gnutar isn't' called in archive_read_support_format_all.