### PR TITLE
sqlite3: only build needed libraries

### DIFF
--- a/projects/sqlite3/build.sh
+++ b/projects/sqlite3/build.sh
@@ -29,7 +29,7 @@ export CFLAGS="$CFLAGS -DSQLITE_MAX_LENGTH=128000000 \
                -DSQLITE_DEBUG=1 \
                -DSQLITE_MAX_PAGE_COUNT=16384"             
                
-../configure
+../configure --enable-shared=no
 make -j$(nproc)
 make sqlite3.c
 


### PR DESCRIPTION
This makes it work with Fuzz Intropector