### PR TITLE
infra: bump fuzz introspector

### DIFF
--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y wget sudo && \
 RUN apt-get update && apt-get install -y git && \
     git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
     cd fuzz-introspector && \
-    git checkout 6b21f6396192f9c01f81d9e6c61ddfe1b36b288b && \
+    git checkout 74a51f53dcfed4e2ec062232fd9cbf480dae6962 && \
     git submodule init && \
     git submodule update && \
     apt-get autoremove --purge -y git && \


### PR DESCRIPTION
Includes
- Several bug fixes for builds
- Refinement of how static analysis is matched with code coverage data (https://github.com/ossf/fuzz-introspector/issues/812)
- More output to `summary.json` to make the following logic less hacky: https://github.com/google/oss-fuzz/blob/3d2ec74dba753ba9a91a3efd942615739f5028be/infra/build/build_status/fuzz_introspector_page_gen.py#L250-L260
- Improvements to the Sink analyser for detecting e.g. code injections: https://fuzz-introspector.readthedocs.io/en/latest/user-guides/analyse-sink-function.html
- Various improvements to the java frontend

Signed-off-by: David Korczynski <david@adalogics.com>