### PR TITLE
[rustls] Add seed corpus

### DIFF
--- a/projects/rustls/Dockerfile
+++ b/projects/rustls/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get --yes update \
    && rm --recursive --force /var/lib/apt/lists/*
 
 RUN git clone https://github.com/ctz/rustls
+RUN git clone --depth 1 https://github.com/guidovranken/rustls-fuzzing-corpora
 
 WORKDIR $SRC
 

--- a/projects/rustls/build.sh
+++ b/projects/rustls/build.sh
@@ -27,6 +27,11 @@ for f in $SRC/rustls/fuzz/fuzzers/*.rs
 do
   FUZZ_TARGET=$(basename ${f%.*})
   cp fuzz/target/x86_64-unknown-linux-gnu/release/${FUZZ_TARGET} $OUT/
+  if [[ -d $SRC/rustls-fuzzing-corpora/$FUZZ_TARGET/ ]]; then
+      zip -jr \
+          $OUT/${FUZZ_TARGET}_seed_corpus.zip \
+          $SRC/rustls-fuzzing-corpora/$FUZZ_TARGET/
+  fi
 done
 
 if [ "$SANITIZER" == "coverage" ]
@@ -34,3 +39,4 @@ then
     rm $OUT/server
     rm $OUT/persist
 fi
+


### PR DESCRIPTION
Adds a seed corpus for the `client` fuzzer which results in ~ 11% code coverage increase.

rustls maintainer has agreed to this: https://github.com/rustls/rustls/issues/1287#issuecomment-1524724234