### PR TITLE
xz: Disable ifunc to fix Issue 60259.

### DIFF
--- a/projects/xz/build.sh
+++ b/projects/xz/build.sh
@@ -24,7 +24,8 @@
   --disable-xz \
   --disable-xzdec \
   --disable-lzmadec \
-  --disable-lzmainfo
+  --disable-lzmainfo \
+  --disable-ifunc
 make clean
 make -j$(nproc) && make -C tests/ossfuzz && \
     cp tests/ossfuzz/config/fuzz.options $OUT/ && \


### PR DESCRIPTION
Indirect function support was added to xz on machines that support it for function dispatching. ifunc is not compatible with -fsanitize=address, so this should be disabled for fuzzing builds.