### PR TITLE
Project-specified srcmap file

### DIFF
--- a/infra/base-images/base-builder/srcmap
+++ b/infra/base-images/base-builder/srcmap
@@ -17,6 +17,19 @@
 
 # Deterimine srcmap of checked out source code
 
+# Emits a JSON map of the form:
+#
+# { { "$DIR" : { "type":"$SCM", "url":"$REMOTE", "rev":"$COMMIT" } }, ... }
+
+# Allow the project to generate this itself in $SRC/srcmap.json and
+# use that if present.  Some integration tools like west or repo don't
+# conform to the conventions below.
+
+if [ -e "$SRC/srcmap.json" ]; then
+  cat "$SRC/srcmap.json"
+  exit
+fi
+
 SRCMAP=$(tempfile)
 echo "{}" > $SRCMAP
 

--- a/projects/sound-open-firmware/Dockerfile
+++ b/projects/sound-open-firmware/Dockerfile
@@ -48,6 +48,7 @@ RUN cd sof && west update
 # origin/commit info for .git directories automatically.  But it
 # assumes that the remote is named "origin", which is not true for
 # west (by design!).  Fix up a fake "origin"
+# FIXME: can remove this once srcmap.json support exists in the base image
 RUN cd sof; sh -c "$(west list -f '(cd {path}; git remote add origin {url});' | sed 1d)"
 
 # Zephyr has its own python requirements
@@ -73,3 +74,8 @@ RUN ln -s /usr/bin/strip /usr/local/bin/llvm-strip
 RUN touch empty.c; gcc -m32 -c empty.c; ar rs /usr/lib32/libstdc++.a empty.o
 
 COPY build.sh $SRC/
+
+# Could probably move this logic into build.sh?  It's not clear to me
+# if srcmap can be run before build.sh or not.
+COPY gen-srcmap.sh $SRC/
+RUN $SRC/gen-srcmap.sh > $SRC/srcmap.json

--- a/projects/sound-open-firmware/gen-srcmap.sh
+++ b/projects/sound-open-firmware/gen-srcmap.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -eux
+# Copyright 2023 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+#
+# Copyright 2023 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FIRST_REC=yes
+
+cd $SRC/sof
+
+echo "{"
+west list -f '{path} {url} {sha}' | sed 1d | while read dir url rev; do
+
+    # Silly logic to suppress trailing comma
+    if [ "$FIRST_REC" = yes ]; then
+	FIRST_REC=no
+    else
+	echo ","
+    fi
+
+    echo    "  \"$SRC/sof/$dir\": {"
+    echo    "    \"type\": \"git\","
+    echo    "    \"url\": \"$url\","
+    echo    "    \"rev\": \"$rev\""
+    echo -n "  }"
+done
+echo
+echo "}"


### PR DESCRIPTION
[Following discussion in #10342 #10383 #10385 . The "right way" turns out to be a pretty simple change to a simple script.  Note that this is only tested piecewise, as I don't know how to run the backend that actually needs srcmap and was running a copy of the script manually.  Also presumably needs documentation somewhere.]

srcmap: Augment to allow project-specified repository maps

The heuristics in this script don't match all possible projects, and
in particular the west tool used by sound-open-firmware doesn't
conform to its expectations (and can provide this info in a more
authoritative way regardless).

Allow the project to emit a "$SRC/srcmap.json" file in its build
image, and use that where present instead of trying to guess.
