### PR TITLE
Update header lint source extension

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -7,7 +7,6 @@ sourceFileExtensions:
   - 'js'
   - 'java'
   - 'Dockerfile'
-  - 'js'
   - 'java'
   - 'c'
   - 'h'
@@ -21,3 +20,4 @@ sourceFileExtensions:
   - 'bash'
   - 'rs'
   - 'proto'
+  - 'swift'


### PR DESCRIPTION
This pr
- Removes duplicate extension from sourceFileExtensions
- Adds `swift` extension as its a oss-fuzz supported language and there exists a project with .swift extension files.  https://github.com/google/oss-fuzz/tree/master/projects/swift-nio