### PR TITLE
[cryptofuzz] Fix build

### DIFF
--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -15,6 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder-rust
+
 ENV GOPATH /root/go
 ENV PATH $PATH:/root/.go/bin:$GOPATH/bin
 RUN install_go.sh

--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-rust@sha256:b942129fbed50e87e554a58dbbbbf90382f17c650dc4d4e27b7a9f8e68b1d494
+FROM gcr.io/oss-fuzz-base/base-builder-rust
 ENV GOPATH /root/go
 ENV PATH $PATH:/root/.go/bin:$GOPATH/bin
 RUN install_go.sh


### PR DESCRIPTION
The cryptofuzz build has been failing for a few days at the [install_go.sh](https://github.com/google/oss-fuzz/blob/41f9210a290a535d8b241c634359133334916240/projects/cryptofuzz/Dockerfile#L20) step. Removing the base-builder-rust commit, making it equivalent to [ecc-diff-fuzzer which uses the same code](https://github.com/google/oss-fuzz/blob/41f9210a290a535d8b241c634359133334916240/projects/ecc-diff-fuzzer/Dockerfile#L17-L20) (and whose builds succeeds), seems to fix the issue.

I'm not sure why cryptofuzz had the specific base-builder-rust commit in the first place?