### PR TITLE
[xs] Set metering limits in xs fuzzer

### DIFF
--- a/projects/xs/build.sh
+++ b/projects/xs/build.sh
@@ -28,7 +28,7 @@ REALBIN_PATH=$OUT
 
 # build main target
 cd "$MODDABLE/xs/makefiles/lin"
-FUZZING=1 OSSFUZZ=1 make debug
+FUZZING=1 OSSFUZZ=1 FUZZ_METER=10240000 make debug
 
 cd "$MODDABLE"
 cp ./build/bin/lin/debug/xst $REALBIN_PATH/xst
@@ -37,7 +37,7 @@ cp $SRC/xst.options $OUT/
 # build jsonparse target
 cd "$MODDABLE/xs/makefiles/lin"
 make -f xst.mk clean
-FUZZING=1 OSSFUZZ=1 OSSFUZZ_JSONPARSE=1 make debug
+FUZZING=1 OSSFUZZ=1 OSSFUZZ_JSONPARSE=1 FUZZ_METER=10240000 make debug
 
 cd "$MODDABLE"
 cp ./build/bin/lin/debug/xst $REALBIN_PATH/xst_jsonparse


### PR DESCRIPTION
XS is a JavaScript engine, the typical timeouts aren't necessarily bugs -- it's expected that code will run for a long time. Over time the fuzzer has generated quite a few timeouts, near-infinite loops. 

We added metering to the XS fuzz target to cap execution to a number of steps. In this PR we set the limits to reduce the amount of timeouts. Timeouts that still reported are more likely to be bugs we should fix (either in engine or in metering feature itself).