### PR TITLE
[centipede] Use /tmp for a workdir.

### DIFF
--- a/infra/base-images/base-runner/bad_build_check
+++ b/infra/base-images/base-runner/bad_build_check
@@ -122,6 +122,8 @@ function check_engine {
     # binaries if they are from trial build and production build.
     # TODO(Dongge): Support run test with sanitized binaries for trial and
     # production build.
+    CENTIPEDE_WORKDIR=/tmp/centipede-workdir
+    mkdir -p $CENTIPEDE_WORKDIR
     SKIP_SEED_CORPUS=1 timeout --preserve-status -s INT 20s run_fuzzer $FUZZER_NAME &>$FUZZER_OUTPUT
     CHECK_PASSED=$(egrep "\[0] begin-fuzz: ft: 0 cov: 0" -c $FUZZER_OUTPUT)
     if (( $CHECK_PASSED == 0 )); then

--- a/infra/base-images/base-runner/run_fuzzer
+++ b/infra/base-images/base-runner/run_fuzzer
@@ -173,7 +173,7 @@ elif [[ "$FUZZING_ENGINE" = honggfuzz ]]; then
 elif [[ "$FUZZING_ENGINE" = centipede ]]; then
 
   # Create the work and corpus directory for Centipede.
-  CENTIPEDE_WORKDIR="${CENTIPEDE_WORKDIR:$OUT}"
+  CENTIPEDE_WORKDIR="${CENTIPEDE_WORKDIR:-$OUT}"
 
   # Centipede only saves crashes to crashes/ in workdir.
   rm -rf $FUZZER_OUT

--- a/infra/base-images/base-runner/run_fuzzer
+++ b/infra/base-images/base-runner/run_fuzzer
@@ -173,7 +173,7 @@ elif [[ "$FUZZING_ENGINE" = honggfuzz ]]; then
 elif [[ "$FUZZING_ENGINE" = centipede ]]; then
 
   # Create the work and corpus directory for Centipede.
-  mkdir -p "/tmp/centipede-workdir"
+  CENTIPEDE_WORKDIR="${CENTIPEDE_WORKDIR:$OUT}"
 
   # Centipede only saves crashes to crashes/ in workdir.
   rm -rf $FUZZER_OUT
@@ -190,7 +190,7 @@ elif [[ "$FUZZING_ENGINE" = centipede ]]; then
   # --address_space_limit_mb=0: No address space limit.
   # --binary: The target binary under test without sanitizer.
   # --extra_binary: The target binaries under test with sanitizers.
-  CMD_LINE="$OUT/centipede --workdir=/tmp/centipede-workdir --corpus_dir=\"$CORPUS_DIR\" --fork_server=1 --exit_on_crash=1 --timeout=1200 --rss_limit_mb=4096 --address_space_limit_mb=5120 $(get_dictionary) --binary=\"$OUT/${FUZZER}\" $(get_extra_binaries) $*"
+  CMD_LINE="$OUT/centipede --workdir=$CENTIPEDE_WORKDIR --corpus_dir=\"$CORPUS_DIR\" --fork_server=1 --exit_on_crash=1 --timeout=1200 --rss_limit_mb=4096 --address_space_limit_mb=5120 $(get_dictionary) --binary=\"$OUT/${FUZZER}\" $(get_extra_binaries) $*"
 else
 
   CMD_LINE="$OUT/$FUZZER $FUZZER_ARGS $*"

--- a/infra/base-images/base-runner/run_fuzzer
+++ b/infra/base-images/base-runner/run_fuzzer
@@ -190,7 +190,7 @@ elif [[ "$FUZZING_ENGINE" = centipede ]]; then
   # --address_space_limit_mb=0: No address space limit.
   # --binary: The target binary under test without sanitizer.
   # --extra_binary: The target binaries under test with sanitizers.
-  CMD_LINE="$OUT/centipede --workdir=\"$OUT/workdir\" --corpus_dir=\"$CORPUS_DIR\" --fork_server=1 --exit_on_crash=1 --timeout=1200 --rss_limit_mb=4096 --address_space_limit_mb=5120 $(get_dictionary) --binary=\"$OUT/${FUZZER}\" $(get_extra_binaries) $*"
+  CMD_LINE="$OUT/centipede --workdir=/tmp/centipede-workdir --corpus_dir=\"$CORPUS_DIR\" --fork_server=1 --exit_on_crash=1 --timeout=1200 --rss_limit_mb=4096 --address_space_limit_mb=5120 $(get_dictionary) --binary=\"$OUT/${FUZZER}\" $(get_extra_binaries) $*"
 else
 
   CMD_LINE="$OUT/$FUZZER $FUZZER_ARGS $*"

--- a/infra/base-images/base-runner/run_fuzzer
+++ b/infra/base-images/base-runner/run_fuzzer
@@ -173,7 +173,7 @@ elif [[ "$FUZZING_ENGINE" = honggfuzz ]]; then
 elif [[ "$FUZZING_ENGINE" = centipede ]]; then
 
   # Create the work and corpus directory for Centipede.
-  mkdir -p "$OUT/workdir"
+  mkdir -p "/tmp/centipede-workdir"
 
   # Centipede only saves crashes to crashes/ in workdir.
   rm -rf $FUZZER_OUT


### PR DESCRIPTION
$OUT gets zipped up and included as part of the build.

Fixes #9345