### PR TITLE
c-blosc: simplify build

### DIFF
--- a/projects/c-blosc/build.sh
+++ b/projects/c-blosc/build.sh
@@ -16,7 +16,9 @@
 ################################################################################
 
 # Build project
-cmake . -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DBUILD_FUZZERS=ON
+cmake . -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS"     \
+        -DBUILD_FUZZERS=ON -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF \
+        -DBUILD_EXAMPLES=OFF -DBUILD_STATIC=ON -DBUILD_SHARED=OFF
 make clean
 make -j$(nproc)
 


### PR DESCRIPTION
Do not build binaries that are not needed: tests, benchmarks and shared libraries. This will stabilise the Fuzz Introspector build which has been a bit spurious lately.