### PR TITLE
infra: make it possible to do a full introspector run

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -1161,9 +1161,9 @@ def coverage(args):
 
 
 def _introspector_prepare_corpus(args):
-  """Helper function for introspector runs to generate corpora"""
+  """Helper function for introspector runs to generate corpora."""
   parser = get_parser()
-  # Generate corpus, either by downloading or running fuzzers
+  # Generate corpus, either by downloading or running fuzzers.
   if args.private_corpora or args.public_corpora:
     corpora_command = ['download_corpora']
     if args.public_corpora:
@@ -1175,7 +1175,7 @@ def _introspector_prepare_corpus(args):
   else:
     fuzzer_targets = _get_fuzz_targets(args.project)
     for fuzzer_name in fuzzer_targets:
-      # Make a corpus directory
+      # Make a corpus directory.
       fuzzer_corpus_dir = args.project.corpus + f'/{fuzzer_name}'
       if not os.path.isdir(fuzzer_corpus_dir):
         os.makedirs(fuzzer_corpus_dir)
@@ -1196,14 +1196,14 @@ def _introspector_prepare_corpus(args):
 
 
 def introspector(args):
-  """Runs a complete end-to-end run of introspector"""
+  """Runs a complete end-to-end run of introspector."""
   parser = get_parser()
 
   args_to_append = []
   if args.source_path:
     args_to_append.append(_get_absolute_path(args.source_path))
 
-  # build fuzzers with ASAN
+  # Build fuzzers with ASAN.
   build_fuzzers_command = [
       'build_fuzzers', '--sanitizer=address', args.project.name
   ] + args_to_append
@@ -1214,7 +1214,7 @@ def introspector(args):
   if not _introspector_prepare_corpus(args):
     return False
 
-  # Build code coverage
+  # Build code coverage.
   build_fuzzers_command = [
       'build_fuzzers', '--sanitizer=coverage', args.project.name
   ] + args_to_append
@@ -1222,7 +1222,7 @@ def introspector(args):
     logging.error('Failed to build project with coverage instrumentation')
     return False
 
-  # Collect coverage
+  # Collect coverage.
   coverage_command = [
       'coverage', '--no-corpus-download', '--port', '', args.project.name
   ]
@@ -1230,7 +1230,7 @@ def introspector(args):
     logging.error('Failed to extract coverage')
     return False
 
-  # Build introspector
+  # Build introspector.
   build_fuzzers_command = [
       'build_fuzzers', '--sanitizer=introspector', args.project.name
   ] + args_to_append
@@ -1243,7 +1243,7 @@ def introspector(args):
     os.rmdir(introspector_dst)
   shutil.copytree(os.path.join(args.project.out, "inspector"), introspector_dst)
 
-  # Copy the coverage reports into the introspector report
+  # Copy the coverage reports into the introspector report.
   dst_cov_report = os.path.join(introspector_dst, "covreport")
   shutil.copytree(os.path.join(args.project.out, "report"), dst_cov_report)
 

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -1234,13 +1234,13 @@ def introspector(args):
   if not build_fuzzers(parse_args(parser, build_fuzzers_command)):
     return False
 
-  inspector_dst = os.path.join(args.project.out, "introspector-report")
-  if os.path.isdir(inspector_dst):
-    os.rmdir(inspector_dst)
-  shutil.copytree(os.path.join(args.project.out, "inspector"), inspector_dst)
+  introspector_dst = os.path.join(args.project.out, "introspector-report")
+  if os.path.isdir(introspector_dst):
+    os.rmdir(introspector_dst)
+  shutil.copytree(os.path.join(args.project.out, "inspector"), introspector_dst)
 
   # Copy the coverage reports into the introspector report
-  dst_cov_report = os.path.join(inspector_dst, "covreport")
+  dst_cov_report = os.path.join(introspector_dst, "covreport")
   shutil.copytree(os.path.join(args.project.out, "report"), dst_cov_report)
 
   # Copy per-target coverage reports
@@ -1250,6 +1250,11 @@ def introspector(args):
     shutil.copytree(os.path.join(src_target_cov_report, target_cov_dir),
                     dst_target_cov_report)
 
