### PR TITLE
openssl: We need to init the fuzz/corpora submodule

### DIFF
--- a/projects/openssl/Dockerfile
+++ b/projects/openssl/Dockerfile
@@ -20,6 +20,7 @@ RUN git clone --depth 1 https://github.com/openssl/openssl.git
 RUN git clone --depth 1 --branch OpenSSL_1_1_1-stable https://github.com/openssl/openssl.git openssl111
 RUN git clone --depth 1 --branch openssl-3.0 https://github.com/openssl/openssl.git openssl30
 WORKDIR openssl
+RUN git submodule update --init --depth 1 fuzz/corpora
 COPY build.sh *.options $SRC/
 ENV AFL_SKIP_OSSFUZZ=1
 ENV AFL_LLVM_MODE_WORKAROUND=0


### PR DESCRIPTION
Otherwise the fuzz corpora files aren't present and the build fails.