### PR TITLE
fluent-bit: speed up the build

### DIFF
--- a/projects/fluent-bit/build.sh
+++ b/projects/fluent-bit/build.sh
@@ -110,6 +110,7 @@ cmake -DFLB_TESTS_INTERNAL=ON \
       ${MISC_PLUGINS} \
       ${OUTPUT_PLUGINS} \
       ..
-make
+
+make -j$(nproc)
 
 cp $SRC/fluent-bit/build/bin/*OSSFUZZ ${OUT}/


### PR DESCRIPTION
The build can take quite a while, which is a time drainer when testing fixes and new fuzzers. This improves it a lot.