### PR TITLE
Use setup-python action to cache dependencies

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -29,6 +29,10 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: 3.8
+          cache: pip
+          cache-dependency-path: |
+            infra/ci/requirements.txt
+            infra/build/functions/requirements.txt
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/project_tests.yml
+++ b/.github/workflows/project_tests.yml
@@ -73,6 +73,9 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: 3.8
+          cache: pip
+          cache-dependency-path: |
+            infra/ci/requirements.txt
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Details

Updated workflows to cache dependencies using [actions/setup-python](https://github.com/actions/setup-python#caching-packages-dependencies). `setup-python@v3` or newer has caching **built-in**.

### AS-IS

```yaml
- name: Setup python environment
  uses: actions/setup-python@v3
  with:
    python-version: 3.8
```

### TO-BE

```yaml
- name: Setup python environment
  uses: actions/setup-python@v3
  with:
    python-version: 3.8
    cache: pip
    cache-dependency-path: |
      infra/ci/requirements.txt
      infra/build/functions/requirements.txt
      infra/cifuzz/requirements.txt
```

## References

- [https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
- [https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/](https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/)
