### PR TITLE
cppcheck: extend set up

### DIFF
--- a/projects/cppcheck/Dockerfile
+++ b/projects/cppcheck/Dockerfile
@@ -16,7 +16,8 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 
-RUN git clone https://github.com/danmar/cppcheck.git
+RUN git clone https://github.com/DavidKorczynski/cppcheck && cd cppcheck && git checkout add-raw-fuzzer
+#RUN git clone https://github.com/danmar/cppcheck.git
 
 WORKDIR cppcheck
 COPY build.sh $SRC/

--- a/projects/cppcheck/build.sh
+++ b/projects/cppcheck/build.sh
@@ -18,7 +18,11 @@
 # build fuzzer
 
 cd $SRC/cppcheck/oss-fuzz
-make oss-fuzz-client
+make oss-fuzz-client raw_fuzzer
 cp oss-fuzz-client $OUT/
+cp raw_fuzzer $OUT/
 
-
+# Build corpus for raw fuzzer
+mkdir $SRC/raw-corpus
+find $SRC/cppcheck -name "*.cpp" -exec cp {} $SRC/raw-corpus/ \;
+zip -rj $OUT/raw_fuzzer_seed_corpus.zip $SRC/raw-corpus/*


### PR DESCRIPTION
This is dependent on https://github.com/danmar/cppcheck/pull/5185

Should get coverage a good amount up which should be displayed here https://introspector.oss-fuzz.com/project-profile?project=cppcheck once things are merged.

Nit: if cppcheck accepts then I have to adjust the `Dockerfile` in this PR to not use my own fork -- I just used the fork to verify the CI while waiting for upstream.