### PR TITLE
Fix the Mutagen fuzzer

### DIFF
--- a/projects/mutagen/fuzz_parser.py
+++ b/projects/mutagen/fuzz_parser.py
@@ -30,9 +30,9 @@ def TestOneInput(data: bytes) -> int:
         f.tags.pprint()
       if f.info:
         f.info.pprint()
-      f.delete()
 
       out = io.BytesIO()
+      f.delete(out)
       f.save(out)
       mutagen.File(out)
   except mutagen.MutagenError:


### PR DESCRIPTION
Mutagen isn't able to write to the BytesIO it's operating on, so we need to pass it something to write into.