### PR TITLE
tensorflow-py: fix build

### DIFF
--- a/projects/tensorflow-py/Dockerfile
+++ b/projects/tensorflow-py/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install --upgrade pip chardet
 
 # Due to Bazel bug, need to symlink python3 to python
 # See https://github.com/bazelbuild/bazel/issues/8665

--- a/projects/tensorflow-py/build.sh
+++ b/projects/tensorflow-py/build.sh
@@ -32,7 +32,7 @@ for fuzzer in $(find $SRC -name '*_fuzz.py'); do
   fuzzer_basename=$(basename -s .py $fuzzer)
   fuzzer_package=${fuzzer_basename}.pkg
 
-  pyinstaller --distpath $OUT --onefile --name $fuzzer_package $fuzzer
+  pyinstaller --distpath $OUT --onefile --name $fuzzer_package $fuzzer --hidden-import=chardet
 
   echo "#!/bin/sh
 # LLVMFuzzerTestOneInput for fuzzer detection.


### PR DESCRIPTION
Fixes the current build issue (https://oss-fuzz-build-logs.storage.googleapis.com/log-455d862d-6130-4650-85d5-2caf99b45a9e.txt):
```
Step #4 - "build-check-libfuzzer-address-x86_64":   File "charset_normalizer/api.py", line 5, in <module>
Step #4 - "build-check-libfuzzer-address-x86_64":   File "PyInstaller/loader/pyimod03_importers.py", line 495, in exec_module
Step #4 - "build-check-libfuzzer-address-x86_64":   File "charset_normalizer/cd.py", line 9, in <module>
Step #4 - "build-check-libfuzzer-address-x86_64": ModuleNotFoundError: No module named 'charset_normalizer.md__mypyc'
```

Signed-off-by: David Korczynski <david@adalogics.com>