### PR TITLE
[coturn] remove patch.

### DIFF
--- a/projects/coturn/build.sh
+++ b/projects/coturn/build.sh
@@ -18,7 +18,7 @@
 mkdir my_build
 
 pushd my_build/
-cmake -DFUZZER=ON -DLIB_FUZZING_ENGINE="$LIB_FUZZING_ENGINE" -DWITH_MYSQL=OFF -Wno-dev ../.
+cmake -DFUZZER=ON -DLIB_FUZZING_ENGINE="$LIB_FUZZING_ENGINE -Wl,-rpath,'\$ORIGIN/lib'" -DWITH_MYSQL=OFF -Wno-dev ../.
 make -j$(nproc)
 popd
 
@@ -30,12 +30,6 @@ popd
 pushd fuzzing/input/
 cp FuzzStun_seed_corpus.zip $OUT/FuzzStun_seed_corpus.zip
 cp FuzzStunClient_seed_corpus.zip $OUT/FuzzStunClient_seed_corpus.zip
-popd
-
-pushd $OUT/
-mkdir $OUT/lib/
-patchelf --set-rpath '$ORIGIN/lib' FuzzStun
-patchelf --set-rpath '$ORIGIN/lib' FuzzStunClient
 popd
 
 pushd /lib/x86_64-linux-gnu/


### PR DESCRIPTION
Binary Patching is breaking the Coverage Build. https://github.com/google/oss-fuzz/issues/9227



Signed-off-by: Arjun Singh <ajsinghyadav00@gmail.com>