### PR TITLE
Fix centipede compilation

### DIFF
--- a/infra/base-images/base-builder/compile_centipede
+++ b/infra/base-images/base-builder/compile_centipede
@@ -25,9 +25,8 @@ fi
 
 cp "$BIN_DIR/libcentipede_runner.pic.a" "$LIB_FUZZING_ENGINE"
 
-export DFTRACING_FLAGS='-fsanitize-coverage=trace-loads'
 export CENTIPEDE_FLAGS=`cat "$SRC/centipede/clang-flags.txt" | tr '\n' ' '`
-export LIBRARIES_FLAGS="-Wno-unused-command-line-argument -ldl -lrt -lpthread $SRC/centipede/weak.o"
+export LIBRARIES_FLAGS="-Wno-unused-command-line-argument -Wl,ldl -Wl,-lrt -Wl,-lpthread -Wl,$SRC/centipede/weak.o"
 
 export CFLAGS="$CFLAGS $DFTRACING_FLAGS $CENTIPEDE_FLAGS $LIBRARIES_FLAGS"
 export CXXFLAGS="$CXXFLAGS $DFTRACING_FLAGS $CENTIPEDE_FLAGS $LIBRARIES_FLAGS"

--- a/infra/base-images/base-builder/compile_centipede
+++ b/infra/base-images/base-builder/compile_centipede
@@ -27,7 +27,7 @@ cp "$BIN_DIR/libcentipede_runner.pic.a" "$LIB_FUZZING_ENGINE"
 
 export CENTIPEDE_FLAGS=`cat "$SRC/centipede/clang-flags.txt" | tr '\n' ' '`
 export LIBRARIES_FLAGS="-Wno-unused-command-line-argument -Wl,-ldl -Wl,-lrt -Wl,-lpthread -Wl,$SRC/centipede/weak.o"
-p
+
 export CFLAGS="$CFLAGS $CENTIPEDE_FLAGS $LIBRARIES_FLAGS"
 export CXXFLAGS="$CXXFLAGS $CENTIPEDE_FLAGS $LIBRARIES_FLAGS"
 

--- a/infra/base-images/base-builder/compile_centipede
+++ b/infra/base-images/base-builder/compile_centipede
@@ -26,8 +26,8 @@ fi
 cp "$BIN_DIR/libcentipede_runner.pic.a" "$LIB_FUZZING_ENGINE"
 
 export CENTIPEDE_FLAGS=`cat "$SRC/centipede/clang-flags.txt" | tr '\n' ' '`
-export LIBRARIES_FLAGS="-Wno-unused-command-line-argument -Wl,ldl -Wl,-lrt -Wl,-lpthread -Wl,$SRC/centipede/weak.o"
-
+export LIBRARIES_FLAGS="-Wno-unused-command-line-argument -Wl,-ldl -Wl,-lrt -Wl,-lpthread -Wl,$SRC/centipede/weak.o"
+p
 export CFLAGS="$CFLAGS $CENTIPEDE_FLAGS $LIBRARIES_FLAGS"
 export CXXFLAGS="$CXXFLAGS $CENTIPEDE_FLAGS $LIBRARIES_FLAGS"
 

--- a/infra/base-images/base-builder/compile_centipede
+++ b/infra/base-images/base-builder/compile_centipede
@@ -28,7 +28,7 @@ cp "$BIN_DIR/libcentipede_runner.pic.a" "$LIB_FUZZING_ENGINE"
 export CENTIPEDE_FLAGS=`cat "$SRC/centipede/clang-flags.txt" | tr '\n' ' '`
 export LIBRARIES_FLAGS="-Wno-unused-command-line-argument -Wl,ldl -Wl,-lrt -Wl,-lpthread -Wl,$SRC/centipede/weak.o"
 
-export CFLAGS="$CFLAGS $DFTRACING_FLAGS $CENTIPEDE_FLAGS $LIBRARIES_FLAGS"
-export CXXFLAGS="$CXXFLAGS $DFTRACING_FLAGS $CENTIPEDE_FLAGS $LIBRARIES_FLAGS"
+export CFLAGS="$CFLAGS $CENTIPEDE_FLAGS $LIBRARIES_FLAGS"
+export CXXFLAGS="$CXXFLAGS $CENTIPEDE_FLAGS $LIBRARIES_FLAGS"
 
 echo 'done.'


### PR DESCRIPTION
1. Don't use trace-loads as it is not fully supported in LLVM and breaks many projects (see https://github.com/google/centipede/commit/9383870160a8cb1d10ec15e9ca85d4b589c8151e)
2. Use -Wl for link time options so they aren't unnecessarily used (also fixes meson based projects).