### PR TITLE
bind9: Also link with -lurcu-common

### DIFF
--- a/projects/bind9/build.sh
+++ b/projects/bind9/build.sh
@@ -24,7 +24,7 @@ make -C tests/libtest -j"$(nproc)" all V=1
 
 LIBISC_CFLAGS="-Ilib/isc/include"
 LIBDNS_CFLAGS="-Ilib/dns/include"
-LIBISC_LIBS="lib/isc/.libs/libisc.a -Wl,-Bstatic -Wl,-u,isc__initialize,-u,isc__shutdown -lssl -lcrypto -lurcu-memb -lurcu-cds -luv -lnghttp2 -Wl,-Bdynamic"
+LIBISC_LIBS="lib/isc/.libs/libisc.a -Wl,-Bstatic -Wl,-u,isc__initialize,-u,isc__shutdown -lssl -lcrypto -lurcu-memb -lurcu-cds -lurcu-common -luv -lnghttp2 -Wl,-Bdynamic"
 LIBDNS_LIBS="lib/dns/.libs/libdns.a -Wl,-Bstatic -lcrypto -lurcu-memb -lurcu-cds -Wl,-Bdynamic"
 LIBTEST_LIBS="tests/libtest/.libs/libtest.a"
 


### PR DESCRIPTION
Fixes a linking issue:

    Step #3 - "compile-afl-address-x86_64": /usr/bin/ld: /usr/bin/ld: DWARF error: invalid or unhandled FORM value: 0x25
    Step #3 - "compile-afl-address-x86_64": lib/dns/.libs/libdns.a(libdns_la-rbtdb.o): in function `free_rbtdb':
    Step #3 - "compile-afl-address-x86_64": rbtdb.c:(.text+0x2bca): undefined reference to `cds_wfs_destroy'
    ...