### PR TITLE
libyang: remove subversion

### DIFF
--- a/projects/libyang/Dockerfile
+++ b/projects/libyang/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y autoconf automake libtool subversion
+RUN apt-get update && apt-get install -y autoconf automake libtool
 RUN git clone https://github.com/CESNET/libyang
 
 RUN git clone https://github.com/PCRE2Project/pcre2 pcre2 && \


### PR DESCRIPTION
PCRE used to be fetched via svn, that is no-longer the case.