### PR TITLE
Disable -Werror on unused-command-line-argument

### DIFF
--- a/infra/base-images/base-builder/compile_centipede
+++ b/infra/base-images/base-builder/compile_centipede
@@ -27,7 +27,7 @@ cp "$BIN_DIR/libcentipede_runner.pic.a" "$LIB_FUZZING_ENGINE"
 
 export DFTRACING_FLAGS='-fsanitize-coverage=trace-loads'
 export CENTIPEDE_FLAGS=`cat "$SRC/centipede/clang-flags.txt" | tr '\n' ' '`
-export LIBRARIES_FLAGS="-ldl -lrt -lpthread $SRC/centipede/weak.o"
+export LIBRARIES_FLAGS="-Wno-error=unused-command-line-argument -ldl -lrt -lpthread $SRC/centipede/weak.o"
 
 export CFLAGS="$CFLAGS $DFTRACING_FLAGS $CENTIPEDE_FLAGS $LIBRARIES_FLAGS"
 export CXXFLAGS="$CXXFLAGS $DFTRACING_FLAGS $CENTIPEDE_FLAGS $LIBRARIES_FLAGS"


### PR DESCRIPTION
Some projects use `-Werror` to turn all warnings into errors.
This affects `Centipede` as we do not separate build and linking flags as it expects, which leads to `unused-command-line-argument` warnings.
This PR disables turning that specific warning into errors and keeps the rest the same.