### PR TITLE
woff2: fix introspector build

### DIFF
--- a/projects/woff2/build.sh
+++ b/projects/woff2/build.sh
@@ -21,6 +21,11 @@ cat brotli/shared.mk | sed -e "s/-no-canonical-prefixes//" \
 > brotli/shared.mk.temp
 mv brotli/shared.mk.temp brotli/shared.mk
 
+if [ "$SANITIZER" == "introspector" ]; then
+  # Modify AR flags as "f" is not a valid option to llvm-ar.
+  sed -i 's/crf/cr/g' Makefile
+fi
+
 # woff2 uses LFLAGS instead of LDFLAGS.
 make clean
 make CC="$CC $CFLAGS" CXX="$CXX $CXXFLAGS" CANONICAL_PREFIXES= all \


### PR DESCRIPTION
It currently runs into:

```
Step #6 - "compile-libfuzzer-introspector-x86_64": clang-15: ␛[0;1;35mwarning: ␛[0m␛[1moptimization flag '-fno-tree-vrp' is not supported [-Wignored-optimization-argument]␛[0m
Step #6 - "compile-libfuzzer-introspector-x86_64": llvm-ar crf src/convert_woff2ttf_fuzzer.a  src/font.o  src/glyph.o  src/normalize.o  src/table_tags.o  src/transform.o  src/woff2_dec.o  src/woff2_enc.o  src/woff2_common.o  src/woff2_out.o  src/variable_length.o \
Step #6 - "compile-libfuzzer-introspector-x86_64":       brotli/bin/obj/c/common/*.o brotli/bin/obj/c/enc/*.o brotli/bin/obj/c/dec/*.o src/convert_woff2ttf_fuzzer.o
Step #6 - "compile-libfuzzer-introspector-x86_64": llvm-ar: ␛[0;1;31merror: ␛[0munknown option f
Step #6 - "compile-libfuzzer-introspector-x86_64": OVERVIEW: LLVM Archiver
```

This fixes the above issue.