### PR TITLE
Fix SystemSan for Python

### DIFF
--- a/infra/experimental/SystemSan/Makefile
+++ b/infra/experimental/SystemSan/Makefile
@@ -1,6 +1,6 @@
 .POSIX:
 CXX     = clang++
-CFLAGS = -std=c++17 -Wall -Wextra -O3 -g3
+CFLAGS = -std=c++17 -Wall -Wextra -O0 -g3
 
 all: clean SystemSan target target_file target_dns
 

--- a/infra/experimental/SystemSan/SystemSan.cpp
+++ b/infra/experimental/SystemSan/SystemSan.cpp
@@ -93,6 +93,7 @@ std::set<std::string> kShellSyntaxErrors = {
   ": missing `]'",        // Unfinished [
   ": event not found",    // ! leads large numbers
   ": No such file or directory",  // Leading < or /
+  ": command not found",     // General. Also matches bash's !!!
   // dash
   ": not found",     // General. Also matches bash's !!!
   // Also matches bash's.
@@ -167,8 +168,10 @@ void match_error_pattern(std::string buffer, std::string shell, pid_t pid) {
 
     // Check that we are ending with the syntax error.
     if (position != std::string::npos) {
+      std::cerr << "pattern: " << pattern << " buffer: " << buffer << std::endl;
       auto pattern_end = position + pattern.length();
-      if (pattern_end != buffer.length()) {
+      if (pattern_end != buffer.length() && ((pattern_end != buffer.length() - 1) && buffer.back() != '\n') ) {
+        std::cerr << "pattern_end: " << pattern_end << " buffer.length(): " << buffer.length() << std::endl;
         printf("continue\n");
         continue;
       }

--- a/infra/experimental/SystemSan/SystemSan.cpp
+++ b/infra/experimental/SystemSan/SystemSan.cpp
@@ -198,7 +198,7 @@ void inspect_for_corruption(pid_t pid, const user_regs_struct &regs) {
 
 void log_file_open(std::string path, int flags, pid_t pid) {
   report_bug(kArbitraryFileOpenError, pid);
-  std::cerr << "===File opened: " << path.c_str() << ", flags = " << flags << ",";
+  std::cerr << "===File opened: " << path << ", flags = " << flags << ",";
   switch (flags & 3) {
     case O_RDONLY:
       std::cerr << "O_RDONLY";


### PR DESCRIPTION
Don't bother supporting stuff like ksh, just support sh and bash (btw these don't always have consistent errors, I've seen capitalization vary between my machine's bash and builder's bash, we should dynamically get these error strings and/or use regexes).