### PR TITLE
libhoextdown: only compile relevant libraries

### DIFF
--- a/projects/hoextdown/build.sh
+++ b/projects/hoextdown/build.sh
@@ -18,7 +18,7 @@
 # temporary hack to make the build honor CFLAGS. Needs proper fix upstream.
 sed -i 's/^CFLAGS.*//g' Makefile
 # build project
-make -j$(nproc) all
+make -j$(nproc) libhoedown.a
 
 # build fuzzers
 $CC $CFLAGS -c -std=c99 -Isrc \


### PR DESCRIPTION
This enable Fuzz Introspector build since we avoid some shared libraries that are not compatible with LLVM LTO.