### PR TITLE
[wolfssl] Include Cryptofuzz built-in tests in seed corpus

### DIFF
--- a/projects/wolfssl/build.sh
+++ b/projects/wolfssl/build.sh
@@ -294,6 +294,9 @@ then
     unzip $SRC/corpus_libressl_expmod.zip -d $SRC/libressl-expmod-corpus/
     find $SRC/libressl-expmod-corpus/ -type f -exec $SRC/cryptofuzz-disable-fastmath/cryptofuzz --from-openssl-expmod={},$SRC/cryptofuzz-seed-corpus/ \;
 
+    # Write Cryptofuzz built-in tests
+    $SRC/cryptofuzz-disable-fastmath/cryptofuzz --from-builtin-tests=$SRC/cryptofuzz-seed-corpus/
+
     # Pack it
     cd $SRC/cryptofuzz_seed_corpus
     zip -r $SRC/cryptofuzz_seed_corpus.zip .


### PR DESCRIPTION
Cryptofuzz has a built-in corpus of inputs that can detect historic and/or hard to find bugs. https://github.com/guidovranken/cryptofuzz/blob/master/builtin_tests_importer.cpp

This change includes those inputs in the seed corpus.