### PR TITLE
feat(gitoxide): Adds autodetection of new fuzzers

### DIFF
--- a/projects/gitoxide/build.sh
+++ b/projects/gitoxide/build.sh
@@ -17,16 +17,7 @@
 
 set -eox pipefail
 
-# TODO: Switch back to this method for fuzzer discovery once all the fuzzers
-# build successfully.
-# FUZZ_CRATES=$(find . -type d -name fuzz -exec readlink -f {} \;)
-
-FUZZ_CRATE_DIRS=("$(pwd)/git-config"\
-                 "$(pwd)/git-pathspec"\
-                 "$(pwd)/git-refspec"\
-                 "$(pwd)/git-date"\
-                 "$(pwd)/git-revision")
-
+FUZZ_CRATE_DIRS=$(find . -type d -name fuzz -exec dirname $(readlink -f {}) \;)
 
 for CRATE_DIR in ${FUZZ_CRATE_DIRS[@]};
 do


### PR DESCRIPTION
The previous configuration had a hardecoded list of fuzz harnesses. This was neccesary as some of the existing fuzz harnesses where broken and wouldn't compile. As these are now fixed, we can switch over to searching for new fuzz tests.