### PR TITLE
libevent: extend fuzzing suite

### DIFF
--- a/projects/libevent/Dockerfile
+++ b/projects/libevent/Dockerfile
@@ -18,4 +18,4 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool cmake pkg-config
 RUN git clone --depth 1 https://github.com/libevent/libevent.git libevent
 WORKDIR libevent
-COPY build.sh *.cc $SRC/
+COPY build.sh *.cc *.c $SRC/

--- a/projects/libevent/build.sh
+++ b/projects/libevent/build.sh
@@ -30,8 +30,17 @@ make install
 # build fuzzer
 for fuzzers in $(find $SRC -name '*_fuzzer.cc'); do
   fuzz_basename=$(basename -s .cc $fuzzers)
-  $CXX $CXXFLAGS -std=c++11 -Iinclude \
+  $CXX $CXXFLAGS -std=c++11 -I../ -Iinclude \
       $fuzzers $LIB_FUZZING_ENGINE ./lib/libevent.a ./lib/libevent_core.a  \
       ./lib/libevent_pthreads.a ./lib/libevent_extra.a \
       -o $OUT/$fuzz_basename
 done
+
+if [[ "$FUZZING_ENGINE" == "honggfuzz" ]]
+then
+  fuzz_basename=$(basename -s .cc $fuzzers)
+  $CC $CFLAGS $LIB_HFND "$HFND_CFLAGS" -Iinclude \
+      $SRC/fuzz_request_cb.c $LIB_FUZZING_ENGINE ./lib/libevent.a ./lib/libevent_core.a  \
+      ./lib/libevent_pthreads.a ./lib/libevent_extra.a \
+      -o $OUT/fuzz_request
+fi

--- a/projects/libevent/fuzz_request_cb.c
+++ b/projects/libevent/fuzz_request_cb.c
@@ -1,0 +1,38 @@
+/* Copyright 2022 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+ * Uses the Honggfuzz netdriver logic:
+ * - https://github.com/google/honggfuzz/tree/master/libhfnetdriver
+ * This fuzzer can only be compiled with Honggfuzz (and not libFuzzer of AFL).
+ */
+#include "libevent/include/event2/buffer.h"
+#include "libevent/include/event2/event.h"
+#include "libevent/include/event2/http.h"
+
+static void handle_request(struct evhttp_request *req, void *arg)
+{
+    const char *uri = evhttp_request_get_uri(req);
+    struct evbuffer *buf = evbuffer_new();
+    evbuffer_add_printf(buf, "From fuzzer cb, %s!", uri);
+    evhttp_send_reply(req, HTTP_OK, "OK", buf);
+    evbuffer_free(buf);
+}
+
+HFND_FUZZING_ENTRY_FUNCTION(int argc, char **argv) {
+    struct event_base *base = event_base_new();
+    struct evhttp *http = evhttp_new(base);
+    evhttp_bind_socket(http, "0.0.0.0", 8666);
+    evhttp_set_gencb(http, handle_request, NULL);
+    event_base_dispatch(base);
+    return 0;
+}

--- a/projects/libevent/parse_query_fuzzer.cc
+++ b/projects/libevent/parse_query_fuzzer.cc
@@ -26,5 +26,17 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   if (evhttp_parse_query(fuzz_string.c_str(), &headers) == 0) {
     evhttp_clear_headers(&headers);
   }
+
+  if (size > 4) {
+    uint32_t flags = *(uint32_t *)data;
+    data += 4;
+    size -= 4;
+    std::string fuzz_string2(reinterpret_cast<const char *>(data), size);
+
+    if (evhttp_parse_query_str_flags(fuzz_string2.c_str(), &headers, flags) == 0) {
+      evhttp_clear_headers(&headers);
+    }
+  }
+
   return 0;
 }

--- a/projects/libevent/utils_fuzzer.cc
+++ b/projects/libevent/utils_fuzzer.cc
@@ -1,0 +1,39 @@
+/* Copyright 2022 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string>
+#include <sys/socket.h>
+
+#include "libevent/include/event2/event.h"
+#include "libevent/include/event2/util.h"
+#include "util-internal.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  int r;
+  int len;
+  char out_buf[128];
+  struct sockaddr_storage ss;
+  std::string fuzz_string(reinterpret_cast<const char *>(data), size);
+
+  r = evutil_parse_sockaddr_port(
+        fuzz_string.c_str(), (struct sockaddr*)&ss, &len);
+  if (r == 0) {
+    evutil_format_sockaddr_port_((struct sockaddr*)&ss,
+                                 out_buf,
+                                 sizeof(out_buf));
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Minor extensions to existing libevent fuzzer and a minor fuzzer that targets utils code. The utils fuzzer should be extended in the near future.

The honggfuzz netdriver is the main addition. This is relatively new addition in oss-fuzz (supporting netdriver fuzzers) so will start small and extend after observing how it runs.

Signed-off-by: David Korczynski <david@adalogics.com>