### PR TITLE
libical: add extended fuzzer

### DIFF
--- a/projects/libical/Dockerfile
+++ b/projects/libical/Dockerfile
@@ -18,8 +18,5 @@ FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN git clone --depth 1 https://github.com/libical/libical.git
 COPY build.sh $SRC
-COPY *.cc $SRC
+COPY *.cc $SRC/
 WORKDIR libical
-
-
-

--- a/projects/libical/Dockerfile
+++ b/projects/libical/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN git clone --depth 1 https://github.com/libical/libical.git
 COPY build.sh $SRC
-COPY libical_fuzzer.cc $SRC
+COPY *.cc $SRC
 WORKDIR libical
 
 

--- a/projects/libical/build.sh
+++ b/projects/libical/build.sh
@@ -1,6 +1,8 @@
 cmake . -DSTATIC_ONLY=ON -DICAL_GLIB=False
 make install -j$(nproc)
 
+
 $CXX $CXXFLAGS -std=c++11 $SRC/libical_fuzzer.cc $LIB_FUZZING_ENGINE /usr/local/lib/libical.a -o $OUT/libical_fuzzer
+$CXX $CXXFLAGS -std=c++11 $SRC/libical_extended_fuzzer.cc $LIB_FUZZING_ENGINE /usr/local/lib/libical.a -o $OUT/libical_extended_fuzzer
 
 find . -name *.ics -print | zip -q $OUT/libical_fuzzer_seed_corpus.zip -@

--- a/projects/libical/build.sh
+++ b/projects/libical/build.sh
@@ -1,3 +1,20 @@
+#!/bin/bash -eu
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
 cmake . -DSTATIC_ONLY=ON -DICAL_GLIB=False
 make install -j$(nproc)
 

--- a/projects/libical/libical_extended_fuzzer.cc
+++ b/projects/libical/libical_extended_fuzzer.cc
@@ -20,7 +20,7 @@
   Usage:
     python infra/helper.py build_image libical
     python infra/helper.py build_fuzzers --sanitizer undefined|address|memory libical
-    python infra/helper.py run_fuzzer libical libical_fuzzer
+    python infra/helper.py run_fuzzer libical libical_extended_fuzzer
 */
 
 #include <stdlib.h>

--- a/projects/libical/libical_extended_fuzzer.cc
+++ b/projects/libical/libical_extended_fuzzer.cc
@@ -1,0 +1,46 @@
+/*
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+*/
+
+/*
+  Usage:
+    python infra/helper.py build_image libical
+    python infra/helper.py build_fuzzers --sanitizer undefined|address|memory libical
+    python infra/helper.py run_fuzzer libical libical_fuzzer
+*/
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <libical/ical.h>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    char *ical_string1 = (char*)malloc(size + 1);
+    memcpy(ical_string1, data, size);
+    ical_string1[size] = '\0';
+
+    icalcomponent *ical1 = icalcomponent_new_from_string(ical_string1);
+    if (ical1 != NULL) {
+        icalcomponent_normalize(ical1);
+    }
+    icalcomponent_free(ical1);
+    free(ical_string1);
+
+    return 0;
+}


### PR DESCRIPTION
Hi @tsdgeos @winterz 

Would you be okay adding the fuzzer of this PR?

I'm developing on Fuzz Introspector (https://github.com/ossf/fuzz-introspector) and was looking at the libical report, where I spotted `icalcomponent_normalize` has a lot of uncovered code. You can find this from the publicly available Fuzz Introspector report in the function table sorting by column `Accummulate cyclomatic complexity`: https://storage.googleapis.com/oss-fuzz-introspector/libical/inspector-report/20230217/fuzz_report.html#Project-functions-overview As such, I thought it would be a nice target to fuzz since it will likely give the fuzzer a lot of code to explore.

![Screenshot from 2023-02-18 20-06-40](https://user-images.githubusercontent.com/657617/219890550-ac66c218-47df-4109-96bb-020a90d1100a.png)
