### PR TITLE
Don't tee build logs.

### DIFF
--- a/infra/build/functions/build_project.py
+++ b/infra/build/functions/build_project.py
@@ -253,7 +253,7 @@ def get_compile_step(project, build, env, parallel, upload_build_logs=None):
       f'{build.architecture} {project.name}\n' + '*' * 80)
   compile_output_redirect = ''
   if upload_build_logs:
-    compile_output_redirect = f'|& tee {LOCAL_BUILD_LOG_PATH} '
+    compile_output_redirect = f'> {LOCAL_BUILD_LOG_PATH} '
 
   compile_step = {
       'name': project.image,

--- a/infra/build/functions/build_project.py
+++ b/infra/build/functions/build_project.py
@@ -253,7 +253,7 @@ def get_compile_step(project, build, env, parallel, upload_build_logs=None):
       f'{build.architecture} {project.name}\n' + '*' * 80)
   compile_output_redirect = ''
   if upload_build_logs:
-    compile_output_redirect = f'> {LOCAL_BUILD_LOG_PATH} '
+    compile_output_redirect = f'&> {LOCAL_BUILD_LOG_PATH} '
 
   compile_step = {
       'name': project.image,


### PR DESCRIPTION
`tee` will override the compile return code.