### PR TITLE
Adds project protobuf (C++)

### DIFF
--- a/projects/protobuf-cplusplus/.bazelrc
+++ b/projects/protobuf-cplusplus/.bazelrc
@@ -1,0 +1,24 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Force the use of Clang for C++ builds.
+build --action_env=CC=clang
+build --action_env=CXX=clang++
+
+# Define the --config=asan-libfuzzer configuration.
+build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing/engines:libfuzzer
+build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=libfuzzer
+build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan

--- a/projects/protobuf-cplusplus/BUILD
+++ b/projects/protobuf-cplusplus/BUILD
@@ -1,0 +1,81 @@
+# Copyright 2022 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
+
+cc_fuzz_test(
+    name = "fuzz_pb2",
+    deps = [
+        ":protobuf",
+        ":cc_test_messages_proto2_proto",
+    ],
+    srcs = ["fuzz/fuzz_pb2.cc"],
+)
+
+cc_fuzz_test(
+    name = "fuzz_pb3",
+    deps = [
+        ":protobuf",
+        ":cc_test_messages_proto3_proto",
+    ],
+    srcs = ["fuzz/fuzz_pb3.cc"],
+)
+
+cc_fuzz_test(
+    name = "fuzz_json2",
+    deps = [
+        ":protobuf",
+        ":cc_test_messages_proto2_proto",
+    ],
+    srcs = ["fuzz/fuzz_json2.cc"],
+)
+
+cc_fuzz_test(
+    name = "fuzz_json3",
+    deps = [
+        ":protobuf",
+        ":cc_test_messages_proto3_proto",
+    ],
+    srcs = ["fuzz/fuzz_json3.cc"],
+)
+
+cc_fuzz_test(
+    name = "fuzz_text2",
+    deps = [
+        ":protobuf",
+        ":cc_test_messages_proto2_proto",
+    ],
+    srcs = ["fuzz/fuzz_text2.cc"],
+)
+
+cc_fuzz_test(
+    name = "fuzz_text3",
+    deps = [
+        ":protobuf",
+        ":cc_test_messages_proto3_proto",
+    ],
+    srcs = ["fuzz/fuzz_text3.cc"],
+)
+
+cc_proto_library(
+    name = "cc_test_messages_proto2_proto",
+    deps = [":test_messages_proto2_proto"],
+)
+
+cc_proto_library(
+    name = "cc_test_messages_proto3_proto",
+    deps = [":test_messages_proto3_proto"],
+)

--- a/projects/protobuf-cplusplus/BUILD2
+++ b/projects/protobuf-cplusplus/BUILD2
@@ -14,23 +14,13 @@
 #
 ################################################################################
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
 
