### PR TITLE
 bitcoin-core: Revert (thin)LTO due to build timeout, try centipede fuzzing engine

### DIFF
--- a/projects/bitcoin-core/build.sh
+++ b/projects/bitcoin-core/build.sh
@@ -26,16 +26,10 @@ if [ "$ARCHITECTURE" = "i386" ]; then
 else
   export BUILD_TRIPLET="x86_64-pc-linux-gnu"
 fi
-
-# Build using ThinLTO, to avoid OOM, and other LLVM issues.
-# See https://github.com/google/oss-fuzz/pull/10123.
-sed -i 's/flto/flto=thin/g' ./depends/hosts/linux.mk
-sed -i 's/flto/flto=thin/g' ./configure.ac
-
 (
   cd depends
   sed -i --regexp-extended '/.*rm -rf .*extract_dir.*/d' ./funcs.mk  # Keep extracted source
-  make HOST=$BUILD_TRIPLET LTO=1 NO_QT=1 NO_BDB=1 NO_ZMQ=1 NO_UPNP=1 NO_NATPMP=1 NO_USDT=1 AR=llvm-ar RANLIB=llvm-ranlib -j$(nproc)
+  make HOST=$BUILD_TRIPLET NO_QT=1 NO_BDB=1 NO_ZMQ=1 NO_UPNP=1 NO_NATPMP=1 NO_USDT=1 -j$(nproc)
 )
 
 # Build the fuzz targets

--- a/projects/bitcoin-core/project.yaml
+++ b/projects/bitcoin-core/project.yaml
@@ -18,3 +18,4 @@ fuzzing_engines:
   - libfuzzer
   - honggfuzz
   - afl
+  - centipede


### PR DESCRIPTION
Looks like LTO is now confirmed to be the problem, see https://github.com/google/oss-fuzz/pull/10252#issuecomment-1535998849, so revert it.

Also, re-try centipede.