### PR TITLE
Envoy: remove memory sanitizer

### DIFF
--- a/projects/envoy/project.yaml
+++ b/projects/envoy/project.yaml
@@ -25,7 +25,6 @@ coverage_extra_args: -ignore-filename-regex=.*\.cache.*envoy_deps_cache.*
 main_repo: 'https://github.com/envoyproxy/envoy.git'
 sanitizers:
  - address
- - memory
  - undefined
 fuzzing_engines:
   - libfuzzer


### PR DESCRIPTION
In PR #9719 I accidentally added the memory sanitizer, which brakes the oss-fuzz build:
```
Step #23 - "compile-libfuzzer-memory-x86_64": ld.lld: error: undefined symbol: __msan_param_tls
Step #23 - "compile-libfuzzer-memory-x86_64": >>> referenced by gtest-internal.h:522 (external/com_google_googletest/googletest/include/gtest/internal/gtest-internal.h:522)
Step #23 - "compile-libfuzzer-memory-x86_64": >>>               bazel-out/k8-fastbuild-ST-d2373e19ffe2/bin/test/common/router/_objs/config_impl_test_lib/config_impl_test.pic.o:(testing::internal::SuiteApiResolver<Envoy::Router::(anonymous namespace)::RouteMatcherTest>::GetSetUpCaseOrSuite(char const*, int))
Step #23 - "compile-libfuzzer-memory-x86_64": >>> referenced by gtest-internal.h:543 (external/com_google_googletest/googletest/include/gtest/internal/gtest-internal.h:543)
Step #23 - "compile-libfuzzer-memory-x86_64": >>>               bazel-out/k8-fastbuild-ST-d2373e19ffe2/bin/test/common/router/_objs/config_impl_test_lib/config_impl_test.pic.o:(testing::internal::SuiteApiResolver<Envoy::Router::(anonymous namespace)::RouteMatcherTest>::GetTearDownCaseOrSuite(char const*, int))
Step #23 - "compile-libfuzzer-memory-x86_64": >>> referenced by gtest-internal.h:522 (external/com_google_googletest/googletest/include/gtest/internal/gtest-internal.h:522)
Step #23 - "compile-libfuzzer-memory-x86_64": >>>               bazel-out/k8-fastbuild-ST-d2373e19ffe2/bin/test/common/router/_objs/config_impl_test_lib/config_impl_test.pic.o:(testing::internal::SuiteApiResolver<Envoy::Router::(anonymous namespace)::HeaderTransformsDoFormattingTest>::GetSetUpCaseOrSuite(char const*, int))
Step #23 - "compile-libfuzzer-memory-x86_64": >>> referenced 377754 more times
```

This PR keeps the address and undefined sanitizer.