### PR TITLE
tcmalloc: fix build by setting bazel to 5.4.0

### DIFF
--- a/projects/tcmalloc/build.sh
+++ b/projects/tcmalloc/build.sh
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 ################################################################################
-
+export USE_BAZEL_VERSION=5.4.0
 bazel_build_fuzz_tests


### PR DESCRIPTION
This resolves the current issues caused by
https://github.com/google/oss-fuzz/issues/9261

tcmalloc fails because of rules_fuzzing having issues with the above issues.

Signed-off-by: David Korczynski <david@adalogics.com>