### PR TITLE
[helper] replace pipes.quote with shlex.quote

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -24,8 +24,8 @@ import datetime
 import errno
 import logging
 import os
-import pipes
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -542,7 +542,7 @@ def _get_absolute_path(path):
 
 def _get_command_string(command):
   """Returns a shell escaped command string."""
-  return ' '.join(pipes.quote(part) for part in command)
+  return ' '.join(shlex.quote(part) for part in command)
 
 
 def _get_project_build_subdir(project, subdir_name):


### PR DESCRIPTION
pipes got deprecated in
https://github.com/python/cpython/commit/2551a6c92f247eed8121b14f151acd95432dff9e and Python3.11 complains about it:
```
infra/helper.py:27: DeprecationWarning: 'pipes' is deprecated and slated for removal in Python 3.13
  import pipes
```

The pipes module just uses shlex.quote so it can be used direcly instead.