### PR TITLE
go-toml: fix coverage

### DIFF
--- a/projects/go-toml/build.sh
+++ b/projects/go-toml/build.sh
@@ -15,4 +15,6 @@
 #
 ################################################################################
 
+mkdir $OUT/benchmark
+cp benchmark/benchmark.toml $OUT/benchmark/benchmark.toml
 compile_go_fuzzer . FuzzToml fuzz_toml gofuzz


### PR DESCRIPTION
This is a temporary fix, Will remove this once upstream supports go native fuzzing.