### PR TITLE
cras: Add libclang for bindgen

### DIFF
--- a/projects/cras/Dockerfile
+++ b/projects/cras/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get -y update && \
       libsndfile-dev \
       libspeexdsp-dev \
       libsystemd-dev \
+      libclang1 \
       libtool \
       libudev-dev \
       wget \


### PR DESCRIPTION
Similar to https://github.com/google/oss-fuzz/pull/9317, we'd be using bindgen so we need libclang.so on the image.