### PR TITLE
jbig2dec: fix build and make introspector work

### DIFF
--- a/projects/jbig2dec/Dockerfile
+++ b/projects/jbig2dec/Dockerfile
@@ -19,8 +19,6 @@ RUN apt-get update && apt-get install -y make libtool pkg-config vim libreadline
 RUN git clone --recursive --depth 1 git://git.ghostscript.com/jbig2dec.git jbig2dec
 RUN mkdir tests
 RUN cp $SRC/jbig2dec/annex-h.jbig2 tests/annex-h.jb2
-RUN cd tests && wget https://jbig2dec.com/tests/t89-halftone.zip && unzip t89-halftone.zip
-RUN cd tests && wget https://jbig2dec.com/tests/jb2streams.zip && unzip jb2streams.zip
 RUN cd tests && zip -q $SRC/jbig2_fuzzer_seed_corpus.zip *.jb2
 RUN rm -rf tests
 COPY *.dict $SRC/

--- a/projects/jbig2dec/build.sh
+++ b/projects/jbig2dec/build.sh
@@ -23,7 +23,7 @@ mkdir -p ${WORK}/jbig2dec
 cd ${WORK}/jbig2dec
 ${SRC}/jbig2dec/configure
 
-LDFLAGS="$CXXFLAGS" make -C ${WORK}/jbig2dec -j$(nproc)
+LDFLAGS="$CXXFLAGS" make -C ${WORK}/jbig2dec jbig2dec -j$(nproc)
 fuzz_target=jbig2_fuzzer
 
 $CXX $CXXFLAGS -std=c++11 -I$SRC/jbig2dec -fno-inline-functions \


### PR DESCRIPTION
.zip folders are no longer available.