### PR TITLE
wasmtime: Allow Wasmtime to handle SIGFPE

### DIFF
--- a/projects/wasmtime/default.options
+++ b/projects/wasmtime/default.options
@@ -2,3 +2,4 @@
 allow_user_segv_handler=1
 handle_sigill=0
 handle_segv=1
+handle_sigfpe=1


### PR DESCRIPTION
Recently Wasmtime switched code generator tactics for the implementation of integer division. This means that Wasmtime expects to receive SIGFPE for divide-by-zero traps and similar. This is similar to other signals that Wasmtime is expected to handle in JIT code.

This commit adds an option for Wasmtime to let it handle signals in the same manner that it's allowed to handle SIGILL and SIGSEGV currently.