### PR TITLE
sound-open-firmware: update additional CCs

### DIFF
--- a/projects/sound-open-firmware/project.yaml
+++ b/projects/sound-open-firmware/project.yaml
@@ -5,12 +5,12 @@ auto_ccs:
   - "cujomalainey@chromium.org"
   - "ranjani.sridharan@intel.corp-partner.google.com"
   - "lgirdwood@gmail.com"
-  - "harsha.p.n@intel.corp-partner.google.com"
   - "sathyanarayana.nujella@intel.corp-partner.google.com"
   - "adrian.bonislawski@intel.com"
   - "michal.wasko@intel.com"
   - "jyri.sarha@intel.com"
   - "rander.wang@intel.com"
+  - "flavio.ceolin@intel.com"
 fuzzing_engines:
   - libfuzzer
 sanitizers:


### PR DESCRIPTION
Add Flavio Ceolin from Intel. Remove Harsha who is no longer active.

This PR replaced https://github.com/google/oss-fuzz/pull/10654