### PR TITLE
[cryptofuzz] Add OpenJDK

### DIFF
--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -58,6 +58,7 @@ RUN apt-get remove -y libunwind8
 RUN apt-get install -y libssl-dev
 RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 RUN wget https://nodejs.org/dist/v14.17.1/node-v14.17.1-linux-x64.tar.xz
+RUN wget https://download.java.net/java/GA/jdk18.0.1/3f48cabb83014f9fab465e280ccf630b/10/GPL/openjdk-18.0.1_linux-x64_bin.tar.gz
 RUN pip3 install -r $SRC/mbedtls/scripts/basic.requirements.txt
 
 COPY build.sh xxd.c $SRC/

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -514,6 +514,20 @@ export WOLFCRYPT_INCLUDE_PATH="$SRC/wolfssl"
 cd $SRC/cryptofuzz/modules/wolfcrypt
 make -B
 
+# Compile Java module
+if [ "$SANITIZER" = undefined ]; then
+    mv $SRC/openjdk-18.0.1_linux-x64_bin.tar.gz $OUT/
+    cd $OUT/
+    tar zxf openjdk-18.0.1_linux-x64_bin.tar.gz
+    export JDK_PATH=$(realpath jdk-18.0.1)
+    export LINK_FLAGS="$LINK_FLAGS -L$JDK_PATH/lib/server/ -ljvm -Wl,-rpath=$JDK_PATH/lib/server/"
+    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_JAVA"
+
+    cd $SRC/cryptofuzz/modules/java/
+    make -f Makefile-OSS-Fuzz -j$(nproc)
+    cp CryptofuzzJavaHarness.class $OUT/
+fi
+
 # OpenSSL can currently not be used together with wolfCrypt due to symbol collisions
 export SAVE_CXXFLAGS="$CXXFLAGS"
 export CXXFLAGS=${CXXFLAGS/-DCRYPTOFUZZ_WOLFCRYPT/}


### PR DESCRIPTION
Tests OpenJDK bignum and some cryptographic operations. Harness will be extended to support more crypto ops.

It doesn't have code coverage at the Java level but it rides on the coverage of other libraries, so it will process meaningful inputs and find bugs.

Only building for UBSAN because ASAN reports memory leaks that I think is just the JVM object that is created at startup and must be retained for the duration of the run, and ASAN doesn't make sense here anyway.

Any bugs found I will report privately to the OpenJDK project.

I had some issues getting this to work properly, if it causes too many spurious crashes I might disable it again.