### PR TITLE
rustls: update build script to avoid hardcoding fuzzer names

### DIFF
--- a/projects/rustls/build.sh
+++ b/projects/rustls/build.sh
@@ -25,11 +25,13 @@ fi
 
 cd $SRC/rustls
 cargo fuzz build -O
-cp fuzz/target/x86_64-unknown-linux-gnu/release/client $OUT/
-cp fuzz/target/x86_64-unknown-linux-gnu/release/deframer $OUT/
-cp fuzz/target/x86_64-unknown-linux-gnu/release/fragment $OUT/
-cp fuzz/target/x86_64-unknown-linux-gnu/release/hsjoiner $OUT/
-cp fuzz/target/x86_64-unknown-linux-gnu/release/message $OUT/
+find fuzz/target/x86_64-unknown-linux-gnu/release \
+    -type f \
+    -perm +0111 \
+    -maxdepth 1 \
+    -print0 \
+    | xargs -0 -I {} cp {} $OUT/
+
 if [ "$SANITIZER" != "coverage" ]
 then
     cp fuzz/target/x86_64-unknown-linux-gnu/release/server $OUT/


### PR DESCRIPTION
I am removing one of the existing fuzzers in https://github.com/rustls/rustls/pull/1171 (which should be subsumed by one of the existing ones). However, the fuzzing CI job that we run is currently failing because the build script hard codes the fuzzer names. Make an attempt at copying whatever the fuzzer builds instead.

I am not very experienced at shell stuff, but in some local testing this seems to do the job.

cc @ctz