### PR TITLE
[cifuzz] Save 1.1GB in image size

### DIFF
--- a/infra/build_fuzzers.Dockerfile
+++ b/infra/build_fuzzers.Dockerfile
@@ -16,7 +16,7 @@
 # Docker image to run fuzzers for CIFuzz (the run_fuzzers action on GitHub
 # actions).
 
-FROM gcr.io/oss-fuzz-base/cifuzz-base
+FROM gcr.io/oss-fuzz-base/cifuzz-base2
 
 # Python file to execute when the docker container starts up
 # We can't use the env var $OSS_FUZZ_ROOT here. Since it's a constant env var,

--- a/infra/cifuzz/cifuzz-base/Dockerfile
+++ b/infra/cifuzz/cifuzz-base/Dockerfile
@@ -20,13 +20,7 @@ RUN apt-get update && \
     apt-get install -y systemd && \
     wget https://download.docker.com/linux/ubuntu/dists/focal/pool/stable/amd64/docker-ce-cli_20.10.8~3-0~ubuntu-focal_amd64.deb -O /tmp/docker-ce.deb && \
     dpkg -i /tmp/docker-ce.deb && \
-    rm /tmp/docker-ce.deb && \
-    mkdir -p /opt/gcloud && \
-    wget -qO- https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-417.0.1-linux-x86_64.tar.gz | tar zx -C /opt/gcloud && \
-    /opt/gcloud/google-cloud-sdk/install.sh --override-components gsutil --usage-reporting=false --bash-completion=false --update-path=false && \
-    apt-get -y install gcc python3-dev && \
-    pip3 install -U crcmod && \
-    apt-get autoremove -y gcc python3-dev
+    rm /tmp/docker-ce.deb
 
 
 ENV PATH=/opt/gcloud/google-cloud-sdk/bin/:$PATH

--- a/infra/cifuzz/cifuzz-base/Dockerfile
+++ b/infra/cifuzz/cifuzz-base/Dockerfile
@@ -22,8 +22,8 @@ RUN apt-get update && \
     dpkg -i /tmp/docker-ce.deb && \
     rm /tmp/docker-ce.deb && \
     mkdir -p /opt/gcloud && \
-    wget -qO- https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz | tar zxv -C /opt/gcloud && \
-    /opt/gcloud/google-cloud-sdk/install.sh --usage-reporting=false --bash-completion=false --disable-installation-options && \
+    wget -qO- https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-417.0.1-linux-x86_64.tar.gz | tar zx -C /opt/gcloud && \
+    /opt/gcloud/google-cloud-sdk/install.sh --override-components gsutil --usage-reporting=false --bash-completion=false --update-path=false && \
     apt-get -y install gcc python3-dev && \
     pip3 install -U crcmod && \
     apt-get autoremove -y gcc python3-dev

--- a/infra/cifuzz/requirements.txt
+++ b/infra/cifuzz/requirements.txt
@@ -1,3 +1,4 @@
 clusterfuzz==2.5.9
 requests==2.28.0
 protobuf==3.20.2
+gsutil==5.20

--- a/infra/run_fuzzers.Dockerfile
+++ b/infra/run_fuzzers.Dockerfile
@@ -16,7 +16,7 @@
 # Docker image for running fuzzers on CIFuzz (the run_fuzzers action on GitHub
 # actions).
 
-FROM gcr.io/oss-fuzz-base/cifuzz-base
+FROM gcr.io/oss-fuzz-base/cifuzz-base2
 
 # Python file to execute when the docker container starts up.
 # We can't use the env var $OSS_FUZZ_ROOT here. Since it's a constant env var,


### PR DESCRIPTION
Default gcloud install is bloated with anthos junk. Install gsutil via pip.
This cuts pull time in half - or about 30 seconds.