### PR TITLE
vitess: bump go

### DIFF
--- a/projects/vitess/Dockerfile
+++ b/projects/vitess/Dockerfile
@@ -17,5 +17,10 @@
 FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN git clone --depth 1 https://github.com/vitessio/vitess
 RUN git clone --depth 1 https://github.com/cncf/cncf-fuzzing
+RUN wget https://go.dev/dl/go1.20.2.linux-amd64.tar.gz \
+    && mkdir temp-go \
+    && rm -rf /root/.go/* \
+    && tar -C temp-go/ -xzf go1.20.2.linux-amd64.tar.gz \
+    && mv temp-go/go/* /root/.go/
 COPY build.sh $SRC/
 WORKDIR $SRC/vitess

--- a/projects/vitess/build.sh
+++ b/projects/vitess/build.sh
@@ -14,5 +14,7 @@
 # limitations under the License.
 #
 ################################################################################
+# Required by Go 1.20
+export CXX="${CXX} -lresolv" 
 cp $SRC/cncf-fuzzing/projects/vitess/vt_schema_fuzzer.go $SRC/vitess/go/test/fuzzing/
 $SRC/cncf-fuzzing/projects/vitess/build.sh


### PR DESCRIPTION
Bump Go for Vitess to 1.20.2