### PR TITLE
Lotus: fixing build issues by using right Go version

### DIFF
--- a/projects/lotus/Dockerfile
+++ b/projects/lotus/Dockerfile
@@ -19,5 +19,12 @@ RUN apt-get update && apt-get install -y mesa-opencl-icd ocl-icd-opencl-dev gcc 
     git bzr jq pkg-config curl clang build-essential hwloc libhwloc-dev
 RUN git clone --depth 1 https://github.com/filecoin-project/lotus
 RUN git clone --depth 1 https://github.com/filecoin-project/fuzzing-lotus
+
+RUN wget https://go.dev/dl/go$(cat lotus/GO_VERSION_MIN).linux-amd64.tar.gz \
+    && mkdir temp-go \
+    && rm -rf /root/.go/* \
+    && tar -C temp-go/ -xzf go$(cat lotus/GO_VERSION_MIN).linux-amd64.tar.gz \
+    && mv temp-go/go/* /root/.go/
+
 COPY build.sh $SRC/
 WORKDIR $SRC/lotus

--- a/projects/lotus/build.sh
+++ b/projects/lotus/build.sh
@@ -17,8 +17,9 @@
 
 # making sure we got these compiled with our go version
 go install github.com/mdempsky/go114-fuzz-build@latest
+rm -f $GOPATH/bin/go-fuzz
 ln -s $GOPATH/bin/go114-fuzz-build $GOPATH/bin/go-fuzz
-go install https://github.com/AdamKorcz/go-118-fuzz-build@master
+go install github.com/AdamKorcz/go-118-fuzz-build@main
 
 make
 

--- a/projects/lotus/build.sh
+++ b/projects/lotus/build.sh
@@ -15,6 +15,11 @@
 #
 ################################################################################
 
+# making sure we got these compiled with our go version
+go install github.com/mdempsky/go114-fuzz-build@latest
+ln -s $GOPATH/bin/go114-fuzz-build $GOPATH/bin/go-fuzz
+go install https://github.com/AdamKorcz/go-118-fuzz-build@master
+
 make
 
 # Not all fuzzers can be compiled with --sanitizer=coverage.


### PR DESCRIPTION
Lotus is enforcing a minimum Go version in its build system, which makes the build currently fail on OSS-Fuzz.

This should fix it.