### PR TITLE
Attempt to fix my permissions

### DIFF
--- a/projects/glib/project.yaml
+++ b/projects/glib/project.yaml
@@ -7,7 +7,7 @@ auto_ccs:
 - iain@orangesquash.org.uk
 - slomo@coaxion.net
 - trevi55@gmail.com
-- mcatanzaro@redhat.com
+- mcatanza@redhat.com
 sanitizers:
 - address
 - undefined


### PR DESCRIPTION
My main email does not match my Google account ID. Maybe changing this will allow me to actually view OSS-Fuzz bug reports? Currently I'm receiving emails for bugs that I cannot view.

CC @pwithnall 