### PR TITLE
Make many projects centipede compatible

### DIFF
--- a/projects/bluez/build.sh
+++ b/projects/bluez/build.sh
@@ -23,22 +23,26 @@ make
 INCLUDES="-I. -I./src -I./lib -I./gobex -I/usr/local/include/glib-2.0/ -I/src/glib/_build/glib/"
 STATIC_LIBS="./src/.libs/libshared-glib.a ./lib/.libs/libbluetooth-internal.a  -l:libical.a -l:libicalss.a -l:libicalvcal.a -l:libdbus-1.a /src/glib/_build/glib/libglib-2.0.a"
 
-$CC $CFLAGS $LIB_FUZZING_ENGINE $INCLUDES \
- $SRC/fuzz_xml.c ./src/bluetoothd-sdp-xml.o -o $OUT/fuzz_xml \
+$CC $CFLAGS $INCLUDES $SRC/fuzz_xml.c -c
+$CC $CFLAGS $INCLUDES $SRC/fuzz_sdp.c -c
+$CC $CFLAGS $INCLUDES $SRC/fuzz_textfile.c -c
+$CC $CFLAGS $INCLUDES $SRC/fuzz_gobex.c -c
+$CC $CFLAGS $INCLUDES $SRC/fuzz_hci.c -c
+
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE \
+ ./src/bluetoothd-sdp-xml.o fuzz_xml.o -o $OUT/fuzz_xml \
  $STATIC_LIBS -ldl -lpthread
 
-$CC $CFLAGS $LIB_FUZZING_ENGINE $INCLUDES \
- $SRC/fuzz_sdp.c -o $OUT/fuzz_sdp \
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE \
+ fuzz_sdp.o -o $OUT/fuzz_sdp $STATIC_LIBS -ldl -lpthread
+
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz_textfile.o -o $OUT/fuzz_textfile \
+  $STATIC_LIBS -ldl -lpthread src/textfile.o
+
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE \
+  fuzz_gobex.o ./gobex/gobex*.o -o $OUT/fuzz_gobex \
  $STATIC_LIBS -ldl -lpthread
 
-$CC $CFLAGS $LIB_FUZZING_ENGINE $INCLUDES \
- $SRC/fuzz_textfile.c -o $OUT/fuzz_textfile \
- $STATIC_LIBS -ldl -lpthread src/textfile.o
-
-$CC $CFLAGS $LIB_FUZZING_ENGINE $INCLUDES \
- $SRC/fuzz_gobex.c ./gobex/gobex*.o -o $OUT/fuzz_gobex \
- $STATIC_LIBS -ldl -lpthread
-
-$CC $CFLAGS $LIB_FUZZING_ENGINE $INCLUDES \
- $SRC/fuzz_hci.c ./gobex/gobex*.o -o $OUT/fuzz_hci \
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE \
+ fuzz_hci.o ./gobex/gobex*.o -o $OUT/fuzz_hci \
  $STATIC_LIBS -ldl -lpthread

--- a/projects/clib/build.sh
+++ b/projects/clib/build.sh
@@ -24,13 +24,14 @@ sed 's/int main(int argc/int main2(int argc/g' -i ./src/clib-configure.c
 find . -name "*.o" -exec ar rcs fuzz_lib.a {} \;
 
 $CC $CFLAGS -Wno-unused-function -U__STRICT_ANSI__  \
-	-DHAVE_PTHREADS=1 -pthread -o fuzz_manifest.o \
-	-c test/fuzzing/fuzz_manifest.c -I./asprintf -I./deps/ \
+	-DHAVE_PTHREADS=1 -pthread \
+	-c src/common/clib-cache.c src/clib-configure.c \
+        src/common/clib-settings.c src/common/clib-package.c \
+        test/fuzzing/fuzz_manifest.c -I./asprintf -I./deps/ \
 	-I./deps/asprintf
 
-$CC $CFLAGS $LIB_FUZZING_ENGINE fuzz_manifest.o \
-	-o $OUT/fuzz_manifest src/common/clib-settings.c src/common/clib-package.c \
-	src/common/clib-cache.c src/clib-configure.c \
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz_manifest.o \
+	-o $OUT/fuzz_manifest  clib-cache.o clib-configure.o clib-settings.o clib-package.o \
 	-I./deps/asprintf -I./deps -I./asprintf \
 	fuzz_lib.a -L/usr/lib/x86_64-linux-gnu -lcurl
 

--- a/projects/croaring/build.sh
+++ b/projects/croaring/build.sh
@@ -17,13 +17,12 @@
 
 mkdir build-dir && cd build-dir
 cmake -DENABLE_ROARING_TESTS=OFF ..
-      
 make -j$(nproc)
 
 $CC $CFLAGS  \
      -I$SRC/croaring/include \
      -c $SRC/croaring_fuzzer.c -o fuzzer.o
