### PR TITLE
helper.py: make shell compatible with build_*

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -1644,9 +1644,10 @@ def shell(args):
 
   run_args = _env_to_docker_args(env)
   if args.source_path:
+    workdir = _workdir_from_dockerfile(args.project)
     run_args.extend([
         '-v',
-        '%s:%s' % (_get_absolute_path(args.source_path), '/src'),
+        '%s:%s' % (_get_absolute_path(args.source_path), workdir),
     ])
 
   run_args.extend([


### PR DESCRIPTION
`infra/helper.py shell project` used to open docker container with different volumes mounted than `infra/helper.py build_fuzzers project` Use the same logics in shell for project workdir calculation as it's used during build procedure. This way we may easier troubleshoot build issues in shell.