### PR TITLE
infra: replace characters to fuzztest coverage urls

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -68,6 +68,8 @@ PROJECT_LANGUAGE_REGEX = re.compile(r'\s*language\s*:\s*([^\s]+)')
 
 WORKDIR_REGEX = re.compile(r'\s*WORKDIR\s*([^\s]+)')
 
+FUZZTEST_CORPUS_URL_REPLACE_CHARS = [ '@', '.' ]
+
 LANGUAGES_WITH_BUILDER_IMAGES = {'go', 'jvm', 'python', 'rust', 'swift'}
 ARM_BUILDER_NAME = 'oss-fuzz-buildx-builder'
 
@@ -818,7 +820,7 @@ def _get_latest_corpus(project, fuzz_target, base_corpus_dir):
     fuzz_target = '%s_%s' % (project.name, fuzz_target)
 
   # Replace chars from fuzztest fuzzers that are replaced in coverage URLs.
-  for c in ['@', '.']:
+  for c in FUZZTEST_CORPUS_URL_REPLACE_CHARS:
     if c in fuzz_target:
       fuzz_target = fuzz_target.replace(c, '-')
 

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -68,7 +68,8 @@ PROJECT_LANGUAGE_REGEX = re.compile(r'\s*language\s*:\s*([^\s]+)')
 
 WORKDIR_REGEX = re.compile(r'\s*WORKDIR\s*([^\s]+)')
 
-FUZZTEST_CORPUS_URL_REPLACE_CHARS = [ '@', '.' ]
+# Regex to match special chars in project name.
+SPECIAL_CHARS_REGEX = re.compile('[^a-zA-Z0-9_-]')
 
 LANGUAGES_WITH_BUILDER_IMAGES = {'go', 'jvm', 'python', 'rust', 'swift'}
 ARM_BUILDER_NAME = 'oss-fuzz-buildx-builder'
@@ -410,6 +411,13 @@ def _check_fuzzer_exists(project, fuzzer_name, architecture='x86_64'):
     return False
 
   return True
+
+
+def _normalized_name(name):
+  """Return normalized name with special chars like slash, colon, etc normalized
+  to hyphen(-). This is important as otherwise these chars break local and cloud
+  storage paths."""
+  return SPECIAL_CHARS_REGEX.sub('-', name).strip('-')
 
 
 def _get_absolute_path(path):
@@ -819,10 +827,8 @@ def _get_latest_corpus(project, fuzz_target, base_corpus_dir):
   if not fuzz_target.startswith(project.name + '_'):
     fuzz_target = '%s_%s' % (project.name, fuzz_target)
 
-  # Replace chars from fuzztest fuzzers that are replaced in coverage URLs.
-  for c in FUZZTEST_CORPUS_URL_REPLACE_CHARS:
-    if c in fuzz_target:
-      fuzz_target = fuzz_target.replace(c, '-')
+  # Normalise fuzz target name.
+  fuzz_target = _normalized_name(fuzz_target)
 
   corpus_backup_url = CORPUS_BACKUP_URL_FORMAT.format(project_name=project.name,
                                                       fuzz_target=fuzz_target)

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -817,7 +817,7 @@ def _get_latest_corpus(project, fuzz_target, base_corpus_dir):
   if not fuzz_target.startswith(project.name + '_'):
     fuzz_target = '%s_%s' % (project.name, fuzz_target)
 
-  # Escape characters that exist in fuzztest fuzzers, which are escaped in
+  # Escape characters that exist in fuzztest fuzzers, which are replace in
   # coverage corpus URLs.
   for c in ['@', '.']:
     if c in fuzz_target:

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -817,6 +817,12 @@ def _get_latest_corpus(project, fuzz_target, base_corpus_dir):
   if not fuzz_target.startswith(project.name + '_'):
     fuzz_target = '%s_%s' % (project.name, fuzz_target)
 
+  # Escape characters that exist in fuzztest fuzzers, which are escaped in
+  # coverage corpus URLs.
+  for c in ['@', '.']:
+    if c in fuzz_target:
+      fuzz_target = fuzz_target.replace(c, '-')
+
   corpus_backup_url = CORPUS_BACKUP_URL_FORMAT.format(project_name=project.name,
                                                       fuzz_target=fuzz_target)
   command = ['gsutil', 'ls', corpus_backup_url]

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -817,8 +817,7 @@ def _get_latest_corpus(project, fuzz_target, base_corpus_dir):
   if not fuzz_target.startswith(project.name + '_'):
     fuzz_target = '%s_%s' % (project.name, fuzz_target)
 
-  # Escape characters that exist in fuzztest fuzzers, which are replace in
-  # coverage corpus URLs.
+  # Replace chars from fuzztest fuzzers that are replaced in coverage URLs.
   for c in ['@', '.']:
     if c in fuzz_target:
       fuzz_target = fuzz_target.replace(c, '-')


### PR DESCRIPTION
The corpus URL generated for fuzztest fuzzers is invalid due to the use of `@` and `.` characters in the fuzzer names.

The current URL created is e.g. `gs://fuzztest-raksha-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer/fuzztest-raksha_value_test@NumberTest.RoundTripNumberThroughDatalogString/` whereas the correct URL is `gs://fuzztest-raksha-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer/fuzztest-raksha_value_test-NumberTest-RoundTripNumberThroughDatalogString/`.

Signed-off-by: David Korczynski <david@adalogics.com>