### PR TITLE
Add additional maintainer to GLib project configuration

### DIFF
--- a/projects/glib/project.yaml
+++ b/projects/glib/project.yaml
@@ -6,6 +6,7 @@ auto_ccs:
 - mwl458@gmail.com
 - iain@orangesquash.org.uk
 - slomo@coaxion.net
+- trevi55@gmail.com
 sanitizers:
 - address
 - undefined


### PR DESCRIPTION
He’s an upstream maintainer:
https://gitlab.gnome.org/GNOME/glib/-/blob/ded3099afca49234f407f67d96b99e684a8ff336/glib.doap#L49-L55

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>