### PR TITLE
croniter: catch top-level exceptions

### DIFF
--- a/projects/croniter/fuzz_iter.py
+++ b/projects/croniter/fuzz_iter.py
@@ -18,9 +18,9 @@ import sys
 
 from datetime import datetime
 import croniter
+from croniter.croniter import CroniterError, CroniterBadTypeRangeError
 
 
-@atheris.instrument_func
 def TestOneInput(data):
   fdp = atheris.FuzzedDataProvider(data)
   base = datetime(2012, 4, 6, 13, 26, 10)
@@ -36,7 +36,7 @@ def TestOneInput(data):
         break
     itr.get_next(base)
     itr.get_prev(base)
-  except (croniter.CroniterBadCronError, croniter.CroniterBadDateError) as e:
+  except (CroniterError, CroniterBadTypeRangeError) as e:
     pass
   except NameError as e:
     # Catch https://github.com/kiorky/croniter/blob/bb5a45196e5f8f15fd0890f4ee5e9697671a3fe2/src/croniter/croniter.py#L781
@@ -46,7 +46,7 @@ def TestOneInput(data):
 
 def main():
   atheris.instrument_all()
-  atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
+  atheris.Setup(sys.argv, TestOneInput)
   atheris.Fuzz()
 
 if __name__ == "__main__":

--- a/projects/croniter/fuzz_match.py
+++ b/projects/croniter/fuzz_match.py
@@ -18,9 +18,12 @@ import sys
 
 import datetime
 import croniter
+from croniter.croniter import CroniterError, CroniterBadTypeRangeError
+
 
 def RandomDateTime(fdp):
     return datetime.datetime.now() + fdp.ConsumeProbability() * datetime.timedelta(days=200000)
+
 
 def TestOneInput(data):
   fdp = atheris.FuzzedDataProvider(data)
@@ -28,7 +31,7 @@ def TestOneInput(data):
   testdate = RandomDateTime(fdp)
   try:
     croniter.croniter.match(cron_str, testdate)
-  except croniter.CroniterBadCronError as e:
+  except (CroniterError, CroniterBadTypeRangeError) as e:
     pass
 
 

--- a/projects/croniter/fuzz_range.py
+++ b/projects/croniter/fuzz_range.py
@@ -18,9 +18,12 @@ import sys
 
 import datetime
 import croniter
+from croniter.croniter import CroniterError, CroniterBadTypeRangeError
+
 
 def RandomDateTime(fdp):
     return datetime.datetime.now() + fdp.ConsumeProbability() * datetime.timedelta(days=200000)
+
 
 def TestOneInput(data):
   fdp = atheris.FuzzedDataProvider(data)
@@ -33,7 +36,7 @@ def TestOneInput(data):
       idx += 1
       if idx > 10:
         break
-  except croniter.CroniterBadCronError as e:
+  except (CroniterError, CroniterBadTypeRangeError) as e:
     pass
 
 


### PR DESCRIPTION
The current exceptions caught are not the top-level croniter ones. This changes it to be that.

Fixes, e.g.: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=57122