### PR TITLE
[xs] Add ps from Moddable

### DIFF
--- a/projects/xs/project.yaml
+++ b/projects/xs/project.yaml
@@ -3,6 +3,7 @@ language: c
 primary_contact: "peter.hoddie@gmail.com"
 auto_ccs:
   - peter@moddable.com
+  - ps@moddable.com
   - ari@agoric.com
   - raphael@agoric.com
 sanitizers:


### PR DESCRIPTION
As titled, adds another member of the Moddable team to allow reviewing OSS-Fuzz stats.