### PR TITLE
[Javassist] Fix project directory and maven build script

### DIFF
--- a/projects/javassist/Dockerfile
+++ b/projects/javassist/Dockerfile
@@ -26,4 +26,5 @@ RUN git clone --depth 1 https://github.com/jboss-javassist/javassist.git
 
 COPY build.sh $SRC/
 COPY ClassFuzzer.java $SRC/
+COPY pom.xml.diff $SRC/javassist
 WORKDIR $SRC/javassist

--- a/projects/javassist/build.sh
+++ b/projects/javassist/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+git apply pom.xml.diff
+mv ./src/main ./src/java
+mkdir ./src/main
+mv ./src/java ./src/main/java
+mv ./src/test ./src/java
+mkdir ./src/test
+mv ./src/java ./src/test/java
 
 MAVEN_ARGS="-Djavac.src.version=15 -Djavac.target.version=15 -DskipTests"
 $MVN package org.apache.maven.plugins:maven-shade-plugin:3.2.4:shade $MAVEN_ARGS

--- a/projects/javassist/pom.xml.diff
+++ b/projects/javassist/pom.xml.diff
@@ -1,0 +1,15 @@
+diff --git a/pom.xml b/pom.xml
+index a604e16..52c8a7b 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -138,8 +138,8 @@
+     </snapshotRepository>
+   </distributionManagement>
+   <build>
+-    <sourceDirectory>src/main/</sourceDirectory>
+-    <testSourceDirectory>src/test/</testSourceDirectory>
++    <sourceDirectory>src/main/java/</sourceDirectory>
++    <testSourceDirectory>src/test/java/</testSourceDirectory>
+     <testResources>
+       <testResource>
+         <directory>src/test/resources</directory>


### PR DESCRIPTION
The default source and test source directory for maven project are src/main/java and src/test/java respectively. The author of Javassist does specify a non-traditional location for the source and test source and manually set it in the pom.xml. Although it does not affect the normal project build, it does affect jacoco coverage report generator to extract the source code of the project because Jacoco will not read the pom.xml settings and only scan the default source and test source directory for source code file. To remedy, this fix aim to do some folder movement to move the source and test source back to the default directory while pointing the pom.xml settings to the default directory. These changes allow the project compile and execute as normal and also allow jacoco correctly retrieve the source code for coverage report generation.

This fix is necessary for fuzz-introspector coverage report to show the code coverage down to the source code line.

Signed-off-by: Arthur Chan <arthur.chan@adalogics.com>