### PR TITLE
lxml: use upstream static dependencies

### DIFF
--- a/projects/lxml/Dockerfile
+++ b/projects/lxml/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-python
 RUN git clone --depth 1 https://github.com/lxml/lxml
-RUN apt-get install -y libxml2-dev libxslt-dev zlib1g-dev
+RUN apt-get install -y zlib1g-dev
 RUN pip3 install Cython
 
 COPY build.sh $SRC/

--- a/projects/lxml/build.sh
+++ b/projects/lxml/build.sh
@@ -15,6 +15,11 @@
 #
 ################################################################################
 
+export LIBXML2_VERSION=2.10.3
+export LIBXSLT_VERSION=1.1.37
+export STATIC_DEPS=true
+export CFLAGS="$CFLAGS -fPIC"
+python3 ./setup.py build --with-cython
 python3 ./setup.py install
 
 # Build fuzzers in $OUT.


### PR DESCRIPTION
The dependencies coming from base-builder-python might be old, let's use the upstream ones that are downloaded by the setup.py script.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47038