### PR TITLE
Wireshark: Update build options and dependencies.

### DIFF
--- a/projects/wireshark/Dockerfile
+++ b/projects/wireshark/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN apt-get update && apt-get install -y ninja-build cmake \
-                       flex bison libc-ares-dev \
+                       flex libc-ares-dev \
                        libglib2.0-dev libgcrypt20-dev
 
 RUN git clone --depth=1 https://gitlab.com/wireshark/wireshark.git

--- a/projects/wireshark/build.sh
+++ b/projects/wireshark/build.sh
@@ -36,8 +36,8 @@ CMAKE_DEFINES="$CMAKE_DEFINES -DENABLE_PCAP=OFF -DENABLE_GNUTLS=OFF"
 
 # There is no need to manually disable programs via BUILD_xxx=OFF since the
 # all-fuzzers targets builds the minimum required binaries. However we do have
-# to disable the Qt GUI or else the cmake step will fail.
-CMAKE_DEFINES="$CMAKE_DEFINES -DBUILD_wireshark=OFF"
+# to disable the Qt GUI and sharkd or else the cmake step will fail.
+CMAKE_DEFINES="$CMAKE_DEFINES -DBUILD_wireshark=OFF -DBUILD_logray=OFF -DBUILD_sharkd=OFF"
 
 cd "$WIRESHARK_BUILD_PATH"
 


### PR DESCRIPTION
The "wireshark", "logray", and "sharkd" targets all depend on SpeexDSP (Wireshark commit ae14849864), so disable them. Don't install bison; we haven't needed it since 2020 (Wireshark commit f21cd2e23f).

Signed-off-by: Gerald Combs <gerald@wireshark.org>