### PR TITLE
[open5gs] using '$OUT' not hardcoded /out/

### DIFF
--- a/projects/open5gs/build.sh
+++ b/projects/open5gs/build.sh
@@ -28,8 +28,8 @@ ninja -C builddir -k 0 || true
 cp builddir/tests/fuzzing/gtp_message_fuzz $OUT/gtp_message_fuzz
 cp builddir/tests/fuzzing/nas_message_fuzz $OUT/nas_message_fuzz
 
-mkdir /out/lib/
-cp /lib/x86_64-linux-gnu/libtalloc.so* /out/lib/
+mkdir $OUT/lib/
+cp /lib/x86_64-linux-gnu/libtalloc.so* $OUT/lib/
 
 cp tests/fuzzing/gtp_message_fuzz_seed_corpus.zip $OUT/gtp_message_fuzz_seed_corpus.zip
 cp tests/fuzzing/nas_message_fuzz_seed_corpus.zip $OUT/nas_message_fuzz_seed_corpus.zip


### PR DESCRIPTION
Fix Error:
```
Step #3 - "compile-afl-address-x86_64": + cp builddir/tests/fuzzing/nas_message_fuzz /workspace/out/afl-address-x86_64/nas_message_fuzz
Step #3 - "compile-afl-address-x86_64": + mkdir /out/lib/
Step #3 - "compile-afl-address-x86_64": mkdir: cannot create directory '/out/lib/': No such file or directory
Step #3 - "compile-afl-address-x86_64": ********************************************************************************
Step #3 - "compile-afl-address-x86_64": Failed to build.
Step #3 - "compile-afl-address-x86_64": To reproduce, run:
```
