### PR TITLE
infra: add Dockerfile for fuzz introspection web app

### DIFF
--- a/infra/build/webapp-fuzz-introspection/Dockerfile
+++ b/infra/build/webapp-fuzz-introspection/Dockerfile
@@ -13,12 +13,12 @@
 # limitations under the License.
 #
 ################################################################################
-FROM python:3.11-slim
+FROM python:3.11-bullseye
 
 # Allow statements and log messages to immediately appear in the Knative logs
 ENV PYTHONUNBUFFERED True
 
-COPY fuzz-introspector /fuzz-introspector
+RUN git clone --depth=1 https://github.com/ossf/fuzz-introspector /fuzz-introspector
 
 # Copy local code to the container image.
 ENV APP_HOME /fuzz-introspector/tools/web-fuzzing-introspection/app/
@@ -30,7 +30,7 @@ RUN pip install --no-cache-dir -r $APP_HOME/../requirements.txt
 # Create the database the webapp will be using
 RUN cd $APP_HOME/static/assets/db/ && \
     python ./web_db_creator_from_summary.py \
-      --max-projects=150 \
+      --max-projects=2000 \
       --since-date=20-04-2023 \
       --output-dir=$PWD \
       --input-dir=$PWD

--- a/infra/build/webapp-fuzz-introspection/Dockerfile
+++ b/infra/build/webapp-fuzz-introspection/Dockerfile
@@ -1,0 +1,46 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM python:3.11-slim
+
+# Allow statements and log messages to immediately appear in the Knative logs
+ENV PYTHONUNBUFFERED True
+
+COPY fuzz-introspector /fuzz-introspector
+
+# Copy local code to the container image.
+ENV APP_HOME /fuzz-introspector/tools/web-fuzzing-introspection/app/
+WORKDIR $APP_HOME
+
+# Install production dependencies.
+RUN pip install --no-cache-dir -r $APP_HOME/../requirements.txt
+
+# Create the database the webapp will be using
+RUN cd $APP_HOME/static/assets/db/ && \
+    python ./web_db_creator_from_summary.py \
+      --max-projects=150 \
+      --since-date=20-04-2023 \
+      --output-dir=$PWD \
+      --input-dir=$PWD
+
+ENV WEBAPP_PORT 8080
+RUN pip install gunicorn==20.1.0
+
+# Run the web service on container startup. Here we use the gunicorn
+# webserver, with one worker process and 8 threads.
+# For environments with multiple CPU cores, increase the number of workers
+# to be equal to the cores available.
+# Timeout is set to 0 to disable the timeouts of the workers to allow Cloud Run to handle instance scaling.
+CMD exec gunicorn --bind :8080 --workers 1 --threads 8 --timeout 0 'main:create_app()'

--- a/infra/build/webapp-fuzz-introspection/Dockerfile
+++ b/infra/build/webapp-fuzz-introspection/Dockerfile
@@ -30,7 +30,6 @@ RUN pip install --no-cache-dir -r $APP_HOME/../requirements.txt
 # Create the database the webapp will be using
 RUN cd $APP_HOME/static/assets/db/ && \
     python ./web_db_creator_from_summary.py \
-      --max-projects=2000 \
       --since-date=20-04-2023 \
       --output-dir=$PWD \
       --input-dir=$PWD
@@ -43,4 +42,4 @@ RUN pip install gunicorn==20.1.0
 # For environments with multiple CPU cores, increase the number of workers
 # to be equal to the cores available.
 # Timeout is set to 0 to disable the timeouts of the workers to allow Cloud Run to handle instance scaling.
-CMD exec gunicorn --bind :8080 --workers 1 --threads 8 --timeout 0 'main:create_app()'
+CMD exec gunicorn --bind :${WEBAPP_PORT} --workers 1 --threads 8 --timeout 0 'main:create_app()'


### PR DESCRIPTION
This Dockerfile is meant to be build as part of the GCP project. I tried to make it as simple as possible to make deployment easy.

I've deployed this on a simple gcp project using:

```
# assume current directory is where the Dockerfile resides
git clone https://github.com/ossf/fuzz-introspector
gcloud builds submit --tag gcr.io/${GOOGLE_CLOUD_PROJECT}/webapp-fuzz:1.0.4 .
gcloud run deploy --image=gcr.io/${GOOGLE_CLOUD_PROJECT}/webapp-fuzz:1.0.4 --platform managed
```
Deployment as created by this Dockerfile: https://webapp-cl76vg7p7a-ey.a.run.app/

~~I've limited the number of projects in the above instance to `--max-projects=150`, where this should be set to `--max-projects=10000`. However, I had some issues with resources when doing this on my gcp project, although I think that's just due to me using a small gcp project.~~ I've now set it as how it should be when deployed, see: https://github.com/google/oss-fuzz/pull/10216#issuecomment-1534527472


----
The Dockerfile is meant to be build once a day and will create the DB for the given instance from a given date, which is given in the call to `python ./web_db_creator_from_summary.py`. The benefit of building the DB from scratch in the Dockerfile in this way, as opposed to accumulating the DB over time, is that we can easily extend features of the webapp that includes data from past introspector reports and that the set up is quite simple. I anticipate we'll do this somewhat regularly, based on e.g. feedback for users as to what information is useful. It does not take that long (a few minutes) to build the container.