### PR TITLE
kimageformats: do not install documentation for libzip

### DIFF
--- a/projects/kimageformats/build.sh
+++ b/projects/kimageformats/build.sh
@@ -35,7 +35,7 @@ make install -j$(nproc)
 
 cd $SRC
 cd libzip
-cmake . -DBUILD_SHARED_LIBS=OFF
+cmake . -DBUILD_SHARED_LIBS=OFF -DBUILD_DOC=OFF
 make install -j$(nproc)
 
 cd $SRC


### PR DESCRIPTION
This should help to solve/avoid issues like https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=54130