### PR TITLE
SystemSan: log correct dns type and class

### DIFF
--- a/infra/experimental/SystemSan/inspect_dns.cpp
+++ b/infra/experimental/SystemSan/inspect_dns.cpp
@@ -108,6 +108,7 @@ struct DnsRequest parse_dns_request(std::vector<std::byte> data, size_t offset) 
   while(offset < data.size()) {
     uint8_t rlen = uint8_t(data[offset]);
     if (rlen == 0) {
+      offset++;
       break;
     }
     r.nb_levels++;


### PR DESCRIPTION
by skipping final null byte of domain name

cc @Alan32Liu 