### PR TITLE
[CFL] Allow users to specify custom env vars for building/running

### DIFF
--- a/infra/cifuzz/build_fuzzers.py
+++ b/infra/cifuzz/build_fuzzers.py
@@ -87,6 +87,12 @@ class Builder:  # pylint: disable=too-many-instance-attributes
 
     build_command = self.ci_system.get_build_command(self.host_repo_path,
                                                      self.image_repo_path)
+
+    # Set extra environment variables so that they are visible to the build.
+    for key in self.config.extra_environment_variables:
+      # Don't specify their value in case they get echoed.
+      docker_args.extend(['-e', key])
+
     docker_args.extend([
         docker.get_project_image_name(self.config.oss_fuzz_project_name),
         '/bin/bash',

--- a/infra/cifuzz/config_utils.py
+++ b/infra/cifuzz/config_utils.py
@@ -63,6 +63,12 @@ def _get_language():
   return os.getenv('LANGUAGE', constants.DEFAULT_LANGUAGE)
 
 
+def _get_extra_environment_variables():
+  """Gets extra environment variables specified by the user with
+  CFL_EXTRA_$NAME=$VALUE."""
+  return [key for key in os.environ if key.startswith('CFL_EXTRA_')]
+
+
 # pylint: disable=too-many-instance-attributes
 
 
@@ -124,6 +130,7 @@ class BaseConfig:
         constants.DEFAULT_EXTERNAL_BUILD_INTEGRATION_PATH)
 
     self.parallel_fuzzing = os.environ.get('PARALLEL_FUZZING')
+    self.extra_environment_variables = _get_extra_environment_variables()
 
     # TODO(metzman): Fix tests to create valid configurations and get rid of
     # CIFUZZ_TEST here and in presubmit.py.


### PR DESCRIPTION
They can do this by prefix the env var with CFL_EXTRA_. E.g. `CFL_EXTRA_BUILD_SERVICE_TOKEN=<redacted>`.
Fixes: https://github.com/google/oss-fuzz/issues/9170
