### PR TITLE
fuzztest-raksha: fix build

### DIFF
--- a/projects/fuzztest-raksha/build.sh
+++ b/projects/fuzztest-raksha/build.sh
@@ -14,9 +14,11 @@
 # limitations under the License.
 #
 ################################################################################
+
 # Extend with oss-fuzz settings. To be upsteamed?
 cd $SRC/raksha
 git apply  --ignore-space-change --ignore-whitespace $SRC/raksha-fuzztest.diff
 
 # Compile gfuzztests
+export FUZZTEST_TARGET_FOLDER="//src/..."
 compile_fuzztests.sh

--- a/projects/fuzztest-raksha/raksha-fuzztest.diff
+++ b/projects/fuzztest-raksha/raksha-fuzztest.diff
@@ -2,19 +2,6 @@ diff --git a/WORKSPACE b/WORKSPACE
 index d69494f..ecb2a43 100644
 --- a/WORKSPACE
 +++ b/WORKSPACE
-@@ -5,9 +5,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
- #--------------------
- http_archive(
-     name = "com_google_googletest",
--    sha256 = "5cf189eb6847b4f8fc603a3ffff3b0771c08eec7dd4bd961bfd45477dd13eb73",
--    strip_prefix = "googletest-609281088cfefc76f9d0ce82e1ff6c30cc3591e5",
--    urls = ["https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip"],
-+    sha256 = "81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2",
-+    strip_prefix = "googletest-release-1.12.1",
-+    urls = ["https://github.com/google/googletest/archive/refs/tags/release-1.12.1.tar.gz"],
- )
- 
- # Protobuf:
 @@ -267,12 +267,12 @@ http_archive(
      ],
  )


### PR DESCRIPTION
Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=54490

Related to https://github.com/google/oss-fuzz/issues/9261

Raksha updated googletest to avoid an old version that referenced the outdated platforms dependency.

Raksha still has some references to `@bazel_tools//platforms` e.g. https://github.com/google-research/raksha/blob/3205399ca08af4b69bbd306a664181aca0b56e6e/gcb/rbe/configs/path/config/BUILD#L23 but we can avoid these by limiting the bazel query for targets to the `src` folder using `export FUZZTEST_TARGET_FOLDER="//src/...`

Signed-off-by: David Korczynski <david@adalogics.com>