### PR TITLE
rtpproxy: initial integration.

### DIFF
--- a/projects/rtpproxy/Dockerfile
+++ b/projects/rtpproxy/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN git clone https://github.com/sippy/rtpproxy
+RUN git -C rtpproxy submodule update --init --recursive
+
+COPY build.sh $SRC/
+
+WORKDIR rtpproxy

--- a/projects/rtpproxy/build.sh
+++ b/projects/rtpproxy/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+bash -x ./scripts/fuzz/oss-fuzz-build.sh

--- a/projects/rtpproxy/project.yaml
+++ b/projects/rtpproxy/project.yaml
@@ -1,0 +1,14 @@
+homepage: "https://rtpproxy.org/"
+main_repo: "https://github.com/sippy/rtpproxy"
+primary_contact: "sobomax@sippysoft.com"
+language: c
+auto_ccs:
+  - "sobomax@gmail.com"
+vendor_ccs:
+  - "razvan@opensips.org"
+  - "liviu@opensips.org"
+fuzzing_engines:
+  - afl
+  - honggfuzz
+  - libfuzzer
+file_github_issue: True


### PR DESCRIPTION
This patch adds OSS-Fuzz integration for the RTPProxy project. The RTPProxy is a companion software used by many of the SIP application servers (OpenSIPS, Kamailio, Sipppy B2BUA etc) to handle RTP streams. We have completed integration on our side already, e.g. https://github.com/sippy/rtpproxy/actions/runs/4226614295/jobs/7340239205.