### PR TITLE
Fix exception in bisector.py

### DIFF
--- a/infra/bisector.py
+++ b/infra/bisector.py
@@ -137,7 +137,8 @@ def _get_dedup_token(output):
 def _check_for_crash(project_name, fuzz_target, testcase_path):
   """Check for crash."""
 
-  def docker_run(args):
+  def docker_run(args, **kwargs):
+    del kwargs
     command = ['docker', 'run', '--rm', '--privileged']
     if sys.stdin.isatty():
       command.append('-i')


### PR DESCRIPTION
The `run_function` is passed an `architecture` keyword argument:
https://github.com/google/oss-fuzz/blob/a8cb9370f0dddf33111b1a7ce6d715633d5400df/infra/helper.py#L1357

This makes the `run_function` passed in the bisector ignore all keyword arguments. 

Related: https://github.com/google/osv.dev/issues/963