### PR TITLE
[libjpeg-turbo] Use external repo to specify fuzz branches

### DIFF
--- a/projects/libjpeg-turbo/Dockerfile
+++ b/projects/libjpeg-turbo/Dockerfile
@@ -1,5 +1,5 @@
 # Copyright 2016 Google Inc.
-# Copyright 2022 D. R. Commander
+# Copyright 2022-2023 D. R. Commander
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,9 +17,10 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make yasm cmake
-RUN git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo libjpeg-turbo.main
-RUN git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo -b 2.0.x libjpeg-turbo.2.0.x
-RUN git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo -b dev libjpeg-turbo.dev || /bin/true
+RUN git clone --depth 1 https://github.com/libjpeg-turbo/fuzz && \
+    cat fuzz/branches.txt | while read branch; do \
+      git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo -b $branch libjpeg-turbo.$branch; \
+    done
 
 RUN git clone --depth 1 https://github.com/libjpeg-turbo/seed-corpora
 RUN cd seed-corpora && zip -r ../decompress_fuzzer_seed_corpus.zip afl-testcases/jpeg* bugs/decompress* $SRC/libjpeg-turbo/testimages/*.jpg

--- a/projects/libjpeg-turbo/build.sh
+++ b/projects/libjpeg-turbo/build.sh
@@ -1,4 +1,4 @@
-# Copyright 2022 D. R. Commander
+# Copyright 2022-2023 D. R. Commander
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,10 +17,7 @@
 set -e
 set -u
 
-for branch in main 2.0.x dev; do
-	if [ "$branch" = "dev" -a ! -d libjpeg-turbo.$branch ]; then
-		continue
-	fi
+cat fuzz/branches.txt | while read branch; do
 	pushd libjpeg-turbo.$branch
 	if [ "$branch" = "main" ]; then
 		sh fuzz/build.sh


### PR DESCRIPTION
Use the contents of branches.txt in
https://github.com/libjpeg-turbo/fuzz to determine which libjpeg-turbo branches to build and fuzz.  This allows the libjpeg-turbo maintainer to control which branches will be tested with OSS-Fuzz, since that will change as new releases are added and support for old stable branches is dropped.