### PR TITLE
infra: base-builder: compile: adjust python package installation

### DIFF
--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -237,9 +237,9 @@ if [ "$SANITIZER" = "introspector" ]; then
   unset CFLAGS
   export G_ANALYTICS_TAG="G-8WTFM1Y62J"
   apt-get install -y libjpeg-dev zlib1g-dev
-  pip3 install --upgrade setuptools
-  pip3 install cxxfilt pyyaml beautifulsoup4 lxml soupsieve
-  pip3 install --prefer-binary matplotlib
+  python3 -m pip install --upgrade setuptools
+  python3 -m pip install cxxfilt pyyaml beautifulsoup4 lxml soupsieve
+  python3 -m pip install --prefer-binary matplotlib
 
   if [ "$FUZZING_LANGUAGE" = "jvm" ]; then
     echo "GOING jvm route"


### PR DESCRIPTION
Using `pip3` is causing issues for projects that have upgraded to `python3.9`, causing the fuzz introspector build to fail.

Dask is an example:
https://oss-fuzz-build-logs.storage.googleapis.com/log-d3b2cb82-93fb-4ad2-ae35-1f434a3507c7.txt

This fixes it.