### PR TITLE
cmake flag to support upcoming rnp changes

### DIFF
--- a/projects/rnp/build.sh
+++ b/projects/rnp/build.sh
@@ -48,6 +48,7 @@ cmake \
     -DBUILD_SHARED_LIBS=on \
     -DBUILD_TESTING=off \
     -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+    -DDOWNLOAD_SEXP:BOOL=ON \
     $SRC/rnp
 make -j$(nproc)
 


### PR DESCRIPTION
Upcoming version of rnp (https://github.com/rnpgp/rnp/pull/1943) depends on a new library https://github.com/rnpgp/sexp cmake script can load and build it via FetchContent but this option is disabled by defauly An extra flag is required to enable it

cc: @ronaldtse

This is a contribution from [RNP](https://www.rnpgp.org) ([GitHub](https://github.com/rnpgp)), a product of [Ribose](https://www.ribose.com) ([GitHub](https://github.com/riboseinc)). 
