### PR TITLE
Improving urllib3 utils coverage

### DIFF
--- a/projects/urllib3/fuzz_urlparse.py
+++ b/projects/urllib3/fuzz_urlparse.py
@@ -23,7 +23,12 @@ def TestOneInput(data):
     original = fdp.ConsumeUnicode(sys.maxsize)
 
     try:
-        urllib3.util.parse_url(original)
+        response = urllib3.util.parse_url(original)
+        response.hostname
+        response.request_uri
+        response.authority
+        response.netloc
+        response.url
     except urllib3.exceptions.LocationParseError:
         None
     return


### PR DESCRIPTION
This is an improvement to the urllib3 utils functions fuzzing. This is my first attempt at contributing to oss-fuzz so feedback appreciated on whether this custom mutator approach is ok.

- `parse_url` function
We now have a custom mutator that drives more url like structures. I originally developed this using Hypothesis, but the quality of fuzzing wasn't good (seems to be a known issue https://github.com/google/atheris/issues/20). Because of this I've used a 3rd party library `exrex` that can generate test data from regular expressions.