### PR TITLE
c-ares: disable tests to make build fuzz introspector compatible

### DIFF
--- a/projects/c-ares/build.sh
+++ b/projects/c-ares/build.sh
@@ -17,7 +17,7 @@
 
 # Build the project.
 ./buildconf
-./configure --enable-debug
+./configure --enable-debug --disable-tests
 make clean
 make -j$(nproc) V=1 all
 


### PR DESCRIPTION
The tests are not needed for fuzzing and avoiding to compile them makes the build Fuzz Introspector compatible