### PR TITLE
Disable arbitrary file read sanitizer.

### DIFF
--- a/infra/experimental/SystemSan/SystemSan.cpp
+++ b/infra/experimental/SystemSan/SystemSan.cpp
@@ -460,7 +460,8 @@ int trace(std::map<pid_t, Tracee> pids) {
           }
 
           if (regs.orig_rax == __NR_openat) {
-            inspect_for_arbitrary_file_open(pid, regs);
+            // TODO(metzman): Re-enable this once we have config/flag support.
+            // inspect_for_arbitrary_file_open(pid, regs);
           }
 
           if (regs.orig_rax == __NR_write &&


### PR DESCRIPTION
This is currently too noisy, and may mask our other sanitizers.

We can re-enable this once we have flag/options support.