### PR TITLE
asteval: catch additional exception

### DIFF
--- a/projects/asteval/fuzz_eval.py
+++ b/projects/asteval/fuzz_eval.py
@@ -29,7 +29,7 @@ def TestOneInput(data):
   try:
     interpreter = asteval.asteval.Interpreter()
     interpreter.eval(fuzz_expr)
-  except (ValueError,):
+  except (ValueError, OSError):
     pass
 
 


### PR DESCRIPTION
This exception is raised spuriously, which causes some issues wrt. coverage builds and trial builds. They are failing on-and-off.