### PR TITLE
zip-rs: Improves code coverage

### DIFF
--- a/projects/zip-rs/build.sh
+++ b/projects/zip-rs/build.sh
@@ -16,5 +16,16 @@
 ################################################################################
 
 cd $SRC/zip
-cargo fuzz build -O 
+cargo fuzz build -O --debug-assertions
+
+for file in tests/data/*.zip
+do
+  mv "$file" "${file%.zip}_zip"
+done
+
+zip from_zip_seed_corpus.zip tests/data/*_zip
+cp from_zip_seed_corpus.zip structured_fuzz_reader_seed_corpus.zip
+
 cp fuzz/target/x86_64-unknown-linux-gnu/release/from_zip $OUT/
+cp fuzz/target/x86_64-unknown-linux-gnu/release/structured_fuzz_reader $OUT/
+cp fuzz/target/x86_64-unknown-linux-gnu/release/roundtrip $OUT/

--- a/projects/zip-rs/fuzz/Cargo.toml
+++ b/projects/zip-rs/fuzz/Cargo.toml
@@ -25,14 +25,25 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys = "0.3"
-#zip = { path = ".." , version = "0.5"}
+libfuzzer-sys = "0.4.6"
 zip = { path = ".." }
+arbitrary = { version = "1", features = ["derive"] }
+
+# Prevent this from interfering with workspaces
+[workspace]
 
 [[bin]]
 name = "from_zip"
 path = "fuzz_targets/fuzz_zip.rs"
 
-# Prevent this from interfering with workspaces
-[workspace]
+[[bin]]
+name = "roundtrip"
+path = "fuzz_targets/roundtrip.rs"
+test = false
+doc = false
 
+[[bin]]
+name = "structured_fuzz_reader"
+path = "fuzz_targets/structured_fuzz_reader.rs"
+test = false
+doc = false

--- a/projects/zip-rs/fuzz/fuzz_targets/fuzz_zip.rs
+++ b/projects/zip-rs/fuzz/fuzz_targets/fuzz_zip.rs
@@ -16,24 +16,17 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use std::io::{Cursor, Seek};
-use zip::CompressionMethod;
-use zip::write::FileOptions;
-use std::fs::File;
-use std::io::Write;
-use std::fs;
-
+use std::io::Cursor;
+use zip;
 
 fuzz_target!(|data: &[u8]| {
     match zip::ZipArchive::new(Cursor::new(data)) {
         Ok(archive) => {
-            for i in 0..archive.len() {
+            for _ in 0..archive.len() {
                 let comment = archive.comment();
-                if !comment.is_empty() {
-                }
-
+                if !comment.is_empty() {}
             }
-        },
-        Err(e) =>  return
+        }
+        Err(_) => return,
     }
 });

--- a/projects/zip-rs/fuzz/fuzz_targets/roundtrip.rs
+++ b/projects/zip-rs/fuzz/fuzz_targets/roundtrip.rs
@@ -1,0 +1,227 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+//limitations under the License.
+//
+//###################
+#![no_main]
+
+use arbitrary::{self, Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use std::hint::black_box;
+use zip::{self, result::ZipError};
+
+fn arbitrary_unix_permissions(u: &mut Unstructured) -> arbitrary::Result<u32> {
+    return Ok(u.int_in_range(0o1..=0o777)?);
+}
+
+// Generate a valid arbitrary path.
+fn arbitrary_path(u: &mut Unstructured) -> arbitrary::Result<String> {
+    let path_len: usize = u.int_in_range(1..=512).unwrap_or(1);
+    Ok((0..=path_len)
+        .map(|_| {
+            let valid_chars: Vec<char> = ('a'..='z')
+                .chain('A'..='Z')
+                .chain("/-_.@".chars())
+                .collect();
+            return valid_chars[u.choose_index(valid_chars.len()).unwrap_or(0)];
+        })
+        .collect())
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct Compression {
+    method: zip::CompressionMethod,
+    level: Option<i32>,
+}
+
+impl<'a> Arbitrary<'a> for Compression {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        use zip::CompressionMethod::*;
+        Ok(match u8::arbitrary(u) {
+            Ok(1) => Compression {
+                method: Stored,
+                level: u.int_in_range(0..=9).ok(),
+            },
+            Ok(2) => Compression {
+                method: Deflated,
+                level: u.int_in_range(0..=9).ok(),
+            },
+            Ok(3) => Compression {
+                method: Bzip2,
+                level: u.int_in_range(1..=9).ok(),
+            },
+            _ => Compression {
+                method: Zstd,
+                level: u.int_in_range(-7..=22).ok(),
+            },
+        })
+    }
+}
+
+fn arbitrary_file(u: &mut Unstructured) -> arbitrary::Result<Vec<u8>> {
+    let file = Vec::<u8>::arbitrary(u)?;
+    if file.len() == 0 {
+        return Err(arbitrary::Error::IncorrectFormat);
+    }
+    return Ok(file);
+}
+
+#[derive(Arbitrary, Clone, Debug, PartialEq)]
+struct File {
+    #[arbitrary(with = arbitrary_path)]
+    zip_path: String,
+    #[arbitrary(with = arbitrary_file)]
+    contents: Vec<u8>,
+    compression: Compression,
+    alignment: Option<u16>,
+    large_file: bool,
+    #[arbitrary(with = arbitrary_unix_permissions)]
+    unix_permissions: u32,
+}
+
+#[derive(Arbitrary, Clone, Debug, PartialEq)]
+enum ZipEntry<'a> {
+    File(File),
+    RawComment(&'a [u8]),
+    Comment(String),
+    Symlink {
+        #[arbitrary(with = arbitrary_path)]
+        src: String,
+        #[arbitrary(with = arbitrary_path)]
+        dst: String,
+    },
+    Directory {
+        #[arbitrary(with = arbitrary_path)]
+        path: String,
+    },
+}
+
+impl<'a> ZipEntry<'a> {
+    fn path(&self) -> Option<String> {
+        match self {
+            ZipEntry::File(file) => Some(file.zip_path.clone()),
+            ZipEntry::Symlink { dst, .. } => Some(dst.clone()),
+            ZipEntry::Directory { path } => Some(path.clone()),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+struct Operations<'a> {
+    zip_entries: Vec<ZipEntry<'a>>,
+}
+
+impl<'a> Arbitrary<'a> for Operations<'a> {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let zip_entries = Vec::<ZipEntry>::arbitrary(u)?;
+        let mut paths = std::collections::HashSet::new();
+        let mut result = Vec::new();
+        for zip_entry in zip_entries.iter() {
+            if let Some(path) = zip_entry.path() {
+                if paths.contains(&path) {
+                    continue;
+                } else {
+                    result.push(zip_entry.clone());
+                    paths.insert(path.clone());
+                }
+            } else {
+                result.push(zip_entry.clone());
+            }
+        }
+        return Ok(Operations {
+            zip_entries: result,
+        });
+    }
+}
+
+fn build_zip(zip_entries: &Vec<ZipEntry>) -> Result<Vec<u8>, ZipError> {
+    use std::io::Write;
+    use zip::write::FileOptions;
+
+    // 1mB
+    let max_zip_size = 1024 * 1024 * 1;
+    let mut buf = vec![0; max_zip_size];
+    let mut zip = zip::ZipWriter::new(std::io::Cursor::new(&mut buf[..]));
+
+    let mut created_paths = std::collections::HashSet::new();
+    for entry in zip_entries.iter() {
+        use ZipEntry::*;
+        match entry {
+            File(file) => {
+                if created_paths.contains(&file.zip_path) {
+                    continue;
+                } else {
+                    created_paths.insert(file.zip_path.clone());
+                }
+                let options = FileOptions::default()
+                    .compression_method(file.compression.method)
+                    .compression_level(file.compression.level)
+                    .large_file(file.large_file)
+                    .unix_permissions(file.unix_permissions);
+                if let Some(alignment) = file.alignment {
+                    zip.start_file_aligned(file.zip_path.clone(), options, alignment)?;
+                } else {
+                    zip.start_file(file.zip_path.clone(), options)?;
+                }
+
+                zip.write(&file.contents)?;
+            }
+            RawComment(comment) => zip.set_raw_comment(comment.to_vec()),
+            Comment(comment) => zip.set_comment(comment),
+            Symlink { src, dst } => {
+                if created_paths.contains(dst) {
+                    continue;
+                } else {
+                    created_paths.insert(dst.clone());
+                }
+                let options = FileOptions::default();
+                zip.add_symlink(dst, src, options)?;
+            }
+            Directory { path } => {
+                if created_paths.contains(path) {
+                    continue;
+                } else {
+                    created_paths.insert(path.clone());
+                }
+                let options = FileOptions::default();
+                zip.add_directory(path, options)?;
+            }
+        }
+    }
+
+    return Ok(zip.finish()?.get_ref().to_vec());
+}
+
+fuzz_target!(|operations: Operations| {
+    match build_zip(&operations.zip_entries) {
+        Ok(compressed) => match zip::ZipArchive::new(std::io::Cursor::new(compressed)) {
+            Ok(mut archive) => {
+                for i in 0..archive.len() {
+                    let mut file = archive
+                        .by_index(i)
+                        .expect("This was a generated zip it should be valid.");
+                    let _ = std::io::copy(&mut file, &mut std::io::sink());
+                }
+            }
+            Err(e) => {
+                let _unused = black_box(format!("{e:?}"));
+                let _unused = black_box(format!("{e:#?}"));
+            }
+        },
+        Err(e) => {
+            let _unused = black_box(format!("{e:?}"));
+            let _unused = black_box(format!("{e:#?}"));
+        }
+    }
+});

--- a/projects/zip-rs/fuzz/fuzz_targets/structured_fuzz_reader.rs
+++ b/projects/zip-rs/fuzz/fuzz_targets/structured_fuzz_reader.rs
@@ -1,0 +1,134 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+//limitations under the License.
+//
+//###################
+
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use std::hint::black_box;
+use std::io::Cursor;
+
+#[derive(Arbitrary, Debug)]
+enum ReadOperations<'a> {
+    ReadByName(String),
+    ReadByNameDecrypt { name: String, password: &'a [u8] },
+    ReadByIterableNames,
+    ReadByIndex(usize),
+    ReadByIndexDecrypt { index: usize, password: &'a [u8] },
+    ReadByIterableIndicies,
+    ReadComment,
+}
+
+#[derive(Arbitrary, Debug)]
+#[repr(C)]
+struct Driver<'a> {
+    // NOTE: we are defining repr(C) so that the struct field ordering is consistent.
+    // This consistent ordering means that we still generate a set of zip files
+    // for the fuzz corpus, which will become the .zip_file, and any leftover data
+    // will be used for structured fuzzing.
+    zip_file: &'a [u8],
+    read_operations: Vec<ReadOperations<'a>>,
+}
+
+fn read_file_attributes(file: &mut zip::read::ZipFile) -> Result<(), zip::result::ZipError> {
+    use std::io::Read;
+    let _unused = black_box(file.name());
+    let _unused = black_box(file.mangled_name());
+    let _unused = black_box(file.enclosed_name());
+    let _unused = black_box(file.compression());
+    let _unused = black_box(file.compressed_size());
+    let _unused = black_box(file.size());
+    let _unused = black_box(file.last_modified());
+    let _unused = black_box(file.is_dir());
+    let _unused = black_box(file.is_file());
+    let _unused = black_box(file.unix_mode());
+    let _unused = black_box(file.crc32());
+    let _unused = black_box(file.data_start());
+    let _unused = black_box(file.header_start());
+    let _unused = black_box(file.central_header_start());
+    let mut s: String = String::new();
+    let _unused = black_box(file.read_to_string(&mut s));
+    return Ok(());
+}
+
+fn fuzzed_extract(driver: Driver) -> Result<(), zip::result::ZipError> {
+    match zip::ZipArchive::new(Cursor::new(driver.zip_file)) {
+        Ok(mut archive) => {
+            for operation in driver.read_operations.iter() {
+                match operation {
+                    ReadOperations::ReadByName(name) => {
+                        let mut file = archive.by_name(name)?;
+                        let _unused = black_box(read_file_attributes(&mut file));
+                    }
+                    // TODO: This could probably use a custom mutator, or a specialised seed corpus.
+                    // The probability that the fuzzer guesses the correct password is exceedingly low.
+                    ReadOperations::ReadByNameDecrypt { name, password } => {
+                        match archive.by_name_decrypt(name, password)? {
+                            Ok(mut file) => {
+                                let _unused = black_box(&read_file_attributes(&mut file));
+                            }
+                            Err(e) => {
+                                let _unused = black_box(format!("{e:?}"));
+                                let _unused = black_box(format!("{e:#?}"));
+                            }
+                        }
+                    }
+                    ReadOperations::ReadByIterableNames => {
+                        let names: Vec<String> =
+                            archive.file_names().map(|x| x.to_string()).collect();
+                        for name in names.iter() {
+                            let mut file = archive.by_name(&name)?;
+                            let _unused = black_box(read_file_attributes(&mut file));
+                        }
+                    }
+                    ReadOperations::ReadByIndex(index) => {
+                        let mut file = archive.by_index(*index)?;
+                        let _unused = black_box(read_file_attributes(&mut file));
+                    }
+                    ReadOperations::ReadByIndexDecrypt { index, password } => {
+                        match archive.by_index_decrypt(*index, password)? {
+                            Ok(mut file) => {
+                                let _unused = black_box(read_file_attributes(&mut file));
+                            }
+                            Err(e) => {
+                                let _unused = black_box(format!("{e:?}"));
+                                let _unused = black_box(format!("{e:#?}"));
+                            }
+                        }
+                    }
+                    ReadOperations::ReadByIterableIndicies => {
+                        for i in 0..archive.len() {
+                            let mut file = archive.by_index(i)?;
+                            let _unused = black_box(read_file_attributes(&mut file));
+                        }
+                    }
+                    ReadOperations::ReadComment => {
+                        let _unused = black_box(archive.comment());
+                    }
+                }
+            }
+        }
+        Err(e) => return Err(e),
+    }
+    return Ok(());
+}
+
+fuzz_target!(|driver: Driver| {
+    if let Err(e) = fuzzed_extract(driver) {
+        let _unused = black_box(format!("{e:?}"));
+        let _unused = black_box(format!("{e:#?}"));
+    }
+});


### PR DESCRIPTION
Adds two new fuzz harnesses;
     - Structured roundtrip.
     - Structured reader.

The read/write functionality implementation level is
    not symmetrical and some functions plugins e.g.
    zipcrypt is only supported for decompressing. Hence
    why we need both a "roundtrip" and a reader harness.

Adds a seed-corpus for;
     - The existing from_zip harness.
     - The new structured reader harness.