### PR TITLE
tensorflow: reduce build script size

### DIFF
--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -111,29 +111,6 @@ if [ -n "${OSS_FUZZ_CI-}" ]
 then
   export FUZZTEST_EXTRA_ARGS="${FUZZTEST_EXTRA_ARGS} --local_ram_resources=HOST_RAM*1.0 --local_cpu_resources=HOST_CPUS*.6 --strip=always"
   export FUZZTEST_TARGET_FOLDER="//tensorflow/security/fuzzing/cc:base64_fuzz"
-
-  # Remove sanitization of various projects to limit memory footprints. This can
-  # also be used across the real fuzzing (i.e. not only in the CI) in order
-  # to speed up fuzzing by reducing 8-bit counters in the instrumented code.
-  # For futher details, see:
-  # https://github.com/google/oss-fuzz/blob/b5a904f070363a617a585e4cf75729bdb14f9ac4/projects/envoy/build.sh#L87
-  # https://blog.envoyproxy.io/a-stroll-down-fuzzer-optimisation-lane-and-why-instrumentation-policies-matter-f0012ec260b3
-  declare -r DI="$(
-    echo " --per_file_copt=^.*com_google_protobuf.*\.cc\$@-fsanitize-coverage=0,-fno-sanitize=all"
-    echo " --per_file_copt=^.*com_google_absl.*\.cc\$@-fsanitize-coverage=0,-fno-sanitize=all"
-    echo " --per_file_copt=^.*boringssl.*\.cc\$@-fsanitize-coverage=0,-fno-sanitize=all"
-    echo " --per_file_copt=^.*com_googlesource_code_re2.*\.cc\$@-fsanitize-coverage=0,-fno-sanitize=all"
-    echo " --per_file_copt=^.*llvm-project.*\.cpp\$@-fsanitize-coverage=0,-fno-sanitize=all"
-    echo " --per_file_copt=^.*mlir.*\.cpp\$@-fsanitize-coverage=0,-fno-sanitize=all"
-    echo " --per_file_copt=^.*mkl_dnn_v1.*\.cpp\$@-fsanitize-coverage=0,-fno-sanitize=all"
-    echo " --per_file_copt=^.*nasm.*\.c\$@-fsanitize-coverage=0,-fno-sanitize=all"
-    echo " --per_file_copt=^.*curl.*\.c\$@-fsanitize-coverage=0,-fno-sanitize=all"
-    echo " --per_file_copt=^.*kernels.*\.cc\$@-fsanitize-coverage=0,-fno-sanitize=all"
-    echo " --per_file_copt=^.*platform.*\.cc\$@-fsanitize-coverage=0,-fno-sanitize=all"
-    echo " --per_file_copt=^.*external.*\.cpp\$@-fsanitize-coverage=0,-fno-sanitize=all"
-    echo " --per_file_copt=^.*external.*\.cc\$@-fsanitize-coverage=0,-fno-sanitize=all"
-  )"
-  export FUZZTEST_EXTRA_ARGS="${FUZZTEST_EXTRA_ARGS} ${DI}"
 else
   export FUZZTEST_EXTRA_ARGS="${FUZZTEST_EXTRA_ARGS} --local_ram_resources=HOST_RAM*1.0 --local_cpu_resources=HOST_CPUS*.5 --strip=never"
 fi


### PR DESCRIPTION
The changes introduced in https://github.com/google/oss-fuzz/pull/9357 for limiting instrumentation in third party libraries are no longer needed, I think. This is because we now specify the explicit fuzz target to compile in the CI, which is much smaller in size than the targets that were built as part of the CI when instrumentation-limitation changes were made. It would be nice to remove these as they add a lot of unnecessary complexity in the build script.