### PR TITLE
Log base-image part of trial builds to bucket

### DIFF
--- a/infra/build/functions/trial_build/cloudbuild.yaml
+++ b/infra/build/functions/trial_build/cloudbuild.yaml
@@ -14,6 +14,5 @@ steps:
     - 'BRANCH=${_HEAD_BRANCH}'
     - 'REPO=${_HEAD_REPO_URL}'
   timeout: 21600s # 6 hours
-options:
-  logging: CLOUD_LOGGING_ONLY
+logsBucket: gs://oss-fuzz-trialbuild-logs
 timeout: 21600s


### PR DESCRIPTION
We can make this public if we want.
You can observe the logs in real time by clicking on "details" of trial build, getting `$BUILD_ID` and then doing
`gsutil cat gs://oss-fuzz-trialbuild-logs/log-$BUILD_ID.txt`