### PR TITLE
[scapy] actually fuzz protocol dissectors

### DIFF
--- a/projects/scapy/pcap_fuzzer.py
+++ b/projects/scapy/pcap_fuzzer.py
@@ -21,6 +21,7 @@ with atheris.instrument_imports():
   import io
   import scapy
   import scapy.error
+  import scapy.layers.all
   import scapy.utils
 
 

--- a/projects/scapy/project.yaml
+++ b/projects/scapy/project.yaml
@@ -5,6 +5,7 @@ primary_contact: "guedou@gmail.com"
 auto_ccs:
   - "jvoisin@google.com"
   - "ipudney@google.com"
+  - "evverx@gmail.com"
 fuzzing_engines:
   - libfuzzer
 sanitizers:


### PR DESCRIPTION
When scapy reads pcap/pcapng files it extracts link layer types from headers and tries to match them with classes representing those layers. Those classes are registered in conf.l2types.num2layer when they are imported so if no layers are imported the only known layer is Raw and it isn't very interesting in terms of fuzzing because it just wraps bytes without parsing anything. Apart from populating l2types when the layers are imported they are bound to make it possible for scapy to guess payloads and move from lower layers all the way up.

The coverage went from 24% to 39%. It can be bumped further but I think it would be better to roll out those changes gradually.

@gpotter2 @guedou @p-l- could you take a look?

FWIW @DavidKorczynski I tried to get FI to work locally but it got killed by the OOM killer. Looking at https://oss-fuzz-build-logs.storage.googleapis.com/index.html#scapy it seems it hasn't been built on OSS-Fuzz since last September. As far as I can tell it doesn't OOM there but just times out
```
Step #6 - "compile-libfuzzer-introspector-x86_64": Opening: /src/pyintro-pack-deps/scapy/layers/x509.py
TIMEOUT
ERROR: context deadline exceeded
```
I wonder if it's a known issue?