-http_archive(
-    name = "rules_fuzzing",
-    sha256 = "d9002dd3cd6437017f08593124fdd1b13b3473c7b929ceb0e60d317cb9346118",
-    strip_prefix = "rules_fuzzing-0.3.2",
-    urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/v0.3.2.zip"],
+
+cc_fuzz_test(
+    name = "fuzz_compiler_parser",
+    deps = [
+        "//:protobuf",
+    ],
+    srcs = ["fuzz/fuzz_compiler_parser.cc"],
 )
-
-load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
-
-rules_fuzzing_dependencies()
-
-pip_parse(
-    name = "fuzzing_py_deps",
-    requirements = "@rules_fuzzing//fuzzing:requirements.txt",
-    )
-
-load("@fuzzing_py_deps//:requirements.bzl", "install_deps")
-install_deps()

--- a/projects/protobuf-cplusplus/Dockerfile
+++ b/projects/protobuf-cplusplus/Dockerfile
@@ -20,13 +20,16 @@ FROM gcr.io/oss-fuzz-base/base-builder-go
 
 RUN git clone --depth 1 --recursive https://github.com/protocolbuffers/protobuf.git
 
-COPY WORKSPACE .bazelrc BUILD $SRC/
+COPY WORKSPACE .bazelrc BUILD BUILD2 $SRC/
 RUN cat WORKSPACE >> $SRC/protobuf/WORKSPACE
 RUN cat .bazelrc >> $SRC/protobuf/.bazelrc
 RUN cat BUILD >> $SRC/protobuf/src/google/protobuf/BUILD.bazel
+RUN cat BUILD2 >> $SRC/protobuf/src/google/protobuf/compiler/BUILD.bazel
 
 RUN mkdir $SRC/protobuf/src/google/protobuf/fuzz
+RUN mkdir $SRC/protobuf/src/google/protobuf/compiler/fuzz
 COPY fuzz*.cc $SRC/protobuf/src/google/protobuf/fuzz/
+COPY fuzz_compiler*.cc $SRC/protobuf/src/google/protobuf/compiler/fuzz/
 
 WORKDIR $SRC/protobuf
 COPY build.sh $SRC/

--- a/projects/protobuf-cplusplus/Dockerfile
+++ b/projects/protobuf-cplusplus/Dockerfile
@@ -1,0 +1,32 @@
+# Copyright 2022 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+
+# RUN apt-get update && apt-get install -y cmake
+
+RUN git clone --depth 1 --recursive https://github.com/protocolbuffers/protobuf.git
+
+COPY WORKSPACE .bazelrc BUILD $SRC/
+RUN cat WORKSPACE >> $SRC/protobuf/WORKSPACE
+RUN cat .bazelrc >> $SRC/protobuf/.bazelrc
+RUN cat BUILD >> $SRC/protobuf/src/google/protobuf/BUILD.bazel
+
+RUN mkdir $SRC/protobuf/src/google/protobuf/fuzz
+COPY fuzz*.cc $SRC/protobuf/src/google/protobuf/fuzz/
+
+WORKDIR $SRC/protobuf
+COPY build.sh $SRC/

--- a/projects/protobuf-cplusplus/WORKSPACE
+++ b/projects/protobuf-cplusplus/WORKSPACE
@@ -1,0 +1,33 @@
+# Copyright 2022 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_fuzzing",
+    sha256 = "23bb074064c6f488d12044934ab1b0631e8e6898d5cf2f6bde087adb01111573",
+    strip_prefix = "rules_fuzzing-0.3.1",
+    urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/v0.3.1.zip"],
+)
+
+load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
+
+rules_fuzzing_dependencies()
+
+load("@rules_fuzzing//fuzzing:init.bzl", "rules_fuzzing_init")
+
+rules_fuzzing_init()
+

--- a/projects/protobuf-cplusplus/build.sh
+++ b/projects/protobuf-cplusplus/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -eu
+# Copyright 2022 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Without this hack, we get /usr/bin/env: 'python3': No such file or directory.
+# Bazel somehow clears the env variable PATH, so python3 must be in system's path.
+cp /usr/local/bin/python3 /usr/bin/
+
+# some third party fuzz target not compiling
+rm -Rf third_party/utf8_range/fuzz/
+
+bazel_build_fuzz_tests

--- a/projects/protobuf-cplusplus/build.sh
+++ b/projects/protobuf-cplusplus/build.sh
@@ -26,3 +26,8 @@ rm -Rf third_party/utf8_range/fuzz/
 sed -i -e 's/rsync/baserm=`bazel info execution_root`; rm \$baserm\/external\/com_google_protobuf\/bazel-protobuf\nrsync/' /usr/local/bin/bazel_build_fuzz_tests
 
 bazel_build_fuzz_tests
+
+mkdir /tmp/corpus
+find . -name "*.proto" | while read i; do cp $i /tmp/corpus/; done
+cd /tmp
+zip -r $OUT/fuzz_compiler_parser_seed_corpus.zip corpus

--- a/projects/protobuf-cplusplus/build.sh
+++ b/projects/protobuf-cplusplus/build.sh
@@ -22,4 +22,7 @@ cp /usr/local/bin/python3 /usr/bin/
 # some third party fuzz target not compiling
 rm -Rf third_party/utf8_range/fuzz/
 
+# Avoid infinite recursion by rsync on symlinks on coverage build
+sed -i -e 's/rsync/baserm=`bazel info execution_root`; rm \$baserm\/external\/com_google_protobuf\/bazel-protobuf\nrsync/' /usr/local/bin/bazel_build_fuzz_tests
+
 bazel_build_fuzz_tests

