### PR TITLE
expat: remove autotools build dependencies

### DIFF
--- a/projects/expat/Dockerfile
+++ b/projects/expat/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool docbook2x cmake
+RUN apt-get update && apt-get install -y cmake docbook2x make
 
 RUN git clone --depth 1 https://github.com/libexpat/libexpat expat
 WORKDIR expat


### PR DESCRIPTION
Expat is built using cmake, so autotools and friends should not be required.