### PR TITLE
binutils: fix build

### DIFF
--- a/projects/binutils/Dockerfile
+++ b/projects/binutils/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make texinfo
+RUN apt-get update && apt-get install -y make texinfo libgmp-dev libmpfr-dev
 RUN apt-get install -y flex bison
 RUN git clone --depth=1 https://github.com/DavidKorczynski/binary-samples binary-samples
 RUN git clone --recursive --depth 1 git://sourceware.org/git/binutils-gdb.git binutils-gdb


### PR DESCRIPTION
Fixes the current error:
```
Step #3 - "compile-afl-address-x86_64": checking for the correct version of gmp.h... no
Step #3 - "compile-afl-address-x86_64": configure: error: Building GDB requires GMP 4.2+, and MPFR 3.1.0+.
Step #3 - "compile-afl-address-x86_64": Try the --with-gmp and/or --with-mpfr options to specify
Step #3 - "compile-afl-address-x86_64": their locations.  If you obtained GMP and/or MPFR from a vendor
```