### PR TITLE
[hermes] Add JS dictionary to improve fuzzing efficiency

### DIFF
--- a/projects/hermes/Dockerfile
+++ b/projects/hermes/Dockerfile
@@ -19,8 +19,16 @@ RUN apt-get update && \
     apt-get install -y make autoconf automake libtool wget \
     python zip libreadline-dev libatomic-ops-dev
 
+# Building ninja requires PEP 517
+RUN pip3 install "pip>=22.3.1"
+
 RUN pip3 install meson ninja
 RUN ln -s /usr/local/bin/ninja /usr/bin/ninja
+
+# Add JS dictionaries
+RUN git clone --depth 1 https://github.com/chromium/chromium && \
+    cat chromium/testing/libfuzzer/fuzzers/dicts/javascript_parser_proto.dict > $SRC/hermes.dict && \
+    cat chromium/testing/libfuzzer/fuzzers/dicts/generated/javascript.dict >> $SRC/hermes.dict
 
 RUN wget https://github.com/unicode-org/icu/archive/refs/tags/cldr/2021-08-25.tar.gz && \
     tar xzvf ./2021-08-25.tar.gz && \

--- a/projects/hermes/build.sh
+++ b/projects/hermes/build.sh
@@ -18,6 +18,9 @@
 # Copy seed corpora
 mv $SRC/hermes_seed_corpus.zip $OUT
 
+# Copy dictionary file
+mv $SRC/hermes.dict $OUT
+
 # build ICU for linking statically.
 cd $SRC/icu/source
 ./configure --disable-shared --enable-static --disable-layoutex \


### PR DESCRIPTION
Currently, the Hermes setup does not use [a dictionary to help mutate input](https://google.github.io/oss-fuzz/getting-started/new-project-guide/#dictionaries). This PR adds JS dictionaries and edits the fuzzing setup to use `hermes.dict` during fuzzing.

