### PR TITLE
Log error no target

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -1153,6 +1153,12 @@ def download_corpora(args):
   else:
     fuzz_targets = _get_fuzz_targets(args.project)
 
+  if not fuzz_targets:
+    logging.error(
+        'Fuzz targets not found. Please find them in %s/build.sh and specify '
+        'them after --fuzz-target', args.project.name)
+    return False
+
   corpus_dir = args.project.corpus
 
   def _download_for_single_target(fuzz_target):

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -428,6 +428,8 @@ def get_parser():  # pylint: disable=too-many-statements,too-many-locals
   download_corpora_parser = subparsers.add_parser(
       'download_corpora', help='Download all corpora for a project.')
   download_corpora_parser.add_argument('--fuzz-target',
+                                       action='extend',
+                                       nargs='+',
                                        help='specify name of a fuzz target')
   download_corpora_parser.add_argument('--public',
                                        action='store_true',
@@ -1149,7 +1151,7 @@ def download_corpora(args):
       return False
 
   if args.fuzz_target:
-    fuzz_targets = [args.fuzz_target]
+    fuzz_targets = args.fuzz_target
   else:
     fuzz_targets = _get_fuzz_targets(args.project)
 


### PR DESCRIPTION
Found this when answering a user request to download corpora:
When no `fuzz_target` is found, we blindly print the success message and create a confusing empty directory because there is no input file to download.

This PR fixes this by:
1. Log an error message asking the user to manually provide fuzz targets with the cmd line parameter `--fuzz-targets` when none was found.
2. Allow the parameter to take multiple targets in a list so that users do not have to download them individually.