### PR TITLE
bitcoin-core: Temporarily disable centipede

### DIFF
--- a/projects/bitcoin-core/project.yaml
+++ b/projects/bitcoin-core/project.yaml
@@ -18,4 +18,4 @@ fuzzing_engines:
   - libfuzzer
   - honggfuzz
   - afl
-  - centipede
+#  - centipede # temporarily disabled due to spurious "Step #22 - "build-check-centipede-none-x86_64": OSError: [Errno 28] No space left on device"


### PR DESCRIPTION
centipede passes locally and in the GitHub Actions CI in this repo, but not on OSS-Fuzz. :man_shrugging: 

Disable it for now @dergoegge @fanquake 