### PR TITLE
bzip2: drop dependencies

### DIFF
--- a/projects/bzip2/Dockerfile
+++ b/projects/bzip2/Dockerfile
@@ -15,7 +15,6 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool wget
 RUN git clone git://sourceware.org/git/bzip2.git
 RUN git clone git://sourceware.org/git/bzip2-tests.git
 COPY build.sh *.c $SRC/


### PR DESCRIPTION
bzip2 invokes the compiler directly, neither using autotools, or wget.