### PR TITLE
Update the email of the primary contact for Apache Avro

### DIFF
--- a/projects/avro/project.yaml
+++ b/projects/avro/project.yaml
@@ -5,7 +5,7 @@ fuzzing_engines:
 main_repo: "https://github.com/apache/avro"
 sanitizers:
   - address
-primary_contact: "mgrigorov@apache.org"
+primary_contact: "martin.grigorov@gmail.com"
 vendor_ccs:
   - "wagner@code-intelligence.com"
   - "yakdan@code-intelligence.com"


### PR DESCRIPTION
I cannot login and see the reports with my @apache.org email. OSS-Fuzz supports only OAuth login via GMail and Github

Related-to: https://github.com/google/oss-fuzz/pull/10453