### PR TITLE
Keep libclang in Docker images

### DIFF
--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -201,7 +201,6 @@ function free_disk_space {
     # libraries.
     # Note: we need fuzzer_no_main libraries for atheris. Don't delete.
     rm -rf \
-      /usr/local/lib/libclang* \
       /usr/local/lib/liblld* \
       /usr/local/lib/cmake/
 }


### PR DESCRIPTION
Allows to easily fuzz Rust projects that rely on the bindgen crate that itself depends on libclang: https://crates.io/crates/bindgen