### PR TITLE
Adding coverage to digest for parser

### DIFF
--- a/projects/digest/fuzz_params.py
+++ b/projects/digest/fuzz_params.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python3
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from unittest.mock import patch
+import atheris
+
+import digest
+import hashlib
+
+
+def TestOneInput(data):
+    fdp = atheris.FuzzedDataProvider(data)
+    encoder = fdp.PickValueInList(list(hashlib.algorithms_available))
+    buffsize = str(fdp.ConsumeInt(16))
+    stdin = fdp.ConsumeBytes(sys.maxsize)
+    try:
+        with patch(
+            "sys.argv", ["python", "-b", buffsize, encoder, "fuzz_digest.py"]
+        ), patch("sys.stdin", stdin):
+            digest.main()
+    except SystemExit:
+        pass
+
+
+def main():
+    atheris.instrument_all()
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This additional fuzzer `fuzz_params` calls the `digest` utility mocking the stdin and parser args inputs. This is closer to how this utility is used normally and gives additional coverage.

This has shook out an issue pretty quickly https://github.com/bmc/digest/issues/4 .

Another issue, the introspector doesn't seem to be able to measure any coverage on digest at all.

<img width="408" alt="image" src="https://user-images.githubusercontent.com/5122866/233772534-976599e4-42dc-4c08-aacd-2a06db0fb177.png">
