### PR TITLE
Add main_repo to project.yaml files 

### DIFF
--- a/projects/bad_example/project.yaml
+++ b/projects/bad_example/project.yaml
@@ -1,6 +1,7 @@
 disabled: true
 homepage: http://www.zlib.net/
 language: c++
+main_repo: https://github.com/madler/zlib
 sanitizers:
 - address
 - memory

--- a/projects/bazel-rules-fuzzing-test-java/project.yaml
+++ b/projects/bazel-rules-fuzzing-test-java/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/bazelbuild/rules_fuzzing"
+main_repo: "https://github.com/bazelbuild/rules_fuzzing"
 language: jvm
 primary_contact: "test@example.com"
 

--- a/projects/bazel-rules-fuzzing-test/project.yaml
+++ b/projects/bazel-rules-fuzzing-test/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/bazelbuild/rules_fuzzing"
+main_repo: "https://github.com/bazelbuild/rules_fuzzing"
 language: c++
 primary_contact: "test@example.com"
 

--- a/projects/catapult/project.yaml
+++ b/projects/catapult/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/nemtech/catapult-server"
+main_repo: "https://github.com/nemtech/catapult-server"
 primary_contact: "wayonb@gmail.com"
 auto_ccs:
   - "gimer.outer.space@gmail.com"

--- a/projects/cctz/project.yaml
+++ b/projects/cctz/project.yaml
@@ -1,4 +1,5 @@
 homepage: https://github.com/google/cctz
+main_repo: https://github.com/google/cctz
 language: c++
 vendor_ccs:
 - david@adalogics.com

--- a/projects/coreutils/project.yaml
+++ b/projects/coreutils/project.yaml
@@ -1,2 +1,3 @@
 homepage: "http://www.gnu.org/software/coreutils/"
+main_repo: "https://github.com/coreutils/coreutils"
 primary_contact: "P@draigBrady.com"

--- a/projects/example/project.yaml
+++ b/projects/example/project.yaml
@@ -1,4 +1,5 @@
 disabled: true
 homepage: https://my-api.example.com
+main_repo: https://github.com/example/my-api
 language: c++
 vendor_ccs: []

--- a/projects/fuzzing-puzzles/project.yaml
+++ b/projects/fuzzing-puzzles/project.yaml
@@ -1,6 +1,7 @@
 homepage: https://github.com/google/fuzzer-test-suite
 language: c++
 primary_contact: kcc@google.com
+main_repo: https://github.com/google/fuzzer-test-suite
 auto_ccs:
   - "metzman@google.com"
   - "mmoroz@google.com"

--- a/projects/gcloud-go/project.yaml
+++ b/projects/gcloud-go/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/googleapis/google-cloud-go"
+main_repo: "https://github.com/googleapis/google-cloud-go"
 primary_contact: "codyoss@google.com"
 language: go
 fuzzing_engines:

--- a/projects/gfwx/project.yaml
+++ b/projects/gfwx/project.yaml
@@ -1,6 +1,7 @@
 homepage: "http://www.gfwx.org/"
 language: c++
 primary_contact: "fyffe@google.com"
+main_repo: "https://github.com/kalcutter/gfwx"
 sanitizers:
  - address
  - undefined

--- a/projects/giflib/project.yaml
+++ b/projects/giflib/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://giflib.sourceforge.net/"
+main_repo: "https://git.code.sf.net/p/giflib/code"
 language: c++
 primary_contact: "esr@thyrsus.com"
 auto_ccs:

--- a/projects/go-json-iterator/project.yaml
+++ b/projects/go-json-iterator/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://jsoniter.com"
+main_repo: "https://github.com/json-iterator/go"
 primary_contact: "taowen@gmail.com"
 auto_ccs : "p.antoine@catenacyber.fr"
 language: go

