### PR TITLE
tint: Add abseil-cpp dependency to fix build

### DIFF
--- a/projects/tint/build.sh
+++ b/projects/tint/build.sh
@@ -38,6 +38,7 @@ fi
 # An un-instrumented build of spirv-as is used to generate a corpus of SPIR-V binaries.
 git clone --depth 1 https://github.com/KhronosGroup/SPIRV-Tools.git spirv-tools
 git clone https://github.com/KhronosGroup/SPIRV-Headers spirv-tools/external/spirv-headers --depth=1
+git clone https://github.com/abseil/abseil-cpp spirv-tools/external/abseil_cpp --depth=1
 mkdir -p out/spirv-tools-build
 pushd out/spirv-tools-build
 

--- a/projects/tint/build.sh
+++ b/projects/tint/build.sh
@@ -89,6 +89,11 @@ tint_mutation_batch_size = 5
 " > "$OUT/${fuzzer}.options"
 done
 
+# Clean up temporary directories and files
+rm -fr $WORK/spirv-corpus
+rm -fr $WORK/spirv-corpus-hashed-names
+rm $WORK/seed_corpus.zip
+
 # Now actually build tint
 
 cp scripts/standalone.gclient .gclient


### PR DESCRIPTION
`spirv-tools` now requires `abseil-cpp` in order to build.

Fetch this into the `spirv-tools/external` directory to fix the build of `tint`.

Bug: [oss-fuzz:59403](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=59403)