### PR TITLE
Pin Wasmtime to an older nightly build

### DIFF
--- a/projects/wasmtime/build.sh
+++ b/projects/wasmtime/build.sh
@@ -15,6 +15,10 @@
 #
 ################################################################################
 
+# Waiting for denoland/rusty_v8#1248 to get fixed
+rustup default nightly-2023-06-01
+rustup component add rust-src
+
 # Commands migrated from Dockerfile to make CIFuzz work
 # REF: https://github.com/google/oss-fuzz/issues/6755
 git submodule update --init --recursive


### PR DESCRIPTION
The latest nightly breaks the build for one of our dependencies so pin it to an older version which works while our dependency updates.