### PR TITLE
openssl: adds 100-ish targets with ngolo-style fuzzing of asn1 api

### DIFF
--- a/projects/openssl/Dockerfile
+++ b/projects/openssl/Dockerfile
@@ -21,6 +21,6 @@ RUN cd $SRC/openssl/ && git submodule update --init fuzz/corpora
 RUN git clone --depth 1 --branch OpenSSL_1_1_1-stable https://github.com/openssl/openssl.git openssl111
 RUN git clone --depth 1 --branch openssl-3.0 https://github.com/openssl/openssl.git openssl30
 WORKDIR openssl
-COPY build.sh *.options $SRC/
+COPY build.sh *.options ngolo.py $SRC/
 ENV AFL_SKIP_OSSFUZZ=1
 ENV AFL_LLVM_MODE_WORKAROUND=0

--- a/projects/openssl/build.sh
+++ b/projects/openssl/build.sh
@@ -64,6 +64,9 @@ function build_fuzzers() {
 
 cd $SRC/openssl/
 build_fuzzers ""
+$CC $CFLAGS -c fuzz/driver.c -o fuzz/driver.o -I include
+ls include/openssl/*.h.in | while read i; do python3 $SRC/ngolo.py $i; done
+cp fuzz_ng_* $OUT/
 cd $SRC/openssl111/
 build_fuzzers "_111"
 cd $SRC/openssl30/

--- a/projects/openssl/build.sh
+++ b/projects/openssl/build.sh
@@ -63,6 +63,9 @@ function build_fuzzers() {
 }
 
 cd $SRC/openssl/
+# special patch to get NAME_CONSTRAINTS_check/punycode
+sed -i -e 's/DECLARE_ASN1_ALLOC_FUNCTIONS(NAME_CONSTRAINTS)/DECLARE_ASN1_FUNCTIONS(NAME_CONSTRAINTS)/' include/openssl/x509v3.h.in
+sed -i -e 's/IMPLEMENT_ASN1_ALLOC_FUNCTIONS(NAME_CONSTRAINTS)/IMPLEMENT_ASN1_FUNCTIONS(NAME_CONSTRAINTS)/' crypto/x509/v3_ncons.c
 build_fuzzers ""
 $CC $CFLAGS -c fuzz/driver.c -o fuzz/driver.o -I include
 ls include/openssl/*.h.in | while read i; do python3 $SRC/ngolo.py $i; done

--- a/projects/openssl/build.sh
+++ b/projects/openssl/build.sh
@@ -67,17 +67,8 @@ cd $SRC/openssl/
 sed -i -e 's/DECLARE_ASN1_ALLOC_FUNCTIONS(NAME_CONSTRAINTS)/DECLARE_ASN1_FUNCTIONS(NAME_CONSTRAINTS)/' include/openssl/x509v3.h.in
 sed -i -e 's/IMPLEMENT_ASN1_ALLOC_FUNCTIONS(NAME_CONSTRAINTS)/IMPLEMENT_ASN1_FUNCTIONS(NAME_CONSTRAINTS)/' crypto/x509/v3_ncons.c
 build_fuzzers ""
-if [[ $CFLAGS = *sanitize=address* ]]
-then
-    if [[ $CFLAGS != *-m32* ]]
-    then
-        if [[ $FUZZING_ENGINE = *libfuzzer* ]]
-        then
-            $CC $CFLAGS -c fuzz/driver.c -o fuzz/driver.o -I include
-            ls include/openssl/*.h.in | while read i; do python3 $SRC/ngolo.py $i; done
-        fi
-    fi
-fi
+$CC $CFLAGS -c fuzz/driver.c -o fuzz/driver.o -I include
+ls include/openssl/*.h.in | while read i; do python3 $SRC/ngolo.py $i; done
 cp fuzz_ng_* $OUT/
 cd $SRC/openssl111/
 build_fuzzers "_111"

--- a/projects/openssl/build.sh
+++ b/projects/openssl/build.sh
@@ -67,8 +67,17 @@ cd $SRC/openssl/
 sed -i -e 's/DECLARE_ASN1_ALLOC_FUNCTIONS(NAME_CONSTRAINTS)/DECLARE_ASN1_FUNCTIONS(NAME_CONSTRAINTS)/' include/openssl/x509v3.h.in
 sed -i -e 's/IMPLEMENT_ASN1_ALLOC_FUNCTIONS(NAME_CONSTRAINTS)/IMPLEMENT_ASN1_FUNCTIONS(NAME_CONSTRAINTS)/' crypto/x509/v3_ncons.c
 build_fuzzers ""
-$CC $CFLAGS -c fuzz/driver.c -o fuzz/driver.o -I include
-ls include/openssl/*.h.in | while read i; do python3 $SRC/ngolo.py $i; done
+if [[ $CFLAGS = *sanitize=address* ]]
+then
+    if [[ $CFLAGS != *-m32* ]]
+    then
+        if [[ $FUZZING_ENGINE = *libfuzzer* ]]
+        then
+            $CC $CFLAGS -c fuzz/driver.c -o fuzz/driver.o -I include
+            ls include/openssl/*.h.in | while read i; do python3 $SRC/ngolo.py $i; done
+        fi
+    fi
+fi
 cp fuzz_ng_* $OUT/
 cd $SRC/openssl111/
 build_fuzzers "_111"

--- a/projects/openssl/ngolo.py
+++ b/projects/openssl/ngolo.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import subprocess
 import sys
 
@@ -102,12 +103,10 @@ def process_fun(funp, asntypes, owning):
         f2.close()
 
         # and now compile it
-        ret = subprocess.run(["clang", "-g", "-fsanitize=address,fuzzer-no-link", "-c", "fuzz/%s.c" % namefun, "-o", "fuzz/%s.o" % namefun, "-I", "include"])
+        ret = subprocess.run([os.environ.get("CC")] + os.environ.get("CFLAGS").split() + ["-c", "fuzz/%s.c" % namefun, "-o", "fuzz/%s.o" % namefun, "-I", "include"])
         if ret.returncode != 0:
             print("failed")
-        cmd = ["clang++", "-g", "-fsanitize=address,fuzzer", "fuzz/%s.o" % namefun, "-o", "fuzz_ng_%s" % namefun, "fuzz/driver.o", "libcrypto.a"]
-        print(cmd)
-        ret = subprocess.run(cmd)
+        ret = subprocess.run([os.environ.get("CXX")] + os.environ.get("CXXFLAGS") + [os.environ.get("LIB_FUZZING_ENGINE"), "fuzz/%s.o" % namefun, "-o", "fuzz_ng_%s" % namefun, "fuzz/driver.o", "libcrypto.a"])
         print(namefun, args)
 
 # first list all asn1 types

--- a/projects/openssl/ngolo.py
+++ b/projects/openssl/ngolo.py
@@ -1,0 +1,135 @@
+#!/usr/bin/python3
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+import sys
+
+target_header = '''
+#include <string.h>
+#include <openssl/e_os2.h>
+#include <openssl/cms.h>
+#include <openssl/crmf.h>
+#include <openssl/ocsp.h>
+#include <openssl/pkcs12.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+#include "internal/nelem.h"
+#include "fuzzer.h"
+
+
+int FuzzerInitialize(int *argc, char ***argv)
+{
+    return 1;
+}
+
+int FuzzerTestOneInput(const uint8_t* data, size_t size){
+    const unsigned char *derp = data;
+'''
+
+target_trailer = '''
+    return 0;
+}
+
+void FuzzerCleanup(void)
+{
+}
+'''
+
+def process_fun(funp, asntypes, owning):
+    namesargs = funp.split('(')
+    # do not support STACK_OF(
+    if len(namesargs) == 2:
+        namefun = namesargs[0].split()[1]
+        owned = namefun in owning
+        args = []
+        for arg in namesargs[1].split(","):
+            argtype = arg.split()[0]
+            if argtype == "const":
+                argtype = arg.split()[1]
+            if arg.split()[-1].startswith("**"):
+                # not supporting pass argument for writing
+                return
+            if argtype not in asntypes:
+                # not supporting not-asn1 argument
+                return
+            args.append(argtype)
+
+        # we can have a fuzzer, let's write it
+        f2 = open("fuzz/%s.c" % namefun, "w")
+        f2.write(target_header)
+        for i in range(len(args)):
+            f2.write("    %s *a%d = NULL;\n" % (args[i], i))
+
+        # parse ASN1
+        for i in range(len(args)):
+            f2.write("    a%d = d2i_%s(NULL, &derp, size - (derp - data));\n" % (i, args[i]))
+            f2.write("    if (a%d == NULL)\n" % i)
+            f2.write("        goto end;\n")
+
+        # call function
+        if owned:
+            f2.write("    if (%s(" % namefun)
+        else:
+            f2.write("    %s(" % namefun)
+        for i in range(len(args)):
+            if i > 0:
+                f2.write(",")
+            f2.write("a%d" % i)
+        if owned:
+            f2.write(")) {\n")
+            f2.write("        a%d = NULL;\n" % (len(args) - 1))
+            f2.write("    }\n")
+        else:
+            f2.write(");\n")
+
+        f2.write("end:\n")
+        for i in range(len(args)):
+            f2.write("    if (a%d != NULL)\n" % i)
+            f2.write("        %s_free(a%d);\n" % (args[i], i))
+        f2.write(target_trailer)
+        f2.close()
+
+        # and now compile it
+        ret = subprocess.run(["clang", "-g", "-fsanitize=address,fuzzer-no-link", "-c", "fuzz/%s.c" % namefun, "-o", "fuzz/%s.o" % namefun, "-I", "include"])
+        if ret.returncode != 0:
+            print("failed")
+        cmd = ["clang++", "-g", "-fsanitize=address,fuzzer", "fuzz/%s.o" % namefun, "-o", "fuzz_ng_%s" % namefun, "fuzz/driver.o", "libcrypto.a"]
+        print(cmd)
+        ret = subprocess.run(cmd)
+        print(namefun, args)
+
+# first list all asn1 types
+asntypes = {}
+ret = subprocess.run(["git", "grep", "DECLARE_ASN1_FUNCTIONS(", "include"], capture_output=True, text=True)
+for l in ret.stdout.split("\n"):
+    fc = l.split(":")
+    if len(fc) > 1 and fc[1].startswith("DECLARE_ASN1_FUNCTIONS("):
+        asntypes[fc[1][len("DECLARE_ASN1_FUNCTIONS("):-1]] = True
+
+# read a h.in file for function prototypes
+funstart = False
+funproto = ""
+f = open(sys.argv[1], "r")
+owningFunctions = ["OSSL_CRMF_MSG_push0_extension", "OSSL_CRMF_MSG_set0_validity", "PKCS7_add0_attrib_signing_time"]
+for l in f.readlines():
+    # restrict to function prototypes returning int
+    if l.startswith("int "):
+        funproto = ""
+        funstart = True
+    if funstart:
+        funproto = funproto + l[:-1].lstrip()
+        if ");" in l:
+            process_fun(funproto, asntypes, owningFunctions)
+            funstart = False

--- a/projects/openssl/ngolo.py
+++ b/projects/openssl/ngolo.py
@@ -106,7 +106,7 @@ def process_fun(funp, asntypes, owning):
         ret = subprocess.run([os.environ.get("CC")] + os.environ.get("CFLAGS").split() + ["-c", "fuzz/%s.c" % namefun, "-o", "fuzz/%s.o" % namefun, "-I", "include"])
         if ret.returncode != 0:
             print("failed")
-        ret = subprocess.run([os.environ.get("CXX")] + os.environ.get("CXXFLAGS") + [os.environ.get("LIB_FUZZING_ENGINE"), "fuzz/%s.o" % namefun, "-o", "fuzz_ng_%s" % namefun, "fuzz/driver.o", "libcrypto.a"])
+        ret = subprocess.run([os.environ.get("CXX")] + os.environ.get("CXXFLAGS").split() + [os.environ.get("LIB_FUZZING_ENGINE"), "fuzz/%s.o" % namefun, "-o", "fuzz_ng_%s" % namefun, "fuzz/driver.o", "libcrypto.a"])
         print(namefun, args)
 
 # first list all asn1 types


### PR DESCRIPTION
Adds 114 fuzz targets to openssl (only master branch)

Inspired by CVE-2023-0286 and the fuzz target v3name which came after it, but generalizing to fuzz every function such as `GENERAL_NAME_cmp` which takes arguments from parsed asn1

For instance `ASN1_GENERALIZEDTIME_check`, `GENERAL_NAME_cmp`, `OTHERNAME_cmp`, `DIST_POINT_set_dpname`, `X509_CRL_match` etc...

Also puny code is reachable through `NAME_CONSTRAINTS_check` with a special patch