### PR TITLE
quic-go: update repo path to quic-go/quic-go

### DIFF
--- a/projects/quic-go/Dockerfile
+++ b/projects/quic-go/Dockerfile
@@ -20,7 +20,7 @@ RUN git clone --depth 1 https://github.com/quic-go/qpack/ && \
   cd qpack && \
   go build
 
-RUN git clone --depth 1 https://github.com/lucas-clemente/quic-go/ && \
+RUN git clone --depth 1 https://github.com/quic-go/quic-go/ && \
   cd quic-go && \
   go build
 

--- a/projects/quic-go/build.sh
+++ b/projects/quic-go/build.sh
@@ -26,11 +26,11 @@ compile_go_fuzzer github.com/quic-go/qpack/fuzzing Fuzz qpack_fuzzer
 (
 cd quic-go
 # Fuzz quic-go
-compile_go_fuzzer github.com/lucas-clemente/quic-go/fuzzing/frames Fuzz frame_fuzzer
-compile_go_fuzzer github.com/lucas-clemente/quic-go/fuzzing/header Fuzz header_fuzzer
-compile_go_fuzzer github.com/lucas-clemente/quic-go/fuzzing/transportparameters Fuzz transportparameter_fuzzer
-compile_go_fuzzer github.com/lucas-clemente/quic-go/fuzzing/tokens Fuzz token_fuzzer
-compile_go_fuzzer github.com/lucas-clemente/quic-go/fuzzing/handshake Fuzz handshake_fuzzer
+compile_go_fuzzer github.com/quic-go/quic-go/fuzzing/frames Fuzz frame_fuzzer
+compile_go_fuzzer github.com/quic-go/quic-go/fuzzing/header Fuzz header_fuzzer
+compile_go_fuzzer github.com/quic-go/quic-go/fuzzing/transportparameters Fuzz transportparameter_fuzzer
+compile_go_fuzzer github.com/quic-go/quic-go/fuzzing/tokens Fuzz token_fuzzer
+compile_go_fuzzer github.com/quic-go/quic-go/fuzzing/handshake Fuzz handshake_fuzzer
 
 if [ $SANITIZER == "coverage" ]; then
     # no need for corpuses if coverage

--- a/projects/quic-go/project.yaml
+++ b/projects/quic-go/project.yaml
@@ -1,8 +1,8 @@
-homepage: "https://github.com/lucas-clemente/quic-go"
+homepage: "https://github.com/quic-go/quic-go"
 primary_contact: "martenseemann@gmail.com"
 language: go
 fuzzing_engines:
 - libfuzzer
 sanitizers:
 - address
-main_repo: 'https://github.com/lucas-clemente/quic-go'
+main_repo: 'https://github.com/quic-go/quic-go'


### PR DESCRIPTION
We recently moved the repo into its own org. See https://github.com/quic-go/quic-go/issues/3611 for motivation and tracking.