### PR TITLE
Change matio repository from sf to github

### DIFF
--- a/projects/matio/Dockerfile
+++ b/projects/matio/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/madler/zlib
-RUN git clone --depth 1 git://git.code.sf.net/p/matio/matio matio
+RUN git clone --depth 1 https://github.com/tbeu/matio.git matio
 ADD https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-1.12.1/src/hdf5-1.12.1.tar.gz hdf5-1.12.1.tar.gz
 WORKDIR matio
 COPY build.sh $SRC/

--- a/projects/matio/project.yaml
+++ b/projects/matio/project.yaml
@@ -7,7 +7,7 @@ sanitizers:
   - undefined
 architectures:
   - x86_64
-main_repo: 'git://git.code.sf.net/p/matio/matio'
+main_repo: 'https://github.com/tbeu/matio'
 
 fuzzing_engines:
   - afl


### PR DESCRIPTION
The git repository in sf wasn't updated more than a year.
@tbeu Do you approve?