### PR TITLE
muduo: do not build examples

### DIFF
--- a/projects/muduo/build.sh
+++ b/projects/muduo/build.sh
@@ -17,7 +17,7 @@
 
 sed -i '34 a $ENV{CXXFLAGS}' CMakeLists.txt
 mkdir -p build-dir && cd build-dir
-cmake -DCMAKE_BUILD_TYPE="release" \
+cmake -DCMAKE_BUILD_TYPE="release" -DMUDUO_BUILD_EXAMPLES=OFF \
       ..
 make -j$(nproc)
 


### PR DESCRIPTION
The examples are not needed. This reduces the build and helps avoid an error that affects the Fuzz Introspector build.