### PR TITLE
Remove none build from CI.

### DIFF
--- a/.github/workflows/project_tests.yml
+++ b/.github/workflows/project_tests.yml
@@ -23,7 +23,6 @@ jobs:
           - memory
           - undefined
           - coverage
-          - none
         architecture:
           - x86_64
         include:


### PR DESCRIPTION
It adds an unsupported and unused libfuzzer-none build. We already have a centipede-none build explicitly there.