### PR TITLE
[bind9] Build internal libtest and link with it as needed

### DIFF
--- a/projects/bind9/Dockerfile
+++ b/projects/bind9/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get -y install		\
 	libssl-dev		\
 	libtool			\
 	libtool-bin		\
+	liburcu-dev		\
 	libuv1-dev		\
 	pkg-config		\
 	zip

--- a/projects/bind9/build.sh
+++ b/projects/bind9/build.sh
@@ -22,10 +22,10 @@ make -C lib/isc -j"$(nproc)" all V=1
 make -C lib/dns -j"$(nproc)" all V=1
 make -C tests/libtest -j"$(nproc)" all V=1
 
-LIBISC_CFLAGS="-Ilib/isc/unix/include -Ilib/isc/pthreads/include -Ilib/isc/include"
+LIBISC_CFLAGS="-Ilib/isc/include"
 LIBDNS_CFLAGS="-Ilib/dns/include"
-LIBISC_LIBS="lib/isc/.libs/libisc.a -Wl,-Bstatic -Wl,-u,isc__initialize,-u,isc__shutdown -lssl -lcrypto -luv -lnghttp2 -Wl,-Bdynamic"
-LIBDNS_LIBS="lib/dns/.libs/libdns.a -Wl,-Bstatic -lcrypto -Wl,-Bdynamic"
+LIBISC_LIBS="lib/isc/.libs/libisc.a -Wl,-Bstatic -Wl,-u,isc__initialize,-u,isc__shutdown -lssl -lcrypto -lurcu-qsbr -lurcu-cds -luv -lnghttp2 -Wl,-Bdynamic"
+LIBDNS_LIBS="lib/dns/.libs/libdns.a -Wl,-Bstatic -lcrypto -lurcu-qsbr -lurcu-cds -Wl,-Bdynamic"
 LIBTEST_LIBS="tests/libtest/.libs/libtest.a"
 
 # dns_name_fromwire needs old.c/old.h code to be linked in

--- a/projects/bind9/build.sh
+++ b/projects/bind9/build.sh
@@ -18,13 +18,15 @@
 # build the project
 autoreconf -fi
 ./configure --disable-shared --enable-static --enable-developer --without-cmocka --without-zlib --prefix="$WORK" --enable-fuzzing=ossfuzz
-(cd lib/isc && make -j"$(nproc)" all V=1)
-(cd lib/dns && make -j"$(nproc)" all V=1)
+make -C lib/isc -j"$(nproc)" all V=1
+make -C lib/dns -j"$(nproc)" all V=1
+make -C tests/libtest -j"$(nproc)" all V=1
 
 LIBISC_CFLAGS="-Ilib/isc/unix/include -Ilib/isc/pthreads/include -Ilib/isc/include"
 LIBDNS_CFLAGS="-Ilib/dns/include"
 LIBISC_LIBS="lib/isc/.libs/libisc.a -Wl,-Bstatic -Wl,-u,isc__initialize,-u,isc__shutdown -lssl -lcrypto -luv -lnghttp2 -Wl,-Bdynamic"
 LIBDNS_LIBS="lib/dns/.libs/libdns.a -Wl,-Bstatic -lcrypto -Wl,-Bdynamic"
+LIBTEST_LIBS="tests/libtest/.libs/libtest.a"
 
 # dns_name_fromwire needs old.c/old.h code to be linked in
 sed -i 's/#include "old.h"/#include "old.c"/' fuzz/dns_name_fromwire.c
@@ -34,12 +36,12 @@ for fuzzer in fuzz/*.c; do
     [ "$output" = "main" ] && continue
     [ "$output" = "old" ] && continue
     # We need to try little bit harder to link everything statically
-    (cd fuzz && make -j"$(nproc)" "${output}.o" V=1)
+    make -C fuzz -j"$(nproc)" "${output}.o" V=1
     ${CXX} ${CXXFLAGS} \
 	   -o "${OUT}/${output}_fuzzer" \
 	   "fuzz/${output}.o" \
 	   -include config.h \
 	   $LIBISC_CFLAGS $LIBDNS_CFLAGS \
-	   $LIBDNS_LIBS $LIBISC_LIBS $LIB_FUZZING_ENGINE
+	   $LIBDNS_LIBS $LIBISC_LIBS $LIBTEST_LIBS $LIB_FUZZING_ENGINE
     zip -j "${OUT}/${output}_seed_corpus.zip" "fuzz/${output}.in/"*
 done


### PR DESCRIPTION
This fixes FTBFS due to missing internal (convenience) libtest library.