--- a/projects/graphicsfuzz-spirv/project.yaml
+++ b/projects/graphicsfuzz-spirv/project.yaml
@@ -1,5 +1,6 @@
 homepage: "https://www.graphicsfuzz.com"
 language: c++
+main_repo: "https://github.com/google/graphicsfuzz"
 primary_contact: "afdx@google.com"
 auto_ccs:
   - "paulthomson@google.com"

--- a/projects/graphicsmagick/project.yaml
+++ b/projects/graphicsmagick/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://www.graphicsmagick.org/"
+main_repo: "https://github.com/kstep/graphicsmagick"
 language: c++
 primary_contact: "bobjfriesenhahn@gmail.com"
 auto_ccs:

--- a/projects/ibmswtpm2/project.yaml
+++ b/projects/ibmswtpm2/project.yaml
@@ -1,6 +1,7 @@
 homepage: https://sourceforge.net/projects/ibmswtpm2/
 language: c++
 primary_contact: kgoldman@us.ibm.com
+main_repo: https://git.code.sf.net/p/ibmswtpm2/tpm2 ibmswtpm2-tpm2
 auto_ccs:
   - "john.s.andersen@intel.com"
   - "william.c.roberts@intel.com"

--- a/projects/ibmswtpm2/project.yaml
+++ b/projects/ibmswtpm2/project.yaml
@@ -1,7 +1,7 @@
 homepage: https://sourceforge.net/projects/ibmswtpm2/
 language: c++
 primary_contact: kgoldman@us.ibm.com
-main_repo: https://git.code.sf.net/p/ibmswtpm2/tpm2 ibmswtpm2-tpm2
+main_repo: https://git.code.sf.net/p/ibmswtpm2/tpm2
 auto_ccs:
   - "john.s.andersen@intel.com"
   - "william.c.roberts@intel.com"

--- a/projects/inchi/project.yaml
+++ b/projects/inchi/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.inchi-trust.org/"
+main_repo: "https://github.com/metamolecular/inchi"
 language: c
 primary_contact: "member-info@inchi-trust.org"
 sanitizers:

--- a/projects/knot-dns/project.yaml
+++ b/projects/knot-dns/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.knot-dns.cz/"
+main_repo: "https://gitlab.nic.cz/knot/knot-dns.git"
 language: c++
 primary_contact: "knot.dns@gmail.com"
 auto_ccs:

--- a/projects/lame/project.yaml
+++ b/projects/lame/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://sourceforge.net/projects/lame/"
+main_repo: "https://svn.code.sf.net/p/lame/svn/trunk/lame"
 language: c++
 primary_contact: "guidovranken@gmail.com"
 auto_ccs:

--- a/projects/libmicrohttpd/project.yaml
+++ b/projects/libmicrohttpd/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.gnu.org/s/libmicrohttpd/"
+main_repo: "https://git.gnunet.org/libmicrohttpd.git"
 primary_contact: "christian@grothoff.org"
 auto_ccs:
          - "k2k@narod.ru"

--- a/projects/libpng-proto/project.yaml
+++ b/projects/libpng-proto/project.yaml
@@ -1,4 +1,5 @@
 homepage: "http://www.libpng.org/pub/png/libpng.html"
+main_repo: "https://git.code.sf.net/p/libpng/code libpng-code"
 language: c++
 primary_contact: "kcc@google.com"
 sanitizers:

--- a/projects/libtheora/project.yaml
+++ b/projects/libtheora/project.yaml
@@ -1,6 +1,7 @@
 homepage: "https://www.theora.org/"
 language: c++
 primary_contact: "guidovranken@gmail.com"
+main_repo: "https://git.xiph.org/theora.git"
 vendor_ccs:
  - "daede003@umn.edu"
  - "twsmith@mozilla.com"

--- a/projects/libyuv/project.yaml
+++ b/projects/libyuv/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://chromium.googlesource.com/libyuv/libyuv/"
+main_repo: "https://chromium.googlesource.com/libyuv/libyuv"
 language: c++
 primary_contact: "mikhal@webrtc.org"
 auto_ccs:

