### PR TITLE
docs: add a list with available sanitizers

### DIFF
--- a/docs/getting-started/new_project_guide.md
+++ b/docs/getting-started/new_project_guide.md
@@ -118,7 +118,8 @@ Any changes to this list must follow these rules:
 - An organization email address is used.
 
 ### sanitizers (optional) {#sanitizers}
-The list of sanitizers to use. If you don't specify a list, `sanitizers` uses a default list of supported
+The list of sanitizers to use. Possible values are: `address`, `memory` and `undefined`.
+If you don't specify a list, `sanitizers` uses a default list of supported
 sanitizers (currently ["address"](https://clang.llvm.org/docs/AddressSanitizer.html) and
 ["undefined"](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html)).
 


### PR DESCRIPTION
It is not clear what sanitizers could be specified in `sanitizers` field in project.yaml. Patch adds a list of available sanitizers to a "New project guide".