### PR TITLE
wolfssl: Cleanups

### DIFF
--- a/projects/wolfssl/Dockerfile
+++ b/projects/wolfssl/Dockerfile
@@ -14,9 +14,7 @@
 #
 ################################################################################
 
-# Held back because of github.com/google/oss-fuzz/pull/8313
-# Please fix failure and upgrade.
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:111d6b9d3a52bd3392602c71dc8936c628607a7a9bc86d381db7586f9b1e840f
+FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN apt-get update && apt-get install -y make autoconf automake libtool zip wget python bsdmainutils libcrypt-dev:i386
 RUN git clone https://github.com/wolfssl/wolfssl --depth 1 $SRC/wolfssl

--- a/projects/wolfssl/build.sh
+++ b/projects/wolfssl/build.sh
@@ -15,7 +15,7 @@
 #
 ################################################################################
 
-if [[ $CFLAGS != *sanitize=dataflow* ]]
+if true
 then
     cd $SRC/wolfssl/
     WOLFCRYPT_CONFIGURE_PARAMS="--enable-static --enable-md2 --enable-md4 --enable-ripemd --enable-blake2 --enable-blake2s --enable-pwdbased --enable-scrypt --enable-hkdf --enable-cmac --enable-arc4 --enable-camellia --enable-aesccm --enable-aesctr --enable-xts --enable-des3 --enable-x963kdf --enable-harden --enable-aescfb --enable-aesofb --enable-aeskeywrap --enable-aessiv --enable-keygen --enable-curve25519 --enable-curve448 --enable-shake256 --disable-crypttests --disable-examples --enable-compkey --enable-ed448 --enable-ed25519 --enable-ecccustcurves --enable-xchacha --enable-cryptocb --enable-eccencrypt --enable-aesgcm-stream --enable-smallstack --enable-ed25519-stream --enable-ed448-stream --enable-aesgcm-stream --enable-shake128 --enable-siphash --enable-eccsi --with-eccminsz=0"


### PR DESCRIPTION
dataflow was removed, trying to build it is an error:

```
helper.py build_fuzzers: error: argument --sanitizer: invalid choice: 'dataflow' (choose from 'address', 'none', 'memory', 'undefined', 'thread', 'coverage', 'introspector', 'hwaddress')
```

Also, unpin image