### PR TITLE
Fix gitea's native fuzzers

### DIFF
--- a/projects/gitea/build.sh
+++ b/projects/gitea/build.sh
@@ -15,11 +15,6 @@
 #
 ################################################################################
 
-# external_renderer.go belongs to the main package and is located in the same directory
-# as the fuzz tests which belong to the fuzz package. This causes a build failure and
-# no fuzzers can be built.
-rm -f $SRC/gitea/tools/external_renderer.go
-
 go get github.com/AdamKorcz/go-118-fuzz-build/testing
 compile_native_go_fuzzer code.gitea.io/gitea/tests/fuzz FuzzMarkdownRenderRaw fuzz_markdown_render_raw gofuzz
 compile_native_go_fuzzer code.gitea.io/gitea/tests/fuzz FuzzMarkupPostProcess fuzz_markup_post_process gofuzz

--- a/projects/gitea/build.sh
+++ b/projects/gitea/build.sh
@@ -20,5 +20,6 @@
 # no fuzzers can be built.
 rm -f $SRC/gitea/tools/external_renderer.go
 
-compile_go_fuzzer code.gitea.io/gitea/tools FuzzMarkdownRenderRaw fuzz_markdown_render_raw gofuzz
-compile_go_fuzzer code.gitea.io/gitea/tools FuzzMarkupPostProcess fuzz_markup_post_process gofuzz
+go get github.com/AdamKorcz/go-118-fuzz-build/testing
+compile_native_go_fuzzer code.gitea.io/gitea/tests/fuzz FuzzMarkdownRenderRaw fuzz_markdown_render_raw gofuzz
+compile_native_go_fuzzer code.gitea.io/gitea/tests/fuzz FuzzMarkupPostProcess fuzz_markup_post_process gofuzz


### PR DESCRIPTION
gitea's fuzz targets now use Go native fuzzing, and they were moved into a dedicated `fuzz` package (https://github.com/go-gitea/gitea/pull/22376).