### PR TITLE
envoy: prevent building with none sanitizer

### DIFF
--- a/projects/envoy/project.yaml
+++ b/projects/envoy/project.yaml
@@ -23,6 +23,10 @@ auto_ccs:
   - "copybara-worker@system.gserviceaccount.com"
 coverage_extra_args: -ignore-filename-regex=.*\.cache.*envoy_deps_cache.*
 main_repo: 'https://github.com/envoyproxy/envoy.git'
+sanitizers:
+ - address
+ - memory
+ - undefined
 fuzzing_engines:
   - libfuzzer
   - honggfuzz


### PR DESCRIPTION
PR #9653 added a "none" sanitizer that broke Envoy's build.
This PR explicitly lists the allowed sanitizers (address, memory, and undefined).