### PR TITLE
envoy: fixing build path after Envoy-Mobile was added

### DIFF
--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 declare -r FUZZ_TARGET_QUERY='
-  let all_fuzz_tests = attr(tags, "fuzz_target", "...") in
+  let all_fuzz_tests = attr(tags, "fuzz_target", "test/...") in
   $all_fuzz_tests - attr(tags, "no_fuzz", $all_fuzz_tests)
 '
 


### PR DESCRIPTION
Following the Envoy-Mobile [project merge](https://github.com/envoyproxy/envoy/pull/24104) this PR fixes the bazel query to fetch the fuzzers.

Signed-off-by: Adi Suissa-Peleg <adip@google.com>