### PR TITLE
powerdns: Use the HTTP corpus for the YaHTTP fuzzing target

### DIFF
--- a/projects/powerdns/build.sh
+++ b/projects/powerdns/build.sh
@@ -63,3 +63,6 @@ fi
 if [ -d ../fuzzing/corpus/zones/ ]; then
     zip -j "${OUT}/fuzz_target_zoneparsertng_seed_corpus.zip" ../fuzzing/corpus/zones/*
 fi
+if [ -d ../fuzzing/corpus/http-raw-payloads/ ]; then
+    zip -j "${OUT}/fuzz_target_yahttp_seed_corpus.zip" ../fuzzing/corpus/http-raw-payloads/*
+fi


### PR DESCRIPTION
Now that https://github.com/PowerDNS/pdns/pull/9709 has been merged.