### PR TITLE
cctz: disable benchmark build

### DIFF
--- a/projects/cctz/build.sh
+++ b/projects/cctz/build.sh
@@ -14,7 +14,7 @@
 #
 ################################################################################
 mkdir build && cd build
-cmake -DBUILD_TESTING=OFF ../
+cmake -DBUILD_TESTING=OFF -DBUILD_BENCHMARK=OFF ../
 make
 
 # Compile fuzzers


### PR DESCRIPTION
This is required for the CI to work on
https://github.com/google/cctz/pull/241