### PR TITLE
disable ANSI color in the output of `build_fuzzers` when stdin's file descripter is not a terminal

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -830,9 +830,11 @@ def build_fuzzers_impl(  # pylint: disable=too-many-arguments,too-many-locals,to
       ]
 
   command += [
-      '-v', f'{project_out}:/out', '-v', f'{project.work}:/work', '-t',
+      '-v', f'{project_out}:/out', '-v', f'{project.work}:/work',
       f'gcr.io/oss-fuzz/{project.name}'
   ]
+  if sys.stdin.isatty():
+    command.insert(-1, '-t')
 
   result = docker_run(command, architecture=architecture)
   if not result:


### PR DESCRIPTION
For example, ANSI colors will not be used when `stdin` is mapped to `DEVNULL`.