### PR TITLE
Fix libgmp download in multiple projects

### DIFF
--- a/projects/bignum-fuzzer/Dockerfile
+++ b/projects/bignum-fuzzer/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y software-properties-common curl sudo mercurial autoconf bison texinfo libboost-all-dev cmake wget
+RUN apt-get update && apt-get install -y software-properties-common curl sudo mercurial autoconf bison texinfo libboost-all-dev cmake wget lzip
 RUN wget https://go.dev/dl/go1.17.5.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.17.5.linux-amd64.tar.gz && ldconfig
 ENV PATH=$PATH:/usr/local/go/bin
 
@@ -32,5 +32,7 @@ RUN wget https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.5.1.ta
 RUN git clone --depth 1 https://github.com/guidovranken/bignum-fuzzer
 RUN git clone --depth 1 https://github.com/openssl/openssl
 RUN git clone https://boringssl.googlesource.com/boringssl
-RUN hg clone https://gmplib.org/repo/gmp/ libgmp/
+#RUN hg clone https://gmplib.org/repo/gmp/ libgmp/
+RUN wget --no-check-certificate https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz
+RUN test "$(sha256sum gmp-6.2.1.tar.lz)" = "2c7f4f0d370801b2849c48c9ef3f59553b5f1d3791d070cffb04599f9fc67b41  gmp-6.2.1.tar.lz"
 COPY build.sh $SRC/

--- a/projects/bignum-fuzzer/build.sh
+++ b/projects/bignum-fuzzer/build.sh
@@ -15,6 +15,10 @@
 #
 ################################################################################
 
+cd $SRC/
+tar --lzip -xvf gmp-6.2.1.tar.lz
+mv $SRC/gmp-6.2.1/ $SRC/libgmp/
+
 # Install Rust nightly
 #curl https://sh.rustup.rs -sSf | sh -s -- -y
 #source $HOME/.cargo/env

--- a/projects/bls-signatures/Dockerfile
+++ b/projects/bls-signatures/Dockerfile
@@ -22,7 +22,8 @@ RUN git clone --depth 1 https://github.com/Chia-Network/bls-signatures.git
 RUN git clone --depth 1 https://github.com/herumi/mcl.git
 RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
-RUN wget https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz
+RUN wget --no-check-certificate https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz
+RUN test "$(sha256sum gmp-6.2.1.tar.lz)" = "2c7f4f0d370801b2849c48c9ef3f59553b5f1d3791d070cffb04599f9fc67b41  gmp-6.2.1.tar.lz"
 RUN wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable.tar.gz
 COPY build.sh $SRC/
 # This is to fix Fuzz Introspector build by using LLVM old pass manager

--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -21,7 +21,7 @@ ENV PATH $PATH:/root/.go/bin:$GOPATH/bin
 RUN install_go.sh
 
 RUN apt-get update && \
-    apt-get install -y software-properties-common wget make autoconf automake libtool build-essential cmake mercurial gyp ninja-build zlib1g-dev libsqlite3-dev bison flex texinfo
+    apt-get install -y software-properties-common wget make autoconf automake libtool build-essential cmake mercurial gyp ninja-build zlib1g-dev libsqlite3-dev bison flex texinfo lzip
 
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora
@@ -40,7 +40,9 @@ RUN hg clone https://hg.mozilla.org/projects/nss
 RUN git clone --depth 1 https://github.com/jedisct1/libsodium.git
 RUN git clone --depth 1 https://github.com/libtom/libtomcrypt.git
 RUN git clone --depth 1 https://github.com/microsoft/SymCrypt.git
-RUN hg clone https://gmplib.org/repo/gmp/ libgmp/
+#RUN hg clone https://gmplib.org/repo/gmp/ libgmp/
+RUN wget --no-check-certificate https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz
+RUN test "$(sha256sum gmp-6.2.1.tar.lz)" = "2c7f4f0d370801b2849c48c9ef3f59553b5f1d3791d070cffb04599f9fc67b41  gmp-6.2.1.tar.lz"
 RUN wget https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.5.1.tar.gz
 RUN git clone --depth 1 https://github.com/indutny/bn.js.git
 RUN git clone --depth 1 https://github.com/MikeMcl/bignumber.js.git

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -19,6 +19,7 @@ cd $SRC/
 tar --lzip -xvf gmp-6.2.1.tar.lz
 mv $SRC/gmp-6.2.1/ $SRC/libgmp/
 
