### PR TITLE
[infra] delete directories with FI reports with rmtree

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -1239,8 +1239,7 @@ def introspector(args):
     return False
 
   introspector_dst = os.path.join(args.project.out, "introspector-report")
-  if os.path.isdir(introspector_dst):
-    os.rmdir(introspector_dst)
+  shutil.rmtree(introspector_dst, ignore_errors=True)
   shutil.copytree(os.path.join(args.project.out, "inspector"), introspector_dst)
 
   # Copy the coverage reports into the introspector report.


### PR DESCRIPTION
Those directories aren't empty usually so `rmdir` fails with
```
INFO:fuzz_introspector.json_report:Finish handling sections that need json output
INFO:__main__:Ending fuzz introspector report generation
INFO:__main__:Ending fuzz introspector post-processing
Traceback (most recent call last):
  File "/home/vagrant/oss-fuzz-2/./infra/helper.py", line 1513, in <module>
    sys.exit(main())
  File "/home/vagrant/oss-fuzz-2/./infra/helper.py", line 192, in main
    result = introspector(args)
  File "/home/vagrant/oss-fuzz-2/./infra/helper.py", line 1243, in introspector
    os.rmdir(introspector_dst)
OSError: [Errno 39] Directory not empty: '/home/vagrant/oss-fuzz-2/build/out/dbus-broker/introspector-report'
```

It should make it possible to run `introspector` a few times in a row when for example fuzz targets are changed locally between subsequent runs.

It's a follow-up to https://github.com/google/oss-fuzz/pull/9243.