### PR TITLE
[elfutils] drop --no-undefined using NO_UNDEFINED

### DIFF
--- a/projects/elfutils/build.sh
+++ b/projects/elfutils/build.sh
@@ -56,7 +56,7 @@ export LIB_FUZZING_ENGINE=${LIB_FUZZING_ENGINE:--fsanitize=fuzzer}
 cd "$SRC/elfutils"
 
 # ASan isn't compatible with -Wl,--no-undefined: https://github.com/google/sanitizers/issues/380
-find -name Makefile.am | xargs sed -i 's/,--no-undefined//'
+sed -i 's/^\(NO_UNDEFINED=\).*/\1/' configure.ac
 
 # ASan isn't compatible with -Wl,-z,defs either:
 # https://clang.llvm.org/docs/AddressSanitizer.html#usage


### PR DESCRIPTION
The elfutils build system no longer passes `--no-undefined` explicitly so it should be dropped by overwriting the NO_UNDEFINED variable instead.

It's a follow-up to https://sourceware.org/git/?p=elfutils.git;a=commitdiff;h=3fa98a6f29b0f370e32549ead7eb897c839af980

Closes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=55999