### PR TITLE
[wuffs] use fork of MozillaSecurity/fuzzdata

### DIFF
--- a/projects/wuffs/Dockerfile
+++ b/projects/wuffs/Dockerfile
@@ -36,9 +36,9 @@ RUN mkdir libjpeg_turbo_corpus && \
     rm -rf seed-corpora
 
 RUN mkdir pngsuite_corpus && \
-    git clone --depth=1 https://github.com/MozillaSecurity/fuzzdata && \
-    mv ./fuzzdata/samples/png/common/*.png ./pngsuite_corpus && \
-    rm -rf fuzzdata
+    git clone --depth=1 https://github.com/nigeltao/mozsec-fuzzdata && \
+    mv ./mozsec-fuzzdata/samples/png/common/*.png ./pngsuite_corpus && \
+    rm -rf mozsec-fuzzdata
 
 RUN wget -O rapidjson.zip "https://github.com/guidovranken/rapidjson-fuzzers/blob/master/fuzzer_seed_corpus.zip?raw=true"
 RUN mkdir rapidjson_corpus


### PR DESCRIPTION
Per https://github.com/google/oss-fuzz/issues/10610 "MozillaSecurity/fuzzdata to be decomissioned soon".

Updates #10610