### PR TITLE
libevent: remove autotools dependencies

### DIFF
--- a/projects/libevent/Dockerfile
+++ b/projects/libevent/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool cmake pkg-config
+RUN apt-get update && apt-get install -y cmake make
 RUN git clone --depth 1 https://github.com/libevent/libevent.git libevent
 WORKDIR libevent
 COPY build.sh *.cc *.c $SRC/


### PR DESCRIPTION
Given that the cmake build system is used, we shouldn't have to install the dependencies to use autotools.