--- a/projects/llvm_libcxxabi/project.yaml
+++ b/projects/llvm_libcxxabi/project.yaml
@@ -1,6 +1,7 @@
 homepage: "http://libcxxabi.llvm.org/"
 language: c++
 primary_contact: "kcc@google.com"
+main_repo: https://github.com/llvm/llvm-project
 auto_ccs:
   - "Erik.Pilkington@gmail.com"
   - "akilsrin@apple.com"

--- a/projects/mandelbulber/project.yaml
+++ b/projects/mandelbulber/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/buddhi1980/mandelbulber2/"
+main_repo: "https://github.com/buddhi1980/mandelbulber2/"
 primary_contact: "robertpancoast77@gmail.com"
 auto_ccs:
  - "buddhi1980@gmail.com"

--- a/projects/mpg123/project.yaml
+++ b/projects/mpg123/project.yaml
@@ -1,7 +1,7 @@
 homepage: "https://www.mpg123.de"
 language: c++
 primary_contact: "maintainer@mpg123.org"
-
+main_repo: "https://github.com/dreamerc/mpg123"
 sanitizers:
   - address
   - undefined

--- a/projects/netdata/project.yaml
+++ b/projects/netdata/project.yaml
@@ -1,2 +1,3 @@
 homepage: "https://my-netdata.io"
+main_repo: "https://github.com/netdata/netdata"
 primary_contact: "costa@tsaousis.gr"

--- a/projects/ntp/project.yaml
+++ b/projects/ntp/project.yaml
@@ -1,6 +1,7 @@
 homepage: "http://www.ntp.org"
 language: c++
 primary_contact: "security@ntp.org"
+main_repo: "https://bitbucket.nwtime.org/scm/websites/ntpwww.git"
 auto_ccs:
   - "p.antoine@catenacyber.fr"
 fuzzing_engines:

--- a/projects/opusfile/project.yaml
+++ b/projects/opusfile/project.yaml
@@ -1,3 +1,4 @@
 homepage: "https://opus-codec.org/"
+main_repo: "https://gitlab.xiph.org/xiph/opusfile.git"
 language: c
 primary_contact: "jmvalin@jmvalin.ca"

--- a/projects/orbit/project.yaml
+++ b/projects/orbit/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/google/orbit"
+main_repo: "https://github.com/google/orbit"
 language: c++
 primary_contact: "hebecker@google.com"
 auto_ccs:

--- a/projects/pcre2/project.yaml
+++ b/projects/pcre2/project.yaml
@@ -1,6 +1,7 @@
 homepage: "http://www.pcre.org/"
 language: c++
 primary_contact: "philip.hazel@gmail.com"
+main_repo: "https://github.com/PCRE2Project/pcre2"
 fuzzing_engines:
   - libfuzzer
   - afl

--- a/projects/pffft/project.yaml
+++ b/projects/pffft/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://bitbucket.org/jpommier/pffft"
+main_repo: "https://bitbucket.org/jpommier/pffft.git"
 language: c++
 primary_contact: "pommier@modartt.com"
 auto_ccs:

--- a/projects/proj4/project.yaml
+++ b/projects/proj4/project.yaml
@@ -1,5 +1,6 @@
 homepage: "https://proj.org/"
 language: c++
+main_repo: "https://github.com/OSGeo/PROJ"
 primary_contact: "even.rouault@gmail.com"
 auto_ccs:
   - "hobu.inc@gmail.com"

--- a/projects/python3-libraries/project.yaml
+++ b/projects/python3-libraries/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.python.org/"
+main_repo: "https://github.com/python/cpython"
 language: c
 primary_contact: "guidovranken@gmail.com"
 auto_ccs:

