### PR TITLE
wasmer: fix coverage build

### DIFF
--- a/projects/wasmer/project.yaml
+++ b/projects/wasmer/project.yaml
@@ -12,3 +12,5 @@ fuzzing_engines:
   - libfuzzer
 vendor_ccs:
   - maxnair.dev@gmail.com
+coverage_extra_args: >
+  -ignore-filename-regex=.*/rustc/.*


### PR DESCRIPTION
This is temp fix for https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=55302. Coverage build is failing with following error:
```
: /workspace/out/libfuzzer-coverage-x86_64/rustc/bd39bbb4bb92df439bf6d85470e296cc6a47ffbd/library/std/src/thread/local.rs: No such file or directory
```
This pr ignores `/rustc/` from coverage report for now.