### PR TITLE
mrab-regex: avoid recursion error exceptions

### DIFF
--- a/projects/mrab-regex/fuzz_regex.py
+++ b/projects/mrab-regex/fuzz_regex.py
@@ -28,6 +28,9 @@ def TestOneInput(data):
   except ValueError:
     # Compile throws several ValueErrors
     pass
+  except RecursionError:
+    # uninteresting
+    pass
 
   # Target regex.sub
   try:
@@ -40,7 +43,9 @@ def TestOneInput(data):
   except ValueError:
     # Compile throws several ValueErrors
     pass
-
+  except RecursionError:
+    # uninteresting
+    pass
 
 def main():
   atheris.instrument_all()


### PR DESCRIPTION
They are uninteresting.

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=54203