### PR TITLE
bump go to 1.19.4

### DIFF
--- a/infra/base-images/base-builder/install_go.sh
+++ b/infra/base-images/base-builder/install_go.sh
@@ -18,7 +18,7 @@
 cd /tmp
 curl -O https://storage.googleapis.com/golang/getgo/installer_linux
 chmod +x ./installer_linux
-SHELL="bash" ./installer_linux -version=1.19
+SHELL="bash" ./installer_linux -version=1.19.4
 rm -rf ./installer_linux
 
 echo 'Set "GOPATH=/root/go"'


### PR DESCRIPTION
Bumps go to 1.19.4. Currently Argo is broken because of an issue in the go compiler that is fixed in 1.19.3.

Signed-off-by: AdamKorcz <adam@adalogics.com>