### PR TITLE
[systemd] turn off centipede

### DIFF
--- a/projects/systemd/project.yaml
+++ b/projects/systemd/project.yaml
@@ -6,6 +6,10 @@ sanitizers:
   - address
   - undefined
   - memory
+fuzzing_engines:
+  - afl
+  - honggfuzz
+  - libfuzzer
 auto_ccs:
   - jonathan@titanous.com
   - zbyszek@in.waw.pl


### PR DESCRIPTION
centipede doesn't support more than one instrumented DSO currently and it leads to crashes like
https://github.com/google/oss-fuzz/pull/10021#issuecomment-1505301564.

It partially reverts 439d0bc2c625eb8d022bfb7a41c4a541b99f1eaf