### PR TITLE
Add main_repo and language to new project doc, and links to field explanations. Fix workflow reference to repo_url.

### DIFF
--- a/docs/getting-started/accepting_new_projects.md
+++ b/docs/getting-started/accepting_new_projects.md
@@ -21,6 +21,7 @@ with a new `projects/<project_name>/project.yaml` file
 2. In the file, provide the following information:
   * Your project's homepage. ([`homepage`]({{ site.baseurl }}/getting-started/new-project-guide/#homepage))
   * Your project's main repository URL. ([`main_repo`]({{ site.baseurl }}/getting-started/new-project-guide/#main_repo))
+  * Your project's primary language. ([`language`]({{ site.baseurl }}/getting-started/new-project-guide/#language))
   * An email address for the engineering contact to be CCed on new issues ([`primary_contact`]({{ site.baseurl }}/getting-started/new-project-guide/#primary)), satisfying the following:
        * The address belongs to an established project committer (according to VCS logs).
         If the address isn't you, or if the address differs from VCS, we'll require an informal

--- a/docs/getting-started/accepting_new_projects.md
+++ b/docs/getting-started/accepting_new_projects.md
@@ -19,8 +19,9 @@ with a new `projects/<project_name>/project.yaml` file
     **Note:** `project_name` can only contain alphanumeric characters,
     underscores(_) or dashes(-).
 2. In the file, provide the following information:
-  * Your project's homepage.
-  * An email address for the engineering contact to be CCed on new issues, satisfying the following:
+  * Your project's homepage. ([`homepage`]({{ site.baseurl }}/getting-started/new-project-guide/#homepage))
+  * Your project's main repository URL. ([`main_repo`]({{ site.baseurl }}/getting-started/new-project-guide/#main_repo))
+  * An email address for the engineering contact to be CCed on new issues ([`primary_contact`]({{ site.baseurl }}/getting-started/new-project-guide/#primary)), satisfying the following:
        * The address belongs to an established project committer (according to VCS logs).
         If the address isn't you, or if the address differs from VCS, we'll require an informal
         email verification.

--- a/infra/pr_helper.py
+++ b/infra/pr_helper.py
@@ -88,7 +88,7 @@ def main():
       repo_url = new_project.get('main_repo')
       if repo_url is None:
         message += (f'{pr_author} is integrating a new project, '
-                    'but the `repo_url` is missing. '
+                    'but the `main_repo` is missing. '
                     'The criticality score cannot be computed.<br/>')
       else:
         message += (f'{pr_author} is integrating a new project:<br/>'


### PR DESCRIPTION
The PR Helper workflow complains if a new project doesn't include a main_repo, so I've added that to the accepting new projects page.

I also added links from there to the specific fields in the new project guide.

I also changed a reference in the workflow output to refer to the yaml field name visible to submitters, rather than to the internal python name for the same field which doesn't match.