### PR TITLE
[CUPS] Issue 54041 in oss-fuzz: cups: Fuzzing build failure

### DIFF
--- a/projects/cups/Dockerfile
+++ b/projects/cups/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y autoconf libtool-bin pkg-config
+RUN apt-get update && apt-get install -y autoconf libtool-bin pkg-config zlib1g-dev
 RUN git clone --depth 1 https://github.com/OpenPrinting/cups
 RUN git clone https://github.com/0x34d/oss-fuzz-bloat
 COPY build.sh $SRC/


### PR DESCRIPTION
```
"compile-afl-address-x86_64": /usr/bin/ld: cannot find -lz
```