### PR TITLE
cmark: enable fuzz introspector

### DIFF
--- a/projects/cmark/build.sh
+++ b/projects/cmark/build.sh
@@ -15,11 +15,14 @@
 #
 ################################################################################
 
-make -j$(nproc) cmake_build
+mkdir build
+cd build
+cmake ../
+make cmark_static
+cd ..
 
 $CC $CFLAGS -Isrc -Ibuild/src -c test/cmark-fuzz.c -o cmark_fuzzer.o
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE cmark_fuzzer.o build/src/libcmark.a -o $OUT/cmark_fuzzer
-
 cp $SRC/*.options $OUT/
 cp test/fuzzing_dictionary $OUT/cmark.dict
 


### PR DESCRIPTION
Only build the static library required by the fuzzer