### PR TITLE
Disable thread safety analysis checks for connectedhomeip

### DIFF
--- a/projects/connectedhomeip/Dockerfile
+++ b/projects/connectedhomeip/Dockerfile
@@ -29,7 +29,10 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN rustup install nightly
 RUN rustup default nightly
 
-RUN git clone --recurse-submodules https://github.com/project-chip/connectedhomeip.git connectedhomeip
+RUN git clone --depth=1 https://github.com/project-chip/connectedhomeip.git connectedhomeip
+
+# checkout submodules required for linux
+RUN cd $SRC/connectedhomeip && scripts/checkout_submodules.py --shallow --platform linux
 
 # Bootstrap pigweed environment
 SHELL ["/bin/bash", "-c"]

--- a/projects/connectedhomeip/build.sh
+++ b/projects/connectedhomeip/build.sh
@@ -26,12 +26,15 @@ set -u
 # - `oss_fuzz` enables OSS-Fuzz build
 # - `is_clang` selects clang toolchains (does not support AFL fuzzing engine)
 # - `enable_rrti` enables RTTI to support UBSan build
+# - `chip_enable_thread_safety_checks` disabled since OSS-Fuzz clang does not
+#   seem to currently support or need this analysis
 # - `target_ldflags` forces compiler to use LLVM's linker
 gn gen out/fuzz_targets \
   --args="
     oss_fuzz=true \
     is_clang=true \
     enable_rtti=true \
+    chip_enable_thread_safety_checks=false \
     target_ldflags=[\"-fuse-ld=lld\"]"
 
 # Deactivate Pigweed environment to use OSS-Fuzz toolchains


### PR DESCRIPTION
This fixes compilation errors of the form:

```
...
Step #3 - "compile-centipede-address-x86_64": [1m../../src/platform/Linux/ConnectivityManagerImpl.h:211:46: [0m[0;1;31merror: [0m[1m'guarded_by' attribute requires arguments whose type is annotated with 'capability' attribute; type here is 'std::mutex' [-Werror,-Wthread-safety-attributes][0m
Step #3 - "compile-centipede-address-x86_64":     static GDBusWpaSupplicant mWpaSupplicant CHIP_GUARDED_BY(mWpaSupplicantMutex);
Step #3 - "compile-centipede-address-x86_64": [0;1;32m                                             ^
Step #3 - "compile-centipede-address-x86_64": [0m[1m../../src/system/SystemMutex.h:75:49: [0m[0;1;30mnote: [0mexpanded from macro 'CHIP_GUARDED_BY'[0m
Step #3 - "compile-centipede-address-x86_64": #define CHIP_GUARDED_BY(x) CHIP_TSA_ATTRIBUTE__(guarded_by(x))
Step #3 - "compile-centipede-address-x86_64": [0;1;32m                                                ^
Step #3 - "compile-centipede-address-x86_64": [0m1 error generated.
```

as reported in https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=58531

Also updated the dockerfile to checkout less things from CHIP so that the checkout step is faster.