### PR TITLE
Fix the introspector report directory in helper.py

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -1238,7 +1238,8 @@ def introspector(args):
     logging.error('Failed to build project with introspector')
     return False
 
-  introspector_dst = os.path.join(args.project.out, "introspector-report")
+  introspector_dst = os.path.join(args.project.out,
+                                  "introspector-report/inspector")
   shutil.rmtree(introspector_dst, ignore_errors=True)
   shutil.copytree(os.path.join(args.project.out, "inspector"), introspector_dst)
 


### PR DESCRIPTION
The reports are written into `oss-fuzz/build/out/PROJECT/introspector-report/inspector/`