### PR TITLE
envoy: add WORKSPACE file to override the default

### DIFF
--- a/projects/envoy/Dockerfile
+++ b/projects/envoy/Dockerfile
@@ -33,3 +33,4 @@ RUN apt-get update && apt-get -y install  \
 RUN git clone https://github.com/envoyproxy/envoy.git
 WORKDIR $SRC/envoy/
 COPY build.sh $SRC/
+COPY WORKSPACE $SRC/envoy/

--- a/projects/envoy/WORKSPACE
+++ b/projects/envoy/WORKSPACE
@@ -1,0 +1,25 @@
+workspace(name = "envoy")
+
+load("//bazel:api_binding.bzl", "envoy_api_binding")
+
+envoy_api_binding()
+
+load("//bazel:api_repositories.bzl", "envoy_api_dependencies")
+
+envoy_api_dependencies()
+
+load("//bazel:repositories.bzl", "envoy_dependencies")
+
+envoy_dependencies()
+
+load("//bazel:repositories_extra.bzl", "envoy_dependencies_extra")
+
+envoy_dependencies_extra(ignore_root_user_error=True)
+
+load("//bazel:python_dependencies.bzl", "envoy_python_dependencies")
+
+envoy_python_dependencies()
+
+load("//bazel:dependency_imports.bzl", "envoy_dependency_imports")
+
+envoy_dependency_imports()


### PR DESCRIPTION
Due to a [recent PR](https://github.com/envoyproxy/envoy/pull/27233), Envoy uses the `python_register_toolchains` macro that prevents using python under the root user. This prevents the [build of the fuzzers](https://oss-fuzz-build-logs.storage.googleapis.com/log-c98579dd-6bc2-4b97-8c41-7ca4e37c219c.txt) with the following error:
```
Error in fail: The current user is root, please run as non-root when using the hermetic Python interpreter
```

This PR overrides the WORKSPACE file, allowing the building of the fuzzers with the root user.