### PR TITLE
etcd: clone the raft repo when building etcd

### DIFF
--- a/projects/etcd/Dockerfile
+++ b/projects/etcd/Dockerfile
@@ -16,6 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN git clone --depth 1 https://github.com/etcd-io/etcd
+RUN git clone --depth 1 https://github.com/etcd-io/raft
 RUN git clone --depth 1 https://github.com/cncf/cncf-fuzzing
 COPY build.sh $SRC/
 WORKDIR $SRC/etcd


### PR DESCRIPTION
The `raft` package was moved into a dedicated repo https://github.com/etcd-io/raft

This PR is currently a draft because we should wait until the corresponding fix is merged in `cncf-fuzzing` (https://github.com/cncf/cncf-fuzzing/pull/271)