### PR TITLE
duckdb: Compile in relassert mode and enable CRASH_ON_ASSERT for fuzzing

### DIFF
--- a/projects/duckdb/build.sh
+++ b/projects/duckdb/build.sh
@@ -15,10 +15,10 @@
 #
 ################################################################################
 
-make CRASH_ON_ASSERT=1
-EXTENSION_LIBS=$(find ./build/release/extension/ -name "*.a")
-THIRD_PARTY_LIBS=$(find ./build/release/third_party/ -name "*.a")
+make relassert CRASH_ON_ASSERT=1
+EXTENSION_LIBS=$(find ./build/relassert/extension/ -name "*.a")
+THIRD_PARTY_LIBS=$(find ./build/relassert/third_party/ -name "*.a")
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE ./test/ossfuzz/parse_fuzz_test.cpp \
     -o $OUT/parse_fuzz_test -I./ -I./src/include \
-    ./build/release/src/libduckdb_static.a \
+    ./build/relassert/src/libduckdb_static.a \
     ${EXTENSION_LIBS} ${THIRD_PARTY_LIBS}

--- a/projects/duckdb/build.sh
+++ b/projects/duckdb/build.sh
@@ -15,7 +15,7 @@
 #
 ################################################################################
 
-make relassert CRASH_ON_ASSERT=1
+make relassert CRASH_ON_ASSERT=1 DISABLE_SANITIZER=1
 EXTENSION_LIBS=$(find ./build/relassert/extension/ -name "*.a")
 THIRD_PARTY_LIBS=$(find ./build/relassert/third_party/ -name "*.a")
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE ./test/ossfuzz/parse_fuzz_test.cpp \

--- a/projects/duckdb/build.sh
+++ b/projects/duckdb/build.sh
@@ -15,7 +15,7 @@
 #
 ################################################################################
 
-make
+make CRASH_ON_ASSERT=1
 EXTENSION_LIBS=$(find ./build/release/extension/ -name "*.a")
 THIRD_PARTY_LIBS=$(find ./build/release/third_party/ -name "*.a")
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE ./test/ossfuzz/parse_fuzz_test.cpp \


### PR DESCRIPTION
This should enable assertion checking, and sets it up so DuckDB calls `abort()` on any assertion trigger, which should lead to more effective fuzzing. 