### PR TITLE
libwebsockets: generalise build.

### DIFF
--- a/projects/libwebsockets/build.sh
+++ b/projects/libwebsockets/build.sh
@@ -20,8 +20,12 @@ DIR=$SRC/libwebsockets/
 cd $DIR
 mkdir build && cd build
 
-cmake -DCMAKE_C_FLAGS="$CFLAGS -fsanitize=address,fuzzer-no-link -g" -DCMAKE_CXX_FLAGS="$CXXFLAGS -fsanitize=address,fuzzer-no-link -g" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,fuzzer-no-link -g" -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address,fuzzer-no-link -g" ..
+cmake -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+      -DCMAKE_EXE_LINKER_FLAGS="$CFLAGS" -DCMAKE_SHARED_LINKER_FLAGS="$CFLAGS" ..
 make -j8
 
 cd $DIR
-$CXX -g -fsanitize=address,fuzzer -I$DIR/build/include -o $OUT/lws_upng_inflate_fuzzer lws_upng_inflate_fuzzer.cpp -L$DIR/build/lib -l:libwebsockets.a -L/usr/lib/x86_64-linux-gnu/ -l:libssl.so -l:libcrypto.so
+$CXX $CFLAGS $LIB_FUZZING_ENGINE -I$DIR/build/include \
+	-o $OUT/lws_upng_inflate_fuzzer lws_upng_inflate_fuzzer.cpp \
+	-L$DIR/build/lib -l:libwebsockets.a \
+	-L/usr/lib/x86_64-linux-gnu/ -l:libssl.so -l:libcrypto.so


### PR DESCRIPTION
The current build applies ASAN flags always which hinders it from extracting coverage and fuzz introspector reports. This PR fixes it.

Signed-off-by: David Korczynski <david@adalogics.com>