### PR TITLE
[cifuzz] Dont report crash on process timeout.

### DIFF
--- a/infra/cifuzz/fuzz_target.py
+++ b/infra/cifuzz/fuzz_target.py
@@ -193,11 +193,16 @@ class FuzzTarget:  # pylint: disable=too-many-instance-attributes
 
         result = engine_impl.fuzz(self.target_path, options, artifacts_dir,
                                   self.duration)
-        print(result.logs)
+        print(f'Fuzzing logs:\n{result.logs}')
 
       if not result.crashes:
         # Libfuzzer max time was reached.
         logging.info('Fuzzer %s finished with no crashes discovered.',
+                     self.target_name)
+        return FuzzResult(None, None, self.latest_corpus_path)
+
+      if result.timed_out:
+        logging.info('Not reporting crash in %s because process timed out.'
                      self.target_name)
         return FuzzResult(None, None, self.latest_corpus_path)
 

--- a/infra/cifuzz/fuzz_target.py
+++ b/infra/cifuzz/fuzz_target.py
@@ -202,7 +202,7 @@ class FuzzTarget:  # pylint: disable=too-many-instance-attributes
         return FuzzResult(None, None, self.latest_corpus_path)
 
       if result.timed_out:
-        logging.info('Not reporting crash in %s because process timed out.'
+        logging.info('Not reporting crash in %s because process timed out.',
                      self.target_name)
         return FuzzResult(None, None, self.latest_corpus_path)
 


### PR DESCRIPTION
Just because nonzero is reported doesn't mean there's a crash.

Related: https://github.com/google/oss-fuzz/issues/9470 https://github.com/google/oss-fuzz/issues/9318
https://github.com/prometheus/prometheus/issues/11810