### PR TITLE
resiprocate: speed up build

### DIFF
--- a/projects/resiprocate/Dockerfile
+++ b/projects/resiprocate/Dockerfile
@@ -15,14 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config
-RUN git clone https://github.com/fmtlib/fmt && \
-    cd fmt && \
-    mkdir build && \
-    cd build && \
-    cmake .. && \
-    make && \
-    make install
+RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config libfmt-dev
 RUN git clone --depth 1 https://github.com/resiprocate/resiprocate.git resiprocate
 WORKDIR resiprocate
 COPY build.sh $SRC/


### PR DESCRIPTION
Avoid building libfmt from source and just use a package. This is particularly needed to make CIFuzz faster: https://github.com/resiprocate/resiprocate/pull/283#issuecomment-1325218011