### PR TITLE
Update pr_helper criticality score

### DIFF
--- a/infra/pr_helper.py
+++ b/infra/pr_helper.py
@@ -35,6 +35,7 @@ CRITICALITY_SCORE_PATH = '/home/runner/go/bin/criticality_score'
 
 def get_criticality_score(repo_url):
   """Gets the criticality score of the project."""
+  # Criticality score does not support repo url ends with '.git'
   if repo_url.endswith('.git'):
     repo_url = repo_url[:-4]
   report = subprocess.run([
@@ -47,8 +48,8 @@ def get_criticality_score(repo_url):
   try:
     report_dict = json.loads(report.stdout)
   except:
-    print(f'stdout: {report.stdout}')
-    print(f'stderr: {report.stderr}')
+    print(f'Criticality score failed with stdout: {report.stdout}')
+    print(f'Criticality score failed with stderr: {report.stderr}')
     return 'N/A'
   return report_dict.get('default_score', 'N/A')
 
@@ -95,7 +96,7 @@ def main():
       repo_url = new_project.get('main_repo')
       if repo_url is None:
         message += (f'{pr_author} is integrating a new project, '
-                    'but the `main_repo` is missing. '
+                    'but the `repo_url` is missing. '
                     'The criticality score cannot be computed.<br/>')
       else:
         message += (f'{pr_author} is integrating a new project:<br/>'

--- a/infra/pr_helper.py
+++ b/infra/pr_helper.py
@@ -35,6 +35,8 @@ CRITICALITY_SCORE_PATH = '/home/runner/go/bin/criticality_score'
 
 def get_criticality_score(repo_url):
   """Gets the criticality score of the project."""
+  if repo_url.endswith('.git'):
+    repo_url = repo_url[:-4]
   report = subprocess.run([
       CRITICALITY_SCORE_PATH, '--format', 'json',
       '-gcp-project-id=clusterfuzz-external', '-depsdev-disable', repo_url
@@ -42,7 +44,12 @@ def get_criticality_score(repo_url):
                           capture_output=True,
                           text=True)
 
-  report_dict = json.loads(report.stdout)
+  try:
+    report_dict = json.loads(report.stdout)
+  except:
+    print(f'stdout: {report.stdout}')
+    print(f'stderr: {report.stderr}')
+    return 'N/A'
   return report_dict.get('default_score', 'N/A')
 
 
@@ -88,7 +95,7 @@ def main():
       repo_url = new_project.get('main_repo')
       if repo_url is None:
         message += (f'{pr_author} is integrating a new project, '
-                    'but the `repo_url` is missing. '
+                    'but the `main_repo` is missing. '
                     'The criticality score cannot be computed.<br/>')
       else:
         message += (f'{pr_author} is integrating a new project:<br/>'


### PR DESCRIPTION
Update repo_url as criticality score does not support url ends with '.git'. 
Example: 
~/go/bin$ `./criticality_score --format json -gcp-project-id=clusterfuzz-external https://github.com/kubernetes/kubernetes.git`
2023-06-21 14:27:39.583	INFO	Preparing default scorer
2023-06-21 14:27:41.007	INFO	deps.dev signal source enabled
`2023-06-21 14:27:41.869	WARN	Repo cannot be collected	{"worker": 0, "url": "https://github.com/kubernetes/kubernetes.git", "error": "repo failed: not found: https://github.com/kubernetes/kubernetes.git"}`
