### PR TITLE
[skia] Fix build by downloading and using ninja

### DIFF
--- a/projects/skia/Dockerfile
+++ b/projects/skia/Dockerfile
@@ -28,6 +28,8 @@ RUN git clone https://skia.googlesource.com/skia.git --depth 1
 WORKDIR skia
 
 RUN python3 bin/sync
+RUN python3 bin/fetch-gn
+RUN python3 bin/fetch-ninja
 
 # Make a directory for fuzzing artifacts that won't be clobbered by CIFuzz.
 RUN mkdir $SRC/skia_data

--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -46,10 +46,10 @@ else
 fi
 # These deprecated warnings get quite noisy and mask other issues.
 CFLAGS= CXXFLAGS="-stdlib=libc++ -Wno-deprecated-declarations" cmake .. -GNinja \
-  -DCMAKE_MAKE_PROGRAM="$SRC/depot_tools/ninja" -D$CMAKE_SANITIZER=1 -DSWIFTSHADER_WARNINGS_AS_ERRORS=FALSE
+  -DCMAKE_MAKE_PROGRAM="$SRC/skia/third_party/ninja/ninja" -D$CMAKE_SANITIZER=1 -DSWIFTSHADER_WARNINGS_AS_ERRORS=FALSE
 
 # Swiftshader only supports Vulkan, so we will build our fuzzers with Vulkan too.
-$SRC/depot_tools/ninja libvk_swiftshader.so
+$SRC/skia/third_party/ninja/ninja libvk_swiftshader.so
 mv libvk_swiftshader.so $OUT
 export SWIFTSHADER_LIB_PATH=$OUT
 
@@ -69,8 +69,6 @@ export LDFLAGS="$LIB_FUZZING_ENGINE $CXXFLAGS -L$SWIFTSHADER_LIB_PATH"
 export CFLAGS_ARR=`echo $CFLAGS | sed -e "s/\s/\",\"/g"`
 export CXXFLAGS_ARR=`echo $CXXFLAGS | sed -e "s/\s/\",\"/g"`
 export LDFLAGS_ARR=`echo $LDFLAGS | sed -e "s/\s/\",\"/g"`
-
-$SRC/skia/bin/fetch-gn
 
 # Avoid OOMs on the CI due to lower memory constraints
 LIMITED_LINK_POOL="link_pool_depth=1"
@@ -115,7 +113,7 @@ $SRC/skia/bin/gn gen out/FuzzDebug\
       extra_cflags_cc=["-DSK_DEBUG","'"$CXXFLAGS_ARR"'"]
       extra_ldflags=["'"$LDFLAGS_ARR"'"]'
 
-$SRC/depot_tools/ninja -C out/Fuzz \
+$SRC/skia/third_party/ninja/ninja -C out/Fuzz \
   android_codec \
   animated_image_decode \
   api_create_ddl \
@@ -150,7 +148,7 @@ $SRC/depot_tools/ninja -C out/Fuzz \
   textblob_deserialize \
   webp_encoder
 
-$SRC/depot_tools/ninja -C out/FuzzDebug \
+$SRC/skia/third_party/ninja/ninja -C out/FuzzDebug \
   cubic_quad_roots \
   skmeshspecification \
   skruntimeeffect \


### PR DESCRIPTION
This moves the fetching to the Dockerfile creation step, for better caching.

Note that gn is downloaded to skia/bin/gn, but ninja is downloaded to skia/third_party/ninja/ninja (for compatibility with depot_tools).