### PR TITLE
powerdns: Build the YaHTTP target first, needed for the new fuzzing target

### DIFF
--- a/projects/powerdns/build.sh
+++ b/projects/powerdns/build.sh
@@ -34,6 +34,7 @@ autoreconf -vi
     --enable-fuzz-targets \
     --disable-dependency-tracking \
     --disable-silent-rules || /bin/bash
+make -j$(nproc) -C ext/yahttp/
 cd pdns
 make -j$(nproc) fuzz_targets
 


### PR DESCRIPTION
See https://github.com/PowerDNS/pdns/pull/9709