### PR TITLE
[libavc, libhevc, libmpeg2]: Update repository paths

### DIFF
--- a/projects/libavc/Dockerfile
+++ b/projects/libavc/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y wget cmake
-RUN git clone https://android.googlesource.com/platform/external/libavc
+RUN git clone https://github.com/ittiam-systems/libavc.git
 ADD https://storage.googleapis.com/android_media/external/libavc/fuzzer/avc_dec_fuzzer_seed_corpus.zip $SRC/
 COPY build.sh $SRC/
 WORKDIR libavc

--- a/projects/libavc/project.yaml
+++ b/projects/libavc/project.yaml
@@ -1,4 +1,4 @@
-homepage: "https://android.googlesource.com/platform/external/libavc/"
+homepage: "https://github.com/ittiam-systems/libavc"
 language: c++
 primary_contact: "harish.mahendrakar@ittiam.com"
 sanitizers:
@@ -23,4 +23,4 @@ vendor_ccs:
 architectures:
   - x86_64
   - i386
-main_repo: 'https://android.googlesource.com/platform/external/libavc'
+main_repo: 'https://github.com/ittiam-systems/libavc.git'

--- a/projects/libhevc/Dockerfile
+++ b/projects/libhevc/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y wget cmake
-RUN git clone https://android.googlesource.com/platform/external/libhevc
+RUN git clone https://github.com/ittiam-systems/libhevc.git
 ADD https://storage.googleapis.com/android_media/external/libhevc/fuzzer/hevc_dec_fuzzer_seed_corpus.zip $SRC/
 COPY build.sh $SRC/
 WORKDIR libhevc

--- a/projects/libhevc/project.yaml
+++ b/projects/libhevc/project.yaml
@@ -1,4 +1,4 @@
-homepage: "https://android.googlesource.com/platform/external/libhevc/"
+homepage: "https://github.com/ittiam-systems/libhevc"
 language: c++
 primary_contact: "harish.mahendrakar@ittiam.com"
 sanitizers:
@@ -23,4 +23,4 @@ vendor_ccs:
 architectures:
   - x86_64
   - i386
-main_repo: 'https://android.googlesource.com/platform/external/libhevc'
+main_repo: 'https://github.com/ittiam-systems/libhevc.git'

--- a/projects/libmpeg2/Dockerfile
+++ b/projects/libmpeg2/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y wget cmake
-RUN git clone https://android.googlesource.com/platform/external/libmpeg2
+RUN git clone https://github.com/ittiam-systems/libmpeg2.git
 ADD https://storage.googleapis.com/android_media/external/libmpeg2/fuzzer/mpeg2_dec_fuzzer_seed_corpus.zip $SRC/
 COPY build.sh $SRC/
 WORKDIR libmpeg2

--- a/projects/libmpeg2/project.yaml
+++ b/projects/libmpeg2/project.yaml
@@ -1,4 +1,4 @@
-homepage: "https://android.googlesource.com/platform/external/libmpeg2/"
+homepage: "https://github.com/ittiam-systems/libmpeg2"
 language: c++
 primary_contact: "harish.mahendrakar@ittiam.com"
 sanitizers:
@@ -23,4 +23,4 @@ vendor_ccs:
 architectures:
   - x86_64
   - i386
-main_repo: 'https://android.googlesource.com/platform/external/libmpeg2'
+main_repo: 'https://github.com/ittiam-systems/libmpeg2.git'


### PR DESCRIPTION
libavc, libhevc and libmpeg2 now have an upstream project and the fuzzers will be built from these paths from now on.