### PR TITLE
[pjsip] Update for ideal integration

### DIFF
--- a/projects/pjsip/Dockerfile
+++ b/projects/pjsip/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y autoconf libtool-bin pkg-config
+RUN apt-get update && apt-get install -y autoconf libtool-bin pkg-config libssl-dev zlib1g-dev
 RUN git clone https://github.com/pjsip/pjproject pjsip
 COPY build.sh $SRC/
 WORKDIR $SRC/pjsip/


### PR DESCRIPTION
`libssl-dev zlib1g-dev` are used for `Differential` fuzzing.

My PR: https://github.com/pjsip/pjproject/pull/3430