### PR TITLE
bind9: Fix liburcu linking

### DIFF
--- a/projects/bind9/build.sh
+++ b/projects/bind9/build.sh
@@ -24,8 +24,8 @@ make -C tests/libtest -j"$(nproc)" all V=1
 
 LIBISC_CFLAGS="-Ilib/isc/include"
 LIBDNS_CFLAGS="-Ilib/dns/include"
-LIBISC_LIBS="lib/isc/.libs/libisc.a -Wl,-Bstatic -Wl,-u,isc__initialize,-u,isc__shutdown -lssl -lcrypto -lurcu-qsbr -lurcu-cds -luv -lnghttp2 -Wl,-Bdynamic"
-LIBDNS_LIBS="lib/dns/.libs/libdns.a -Wl,-Bstatic -lcrypto -lurcu-qsbr -lurcu-cds -Wl,-Bdynamic"
+LIBISC_LIBS="lib/isc/.libs/libisc.a -Wl,-Bstatic -Wl,-u,isc__initialize,-u,isc__shutdown -lssl -lcrypto -lurcu-memb -lurcu-cds -luv -lnghttp2 -Wl,-Bdynamic"
+LIBDNS_LIBS="lib/dns/.libs/libdns.a -Wl,-Bstatic -lcrypto -lurcu-memb -lurcu-cds -Wl,-Bdynamic"
 LIBTEST_LIBS="tests/libtest/.libs/libtest.a"
 
 # dns_name_fromwire needs old.c/old.h code to be linked in


### PR DESCRIPTION
`./configure` picked the membarrier flavor but was asked to link with qsbc:

    /usr/bin/ld: /usr/bin/ld: DWARF error: invalid or unhandled FORM value: 0x25
    lib/isc/.libs/libisc.a(libisc_la-loop.o): in function `quiescent_cb':
    loop.c:(.text+0x833a): undefined reference to `urcu_memb_read_ongoing'
    /usr/bin/ld: /usr/bin/ld: DWARF error: invalid or unhandled FORM value: 0x25
    lib/isc/.libs/libisc.a(libisc_la-thread.o): in function `isc_thread_main':
    thread.c:(.text+0x156): undefined reference to `urcu_memb_register_thread'
    /usr/bin/ld: thread.c:(.text+0x161): undefined reference to `urcu_memb_unregister_thread'
    /usr/bin/ld: lib/isc/.libs/libisc.a(libisc_la-thread.o): in function `thread_run':
    thread.c:(.text+0x88e): undefined reference to `urcu_memb_register_thread'
    /usr/bin/ld: thread.c:(.text+0x89d): undefined reference to `urcu_memb_unregister_thread'
    /usr/bin/ld: /usr/bin/ld: DWARF error: invalid or unhandled FORM value: 0x25
    lib/isc/.libs/libisc.a(libisc_la-work.o): in function `isc__work_cb':
    work.c:(.text+0x40c): undefined reference to `urcu_memb_register_thread'
    /usr/bin/ld: work.c:(.text+0x448): undefined reference to `urcu_memb_unregister_thread'