### PR TITLE
Update build_and_push_test_images.py (Input Validation Of Image)

### DIFF
--- a/infra/build/functions/build_and_push_test_images.py
+++ b/infra/build/functions/build_and_push_test_images.py
@@ -22,11 +22,11 @@ import multiprocessing
 import os
 import subprocess
 import sys
-
 import yaml
-
 import base_images
 import build_lib
+import argparse
+
 
 CLOUD_PROJECT = 'oss-fuzz-base'
 INFRA_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
@@ -140,7 +140,19 @@ def build_and_push_images(test_image_suffix):
 def main():
   """Builds base-images tags them with "-testing" suffix (in addition to normal
   tag) and pushes testing suffixed images to docker registry."""
-  test_image_suffix = sys.argv[1]
+  parser = argparse.ArgumentParser()
+  parser.add_argument("test_image_suffix", help="Suffix for test images")
+  args = parser.parse_args()
+
+  test_image_suffix = args.test_image_suffix
+
+  # Validate the test image suffix
+  if not test_image_suffix:
+    print("Error: Test image suffix is required.")
+    sys.exit(1)
+
+  # Perform additional validation if necessary
+
   logging.basicConfig(level=logging.DEBUG)
   logging.info('Doing simple gcloud command to ensure 2FA passes.')
   subprocess.run(['gcloud', 'projects', 'list', '--limit=1'], check=True)


### PR DESCRIPTION
#10446 
In the updated version of the script, input validation is included for the test image suffix provided as a command-line argument. The `argparse` module is used to handle command-line arguments and the script expects the test image suffix as an argument. If it is not provided, an error message is displayed and the script exits with a non-zero status code. 
Validating input arguments or configuration values ensures they meet expected format or constraints, helping prevent runtime errors or unexpected behavior.