### PR TITLE
Fix issues with PR helper

### DIFF
--- a/infra/pr_helper.py
+++ b/infra/pr_helper.py
@@ -115,10 +115,10 @@ def main():
       continue
 
     # If the previous commit is not associated with a pull request.
-    pr_message = (f'{pr_author} has previously contributed to '
-                  f'[{project_path}]({project_url}). The previous commit was '
-                  f'{GITHUB_NONREF_URL}/{OWNER}/{REPO}/commit/{commit_sha}<br/>'
-                  )
+    pr_message = (
+        f'{pr_author} has previously contributed to '
+        f'[{project_path}]({project_url}). The previous commit was '
+        f'{GITHUB_NONREF_URL}/{OWNER}/{REPO}/commit/{commit_sha}<br/>')
 
     pr_url = github.get_pull_request_url(commit_sha)
     if pr_url is not None:

--- a/infra/pr_helper.py
+++ b/infra/pr_helper.py
@@ -26,6 +26,7 @@ import yaml
 OWNER = 'google'
 REPO = 'oss-fuzz'
 GITHUB_URL = 'https://github.com/'
+GITHUB_NOREF_URL = 'https://www.github.com/'  # Github URL that doesn't send emails on linked issues.
 API_URL = 'https://api.github.com'
 BASE_URL = f'{API_URL}/repos/{OWNER}/{REPO}'
 BRANCH = 'master'
@@ -86,11 +87,11 @@ def main():
       new_project = github.get_integrated_project_info()
       repo_url = new_project.get('main_repo')
       if repo_url is None:
-        message += (f'@{pr_author} is integrating a new project, '
+        message += (f'{pr_author} is integrating a new project, '
                     'but the `repo_url` is missing. '
                     'The criticality score cannot be computed.<br/>')
       else:
-        message += (f'@{pr_author} is integrating a new project:<br/>'
+        message += (f'{pr_author} is integrating a new project:<br/>'
                     f'- Main repo: {repo_url}<br/> - Criticality score: '
                     f'{get_criticality_score(repo_url)}<br/>')
       continue
@@ -99,34 +100,29 @@ def main():
     if email:
       if is_known_contributor(content_dict, email):
         # Checks if the email is verified.
-        if verified:
-          message += (
-              f'@{pr_author} is either the primary contact or '
-              f'is in the CCs list of [{project_path}]({project_url}).<br/>')
-          continue
-        message += (f'@{pr_author} is either the primary contact or '
-                    f'is in the CCs list of [{project_path}]({project_url}), '
-                    f'but their email {email} '
-                    'is not verified.<br/>')
+        message += (
+            f'{pr_author} is either the primary contact or is in the CCs list '
+            f'of [{project_path}]({project_url}).<br/>')
 
     # Checks the previous commits.
     commit_sha = github.has_author_modified_project(project_path)
     if commit_sha is None:
       message += (
-          f'@{pr_author} is a new contributor to '
+          f'{pr_author} is a new contributor to '
           f'[{project_path}]({project_url}). The PR must be approved by known '
           'contributors before it can be merged.<br/>')
       is_ready_for_merge = False
       continue
 
     # If the previous commit is not associated with a pull request.
-    pr_message = (f'@{pr_author} has previously contributed to '
+    pr_message = (f'{pr_author} has previously contributed to '
                   f'[{project_path}]({project_url}). The previous commit was '
-                  f'{GITHUB_URL}/{OWNER}/{REPO}/commit/{commit_sha}<br/>')
+                  f'{GITHUB_NONREF_URL}/{OWNER}/{REPO}/commit/{commit_sha}<br/>'
+                  )
 
     pr_url = github.get_pull_request_url(commit_sha)
     if pr_url is not None:
-      pr_message = (f'@{pr_author} has previously contributed to '
+      pr_message = (f'{pr_author} has previously contributed to '
                     f'[{project_path}]({project_url}). '
                     f'The previous PR was {pr_url}<br/>')
     message += pr_message
@@ -162,7 +158,7 @@ class GithubHandler:
       dir_path = os.path.dirname(file_path)
       if dir_path is not None and dir_path.split(os.sep)[0] == 'projects':
         projects_path.add(dir_path)
-    return list(projects_path)
+    return list(set(projects_path))
 
   def get_author_email(self):
     """Retrieves the author's email address for a pull request,


### PR DESCRIPTION
1. Don't repeat criticality score for each file, only for each project.
2. Don't link to past issues to avoid notifying people unnecessarily
3. Don't @-mention people so we don't send more notifications.