### PR TITLE
neomutt: add pkgconf to build

### DIFF
--- a/projects/neomutt/Dockerfile
+++ b/projects/neomutt/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN	apt-get update && \
-	apt-get install -y libncursesw5-dev libtinfo5 libtool make
+	apt-get install -y libncursesw5-dev libtinfo5 libtool make pkgconf
 
 RUN git clone --depth 1 https://github.com/neomutt/neomutt
 RUN git clone --depth 1 https://github.com/neomutt/corpus-address

--- a/projects/neomutt/project.yaml
+++ b/projects/neomutt/project.yaml
@@ -10,6 +10,5 @@ sanitizers:
  - undefined
 fuzzing_engines:
  - afl
- - honggfuzz
  - libfuzzer
  - centipede


### PR DESCRIPTION
Add `pkgconf` package to the Docker build so that NeoMutt builds.

Six months ago, we updated our build to use `pkg-config` and the fuzzer has been working correctly.
Some time in the last couple of days, the fuzzer stopped working because the build couldn't find `pkg-config`.

The problem only seems to exist for the GitHub actions.
Locally, I can run the fuzzer without problems.

---

**Update**:
I've dropped honggfuzz from the config as it doesn't work.