### PR TITLE
qpid-proton: disable LTO to fix honggfuzz linking

### DIFF
--- a/projects/qpid-proton/build.sh
+++ b/projects/qpid-proton/build.sh
@@ -15,15 +15,21 @@
 #
 ################################################################################
 
+env
 # workaround https://github.com/google/oss-fuzz/issues/9857
 ln -s /usr/local/bin/llvm-ar /src/aflplusplus/afl-llvm-ar
 ln -s /usr/local/bin/llvm-ranlib /src/aflplusplus/afl-llvm-ranlib
 
 mkdir build
 pushd build
-  cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_STATIC_LIBS=ON -DENABLE_FUZZ_TESTING=ON -DFUZZ_REGRESSION_TESTS=OFF
+  cmake .. \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DENABLE_LINKTIME_OPTIMIZATION=OFF \
+    -DBUILD_STATIC_LIBS=ON \
+    -DENABLE_FUZZ_TESTING=ON \
+    -DFUZZ_REGRESSION_TESTS=OFF
   pushd c/tests/fuzz/
-    make -j $(nproc)
+    VERBOSE=1 make -j $(nproc)
   popd
   cp c/tests/fuzz/{fuzz-connection-driver,fuzz-message-decode} $OUT/
 popd


### PR DESCRIPTION
@astitcher The issue is https://github.com/google/honggfuzz/issues/336#issuecomment-1458427538, for some reason the weak symbol from honggfuzz (placeholder function that prints help message and kills the fuzzer) gets used instead of our LLVMFuzzerTestOneInput.

I think that disabling LTO is a good temporary fix, to at least get all the fuzz builds working.