### PR TITLE
[elfutils] disable demangler

### DIFF
--- a/projects/elfutils/build.sh
+++ b/projects/elfutils/build.sh
@@ -80,7 +80,7 @@ fi
 
 autoreconf -i -f
 if ! ./configure --enable-maintainer-mode --disable-debuginfod --disable-libdebuginfod \
-            --without-bzlib --without-lzma --without-zstd \
+            --disable-demangler --without-bzlib --without-lzma --without-zstd \
 	    CC="$CC" CFLAGS="-Wno-error $CFLAGS" CXX="-Wno-error $CXX" CXXFLAGS="$CXXFLAGS" LDFLAGS="$CFLAGS"; then
     cat config.log
     exit 1


### PR DESCRIPTION
It should be turned off explicitly now.

It's a follow-up to
https://sourceware.org/git/?p=elfutils.git;a=commitdiff;h=77d237798c8f262d618bd3ed2db8864022bfcacb https://sourceware.org/git/?p=elfutils.git;a=commitdiff;h=73e212b0a778c6dbe84f79b7eb2647dea50ea16f

Closes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=56085