### PR TITLE
cilium: bump Go

### DIFF
--- a/projects/cilium/Dockerfile
+++ b/projects/cilium/Dockerfile
@@ -17,6 +17,11 @@
 FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN apt-get update && apt-get install -y wget
 RUN wget https://raw.githubusercontent.com/google/AFL/master/dictionaries/json.dict -O $OUT/fuzz.dict
+RUN wget https://go.dev/dl/go1.20.2.linux-amd64.tar.gz \
+    && mkdir temp-go \
+    && rm -rf /root/.go/* \
+    && tar -C temp-go/ -xzf go1.20.2.linux-amd64.tar.gz \
+    && mv temp-go/go/* /root/.go/
 
 RUN git clone --depth 1 https://github.com/dvyukov/go-fuzz-corpus
 RUN zip $OUT/fuzz_seed_corpus.zip go-fuzz-corpus/json/corpus/*

--- a/projects/cilium/build.sh
+++ b/projects/cilium/build.sh
@@ -15,5 +15,6 @@
 #
 ################################################################################
 
+export CXXFLAGS="${CXXFLAGS} -lresolv"
 $SRC/cilium/test/fuzzing/oss-fuzz-build.sh
 $SRC/cncf-fuzzing/projects/cilium/build.sh


### PR DESCRIPTION
Ciliums `go.mod` now uses Go 1.20, so bumping the fuzz build as well.