### PR TITLE
infra: bump introspector

### DIFF
--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y wget sudo && \
 RUN apt-get update && apt-get install -y git && \
     git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
     cd fuzz-introspector && \
-    git checkout 9794553953de288e24795b39aabead57bf22c0d7 && \
+    git checkout eadd010275989e3ca019899039a39230336801d9 && \
     git submodule init && \
     git submodule update && \
     apt-get autoremove --purge -y git && \

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -129,7 +129,7 @@ cp -rf /fuzz-introspector/frontends/llvm/lib/Transforms/FuzzIntrospector ./llvm/
 
 # LLVM currently does not support dynamically loading LTO passes. Thus, we
 # hardcode it into Clang instead. Ref: https://reviews.llvm.org/D77704
-/fuzz-introspector/sed_cmds.sh
+/fuzz-introspector/frontends/llvm/patch-llvm.sh
 cd $OLD_WORKING_DIR
 
 mkdir -p $WORK/llvm-stage2 $WORK/llvm-stage1


### PR DESCRIPTION
The main changes are:
- improvements to code injection sink analyser
- output of data about all functions into summary.json. This is useful for e.g. comparing reports and making historical analysis.

Signed-off-by: David Korczynski <david@adalogics.com>