### PR TITLE
dapr: bump go

### DIFF
--- a/projects/dapr/Dockerfile
+++ b/projects/dapr/Dockerfile
@@ -15,6 +15,11 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN wget https://go.dev/dl/go1.20.2.linux-amd64.tar.gz \
+    && mkdir temp-go \
+    && rm -rf /root/.go/* \
+    && tar -C temp-go/ -xzf go1.20.2.linux-amd64.tar.gz \
+    && mv temp-go/go/* /root/.go/
 RUN git clone --depth 1 https://github.com/dapr/dapr
 RUN git clone --depth 1 https://github.com/cncf/cncf-fuzzing
 WORKDIR $SRC/dapr

--- a/projects/dapr/build.sh
+++ b/projects/dapr/build.sh
@@ -14,4 +14,5 @@
 # limitations under the License.
 #
 ################################################################################
+export CXXFLAGS="${CXXFLAGS} -lresolv"
 $SRC/cncf-fuzzing/projects/dapr/build.sh


### PR DESCRIPTION
Dapr's `go.mod` now uses Go 1.20, so bumping the fuzz build as well.