### PR TITLE
Rename swift.md for consistency with _lang.md pattern

### DIFF
--- a/docs/getting-started/new-project-guide/swift_lang.md
+++ b/docs/getting-started/new-project-guide/swift_lang.md
@@ -4,7 +4,7 @@ title: Integrating a Swift project
 parent: Setting up a new project
 grand_parent: Getting started
 nav_order: 1
-permalink: /getting-started/new-project-guide/swift/
+permalink: /getting-started/new-project-guide/swift-lang/
 ---
 
 # Integrating a Swift project

--- a/docs/getting-started/new_project_guide.md
+++ b/docs/getting-started/new_project_guide.md
@@ -100,7 +100,7 @@ Programming language the project is written in. Values you can specify include:
 * [`rust`]({{ site.baseurl }}//getting-started/new-project-guide/rust-lang/)
 * [`python`]({{ site.baseurl }}//getting-started/new-project-guide/python-lang/)
 * [`jvm` (Java, Kotlin, Scala and other JVM-based languages)]({{ site.baseurl }}//getting-started/new-project-guide/jvm-lang/)
-* [`swift`]({{ site.baseurl }}//getting-started/new-project-guide/swift/)
+* [`swift`]({{ site.baseurl }}//getting-started/new-project-guide/swift-lang/)
 
 ### primary_contact, auto_ccs {#primary}
 The primary contact and list of other contacts to be CCed. Each person listed gets access to ClusterFuzz, including crash reports and fuzzer statistics, and are auto-cced on new bugs filed in the OSS-Fuzz


### PR DESCRIPTION
All other language-specific guide files are named `foo_lang.md`, as distinct from `bazel.md` which is not for an implementation language (and should probably get its own suffix, maybe bazel_build.md, but that's another matter).