### PR TITLE
infra: dump names of all fuzz targets used in coverage analysis

### DIFF
--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -49,6 +49,7 @@ done
 
 PROFILE_FILE="$DUMPS_DIR/merged.profdata"
 SUMMARY_FILE="$REPORT_PLATFORM_DIR/summary.json"
+COVERAGE_TARGET_FILE="$FUZZER_STATS_DIR/coverage_targets.txt"
 
 # Use path mapping, as $SRC directory from the builder is copied into $OUT/$SRC.
 PATH_EQUIVALENCE_ARGS="-path-equivalence=/,$OUT"
@@ -300,9 +301,17 @@ for fuzz_target in $FUZZ_TARGETS; do
     if [[ $FUZZING_ENGINE != "none" ]]; then
       grep "FUZZ_CORPUS_DIR" $fuzz_target > /dev/null 2>&1 || grep "testing\.T" $fuzz_target > /dev/null 2>&1 || continue
     fi
+    # Log the target in the targets file.
+    echo ${fuzz_target} >> $COVERAGE_TARGET_FILE
+
+    # Run the coverage collection.
     run_go_fuzz_target $fuzz_target &
   elif [[ $FUZZING_LANGUAGE == "python" ]]; then
     echo "Entering python fuzzing"
+    # Log the target in the targets file.
+    echo ${fuzz_target} >> $COVERAGE_TARGET_FILE
+
+    # Run the coverage collection.
     run_python_fuzz_target $fuzz_target
   elif [[ $FUZZING_LANGUAGE == "jvm" ]]; then
     # Continue if not a fuzz target.
@@ -311,6 +320,10 @@ for fuzz_target in $FUZZ_TARGETS; do
     fi
 
     echo "Running $fuzz_target"
+    # Log the target in the targets file.
+    echo ${fuzz_target} >> $COVERAGE_TARGET_FILE
+
+    # Run the coverage collection.
     run_java_fuzz_target $fuzz_target &
   elif [[ $FUZZING_LANGUAGE == "javascript" ]]; then
     # Continue if not a fuzz target.
@@ -319,6 +332,10 @@ for fuzz_target in $FUZZ_TARGETS; do
     fi
 
     echo "Running $fuzz_target"
+    # Log the target in the targets file.
+    echo ${fuzz_target} >> $COVERAGE_TARGET_FILE
+
+    # Run the coverage collection.
     run_javascript_fuzz_target $fuzz_target &
   else
     # Continue if not a fuzz target.
@@ -327,6 +344,10 @@ for fuzz_target in $FUZZ_TARGETS; do
     fi
 
     echo "Running $fuzz_target"
+    # Log the target in the targets file.
+    echo ${fuzz_target} >> $COVERAGE_TARGET_FILE
+
+    # Run the coverage collection.
     run_fuzz_target $fuzz_target &
 
     # Rewrite object if its a FUZZTEST target


### PR DESCRIPTION
Currently there is no consistent logging or information about the number of fuzz targets for a given project. This PR adds a file in the fuzzer stats directory with such information by way of the coverage runner.

The use of this comes making https://introspector.oss-fuzz.com where we'd like to display how many fuzzers exist for each project. This is to make https://introspector.oss-fuzz.com available to all projects with successful coverage builds, whereas currently it's only for projects with successful introspector builds, which is too limiting. Once we have the number of fuzzers for each project then we have enough to switch https://introspector.oss-fuzz.com into showing data about all projects with coverage builds, including those that fail introspector builds and also goland/rust/javascript projects which are unsupported by Fuzz Introspector.

A PR relevant on the Fuzz Introspector repo is https://github.com/ossf/fuzz-introspector/pull/1059