### PR TITLE
python-projects: cleanup UBSAN from project.yaml

### DIFF
--- a/projects/asn1crypto/project.yaml
+++ b/projects/asn1crypto/project.yaml
@@ -5,7 +5,6 @@ language: python
 main_repo: https://github.com/wbond/asn1crypto
 sanitizers:
 - address
-- undefined
 primary_contact: "will@wbond.net"
 vendor_ccs:
 - david@adalogics.com

--- a/projects/cffi/project.yaml
+++ b/projects/cffi/project.yaml
@@ -5,6 +5,5 @@ language: python
 main_repo: https://foss.heptapod.net/pypy/cffi
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com

--- a/projects/dask/project.yaml
+++ b/projects/dask/project.yaml
@@ -5,7 +5,6 @@ language: python
 main_repo: https://github.com/dask/dask
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com
 - adam@adalogics.com

--- a/projects/decorator/project.yaml
+++ b/projects/decorator/project.yaml
@@ -5,7 +5,6 @@ language: python
 main_repo: https://github.com/micheles/decorator
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com
 - adam@adalogics.com

--- a/projects/html5lib-python/project.yaml
+++ b/projects/html5lib-python/project.yaml
@@ -5,6 +5,5 @@ fuzzing_engines:
 - libfuzzer
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com

--- a/projects/mako/project.yaml
+++ b/projects/mako/project.yaml
@@ -6,7 +6,6 @@ main_repo: https://github.com/sqlalchemy/mako
 primary_contact: mike_mp@zzzcomputing.com
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com
 - adam@adalogics.com

--- a/projects/networkx/project.yaml
+++ b/projects/networkx/project.yaml
@@ -5,6 +5,5 @@ language: python
 main_repo: https://github.com/networkx/networkx
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com

--- a/projects/parso/project.yaml
+++ b/projects/parso/project.yaml
@@ -5,6 +5,5 @@ language: python
 main_repo: https://github.com/davidhalter/parso
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com

--- a/projects/pasta/project.yaml
+++ b/projects/pasta/project.yaml
@@ -5,6 +5,5 @@ language: python
 main_repo: https://github.com/google/pasta
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com

--- a/projects/pem/project.yaml
+++ b/projects/pem/project.yaml
@@ -5,7 +5,6 @@ fuzzing_engines:
 - libfuzzer
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com
 - adam@adalogics.com

--- a/projects/pytables/project.yaml
+++ b/projects/pytables/project.yaml
@@ -5,6 +5,5 @@ language: python
 main_repo: https://github.com/pytables/pytables
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com

--- a/projects/python-rison/project.yaml
+++ b/projects/python-rison/project.yaml
@@ -5,6 +5,5 @@ fuzzing_engines:
 - libfuzzer
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com

--- a/projects/rich/project.yaml
+++ b/projects/rich/project.yaml
@@ -5,6 +5,5 @@ fuzzing_engines:
 - libfuzzer
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com

--- a/projects/tinycss2/project.yaml
+++ b/projects/tinycss2/project.yaml
@@ -5,6 +5,5 @@ fuzzing_engines:
 - libfuzzer
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com

--- a/projects/tomlkit/project.yaml
+++ b/projects/tomlkit/project.yaml
@@ -5,6 +5,5 @@ fuzzing_engines:
 - libfuzzer
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com

--- a/projects/toolz/project.yaml
+++ b/projects/toolz/project.yaml
@@ -5,6 +5,5 @@ fuzzing_engines:
 - libfuzzer
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com

--- a/projects/uritemplate/project.yaml
+++ b/projects/uritemplate/project.yaml
@@ -5,6 +5,5 @@ language: python
 main_repo: https://github.com/python-hyper/uritemplate
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com


### PR DESCRIPTION
The projects do not build any native code. No need for two sanitizers.