### PR TITLE
Croniter get_next fix

### DIFF
--- a/projects/croniter/fuzz_iter.py
+++ b/projects/croniter/fuzz_iter.py
@@ -27,15 +27,15 @@ def TestOneInput(data):
   try:
     cron_str = fdp.ConsumeString(50)
     hash_id = fdp.ConsumeBytes(2)
-    croniter.croniter.is_valid(cron_str)
+    croniter.croniter.is_valid(cron_str, hash_id=hash_id)
     itr = croniter.croniter(cron_str, base, hash_id=hash_id)
     idx = 0
     for v in itr.all_next():
       idx += 1
       if idx > 10:
         break
-    itr.get_next(base)
-    itr.get_prev(base)
+    itr.get_next()
+    itr.get_prev()
   except (CroniterError, CroniterBadTypeRangeError) as e:
     pass
   except NameError as e:


### PR DESCRIPTION
Fix for an incorrect call to `get_next` that was stopping the Croniter `fuzz_iter` executing, see [https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=57139#c2](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=57139#c2).

It was being called with a `datetime` object instead of a `datetime` class as it's `ret_type` argument causing a type error.  I've removed the argument that's fixed it.

Also I've added the `undefined` sanitizer as it was missing from the `project.yaml`. I've done a local run and it works fine with it enabled.
