### PR TITLE
adjust test code to better fit into HtmlUnit

### DIFF
--- a/projects/htmlunit/htmlunit-fuzzer/src/main/java/ossfuzz/HtmlParserFuzzer.java
+++ b/projects/htmlunit/htmlunit-fuzzer/src/main/java/ossfuzz/HtmlParserFuzzer.java
@@ -32,9 +32,7 @@ public class HtmlParserFuzzer {
 	private FuzzedDataProvider fuzzedDataProvider;
 
 	public HtmlParserFuzzer(FuzzedDataProvider fuzzedDataProvider) {
-
 		this.fuzzedDataProvider = fuzzedDataProvider;
-
 	}
 
 	BrowserVersion getBrowserVersion() {
@@ -42,33 +40,26 @@ public class HtmlParserFuzzer {
 		 * from src/test/java/com/gargoylesoftware/htmlunit/WebTestCase.java
 		 */
 		return new BrowserVersion.BrowserVersionBuilder(BrowserVersion.BEST_SUPPORTED)
-                    .setApplicationName("FLAG_ALL_BROWSERS")
-                    .build();
+					.setApplicationName("FLAG_ALL_BROWSERS")
+					.build();
 	}
 
 	void test() {
-		try {
-			WebClient webClient = new WebClient(getBrowserVersion());
-			WebResponse webResponse = new StringWebResponse(fuzzedDataProvider.consumeRemainingAsString(), new URL("http://localhost.edu/index.html"));
-			HtmlPage page = new HtmlPage(webResponse, webClient.getCurrentWindow());
-        
+		try (WebClient webClient = new WebClient(getBrowserVersion())) {
 			/*
 			 * net.sourceforge.htmlunit.corejs.javascript.EvaluatorException
 			 * seems to be fatal
 			 */
 			webClient.getOptions().setThrowExceptionOnScriptError(false);
 
-			webClient.getCurrentWindow().setEnclosedPage(page);
-			webClient.getPageCreator().getHtmlParser().parse(webResponse, page, false, false);
+			webClient.loadHtmlCodeIntoCurrentWindow(fuzzedDataProvider.consumeRemainingAsString());
 		} catch (IllegalArgumentException e) {
-		} catch (MalformedURLException e) {
 		} catch (IOException e) {
 		}
 
 	}
 
 	public static void fuzzerTestOneInput(FuzzedDataProvider fuzzedDataProvider) {
-
 		HtmlParserFuzzer testFixture = new HtmlParserFuzzer(fuzzedDataProvider);
 		testFixture.test();
 	}


### PR DESCRIPTION
some code cleanup
* webClient.loadHtmlCodeIntoCurrentWindow() is a convenience method doing the same as the current code
* close the webClient after the test
* MalformedURLException is a IOException - no need to handle separately