### PR TITLE
Add a --no-serve option to the helper coverage command.

### DIFF
--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -518,12 +518,16 @@ else
 
     generate_html $profdata_path "$shared_libraries" "$fuzz_target" "$report_dir"
   done
+
+  set +e
 fi
 
 # Make sure report is readable.
 chmod -R +r $REPORT_ROOT_DIR $REPORT_BY_TARGET_ROOT_DIR
 find $REPORT_ROOT_DIR $REPORT_BY_TARGET_ROOT_DIR -type d -exec chmod +x {} +
 
+# HTTP_PORT is optional.
+set +u
 if [[ -n $HTTP_PORT ]]; then
   # Serve the report locally.
   echo "Serving the report on http://127.0.0.1:$HTTP_PORT/linux/index.html"

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -372,6 +372,9 @@ def get_parser():  # pylint: disable=too-many-statements,too-many-locals
                                help='do not download corpus backup from '
                                'OSS-Fuzz; use corpus located in '
                                'build/corpus/<project>/<fuzz_target>/')
+  coverage_parser.add_argument('--no-serve',
+                               action='store_true',
+                               help='do not serve a local HTTP server.')
   coverage_parser.add_argument('--port',
                                default='8008',
                                help='specify port for'
@@ -1207,10 +1210,12 @@ def coverage(args):
       'FUZZING_LANGUAGE=%s' % args.project.language,
       'PROJECT=%s' % args.project.name,
       'SANITIZER=coverage',
-      'HTTP_PORT=%s' % args.port,
       'COVERAGE_EXTRA_ARGS=%s' % ' '.join(args.extra_args),
       'ARCHITECTURE=' + args.architecture,
   ]
+
+  if not args.no_serve:
+    env.append(f'HTTP_PORT={args.port}')
 
   run_args = _env_to_docker_args(env)
 


### PR DESCRIPTION
This turns off the http report serving after a successful generation.