### PR TITLE
nDPI: use upstream build script

### DIFF
--- a/projects/ndpi/build.sh
+++ b/projects/ndpi/build.sh
@@ -15,46 +15,4 @@
 #
 ################################################################################
 
-if [[ "$SANITIZER" != "memory" ]]; then
-	#Disable code instrumentation
-	CFLAGS_SAVE="$CFLAGS"
-	CXXFLAGS_SAVE="$CXXFLAGS"
-	unset CFLAGS
-	unset CXXFLAGS
-	export AFL_NOOPT=1
-fi
-
-# build libpcap
-tar -xvzf libpcap-1.9.1.tar.gz
-cd libpcap-1.9.1
-./configure --disable-shared
-make -j$(nproc)
-make install
-cd ..
-
-if [[ "$SANITIZER" != "memory" ]]; then
-	#Re-enable code instrumentation
-	export CFLAGS="${CFLAGS_SAVE}"
-	export CXXFLAGS="${CXXFLAGS_SAVE}"
-	unset AFL_NOOPT
-fi
-
-# build project
-cd ndpi
-# Set LDFLAGS variable and `--with-only-libndpi` option as workaround for the
-# "missing dependencies errors" in the introspector build. See #8939
-LDFLAGS="-lpcap" ./autogen.sh --enable-fuzztargets --with-only-libndpi
-make -j$(nproc)
-# Copy fuzzers
-ls fuzz/fuzz* | grep -v "\." | while read i; do cp $i $OUT/; done
-# Copy dictionaries
-cp fuzz/*.dict $OUT/
-# Copy seed corpus
-cp fuzz/*.zip $OUT/
-# Copy configuration files
-cp example/protos.txt $OUT/
-cp example/categories.txt $OUT/
-cp example/risky_domains.txt $OUT/
-cp example/ja3_fingerprints.csv $OUT/
-cp example/sha1_fingerprints.csv $OUT/
-cp fuzz/ipv4_addresses.txt $OUT/
+bash -x ./ndpi/tests/ossfuzz.sh


### PR DESCRIPTION
Since https://github.com/ntop/nDPI/commit/96340ccea22fc5deeba6a4fd523a6d0d0fbde5cb the script for building oss-fuzz stuff is available directly in the nDPI project. This way, we can easily update it, without bothering oss-fuzz guys...