### PR TITLE
zlib: re-enable "make check"

### DIFF
--- a/projects/zlib/build.sh
+++ b/projects/zlib/build.sh
@@ -18,9 +18,7 @@
 ./configure
 make -j$(nproc) clean
 make -j$(nproc) all
-
-# Do not make check as there are tests that fail when compiled with MSAN.
-# make -j$(nproc) check
+make -j$(nproc) check
 
 for f in $(find $SRC -name '*_fuzzer.cc'); do
     b=$(basename -s .cc $f)

--- a/projects/zlib/project.yaml
+++ b/projects/zlib/project.yaml
@@ -1,4 +1,4 @@
-homepage: "http://www.zlib.net/"
+homepage: "https://www.zlib.net/"
 language: c++
 primary_contact: "glennrp@gmail.com"
 auto_ccs:


### PR DESCRIPTION
This was disabled 4 years ago, due to issues with MSAN.
I currently cannot reproduce under MSAN.
If the issue does reproduce, we could better document what it is.