### PR TITLE
jsonnet: only build required libraries

### DIFF
--- a/projects/jsonnet/build.sh
+++ b/projects/jsonnet/build.sh
@@ -19,7 +19,7 @@ mkdir jsonnet/build
 pushd jsonnet/build
 cmake -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" \
   -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DBUILD_TESTS=OFF ..
-make -j$(nproc)
+make -j$(nproc) libjsonnet_static
 popd
 
 INSTALL_DIR="$SRC/jsonnet"


### PR DESCRIPTION
We only need to build the static library in jsonnet so am restricting the build to do that. This enables Fuzz Introspector