### PR TITLE
[libbpf] add more libbpf contributors

### DIFF
--- a/projects/libbpf/project.yaml
+++ b/projects/libbpf/project.yaml
@@ -12,6 +12,7 @@ auto_ccs:
   - hengqi.chen@gmail.com
   - yulia.kartseva@gmail.com
   - evverx@gmail.com
+  - shunghsiyu@gmail.com
 main_repo: "https://github.com/libbpf/libbpf"
 builds_per_day: 4
 view_restrictions: none


### PR DESCRIPTION
even though libbpf bug reports on Monorail are public and mirrored on GitHub it's necessary to have access to oss-fuzz.com to view full backtraces/statistics and so on.

cc @shunghsiyu