### PR TITLE
Do not install Jazzer.js in the compile_javascript_fuzzer script

### DIFF
--- a/infra/base-images/base-builder/compile_javascript_fuzzer
+++ b/infra/base-images/base-builder/compile_javascript_fuzzer
@@ -23,9 +23,6 @@ jazzerjs_args=${@:3}
 
 # Copy source code into the $OUT directory and install Jazzer.js into the project.
 if [ ! -d $OUT/$project ]; then
-  pushd $SRC/$project
-  npm install @jazzer.js/core
-  popd
   cp -r $SRC/$project $OUT/$project
 fi
 

--- a/projects/javascript-example/build.sh
+++ b/projects/javascript-example/build.sh
@@ -18,6 +18,9 @@
 # Install dependencies.
 npm install
 
+# Install Jazzer.js
+npm install --save-dev @jazzer.js/core
+
 # Build Fuzzers.
 compile_javascript_fuzzer example fuzz_promise.js
 compile_javascript_fuzzer example fuzz_string_compare.js --sync

--- a/projects/ua-parser-js/build.sh
+++ b/projects/ua-parser-js/build.sh
@@ -18,6 +18,9 @@
 # Install dependencies.
 npm install
 
+# Install Jazzer.js
+npm install --save-dev @jazzer.js/core
+
 # Build Fuzzers.
 #compile_javascript_fuzzer example fuzz_promise.js
 #compile_javascript_fuzzer example fuzz_string_compare.js --sync


### PR DESCRIPTION
This causes issues in two cases:
1. using other package managers than npm, e.g., yarn.
2. fuzzing pure ECMAScript projects. In this case, we have to transform those projects into CommonJS projects so that they can be instrumented properly.