### PR TITLE
Bump memory on fuzz introspector webapp.

### DIFF
--- a/infra/build/fuzz-introspector-webapp/cloudbuild.yaml
+++ b/infra/build/fuzz-introspector-webapp/cloudbuild.yaml
@@ -27,3 +27,5 @@ steps:
     - '1'
     - '--max-instances'
     - '10'
+    - '--memory'
+    - '8Gi'


### PR DESCRIPTION
The webapp was down due to OOM.