### PR TITLE
boringssl: Switch Docker base image to base-builder-go

### DIFF
--- a/projects/boringssl/Dockerfile
+++ b/projects/boringssl/Dockerfile
@@ -14,9 +14,9 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN apt-get update && apt-get install -y wget \
-    golang binutils cmake ninja-build liblzma-dev libz-dev \
+    binutils cmake ninja-build liblzma-dev libz-dev \
     pkg-config autoconf libtool
 RUN git clone --depth 1 https://boringssl.googlesource.com/boringssl
 # Use ASN.1 pdu protobuf and converter from the google/fuzzing repo.


### PR DESCRIPTION
This is to fix https://crbug.com/oss-fuzz/53701, a build failure.

The Go from apt is old (1.13). Instead, use base-builder-go to pick up oss-fuzz's copy of Go. We're technically a C/C++ project, but since C/C++ is part of the baseline, we can just use the Go one.

If we ever need two languages, we can follow the advice in https://google.github.io/oss-fuzz/getting-started/new-project-guide/#dockerfile to run install_lang.sh. (Although after https://crbug.com/boringssl/542, we may not need Go anyway.)