### PR TITLE
quic-go: fix build because the qpack repo was moved

### DIFF
--- a/projects/quic-go/Dockerfile
+++ b/projects/quic-go/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
 
-RUN git clone --depth 1 https://github.com/marten-seemann/qpack/ && \
+RUN git clone --depth 1 https://github.com/quic-go/qpack/ && \
   cd qpack && \
   go build
 

--- a/projects/quic-go/build.sh
+++ b/projects/quic-go/build.sh
@@ -20,7 +20,7 @@ set -ex
 (
 cd qpack
 # Fuzz qpack
-compile_go_fuzzer github.com/marten-seemann/qpack/fuzzing Fuzz qpack_fuzzer
+compile_go_fuzzer github.com/quic-go/qpack/fuzzing Fuzz qpack_fuzzer
 )
 
 (


### PR DESCRIPTION
The `qpack` repo was moved to https://github.com/quic-go/qpack