### PR TITLE
pistache: only build required library

### DIFF
--- a/projects/pistache/build.sh
+++ b/projects/pistache/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 mkdir build && cd build
-meson --default-library=static ../
-ninja
+cmake -DBUILD_SHARED_LIBS=OFF ..
+make pistache_static
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE -o $OUT/fuzz_parsers \
     -std=c++17 -I../include/ ../tests/fuzzers/fuzz_parser.cpp ./src/libpistache.a


### PR DESCRIPTION
This enables fuzz introspector