### PR TITLE
bitcoin-core: Remove centipede for now

### DIFF
--- a/projects/bitcoin-core/project.yaml
+++ b/projects/bitcoin-core/project.yaml
@@ -18,4 +18,3 @@ fuzzing_engines:
   - libfuzzer
   - honggfuzz
   - afl
-  - centipede


### PR DESCRIPTION
Attempt to work around the build timeout for now ( https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=58304 )