### PR TITLE
Update pr helper trigger on pull_request_target

### DIFF
--- a/.github/workflows/pr_helper.yml
+++ b/.github/workflows/pr_helper.yml
@@ -1,8 +1,7 @@
 name: PR helper
 on:
-  pull_request:
-    types:
-      - opened
+  pull_request_target:
+    types: [opened, reopened]
     branches:
       - master
     paths:


### PR DESCRIPTION
[PR helper failed ](https://github.com/google/oss-fuzz/actions/runs/5193059405/jobs/9364838612)on fork branch as the [maximum access for pull requests from public forked repositories is read](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token). 
Convert to [pull_request_target ](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target).
Difference between pull_request and pull_request_target: [github blog](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/), [stack overflow](https://stackoverflow.com/questions/74957218/what-is-the-difference-between-pull-request-and-pull-request-target-event-in-git#:~:text=on%20this%20post.-,What%20is%20the%20difference%20between%20pull_request%20and%20pull_request_target%20event%20in,as%20the%20pull_request%20event%20does).