### PR TITLE
Update Centipede to 7a20b4e

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -134,7 +134,7 @@ RUN precompile_honggfuzz
 RUN cd $SRC && \
     git clone https://github.com/google/centipede.git && \
     cd centipede && \
-    git checkout eb91dd2157710e6c82579f8be19d7fab9423b781 && \
+    git checkout 7a20b4e58c8363df0fb73bc28927241043bc0dc2 && \
     rm -rf .git
 
 COPY precompile_centipede /usr/local/bin/


### PR DESCRIPTION
Update Centipede to its latest version.
Will push another PR to ClusterFuzz to capture the new crash log outputs so that the RegEx in ClusterFuzz is consistent with the format test cases in Centipede.