### PR TITLE
nccl: actual fix

### DIFF
--- a/projects/nccl/build.sh
+++ b/projects/nccl/build.sh
@@ -29,6 +29,6 @@ $CXX $LIB_FUZZING_ENGINE $CXXFLAGS $SRC/fuzz_xml.cpp -o $OUT/fuzz_xml \
     ./build/lib/libnccl_static.a \
     /usr/local/cuda-11.0/targets/x86_64-linux/lib/libcudart.so
 
-cp /usr/local/cuda-11.0/targets/x86_64-linux/lib/libcudart.so.11.0 /out/libcudart.so.11.0
-cp /usr/local/cuda-11.0/targets/x86_64-linux/lib/libcudart.so /out/libcudart.so
+cp /usr/local/cuda-11.0/targets/x86_64-linux/lib/libcudart.so.11.0 $OUT/libcudart.so.11.0
+cp /usr/local/cuda-11.0/targets/x86_64-linux/lib/libcudart.so $OUT/libcudart.so
 patchelf --set-rpath '$ORIGIN/' /out/fuzz_xml


### PR DESCRIPTION
The fix in https://github.com/google/oss-fuzz/pull/10308 was not right -- the issue is missing use of $OUT

The broken log
```
Step #3 - "compile-afl-address-x86_64": + /src/aflplusplus/afl-clang-fast++ /usr/lib/libFuzzingEngine.a -O1 -fno-omit-frame-pointer -gline-tables-only -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=address -fsanitize-address-use-after-scope -stdlib=libc++ /src/fuzz_xml.cpp -o /workspace/out/afl-address-x86_64/fuzz_xml -I./src/graph/ -I./src/include -I./build/include/ -I/usr/local/cuda-11.0/targets/x86_64-linux/include/ ./build/lib/libnccl_static.a /usr/local/cuda-11.0/targets/x86_64-linux/lib/libcudart.so
Step #3 - "compile-afl-address-x86_64": + cp /usr/local/cuda-11.0/targets/x86_64-linux/lib/libcudart.so.11.0 /out/
Step #3 - "compile-afl-address-x86_64": cp: cannot create regular file '/out/': Not a directory
```