### PR TITLE
[tarantool] Append -lc++ after $LIB_FUZZING_ENGINE

### DIFF
--- a/projects/tarantool/build.sh
+++ b/projects/tarantool/build.sh
@@ -39,6 +39,8 @@ cd $SRC/tarantool
 # not unused, but the compilers are complaining.
 sed -i 's/total = 0;/total = 0;(void)total;/g' ./src/lib/core/crash.c
 sed -i 's/n = 0;/n = 0;(void)n;/g' ./src/lib/core/sio.c
+# Avoid compilation issue due to some undefined references. They are defined in
+# libc++ and used by Centipede so -lc++ needs to come after centipede's lib.
 if [[ $FUZZING_ENGINE == centipede ]]
 then
     sed -i \

--- a/projects/tarantool/build.sh
+++ b/projects/tarantool/build.sh
@@ -39,6 +39,12 @@ cd $SRC/tarantool
 # not unused, but the compilers are complaining.
 sed -i 's/total = 0;/total = 0;(void)total;/g' ./src/lib/core/crash.c
 sed -i 's/n = 0;/n = 0;(void)n;/g' ./src/lib/core/sio.c
+if [[ $FUZZING_ENGINE == centipede ]]
+then
+    sed -i \
+        '/$ENV{LIB_FUZZING_ENGINE}/a \ \ \ \ \ \ \ \ -lc++' \
+        test/fuzz/CMakeLists.txt
+fi
 
 case $SANITIZER in
   address) SANITIZERS_ARGS="-DENABLE_ASAN=ON" ;;


### PR DESCRIPTION
Add a line to `CMakeLists.txt` to ensure `-lc++` is added after `$LIB_FUZZING_ENGINE`.
This is done in the same way as the other two existing modifications.

We could probably request the project owners to add this (that code block is only used by `OSS-Fuzz`), but I suppose this also ensures it only affects `Centipede`.