### PR TITLE
OpenSK fuzzing path

### DIFF
--- a/projects/opensk/build.sh
+++ b/projects/opensk/build.sh
@@ -19,7 +19,7 @@ FUZZ_TARGET_OUTPUT_DIR=fuzz/target/x86_64-unknown-linux-gnu/release
 
 # do not use override toolchain
 # cf https://rust-lang.github.io/rustup/overrides.html
-export RUSTUP_TOOLCHAIN=nightly-2021-11-01
+export RUSTUP_TOOLCHAIN=nightly
 
 build_and_copy() {
   pushd "$1"
@@ -33,8 +33,8 @@ build_and_copy() {
 
 cd OpenSK
 
-# Main OpenSK fuzzing targets
-build_and_copy "."
+# CTAP library fuzzing targets
+build_and_copy libraries/opensk
 
 # persistent storage library
 build_and_copy libraries/persistent_store


### PR DESCRIPTION
OpenSK moved its CTAP code into a library, and all fuzzing has moved with it. As an advantage, we are now independent of other dependencies that restricted the compiler versions we could use. Therefore, we are now fuzzing on the latest nightly, hopefully fixing some issues that came with the compiler restriction before.

The corresponding PR on our GitHub is https://github.com/google/OpenSK/pull/602