### PR TITLE
projects/sound-open-firmware: New fuzzing framework

### DIFF
--- a/projects/sound-open-firmware/Dockerfile
+++ b/projects/sound-open-firmware/Dockerfile
@@ -20,39 +20,50 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 
-RUN apt-get -y update && \
-	    apt-get install -y \
-	    	autoconf \
-		bison \
-		build-essential \
-		flex \
-		gawk \
-		gettext \
-		git \
-		gperf \
-		help2man \
-		libncurses5-dev \
-		libssl-dev \
-		libtool \
-		libtool-bin \
-		pkg-config \
-		software-properties-common \
-		texinfo \
-		udev \
-		cmake \
-		libglib2.0-dev
+# Base packages
+RUN apt-get -y update
+RUN apt-get install -y \
+      gettext git libc6-dev-i386 libglib2.0-dev libncurses5-dev \
+      libtool ninja-build python3-pip
+RUN pip3 install west
 
-ARG CLONE_DEFAULTS="--depth 5"
+# Zephyr SDK:
+#
+# Zephyr doesn't provide a clean "get the latest version" URL, but
+# note that the use of the /latest/ path component at least ensures
+# this will fail on a new release.
+ARG SDK_VER=0.16.1
+WORKDIR /root
+RUN curl -L -o sdktmp.tar.xz https://github.com/zephyrproject-rtos/sdk-ng/releases/latest/download/zephyr-sdk-${SDK_VER}_linux-x86_64_minimal.tar.xz
+RUN tar xf sdktmp.tar.xz; rm sdktmp.tar.xz
+RUN zephyr-sdk-*/setup.sh -h
 
-# Use ToT alsa utils for the latest topology patches.
-RUN cd /tmp && \
-git clone $CLONE_DEFAULTS https://github.com/thesofproject/alsa-lib.git && \
-git clone $CLONE_DEFAULTS https://github.com/thesofproject/alsa-utils.git && \
-cd /tmp/alsa-lib && ./gitcompile &&  make install && \
-cd /tmp/alsa-utils && ./gitcompile &&  make install
+WORKDIR $SRC
 
-ARG GITHUB_SOF=https://github.com/thesofproject
+# SOF itself (also pulls in Zephyr + modules via west)
+RUN west init -m https://github.com/thesofproject/sof sof
+RUN cd sof && west update
 
-RUN cd $SRC && git clone $CLONE_DEFAULTS $GITHUB_SOF/sof
-WORKDIR sof
+# Zephyr has its own python requirements
+RUN pip3 install -r sof/zephyr/scripts/requirements-base.txt
+
+# Hacks: the oss-fuzz-base/base-clang image (and its derivatives) lack
+# some of the binutils-compatible LLVM tools that a SOF/Zephyr build
+# relies on (when set to build with clang instead of gcc, obviously).
+# Rather than figure out how to install them or why they're missing,
+# just symlink to the GNU tools already installed.
+RUN ln -s /usr/bin/objdump /usr/local/bin/llvm-objdump
+RUN ln -s /usr/bin/strip /usr/local/bin/llvm-strip
+
+# This is the worst.  SOF builds with C++ support even though it won't
+# call it (there are eternal components that use C++, but nothing
+# in-tree that can be fuzzed here).  For obscure compatibility
+# reasons, when using clang Zephyr will still do the final link using
+# binutils, which will pull in libstdc++ and not libc++.  Also, SOF is
+# a 32 bit fuzz binary (it's firmware for a 32 bit DSP, and no one has
+# done the work to make the source base 64 bit clean).  The oss-fuzz
+# runner image does not have a i386 libstdc++.so.6!  But, well, we
+# don't actually need any symbols from it, so...
+RUN touch empty.c; gcc -m32 -c empty.c; ar rs /usr/lib32/libstdc++.a empty.o
+
 COPY build.sh $SRC/

--- a/projects/sound-open-firmware/project.yaml
+++ b/projects/sound-open-firmware/project.yaml
@@ -1,7 +1,8 @@
 homepage: "https://thesofproject.github.io"
-primary_contact: "cujomalainey@chromium.org"
+primary_contact: "andyross@google.com"
 language: c
 auto_ccs:
+  - "cujomalainey@chromium.org"
   - "ranjani.sridharan@intel.corp-partner.google.com"
   - "lgirdwood@gmail.com"
   - "harsha.p.n@intel.corp-partner.google.com"
@@ -9,7 +10,9 @@ auto_ccs:
   - "adrian.bonislawski@intel.com"
   - "michal.wasko@intel.com"
 fuzzing_engines:
-  - afl
-  - honggfuzz
   - libfuzzer
+sanitizers:
+  - address
+architectures:
+  - i386
 main_repo: "https://github.com/thesofproject/sof"


### PR DESCRIPTION
[First submission to oss-fuzz.  Not sure if I'm checking all the correct boxes to get this submitted successfully.  Be gentle.]

SOF has a new fuzzing framework that leverages the underlying Zephyr OS's native_posix integration to get a more complete build than just the protocol layer.  In theory all the non-hardware-specific code is reachable from the fuzzer inputs.

Also adds support for the newer "IPC4" protocol as a separate target.