### PR TITLE
Upgrade to Go 1.20

### DIFF
--- a/infra/base-images/base-builder/install_go.sh
+++ b/infra/base-images/base-builder/install_go.sh
@@ -18,7 +18,7 @@
 cd /tmp
 curl --silent -O https://storage.googleapis.com/golang/getgo/installer_linux
 chmod +x ./installer_linux
-SHELL="bash" ./installer_linux -version=1.19
+SHELL="bash" ./installer_linux -version=1.20
 rm -rf ./installer_linux
 
 echo 'Set "GOPATH=/root/go"'

--- a/infra/base-images/base-runner/install_go.sh
+++ b/infra/base-images/base-runner/install_go.sh
@@ -22,7 +22,7 @@ case $(uname -m) in
       # Download and install the latest stable Go.
       wget -q https://storage.googleapis.com/golang/getgo/installer_linux -O $SRC/installer_linux
       chmod +x $SRC/installer_linux
-      SHELL="bash" $SRC/installer_linux -version 1.19
+      SHELL="bash" $SRC/installer_linux -version 1.20
       rm $SRC/installer_linux
       # Set up Golang coverage modules.
       printf $(find . -name gocoverage)


### PR DESCRIPTION
This PR is meant to address issue https://github.com/google/oss-fuzz/issues/9949.

>`install_go.sh` says it downloads and installs the latest stable Go, but it uses Go 1.19 instead.
>
>https://github.com/google/oss-fuzz/blob/c9e3a82e3dc1c7142bbff53cdf1eb6dce07d776d/infra/base-images/base-runner/install_go.sh#L22-L25
>
>We should either use Go 1.20 (the latest stable Go at time of writing) or remove the misleading comment.