### PR TITLE
http-parser: fix fuzz-introspector build

### DIFF
--- a/projects/http-parser/build.sh
+++ b/projects/http-parser/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 cd http-parser
-make
+make http_parser.o
 
 $CC $CFLAGS -I. -DHTTP_PARSER_STRICT=0  -Wall -Wextra -Werror -c fuzzers/fuzz_parser.c -o fuzz_parser.o
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE -Wall -Wextra -Werror http_parser.o fuzz_parser.o -o $OUT/fuzz_parser


### PR DESCRIPTION
Only build the necessary components for the fuzzers. One test is causing issues for fuzz introspector, this fixes it.