### PR TITLE
[xs] disable leak check at exit

### DIFF
--- a/projects/xs/xst.options
+++ b/projects/xs/xst.options
@@ -1,2 +1,3 @@
 [asan]
 detect_stack_use_after_return=0
+leak_check_at_exit=0


### PR DESCRIPTION
This PR instructs ASAN to not check for leaks at exit (i.e., after fuzzing is done), and use only the detection in libfuzzer using lsan's non-destructive checks.

Currently, the fuzzer reports leaks that only occur because it's in-process, so they are not true positives. When XS expects to exit (no `free` immediately before exit), it doesn't actually exit and continues to the next case. A comprehensive fix would be expensive. 

To reduce the amount of false-positives we suppress LSAN in abort paths, since any allocation would be short lived. However, the at-exit leak detection still reports non-reproducible leaks when fuzzer is exiting. We are disabling while we explore other alternatives to fix comprehensively (a possible one is #7347).