### PR TITLE
Disable Centipede on Project `neomutt`

### DIFF
--- a/projects/neomutt/project.yaml
+++ b/projects/neomutt/project.yaml
@@ -11,4 +11,3 @@ sanitizers:
 fuzzing_engines:
  - afl
  - libfuzzer
- - centipede


### PR DESCRIPTION
Fixes #10143.
`Centipede` runs into a timeout error when running the build tests on the unsanitized binary of the project.
This is likely caused by `Centipede` as [a similar issue](https://github.com/google/oss-fuzz/pull/10021#issuecomment-1519206462) was observed on a different project.
But given most projects work fine on `Centipede`, the most straightforward solution is to disable `Centipede` on the project for now.