### PR TITLE
[cryptofuzz, bignum-fuzzer] Fix libgmp download

### DIFF
--- a/projects/bignum-fuzzer/Dockerfile
+++ b/projects/bignum-fuzzer/Dockerfile
@@ -32,5 +32,7 @@ RUN wget https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.5.1.ta
 RUN git clone --depth 1 https://github.com/guidovranken/bignum-fuzzer
 RUN git clone --depth 1 https://github.com/openssl/openssl
 RUN git clone https://boringssl.googlesource.com/boringssl
-RUN hg clone https://gmplib.org/repo/gmp/ libgmp/
+RUN hg clone https://gmplib.org/repo/gmp/ libgmp/ || \
+    (wget --no-check-certificate 'https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz' && tar xf gmp-6.2.1.tar.lz && mv $SRC/gmp-6.2.1/ $SRC/libgmp/)
+
 COPY build.sh $SRC/

--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -40,7 +40,8 @@ RUN hg clone https://hg.mozilla.org/projects/nss
 RUN git clone --depth 1 https://github.com/jedisct1/libsodium.git
 RUN git clone --depth 1 https://github.com/libtom/libtomcrypt.git
 RUN git clone --depth 1 https://github.com/microsoft/SymCrypt.git
-RUN hg clone https://gmplib.org/repo/gmp/ libgmp/
+RUN hg clone https://gmplib.org/repo/gmp/ libgmp/ || \
+    (wget --no-check-certificate 'https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz' && tar xf gmp-6.2.1.tar.lz && mv $SRC/gmp-6.2.1/ $SRC/libgmp/)
 RUN wget https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.5.1.tar.gz
 RUN git clone --depth 1 https://github.com/indutny/bn.js.git
 RUN git clone --depth 1 https://github.com/MikeMcl/bignumber.js.git

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -420,24 +420,25 @@ export LIBSODIUM_INCLUDE_PATH="$SRC/libsodium/src/libsodium/include"
 cd $SRC/cryptofuzz/modules/libsodium
 make -B
 
-if [[ $CFLAGS != *sanitize=memory* && $CFLAGS != *-m32* ]]
-then
-    # Compile EverCrypt (with assembly)
-    cd $SRC/evercrypt/dist
-    make -C portable -j$(nproc) libevercrypt.a
-    make -C kremlin/kremlib/dist/minimal -j$(nproc)
-
-    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_EVERCRYPT"
-    export EVERCRYPT_A_PATH="$SRC/evercrypt/dist/portable/libevercrypt.a"
-    export KREMLIN_A_PATH="$SRC/evercrypt/dist/kremlin/kremlib/dist/minimal/*.o"
-    export EVERCRYPT_INCLUDE_PATH="$SRC/evercrypt/dist"
-    export KREMLIN_INCLUDE_PATH="$SRC/evercrypt/dist/kremlin/include"
-    export INCLUDE_PATH_FLAGS="$INCLUDE_PATH_FLAGS -I $EVERCRYPT_INCLUDE_PATH -I $KREMLIN_INCLUDE_PATH"
-
-    # Compile Cryptofuzz EverCrypt (with assembly) module
-    cd $SRC/cryptofuzz/modules/evercrypt
-    make -B
-fi
+# Disabled because NSS now also embeds evercrypt, leading to symbol collisions
+#if [[ $CFLAGS != *sanitize=memory* && $CFLAGS != *-m32* ]]
+#then
+#    # Compile EverCrypt (with assembly)
+#    cd $SRC/evercrypt/dist
+#    make -C portable -j$(nproc) libevercrypt.a
+#    make -C kremlin/kremlib/dist/minimal -j$(nproc)
+#
+#    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_EVERCRYPT"
+#    export EVERCRYPT_A_PATH="$SRC/evercrypt/dist/portable/libevercrypt.a"
+#    export KREMLIN_A_PATH="$SRC/evercrypt/dist/kremlin/kremlib/dist/minimal/*.o"
+#    export EVERCRYPT_INCLUDE_PATH="$SRC/evercrypt/dist"
+#    export KREMLIN_INCLUDE_PATH="$SRC/evercrypt/dist/kremlin/include"
+#    export INCLUDE_PATH_FLAGS="$INCLUDE_PATH_FLAGS -I $EVERCRYPT_INCLUDE_PATH -I $KREMLIN_INCLUDE_PATH"
+#
+#    # Compile Cryptofuzz EverCrypt (with assembly) module
+#    cd $SRC/cryptofuzz/modules/evercrypt
+#    make -B
+#fi
 
 ##############################################################################
 # Compile Cryptofuzz reference (without assembly) module


### PR DESCRIPTION
The libgmp Mercurial server is frequently down, and this causes builds to fail. Unfortunately they do not have a Github mirror.

This PR causes the Dockerfile to revert to downloading the latest libgmp stable release if the Mercurial clone doesn't work.