### PR TITLE
Fix bug that affects reproducibility

### DIFF
--- a/projects/ruby/fuzz_ruby_gems.c
+++ b/projects/ruby/fuzz_ruby_gems.c
@@ -404,6 +404,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     uint32_t x = 0;
     BytesStream_get_uint32_t(&bs, &x);
     workaround_UBSAN_CALLS_THRESHOLD_FOR_UBSAN_BUILD(x);
+
+    // Reset the byte stream
+    ByteStream_init(&bs, data, size);
   }
 
   // Choose a function from `target_functions`.


### PR DESCRIPTION
I made a mistake when I implemented this workaround:

https://github.com/google/oss-fuzz/blob/6e299b2e237bde05759d55009084097f0869c244/projects/ruby/fuzz_ruby_gems.c#L288-L291

To ensure that the workaround code won't get dead-code-eliminated by a clever compiler optimization, I decided to feed bytes from the test data in as an argument:

https://github.com/google/oss-fuzz/blob/6e299b2e237bde05759d55009084097f0869c244/projects/ruby/fuzz_ruby_gems.c#L404-L406

But that code only gets run on the first iteration (it's protected by a static variable). That means that the code behaves differently when you're trying to reproduce a testcase. This PR fixes the bug by rewinding the bytestream back to the beginning after it's been used for the workaround code.