### PR TITLE
helper: Don't expose ports when --no-serve is passed to coverage.

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -1219,7 +1219,7 @@ def coverage(args):
 
   run_args = _env_to_docker_args(env)
 
-  if args.port:
+  if args.port and not args.no_serve:
     run_args.extend([
         '-p',
         '%s:%s' % (args.port, args.port),


### PR DESCRIPTION
Follow up to #10628.