### PR TITLE
cmake: fix up fuzz introspector build

### DIFF
--- a/projects/cmake/build.sh
+++ b/projects/cmake/build.sh
@@ -17,8 +17,8 @@
 
 # Build CMake.
 mkdir build-dir && cd build-dir
-../bootstrap && make -j$(nproc)
-
+../bootstrap
+make -j$(nproc) CMakeLib
 
 # Build fuzzers.
 cd ../Tests/Fuzzing


### PR DESCRIPTION
Only build the static library needed for the fuzzers.