### PR TITLE
libarchive: compile libxml without instrumentation

### DIFF
--- a/projects/libarchive/Dockerfile
+++ b/projects/libarchive/Dockerfile
@@ -24,6 +24,19 @@ RUN curl -LO http://mirrors.kernel.org/ubuntu/pool/main/a/automake-1.16/automake
     apt install ./automake_1.16.5-1.3_all.deb
 RUN git clone --depth 1 https://github.com/libarchive/libarchive.git
 RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/libxml2.git
+# compile libxml2 from source so we can statically link
+RUN mkdir /deps && \
+  cd $SRC/libxml2 && \
+  ./autogen.sh \
+      --without-debug \
+      --without-ftp \
+      --without-http \
+      --without-legacy \
+      --without-python \
+      --enable-static && \
+  make -j$(nproc) && \
+  make install && \
+  cp .libs/libxml2.a /deps/
 
 COPY build.sh libarchive_fuzzer.cc $SRC/
 WORKDIR $SRC

--- a/projects/libarchive/build.sh
+++ b/projects/libarchive/build.sh
@@ -23,20 +23,8 @@ FILES_TO_AVOID
 libxml2
 EOF
 
-# compile libxml2 from source so we can statically link
 DEPS=/deps
-mkdir ${DEPS}
-cd $SRC/libxml2
-./autogen.sh \
-    --without-debug \
-    --without-ftp \
-    --without-http \
-    --without-legacy \
-    --without-python \
-    --enable-static
-make -j$(nproc)
-make install
-cp .libs/libxml2.a ${DEPS}/
+
 cd $SRC/libarchive
 
 sed -i 's/-Wall//g' ./CMakeLists.txt


### PR DESCRIPTION
This makes the coverage reporting for lxml go away.

Ref:
https://github.com/ossf/fuzz-introspector/issues/580#issuecomment-1318961239

Signed-off-by: David Korczynski <david@adalogics.com>