### PR TITLE
Build qpdf's libjpeg-turbo with position-independent code

### DIFF
--- a/projects/qpdf/build.sh
+++ b/projects/qpdf/build.sh
@@ -24,7 +24,7 @@ popd
 
 # libjpeg-turbo
 pushd $SRC/libjpeg-turbo
-cmake . -DCMAKE_INSTALL_PREFIX="$WORK" -DENABLE_STATIC:bool=on
+cmake . -DCMAKE_INSTALL_PREFIX="$WORK" -DENABLE_STATIC=1 -DENABLE_SHARED=0 -DCMAKE_POSITION_INDEPENDENT_CODE=1
 make -j$(nproc)
 make install
 popd


### PR DESCRIPTION
qpdf's build has been failing with errors within its own build of libjpeg-turbo because of lack of position-independent code. This change forces libjpeg-turbo to build with PIC even though we continue to build only static libraries. I have reproduced the build failure locally using the fuzz docker images and have reproduced locally that this fixes it.