### PR TITLE
parso: catch recursion errors

### DIFF
--- a/projects/parso/parso_fuzz.py
+++ b/projects/parso/parso_fuzz.py
@@ -19,7 +19,11 @@ import parso
 
 def TestOneInput(data):
   fdp = atheris.FuzzedDataProvider(data)
-  parso.parse(fdp.ConsumeUnicodeNoSurrogates(sys.maxsize))
+  try:
+    parso.parse(fdp.ConsumeUnicodeNoSurrogates(sys.maxsize))
+  except RecursionError:
+    # Not interesting
+    pass
 
 
 def main():


### PR DESCRIPTION
Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=55379