--- a/projects/qubes-os/project.yaml
+++ b/projects/qubes-os/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.qubes-os.org/"
+main_repo: "https://github.com/QubesOS"
 language: c++
 primary_contact: "jpo@vt.edu"
 auto_ccs:

--- a/projects/racket/project.yaml
+++ b/projects/racket/project.yaml
@@ -1,5 +1,6 @@
 homepage: "https://racket-lang.org"
 primary_contact: "pocmatos@gmail.com"
+main_repo: "https://github.com/racket/racket/"
 auto_ccs:
   - samth@racket-lang.org
 sanitizers:

--- a/projects/realm-core/project.yaml
+++ b/projects/realm-core/project.yaml
@@ -1,2 +1,3 @@
 homepage: "https://github.com/realm/realm-core"
+main_repo: "https://github.com/realm/realm-core"
 primary_contact: "ez@realm.io"

--- a/projects/ring/project.yaml
+++ b/projects/ring/project.yaml
@@ -1,5 +1,6 @@
 homepage: "https://github.com/briansmith/ring"
 primary_contact: "brian@briansmith.org"
+main_repo: "https://github.com/briansmith/ring"
 sanitizers:
 - address
 - memory

--- a/projects/rust-regex/project.yaml
+++ b/projects/rust-regex/project.yaml
@@ -1,5 +1,6 @@
 homepage: "https://github.com/rust-lang/regex"
 primary_contact: "jamslam@gmail.com"
+main_repo: "https://github.com/rust-lang/regex"
 sanitizers:
   - address
 fuzzing_engines:

--- a/projects/serde_json/project.yaml
+++ b/projects/serde_json/project.yaml
@@ -1,5 +1,6 @@
 homepage: "https://github.com/serde-rs/json"
 primary_contact: "dtolnay@gmail.com"
+main_repo: "https://github.com/serde-rs/json"
 sanitizers:
   - address
 fuzzing_engines:

--- a/projects/sqlite3/project.yaml
+++ b/projects/sqlite3/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://sqlite.org/"
+main_repo: "https://sqlite.org/src/dir"
 language: c++
 primary_contact: "drhsqlite@gmail.com"
 auto_ccs:

--- a/projects/ujson/project.yaml
+++ b/projects/ujson/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/ultrajson/ultrajson"
+main_repo: "https://github.com/ultrajson/ultrajson"
 language: python
 # TODO(mbarbella): Reach out to project maintainers for a better primary contact.
 primary_contact: "mbarbella@google.com"

--- a/projects/weechat/project.yaml
+++ b/projects/weechat/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/weechat/weechat"
+main_repo: "https://github.com/weechat/weechat"
 primary_contact: "flashcode@flashtux.org"
 auto_ccs:
   - "security@weechat.org"

--- a/projects/xvid/project.yaml
+++ b/projects/xvid/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://www.xvid.com/"
+main_repo: "http://svn.xvid.org/trunk"
 language: c++
 primary_contact: "guidovranken@gmail.com"
 auto_ccs:


### PR DESCRIPTION
### Changes

I tried to find out which would be the main_repo and it is important to notice that many are not hosted on github or neither using a git repo (using svn for example).

Besides that, I was also not able to find out the main repo for the following projects:


| **file**               | **comment**                                                                       |
|------------------------|-----------------------------------------------------------------------------------|
| lzo/project.yaml       |                                                                                   |
| qcms/project.yaml      |                                                                                   |
| bzip2/project.yaml     |                                                                                   |
| dlplibs/project.yaml   |                                                                                   |
| freeimage/project.yaml | hosted on csv https://sourceforge.net/p/freeimage/code/                           |
| xerces-c/project.yaml  |                                                                                   |
| xpdf/project.yaml      |                                                                                   |
| lzma/project.yaml      | at source forge but no code section found https://sourceforge.net/projects/p7zip/ |

Another case that I was not sure about which url do add on the `qubes-os/project.yaml`. Its homepage is related to the entire org.