### PR TITLE
libvips: link with tiff before jpeg

### DIFF
--- a/projects/libvips/build.sh
+++ b/projects/libvips/build.sh
@@ -223,8 +223,8 @@ for fuzzer in fuzz/*_fuzzer.cc; do
     -I/usr/include/glib-2.0 \
     -I/usr/lib/x86_64-linux-gnu/glib-2.0/include \
     $LDFLAGS \
-    -lvips -lexif -llcms2 -ljpeg -lpng -lspng -lz \
-    -ltiff -lwebpmux -lwebpdemux -lwebp -lsharpyuv -lheif -laom \
+    -lvips -lexif -llcms2 -ltiff -ljpeg -lpng -lspng -lz \
+    -lwebpmux -lwebpdemux -lwebp -lsharpyuv -lheif -laom \
     -limagequant -lcgif -lpdfium \
     $LIB_FUZZING_ENGINE \
     -Wl,-Bstatic \


### PR DESCRIPTION
The libvips build is currently failing due to an API change in `libjpeg-turbo` that "unlocked" a previously-unused feature of `libtiff`, which means the dependency order between the two must now change.

https://oss-fuzz-build-logs.storage.googleapis.com/index.html#libvips