### PR TITLE
ci: Double free space from 30 GB to 60 GB

### DIFF
--- a/.github/workflows/project_tests.yml
+++ b/.github/workflows/project_tests.yml
@@ -68,23 +68,15 @@ jobs:
       - name: Clear unnecessary files
         run: |
           df -h
-          echo "Remove largest packages >200M, inspired by https://github.com/apache/flink/blame/master/tools/azure-pipelines/free_disk_space.sh"
-          dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 15
-          sudo apt-get remove -y azure-cli google-cloud-sdk microsoft-edge-stable google-chrome-stable firefox powershell
-          sudo apt-get remove -y '^llvm-.*'
-          sudo apt-get remove -y '^dotnet-.*'
-          sudo rm -rf /usr/share/dotnet/
-          sudo rm -rf /usr/local/graalvm/
-          sudo rm -rf /usr/local/.ghcup/
-          sudo rm -rf /usr/local/share/powershell
-          sudo rm -rf /usr/local/share/chromium
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /usr/local/lib/node_modules
           sudo swapoff -a
           sudo rm -f /swapfile
           sudo apt clean
           docker rmi $(docker images -a -q)
           df -h
+          echo "Remove largest packages >200M, inspired by https://github.com/apache/flink/blame/master/tools/azure-pipelines/free_disk_space.sh"
+          dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 15
+          sudo apt-get remove -y azure-cli google-cloud-sdk microsoft-edge-stable google-chrome-stable firefox powershell '^llvm-.*' '^dotnet-.*'
+          sudo bash -c '(rm -rf /usr/share/dotnet/ /usr/local/graalvm/ /usr/local/.ghcup/ /usr/local/share/powershell /usr/local/share/chromium /usr/local/lib/android /usr/local/lib/node_modules)&'
 
       - name: Setup python environment
         uses: actions/setup-python@v3

--- a/.github/workflows/project_tests.yml
+++ b/.github/workflows/project_tests.yml
@@ -68,11 +68,18 @@ jobs:
       - name: Clear unnecessary files
         run: |
           df -h
-          echo "Remove largest packages >200M"
+          echo "Remove largest packages >200M, inspired by https://github.com/apache/flink/blame/master/tools/azure-pipelines/free_disk_space.sh"
           dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 30
           sudo apt-get remove -y azure-cli google-cloud-sdk microsoft-edge-stable google-chrome-stable firefox powershell
           sudo apt-get remove -y '^llvm-.*'
           sudo apt-get remove -y '^dotnet-.*'
+          sudo rm -rf /usr/share/dotnet/
+          sudo rm -rf /usr/local/graalvm/
+          sudo rm -rf /usr/local/.ghcup/
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/local/share/chromium
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/local/lib/node_modules
           sudo swapoff -a
           sudo rm -f /swapfile
           sudo apt clean

--- a/.github/workflows/project_tests.yml
+++ b/.github/workflows/project_tests.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           df -h
           echo "Remove largest packages >200M, inspired by https://github.com/apache/flink/blame/master/tools/azure-pipelines/free_disk_space.sh"
-          dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 30
+          dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 15
           sudo apt-get remove -y azure-cli google-cloud-sdk microsoft-edge-stable google-chrome-stable firefox powershell
           sudo apt-get remove -y '^llvm-.*'
           sudo apt-get remove -y '^dotnet-.*'

--- a/.github/workflows/project_tests.yml
+++ b/.github/workflows/project_tests.yml
@@ -67,6 +67,12 @@ jobs:
 
       - name: Clear unnecessary files
         run: |
+          df -h
+          echo "Remove largest packages >200M"
+          dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 30
+          sudo apt-get remove -y azure-cli google-cloud-sdk microsoft-edge-stable google-chrome-stable firefox powershell
+          sudo apt-get remove -y '^llvm-.*'
+          sudo apt-get remove -y '^dotnet-.*'
           sudo swapoff -a
           sudo rm -f /swapfile
           sudo apt clean

--- a/.github/workflows/project_tests.yml
+++ b/.github/workflows/project_tests.yml
@@ -72,11 +72,11 @@ jobs:
           sudo rm -f /swapfile
           sudo apt clean
           docker rmi $(docker images -a -q)
-          df -h
           echo "Remove largest packages >200M, inspired by https://github.com/apache/flink/blame/master/tools/azure-pipelines/free_disk_space.sh"
           dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 15
           sudo apt-get remove -y azure-cli google-cloud-sdk microsoft-edge-stable google-chrome-stable firefox powershell '^llvm-.*' '^dotnet-.*'
-          sudo bash -c '(rm -rf /usr/share/dotnet/ /usr/local/graalvm/ /usr/local/.ghcup/ /usr/local/share/powershell /usr/local/share/chromium /usr/local/lib/android /usr/local/lib/node_modules)&'
+          df -h
+          sudo bash -c '(ionice -c 3 nice -n 19 rm -rf /usr/share/dotnet/ /usr/local/graalvm/ /usr/local/.ghcup/ /usr/local/share/powershell /usr/local/share/chromium /usr/local/lib/android /usr/local/lib/node_modules)&'
 
       - name: Setup python environment
         uses: actions/setup-python@v3

--- a/.github/workflows/project_tests.yml
+++ b/.github/workflows/project_tests.yml
@@ -72,10 +72,8 @@ jobs:
           sudo rm -f /swapfile
           sudo apt clean
           docker rmi $(docker images -a -q)
-          echo "Remove largest packages >200M, inspired by https://github.com/apache/flink/blame/master/tools/azure-pipelines/free_disk_space.sh"
-          dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 15
-          sudo apt-get remove -y azure-cli google-cloud-sdk microsoft-edge-stable google-chrome-stable firefox powershell '^llvm-.*' '^dotnet-.*'
           df -h
+          echo "Remove large unused folders, inspired by https://github.com/apache/flink/blame/master/tools/azure-pipelines/free_disk_space.sh"
           sudo bash -c '(ionice -c 3 nice -n 19 rm -rf /usr/share/dotnet/ /usr/local/graalvm/ /usr/local/.ghcup/ /usr/local/share/powershell /usr/local/share/chromium /usr/local/lib/android /usr/local/lib/node_modules)&'
 
       - name: Setup python environment

--- a/projects/bitcoin-core/build.sh
+++ b/projects/bitcoin-core/build.sh
@@ -47,7 +47,6 @@ else
   CONFIG_SITE="$PWD/depends/$BUILD_TRIPLET/share/config.site" ./configure --with-seccomp=no --enable-fuzz SANITIZER_LDFLAGS="$LIB_FUZZING_ENGINE"
 fi
 
-
 if [ "$SANITIZER" = "memory" ]; then
   # MemorySanitizer (MSAN) does not support tracking memory initialization done by
   # using the Linux getrandom syscall. Avoid using getrandom by undefining


### PR DESCRIPTION
My understanding is that basically only `git docker.io python` are needed for oss-fuzz, so 5 GB of the largest packages and 20+ GB of folders can be dropped from the CI image to make room for other stuff.