### PR TITLE
wasmer: fix build

### DIFF
--- a/projects/wasmer/Dockerfile
+++ b/projects/wasmer/Dockerfile
@@ -17,10 +17,17 @@
 FROM gcr.io/oss-fuzz-base/base-builder-rust
 
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
-   zlib1g-dev libffi-dev build-essential \
-   clang-12 llvm-12 llvm-12-dev llvm-12-tools
+   zlib1g-dev libffi-dev build-essential libxml2-dev
+
+# until clang 16 is used for C cf https://github.com/rust-lang/rust/issues/107149#issuecomment-1492637779
+RUN rustup install nightly-2023-03-24
+RUN rustup component add rust-src --toolchain nightly-2023-03-24-x86_64-unknown-linux-gnu
 
 RUN git clone --depth 1 https://github.com/wasmerio/wasmer wasmer
+
+RUN mkdir -p $SRC/.llvm && curl --proto '=https' --tlsv1.2 -sSf \
+    https://github.com/wasmerio/llvm-custom-builds/releases/download/14.x/llvm-linux-amd64.tar.xz -L -o - | \
+    tar xJv -C $SRC/.llvm
 
 WORKDIR wasmer
 

--- a/projects/wasmer/build.sh
+++ b/projects/wasmer/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -eu
+#j
 # Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +16,10 @@
 #
 ################################################################################
 
-export LLVM_SYS_120_PREFIX=$(llvm-config-12 --prefix)
+# until clang 16 is used for C cf https://github.com/rust-lang/rust/issues/107149#issuecomment-1492637779
+rustup default nightly-2023-03-24
+
+export LLVM_SYS_140_PREFIX=$($SRC/.llvm/bin/llvm-config --prefix)
 
 cargo +nightly fuzz build universal_cranelift --features=universal,cranelift -O
 cargo +nightly fuzz build universal_llvm --features=universal,llvm -O

--- a/projects/wasmer/build.sh
+++ b/projects/wasmer/build.sh
@@ -1,5 +1,4 @@
 #!/bin/bash -eu
-#j
 # Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
- Updates wasmer to use llvm 14+ 
- Pinned rust version as it was crashing the build, fix  copied from (https://github.com/google/oss-fuzz/pull/10019)  
Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=56795