### PR TITLE
Guava: Choose proper minimumBits value for HashingFuzzer

### DIFF
--- a/projects/guava/HashingFuzzer.java
+++ b/projects/guava/HashingFuzzer.java
@@ -148,7 +148,8 @@ public class HashingFuzzer {
 	}
 
 	public static void fuzzerTestOneInput(FuzzedDataProvider fuzzedDataProvider) {
-		int minimumBits = fuzzedDataProvider.consumeInt();
+		// Choose realistic and valid minimumBits value; this is normally not controlled by the user
+		int minimumBits = fuzzedDataProvider.consumeInt(1, 8192);
 		int seed = fuzzedDataProvider.consumeInt();
 		int k0 = fuzzedDataProvider.consumeInt();
 		int k1 = fuzzedDataProvider.consumeInt();


### PR DESCRIPTION
See https://github.com/google/guava/issues/6324#issuecomment-1433981628 for more context.
This change makes sure that (1) `minimumBits` is valid (previously it could be negative, which is invalid) and (2) is not too large to prevent spurious `OutOfMemoryError`s.