### PR TITLE
croaring: do not build tests

### DIFF
--- a/projects/croaring/build.sh
+++ b/projects/croaring/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 mkdir build-dir && cd build-dir
-cmake ..
+cmake -DENABLE_ROARING_TESTS=OFF ..
       
 make -j$(nproc)
 


### PR DESCRIPTION
This is an effort to stabilise the fuzz introspector build which seems to segfault for some of the tests on-and-off