### PR TITLE
zip4j: Add retry handler setting for maven build

### DIFF
--- a/projects/zip4j/build.sh
+++ b/projects/zip4j/build.sh
@@ -18,6 +18,9 @@
 mv $SRC/{*.zip,*.dict} $OUT
 
 MAVEN_ARGS="-Dmaven.test.skip=true -Djavac.src.version=15 -Djavac.target.version=15"
+MAVEN_ARGS=$MAVEN_ARGS" -Dmaven.wagon.httpconnectionManager.ttlSeconds=120"
+MAVEN_ARGS=$MAVEN_ARGS" -Dmaven.wagon.http.retryHandler.requestSentEnabled=true"
+MAVEN_ARGS=$MAVEN_ARGS" -Dmaven.wagon.http.retryHandler.count=5"
 $MVN package org.apache.maven.plugins:maven-shade-plugin:3.2.4:shade $MAVEN_ARGS
 CURRENT_VERSION=$($MVN org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate \
  -Dexpression=project.version -q -DforceStdout)


### PR DESCRIPTION
The Maven build process requires fetching dependency libraries from the central repository with Apache Wagon. This fetching action will fail because of an unstable connection or connection rest by the repository server because there are too many fetching requests. By default, maven build does not retry the fetching if it is not an error in the request-sending methods. Thus these failing dependency fetching will cause maven project fail to build randomly. This PR fixes the build script to configure the maven wagon parameter to force it to retry when failing and also increases the timeout and retry count to decrease the chance of build failure from dependencies fetching failure cases.