### PR TITLE
bind9: fix build by force-linking two symbols

### DIFF
--- a/projects/bind9/build.sh
+++ b/projects/bind9/build.sh
@@ -23,7 +23,7 @@ autoreconf -fi
 
 LIBISC_CFLAGS="-Ilib/isc/unix/include -Ilib/isc/pthreads/include -Ilib/isc/include"
 LIBDNS_CFLAGS="-Ilib/dns/include"
-LIBISC_LIBS="lib/isc/.libs/libisc.a -Wl,-Bstatic -lssl -lcrypto -luv -lnghttp2 -Wl,-Bdynamic"
+LIBISC_LIBS="lib/isc/.libs/libisc.a -Wl,-Bstatic -Wl,-u,isc__initialize,-u,isc__shutdown -lssl -lcrypto -luv -lnghttp2 -Wl,-Bdynamic"
 LIBDNS_LIBS="lib/dns/.libs/libdns.a -Wl,-Bstatic -lcrypto -Wl,-Bdynamic"
 
 # dns_name_fromwire needs old.c/old.h code to be linked in


### PR DESCRIPTION
`isc__initialize()` is a libisc function that is marked with `__attribute__((constructor))`; it works as expected when the library is linked dynamically, but it gets stripped away in static builds prepared by OSS-Fuzz as it is not called directly by any of the fuzzers. However, one of the fuzzers (`fuzz/dns_message_checksig.c`) calls `dns_view_create()`, which calls `isc_file_sanitize()`, which in turn calls `isc_md(ISC_MD_SHA256, ...)`.  The latter does not work unless `isc__md_initialize()` is called beforehand and that function is in turn expected to be called by `isc__initialize()`.  Since the latter is absent from OSS-Fuzz builds, the `dns_message_checksig` fuzzer crashes on every input.

Since this is only an issue for static builds, which BIND 9 currently does not support except for OSS-Fuzz specifically, use the `-u` linker flag to force-link `isc__initialize()` into the fuzzer binaries.  Also force-link `isc__shutdown()` (a libisc destructor) for consistency.