+  logging.info('Introspector run complete. Report in %s' % introspector_dst)
+  logging.info(
+      'To browse the report, run: `python3 -m http.server 8008 --directory %s`'
+      'and navigate to localhost:8008/fuzz_report.html in your browser' %
+      introspector_dst)
   return True
 
 

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -355,16 +355,16 @@ def get_parser():  # pylint: disable=too-many-statements
   _add_external_project_args(coverage_parser)
   _add_architecture_args(coverage_parser)
 
-  introspector_parser = subparsers.add_parser('introspector',
-                                   help='Run a complete end-to-end run of '
-                                   'fuzz introspector. This involves (1) '
-                                   'building the fuzzers with ASAN; (2) '
-                                   'running all fuzzers; (3) building '
-                                   'fuzzers with coverge; (4) extracting '
-                                   'coverage; (5) building fuzzers using '
-                                   'introspector')
-  introspector_parser.add_argument('project',
-                                    help='name of the project')
+  introspector_parser = subparsers.add_parser(
+      'introspector',
+      help='Run a complete end-to-end run of '
+      'fuzz introspector. This involves (1) '
+      'building the fuzzers with ASAN; (2) '
+      'running all fuzzers; (3) building '
+      'fuzzers with coverge; (4) extracting '
+      'coverage; (5) building fuzzers using '
+      'introspector')
+  introspector_parser.add_argument('project', help='name of the project')
   introspector_parser.add_argument('--seconds',
                                    help='number of seconds to run fuzzers')
 
@@ -1152,58 +1152,54 @@ def introspector(args):
 
   # build fuzzers command
   build_fuzzers_command = [
-    'build_fuzzers', args.project.name, '--sanitizer', 'address'
+      'build_fuzzers', args.project.name, '--sanitizer', 'address'
   ]
   parsed_args = parse_args(parser, build_fuzzers_command)
-  print("parsed args: %s"%(parsed_args))
   build_fuzzers(parsed_args)
 
   # Run all fuzzers
   fuzzer_targets = _get_fuzz_targets(args.project)
-  print("Fuzz targets: %s" % str(fuzzer_targets))
   for fuzzer_name in fuzzer_targets:
-      # Make a corpus directory
-      fuzzer_corpus_dir = args.project.corpus + f'/{fuzzer_name}'
-      if not os.path.isdir(fuzzer_corpus_dir):
-          os.makedirs(fuzzer_corpus_dir)
-      run_fuzzer_command = [
-          'run_fuzzer', args.project.name, fuzzer_name, '--sanitizer', 'address', '--corpus-dir', fuzzer_corpus_dir
-      ]
-      
-      parser = get_parser()
-      parsed_args = parse_args(parser, run_fuzzer_command)
-      parsed_args.fuzzer_args = ['-max_total_time=3', '-detect_leaks=0']
-      print("parsed args: %s"%(parsed_args))
-      run_fuzzer(parsed_args)
+    # Make a corpus directory
+    fuzzer_corpus_dir = args.project.corpus + f'/{fuzzer_name}'
+    if not os.path.isdir(fuzzer_corpus_dir):
+      os.makedirs(fuzzer_corpus_dir)
+    run_fuzzer_command = [
+        'run_fuzzer', args.project.name, fuzzer_name, '--sanitizer', 'address',
+        '--corpus-dir', fuzzer_corpus_dir
+    ]
 
+    parser = get_parser()
+    parsed_args = parse_args(parser, run_fuzzer_command)
+    parsed_args.fuzzer_args = [
+        f'-max_total_time={args.seconds}', '-detect_leaks=0'
+    ]
+    run_fuzzer(parsed_args)
 
   # Build code coverage
   parser = get_parser()
   build_fuzzers_command = [
-    'build_fuzzers', args.project.name, '--sanitizer', 'coverage'
+      'build_fuzzers', args.project.name, '--sanitizer', 'coverage'
   ]
   parsed_args = parse_args(parser, build_fuzzers_command)
-  print("parsed args: %s"%(parsed_args))
   build_fuzzers(parsed_args)
 
   # Collect coverage
   parser = get_parser()
   build_fuzzers_command = [
-    'coverage', '--no-corpus-download', '--port \'\'', args.project.name
+      'coverage', '--no-corpus-download', '--port \'\'', args.project.name
   ]
   parsed_args = parse_args(parser, build_fuzzers_command)
