### PR TITLE
[util-linux] bring back 32-bit builds

### DIFF
--- a/projects/util-linux/project.yaml
+++ b/projects/util-linux/project.yaml
@@ -11,6 +11,7 @@ auto_ccs:
   - "thomas@t-8ch.de"
 architectures:
   - x86_64
+  - i386
 sanitizers:
   - address
   - undefined


### PR DESCRIPTION
Looks like util-linux no longer fails to compile on Ubuntu Focal due to https://oss-fuzz-build-logs.storage.googleapis.com/log-86fe7f9b-945a-4514-84ce-8f435b34dce0.txt so it should be possible to bring 32-bit builds back.