### PR TITLE
[cryptofuzz, bignum-fuzzer] Use libgmp repo again

### DIFF
--- a/projects/bignum-fuzzer/Dockerfile
+++ b/projects/bignum-fuzzer/Dockerfile
@@ -32,7 +32,5 @@ RUN wget https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.5.1.ta
 RUN git clone --depth 1 https://github.com/guidovranken/bignum-fuzzer
 RUN git clone --depth 1 https://github.com/openssl/openssl
 RUN git clone https://boringssl.googlesource.com/boringssl
-#RUN hg clone https://gmplib.org/repo/gmp/ libgmp/
-RUN wget --no-check-certificate https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz
-RUN test "$(sha256sum gmp-6.2.1.tar.lz)" = "2c7f4f0d370801b2849c48c9ef3f59553b5f1d3791d070cffb04599f9fc67b41  gmp-6.2.1.tar.lz"
+RUN hg clone https://gmplib.org/repo/gmp/ libgmp/
 COPY build.sh $SRC/

--- a/projects/bignum-fuzzer/build.sh
+++ b/projects/bignum-fuzzer/build.sh
@@ -15,10 +15,6 @@
 #
 ################################################################################
 
-cd $SRC/
-tar --lzip -xvf gmp-6.2.1.tar.lz
-mv $SRC/gmp-6.2.1/ $SRC/libgmp/
-
 # Install Rust nightly
 #curl https://sh.rustup.rs -sSf | sh -s -- -y
 #source $HOME/.cargo/env

--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -40,9 +40,7 @@ RUN hg clone https://hg.mozilla.org/projects/nss
 RUN git clone --depth 1 https://github.com/jedisct1/libsodium.git
 RUN git clone --depth 1 https://github.com/libtom/libtomcrypt.git
 RUN git clone --depth 1 https://github.com/microsoft/SymCrypt.git
-#RUN hg clone https://gmplib.org/repo/gmp/ libgmp/
-RUN wget --no-check-certificate https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz
-RUN test "$(sha256sum gmp-6.2.1.tar.lz)" = "2c7f4f0d370801b2849c48c9ef3f59553b5f1d3791d070cffb04599f9fc67b41  gmp-6.2.1.tar.lz"
+RUN hg clone https://gmplib.org/repo/gmp/ libgmp/
 RUN wget https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.5.1.tar.gz
 RUN git clone --depth 1 https://github.com/indutny/bn.js.git
 RUN git clone --depth 1 https://github.com/MikeMcl/bignumber.js.git

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -15,11 +15,6 @@
 #
 ################################################################################
 
-cd $SRC/
-tar --lzip -xvf gmp-6.2.1.tar.lz
-mv $SRC/gmp-6.2.1/ $SRC/libgmp/
-
-
 # TODO(metzman): Switch this to LIB_FUZZING_ENGINE when it works.
 # https://github.com/google/oss-fuzz/issues/2336
 


### PR DESCRIPTION
I recently configured several projects to use a stable source archive of libgmp, instead of cloning from the repository, because the certificate gmplib.org had expired: https://github.com/google/oss-fuzz/pull/9314

gmplib.org have fixed their certificate so with this PR I'm cloning from the repo again.