### PR TITLE
tarantool: enable debug compile options

### DIFF
--- a/projects/tarantool/build.sh
+++ b/projects/tarantool/build.sh
@@ -51,6 +51,8 @@ cmake_args=(
     -DENABLE_BACKTRACE=OFF
     -DENABLE_FUZZER=ON
     -DOSS_FUZZ=ON
+    -DLUA_USE_APICHECK=ON
+    -DLUA_USE_ASSERT=ON
     $SANITIZERS_ARGS
 
     # C compiler


### PR DESCRIPTION
- LUA_USE_ASSERT turns on all assertions inside Lua.
- LUA_USE_APICHECK turns on several consistency checks on the C API.