### PR TITLE
Add additional CC to GLib project configuration

### DIFF
--- a/projects/glib/project.yaml
+++ b/projects/glib/project.yaml
@@ -8,6 +8,7 @@ auto_ccs:
 - slomo@coaxion.net
 - trevi55@gmail.com
 - mcatanza@redhat.com
+- tcullum@redhat.com
 sanitizers:
 - address
 - undefined


### PR DESCRIPTION
Todd Cullum is on the Red Hat security team and has been vouched for by Michael Catanzaro. He is not a GLib upstream maintainer.