### PR TITLE
llvm: fix build deprecate LLVM_ENABLE_PROJECTS

### DIFF
--- a/projects/llvm/build.sh
+++ b/projects/llvm/build.sh
@@ -65,7 +65,8 @@ mkdir build
 cd build
 
 cmake -GNinja -DCMAKE_BUILD_TYPE=Release ../$LLVM \
-    -DLLVM_ENABLE_PROJECTS="clang;libcxx;libcxxabi;compiler-rt;lld;clang-tools-extra" \
+    -DLLVM_ENABLE_PROJECTS="clang;lld;clang-tools-extra" \
+    -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;compiler-rt" \
     -DLLVM_ENABLE_ASSERTIONS=ON \
     -DCMAKE_C_COMPILER="${CC}" \
     -DCMAKE_CXX_COMPILER="${CXX}" \


### PR DESCRIPTION
llvm build has been broken, the reason is that
1.  [`LLVM_ENABLE_PROJECTS` for libc++, libc++abi was deprecate](https://reviews.llvm.org/D112724)
2. compiler-rt is also a runtime according to the [llvm-docs](https://llvm.org/docs/CMake.html#llvm-related-variables)