### PR TITLE
openh264: only build static library

### DIFF
--- a/projects/openh264/build.sh
+++ b/projects/openh264/build.sh
@@ -26,5 +26,5 @@ if [[ $CXXFLAGS = *sanitize=memory* ]]; then
 else
   ASM_BUILD=Yes
 fi
-make -j$(nproc) ARCH=$ARCHITECTURE USE_ASM=$ASM_BUILD BUILDTYPE=Debug libraries libopenh264.a
+make -j$(nproc) ARCH=$ARCHITECTURE USE_ASM=$ASM_BUILD BUILDTYPE=Debug libopenh264.a
 $CXX $CXXFLAGS -o $OUT/decoder_fuzzer -I./codec/api/wels -I./codec/console/common/inc -I./codec/common/inc -L. $LIB_FUZZING_ENGINE $SRC/decoder_fuzzer.cpp libopenh264.a


### PR DESCRIPTION
The dynamic library is not used and this will enable fuzz introspector