### PR TITLE
tpm2-tss: disable spi lt2go TCTI

### DIFF
--- a/projects/tpm2-tss/build.sh
+++ b/projects/tpm2-tss/build.sh
@@ -31,6 +31,7 @@ export GEN_FUZZ=1
   --disable-tcti-device \
   --disable-tcti-mssim \
   --disable-tcti-swtpm \
+  --disable-tcti-spi-lt2go \
   --disable-doxygen-doc \
   --disable-shared \
   --disable-fapi \


### PR DESCRIPTION
Disable "Lets Trust TPM2Go" TCTI for fuzz testing as the only TCTI

Signed-off-by: William Roberts <william.c.roberts@intel.com>