### PR TITLE
[infra] Add SELinux Option to Docker Volume Mount

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -512,7 +512,7 @@ def _check_fuzzer_exists(project, fuzzer_name, architecture='x86_64'):
   """Checks if a fuzzer exists."""
   platform = 'linux/arm64' if architecture == 'aarch64' else 'linux/amd64'
   command = ['docker', 'run', '--rm', '--platform', platform]
-  command.extend(['-v', '%s:/out:Z' % project.out])
+  command.extend(['-v', '%s:/out:z' % project.out])
   command.append(BASE_RUNNER_IMAGE)
 
   command.extend(['/bin/bash', '-c', 'test -f /out/%s' % fuzzer_name])

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -512,7 +512,7 @@ def _check_fuzzer_exists(project, fuzzer_name, architecture='x86_64'):
   """Checks if a fuzzer exists."""
   platform = 'linux/arm64' if architecture == 'aarch64' else 'linux/amd64'
   command = ['docker', 'run', '--rm', '--platform', platform]
-  command.extend(['-v', '%s:/out' % project.out])
+  command.extend(['-v', '%s:/out:Z' % project.out])
   command.append(BASE_RUNNER_IMAGE)
 
   command.extend(['/bin/bash', '-c', 'test -f /out/%s' % fuzzer_name])


### PR DESCRIPTION
This PR updates the Docker volume mount command to use the `:z` option, necessary for systems with SELinux in enforcing mode, like Fedora, CentOS, and RHEL. The `:z` option assigns a SELinux context that allows multiple containers to access the volume. This change does not affect systems where SELinux is not enabled, such as most Debian and Ubuntu systems.

`Written by : ChatGPT-4`

Fix : https://github.com/google/oss-fuzz/issues/10352