### PR TITLE
Revert "Update Centipede to 7a20b4e (#10021)"

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -134,7 +134,7 @@ RUN precompile_honggfuzz
 RUN cd $SRC && \
     git clone https://github.com/google/centipede.git && \
     cd centipede && \
-    git checkout 7a20b4e58c8363df0fb73bc28927241043bc0dc2 && \
+    git checkout eb91dd2157710e6c82579f8be19d7fab9423b781 && \
     rm -rf .git
 
 COPY precompile_centipede /usr/local/bin/


### PR DESCRIPTION
This reverts commit e3fdcc25ec5ad39538301d7f9b8ef8622649fd29 to temporarily avoid [the issues](https://github.com/google/oss-fuzz/pull/10021#issuecomment-1505301564) mentioned in #10021 during further investigation.
Backward-compatibility of `Centipede` is validated by https://github.com/google/clusterfuzz/pull/2999.