### PR TITLE
libevent: speed up build and fix fuzz-introspector

### DIFF
--- a/projects/libevent/build.sh
+++ b/projects/libevent/build.sh
@@ -18,7 +18,12 @@
 # build project
 mkdir build
 cd build
-cmake -DEVENT__DISABLE_MBEDTLS=ON -DEVENT__DISABLE_OPENSSL=ON -DEVENT__LIBRARY_TYPE=STATIC ../
+cmake -DEVENT__DISABLE_MBEDTLS=ON \
+      -DEVENT__DISABLE_OPENSSL=ON \
+      -DEVENT__LIBRARY_TYPE=STATIC \
+      -DEVENT__DISABLE_TESTS=ON \
+      -DEVENT__DISABLE_SAMPLES=ON \
+      ../
 make
 make install
 


### PR DESCRIPTION
Refine the libevent build. Currently, fuzz-introspector is broken due to a segfault that happens in LTO mode (probably a case of https://github.com/ossf/fuzz-introspector/issues/504 -- see https://oss-fuzz-build-logs.storage.googleapis.com/index.html#libevent and https://oss-fuzz-build-logs.storage.googleapis.com/log-73424dc1-43b3-4a1d-844e-a98d2f7f84db.txt) 

The fault only happens when building one of the tests.

This pr fixes it by not building tests and samples when building the project, which has a nice side effect of speeding it up too which will be helpful for the recent cifuzz integration https://github.com/libevent/libevent/pull/1382. 
CC @azat 