### PR TITLE
infra: bump fuzz introspector

### DIFF
--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y wget sudo && \
 RUN apt-get update && apt-get install -y git && \
     git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
     cd fuzz-introspector && \
-    git checkout 3a6cdf26415b22cc3e4f23a58dfe94f8e8f5a097 && \
+    git checkout fe85aff3b52e6c92b6df56b1ef205b9524272bbf && \
     git submodule init && \
     git submodule update && \
     apt-get autoremove --purge -y git && \

--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y wget sudo && \
 RUN apt-get update && apt-get install -y git && \
     git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
     cd fuzz-introspector && \
-    git checkout 74a51f53dcfed4e2ec062232fd9cbf480dae6962 && \
+    git checkout 3a6cdf26415b22cc3e4f23a58dfe94f8e8f5a097 && \
     git submodule init && \
     git submodule update && \
     apt-get autoremove --purge -y git && \


### PR DESCRIPTION
This change includes:
- bug fixes for https://github.com/google/oss-fuzz/issues/9914
- bug fixes for overall coverage calculation in python projects. This is the issue mentioned here: https://github.com/google/oss-fuzz/pull/9957#issuecomment-1476490231 At this stage fuzz introspector should give a more accurate overview of "how much coverage does the fuzzers have" than the code coverage reports itself due to the nature of python coverage, as described in the above comment
- updates on the java frontend that makes it possible to refine which java code to analyse
- updates to the output `.json` of fuzz introspector which will enable us to solve the issues mentioned here: https://github.com/google/oss-fuzz/blob/9fc6c644b93b90415a6111fdbea027be701337ae/infra/build/build_status/fuzz_introspector_page_gen.py#L250-L253