### PR TITLE
[fast-dds] Fix asio version to 1-18-1

### DIFF
--- a/projects/fast-dds/Dockerfile
+++ b/projects/fast-dds/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt install -y autoconf automake pkg-config
 RUN git clone --depth 1 https://github.com/leethomason/tinyxml2
-RUN git clone --depth 1 https://github.com/chriskohlhoff/asio/
+RUN git clone --depth 1 --branch asio-1-18-1 https://github.com/chriskohlhoff/asio/
 RUN git clone --depth 1 https://github.com/eProsima/Fast-CDR.git
 RUN git clone --depth 1 https://github.com/eProsima/foonathan_memory_vendor.git
 RUN git clone --depth 1 https://github.com/eProsima/Fast-DDS.git


### PR DESCRIPTION
Should fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=53025 by fixing the asio version to the one used on Fast DDS as submodule. We could probably revert this after https://github.com/chriskohlhoff/asio/issues/1188 is solved.