### PR TITLE
imageio: fix coverage build

### DIFF
--- a/projects/imageio/build.sh
+++ b/projects/imageio/build.sh
@@ -19,15 +19,5 @@ python3 setup.py build install
 
 # Build fuzzers in $OUT.
 for fuzzer in $(find . -name 'fuzz_*.py'); do
-  fuzzer_basename=$(basename -s .py $fuzzer)
-  fuzzer_package=${fuzzer_basename}.pkg
-  pyinstaller --distpath $OUT --onefile --name $fuzzer_package $fuzzer
-
-  # Create execution wrapper.
-  echo "#!/bin/sh
-# LLVMFuzzerTestOneInput for fuzzer detection.
-this_dir=\$(dirname \"\$0\")
-ASAN_OPTIONS=\$ASAN_OPTIONS:symbolize=1:external_symbolizer_path=\$this_dir/llvm-symbolizer:detect_leaks=0 \
-\$this_dir/$fuzzer_package \$@" > $OUT/$fuzzer_basename
-  chmod +x $OUT/$fuzzer_basename
+  compile_python_fuzzer $fuzzer
 done


### PR DESCRIPTION
In order for code coverage to work we need to use `compile_python_fuzzer` when building the fuzzers

Fixes: https://github.com/google/oss-fuzz/issues/9442