### PR TITLE
binutils/fuzz_dwarf memory leak

### DIFF
--- a/projects/binutils/fuzz_dwarf.c
+++ b/projects/binutils/fuzz_dwarf.c
@@ -29,13 +29,16 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
   fwrite(data, size, 1, fp);
   fclose(fp);
 
-  bfd *file;
-  file = bfd_openr (filename, NULL);
-  if (file) {
-  if (bfd_check_format (file, bfd_object)) {
-    load_separate_debug_files(file, bfd_get_filename(file));
+  bfd *file = bfd_openr (filename, NULL);
+  if (file)
+    {
+      if (bfd_check_format (file, bfd_object))
+	{
+	  load_separate_debug_files (file, bfd_get_filename (file));
+	  free_debug_memory ();
+	}
+      bfd_close_all_done (file);
     }
-  }
   unlink(filename);
   return 0;
 }


### PR DESCRIPTION
Fixes issue 42739, a leak in the fuzzer.