### PR TITLE
tarantool: fix non-zero exit code when corpus dir doesn't exist

### DIFF
--- a/projects/tarantool/build.sh
+++ b/projects/tarantool/build.sh
@@ -89,5 +89,7 @@ do
   corpus_dir="test/static/corpus/$module"
   echo "Copying for $module";
   cp $f $OUT/
-  [[ -e $corpus_dir ]] && zip -j $OUT/"$module"_fuzzer_seed_corpus.zip $corpus_dir/*
+  if [ -e "$corpus_dir" ]; then
+    zip -j $OUT/"$module"_fuzzer_seed_corpus.zip $corpus_dir/*
+  fi
 done


### PR DESCRIPTION
Follows up https://github.com/tarantool/tarantool/issues/8488
Follows up https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=57298

CC: @ylobankov 