### PR TITLE
cryptsetup: increase builds_per_day

### DIFF
--- a/projects/cryptsetup/project.yaml
+++ b/projects/cryptsetup/project.yaml
@@ -1,5 +1,6 @@
 homepage: "https://gitlab.com/cryptsetup/cryptsetup"
 language: c
+builds_per_day: 2
 primary_contact: "gmazyland@gmail.com"
 auto_ccs:
   - okozina@redhat.com


### PR DESCRIPTION
The builds_per_day set to 2 seems to fit better cryptsetup project metadata.

Signed-off-by: Milan Broz <gmazyland@gmail.com>