### PR TITLE
libgit2: remove autotools deps

### DIFF
--- a/projects/libgit2/Dockerfile
+++ b/projects/libgit2/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool cmake
+RUN apt-get update && apt-get install -y cmake make
 RUN git clone --depth 1 https://github.com/libgit2/libgit2 libgit2
 WORKDIR libgit2
 


### PR DESCRIPTION
CMake is used for the build.