### PR TITLE
gss-ntlmssp: New project

### DIFF
--- a/projects/gss-ntlmssp/Dockerfile
+++ b/projects/gss-ntlmssp/Dockerfile
@@ -1,0 +1,32 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y \
+    autoconf \
+    docbook-xsl \
+    gettext \
+    libkrb5-dev \
+    libtool \
+    libunistring-dev \
+    libxml2-utils \
+    make \
+    xsltproc \
+    zlib1g-dev
+RUN git clone --depth 1 https://github.com/gssapi/gss-ntlmssp
+COPY build.sh $SRC/
+COPY fuzzing/ $SRC/gss-ntlmssp/fuzzing/
+WORKDIR $SRC/gss-ntlmssp/

--- a/projects/gss-ntlmssp/build.sh
+++ b/projects/gss-ntlmssp/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -eu
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+autoreconf -f -i
+./configure --disable-shared --enable-static --without-wbclient
+make
+
+pushd fuzzing/
+make fuzzer
+
+cp fuzz-accept-sec-context $OUT/
+cp fuzz-accept-sec-context.dict $OUT/
+popd

--- a/projects/gss-ntlmssp/fuzzing/Makefile
+++ b/projects/gss-ntlmssp/fuzzing/Makefile
@@ -1,0 +1,5 @@
+all: fuzzer
+
+fuzzer:
+	$(CC) $(CFLAGS) $(EXTCFLAGS) -I../include -I../src -c fuzz-accept-sec-context.c
+	$(CXX) $(CFLAGS) -o fuzz-accept-sec-context fuzz-accept-sec-context.o ../.libs/gssntlmssp.a $(LIB_FUZZING_ENGINE) -lssl -lcrypto -lgssapi_krb5 -lkrb5 -lk5crypto -lcom_err -lunistring -lz

--- a/projects/gss-ntlmssp/fuzzing/fuzz-accept-sec-context.c
+++ b/projects/gss-ntlmssp/fuzzing/fuzz-accept-sec-context.c
@@ -1,0 +1,66 @@
+#include <string.h>
+
+#include <krb5.h>
+#include <gssapi.h>
+#include "gss_ntlmssp.h"
+
+extern int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
+{
+    OM_uint32 maj_stat, min_stat;
+
+    gss_ctx_id_t ctx = GSS_C_NO_CONTEXT;
+    gss_name_t client_name = GSS_C_NO_NAME;
+    gss_cred_id_t deleg_cred = GSS_C_NO_CREDENTIAL;
+
+    /* Each fuzz input contains multiple tokens preceded by a length field.
+     * Process them in turn with gss_accept_sec_context while
+     * GSS_S_CONTINUE_NEEDED is set
+     */
+    do {
+        unsigned short token_length;
+
+        gss_buffer_desc input_token, output_token = GSS_C_EMPTY_BUFFER;
+
+        if (Size < sizeof(token_length))
+            break;
+
+        token_length = *(unsigned short *)Data;
+
+        Data += sizeof(token_length);
+        Size -= sizeof(token_length);
+
+        if (token_length == 0 || token_length > Size)
+            break;
+
+        input_token.length = token_length;
+        input_token.value = malloc(token_length);
+        memcpy(input_token.value, Data, token_length);
+
+        Data += token_length;
+        Size -= token_length;
+
+        maj_stat = gssntlm_accept_sec_context(
+            &min_stat,
+            &ctx,
+            GSS_C_NO_CREDENTIAL, /* server_creds */
+            &input_token,
+            GSS_C_NO_CHANNEL_BINDINGS, /* input_bindings */
+            &client_name,
+            NULL, /* mech_type */
+            &output_token,
+            NULL, /* ret_flags */
+            NULL, /* time */
+            &deleg_cred
+        );
+
+        gss_release_buffer(&min_stat, &input_token);
+        gss_release_buffer(&min_stat, &output_token);
+    } while(maj_stat == GSS_S_CONTINUE_NEEDED);
+
+    gss_release_name(&min_stat, &client_name);
+    gss_release_cred(&min_stat, &deleg_cred);
+
+    gss_delete_sec_context(&min_stat, &ctx, GSS_C_NO_BUFFER);
+
+    return 0;
+}

--- a/projects/gss-ntlmssp/fuzzing/fuzz-accept-sec-context.c
+++ b/projects/gss-ntlmssp/fuzzing/fuzz-accept-sec-context.c
@@ -1,3 +1,14 @@
+/* Copyright 2023 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 #include <string.h>
 
 #include <krb5.h>

--- a/projects/gss-ntlmssp/fuzzing/fuzz-accept-sec-context.dict
+++ b/projects/gss-ntlmssp/fuzzing/fuzz-accept-sec-context.dict
@@ -1,0 +1,7 @@
+"BAR\\foo"
+"foo@BAR"
+"foo\\@bar.example.com"
+"foo\\@bar.example.com@BAR"
+"\\foo@bar.example.com"
+"BAR\\foo@bar.example.com"
+"BAR@dom\\foo@bar.example.com"

--- a/projects/gss-ntlmssp/project.yaml
+++ b/projects/gss-ntlmssp/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://github.com/gssapi/gss-ntlmssp"
+language: c
+primary_contact: "simo@redhat.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+sanitizers:
+  - address
+  - memory
+  - undefined
+main_repo: "https://github.com/gssapi/gss-ntlmssp"


### PR DESCRIPTION
This PR adds a new gss-ntlmssp project. [gss-ntlmssp](https://github.com/gssapi/gss-ntlmssp) is a mechglue plugin for [krb5](https://github.com/krb5/krb5) that implements NTLM authentication via GSSAPI.

The plugin is available in the Debian, Ubuntu and Suse package repositories.

cc @simo5 as the gss-ntlmssp maintainer.