### PR TITLE
bitcoin-core: drop additional dependency cflags passing

### DIFF
--- a/projects/bitcoin-core/build.sh
+++ b/projects/bitcoin-core/build.sh
@@ -29,7 +29,7 @@ fi
 (
   cd depends
   sed -i --regexp-extended '/.*rm -rf .*extract_dir.*/d' ./funcs.mk  # Keep extracted source
-  make HOST=$BUILD_TRIPLET NO_QT=1 NO_BDB=1 NO_ZMQ=1 NO_UPNP=1 NO_NATPMP=1 libevent_cflags="${CFLAGS}" sqlite_cflags="${CFLAGS}" -j$(nproc)
+  make HOST=$BUILD_TRIPLET NO_QT=1 NO_BDB=1 NO_ZMQ=1 NO_UPNP=1 NO_NATPMP=1 -j$(nproc)
   # DEBUG=1 is temporarily disabled due to libc++ bugs
 )
 


### PR DESCRIPTION
After some changes we made upstream, passing the flags in this way *should* no-longer be required.