### PR TITLE
zeek: Ignore some paths in the coverage output

### DIFF
--- a/projects/zeek/project.yaml
+++ b/projects/zeek/project.yaml
@@ -17,3 +17,7 @@ fuzzing_engines:
 sanitizers:
   - address
 main_repo: 'https://github.com/zeek/zeek'
+coverage_extra_args: >
+  -ignore-filename-regex=src/3rdparty/.*
+  -ignore-filename-regex=build/zeek/3rdparty/.*
+  -ignore-filename-regex=auxil/.*


### PR DESCRIPTION
I was only able to test these paths by passing them as arguments to `infra/helper.py` but not built-in to the image itself locally. I'm not sure if that's intentional, but passing them as arguments did what I wanted it to do.