### PR TITLE
Don't use -fsanitize=fuzzer-no-link with centipede

### DIFF
--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -99,7 +99,7 @@ then
 fi
 
  # Don't need coverage instrumentation for engine-less, afl++ builds.
-if [ $FUZZING_ENGINE = "none" ] || [ $FUZZING_ENGINE = "afl" ]; then
+if [ $FUZZING_ENGINE = "none" ] || [ $FUZZING_ENGINE = "afl" ] || [ $FUZZING_ENGINE = "centipede" ] ; then
   export COVERAGE_FLAGS=
 fi
 


### PR DESCRIPTION
It's pointless and has these drawbacks:
1. It add useless instrumentation not used by centipede that slows down the target
2. It adds instrumentation that expects an implementation at link time (__sancov_lowest_stack) which can break projects builds.

Fixes https://github.com/google/oss-fuzz/issues/9609
Related: https://github.com/google/oss-fuzz/issues/9299 https://github.com/google/oss-fuzz/issues/9583