### PR TITLE
Suppress pylint false positive

### DIFF
--- a/infra/base-images/base-builder/sanitizers/pysecsan/pysecsan/command_injection.py
+++ b/infra/base-images/base-builder/sanitizers/pysecsan/pysecsan/command_injection.py
@@ -32,6 +32,7 @@ def get_all_substr_prefixes(main_str, sub_str):
     idx += len(sub_str)
 
 
+# pylint: disable=unsubscriptable-object
 def check_code_injection_match(elem, check_unquoted=False) -> Optional[str]:
   """identify if elem is an injection match."""
   # Check exact match

--- a/infra/base-images/base-builder/sanitizers/pysecsan/pysecsan/sanlib.py
+++ b/infra/base-images/base-builder/sanitizers/pysecsan/pysecsan/sanlib.py
@@ -158,6 +158,7 @@ def create_object_wrapper(**methods):
   return Wrapper
 
 
+# pylint: disable=unsubscriptable-object
 def add_hook(function: Callable[[Any], Any],
              pre_exec_hook: Optional[Callable[[Any], Any]] = None,
              post_exec_hook: Optional[Callable[[Any], Any]] = None):


### PR DESCRIPTION
Based on #10014:
`pylint` prints false positive error messages complaining about `unsubscriptable-object`.

This PR suppresses these messages.