### PR TITLE
giflib: prune dockerfile deps

### DIFF
--- a/projects/giflib/Dockerfile
+++ b/projects/giflib/Dockerfile
@@ -16,8 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update -y && \
-    apt-get install -y make autoconf automake libtool wget zlib1g-dev \
-    binutils cmake ninja-build liblzma-dev libz-dev pkg-config
+    apt-get install -y cmake liblzma-dev libz-dev make ninja-build wget zlib1g-dev
 RUN git clone --depth=1 https://git.code.sf.net/p/giflib/code $SRC/giflib-code
 RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
 RUN (mkdir LPM && cd LPM && cmake ../libprotobuf-mutator -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release && ninja)


### PR DESCRIPTION
binutils is in the base image.
CMake is used otherwise.