### PR TITLE
toml: call loads with explicit path

### DIFF
--- a/projects/toml/fuzz_loads.py
+++ b/projects/toml/fuzz_loads.py
@@ -22,7 +22,7 @@ import toml
 def TestOneInput(data):
     fdp = atheris.FuzzedDataProvider(data)
     try:
-        toml.loads(fdp.ConsumeString(sys.maxsize))
+        toml.decoder.loads(fdp.ConsumeString(sys.maxsize))
     except toml.TomlDecodeError:
         pass
 


### PR DESCRIPTION
To make the fuzz introspector nicer: https://github.com/google/oss-fuzz/pull/9834#issuecomment-1450019886