--- a/projects/protobuf-cplusplus/fuzz_compiler_parser.cc
+++ b/projects/protobuf-cplusplus/fuzz_compiler_parser.cc
@@ -1,0 +1,50 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include "google/protobuf/compiler/parser.h"
+#include "google/protobuf/io/tokenizer.h"
+#include "google/protobuf/descriptor.h"
+#include "google/protobuf/descriptor.pb.h"
+
+class MockErrorCollector : public google::protobuf::io::ErrorCollector {
+ public:
+  MockErrorCollector() = default;
+  ~MockErrorCollector() override = default;
+
+  // implements ErrorCollector ---------------------------------------
+  void AddWarning(int line, int column, const std::string& message) override {
+  }
+
+  void AddError(int line, int column, const std::string& message) override {
+  }
+};
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    MockErrorCollector error_collector_;
+    auto input1 = new google::protobuf::io::ArrayInputStream(data, size);
+    auto input = new google::protobuf::io::Tokenizer(input1, &error_collector_);
+    google::protobuf::FileDescriptorProto result;
+    auto parser = new google::protobuf::compiler::Parser();
+
+    if (parser->Parse(input, &result)) {
+        auto pool = new google::protobuf::DescriptorPool();
+        auto fd = pool->BuildFile(result);
+        if (fd) {
+            fd->DebugString();
+        }
+    }
+    return 0;
+}

--- a/projects/protobuf-cplusplus/fuzz_compiler_parser.cc
+++ b/projects/protobuf-cplusplus/fuzz_compiler_parser.cc
@@ -45,6 +45,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
         if (fd) {
             fd->DebugString();
         }
+        delete pool;
     }
+    delete parser;
+    delete input;
+    delete input1;
     return 0;
 }

--- a/projects/protobuf-cplusplus/fuzz_json2.cc
+++ b/projects/protobuf-cplusplus/fuzz_json2.cc
@@ -1,0 +1,33 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include "google/protobuf/test_messages_proto2.pb.h"
+#include "google/protobuf/util/json_util.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    protobuf_test_messages::proto2::TestAllTypesProto2 t;
+    std::string out;
+
+    std::string input = std::string((const char *) data, size);
+    if (google::protobuf::util::JsonStringToMessage(input, &t) == absl::OkStatus()) {
+        t.DebugString();
+        t.ShortDebugString();
+        t.Utf8DebugString();
+        t.SerializeToString(&out);
+        google::protobuf::util::MessageToJsonString(t, &out);
+    }
+    return 0;
+}

--- a/projects/protobuf-cplusplus/fuzz_json3.cc
+++ b/projects/protobuf-cplusplus/fuzz_json3.cc
@@ -1,0 +1,33 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include "google/protobuf/test_messages_proto3.pb.h"
+#include "google/protobuf/util/json_util.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    protobuf_test_messages::proto3::TestAllTypesProto3 t;
+    std::string out;
+
+    std::string input = std::string((const char *) data, size);
+    if (google::protobuf::util::JsonStringToMessage(input, &t) == absl::OkStatus()) {
+        t.DebugString();
+        t.ShortDebugString();
+        t.Utf8DebugString();
+        t.SerializeToString(&out);
+        google::protobuf::util::MessageToJsonString(t, &out);
+    }
+    return 0;
+}

--- a/projects/protobuf-cplusplus/fuzz_pb2.cc
+++ b/projects/protobuf-cplusplus/fuzz_pb2.cc
@@ -1,0 +1,38 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include "google/protobuf/test_messages_proto2.pb.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    // google::protobuf::
+    protobuf_test_messages::proto2::TestAllTypesProto2 t;
+    std::string out;
+
+    if (t.ParseFromArray(data, size)) {
+        t.DebugString();
+        t.ShortDebugString();
+        t.Utf8DebugString();
+        t.SerializeToString(&out);
+        // #include "google/protobuf/text_format.h"
+        // google::protobuf::TextFormat::PrintToString(t, &out);
+    } else if (t.ParsePartialFromArray(data, size)) {
+        t.DebugString();
+        t.ShortDebugString();
+        t.Utf8DebugString();
+        t.SerializePartialToString(&out);
+    }
+    return 0;
+}

--- a/projects/protobuf-cplusplus/fuzz_pb3.cc
+++ b/projects/protobuf-cplusplus/fuzz_pb3.cc
@@ -1,0 +1,38 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include "google/protobuf/test_messages_proto3.pb.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    // google::protobuf::
+    protobuf_test_messages::proto3::TestAllTypesProto3 t;
+    std::string out;
+
+    if (t.ParseFromArray(data, size)) {
+        t.DebugString();
+        t.ShortDebugString();
+        t.Utf8DebugString();
+        t.SerializeToString(&out);
+        // #include "google/protobuf/text_format.h"
+        // google::protobuf::TextFormat::PrintToString(t, &out);
+    } else if (t.ParsePartialFromArray(data, size)) {
+        t.DebugString();
+        t.ShortDebugString();
+        t.Utf8DebugString();
+        t.SerializePartialToString(&out);
+    }
+    return 0;
+}

