### PR TITLE
Add Kazuyoshi Kato on containerd

### DIFF
--- a/projects/containerd/project.yaml
+++ b/projects/containerd/project.yaml
@@ -8,6 +8,7 @@ auto_ccs :
   - "estesp@gmail.com"
   - "mikebrow@gmail.com"
   - "cjingram@google.com"
+  - "kato.kazuyoshi@gmail.com"
 language: go
 fuzzing_engines:
   - libfuzzer


### PR DESCRIPTION
Kazuyoshi Kato is a containerd maintainer and has been working with @AdamKorcz to port fuzzers from cncf-fuzzing to containerd itself.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>