### PR TITLE
python-email-validator: disable dns check

### DIFF
--- a/projects/python-email-validator/fuzz_validator.py
+++ b/projects/python-email-validator/fuzz_validator.py
@@ -22,7 +22,7 @@ from email_validator import EmailSyntaxError, \
 
 def TestOneInput(data):
     try:
-        validate_email(data)
+        validate_email(data, check_deliverability=False)
     except (EmailSyntaxError, EmailUndeliverableError):
         pass
 


### PR DESCRIPTION
Disables dns deliverability check hence avoids dns package from code coverage, as underlying dns-python is already being fuzzed in oss-fuzz.