### PR TITLE
suricata: fix coverage build by using right rustc

### DIFF
--- a/projects/suricata/Dockerfile
+++ b/projects/suricata/Dockerfile
@@ -31,6 +31,7 @@ ADD https://rules.emergingthreats.net/open/suricata/emerging.rules.zip emerging.
 # until clang 16 is used for C cf https://github.com/rust-lang/rust/issues/107149#issuecomment-1492637779
 RUN rustup install nightly-2023-03-24
 RUN rustup component add rust-src --toolchain nightly-2023-03-24-x86_64-unknown-linux-gnu
+RUN rustup default nightly-2023-03-24
 RUN cargo install --force cbindgen
 
 RUN git clone --depth 1 https://github.com/OISF/suricata.git suricata

--- a/projects/suricata/build.sh
+++ b/projects/suricata/build.sh
@@ -15,9 +15,6 @@
 #
 ################################################################################
 
-# until clang 16 is used for C cf https://github.com/rust-lang/rust/issues/107149#issuecomment-1492637779
-rustup default nightly-2023-03-24
-
 # build dependencies statically
 if [ "$SANITIZER" = "memory" ]
 then


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=57763

The `compile` script was not using the right rustc toolchain for source copy for coverage report 
cf rustch=`rustc --version --verbose | grep commit-hash | cut -d' ' -f2` in compile