### PR TITLE
Uses Google account instead ASF one

### DIFF
--- a/projects/struts/project.yaml
+++ b/projects/struts/project.yaml
@@ -1,7 +1,7 @@
 homepage: "https://github.com/apache/struts"
 language: jvm
 main_repo: "https://github.com/apache/struts.git"
-primary_contact: "lukaszlenart@apache.org"
+primary_contact: "lukasz.lenart@gmail.com"
 fuzzing_engines:
   - libfuzzer
 sanitizers:


### PR DESCRIPTION
My ASF account is linked to my Google account, but OSS-Fuzz supports only Google integrated login

Refs #9915
Refs [WW-5291](https://issues.apache.org/jira/browse/WW-5291)