### PR TITLE
[firefox] Add missing dep

### DIFF
--- a/projects/firefox/Dockerfile
+++ b/projects/firefox/Dockerfile
@@ -21,10 +21,58 @@ RUN apt-get update && \
     apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
+      cmake \
       gawk \
+      git \
       libstdc++6 \
       m4 \
-      python python3-pip python3-setuptools python3-wheel cmake git nasm 
+      nasm \
+      python \
+      python3-pip \
+      python3-setuptools \
+      python3-wheel
+
+# install Firefox deps
+# built using https://packages.ubuntu.com/focal/firefox as a reference
+RUN apt-get install -y --no-install-recommends \
+    libasound2 \
+    libatk1.0-0 \
+    libc6 \
+    libcairo-gobject2 \
+    libcairo2 \
+    libdbus-1-3 \
+    libdbus-glib-1-2 \
+    libffi7 \
+    libfontconfig1 \
+    libfreetype6 \
+    libgcc-s1 \
+    libgdk-pixbuf2.0-0 \
+    libglib2.0-0 \
+    libgtk-3-0 \
+    libharfbuzz0b \
+    libpango-1.0-0 \
+    libpangocairo-1.0-0 \
+    libpangoft2-1.0-0 \
+    libstdc++6 \
+    libx11-6 \
+    libx11-xcb1 \
+    libxcb-shm0 \
+    libxcb1 \
+    libxcomposite1 \
+    libxcursor1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxi6 \
+    libxrandr2 \
+    libxrender1 \
+    libxt6 \
+    libxtst6 \
+    lsb-release \
+    libcanberra0 \
+    libdbusmenu-glib4 \
+    libdbusmenu-gtk3-4
+
 RUN pip3 install meson ninja
 
 # This wrapper of cargo seems to interfere with our build system.


### PR DESCRIPTION
Attempting to fix broken build:
```
Step #3 - "compile-libfuzzer-address-x86_64": [34m 1:59.04(B[m /work/obj-fuzz/dist/bin/firefox -unittest --gtest_death_test_style=threadsafe(B[m(B[m
Step #3 - "compile-libfuzzer-address-x86_64": XPCOMGlueLoad error for file /work/obj-fuzz/dist/bin/libmozgtk.so:
Step #3 - "compile-libfuzzer-address-x86_64": libgtk-3.so.0: cannot open shared object file: No such file or directory
Step #3 - "compile-libfuzzer-address-x86_64": Couldn't load XPCOM.
Step #3 - "compile-libfuzzer-address-x86_64": ********************************************************************************
Step #3 - "compile-libfuzzer-address-x86_64": Failed to build.
Step #3 - "compile-libfuzzer-address-x86_64": To reproduce, run:
Step #3 - "compile-libfuzzer-address-x86_64": python infra/helper.py build_image firefox
Step #3 - "compile-libfuzzer-address-x86_64": python infra/helper.py build_fuzzers --sanitizer address --engine libfuzzer --architecture x86_64 firefox
Step #3 - "compile-libfuzzer-address-x86_64": ********************************************************************************
Finished Step #3 - "compile-libfuzzer-address-x86_64"
ERROR
ERROR: build step 3 "gcr.io/cloud-builders/docker" failed: step exited with non-zero status: 1
```