### PR TITLE
netlink: initial integration

### DIFF
--- a/projects/netlink/Dockerfile
+++ b/projects/netlink/Dockerfile
@@ -17,4 +17,4 @@
 FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN git clone --depth 1 https://github.com/vishvananda/netlink
 WORKDIR $SRC/netlink
-COPY build.sh route_linux_fuzzer.go $SRC/
+COPY build.sh fuzz_test.go route_linux_fuzzer.go $SRC/

--- a/projects/netlink/Dockerfile
+++ b/projects/netlink/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/vishvananda/netlink
+WORKDIR $SRC/netlink
+COPY build.sh route_linux_fuzzer.go $SRC/

--- a/projects/netlink/build.sh
+++ b/projects/netlink/build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -eu
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cp $SRC/route_linux_fuzzer.go $SRC/netlink
+go mod tidy
+go get github.com/AdamKorcz/go-118-fuzz-build/testing
+go get golang.org/x/sys
+go get github.com/vishvananda/netns
+
+if [ -n "${OSS_FUZZ_CI-}" ]
+then
+	echo "temporarily not running fuzzer in OSS-Fuzz CI"
+else
+	compile_native_go_fuzzer github.com/vishvananda/netlink FuzzDeserializeRoute FuzzDeserializeRoute
+fi
+
+compile_native_go_fuzzer github.com/vishvananda/netlink FuzzParseRawData FuzzParseRawData

--- a/projects/netlink/build.sh
+++ b/projects/netlink/build.sh
@@ -16,6 +16,7 @@
 ################################################################################
 
 cp $SRC/route_linux_fuzzer.go $SRC/netlink
+cp $SRC/fuzz_test.go $SRC/netlink/
 go mod tidy
 go get github.com/AdamKorcz/go-118-fuzz-build/testing
 go get golang.org/x/sys
@@ -29,3 +30,4 @@ else
 fi
 
 compile_native_go_fuzzer github.com/vishvananda/netlink FuzzParseRawData FuzzParseRawData
+compile_native_go_fuzzer github.com/vishvananda/netlink FuzzLinkByName FuzzLinkByName

--- a/projects/netlink/fuzz_test.go
+++ b/projects/netlink/fuzz_test.go
@@ -1,0 +1,37 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netlink
+
+import (
+	"testing"
+)
+
+func FuzzLinkByName(f *testing.F) {
+	f.Fuzz(func(t *testing.T, ifaceName string) {
+		dev, err := LinkByName(ifaceName)
+		if err != nil {
+			t.Skip()
+		}
+
+		addrs, err := AddrList(dev, FAMILY_V4)
+		if err != nil {
+			t.Skip()
+		}
+
+		for _, addr := range addrs {
+			_ = addr.IP.To4()
+		}
+	})
+}

--- a/projects/netlink/project.yaml
+++ b/projects/netlink/project.yaml
@@ -1,0 +1,11 @@
+homepage: "https://github.com/vishvananda/netlink"
+language: go
+primary_contact: ""
+main_repo: "https://github.com/vishvananda/netlink"
+vendor_ccs:
+  - "adam@adalogics.com"
+  - "david@adalogics.com"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address

--- a/projects/netlink/route_linux_fuzzer.go
+++ b/projects/netlink/route_linux_fuzzer.go
@@ -1,0 +1,31 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netlink
+
+import (
+	"testing"
+)
+
+func FuzzDeserializeRoute(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = deserializeRoute(data)
+	})
+}
+
+func FuzzParseRawData(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_ = parseRawData(data)
+	})
+}


### PR DESCRIPTION
@vishvananda @aboch This PR creates an initial integration of netlink into OSS-Fuzz with 2 fuzzers. Do you want to integrate netlink so that it can be fuzzed continuously?

Signed-off-by: AdamKorcz <adam@adalogics.com>