### PR TITLE
base-runner: check fuzz target validity for jvm targets

### DIFF
--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -414,6 +414,10 @@ elif [[ $FUZZING_LANGUAGE == "jvm" ]]; then
   classes_dir=$DUMPS_DIR/classes
   mkdir $classes_dir
   for fuzz_target in $FUZZ_TARGETS; do
+    # Continue if not a fuzz target.
+    if [[ $FUZZING_ENGINE != "none" ]]; then
+      grep "LLVMFuzzerTestOneInput" $fuzz_target > /dev/null 2>&1 || continue
+    fi
     cp -r $DUMPS_DIR/${fuzz_target}_classes/* $classes_dir/
   done
 


### PR DESCRIPTION
When running fuzz targets we check for validity by checking if `LLVMFuzzerTestOneInput` exists in the target file: https://github.com/google/oss-fuzz/blob/8d1f1306fda3464fb3a7ec8b4227308d315ed495/infra/base-images/base-runner/coverage#L307-L314 However, this is not done in the post processing step of the coverage utility: https://github.com/google/oss-fuzz/blob/8d1f1306fda3464fb3a7ec8b4227308d315ed495/infra/base-images/base-runner/coverage#L415-L418

This causes coverage build issues e.g.
https://oss-fuzz-build-logs.storage.googleapis.com/log-b8d4899d-ecc3-498c-8485-2e88d162dc57.txt
```
Step #5: [INFO] Loading execution data file /workspace/out/libfuzzer-coverage-x86_64/dumps/OpenSSHConfigFuzzer.exec.
Step #5: [INFO] Analyzing 3 classes.
Step #5: [INFO] Loading execution data file /workspace/out/libfuzzer-coverage-x86_64/dumps/OpenSSHConfigFuzzer.exec.
Step #5: [INFO] Writing execution data to /workspace/out/libfuzzer-coverage-x86_64/dumps/jacoco.merged.exec.
Step #5: cp: cannot stat '/workspace/out/libfuzzer-coverage-x86_64/dumps/jsch-fuzzer-0.2.10-SNAPSHOT.jar_classes/*': No such file or directory
Step #5: ********************************************************************************
```

