### PR TITLE
Update the Maven binary for Gson.

### DIFF
--- a/projects/gson/Dockerfile
+++ b/projects/gson/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool wget ope
 RUN curl -L https://downloads.apache.org/maven/maven-3/3.9.0/binaries/apache-maven-3.9.0-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \
     rm -rf maven.zip
-ENV MVN $SRC/maven/apache-maven-3.8.7/bin/mvn
+ENV MVN $SRC/maven/apache-maven-3.9.0/bin/mvn
 
 RUN git clone --depth 1 https://github.com/google/gson gson
 WORKDIR gson

--- a/projects/gson/Dockerfile
+++ b/projects/gson/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 RUN apt-get update && apt-get install -y make autoconf automake libtool wget openjdk-17-jdk
 
-RUN curl -L https://downloads.apache.org/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.zip -o maven.zip && \
+RUN curl -L https://downloads.apache.org/maven/maven-3/3.9.0/binaries/apache-maven-3.9.0-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \
     rm -rf maven.zip
 ENV MVN $SRC/maven/apache-maven-3.8.7/bin/mvn


### PR DESCRIPTION
For some reason the original binary has disappeared. That might be a temporary problem, but anyway we might as well use a more recent version.