### PR TITLE
Add coverage for toml encoder

### DIFF
--- a/projects/toml/Dockerfile
+++ b/projects/toml/Dockerfile
@@ -16,7 +16,5 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-python
 RUN git clone --depth 1 https://github.com/uiri/toml toml
-
 COPY build.sh fuzz_*.py atheris_dict.py $SRC/
-
 WORKDIR $SRC/toml

--- a/projects/toml/atheris_dict.py
+++ b/projects/toml/atheris_dict.py
@@ -40,7 +40,7 @@ def random_float():
 
 
 def random_string():
-    return fdp.ConsumeString(sys.maxsize)
+    return fdp.ConsumeString(fdp.ConsumeIntInRange(0, 1024))
 
 
 def random_datetime():

--- a/projects/toml/atheris_dict.py
+++ b/projects/toml/atheris_dict.py
@@ -1,0 +1,137 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# This is a modified version of https://github.com/robtandy/randomdict which has
+# been changed to
+#    - Work with the atheris fuzzer
+#    - Filter duplicate keys
+#    - Target the TOML encoder library
+
+import datetime
+from itertools import product
+from random import choice, shuffle
+from typing import Callable, List
+import pathlib
+import sys
+from toml.decoder import InlineTableDict
+
+fdp = None
+
+
+def random_int():
+    return fdp.ConsumeInt(16)
+
+
+def random_float():
+    return fdp.ConsumeFloat()
+
+
+def random_string():
+    return fdp.ConsumeString(sys.maxsize)
+
+
+def random_datetime():
+    return datetime.time(
+        hour=fdp.ConsumeIntInRange(0, 23), minute=fdp.ConsumeIntInRange(0, 59)
+    )
+
+
+def random_list():
+    t = fdp.ConsumeIntList(10, 16)
+    for i in range(fdp.ConsumeIntInRange(0, 2)):
+        # Add dictionary to hit nested arrayoftables functionality
+        t.append(random_dict(2, 2))
+    return t
+
+
+def random_inline_table_dict():
+    class TestDict(dict, InlineTableDict):
+        pass
+
+    t = TestDict()
+    t[random_string()] = random_float()
+    return t
+
+
+def random_path():
+    return pathlib.Path("/hello/world")
+
+
+# Return a random set of functions from list
+def _value_gen(sources: List[Callable], number: int) -> Callable:
+    for _ in range(number):
+        yield choice(sources)
+
+
+generators = (random_int, random_float, random_string)
+
+
+def random_dict(
+    max_depth,
+    max_height,
+    generators=(
+        random_int,
+        random_float,
+        random_string,
+        random_datetime,
+        random_list,
+        random_inline_table_dict,
+        random_path,
+    ),
+    generators_combinations=5,
+    fdp_generator=None,
+):
+    # Create a handle to the fdp generator
+    if fdp_generator:
+        global fdp
+        fdp = fdp_generator
+
+    # Create random combinations of key and value generators
+    # e.g. random_string, random_int
+    generators_tuples = list(
+        product(_value_gen(generators, max_height), _value_gen(generators, max_height))
+    )
+
+    # Shuffle that list
+    shuffle(generators_tuples)
+
+    # Return a dictionary item
+    result = {}
+    for key_gen, val_gen in generators_tuples[:generators_combinations]:
+        # Filter out types that can't be used as dictionary keys
+        # Currently we're filtering out valid python key types because toml throws
+        # exception when using them. See issue https://github.com/uiri/toml/issues/408
+        if key_gen not in [
+            random_list,
+            random_inline_table_dict,
+            random_datetime,
+            random_path,
+            random_int,
+            random_float,
+        ]:
+            # New logic to remove duplicates
+            newKey = key_gen()
+            if newKey not in result:
+                result[key_gen()] = (
+                    random_dict(
+                        fdp.ConsumeIntInRange(1, max_depth - 1),
+                        fdp.ConsumeIntInRange(1, max_height - 1),
+                        generators,
+                    )
+                    if max_depth > 1 and max_height > 1
+                    else val_gen()
+                )
+    return result

