### PR TITLE
go native: Add support for linking static libs

### DIFF
--- a/infra/base-images/base-builder/compile_native_go_fuzzer
+++ b/infra/base-images/base-builder/compile_native_go_fuzzer
@@ -15,6 +15,8 @@
 #
 ################################################################################
 
+ADDITIONAL_LIBS="${ADDITIONAL_LIBS:-}"
+
 function build_native_go_fuzzer() {
 	fuzzer=$1
 	function=$2
@@ -30,7 +32,7 @@ function build_native_go_fuzzer() {
 		cd $current_dir
 	else
 		go-118-fuzz-build -o $fuzzer.a -func $function $abs_file_dir
-		$CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
+		$CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer $ADDITIONAL_LIBS
 	fi
 }
 


### PR DESCRIPTION
Some specific projects (FluxCD) may require the linking of static libraries. The new environment variable
`ADDITIONAL_LIBS` enables multiple space separated libs to be linked.

This is to remove the [current hack](https://github.com/fluxcd/source-controller/blob/b2eb601ba73d08c8fe6406fff95e9621da755bc7/tests/fuzz/oss_fuzz_build.sh#L95) within the Flux project that enables the linking of `libgit2.a` during fuzz compilation.