### PR TITLE
tinyxml2: make OSS-Fuzz flags are used in build

### DIFF
--- a/projects/tinyxml2/build.sh
+++ b/projects/tinyxml2/build.sh
@@ -14,6 +14,10 @@
 # limitations under the License.
 #
 ################################################################################
+
+# Make sure OSS-Fuzz's CXXFLAGS are propagated into the build
+sed -i 's/CXXFLAGS =/#CXXFLAGS/g' Makefile
+
 make -j$(nproc) clean
 make -j$(nproc) all
 


### PR DESCRIPTION
Currently OSS-Fuzz flags are not set when building the tinyxml2 library due to https://github.com/leethomason/tinyxml2/blob/e05956094c27117f989d22f25b75633123d72a83/Makefile#L13. Consequentially, coverage is low (only that which is in the fuzzer source file). This fixes it by avoiding to overwrite the CXXFLAGS in the build.