### PR TITLE
Update test_utils.py

### DIFF
--- a/infra/build/functions/test_utils.py
+++ b/infra/build/functions/test_utils.py
@@ -18,7 +18,6 @@ import datetime
 import os
 import subprocess
 import threading
-
 import requests
 
 DATASTORE_READY_INDICATOR = b'is now running'
@@ -101,8 +100,9 @@ def reset_ds_emulator():
 
 def cleanup_emulator(ds_emulator):
   """Cleanup the system processes made by ds emulator."""
-  del ds_emulator  #To do, find a better way to cleanup emulator
-  os.system('pkill -f datastore')
+    ds_emulator.terminate()
+    ds_emulator.wait()
+    subprocess.run(['pkill', '-f', 'datastore'])
 
 
 def set_gcp_environment():


### PR DESCRIPTION
#10441 
Finded better way to cleanup emulator In the updated version, the `terminate()` method is used to send a termination signal to the `ds_emulator` process. The `wait()` method is then used to allow the process to exit gracefully. Finally, the `subprocess.run()` function is used to execute the `pkill` command and kill any remaining datastore processes. This approach allows for safe termination and clean up of the emulator process without relying on the `del` statement, which is not an ideal way to terminate processes.