### PR TITLE
cras: Build Rust code from ${SRC}/adhd

### DIFF
--- a/projects/cras/Dockerfile
+++ b/projects/cras/Dockerfile
@@ -41,7 +41,6 @@ RUN apt-get -y update && \
       libtool \
       libudev-dev \
       wget \
-      vim \
       zip
 RUN apt-get clean
 
@@ -63,7 +62,6 @@ RUN mkdir -p /tmp/alsa-build && cd /tmp/alsa-build && \
       make clean && \
       make -j$(nproc) all && \
       make install
-
 
 RUN cd $SRC && git clone https://chromium.googlesource.com/chromiumos/third_party/adhd
 WORKDIR adhd

--- a/projects/cras/build.sh
+++ b/projects/cras/build.sh
@@ -21,12 +21,20 @@
 # Builds fuzzers from within a container into /out/ directory.
 # Expects /src/cras to contain a cras checkout.
 
-cd ${SRC}/adhd/cras/src/server/rust
-export CARGO_BUILD_TARGET="x86_64-unknown-linux-gnu"
-cargo build --release --target-dir=${WORK}/cargo_out
-cp ${WORK}/cargo_out/${CARGO_BUILD_TARGET}/release/libcras_rust.a /usr/local/lib
 
 cd ${SRC}/adhd
+
+#
+# Build Rust code.
+#
+export CARGO_BUILD_TARGET="x86_64-unknown-linux-gnu"
+cargo build --package=cras_rust --release --target-dir=${WORK}/cargo_out
+cp ${WORK}/cargo_out/${CARGO_BUILD_TARGET}/release/libcras_rust.a /usr/local/lib
+
+#
+# Build C code.
+#
+
 # Set bazel options.
 # See also:
 # https://github.com/google/oss-fuzz/blob/master/infra/base-images/base-builder/bazel_build_fuzz_tests


### PR DESCRIPTION
We have a unified Cargo workspace now, so we don't have to build inside the rust specific directory