### PR TITLE
bottleneck: catch some known exceptions

### DIFF
--- a/projects/bottleneck/fuzz_bn.py
+++ b/projects/bottleneck/fuzz_bn.py
@@ -67,16 +67,22 @@ def TestOneInput(data):
   # Test move operations
   window = fdp.ConsumeIntInRange(2, 50)
   min_count = fdp.ConsumeIntInRange(1, window)
-  actual = bn.move_median(
-    a,
-    window=window,
-    min_count = fdp.ConsumeIntInRange(1,100)
-  )
-  desired = bn.slow.move_median(
-    a,
-    window=window,
-    min_count=fdp.ConsumeIntInRange(1, 100)
-  )
+  try:
+    actual = bn.move_median(
+      a,
+      window=window,
+      min_count = fdp.ConsumeIntInRange(1,100)
+    )
+  except ValueError:
+    return
+  try:
+    desired = bn.slow.move_median(
+      a,
+      window=window,
+      min_count=fdp.ConsumeIntInRange(1, 100)
+    )
+  except ValueError:
+    return
   assert_array_almost_equal(
     actual,
     desired,


### PR DESCRIPTION
`ValueError` are raised various places, e.g. https://github.com/pydata/bottleneck/blob/ffb2fe8cf201ec24b6a263cf65e040bf02ae1010/bottleneck/src/move_template.c#L974

Fixes e.g. https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=50587