### PR TITLE
infra: fix presubmit when project.yaml fails

### DIFF
--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -176,7 +176,8 @@ class ProjectYamlChecker:
     """Returns True if all section names are valid."""
     for name in self.data:
       if name not in self.VALID_SECTION_NAMES:
-        self.error(f'{name} is not a valid section name ({valid_names})')
+        self.error(
+            f'{name} is not a valid section name ({self.VALID_SECTION_NAMES})')
 
   def check_required_sections(self):
     """Returns True if all required sections are in |self.data|."""


### PR DESCRIPTION
Currently a `project.yaml` with wrong key names will result in the following error:

```
...
    return all([check(changed_files) for check in checks])
  File "infra/presubmit.py", line 229, in check_project_yaml
    return all([_check_one_project_yaml(path) for path in paths])
  File "infra/presubmit.py", line 229, in <listcomp>
    return all([_check_one_project_yaml(path) for path in paths])
  File "infra/presubmit.py", line 223, in _check_one_project_yaml
    return checker.do_checks()
  File "infra/presubmit.py", line 131, in do_checks
    check_function()
  File "infra/presubmit.py", line 179, in check_valid_section_names
    self.error(f'{name} is not a valid section name ({valid_names})')
NameError: name 'valid_names' is not defined
```

This fixes it.