### PR TITLE
Temporarily pin Wasmtime to an older nightly Rust

### DIFF
--- a/projects/wasmtime/build.sh
+++ b/projects/wasmtime/build.sh
@@ -15,6 +15,9 @@
 #
 ################################################################################
 
+rustup default nighlty-2023-04-01
+rustup component add rust-src
+
 # Commands migrated from Dockerfile to make CIFuzz work
 # REF: https://github.com/google/oss-fuzz/issues/6755
 git submodule update --init --recursive

--- a/projects/wasmtime/build.sh
+++ b/projects/wasmtime/build.sh
@@ -15,7 +15,7 @@
 #
 ################################################################################
 
-rustup default nighlty-2023-04-01
+rustup default nightly-2023-04-01
 rustup component add rust-src
 
 # Commands migrated from Dockerfile to make CIFuzz work


### PR DESCRIPTION
This is an attempt to investigate #10186 by moving Rust from the latest nightly to what is in theory a good nightly from when we weren't seeing startup crashes. If this works then it seems like Rust's own nightly compiler is the culprit. If it doesn't I'm hoping I'll figure out what's next best to try after that.