### PR TITLE
llvm_libcxxabi: remove subversion

### DIFF
--- a/projects/llvm_libcxxabi/Dockerfile
+++ b/projects/llvm_libcxxabi/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y subversion
+RUN apt-get update
 
 RUN git clone --depth 1 https://github.com/llvm/llvm-project.git
 WORKDIR llvm-project/libcxxabi

--- a/projects/llvm_libcxxabi/project.yaml
+++ b/projects/llvm_libcxxabi/project.yaml
@@ -1,4 +1,4 @@
-homepage: "http://libcxxabi.llvm.org/"
+homepage: "https://libcxxabi.llvm.org/"
 language: c++
 primary_contact: "kcc@google.com"
 main_repo: https://github.com/llvm/llvm-project


### PR DESCRIPTION
A leftover from when the repos used svn.