### PR TITLE
Updating tomlkit maintainers list

### DIFF
--- a/projects/tomlkit/project.yaml
+++ b/projects/tomlkit/project.yaml
@@ -7,3 +7,4 @@ sanitizers:
 - address
 vendor_ccs:
 - david@adalogics.com
+- sean@compactcloud.co.uk


### PR DESCRIPTION
Need access to see any issues with the new `dumps()` fuzzer, see https://github.com/google/oss-fuzz/pull/10046 .

Waiting on maintainer approval.
