### PR TITLE
Update Jackson branches to latest 2.x, 2.15 (from 2.14)

### DIFF
--- a/projects/jackson-core/Dockerfile
+++ b/projects/jackson-core/Dockerfile
@@ -26,7 +26,7 @@ RUN git clone --depth 1 https://github.com/dvyukov/go-fuzz-corpus && \
     zip -j $SRC/JsonFuzzer_seed_corpus.zip go-fuzz-corpus/json/corpus/* && \
     zip -j $SRC/DataInputFuzzer_seed_corpus.zip go-fuzz-corpus/json/corpus/*
 
-ENV JACKSON_BRANCH=2.14
+ENV JACKSON_BRANCH=2.15
 
 RUN git clone --depth 1 --branch=$JACKSON_BRANCH https://github.com/FasterXML/jackson-core
 RUN git clone --depth 1 --branch=$JACKSON_BRANCH https://github.com/FasterXML/jackson-databind

--- a/projects/jackson-databind/Dockerfile
+++ b/projects/jackson-databind/Dockerfile
@@ -30,7 +30,7 @@ RUN git clone --depth 1 https://github.com/dvyukov/go-fuzz-corpus && \
     zip -q $SRC/ObjectWriterFuzzer_seed_corpus.zip go-fuzz-corpus/json/corpus/* && \
     rm -rf go-fuzz-corpus
 
-RUN git clone --depth 1 --branch 2.14 https://github.com/FasterXML/jackson-databind
+RUN git clone --depth 1 --branch 2.15 https://github.com/FasterXML/jackson-databind
 
 RUN git clone --depth 1 https://github.com/forge/roaster
 

--- a/projects/jackson-dataformat-xml/Dockerfile
+++ b/projects/jackson-dataformat-xml/Dockerfile
@@ -30,7 +30,7 @@ RUN git clone --depth 1 https://github.com/dvyukov/go-fuzz-corpus && \
     zip -j $SRC/XmlFuzzer_seed_corpus.zip go-fuzz-corpus/xml/corpus/* && \
     rm -rf go-fuzz-corpus
 
-ENV JACKSON_BRANCH=2.14
+ENV JACKSON_BRANCH=2.15
 
 RUN git clone --depth 1 --branch=$JACKSON_BRANCH https://github.com/FasterXML/jackson-dataformat-xml
 

--- a/projects/jackson-dataformats-binary/Dockerfile
+++ b/projects/jackson-dataformats-binary/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 RUN apt-get update && apt-get install -y maven
 
-ENV JACKSON_BRANCH=2.14
+ENV JACKSON_BRANCH=2.15
 
 RUN git clone --depth 1 --branch=$JACKSON_BRANCH https://github.com/FasterXML/jackson-dataformats-binary
 RUN git clone --depth 1 --branch=$JACKSON_BRANCH https://github.com/FasterXML/jackson-databind


### PR DESCRIPTION
As per title, development has moved to 2.15 from 2.14 for next version.