### PR TITLE
suricata: fix rust+C MSAN build

### DIFF
--- a/projects/suricata/build.sh
+++ b/projects/suricata/build.sh
@@ -25,6 +25,9 @@ then
     make -j$(nproc) all
     make -j$(nproc) install
     )
+    # Temporary workaround for https://github.com/rust-lang/rust/issues/107149
+    # until oss-fuzz clang is up to rustc clang (15.0.6).
+    export RUSTFLAGS="$RUSTFLAGS -Zsanitizer-memory-track-origins -Cllvm-args=-msan-eager-checks=0"
 fi
 
 (


### PR DESCRIPTION
Rust MSAN produces false positives when C clang version is not up to the latest version.
See https://github.com/rust-lang/rust/issues/107149

Will fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=55239&q=label%3AProj-suricata and such

Should the fix be generic for other projects ?