### PR TITLE
Call bfd_init on each test file

### DIFF
--- a/projects/binutils/fuzz_bfd.c
+++ b/projects/binutils/fuzz_bfd.c
@@ -35,18 +35,14 @@ static int bufferToFile(char * name, const uint8_t *Data, size_t Size) {
     return 0;
 }
 
-static int initialized = 0;
 //TODO? part of fuzzing
 char *target = NULL;
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     char tmpfilename[32];
-    if (initialized == 0) {
-        if (bfd_init () != BFD_INIT_MAGIC) {
-            abort();
-        }
-        initialized = 1;
-    }
+
+    if (bfd_init() != BFD_INIT_MAGIC)
+      abort();
 
     strncpy(tmpfilename, "/tmp/fuzz.bfd-XXXXXX", 31);
     if (bufferToFile(tmpfilename, Data, Size) < 0) {

--- a/projects/binutils/fuzz_bfd_ext.c
+++ b/projects/binutils/fuzz_bfd_ext.c
@@ -41,16 +41,12 @@ static int bufferToFile(char *name, const uint8_t *Data, size_t Size) {
   return 0;
 }
 
-static int initialized = 0;
-
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
   char tmpfilename[32];
-  if (initialized == 0) {
-    if (bfd_init() != BFD_INIT_MAGIC) {
-      abort();
-    }
-    initialized = 1;
-  }
+
+  if (bfd_init() != BFD_INIT_MAGIC)
+    abort();
+
   /*
       char **names = bfd_target_list();
       while (*names != NULL) {

--- a/projects/binutils/fuzz_objcopy.c
+++ b/projects/binutils/fuzz_objcopy.c
@@ -19,8 +19,6 @@ limitations under the License.
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
 
-static int initialized = 0;
-
 void
 init_objcopy_global_state() {
   // status is a global variable that is set to 0 initially,
@@ -106,18 +104,15 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
   program_name = filename;
 
-  if (initialized == 0) {
-    if (bfd_init () != BFD_INIT_MAGIC) {
-      abort();
-    }
-    set_default_bfd_target();
-    initialized = 1;
-  }
+  if (bfd_init() != BFD_INIT_MAGIC)
+    abort();
+
+  set_default_bfd_target();
 
   init_objcopy_global_state();
 
   char *fakeArgv[12];
-  fakeArgv[0] = "fuzz_objdump";
+  fakeArgv[0] = "fuzz_objcopy";
   fakeArgv[1] = "-S";
   fakeArgv[2] = "--decompress-debug-sections";
   fakeArgv[3] = "--extract-dwo";


### PR DESCRIPTION
bfd_init doesn't do much at the moment, but I'm planning on changing it to re-initialise static state, with the aim of getting rid of some of the flaky crashes reported by oss-fuzz.