### PR TITLE
gitoxide: Filter out rustc from coverage reports

### DIFF
--- a/projects/gitoxide/project.yaml
+++ b/projects/gitoxide/project.yaml
@@ -9,3 +9,5 @@ sanitizers:
   - address
 fuzzing_engines:
   - libfuzzer
+coverage_extra_args: >
+  -ignore-filename-regex=.*/rustc/.*


### PR DESCRIPTION
Signed-off-by: Nathaniel Brough <nathaniel.brough@gmail.com>