### PR TITLE
dgraph: fix build

### DIFF
--- a/projects/dgraph/build.sh
+++ b/projects/dgraph/build.sh
@@ -15,4 +15,4 @@
 #
 ################################################################################
 
-compile_go_fuzzer github.com/dgraph-io/dgraph/gql Fuzz parser_fuzzer
+compile_go_fuzzer github.com/dgraph-io/dgraph/dql Fuzz parser_fuzzer


### PR DESCRIPTION
The `gql` package was renamed to `dql`
https://github.com/dgraph-io/dgraph/commit/186c9c23c46d4e4da3c30d4f2eb5820dc8c19985