### PR TITLE
[resiprocate]: build with CMake

### DIFF
--- a/projects/resiprocate/Dockerfile
+++ b/projects/resiprocate/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config libfmt-dev
-RUN git clone --depth 1 https://github.com/resiprocate/resiprocate.git resiprocate
+RUN apt-get update && apt-get install -y cmake ninja-build pkg-config libfmt-dev
+RUN git clone --depth 1 --single-branch --branch master https://github.com/resiprocate/resiprocate.git resiprocate
 WORKDIR resiprocate
 COPY build.sh $SRC/


### PR DESCRIPTION
The resiprocate project switched its build system from autotools to CMake. The fuzzer build changes are [there](https://github.com/resiprocate/resiprocate/commit/9e84cc44b9a2dedefed7b1cd7183454749788410).