### PR TITLE
Get off deprecated GitHub Actions action styfle/cancel-workflow-action@0.9.1

### DIFF
--- a/.github/workflows/infra_tests.yml
+++ b/.github/workflows/infra_tests.yml
@@ -16,7 +16,7 @@ jobs:
       actions: write
     steps:
       - name: Cancel previous
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
 

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -15,7 +15,7 @@ jobs:
       actions: write
     steps:
       - name: Cancel previous
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
 

--- a/.github/workflows/project_tests.yml
+++ b/.github/workflows/project_tests.yml
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Cancel previous
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
 


### PR DESCRIPTION
GitHub Actions was complaining:

![styfle_cancel-workflow-action_0_9_1_Screenshot_20230610_230739](https://github.com/google/oss-fuzz/assets/1577132/766b1bc5-5e0f-4f15-889f-05db0759e075)

I can add another pull request introducing GitHub Dependabot if you would like to be safe from future issues like this.