### PR TITLE
infra: use an absolute path to the JavaScript fuzz test file

### DIFF
--- a/infra/base-images/base-builder/compile_javascript_fuzzer
+++ b/infra/base-images/base-builder/compile_javascript_fuzzer
@@ -34,7 +34,7 @@ fuzzer_basename=$(basename -s .js $fuzz_target)
 # Create an execution wrapper that executes Jazzer.js with the correct arguments.
 echo "#!/bin/bash
 # LLVMFuzzerTestOneInput so that the wrapper script is recognized as a fuzz target for 'check_build'.
-this_dir=\$(dirname \"\$0\")
-\$this_dir/$project/node_modules/@jazzer.js/core/dist/cli.js $project/$fuzz_target $jazzerjs_args \$JAZZERJS_EXTRA_ARGS -- \$@" > $OUT/$fuzzer_basename
+project_dir=\$(dirname \"\$0\")/$project
+\$project_dir/node_modules/@jazzer.js/core/dist/cli.js \$project_dir/$fuzz_target $jazzerjs_args \$JAZZERJS_EXTRA_ARGS -- \$@" > $OUT/$fuzzer_basename
 
 chmod +x $OUT/$fuzzer_basename


### PR DESCRIPTION
This fixes the issue of running Jazzer.js fuzzer using an absolute path such as `/out/fuzzer`. 

@oliverchang We needed a minor fix in Jazzer.js (https://github.com/CodeIntelligenceTesting/jazzer.js/pull/341), so you would need to rebuild the project so that the latest version (1.4.0) is fetched from npm.