### PR TITLE
croniter PYFUZZPACKAGE reachability analysis workaround

### DIFF
--- a/projects/croniter/build.sh
+++ b/projects/croniter/build.sh
@@ -17,6 +17,10 @@
 
 pip3 install .
 
+# Workaround for oss-fuzz not being able to recognise which croniter modules are used
+# See https://github.com/ossf/fuzz-introspector/issues/1010
+export PYFUZZPACKAGE=$SRC/croniter/src/croniter
+
 # Build fuzzers in $OUT.
 for fuzzer in $(find $SRC -name 'fuzz_*.py'); do
   compile_python_fuzzer $fuzzer

--- a/projects/croniter/fuzz_iter.py
+++ b/projects/croniter/fuzz_iter.py
@@ -17,7 +17,7 @@ import atheris
 import sys
 
 from datetime import datetime
-import croniter
+from croniter import croniter
 from croniter.croniter import CroniterError, CroniterBadTypeRangeError
 
 
@@ -27,8 +27,8 @@ def TestOneInput(data):
   try:
     cron_str = fdp.ConsumeString(50)
     hash_id = fdp.ConsumeBytes(2)
-    croniter.croniter.is_valid(cron_str, hash_id=hash_id)
-    itr = croniter.croniter(cron_str, base, hash_id=hash_id)
+    croniter.is_valid(cron_str, hash_id=hash_id)
+    itr = croniter(cron_str, base, hash_id=hash_id)
     idx = 0
     for v in itr.all_next():
       idx += 1

--- a/projects/croniter/fuzz_match.py
+++ b/projects/croniter/fuzz_match.py
@@ -17,7 +17,7 @@ import atheris
 import sys
 
 import datetime
-import croniter
+from croniter import croniter
 from croniter.croniter import CroniterError, CroniterBadTypeRangeError
 
 
@@ -30,7 +30,7 @@ def TestOneInput(data):
   cron_str = fdp.ConsumeString(50)
   testdate = RandomDateTime(fdp)
   try:
-    croniter.croniter.match(cron_str, testdate)
+    croniter.match(cron_str, testdate)
   except (CroniterError, CroniterBadTypeRangeError) as e:
     pass
 

--- a/projects/croniter/fuzz_range.py
+++ b/projects/croniter/fuzz_range.py
@@ -17,7 +17,7 @@ import atheris
 import sys
 
 import datetime
-import croniter
+from croniter import croniter_range
 from croniter.croniter import CroniterError, CroniterBadTypeRangeError
 
 
@@ -32,7 +32,7 @@ def TestOneInput(data):
   stop = RandomDateTime(fdp)
   try:
     idx = 0
-    for dt in croniter.croniter_range(start, stop, cron_str):
+    for dt in croniter_range(start, stop, cron_str):
       idx += 1
       if idx > 10:
         break


### PR DESCRIPTION
Work around for issue resolving croniter function names, see https://github.com/ossf/fuzz-introspector/issues/1010 .

Setting the `PYFUZZPACKAGE` environment variable takes coverage from `2/48` functions reachable to an improved `22/48` reachable. I've also updated how croniter is imported to have a higher number of matches.

There are still some issues in the callgraph analysis but this is a big improvement in the metrics.