### PR TITLE
[libfido2] Switch to OpenSSL 3.0, update libcbor

### DIFF
--- a/projects/libfido2/Dockerfile
+++ b/projects/libfido2/Dockerfile
@@ -17,8 +17,8 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN apt-get install -y cmake libpcsclite-dev libudev-dev pkg-config chrpath
-RUN git clone --depth 1 --branch v0.10.1 https://github.com/PJK/libcbor
-RUN git clone --depth 1 --branch OpenSSL_1_1_1-stable https://github.com/openssl/openssl
+RUN git clone --depth 1 --branch v0.10.2 https://github.com/PJK/libcbor
+RUN git clone --depth 1 --branch openssl-3.0 https://github.com/openssl/openssl
 RUN git clone --depth 1 --branch v1.2.13 https://github.com/madler/zlib
 RUN git clone --depth 1 https://github.com/Yubico/libfido2
 # CIFuzz will replace the libfido directory so put the corpus outside

--- a/projects/libfido2/build.sh
+++ b/projects/libfido2/build.sh
@@ -33,7 +33,7 @@ then
   CONFIGURE_FLAGS="no-asm"
 fi
 ./config --debug no-tests ${CFLAGS} --prefix=${WORK} \
-	 --openssldir=${WORK}/openssl ${CONFIGURE_FLAGS}
+         --openssldir=${WORK}/openssl --libdir=lib ${CONFIGURE_FLAGS}
 make -j$(nproc) LDCMD="${CXX} ${CXXFLAGS}"
 make install_sw
 


### PR DESCRIPTION
With OpenSSL 1.1's imminent EOL, switch libfido2 to OpenSSL 3.0. While here, update libcbor to 0.10.2. Tested locally with asan/msan and libFuzzer, Honggfuzz, and AFL. 