### PR TITLE
tensorflow: specify explicit fuzztest to build

### DIFF
--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -63,7 +63,7 @@ fi
 sed -i -e 's/linkstatic/linkopts = \["-fsanitize=fuzzer"\],\nlinkstatic/' tensorflow/security/fuzzing/tf_fuzzing.bzl
 
 # Compile fuzztest fuzzers
-export FUZZTEST_TARGET_FOLDER="//tensorflow/security/fuzzing/..."
+export FUZZTEST_TARGET_FOLDER="//tensorflow/security/fuzzing/cc:status_fuzz"
 export FUZZTEST_EXTRA_ARGS="--spawn_strategy=sandboxed --action_env=ASAN_OPTIONS=detect_leaks=0,detect_odr_violation=0 --define force_libcpp=enabled --verbose_failures --copt=-UNDEBUG --config=monolithic"
 if [ -n "${OSS_FUZZ_CI-}" ]
 then


### PR DESCRIPTION
Build only status_fuzz fuzztest for now in addition to all the non-fuzztest fuzzers. The build will be extended to new fuzztest fuzzers once the overall build starts passing again.

Recent commits on Tensorflow made the build not work  e.g. https://github.com/tensorflow/tensorflow/commit/77e348099872c2065c39267f4d309c54aed661a4 and the reason is we need proper diffing in place (e.g. remove `no_oss` in the BUILD tag).  These should be included in the build, but will handle that after the current build starts working agains.

Signed-off-by: David Korczynski <david@adalogics.com>