### PR TITLE
pillow: update build to support coverage

### DIFF
--- a/projects/pillow/build.sh
+++ b/projects/pillow/build.sh
@@ -15,4 +15,22 @@
 #
 ################################################################################
 
-./Tests/oss-fuzz/build.sh
+python3 setup.py build --build-base=/tmp/build install
+
+# Build fuzzers in $OUT.
+for fuzzer in $(find $SRC -name 'fuzz_*.py'); do
+  compile_python_fuzzer $fuzzer \
+      --add-binary /usr/local/lib/libjpeg.so.62.3.0:. \
+      --add-binary /usr/local/lib/libfreetype.so.6:. \
+      --add-binary /usr/local/lib/liblcms2.so.2:. \
+      --add-binary /usr/local/lib/libopenjp2.so.7:. \
+      --add-binary /usr/local/lib/libpng16.so.16:. \
+      --add-binary /usr/local/lib/libtiff.so.5:. \
+      --add-binary /usr/local/lib/libwebp.so.7:. \
+      --add-binary /usr/local/lib/libwebpdemux.so.2:. \
+      --add-binary /usr/local/lib/libwebpmux.so.3:. \
+      --add-binary /usr/local/lib/libxcb.so.1:.
+done
+
+find Tests/images Tests/icc -print | zip -q $OUT/fuzz_pillow_seed_corpus.zip -@
+find Tests/fonts -print | zip -q $OUT/fuzz_font_seed_corpus.zip -@


### PR DESCRIPTION
This should not be merged, but is only used to show how https://github.com/google/oss-fuzz/issues/9086 is fixed. Changes should go upstream