### PR TITLE
Fixing urllib3 port binding crash

### DIFF
--- a/projects/urllib3/fuzz_requests.py
+++ b/projects/urllib3/fuzz_requests.py
@@ -16,12 +16,12 @@
 
 import atheris
 from http.server import BaseHTTPRequestHandler, HTTPServer
+import os
+import random
 import sys
 import threading
 import time
-
-with atheris.instrument_imports():
-    import urllib3
+import urllib3
 
 timeout = urllib3.util.Timeout(connect=1.0, read=1.0)
 urllib_pool = urllib3.PoolManager(timeout=timeout)
@@ -117,13 +117,22 @@ def TestOneInput(input_bytes):
     r.data
     r.headers
 
-
-if __name__ == "__main__":
-    x = threading.Thread(target=run_webserver, daemon=True)
-    x.start()
+def main():
+    # Try and get an open port to run our test web server
+    for attempt in range(10):
+        try:
+            PORT = random.randint(8000,9999)
+            x = threading.Thread(target=run_webserver, daemon=True)
+            x.start()
+            break
+        except OSError as e:
+            pass 
 
     time.sleep(0.5)  # Short delay to start test server
-    
-    atheris.Setup(sys.argv, TestOneInput)
 
+    atheris.instrument_all()
+    atheris.Setup(sys.argv, TestOneInput)
     atheris.Fuzz()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I've managed to recreate the issue that was stopping the `fuzz_requests` coverage on `urllib3` ( see #9863 )

The issues not visible running introspector locally but can be see in clusterfuzzlite which is a port binding error. This change randomises the port that's used and ensures that it can bind to it before fuzzing starts. Change is tested and demonstrated as working here [sg3-141-592/urllib3 - ClusterFuzzLite PR fuzzing](https://github.com/sg3-141-592/urllib3/actions/runs/4466205991/jobs/7844093473?pr=1).

Also I've changed the style of the main block and atheris to be consistent with the other fuzzers added lately.