### PR TITLE
Fixed installing extra test images

### DIFF
--- a/projects/pillow/Dockerfile
+++ b/projects/pillow/Dockerfile
@@ -38,7 +38,7 @@ RUN ln -s /usr/local/bin/python3 /usr/local/bin/python \
     && bash $SRC/build_depends.sh
 
 # install extra test images for a better starting corpus
-RUN cd Pillow && depends/install_extra_test_images.sh
+RUN cd Pillow/depends && ./install_extra_test_images.sh
 
 COPY build.sh $SRC/
 


### PR DESCRIPTION
Over at python-pillow, our CIFuzz job has [started failing](https://github.com/python-pillow/Pillow/actions/runs/4147683686/jobs/7174854267#step:4:7800) -
> depends/install_extra_test_images.sh: line 6: ./download-and-extract.sh: No such file or directory

This is because we recently merged https://github.com/python-pillow/Pillow/pull/6918, which changes `depends/install_extra_test_images.sh` to call `./download-and-extract.sh`, which exists inside [`depends`](https://github.com/python-pillow/Pillow/tree/main/depends). So when
https://github.com/google/oss-fuzz/blob/00b08f6592b90d438e113138c64cd4025fbb3bdf/projects/pillow/Dockerfile#L41
runs, it can't find `./download-and-extract.sh`, because it is running from the base Pillow directory.

So this PR changes the command to run from inside `depends` instead.