### PR TITLE
wabt: fix build of external fuzzers with `-std=c++17`

### DIFF
--- a/projects/wabt/build.sh
+++ b/projects/wabt/build.sh
@@ -24,13 +24,13 @@ cd ..
 
 for fuzzers in $(find $SRC -name '*_fuzzer.cc' | grep -v wasm_objdump_fuzzer); do
   fuzz_basename=$(basename -s .cc $fuzzers)
-  $CXX $CXXFLAGS -std=c++11 -I. -Ibuild -Iinclude -Ibuild/include \
+  $CXX $CXXFLAGS -std=c++17 -I. -Ibuild -Iinclude -Ibuild/include \
   $fuzzers $LIB_FUZZING_ENGINE ./build/libwabt.a \
   -o $OUT/$fuzz_basename
 done
 
 # wasm_objdump_fuzzer needs to be linked together with binary-reader-objdump.cc
-$CXX $CXXFLAGS -std=c++11 -I. -Ibuild -Ibuild/include -Iinclude /src/wasm_objdump_fuzzer.cc \
+$CXX $CXXFLAGS -std=c++17 -I. -Ibuild -Ibuild/include -Iinclude /src/wasm_objdump_fuzzer.cc \
         ./src/binary-reader-objdump.cc $LIB_FUZZING_ENGINE ./build/libwabt.a \
         -o $OUT/wasm_objdump_fuzzer
 


### PR DESCRIPTION
wabt moved from C++11 to C++17 about a year ago (https://github.com/WebAssembly/wabt/pull/1825), but the oss-fuzz repo includes external fuzzers that were built with C++11. A recent commit (https://github.com/WebAssembly/wabt/pull/2152) broke the build.
