### PR TITLE
tensorflow: limit CPUs used for fuzztest fuzzers

### DIFF
--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -91,6 +91,8 @@ then
     echo " --per_file_copt=^.*external.*\.cc\$@-fsanitize-coverage=0,-fno-sanitize=all"
   )"
   export FUZZTEST_EXTRA_ARGS="${FUZZTEST_EXTRA_ARGS} ${DI}"
+else
+  export FUZZTEST_EXTRA_ARGS="${FUZZTEST_EXTRA_ARGS} --local_ram_resources=HOST_RAM*1.0 --local_cpu_resources=HOST_CPUS*.5 --strip=never"
 fi
 
 compile_fuzztests.sh


### PR DESCRIPTION
Reduce the mount of CPUs for building Fuzztest fuzzers as this is causing the build to exhaust resources: https://oss-fuzz-build-logs.storage.googleapis.com/log-1f5769dc-3170-4205-bcda-17cd48c52985.txt

```
...
/src/tensorflow/tensorflow/core/kernels/BUILD:1038:18: Compiling tensorflow/core/kernels/pad_op.cc failed: (Killed): clang-15 failed: error executing command 
Step #12 - "compile-libfuzzer-undefined-x86_64":   (cd /root/.cache/bazel/_bazel_root/1c025c2968c1aa16bac5eca67aaf21d1/sandbox/linux-sandbox/3063/execroot/org_tensorflow && \
```