### PR TITLE
[flac] Prepare for addition of seed corpora

### DIFF
--- a/projects/flac/build.sh
+++ b/projects/flac/build.sh
@@ -67,3 +67,9 @@ make -j$(nproc)
 # Copy encoder fuzzers
 cd $SRC/flac/oss-fuzz
 cp fuzzer_encoder fuzzer_encoder_v2 $OUT
+
+# Copy seed corpus
+cd $SRC/flac/oss-fuzz/seedcorpus || exit 0
+for fuzzerName in *; do
+    zip -j $OUT/${fuzzerName}_seed_corpus.zip ${fuzzerName}/*
+done


### PR DESCRIPTION
Currently coverage for some flac fuzzers is missing for some complicated inputs. I'd like to add a few seeds manually for this.

I am assuming that adding a (cherry-picked) seed corpus will result in it being 'added' to the existing corpus, not replacing it. Please let me know whether that assumption is correct.

BTW, the `|| exit 0` is because I'd like to test the seed corpora with CI-Fuzz, which means I cannot add them before this change is merged, and makes sure the build doesn't fail despite no seed corpora being present yet.