### PR TITLE
ada-url: initial integration

### DIFF
--- a/projects/ada-url/Dockerfile
+++ b/projects/ada-url/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make cmake
+RUN git clone --depth 1 https://github.com/ada-url/ada ada-url
+RUN cp ada-url/fuzz/build.sh $SRC/
+WORKDIR ada-url

--- a/projects/ada-url/project.yaml
+++ b/projects/ada-url/project.yaml
@@ -1,0 +1,15 @@
+homepage: "https://ada-url.github.io/ada"
+language: c++
+primary_contact: "yagiz@nizipli.com"
+auto_ccs:
+  - "daniel@lemire.me"
+main_repo: "https://github.com/ada-url/ada.git"
+sanitizers:
+  - address
+  - undefined
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+  - centipede
+file_github_issue: true


### PR DESCRIPTION
Ada URL parser is the default URL parser for Node.js 18 (LTS version), 19, and 20. Node.js is used by millions of applications worldwide. 

The download statistics for Node.js [can be found from here](https://nodejs.org/metrics/).
