### PR TITLE
Grant Evan access to Knative fuzzing repots

### DIFF
--- a/projects/knative/project.yaml
+++ b/projects/knative/project.yaml
@@ -5,6 +5,9 @@ main_repo: "https://github.com/knative"
 vendor_ccs:
   - "adam@adalogics.com"
   - "david@adalogics.com"
+auto_ccs:
+  - "evana@vmware.com"
+  - "evan.k.anderson@gmail.com"
 fuzzing_engines:
   - libfuzzer
 sanitizers:


### PR DESCRIPTION
(Both my work and personal email addresses.)

I'm the main recipient of `security@knative.dev` emails at the moment, and it turns out by using the mailing list we'll need to get each recipient added here.