+
 # TODO(metzman): Switch this to LIB_FUZZING_ENGINE when it works.
 # https://github.com/google/oss-fuzz/issues/2336
 

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -15,6 +15,10 @@
 #
 ################################################################################
 
+cd $SRC/
+tar --lzip -xvf gmp-6.2.1.tar.lz
+mv $SRC/gmp-6.2.1/ $SRC/libgmp/
+
 # TODO(metzman): Switch this to LIB_FUZZING_ENGINE when it works.
 # https://github.com/google/oss-fuzz/issues/2336
 

--- a/projects/libecc/Dockerfile
+++ b/projects/libecc/Dockerfile
@@ -22,7 +22,8 @@ RUN git clone https://github.com/ANSSI-FR/libecc.git
 RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone https://github.com/wolfssl/wolfssl
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
-RUN wget https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz
+RUN wget --no-check-certificate https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz
+RUN test "$(sha256sum gmp-6.2.1.tar.lz)" = "2c7f4f0d370801b2849c48c9ef3f59553b5f1d3791d070cffb04599f9fc67b41  gmp-6.2.1.tar.lz"
 RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 COPY build.sh $SRC/
 # This is to fix Fuzz Introspector build by using LLVM old pass manager

--- a/projects/libressl/Dockerfile
+++ b/projects/libressl/Dockerfile
@@ -24,7 +24,8 @@ RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora
 RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 RUN git clone --depth 1 https://github.com/randombit/botan.git
-RUN wget https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz
+RUN wget --no-check-certificate https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz
+RUN test "$(sha256sum gmp-6.2.1.tar.lz)" = "2c7f4f0d370801b2849c48c9ef3f59553b5f1d3791d070cffb04599f9fc67b41  gmp-6.2.1.tar.lz"
 WORKDIR libressl
 RUN ./update.sh
 COPY build.sh *.options $SRC/

--- a/projects/nettle/Dockerfile
+++ b/projects/nettle/Dockerfile
@@ -23,7 +23,8 @@ RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora
 RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
-RUN wget https://gmplib.org/download/gmp/gmp-6.2.0.tar.lz
+RUN wget --no-check-certificate https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz
+RUN test "$(sha256sum gmp-6.2.1.tar.lz)" = "2c7f4f0d370801b2849c48c9ef3f59553b5f1d3791d070cffb04599f9fc67b41  gmp-6.2.1.tar.lz"
 COPY build.sh $SRC/
 # This is to fix Fuzz Introspector build by using LLVM old pass manager
 # re https://github.com/ossf/fuzz-introspector/issues/305

--- a/projects/nettle/build.sh
+++ b/projects/nettle/build.sh
@@ -37,10 +37,10 @@ if [[ $CFLAGS != *sanitize=memory* ]]
 then
     # Compile libgmp
         cd $SRC/
-        lzip -d gmp-6.2.0.tar.lz
-        tar xf gmp-6.2.0.tar
+        lzip -d gmp-6.2.1.tar.lz
+        tar xf gmp-6.2.1.tar
 
-        cd gmp-6.2.0/
+        cd gmp-6.2.1/
         autoreconf -ivf
         if [[ $CFLAGS != *-m32* ]]
         then


### PR DESCRIPTION
The certificate of https://gmplib.org/ has expired. The website displays the following message:

```
YES, THE CERTIFICATE IS EXPIRED. Sorry about that. We're working on the renewal process. Unfortunately, our SSL provider changes the renewal interface each year, and it is always a challenge to figure out what to do. Now the only actions are REGENERATE (actiually not, as the cert is expired), REVOKE (well, not desirable) and INTERMEDIATE CERTIFICATE (which is not an action but a thing, oh well.
```

But this is breaking a lot of builds and this still hasn't been fixed after a few days, so with this PR I'm instead downloading the libgmp source archive and bypass the certificate check and manually verify the sha256 hash of the downloaded file.

Only the `cryptofuzz` and `bignum-fuzzer` projects ideally need to use the latest repository checkout, instead of a versioned source archive, because with these projects the aim is to find bugs in libgmp. In all other projects, libgmp only serves as an oracle, and using the latest stable version is fine.

Once gmp fixes their certificate, I will revert `cryptofuzz` and `bignum-fuzzer` to use the repository again. For now it's ok to use the latest stable version.