### PR TITLE
crosvm: Fix build and add additional cc's to the project

### DIFF
--- a/projects/crosvm/build.sh
+++ b/projects/crosvm/build.sh
@@ -19,15 +19,11 @@ cd crosvm
 
 # Build crosvm fuzzers
 # Unset the SRC variable as it will interfere with minijail's common.mk framework.
-env -u SRC cargo +nightly \
-    fuzz build \
-    -O \
-    --fuzz-dir=crosvm-fuzz \
-    --features upstream-fuzz
+env -u SRC cargo +nightly fuzz build -O
 
 # Copy fuzzer binaries to $OUT
 FUZZ_TARGET_OUTPUT_DIR="target/x86_64-unknown-linux-gnu/release"
-for f in crosvm-fuzz/*.rs; do
+for f in fuzz/fuzz_targets/*.rs; do
     FUZZ_TARGET_NAME=$(basename ${f%.*})
-    cp "${FUZZ_TARGET_OUTPUT_DIR}/crosvm_${FUZZ_TARGET_NAME}" "$OUT/"
+    cp "${FUZZ_TARGET_OUTPUT_DIR}/${FUZZ_TARGET_NAME}" "$OUT/"
 done

--- a/projects/crosvm/project.yaml
+++ b/projects/crosvm/project.yaml
@@ -3,6 +3,11 @@ language: rust
 primary_contact: "denniskempin@google.com"
 auto_ccs:
   - "crosvm-core@google.com"
+  - "dverkamp@google.com"
+  - "fmayle@google.com"
+  - "keiichiw@google.com"
+  - "takayas@google.com"
+  - "zihanchen@google.com"
 main_repo: "https://chromium.googlesource.com/crosvm/crosvm"
 sanitizers:
   - address


### PR DESCRIPTION
Crosvm was updated to follow a more standard `cargo fuzz` layout. So the build script here can be simplified.

Also addition a few more people interested in our fuzzer results.

Tested with `presubmit.py` and `helper.py build crosvm`