### PR TITLE
spirv-tools: partially unshallow spirv-tools clone

### DIFF
--- a/projects/spirv-tools/Dockerfile
+++ b/projects/spirv-tools/Dockerfile
@@ -16,6 +16,6 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool ninja-build
-RUN git clone --depth 1 https://github.com/KhronosGroup/SPIRV-Tools.git spirv-tools
+RUN git clone --filter=tree:0 https://github.com/KhronosGroup/SPIRV-Tools.git spirv-tools
 WORKDIR spirv-tools
 COPY build.sh $SRC/


### PR DESCRIPTION
SPIRV-Tools now requires some history to determine its version. This is done using tags on the current branch. Using --depth=1 was preventing the version to be generated correctly.
Using --filter=tree:0 should still limit the amount of fetch data, while giving us tags.
