### PR TITLE
libplist: Do not build test suite

### DIFF
--- a/projects/libplist/build.sh
+++ b/projects/libplist/build.sh
@@ -16,7 +16,7 @@
 #
 ################################################################################
 
-./autogen.sh --without-cython --enable-debug
+./autogen.sh --without-cython --enable-debug --without-tests
 make -j$(nproc) clean
 make -j$(nproc) all
 


### PR DESCRIPTION
As the test suite currently fails building for coverage due to this error:
```
Step #3 - "compile-libfuzzer-coverage-x86_64":   CXXLD    plist_test++
Step #3 - "compile-libfuzzer-coverage-x86_64": /usr/bin/ld: .libs/plist_test++: hidden symbol `atexit' in /usr/lib/x86_64-linux-gnu/libc_nonshared.a(atexit.oS) is referenced by DSO
Step #3 - "compile-libfuzzer-coverage-x86_64": /usr/bin/ld: final link failed: bad value
```
I thought I'd add an option to allow disabling building those - and use this option here - since the test case binaries are not really required for fuzzing.