### PR TITLE
lzo: fix crash on large inputs

### DIFF
--- a/projects/lzo/lzo_compress_target.c
+++ b/projects/lzo/lzo_compress_target.c
@@ -36,6 +36,13 @@ extern int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     int r;
     lzo_uint out_len;
     lzo_uint new_len;
+
+    /* Since we allocate in/out on the stack,
+     * we can't handle too large size.
+     */
+    if (size > (1 << 20))
+        size = 1 << 20;
+
     /* We want to compress the data block at 'in' with length 'IN_LEN' to
      * the block at 'out'. Because the input block may be incompressible,
      * we must provide a little more output space in case that compression


### PR DESCRIPTION
The target allocates 2*size buffers on the stack.
Stack is not always infinite. If we allocate on the stack,
we need to cap input size.