### PR TITLE
Update email address for primary contact of GSS-NTLMSSP

### DIFF
--- a/projects/gss-ntlmssp/project.yaml
+++ b/projects/gss-ntlmssp/project.yaml
@@ -1,6 +1,6 @@
 homepage: "https://github.com/gssapi/gss-ntlmssp"
 language: c
-primary_contact: "simo@redhat.com"
+primary_contact: "ssorce@redhat.com"
 fuzzing_engines:
   - libfuzzer
   - afl


### PR DESCRIPTION
Oss-fuzz is crearting bugs in https://bugs.chromium.org/p/oss-fuzz/issues/ and adding me in CC with my alias. Unfortunately that project uses Google's authentication and my employer does not have a mechanism to authenticate my mail alias. So change the contact to my "standard" email address. It is the same person I can confirm by whatever mean if needed. In fact if someone in the project could reassign issue 58049 to ssorce@redhat.com I could prove it by authenticating to the issues and leaving a comment.