### PR TITLE
Revert "Temporarily pin Wasmtime to an older nightly Rust (#10270)"

### DIFF
--- a/projects/wasmtime/build.sh
+++ b/projects/wasmtime/build.sh
@@ -15,9 +15,6 @@
 #
 ################################################################################
 
-rustup default nightly-2023-04-01
-rustup component add rust-src
-
 # Commands migrated from Dockerfile to make CIFuzz work
 # REF: https://github.com/google/oss-fuzz/issues/6755
 git submodule update --init --recursive


### PR DESCRIPTION
This reverts commit 7c85835070504c278bc4b38be3f226b4291ca3a3. Related to investigation in https://github.com/google/oss-fuzz/issues/10186