### PR TITLE
powerdns: Build the arcrandom target first

### DIFF
--- a/projects/powerdns/build.sh
+++ b/projects/powerdns/build.sh
@@ -34,6 +34,7 @@ autoreconf -vi
     --enable-fuzz-targets \
     --disable-dependency-tracking \
     --disable-silent-rules || /bin/bash
+make -j$(nproc) -C ext/arc4random/
 make -j$(nproc) -C ext/yahttp/
 cd pdns
 make -j$(nproc) fuzz_targets


### PR DESCRIPTION
This is now required for the build to pass.

See https://github.com/PowerDNS/pdns/pull/12931