### PR TITLE
packaging: fix fuzzer

### DIFF
--- a/projects/packaging/fuzz_packaging.py
+++ b/projects/packaging/fuzz_packaging.py
@@ -16,28 +16,28 @@
 
 import sys
 import atheris
-from packaging.utils import (
-  canonicalize_version,
-  parse_wheel_filename,
-  parse_sdist_filename,
-  InvalidSdistFilename,
-  InvalidWheelFilename
-)
+from packaging.utils import (canonicalize_version, parse_wheel_filename,
+                             parse_sdist_filename, InvalidSdistFilename,
+                             InvalidWheelFilename)
 
 from packaging.specifiers import InvalidSpecifier, Specifier
+from packaging.version import InvalidVersion
 
 
 def fuzz_utils(data):
   """Logic to hit routines in src/packaging/utils."""
   fdp = atheris.FuzzedDataProvider(data)
-  canonicalize_version(fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(0, 1024)))
+  canonicalize_version(
+      fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(0, 1024)))
   try:
-    parse_sdist_filename(fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(0, 1024)))
+    parse_sdist_filename(
+        fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(0, 1024)))
   except InvalidSdistFilename:
     pass
 
   try:
-    parse_wheel_filename(fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(0, 1024)))
+    parse_wheel_filename(
+        fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(0, 1024)))
   except InvalidWheelFilename:
     pass
 
@@ -46,18 +46,19 @@ def fuzz_specifier(data):
   """Logic to hit routines in src/packaging/specifiers."""
   fdp = atheris.FuzzedDataProvider(data)
   try:
-    spec1 = Specifier(fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(0, 1024)))
-    spec2 = Specifier(fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(0, 1024)))
+    spec1 = Specifier(
+        fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(0, 1024)))
+    spec2 = Specifier(
+        fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(0, 1024)))
   except InvalidSpecifier:
     return
 
   b1 = spec1 == spec2
   b2 = spec1 != spec2
-  b3 = spec1 <= spec2
-  b4 = spec1 >= spec2
-  b5 = spec1 < spec2
-  b6 = spec1 > spec2
-  b7 = spec1.constains(fdp.ConsumeUnicodeNoSurrogates(24))
+  try:
+    b7 = spec1.contains(fdp.ConsumeUnicodeNoSurrogates(24))
+  except InvalidVersion:
+    pass
 
 
 def TestOneInput(data):


### PR DESCRIPTION
Catch an exception thrown by the code and remove invalid operators.

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=56761