### PR TITLE
igraph: remove unused dependencies, enable centipede

### DIFF
--- a/projects/igraph/Dockerfile
+++ b/projects/igraph/Dockerfile
@@ -15,8 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool \
-  pkg-config cmake bison flex
+RUN apt-get update && apt-get install -y cmake bison flex
 RUN git clone --branch master  https://github.com/igraph/igraph
 WORKDIR igraph
 RUN cp $SRC/igraph/fuzzing/build.sh $SRC/build.sh

--- a/projects/igraph/project.yaml
+++ b/projects/igraph/project.yaml
@@ -13,9 +13,3 @@ sanitizers:
 architectures:
  - x86_64
  - i386
-
-fuzzing_engines:
-  - afl
-  - honggfuzz
-  - libfuzzer
-


### PR DESCRIPTION
Two changes:

 - Simplify Dockerfile, do not install packages which are no longer used as dependencies
 - Remove `fuzzing_engines` from `project.yaml` to ensure that all fuzzing engines are used, including centipede