### PR TITLE
Add new project: mp4san

### DIFF
--- a/projects/mp4san/Dockerfile
+++ b/projects/mp4san/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+
+RUN git clone --depth 1 https://github.com/privacyresearchgroup/mp4san mp4san
+WORKDIR mp4san
+
+COPY build.sh $SRC/

--- a/projects/mp4san/build.sh
+++ b/projects/mp4san/build.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -eu
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+PROJECT_DIR=$SRC/mp4san
+FUZZ_DIR=$PROJECT_DIR/mp4san/fuzz
+cd $FUZZ_DIR && cargo fuzz build -O --debug-assertions
+
+FUZZ_INPUT_DIR=$FUZZ_DIR/input
+
+FUZZ_TARGET_OUTPUT_DIR=$FUZZ_DIR/target/x86_64-unknown-linux-gnu/release/
+for fuzz_target in $FUZZ_DIR/fuzz_targets/*.rs
+do
+    FUZZ_TARGET_NAME=$(basename ${fuzz_target%.*})
+    cp $FUZZ_TARGET_OUTPUT_DIR/$FUZZ_TARGET_NAME $OUT/
+    cp $FUZZ_DIR/mp4.dict $OUT/$FUZZ_TARGET_NAME.dict
+    zip -jr $OUT/${FUZZ_TARGET_NAME}_seed_corpus.zip $FUZZ_INPUT_DIR/
+done

--- a/projects/mp4san/project.yaml
+++ b/projects/mp4san/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/privacyresearchgroup/mp4san"
+language: rust
+primary_contact: "usual.beach5937@jessacake.com"
+main_repo: "https://github.com/privacyresearchgroup/mp4san"
+vendor_ccs:
+  - "security@signal.org"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer


### PR DESCRIPTION
This adds a new project, the Rust crate [mp4san](https://github.com/privacyresearchgroup/mp4san), which is used in the popular Signal messaging app: https://github.com/signalapp/libsignal/blob/main/rust/media/Cargo.toml.