-  print("parsed args: %s"%(parsed_args))
   coverage(parsed_args)
 
   # Build introspector
   parser = get_parser()
   build_fuzzers_command = [
-    'build_fuzzers', args.project.name, '--sanitizer', 'introspector'
+      'build_fuzzers', args.project.name, '--sanitizer', 'introspector'
   ]
   parsed_args = parse_args(parser, build_fuzzers_command)
-  print("parsed args: %s"%(parsed_args))
   build_fuzzers(parsed_args)
-  
+
 
 def run_fuzzer(args):
   """Runs a fuzzer in the container."""

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -1169,8 +1169,8 @@ def _introspector_prepare_corpus(args):
     if args.public_corpora:
       corpora_command.append('--public')
     corpora_command.append(args.project.name)
-    #parsed_args = parse_args(parser, corpora_command)
     if not download_corpora(parse_args(parser, corpora_command)):
+      logging.error('Failed to download corpora')
       return False
   else:
     fuzzer_targets = _get_fuzz_targets(args.project)
@@ -1208,6 +1208,7 @@ def introspector(args):
       'build_fuzzers', '--sanitizer=address', args.project.name
   ] + args_to_append
   if not build_fuzzers(parse_args(parser, build_fuzzers_command)):
+    logging.error('Failed to build project with ASAN')
     return False
 
   if not _introspector_prepare_corpus(args):
@@ -1218,6 +1219,7 @@ def introspector(args):
       'build_fuzzers', '--sanitizer=coverage', args.project.name
   ] + args_to_append
   if not build_fuzzers(parse_args(parser, build_fuzzers_command)):
+    logging.error('Failed to build project with coverage instrumentation')
     return False
 
   # Collect coverage
@@ -1225,6 +1227,7 @@ def introspector(args):
       'coverage', '--no-corpus-download', '--port', '', args.project.name
   ]
   if not coverage(parse_args(parser, coverage_command)):
+    logging.error('Failed to extract coverage')
     return False
 
   # Build introspector
@@ -1232,6 +1235,7 @@ def introspector(args):
       'build_fuzzers', '--sanitizer=introspector', args.project.name
   ] + args_to_append
   if not build_fuzzers(parse_args(parser, build_fuzzers_command)):
+    logging.error('Failed to build project with introspector')
     return False
 
   introspector_dst = os.path.join(args.project.out, "introspector-report")

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -1250,10 +1250,10 @@ def introspector(args):
     shutil.copytree(os.path.join(src_target_cov_report, target_cov_dir),
                     dst_target_cov_report)
 
-  logging.info('Introspector run complete. Report in %s' % introspector_dst)
+  logging.info('Introspector run complete. Report in %s', introspector_dst)
   logging.info(
       'To browse the report, run: `python3 -m http.server 8008 --directory %s`'
-      'and navigate to localhost:8008/fuzz_report.html in your browser' %
+      'and navigate to localhost:8008/fuzz_report.html in your browser',
       introspector_dst)
   return True
 

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -1200,6 +1200,8 @@ def introspector(args):
   parsed_args = parse_args(parser, build_fuzzers_command)
   build_fuzzers(parsed_args)
 
+  return True
+
 
 def run_fuzzer(args):
   """Runs a fuzzer in the container."""


### PR DESCRIPTION
Make it possible to do a full run of introspector locally. This will make it a lot easier for users to integrate it into the fuzzer building workflow.

To trigger, just run: `python3 infra/helper.py introspector PROJ_NAME`

Other example commands:
`python3 infra/helper.py introspector --public-corpora PROJ_NAME` : will download the latest public corpus for project PROJ_NAME and use that when collecting coverage
`python3 infra/helper.py introspector --seconds=X PROJ_NAME`: will run the fuzzers for X seconds for corpus collection
`python3 infra/helper.py introspector PROJ_NAME LOCAL_PATH` will do the introspector run using the LOCAL_PATH as source code folder (for testing modifications)

CC @evverx -- please let me know if there are other features you might like.

Ref: https://github.com/ossf/fuzz-introspector/issues/587

Signed-off-by: David Korczynski <david@adalogics.com>