### PR TITLE
python projects: remove UBSAN

### DIFF
--- a/projects/black/project.yaml
+++ b/projects/black/project.yaml
@@ -5,6 +5,5 @@ fuzzing_engines:
 - libfuzzer
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com

--- a/projects/bz2file/project.yaml
+++ b/projects/bz2file/project.yaml
@@ -5,6 +5,5 @@ fuzzing_engines:
 - libfuzzer
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com

--- a/projects/charset_normalizer/project.yaml
+++ b/projects/charset_normalizer/project.yaml
@@ -6,7 +6,6 @@ main_repo: https://github.com/Ousret/charset_normalizer
 primary_contact: ahmed.tahri@cloudnursery.dev
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com
 - adam@adalogics.com

--- a/projects/configparser/project.yaml
+++ b/projects/configparser/project.yaml
@@ -5,6 +5,5 @@ fuzzing_engines:
 - libfuzzer
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com

--- a/projects/croniter/project.yaml
+++ b/projects/croniter/project.yaml
@@ -5,7 +5,6 @@ language: python
 main_repo: https://github.com/kiorky/croniter
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com
 - adam@adalogics.com

--- a/projects/dill/project.yaml
+++ b/projects/dill/project.yaml
@@ -5,6 +5,5 @@ fuzzing_engines:
 - libfuzzer
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com

--- a/projects/glom/project.yaml
+++ b/projects/glom/project.yaml
@@ -5,7 +5,6 @@ language: python
 main_repo: https://github.com/mahmoud/glom
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com
 - adam@adalogics.com

--- a/projects/idna/project.yaml
+++ b/projects/idna/project.yaml
@@ -6,7 +6,6 @@ main_repo: https://github.com/kjd/idna
 primary_contact: kim@cynosure.com.au
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com
 - adam@adalogics.com

--- a/projects/isodate/project.yaml
+++ b/projects/isodate/project.yaml
@@ -5,6 +5,5 @@ language: python
 main_repo: https://github.com/gweis/isodate
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com

--- a/projects/jsmin/project.yaml
+++ b/projects/jsmin/project.yaml
@@ -5,7 +5,6 @@ language: python
 main_repo: https://github.com/tikitu/jsmin
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com
 - riccardo.schirone@trailofbits.com

--- a/projects/markupsafe/project.yaml
+++ b/projects/markupsafe/project.yaml
@@ -5,6 +5,5 @@ language: python
 main_repo: https://github.com/pallets/markupsafe
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com

--- a/projects/more-itertools/project.yaml
+++ b/projects/more-itertools/project.yaml
@@ -5,6 +5,5 @@ language: python
 main_repo: https://github.com/more-itertools/more-itertools
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com

--- a/projects/olefile/project.yaml
+++ b/projects/olefile/project.yaml
@@ -5,7 +5,6 @@ language: python
 main_repo: https://github.com/decalage2/olefile
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com
 - riccardo.schirone@trailofbits.com

--- a/projects/ply/project.yaml
+++ b/projects/ply/project.yaml
@@ -5,6 +5,5 @@ language: python
 main_repo: https://github.com/dabeaz/ply
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com

--- a/projects/pyjwt/project.yaml
+++ b/projects/pyjwt/project.yaml
@@ -5,7 +5,6 @@ language: python
 main_repo: https://github.com/jpadilla/pyjwt
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com
 - adam@adalogics.com

--- a/projects/python-future/project.yaml
+++ b/projects/python-future/project.yaml
@@ -5,6 +5,5 @@ language: python
 main_repo: https://github.com/PythonCharmers/python-future
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com

--- a/projects/rfc3967/project.yaml
+++ b/projects/rfc3967/project.yaml
@@ -5,6 +5,5 @@ fuzzing_engines:
 - libfuzzer
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com

--- a/projects/six/project.yaml
+++ b/projects/six/project.yaml
@@ -5,6 +5,5 @@ language: python
 main_repo: https://github.com/benjaminp/six
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com

--- a/projects/toml/project.yaml
+++ b/projects/toml/project.yaml
@@ -5,7 +5,6 @@ language: python
 main_repo: https://github.com/uiri/toml/
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com
 - riccardo.schirone@trailofbits.com

--- a/projects/tomli/project.yaml
+++ b/projects/tomli/project.yaml
@@ -5,6 +5,5 @@ language: python
 main_repo: https://github.com/hukkinj1/tomli
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com

--- a/projects/tqdm/project.yaml
+++ b/projects/tqdm/project.yaml
@@ -6,6 +6,5 @@ fuzzing_engines:
   - libfuzzer
 sanitizers:
   - address
-  - undefined
 vendor_ccs:
   - "david@adalogics.com"

--- a/projects/underscore/project.yaml
+++ b/projects/underscore/project.yaml
@@ -6,7 +6,6 @@ fuzzing_engines:
 - libfuzzer
 sanitizers:
 - address
-- undefined
 vendor_ccs:
 - david@adalogics.com
 - adam@adalogics.com


### PR DESCRIPTION
These projects do not have native code compiled. No need to have multiple sanitizers.