### PR TITLE
Updating croniter project.yaml

### DIFF
--- a/projects/croniter/project.yaml
+++ b/projects/croniter/project.yaml
@@ -10,3 +10,4 @@ vendor_ccs:
 - adam@adalogics.com
 - riccardo.schirone@trailofbits.com
 - facundo.tuesca@trailofbits.com
+- sean@compactcloud.co.uk


### PR DESCRIPTION
I've had approval today from the croniter maintainer to be added to the croniter 
`project.yaml`, see [https://github.com/kiorky/croniter/issues/32](https://github.com/kiorky/croniter/issues/32).

I need this to see what the current issue is that's stopping `fuzz_iter.py` running on the croniter project.