### PR TITLE
golang: fixes libfuzzer signal handling

### DIFF
--- a/infra/base-images/base-builder-go/Dockerfile
+++ b/infra/base-images/base-builder-go/Dockerfile
@@ -23,6 +23,8 @@ ENV GOPATH /root/go
 # $GOPATH/bin is for the binaries from the dependencies installed via "go get".
 ENV PATH $PATH:/root/.go/bin:$GOPATH/bin
 
+COPY gosigfuzz.c $GOPATH/gosigfuzz/
+
 RUN install_go.sh
 
 # TODO(jonathanmetzman): Install this file using install_go.sh.

--- a/infra/base-images/base-builder-go/gosigfuzz.c
+++ b/infra/base-images/base-builder-go/gosigfuzz.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 Google LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *      http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+#include<stdlib.h>
+#include<signal.h>
+
+static void fixSignalHandler(int signum) {
+    struct sigaction new_action;
+    struct sigaction old_action;
+    sigemptyset (&new_action.sa_mask);
+    sigaction (signum, NULL, &old_action);
+    new_action.sa_flags = old_action.sa_flags | SA_ONSTACK;
+    new_action.sa_sigaction = old_action.sa_sigaction;
+    new_action.sa_handler = old_action.sa_handler;
+    sigaction (signum, &new_action, NULL);
+}
+
+static void FixStackSignalHandler() {
+    fixSignalHandler(SIGSEGV);
+    fixSignalHandler(SIGABRT);
+    fixSignalHandler(SIGALRM);
+    fixSignalHandler(SIGINT);
+    fixSignalHandler(SIGTERM);
+    fixSignalHandler(SIGBUS);
+    fixSignalHandler(SIGFPE);
+    fixSignalHandler(SIGXFSZ);
+    fixSignalHandler(SIGUSR1);
+    fixSignalHandler(SIGUSR2);
+}
+
+int LLVMFuzzerInitialize(int *argc, char ***argv) {
+    FixStackSignalHandler();
+    return 0;
+}

--- a/infra/base-images/base-builder/compile_libfuzzer
+++ b/infra/base-images/base-builder/compile_libfuzzer
@@ -17,6 +17,10 @@
 
 echo -n "Compiling libFuzzer to $LIB_FUZZING_ENGINE... "
 export LIB_FUZZING_ENGINE="-fsanitize=fuzzer"
+if [ "$FUZZING_LANGUAGE" = "go" ]; then
+    export LIB_FUZZING_ENGINE="$LIB_FUZZING_ENGINE $GOPATH/gosigfuzz/gosigfuzz.o"
+fi
+
 cp /usr/local/lib/clang/*/lib/linux/libclang_rt.fuzzer-$ARCHITECTURE.a \
   $LIB_FUZZING_ENGINE_DEPRECATED
 echo " done."

--- a/infra/base-images/base-builder/install_go.sh
+++ b/infra/base-images/base-builder/install_go.sh
@@ -27,6 +27,8 @@ echo 'Set "PATH=$PATH:/root/.go/bin:$GOPATH/bin"'
 go install github.com/mdempsky/go114-fuzz-build@latest
 ln -s $GOPATH/bin/go114-fuzz-build $GOPATH/bin/go-fuzz
 
+clang -fsanitize=address -c $GOPATH/gosigfuzz/gosigfuzz.c -o $GOPATH/gosigfuzz/gosigfuzz.o
+
 cd /tmp
 git clone https://github.com/AdamKorcz/go-118-fuzz-build
 cd go-118-fuzz-build

--- a/projects/golang/build.sh
+++ b/projects/golang/build.sh
@@ -213,14 +213,14 @@ go get github.com/AdamKorcz/go-118-fuzz-build/testing
 compile_native_go_fuzzer gzipPackage FuzzReader fuzz_std_lib_gzip_reader
 zip $OUT/fuzz_std_lib_gzip_reader_seed_corpus.zip $SRC/go/src/compress/gzip/testdata/*
 
+# golangs build from source currently breaks.
+exit 0
+
 cd $SRC/go/src/html
 go mod init htmlPackage
 go mod tidy
 go get github.com/AdamKorcz/go-118-fuzz-build/testing
 compile_go_fuzzer htmlPackage Fuzz fuzz_html_escape_unescape
-
-# golangs build from source currently breaks.
-exit 0
 
 # Install latest Go from master branch and build fuzzers again
 cd $SRC

--- a/projects/golang/build.sh
+++ b/projects/golang/build.sh
@@ -177,11 +177,17 @@ cd $SRC/go/src/internal/saferio
 go mod init saferioPackage
 go mod tidy
 
+cd $SRC/go/src/internal/zstd
+go mod init zstdPackage
+go mod tidy
+
 cd $SRC/go/src/debug/elf
 go mod init elfPackage
 go mod tidy
 go mod edit -replace internal/saferio=../../internal/saferio
 go get internal/saferio
+go mod edit -replace internal/zstd=../../internal/zstd
+go get internal/zstd
 cp $SRC/elf_fuzzer.go ./
 rm ./*_test.go
 compile_go_fuzzer elfPackage FuzzElfOpen fuzz_elf_open


### PR DESCRIPTION
libfuzzer needs to have its signal handler with SA_ONSTACK because golang stacks are small and not guarded against overflows

Waiting for the clang libfuzzer patch cf https://reviews.llvm.org/D150231, we can fix the signal handlers with the help of `LLVMFuzzerInitialize`

Long story : https://github.com/golang/go/issues/49075

cc @randal77

cc @DavidKorczynski for go119build

cc @jonathanmetzman 

I hope it will improve the stability of all golang projects