--- a/projects/toml/fuzz_dump.py
+++ b/projects/toml/fuzz_dump.py
@@ -1,0 +1,53 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+import io
+import sys
+import atheris
+import atheris_dict
+
+with atheris.instrument_imports():
+    import toml
+
+
+def TestOneInput(data):
+    fdp = atheris.FuzzedDataProvider(data)
+
+    # Pick from a random set of encoders
+    ENCODERS = [
+        toml.TomlEncoder(preserve=fdp.ConsumeBool()),  # Optional formatting argument
+        toml.TomlPreserveInlineDictEncoder(),
+        toml.TomlArraySeparatorEncoder(separator=",\t"),
+        toml.TomlPreserveCommentEncoder(),
+        toml.TomlPathlibEncoder(),
+        None,
+    ]
+
+    # Generate a random dictionary object
+    fuzz_dict = atheris_dict.random_dict(10, 10, fdp_generator=fdp)
+
+    with io.StringIO("") as outfile:
+        result = toml.encoder.dump(fuzz_dict, outfile, fdp.PickValueInList(ENCODERS))
+
+
+def main():
+    atheris.instrument_all()
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/toml/fuzz_dump.py
+++ b/projects/toml/fuzz_dump.py
@@ -19,8 +19,7 @@ import sys
 import atheris
 import atheris_dict
 
-with atheris.instrument_imports():
-    import toml
+import toml
 
 
 def TestOneInput(data):

--- a/projects/toml/fuzz_dumps.py
+++ b/projects/toml/fuzz_dumps.py
@@ -1,0 +1,50 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+import sys
+import atheris
+import atheris_dict
+
+import toml
+
+
+def TestOneInput(data):
+    fdp = atheris.FuzzedDataProvider(data)
+
+    # Pick from a random set of encoders
+    ENCODERS = [
+        toml.TomlEncoder(preserve=fdp.ConsumeBool()),  # Optional formatting argument
+        toml.TomlPreserveInlineDictEncoder(),
+        toml.TomlArraySeparatorEncoder(separator=",\t"),
+        toml.TomlPreserveCommentEncoder(),
+        toml.TomlPathlibEncoder(),
+        None,
+    ]
+
+    # Generate a random dictionary object
+    fuzz_dict = atheris_dict.random_dict(10, 10, fdp_generator=fdp)
+
+    result = toml.encoder.dumps(fuzz_dict, fdp.PickValueInList(ENCODERS))
+
+
+def main():
+    atheris.instrument_all()
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/toml/fuzz_load.py
+++ b/projects/toml/fuzz_load.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,9 +14,26 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-python
-RUN git clone --depth 1 https://github.com/uiri/toml toml
+import sys
+import atheris
+import io
 
-COPY build.sh fuzz_*.py atheris_dict.py $SRC/
+import toml
 
-WORKDIR $SRC/toml
+def TestOneInput(data):
+    fdp = atheris.FuzzedDataProvider(data)
+    try:
+        f = io.StringIO(fdp.ConsumeString(sys.maxsize))
+        result = toml.decoder.load(f)
+    except toml.TomlDecodeError:
+        pass
+
+
+def main():
+    atheris.instrument_all()
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This change fuzzes random dictionaries at the different toml encoders to get coverage of `toml/encoder.py`. The dictionary fuzzing technique (`atheris_dict.py`) is derivative of another library [python-dict](github.com/abc), which is attributed in the source code.

Doing some local runs this takes `toml/encoder.py` from `16%` to `64%` statement coverage when using libfuzz.

Interestingly I'm finding for certain parameters like the `ENCODER` selection Python random `choice()` statements are a lot more effective at getting coverage that the `fdp.PickValueInList()` getting an extra 9% coverage. For now I've kept everything as the atheris fuzzer but can switch this over if you think it's worth doing.

The introspector call graphs and coverage don't look right, which is likely related to the existing issues on [https://github.com/ossf/fuzz-introspector](https://github.com/ossf/fuzz-introspector).
 
![image](https://user-images.githubusercontent.com/5122866/222126280-eac53006-73e3-4a36-9983-b4acc13beae7.png)

![image](https://user-images.githubusercontent.com/5122866/222126350-b7ce3cc9-d6d2-454c-9ba7-06000a906fb9.png)

