### PR TITLE
nDPI: fix introspector build

### DIFF
--- a/projects/ndpi/Dockerfile
+++ b/projects/ndpi/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake autogen pkg-config libtool flex bison cmake libnuma-dev libgcrypt20-dev libpcre2-dev
+RUN apt-get update && apt-get install -y make autoconf automake autogen pkg-config libtool flex bison cmake libnuma-dev libpcre2-dev
 RUN git clone --depth 1 https://github.com/json-c/json-c.git json-c
 RUN git clone --depth 1 https://github.com/ntop/nDPI.git ndpi
 ADD https://www.tcpdump.org/release/libpcap-1.9.1.tar.gz libpcap-1.9.1.tar.gz

--- a/projects/ndpi/build.sh
+++ b/projects/ndpi/build.sh
@@ -44,7 +44,8 @@ unset AFL_NOOPT
 
 # build project
 cd ndpi
-sh autogen.sh
-./configure --enable-fuzztargets
+# Set LDFLAGS variable and `--with-only-libndpi` option as workaround for the
+# "missing dependencies errors" in the introspector build. See #8939
+LDFLAGS="-lpcap" ./autogen.sh --enable-debug-messages --enable-fuzztargets --with-only-libndpi
 make
-ls fuzz/fuzz* | grep -v "\." | grep -v "with_main" | while read i; do cp $i $OUT/; done
+ls fuzz/fuzz* | grep -v "\." | while read i; do cp $i $OUT/; done


### PR DESCRIPTION
Since https://github.com/ntop/nDPI/commit/3e4ab39b528e43db8fefdaa542a91260bd100ab2 nDPI should be compatibile with LTO and Gold Linker.
Add a workaround for the "missing dependencies errors" described in #8939