### PR TITLE
Integration of cachetools into oss-fuzz

### DIFF
--- a/projects/cachetools/Dockerfile
+++ b/projects/cachetools/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-python
+RUN git clone https://github.com/tkem/cachetools/
+COPY build.sh *.py $SRC/
+WORKDIR cachetools

--- a/projects/cachetools/build.sh
+++ b/projects/cachetools/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+pip3 install .
+
+# Build fuzzers in $OUT.
+for fuzzer in $(find $SRC -name 'fuzz_*.py'); do
+  compile_python_fuzzer $fuzzer
+done

--- a/projects/cachetools/fuzz_cached.py
+++ b/projects/cachetools/fuzz_cached.py
@@ -1,0 +1,69 @@
+#!/usr/bin/python3
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import atheris
+import cachetools
+import random
+import datetime
+from threading import Lock
+
+def get_ttu(_key, value, now):
+    # assume value.ttl contains the item's time-to-live in hours
+    return datetime.datetime.now() + random.random() * datetime.timedelta(days=200000)
+
+def TestOneInput(data):
+    fdp = atheris.FuzzedDataProvider(data)
+
+    cache_size = fdp.ConsumeIntInRange(1,32)
+    cache_ttl = fdp.ConsumeProbability()
+    cache_lock = None
+    if fdp.ConsumeBool():
+        cache_lock = Lock()
+
+    # Random caching types
+    CACHE_TYPES = [
+        {},
+        cachetools.FIFOCache(maxsize=cache_size),
+        cachetools.LFUCache(maxsize=cache_size),
+        cachetools.LRUCache(maxsize=cache_size),
+        cachetools.MRUCache(maxsize=cache_size),
+        cachetools.RRCache(maxsize=cache_size, choice=random.choice),
+        cachetools.TTLCache(maxsize=cache_size, ttl=cache_ttl),
+        cachetools.TLRUCache(maxsize=cache_size, ttu=get_ttu, timer=datetime.datetime.now)
+    ]
+
+    # Generate a random cached function
+    @cachetools.cached(cache=fdp.PickValueInList(CACHE_TYPES), lock=cache_lock, info=fdp.ConsumeBool())
+    def fib(n):
+        return n if n < 2 else fib(n - 1) + fib(n - 2)
+    
+    for i in range(20):
+        fib(fdp.ConsumeIntInRange(1, 20))
+        # Try and get coverage of different properties
+        try:
+            fib.maxsize()
+            fib.currsize()
+        except AttributeError:
+            pass
+
+def main():
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+if __name__ == "__main__":
+    atheris.instrument_all()
+    main()

--- a/projects/cachetools/project.yaml
+++ b/projects/cachetools/project.yaml
@@ -1,0 +1,10 @@
+fuzzing_engines:
+- libfuzzer
+homepage: https://github.com/tkem/cachetools/
+language: python
+main_repo: https://github.com/tkem/cachetools/
+sanitizers:
+- address
+- undefined
+vendor_ccs:
+- sean@compactcloud.co.uk


### PR DESCRIPTION
This is a proposed initial integration of the [cachetools](https://github.com/tkem/cachetools) library into oss-fuzz.

I think this is might be a suitable project for OSS-Fuzz because it is the 22nd most downloaded Python package from pypi https://hugovk.github.io/top-pypi-packages/ and generates a [criticality score](https://github.com/ossf/criticality_score) of 0.54756.

```
repo.url: https://github.com/tkem/cachetools
repo.language: Python
repo.license: MIT License
repo.star_count: 1601
repo.created_at: 2014-03-22T10:09:33Z
repo.updated_at: 2023-03-17T22:10:49Z
legacy.created_since: 109
legacy.updated_since: 0
legacy.contributor_count: 9
legacy.org_count: 5
legacy.commit_frequency: 0.52
legacy.recent_release_count: 4
legacy.updated_issues_count: 187
legacy.closed_issues_count: 183
legacy.issue_comment_frequency: 2.97
legacy.github_mention_count: 1088
default_score: 0.54756
```

Code coverage is pretty good (71.5%), the introspector numbers aren't so great

<img width="596" alt="image" src="https://user-images.githubusercontent.com/5122866/226210282-2768c604-d2ac-4e06-974e-ffcecc1b9cc3.png">

I was hoping to get some feedback on this change before reaching out to the cachetools maintainers, as it's my first integration and I'm not sure if it's suitable for OSS-Fuzz or not.