### PR TITLE
bitcoin-core: remove duplicate dependencies

### DIFF
--- a/projects/bitcoin-core/Dockerfile
+++ b/projects/bitcoin-core/Dockerfile
@@ -20,9 +20,8 @@ FROM gcr.io/oss-fuzz-base/base-builder-rust
 # * https://github.com/bitcoin/bitcoin/blob/master/doc/build-unix.md#dependency-build-instructions
 # * https://github.com/bitcoin/bitcoin/blob/master/depends/README.md#for-linux-including-i386-arm-cross-compilation
 RUN apt-get update && apt-get install -y \
-  build-essential libtool autotools-dev automake pkg-config bsdmainutils python3 \
-  make automake cmake curl g++-multilib libtool binutils-gold bsdmainutils pkg-config patch bison \
-  wget zip
+  automake autotools-dev bsdmainutils build-essential cmake curl g++-multilib libtool make \
+  patch pkg-config python3 wget zip
 
 RUN git clone --depth=1 https://github.com/bitcoin/bitcoin.git bitcoin-core
 RUN git clone --depth=1 https://github.com/bitcoin-core/qa-assets bitcoin-core/assets


### PR DESCRIPTION
Remove duplicate deps (automake, bsdmainutils, pkg-config).
Remove bison (built with NO_QT=1).
Remove binutils-gold (unneeded).