### PR TITLE
cgif: enable memory sanitizer

### DIFF
--- a/projects/cgif/project.yaml
+++ b/projects/cgif/project.yaml
@@ -3,6 +3,10 @@ language: c
 primary_contact: "dloebl.2000@gmail.com"
 auto_ccs:
   - "matthias.loebl@rwth-aachen.de"
+sanitizers:
+- address
+- undefined
+- memory
 architectures:
   - x86_64
   - i386


### PR DESCRIPTION
Enable memory sanitizer for [cgif](https://github.com/dloebl/cgif). I already found one small issue testing it locally (timeout crash reported by oss-fuzz):

```
$ ./build/fuzz/cgif_fuzzer_standalone clusterfuzz-testcase-cgif_fuzzer-6560939899224064

==26604==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x7f6a00f022ba  (/home/dbl/projects/cgif/build/fuzz/../libcgif.so.0+0x162ba) (BuildId: 41f9aa2f4c1d42966ca54004a6e73b2e1bb38d78)
   [...]
SUMMARY: MemorySanitizer: use-of-uninitialized-value (/home/dbl/projects/cgif/build/fuzz/../libcgif.so.0+0x162ba) (BuildId: 41f9aa2f4c1d42966ca54004a6e73b2e1bb38d78) 
Exiting
```

Fixed with https://github.com/dloebl/cgif/pull/57.