### PR TITLE
introspector_page: only display if numbers are accurate

### DIFF
--- a/infra/build/build_status/fuzz_introspector_page_gen.py
+++ b/infra/build/build_status/fuzz_introspector_page_gen.py
@@ -212,6 +212,15 @@ def refine_percentage_string(percentage_string):
 
   if len(percentage_string) > 5:
     percentage_string = percentage_string[:5]
+
+  # Check if the percentage is withing range of [0.0 : 100.0]
+  # Some old reports from 2022 have deprecated data, which we do not want to
+  # display.
+  float_val = float(percentage_string)
+  if float_val < 0.0 or float_val > 100.0:
+    # Raise exception to make the code display '-' elements.
+    raise Exception('Out of range numbers')
+
   return percentage_string + "%"
 
 


### PR DESCRIPTION
Some old reports e.g.
https://storage.googleapis.com/oss-fuzz-introspector/upb/inspector-report/20221025/summary.json have deprecated data. We should not display this information. Only show if the percentage numbers make sense.

Signed-off-by: David Korczynski <david@adalogics.com>