### PR TITLE
[wolfssl] Upgrade Boost

### DIFF
--- a/projects/wolfssl/Dockerfile
+++ b/projects/wolfssl/Dockerfile
@@ -26,7 +26,7 @@ RUN git clone --depth 1 https://github.com/guidovranken/wolf-ssl-ssh-fuzzers
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone --depth 1 https://github.com/google/wycheproof.git
-RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
+RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.82.0/source/boost_1_82_0.tar.bz2
 RUN git clone https://github.com/wolfssl/oss-fuzz-targets --depth 1 $SRC/fuzz-targets
 
 # Retrieve corpora from other projects

--- a/projects/wolfssl/build.sh
+++ b/projects/wolfssl/build.sh
@@ -26,8 +26,8 @@ then
 
     # Install Boost headers
     cd $SRC/
-    tar jxf boost_1_74_0.tar.bz2
-    cd boost_1_74_0/
+    tar jxf boost_1_82_0.tar.bz2
+    cd boost_1_82_0/
     CFLAGS="" CXXFLAGS="" ./bootstrap.sh
     CFLAGS="" CXXFLAGS="" ./b2 headers
     cp -R boost/ /usr/include/


### PR DESCRIPTION
Upgrade Boost to the latest version.

Older Boost contains a bug (https://github.com/boostorg/multiprecision/issues/526) which is the cause of a bug report in the wolfssl project (https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=55930).