### PR TITLE
hostap: Remove unused dataflow workaround

### DIFF
--- a/projects/hostap/build.sh
+++ b/projects/hostap/build.sh
@@ -33,12 +33,6 @@ export FUZZ_FLAGS=
 for target in fuzzing/*; do
   [[ -d "$target" ]] || continue
 
-  if [[ "$SANITIZER" == "dataflow" ]]; then
-	  # libcrypto seems to cause problems with 'dataflow' sanitizer.
-	  [[ "$target" == "fuzzing/dpp-uri" ]] && continue || :
-	  [[ "$target" == "fuzzing/sae" ]] && continue || :
-  fi
-
   (
     cd "$target"
     make clean


### PR DESCRIPTION
dataflow was removed, trying to build it is an error:

```
helper.py build_fuzzers: error: argument --sanitizer: invalid choice: 'dataflow' (choose from 'address', 'none', 'memory', 'undefined', 'thread', 'coverage', 'introspector', 'hwaddress')
