### PR TITLE
bitcoin-core: re-enable DEBUG=1 for 32-bit builds

### DIFF
--- a/projects/bitcoin-core/build.sh
+++ b/projects/bitcoin-core/build.sh
@@ -32,16 +32,16 @@ fi
 sed -i 's/flto/flto=thin/g' ./depends/hosts/linux.mk
 sed -i 's/flto/flto=thin/g' ./configure.ac
 
+if [ "$ARCHITECTURE" = "i386" ]; then
+# Temporary workaround for building sqlite for 32-bit. Due to https://github.com/google/oss-fuzz/pull/10466#issuecomment-1576658462
+sed -i 's/-D_LIBCPP_ENABLE_ASSERTIONS=1/-D_LIBCPP_ENABLE_ASSERTIONS=1 -m32/g' ./depends/hosts/linux.mk
+fi
+
 (
   cd depends
   sed -i --regexp-extended '/.*rm -rf .*extract_dir.*/d' ./funcs.mk  # Keep extracted source
   # LTO=1 temporarily disabled due to https://github.com/google/oss-fuzz/pull/9461#issuecomment-1568189633
-  if [ "$ARCHITECTURE" = "i386" ]; then
-    # DEBUG=1 temporarily disabled due to https://github.com/google/oss-fuzz/pull/10466#issuecomment-1576658462
-    make HOST=$BUILD_TRIPLET         NO_QT=1 NO_BDB=1 NO_ZMQ=1 NO_UPNP=1 NO_NATPMP=1 NO_USDT=1 AR=llvm-ar RANLIB=llvm-ranlib -j$(nproc)
-  else
-    make HOST=$BUILD_TRIPLET DEBUG=1 NO_QT=1 NO_BDB=1 NO_ZMQ=1 NO_UPNP=1 NO_NATPMP=1 NO_USDT=1 AR=llvm-ar RANLIB=llvm-ranlib -j$(nproc)
-  fi
+  make HOST=$BUILD_TRIPLET DEBUG=1 NO_QT=1 NO_BDB=1 NO_ZMQ=1 NO_UPNP=1 NO_NATPMP=1 NO_USDT=1 AR=llvm-ar RANLIB=llvm-ranlib -j$(nproc)
 )
 
 # Build the fuzz targets


### PR DESCRIPTION
cc @MarcoFalke @dergoegge

Builds locally with:
```bash
python3 infra/helper.py build_fuzzers bitcoin-core --engine libfuzzer --sanitizer address --architecture i386
```