### PR TITLE
[centipede] Turn off warnings during compilation.

### DIFF
--- a/infra/base-images/base-builder/compile_centipede
+++ b/infra/base-images/base-builder/compile_centipede
@@ -27,7 +27,7 @@ cp "$BIN_DIR/libcentipede_runner.pic.a" "$LIB_FUZZING_ENGINE"
 
 export DFTRACING_FLAGS='-fsanitize-coverage=trace-loads'
 export CENTIPEDE_FLAGS=`cat "$SRC/centipede/clang-flags.txt" | tr '\n' ' '`
-export LIBRARIES_FLAGS="-Wno-error=unused-command-line-argument -ldl -lrt -lpthread $SRC/centipede/weak.o"
+export LIBRARIES_FLAGS="-Wno-unused-command-line-argument -ldl -lrt -lpthread $SRC/centipede/weak.o"
 
 export CFLAGS="$CFLAGS $DFTRACING_FLAGS $CENTIPEDE_FLAGS $LIBRARIES_FLAGS"
 export CXXFLAGS="$CXXFLAGS $DFTRACING_FLAGS $CENTIPEDE_FLAGS $LIBRARIES_FLAGS"


### PR DESCRIPTION
Related: https://github.com/google/oss-fuzz/issues/9299