### PR TITLE
[xs] Remove xs wrapper stub

### DIFF
--- a/projects/xs/build.sh
+++ b/projects/xs/build.sh
@@ -18,7 +18,6 @@ mv $SRC/{*.zip,*.dict} $OUT
 
 
 export MODDABLE=$PWD
-export ASAN_OPTIONS="detect_leaks=0"
 
 FUZZ_TARGETS=(
   xst
@@ -26,22 +25,6 @@ FUZZ_TARGETS=(
 )
 
 REALBIN_PATH=$OUT
-if [ "$SANITIZER" = "coverage" ]
-then
-  echo "this is a coverage build"
-else
-  # Stash actual binaries in subdirectory so they aren't picked up by target discovery
-  mkdir -p $OUT/real
-  REALBIN_PATH=$OUT/real
-
-  # Build a wrapper binary for each target to set environment variables.
-  for FUZZ_TARGET in ${FUZZ_TARGETS[@]}
-  do
-    $CC $CFLAGS -O0 \
-      -DFUZZ_TARGET=$FUZZ_TARGET \
-      $SRC/target.c -o $OUT/$FUZZ_TARGET
-  done
-fi
 
 # build main target
 cd "$MODDABLE/xs/makefiles/lin"

--- a/projects/xs/xst.options
+++ b/projects/xs/xst.options
@@ -2,3 +2,4 @@
 detect_leaks=0
 [asan]
 detect_stack_use_after_return=0
+detect_leaks=0


### PR DESCRIPTION
Previously in #7910 we added a wrapper that injected `detect_leaks=0` into our fuzz targets, as certain runs of the targets did not disable and it did not behave well with the allocator and gc (#7708). As far as I can tell this is no longer needed as most runs of the fuzzing target binary seem to use the options file to construct its arguments.

* The `run_fuzzer` command respects options.
* The `reproduce` command respects options (locally and in [reproducer reports](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=53429)).

Therefore, we should remove it. I've tested this running, reproducing, debugging, and coverage with no observed changes.