### PR TITLE
srcmap: Allow non-"origin" git remotes

### DIFF
--- a/infra/base-images/base-builder/srcmap
+++ b/infra/base-images/base-builder/srcmap
@@ -35,7 +35,7 @@ fi
 for DOT_GIT_DIR in $(find $PATHS_TO_SCAN -name ".git" -type d); do
   GIT_DIR=$(dirname $DOT_GIT_DIR)
   cd $GIT_DIR
-  GIT_URL=$(git config --get remote.origin.url)
+  GIT_URL=$(git config --get remote.$(git remote | head -1).url)
   GIT_REV=$(git rev-parse HEAD)
   jq_inplace $SRCMAP ".\"$GIT_DIR\" = { type: \"git\", url: \"$GIT_URL\", rev: \"$GIT_REV\" }"
 done


### PR DESCRIPTION
The srcmap tool was assuming that all .git directories are pulled from a remote named "origin", as per default.  Some tools (e.g. west, used for sound-open-firmware) give remotes custom/user-defined names ("thesofproject") instead, and this broke.

Instead, just take the first remote listed.  This will work for both conventions.  Longer term, it will probably be necessary to allow the srcmap JSON to be project-generated somehow, as in general not all .git directores are going to be unique results of a single pull.