### PR TITLE
binutils fuzzer trouble with getopt

### DIFF
--- a/projects/binutils/fuzz_addr2line.c
+++ b/projects/binutils/fuzz_addr2line.c
@@ -32,31 +32,23 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
   program_name = filename;
 
-  char **c2 = malloc(sizeof(char*)*6);
-  char *c2_1 = strdup("AAABC");
-  char *c2_2 = strdup("BBC");
-  char *c2_3 = strdup("0xbeefbeef");
-  char *c2_4 = strdup("0xcafebabe");
-  char *c2_5 = strdup("5123423");
-  c2[0] = c2_1;
-  c2[1] = c2_2;
-  c2[2] = c2_3;
-  c2[3] = c2_4;
-  c2[4] = c2_5;
+  char **c2 = xmalloc(sizeof(char*)*6);
+  c2[0] = xstrdup("AAABC");
+  c2[1] = xstrdup("BBC");
+  c2[2] = xstrdup("0xbeefbeef");
+  c2[3] = xstrdup("0xcafebabe");
+  c2[4] = xstrdup("5123423");
   c2[5] = NULL;
 
-  naddr  = 2;
+  naddr = 5;
   addr = c2;
 
   // Main fuzz entrypoint in addr2line.c
   process_file(filename, NULL, NULL);
- 
+
+  for (int i = 5; --i >= 0; )
+    free(c2[i]);
   free(c2);
-  free(c2_1);
-  free(c2_2);
-  free(c2_3);
-  free(c2_4);
-  free(c2_5);
 
   unlink(filename);
   return 0;

--- a/projects/binutils/fuzz_objcopy.c
+++ b/projects/binutils/fuzz_objcopy.c
@@ -111,6 +111,14 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
   init_objcopy_global_state();
 
+  /* glibc getopt has internal static state.  Setting optind to zero
+     reinitialises it.  Do this every second run, which effectively
+     alternates objcopy with options then objcopy without options.
+     (optind will be 9 when copy_main returns.)  */
+  static int iter;
+  if (++iter & 1)
+    optind = 0;
+
   char *fakeArgv[12];
   fakeArgv[0] = "fuzz_objcopy";
   fakeArgv[1] = "-S";


### PR DESCRIPTION
fuzz_objcopy.c calls copy_main that calls getopt.  Without reinitialisation of optind, this means that of the 100 iterations per sample only the first would see the fake command line options.  And if another sample was then tested in the same running process, no iteration would see the command line options.  Fix this by setting optind.  Do so every second iteration because it's usefull to test with default options too.

fuzz_addr2line set up five command line addresses but then only used two.  Fix that too, and use xmalloc/xstrdup so that malloc fails are fatal.