### PR TITLE
[libjpeg-turbo] Add TGA images to compression seed corpus

### DIFF
--- a/projects/libjpeg-turbo/Dockerfile
+++ b/projects/libjpeg-turbo/Dockerfile
@@ -24,7 +24,7 @@ RUN git clone --depth 1 https://github.com/libjpeg-turbo/fuzz && \
 
 RUN git clone --depth 1 https://github.com/libjpeg-turbo/seed-corpora
 RUN cd seed-corpora && zip -r ../decompress_fuzzer_seed_corpus.zip afl-testcases/jpeg* bugs/decompress* $SRC/libjpeg-turbo/testimages/*.jpg
-RUN cd seed-corpora && zip -r ../compress_fuzzer_seed_corpus.zip afl-testcases/bmp afl-testcases/gif* bugs/compress* $SRC/libjpeg-turbo/testimages/*.bmp $SRC/libjpeg-turbo/testimages/*.ppm
+RUN cd seed-corpora && zip -r ../compress_fuzzer_seed_corpus.zip afl-testcases/bmp afl-testcases/gif* afl-testcases/targa bugs/compress* $SRC/libjpeg-turbo/testimages/*.bmp $SRC/libjpeg-turbo/testimages/*.ppm
 RUN rm -rf seed-corpora
 
 COPY build.sh $SRC/


### PR DESCRIPTION
Our "cjpeg" fuzz target, which tests rarely-used compression code paths, inputs only TARGA images (because that's a rarely-used compression code path as well), so the lack of those images in the seed corpus was preventing the rarely-used compression code paths from being fuzz-tested at all.  This should improve the overall coverage.