### PR TITLE
Update fluxcd to Go 1.20

### DIFF
--- a/projects/fluxcd/Dockerfile
+++ b/projects/fluxcd/Dockerfile
@@ -16,6 +16,12 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
 
+RUN wget https://go.dev/dl/go1.20.5.linux-amd64.tar.gz \
+    && mkdir temp-go \
+    && rm -rf /root/.go/* \
+    && tar -C temp-go/ -xzf go1.20.5.linux-amd64.tar.gz \
+    && mv temp-go/go/* /root/.go/
+
 ENV GOPATH="${GOPATH:-/root/go}"
 ENV ORG_ROOT="${ORG_ROOT:-${GOPATH}/src/github.com/fluxcd}"
 

--- a/projects/fluxcd/build.sh
+++ b/projects/fluxcd/build.sh
@@ -20,6 +20,9 @@
 # - Supporting single (during PR checks) or multiple repositories (oss-fuzz).
 # - Enabling execution via CI builds and Makefile targets for each repo.
 
+# required by Go 1.20
+export CXX="${CXX} -lresolv"
+
 GOPATH="${GOPATH:-/root/go}"
 ORG_ROOT="${ORG_ROOT:-${GOPATH}/src/github.com/fluxcd}"
 PREBUILD_SCRIPT_PATH="${PREBUILD_SCRIPT_PATH:-tests/fuzz/oss_fuzz_prebuild.sh}"


### PR DESCRIPTION
We're migrating all Flux controllers to Go 1.20 and we're blocked by `cr.io/oss-fuzz-base/base-builder-go` which comes with Go 1.19. This PR installs Go 1.20 over 1.19 and adds `export CXX="${CXX} -lresolv"` to the build script to avoid:

```
Building ./internal/controller/gitrepository_controller_fuzz_test.go.FuzzRandomGitFiles into FuzzRandomGitFiles
+ echo 'Building ./internal/controller/gitrepository_controller_fuzz_test.go.FuzzRandomGitFiles into FuzzRandomGitFiles'
+ compile_native_go_fuzzer ./internal/controller FuzzRandomGitFiles FuzzRandomGitFiles
/usr/bin/ld: /usr/bin/ld: DWARF error: invalid or unhandled FORM value: 0x25
FuzzRandomGitFiles.a(000020.o): in function `_cgo_cbcce81e6342_C2func_res_search':
cgo_unix_cgo_res.cgo2.c:(.text+0x32): undefined reference to `__res_search'
/usr/bin/ld: FuzzRandomGitFiles.a(000020.o): in function `_cgo_cbcce81e6342_Cfunc_res_search':
cgo_unix_cgo_res.cgo2.c:(.text+0x81): undefined reference to `__res_search'
clang-15: error: linker command failed with exit code 1 (use -v to see invocation)
```