### PR TITLE
libarchive: handle erroneous archives

### DIFF
--- a/projects/libarchive/libarchive_fuzzer.cc
+++ b/projects/libarchive/libarchive_fuzzer.cc
@@ -33,7 +33,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len) {
     return 0;
   }
 
-  archive_read_open_memory(a, buf, len);
+  if (ARCHIVE_OK != archive_read_open_memory(a, buf, len)) {
+    archive_read_free(a);
+    return 0;
+  }
+
   archive_read_add_passphrase(a, "secret");
 
   while(1) {


### PR DESCRIPTION
Some more codepaths were added to the fuzzer in
https://github.com/google/oss-fuzz/pull/9003 However, these paths are only valid to call in the event `archive_read_open_memory` returns `ARCHIVE_OK` -- the fuzzer is currently blocked due to this and is why the coverage decreased between 17th Nov to 19th Nov (https://storage.googleapis.com/oss-fuzz-coverage/libarchive/reports/20221117/linux/src/libarchive/report.html vs
https://storage.googleapis.com/oss-fuzz-coverage/libarchive/reports/20221119/linux/src/libarchive/report.html)

Am looking to get the coverage back up as I'm writing some documentation about
https://github.com/ossf/fuzz-introspector/issues/580#issuecomment-1318961239

@jvoisin could you help review?

Signed-off-by: David Korczynski <david@adalogics.com>