### PR TITLE
nDPI: disable debug logs

### DIFF
--- a/projects/ndpi/build.sh
+++ b/projects/ndpi/build.sh
@@ -50,7 +50,7 @@ fi
 cd ndpi
 # Set LDFLAGS variable and `--with-only-libndpi` option as workaround for the
 # "missing dependencies errors" in the introspector build. See #8939
-LDFLAGS="-lpcap" ./autogen.sh --enable-debug-messages --enable-fuzztargets --with-only-libndpi
+LDFLAGS="-lpcap" ./autogen.sh --enable-fuzztargets --with-only-libndpi
 make -j$(nproc)
 # Copy fuzzers
 ls fuzz/fuzz* | grep -v "\." | while read i; do cp $i $OUT/; done


### PR DESCRIPTION
Enabling them in 3baf95b6ec9425509b1ea370621c82ad180a2f7a wasn't a great idea