-$CC $CFLAGS $LIB_FUZZING_ENGINE fuzzer.o   \
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzzer.o   \
      -o $OUT/croaring_fuzzer $SRC/croaring/build-dir/src/libroaring.a
 
 zip $OUT/croaring_fuzzer_seed_corpus.zip $SRC/croaring/tests/testdata/*bin

--- a/projects/h3/build.sh
+++ b/projects/h3/build.sh
@@ -34,7 +34,7 @@ for fuzzer in $(find $H3_BASE/src/apps/fuzzers -name '*.c'); do
     -o $fuzzer_basename.o \
     -c $fuzzer
 
-  $CC $CFLAGS $LIB_FUZZING_ENGINE -rdynamic \
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE -rdynamic \
     $fuzzer_basename.o \
     -o $OUT/$fuzzer_basename \
     lib/libh3.a

--- a/projects/hdf5/build.sh
+++ b/projects/hdf5/build.sh
@@ -36,6 +36,8 @@ cmake -G "Unix Makefiles" \
 cmake --build . --verbose --config Release -j$(nproc)
 cd $SRC/hdf5
 
-$CC $CXXFLAGS $LIB_FUZZING_ENGINE -std=c99 \
-    -I/src/hdf5/src -I/src/hdf5/build-dir/src -I./src/H5FDsubfiling/ \
-    $SRC/h5_read_fuzzer.c ./build-dir/bin/libhdf5.a  -lz -o $OUT/h5_read_fuzzer
+$CC $CFLAGS  -std=c99 -c \
+  -I/src/hdf5/src -I/src/hdf5/build-dir/src -I./src/H5FDsubfiling/ \
+  $SRC/h5_read_fuzzer.c
+
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE h5_read_fuzzer.o ./build-dir/bin/libhdf5.a -lz -o $OUT/h5_read_fuzzer

--- a/projects/hiredis/build.sh
+++ b/projects/hiredis/build.sh
@@ -21,5 +21,5 @@ mv fuzzing/format_command_fuzzer.c .
 $CC $CFLAGS -std=c99 -pedantic -c -O3 -fPIC \
 	format_command_fuzzer.c -o format_command_fuzzer.o
 
-$CC $CFLAGS -O3 -fPIC $LIB_FUZZING_ENGINE format_command_fuzzer.o \
+$CXX $CXXFLAGS -O3 -fPIC $LIB_FUZZING_ENGINE format_command_fuzzer.o \
 	-o $OUT/format_command_fuzzer libhiredis.a

--- a/projects/kamailio/build.sh
+++ b/projects/kamailio/build.sh
@@ -28,10 +28,19 @@ cd src
 mkdir objects && find . -name "*.o" -exec cp {} ./objects/ \;
 ar -r libkamilio.a ./objects/*.o
 cd ../
-$CC $CFLAGS $LIB_FUZZING_ENGINE ./misc/fuzz/fuzz_uri.c -o $OUT/fuzz_uri \
+$CC $CFLAGS -c ./misc/fuzz/fuzz_uri.c \
     -DFAST_LOCK -D__CPU_i386 ./src/libkamilio.a \
     -I./src/ -I./src/core/parser -ldl -lresolv -lm
 
-$CC $CFLAGS $LIB_FUZZING_ENGINE ./misc/fuzz/fuzz_parse_msg.c -o $OUT/fuzz_parse_msg \
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz_uri.o -o $OUT/fuzz_uri \
     -DFAST_LOCK -D__CPU_i386 ./src/libkamilio.a \
     -I./src/ -I./src/core/parser -ldl -lresolv -lm
+
+$CC $CFLAGS  ./misc/fuzz/fuzz_parse_msg.c -c \
+    -DFAST_LOCK -D__CPU_i386 ./src/libkamilio.a \
+    -I./src/ -I./src/core/parser -ldl -lresolv -lm
+
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz_parse_msg.o -o $OUT/fuzz_parse_msg \
+    -DFAST_LOCK -D__CPU_i386 ./src/libkamilio.a \
+    -I./src/ -I./src/core/parser -ldl -lresolv -lm
+

--- a/projects/libdwarf/build.sh
+++ b/projects/libdwarf/build.sh
@@ -34,6 +34,7 @@ zip -r -j $OUT/fuzz_init_path_seed_corpus.zip $SRC/corp
 cp $OUT/fuzz_init_path_seed_corpus.zip $OUT/fuzz_init_binary_seed_corpus.zip
 
 for fuzzName in init_path init_binary; do
-  $CC $CFLAGS $LIB_FUZZING_ENGINE -I../src/lib/libdwarf/ \
-    $SRC/fuzz_${fuzzName}.c -o $OUT/fuzz_${fuzzName} ./src/lib/libdwarf/libdwarf.a -lz
+  $CC $CFLAGS -I../src/lib/libdwarf/ $SRC/fuzz_${fuzzName}.c -c
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE -o $OUT/fuzz_${fuzzName} fuzz_${fuzzName}.o \
+    ./src/lib/libdwarf/libdwarf.a -lz
 done

--- a/projects/libpg_query/build.sh
+++ b/projects/libpg_query/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 # Copyright 2021 Google LLC
-#
+#n
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -16,4 +16,5 @@
 ################################################################################
 
 make build
-$CC $CFLAGS $LIB_FUZZING_ENGINE ./test/fuzz/fuzz_parser.c ./libpg_query.a -I./ -o $OUT/fuzz_parser
+$CC $CFLAGS -c ./test/fuzz/fuzz_parser.c ./libpg_query.a -I./
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz_parser.o ./libpg_query.a -I./ -o $OUT/fuzz_parser

--- a/projects/libucl/build.sh
+++ b/projects/libucl/build.sh
@@ -16,10 +16,12 @@
 
 cp $SRC/ucl_add_string_fuzzer.options $OUT/
 
-cd libucl 
+cd libucl
 ./autogen.sh && ./configure
 make
 
-$CC $CFLAGS $LIB_FUZZING_ENGINE tests/fuzzers/ucl_add_string_fuzzer.c \
-    -DHAVE_CONFIG_H -I./src -I./include src/.libs/libucl.a -I./ \
-    -o $OUT/ucl_add_string_fuzzer
+$CC $CFLAGS -c tests/fuzzers/ucl_add_string_fuzzer.c \
+  -DHAVE_CONFIG_H -I./src -I./include src/.libs/libucl.a -I./ \
+  -o $OUT/ucl_add_string_fuzzer.o
+
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE $OUT/ucl_add_string_fuzzer.o -DHAVE_CONFIG_H -I./src -I./include src/.libs/libucl.a -I. -o $OUT/ucl_add_string_fuzzer

--- a/projects/libyang/build.sh
+++ b/projects/libyang/build.sh
@@ -20,12 +20,13 @@ git checkout devel
 
 sed -i 's/add_subdirectory/#add_subdirectory/g' ./tools/CMakeLists.txt
 mkdir build && cd build
-cmake ../ -DENABLE_STATIC=ON 
+cmake ../ -DENABLE_STATIC=ON
 make
 
 static_pcre=($(find /src/pcre2 -name "libpcre2-8.a"))
 
 for fuzzer in lyd_parse_mem_json lyd_parse_mem_xml lys_parse_mem; do
-    $CC $CFLAGS $LIB_FUZZING_ENGINE ../tests/fuzz/${fuzzer}.c -o $OUT/${fuzzer} \
-        ./libyang.a -I../src -I../src/plugins_exts -I./src -I./compat ${static_pcre}
+  $CC $CFLAGS -c ../tests/fuzz/${fuzzer}.c -I../src -I../src/plugins_exts -I./src -I./compat
+  $CXX $CXXFLAGS $LIB_FUZZING_ENGINE ${fuzzer}.o -o $OUT/${fuzzer} \
+    ./libyang.a ${static_pcre}
 done

--- a/projects/llhttp/build.sh
+++ b/projects/llhttp/build.sh
@@ -20,4 +20,5 @@ npm link typescript
 npm install .
 make build/libllhttp.a
 
-$CC $CFLAGS $LIB_FUZZING_ENGINE ./test/fuzzers/fuzz_parser.c -I./build/ ./build/libllhttp.a -o $OUT/fuzz_parser
+$CC $CFLAGS -c ./test/fuzzers/fuzz_parser.c -I./build/ ./build/libllhttp.a -o $OUT/fuzz_parser.o
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE -fuse-ld=lld -I./build/ ./build/libllhttp.a $OUT/fuzz_parser.o -o $OUT/fuzz_parser

--- a/projects/md4c/build.sh
+++ b/projects/md4c/build.sh
@@ -18,5 +18,6 @@
 mkdir build && cd build
 cmake ../ -DBUILD_SHARED_LIBS=OFF
 make
-$CC $CFLAGS $LIB_FUZZING_ENGINE ../test/fuzzers/fuzz-mdhtml.c -o $OUT/fuzz-mdhtml \
-    -I../src ./src/libmd4c-html.a ./src/libmd4c.a
+$CC $CFLAGS -c ../test/fuzzers/fuzz-mdhtml.c -I../src
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz-mdhtml.o -o $OUT/fuzz-mdhtml \
+    ./src/libmd4c-html.a ./src/libmd4c.a

--- a/projects/postfix/build.sh
+++ b/projects/postfix/build.sh
@@ -31,7 +31,7 @@ $CC $CFLAGS -DHAS_DEV_URANDOM -DSNAPSHOT -UUSE_DYNAMIC_LIBS -DDEF_SHLIB_DIR=\"no
 
 # Link fuzzers
 cd ${BASE}
-$CC $CFLAGS $LIB_FUZZING_ENGINE ./src/global/fuzz_tok822.o -o $OUT/fuzz_tok822 \
-  ./lib/libglobal.a ./lib/libutil.a
-$CC $CFLAGS $LIB_FUZZING_ENGINE ./src/global/fuzz_mime.o -o $OUT/fuzz_mime \
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE ./src/global/fuzz_tok822.o \
+  -o $OUT/fuzz_tok822 ./lib/libglobal.a ./lib/libutil.a
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE ./src/global/fuzz_mime.o -o $OUT/fuzz_mime \
   ./lib/libglobal.a ./lib/libutil.a -ldb -lnsl


### PR DESCRIPTION
Previously, they would break because they incorrectly used $CC to link fuzz targets.