### PR TITLE
hdf5: disable leak detection for extended fuzzer

### DIFF
--- a/projects/hdf5/Dockerfile
+++ b/projects/hdf5/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool \
   pkg-config cmake zlib1g-dev
 RUN git clone --depth 1 https://github.com/HDFGroup/hdf5
 WORKDIR hdf5
-COPY build.sh *.c $SRC/
+COPY build.sh *.c *.options $SRC/

--- a/projects/hdf5/build.sh
+++ b/projects/hdf5/build.sh
@@ -48,3 +48,4 @@ $CC $CFLAGS  -std=c99 -c \
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE h5_extended_fuzzer.o ./build-dir/bin/libhdf5.a -lz -o $OUT/h5_extended_fuzzer
 
 zip -j $OUT/h5_extended_fuzzer_seed_corpus.zip $SRC/hdf5/test/*.h5
+cp $SRC/*.options $OUT/

--- a/projects/hdf5/h5_extended_fuzzer.options
+++ b/projects/hdf5/h5_extended_fuzzer.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+detect_leaks=0


### PR DESCRIPTION
The fuzzer runs into them quickly and it would be nice to have it explore more code for now.