--- a/projects/protobuf-cplusplus/fuzz_text2.cc
+++ b/projects/protobuf-cplusplus/fuzz_text2.cc
@@ -1,0 +1,33 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include "google/protobuf/test_messages_proto2.pb.h"
+#include "google/protobuf/text_format.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    protobuf_test_messages::proto2::TestAllTypesProto2 t;
+    std::string out;
+
+    std::string input = std::string((const char *) data, size);
+    if ( google::protobuf::TextFormat::ParseFromString(input, &t)) {
+        t.DebugString();
+        t.ShortDebugString();
+        t.Utf8DebugString();
+        t.SerializeToString(&out);
+        google::protobuf::TextFormat::PrintToString(t, &out);
+    }
+    return 0;
+}

--- a/projects/protobuf-cplusplus/fuzz_text3.cc
+++ b/projects/protobuf-cplusplus/fuzz_text3.cc
@@ -1,0 +1,33 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include "google/protobuf/test_messages_proto3.pb.h"
+#include "google/protobuf/text_format.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    protobuf_test_messages::proto3::TestAllTypesProto3 t;
+    std::string out;
+
+    std::string input = std::string((const char *) data, size);
+    if ( google::protobuf::TextFormat::ParseFromString(input, &t)) {
+        t.DebugString();
+        t.ShortDebugString();
+        t.Utf8DebugString();
+        t.SerializeToString(&out);
+        google::protobuf::TextFormat::PrintToString(t, &out);
+    }
+    return 0;
+}

--- a/projects/protobuf-cplusplus/project.yaml
+++ b/projects/protobuf-cplusplus/project.yaml
@@ -13,4 +13,8 @@ sanitizers:
   - memory
   - undefined
 
+fuzzing_engines:
+  - libfuzzer
+  - afl
+
 main_repo: https://github.com/protocolbuffers/protobuf

--- a/projects/protobuf-cplusplus/project.yaml
+++ b/projects/protobuf-cplusplus/project.yaml
@@ -1,8 +1,26 @@
 homepage: "https://developers.google.com/protocol-buffers"
 language: c++
-primary_contact: "p.antoine@catenacyber.fr"
+primary_contact: kfm@google.com
 auto_ccs:
 - protobuf-oss-fuzz@google.com
+- jgm@google.com
+- jgrimes@google.com
+- pzd@google.com
+- acozzette@google.com
+- deannagarcia@google.com
+- gberg@google.com
+- haberman@google.com
+- jieluo@google.com
+- jorg@google.com
+- mcyoung@google.com
+- mkruskal@google.com
+- salo@google.com
+- sandyzhang@google.com
+- sbenza@google.com
+- shaod@google.com
+- theodorerose@google.com
+- copybara-watcher-pod-watcher-git@system.gserviceaccount.com
+- copybara-worker@system.gserviceaccount.com
 
 architectures:
 - x86_64
@@ -12,9 +30,15 @@ sanitizers:
   - address
   - memory
   - undefined
+labels:
+  "*":
+    - protobuf-ossfuzz-bugz-1260285
 
 fuzzing_engines:
   - libfuzzer
   - afl
 
 main_repo: https://github.com/protocolbuffers/protobuf
+
+vendor_ccs:
+- p.antoine@catenacyber.fr

--- a/projects/protobuf-cplusplus/project.yaml
+++ b/projects/protobuf-cplusplus/project.yaml
@@ -1,0 +1,14 @@
+homepage: "https://developers.google.com/protocol-buffers"
+language: c++
+primary_contact: "p.antoine@catenacyber.fr"
+auto_ccs:
+- protobuf-oss-fuzz@google.com
+
+architectures:
+- x86_64
+- i386
+
+sanitizers:
+  - address
+  - memory
+  - undefined

--- a/projects/protobuf-cplusplus/project.yaml
+++ b/projects/protobuf-cplusplus/project.yaml
@@ -12,3 +12,5 @@ sanitizers:
   - address
   - memory
   - undefined
+
+main_repo: https://github.com/protocolbuffers/protobuf


### PR DESCRIPTION
@jonathanmetzman @inferno-chromium 
Looks like protobuf itself is not on oss-fuzz (there is official java, python, golang, unofficial C but not the C++ standard)
