### PR TITLE
crossplane: moved tests to project repository

### DIFF
--- a/projects/crossplane/Dockerfile
+++ b/projects/crossplane/Dockerfile
@@ -15,7 +15,6 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
-RUN git clone --depth 1 https://github.com/crossplane/crossplane
-RUN git clone --depth 1 https://github.com/cncf/cncf-fuzzing
+RUN git clone --depth 1 https://github.com/crossplane/crossplane $SRC/crossplane
 COPY build.sh $SRC/
 WORKDIR $SRC/crossplane

--- a/projects/crossplane/build.sh
+++ b/projects/crossplane/build.sh
@@ -15,4 +15,4 @@
 #
 ################################################################################
 
-$SRC/cncf-fuzzing/projects/crossplane/build.sh
+$SRC/crossplane/test/fuzz/oss_fuzz_build.sh


### PR DESCRIPTION
Once https://github.com/crossplane/crossplane/pull/3671 all test cases will have been moved to `crossplane/crossplane`, so we can switch the build script to use that directly.

Signed-off-by: Philippe Scorsolini <p.scorsolini@gmail.com>