### PR TITLE
Add javascript to new project guide

### DIFF
--- a/docs/getting-started/new_project_guide.md
+++ b/docs/getting-started/new_project_guide.md
@@ -101,6 +101,7 @@ Programming language the project is written in. Values you can specify include:
 * [`python`]({{ site.baseurl }}//getting-started/new-project-guide/python-lang/)
 * [`jvm` (Java, Kotlin, Scala and other JVM-based languages)]({{ site.baseurl }}//getting-started/new-project-guide/jvm-lang/)
 * [`swift`]({{ site.baseurl }}//getting-started/new-project-guide/swift/)
+* [`javascript`]({{ site.baseurl }}//getting-started/new-project-guide/javascript-lang/)
 
 ### primary_contact, auto_ccs {#primary}
 The primary contact and list of other contacts to be CCed. Each person listed gets access to ClusterFuzz, including crash reports and fuzzer statistics, and are auto-cced on new bugs filed in the OSS-Fuzz


### PR DESCRIPTION
This seems to have been left out when `javascript_lang.md` was created and support for `language: javascript` was added.