### PR TITLE
binutils: don't use binutils-preconditions

### DIFF
--- a/projects/binutils/Dockerfile
+++ b/projects/binutils/Dockerfile
@@ -19,7 +19,6 @@ RUN apt-get update && apt-get install -y make texinfo libgmp-dev libmpfr-dev
 RUN apt-get install -y flex bison
 RUN git clone --depth=1 https://github.com/DavidKorczynski/binary-samples binary-samples
 RUN git clone --recursive --depth 1 git://sourceware.org/git/binutils-gdb.git binutils-gdb
-RUN git clone --depth=1 https://github.com/DavidKorczynski/binutils-preconditions binutils-preconditions
 WORKDIR $SRC
 COPY build.sh $SRC/
 COPY fuzz_*.c $SRC/

--- a/projects/binutils/build.sh
+++ b/projects/binutils/build.sh
@@ -68,9 +68,6 @@ cd ../binutils
 # The general strategy is to remove main functions such that the fuzzer (which has its own main)
 # can link against the code.
 
-# Copy over precondition files
-cp $SRC/binutils-preconditions/*.h .
-
 #
 # Patching
 #

--- a/projects/binutils/fuzz_addr2line.c
+++ b/projects/binutils/fuzz_addr2line.c
@@ -17,19 +17,6 @@ limitations under the License.
  */
 #include "fuzz_addr2line.h"
 
-/* for precondition checks */
-#include "ada_addr2line.h"
-
-/*
- * Preconditions that should be met so we won't run into bfd_fatal calls.
- * The fuzz_slurp_symtab and fuzz_preconditions_check implement simplified
- * versions of process_file and slurp_symtab of addr2line that only incorporates
- * the logic resulting in bfd_fatal calls.
- * If fuzz_preconditions_check returns 1, it means process_file should be
- * good to be called and there won't be any bfd_fatal call.
- */
-
-
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
 int
 LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
@@ -62,9 +49,7 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
   addr = c2;
 
   // Main fuzz entrypoint in addr2line.c
-  if (fuzz_preconditions_check(filename, NULL) == 1) {
-    process_file(filename, NULL, NULL);
-  }
+  process_file(filename, NULL, NULL);
  
   free(c2);
   free(c2_1);

--- a/projects/binutils/fuzz_nm.c
+++ b/projects/binutils/fuzz_nm.c
@@ -16,7 +16,6 @@ limitations under the License.
  * the binutils fuzzers.
  */
 #include "fuzz_nm.h"
-#include "ada_nm.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
 int
@@ -40,9 +39,7 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
 
   // Main fuzz entrypoint in nm.c
-  if (fuzz_preconditions(filename) == 1) {
-    display_file(filename);
-  }
+  display_file(filename);
 
   unlink(filename);
   return 0;

--- a/projects/binutils/fuzz_objdump.c
+++ b/projects/binutils/fuzz_objdump.c
@@ -17,9 +17,6 @@ limitations under the License.
  */
 #include "fuzz_objdump.h"
 
-/* for precondition checking */
-#include "ada_objdump.h"
-
 void objdump_reset() {
   process_links = true;
   do_follow_links = true;
@@ -66,14 +63,6 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
   //dump_dynamic_reloc_info = true;
   //dump_ctf_section_info = true;
   disassemble = true;
-#else
-  // Check preconditions are met, so the fuzzer wont exit (too often) prematurely.
-  // Reset objdump variables before and after this call, to ensure nothing no globals
-  // are carried over.
-  if (fuzz_preconditions(filename) == 0) {
-    return 0;
-  }
-  objdump_reset();
 #endif
 
   // Main fuzz entrypoint in objdump.c


### PR DESCRIPTION
binutils upstream addr2line, nm and objdump should no longer exit on various bfd failures, so oss-fuzz will be able to do without any of the "preconditions" checks.  Upstream has also changed so that binutils-preconditions/ada_nm.h no longer compiles.