### PR TITLE
doc: replace libfuzzer.info links with llvm.org

### DIFF
--- a/docs/advanced-topics/ideal_integration.md
+++ b/docs/advanced-topics/ideal_integration.md
@@ -25,7 +25,7 @@ covers most of the items.
 
 ## Summary
 
-Every [fuzz target](http://libfuzzer.info/#fuzz-target):
+Every [fuzz target](https://llvm.org/docs/LibFuzzer.html#fuzz-target):
 * Is [maintained by code owners](#fuzz-target) in their RCS (Git, SVN, etc).
 * Is [built with the rest of the tests](#build-support) - no bit rot! 
 * Has a [seed corpus](#seed-corpus) with good [code coverage](#coverage).
@@ -36,7 +36,7 @@ Every [fuzz target](http://libfuzzer.info/#fuzz-target):
 
 ## Fuzz Target
 
-The code of the [fuzz target(s)](http://libfuzzer.info/#fuzz-target) should be
+The code of the [fuzz target(s)](https://llvm.org/docs/LibFuzzer.html#fuzz-target) should be
 part of the project's source code repository.  All fuzz targets should be easily
 discoverable (reside in the same directory, follow the same naming pattern,
 etc.). 
@@ -49,7 +49,7 @@ it does not crash, hang, or run out of memory instantly. If you're having
 trouble, read about [what makes a good fuzz
 target](https://github.com/google/fuzzing/blob/master/docs/good-fuzz-target.md).
 
-The interface between the [fuzz target]((http://libfuzzer.info/#fuzz-target))
+The interface between the [fuzz target]((https://llvm.org/docs/LibFuzzer.html#fuzz-target))
 and the fuzzing engines is C, so you can use either C or C++ to implement the
 fuzz target.
 
@@ -116,7 +116,7 @@ XML parser, a dictionary of XML tokens is helpful. AFL++ has a
 [collection](https://github.com/AFLplusplus/AFLplusplus/tree/master/dictionaries)
 of dictionaries for popular data formats. Ideally, a dictionary should be
 maintained alongside the fuzz target, and it must use [correct
-syntax](http://libfuzzer.info/#dictionaries).
+syntax](https://llvm.org/docs/LibFuzzer.html#dictionaries).
 
 ## Coverage
 

--- a/docs/advanced-topics/reproducing.md
+++ b/docs/advanced-topics/reproducing.md
@@ -23,7 +23,7 @@ reproduce it.
 Every issue has a [reproducer file]({{ site.baseurl
 }}/reference/glossary/#reproducer) (also know as a "testcase" file) attached.
 Download it. This file contains the bytes that were fed to the [fuzz
-target](http://libfuzzer.info/#fuzz-target).
+target](https://llvm.org/docs/LibFuzzer.html#fuzz-target).
 
 **Note:** If the issue is not public, you will need to login using a
 [Google account](https://support.google.com/accounts/answer/176347?hl=en)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -144,7 +144,7 @@ coverage, it may mean several things:
   Need to add more seeds.
 - There is some crypto/crc stuff in the code that will prevent any fuzzing
   engine from going deeper, in which case the crypto should be disabled in
-  [fuzzing mode](http://libfuzzer.info#fuzzer-friendly-build-mode).
+  [fuzzing mode](https://llvm.org/docs/LibFuzzer.html#fuzzer-friendly-build-mode).
   Examples: [openssl](https://github.com/openssl/openssl/tree/master/fuzz#reproducing-issues),
   [boringssl](https://boringssl.googlesource.com/boringssl/+/HEAD/FUZZING.md#Fuzzer-mode)
 - It is also possible that the fuzzer is running too slow

--- a/docs/getting-started/new_project_guide.md
+++ b/docs/getting-started/new_project_guide.md
@@ -441,7 +441,7 @@ OSS-Fuzz only: See also [Accessing Corpora]({{ site.baseurl }}/advanced-topics/c
 ### Dictionaries
 
 Dictionaries hugely improve fuzzing efficiency for inputs with lots of similar
-sequences of bytes. [libFuzzer documentation](http://libfuzzer.info#dictionaries)
+sequences of bytes. [libFuzzer documentation](https://llvm.org/docs/LibFuzzer.html#dictionaries)
 
 Put your dict file in `$OUT`. If the dict filename is the same as your target
 binary name (i.e. `%fuzz_target%.dict`), it will be automatically used. If the

--- a/docs/oss-fuzz/architecture.md
+++ b/docs/oss-fuzz/architecture.md
@@ -12,7 +12,7 @@ parent: OSS-Fuzz
 The process works like this:
 
 1. A maintainer of an open source project (or an outside volunteer) creates
-one or more [fuzz targets](http://libfuzzer.info/#fuzz-target)
+one or more [fuzz targets](https://llvm.org/docs/LibFuzzer.html#fuzz-target)
 and [integrates]({{ site.baseurl }}/advanced-topics/ideal-integration/) them
 with the project's build and test system.
 1. The project is [accepted to OSS-Fuzz]({{ site.baseurl }}/getting-started/accepting-new-projects/) and the developer commits their build configurations.

--- a/docs/reference/useful_links.md
+++ b/docs/reference/useful_links.md
@@ -42,8 +42,8 @@ parent: Reference
 
 ## Tutorials
 
-* [libFuzzer documentation](http://libfuzzer.info)
-* [libFuzzer tutorial](http://tutorial.libfuzzer.info)
+* [libFuzzer documentation](https://llvm.org/docs/LibFuzzer.html)
+* [libFuzzer tutorial](https://github.com/google/fuzzing/blob/master/tutorial/libFuzzerTutorial.md)
 * [libFuzzer workshop](https://github.com/Dor1s/libfuzzer-workshop)
 * [Structure-Aware Fuzzing with libFuzzer](https://github.com/google/fuzzer-test-suite/blob/master/tutorial/structure-aware-fuzzing.md)
 * [Chromium Fuzzing Page](https://chromium.googlesource.com/chromium/src/testing/libfuzzer/)

--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -54,7 +54,7 @@ ENV CXX "clang++"
 ENV CCC "clang++"
 
 # FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION is described at
-# http://libfuzzer.info#fuzzer-friendly-build-mode
+# https://llvm.org/docs/LibFuzzer.html#fuzzer-friendly-build-mode
 
 ENV CFLAGS "-O1 -fno-omit-frame-pointer -gline-tables-only -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"
 ENV CXXFLAGS_EXTRA "-stdlib=libc++"

--- a/infra/cifuzz/test_data/external-project/do_stuff_fuzzer.cpp
+++ b/infra/cifuzz/test_data/external-project/do_stuff_fuzzer.cpp
@@ -16,7 +16,7 @@
 #include <string>
 
 // Simple fuzz target for DoStuff().
-// See http://libfuzzer.info for details.
+// See https://llvm.org/docs/LibFuzzer.html for details.
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   std::string str(reinterpret_cast<const char *>(data), size);
   DoStuff(str);  // Disregard the output.

--- a/infra/cifuzz/test_data/external-project/do_stuff_fuzzer.dict
+++ b/infra/cifuzz/test_data/external-project/do_stuff_fuzzer.dict
@@ -1,6 +1,6 @@
 # A dictionary for more efficient fuzzing of DoStuff(). 
 # If the inputs contain multi-byte tokens, list them here.
-# See http://libfuzzer.info#dictionaries
+# See https://llvm.org/docs/LibFuzzer.html#dictionaries
 "foo"
 "bar"
 "ouch"

--- a/projects/example/my-api-repo/README.md
+++ b/projects/example/my-api-repo/README.md
@@ -7,7 +7,7 @@ Imagine that these files reside in your project's repository:
 
 * [my_api.h](my_api.h): and [my_api.cpp](my_api.cpp) implement the API we want to test/fuzz. The function `DoStuff()` inside [my_api.cpp](my_api.cpp) contains a bug. (Find it!)
 * [do_stuff_unittest.cpp](do_stuff_unittest.cpp): is a unit test for `DoStuff()`. Unit tests are not necessary for fuzzing but are generally a good practice.
-* [do_stuff_fuzzer.cpp](do_stuff_fuzzer.cpp): is a [fuzz target](http://libfuzzer.info/#fuzz-target) for `DoStuff()`.
+* [do_stuff_fuzzer.cpp](do_stuff_fuzzer.cpp): is a [fuzz target](https://llvm.org/docs/LibFuzzer.html#fuzz-target) for `DoStuff()`.
 * [do_stuff_test_data](do_stuff_test_data): corpus directory for [do_stuff_fuzzer.cpp](do_stuff_fuzzer.cpp).
 * [do_stuff_fuzzer.dict](do_stuff_fuzzer.dict): a [fuzzing dictionary file](https://google.github.io/oss-fuzz/getting-started/new-project-guide#dictionaries) for `DoStuff()`. Optional, but may improve fuzzing in many cases. 
 * [Makefile](Makefile): is a build file (the same can be done with other build systems):

--- a/projects/example/my-api-repo/do_stuff_fuzzer.cpp
+++ b/projects/example/my-api-repo/do_stuff_fuzzer.cpp
@@ -1,5 +1,16 @@
-// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2020 Google LLC
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include "my_api.h"
 
 #include <string>

--- a/projects/example/my-api-repo/do_stuff_fuzzer.cpp
+++ b/projects/example/my-api-repo/do_stuff_fuzzer.cpp
@@ -5,7 +5,7 @@
 #include <string>
 
 // Simple fuzz target for DoStuff().
-// See http://libfuzzer.info for details.
+// See https://llvm.org/docs/LibFuzzer.html for details.
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   std::string str(reinterpret_cast<const char *>(data), size);
   DoStuff(str);  // Disregard the output.

--- a/projects/example/my-api-repo/do_stuff_fuzzer.dict
+++ b/projects/example/my-api-repo/do_stuff_fuzzer.dict
@@ -1,6 +1,6 @@
 # A dictionary for more efficient fuzzing of DoStuff(). 
 # If the inputs contain multi-byte tokens, list them here.
-# See http://libfuzzer.info#dictionaries
+# See https://llvm.org/docs/LibFuzzer.html#dictionaries
 "foo"
 "bar"
 "ouch"


### PR DESCRIPTION
These all already redirect to the new locations.