### PR TITLE
tor: skip building libevent tests & samples

### DIFF
--- a/projects/tor/build.sh
+++ b/projects/tor/build.sh
@@ -22,7 +22,12 @@ mkdir -p $TOR_DEPS
 # Build libevent with proper instrumentation.
 cd ${SRC}/libevent
 mkdir build && cd build
-cmake -DEVENT__DISABLE_MBEDTLS=ON -DEVENT__DISABLE_OPENSSL=ON -DEVENT__LIBRARY_TYPE=STATIC ../
+cmake -DEVENT__DISABLE_MBEDTLS=ON \
+      -DEVENT__DISABLE_OPENSSL=ON \
+      -DEVENT__LIBRARY_TYPE=STATIC \
+      -DEVENT__DISABLE_TESTS=ON \
+      -DEVENT__DISABLE_SAMPLES=ON \
+      ../
 make && make install
 
 # Build OpenSSL with proper instrumentation.


### PR DESCRIPTION
Skip building libevents tests and samples as part of tors build.