### PR TITLE
[FFmpeg] Drop libXext

### DIFF
--- a/projects/ffmpeg/Dockerfile
+++ b/projects/ffmpeg/Dockerfile
@@ -31,7 +31,6 @@ RUN git clone https://git.ffmpeg.org/ffmpeg.git ffmpeg
 
 RUN wget https://www.alsa-project.org/files/pub/lib/alsa-lib-1.1.0.tar.bz2
 RUN git clone --depth 1 https://github.com/mstorsjo/fdk-aac.git
-RUN git clone --depth 1 git://anongit.freedesktop.org/xorg/lib/libXext
 RUN git clone --depth 1 https://github.com/intel/libva
 RUN git clone --depth 1 -b libvdpau-1.2 git://people.freedesktop.org/~aplattner/libvdpau
 RUN git clone --depth 1 https://chromium.googlesource.com/webm/libvpx

--- a/projects/ffmpeg/build.sh
+++ b/projects/ffmpeg/build.sh
@@ -58,13 +58,6 @@ make clean
 make -j$(nproc) all
 make install
 
-cd $SRC/libXext
-./autogen.sh
-./configure --prefix="$FFMPEG_DEPS_PATH" --enable-static
-make clean
-make -j$(nproc)
-make install
-
 cd $SRC/libva
 ./autogen.sh
 ./configure --prefix="$FFMPEG_DEPS_PATH" --enable-static --disable-shared


### PR DESCRIPTION
libXext build fails, it seems needing autoconf 2.70 which seems unavailable in ubuntu 20.04 which seems what ossfuzz docker uses.

It appears things still work fine after this removial