### PR TITLE
bazel-rules-fuzzing-test: Link python to python3

### DIFF
--- a/projects/bazel-rules-fuzzing-test-java/Dockerfile
+++ b/projects/bazel-rules-fuzzing-test-java/Dockerfile
@@ -16,6 +16,9 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 
+RUN apt-get update && \
+    apt-get install -y python-is-python3
+
 RUN git clone https://github.com/bazelbuild/rules_fuzzing.git
 WORKDIR $SRC/rules_fuzzing/
 COPY build.sh $SRC/

--- a/projects/bazel-rules-fuzzing-test/Dockerfile
+++ b/projects/bazel-rules-fuzzing-test/Dockerfile
@@ -16,6 +16,9 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 
+RUN apt-get update && \
+    apt-get install -y python-is-python3
+
 RUN git clone https://github.com/bazelbuild/rules_fuzzing.git
 WORKDIR $SRC/rules_fuzzing/
 COPY build.sh $SRC/


### PR DESCRIPTION
rules_fuzzing uses Bazel 4, which still expects `python` in `PATH`.

Work towards https://github.com/bazelbuild/rules_fuzzing/pull/212#issuecomment-1317260421