### PR TITLE
Add 'none' as a supported sanitizer for libFuzzer.

### DIFF
--- a/infra/build/functions/build_lib.py
+++ b/infra/build/functions/build_lib.py
@@ -58,9 +58,10 @@ EngineInfo = collections.namedtuple(
 
 ENGINE_INFO = {
     'libfuzzer':
-        EngineInfo(upload_bucket='clusterfuzz-builds',
-                   supported_sanitizers=['address', 'memory', 'undefined'],
-                   supported_architectures=['x86_64', 'i386', 'aarch64']),
+        EngineInfo(
+            upload_bucket='clusterfuzz-builds',
+            supported_sanitizers=['address', 'memory', 'undefined', 'none'],
+            supported_architectures=['x86_64', 'i386', 'aarch64']),
     'afl':
         EngineInfo(upload_bucket='clusterfuzz-builds-afl',
                    supported_sanitizers=['address'],


### PR DESCRIPTION
This is needed for Jazzer.js: #8324