### PR TITLE
Unpin Wasmtime's rust compiler version

### DIFF
--- a/projects/wasmtime/build.sh
+++ b/projects/wasmtime/build.sh
@@ -15,10 +15,6 @@
 #
 ################################################################################
 
-# Waiting for denoland/rusty_v8#1248 to get fixed
-rustup default nightly-2023-06-01
-rustup component add rust-src
-
 # Commands migrated from Dockerfile to make CIFuzz work
 # REF: https://github.com/google/oss-fuzz/issues/6755
 git submodule update --init --recursive


### PR DESCRIPTION
Upstream issues have been fixed and fuzzers can now build again with the latest nightly release.