### PR TITLE
cmark: Update seed corpus

### DIFF
--- a/projects/cmark/Dockerfile
+++ b/projects/cmark/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make cmake
+RUN apt-get update && apt-get install -y make cmake python3
 RUN git clone --depth 1 https://github.com/commonmark/cmark.git cmark
 WORKDIR cmark
 COPY build.sh *.dict *.options $SRC/


### PR DESCRIPTION
Generate seed corpus from our own test suite instead of relying on an external repo.

Also remove redundant $SRC/cmark from paths.