### PR TITLE
Onboard rust-base64

### DIFF
--- a/projects/rust-base64/Dockerfile
+++ b/projects/rust-base64/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+
+RUN git clone --depth=1 https://github.com/marshallpierce/rust-base64 $SRC/rust-base64
+
+COPY build.sh $SRC

--- a/projects/rust-base64/build.sh
+++ b/projects/rust-base64/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -eu
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd rust-base64
+
+# Build fuzzers
+cargo +nightly fuzz build --release
+
+# Copy fuzzer binaries to $OUT
+FUZZ_TARGET_OUTPUT_DIR="fuzz/target/x86_64-unknown-linux-gnu/release"
+for f in $(cargo fuzz list); do
+    cp "${FUZZ_TARGET_OUTPUT_DIR}/${f}" "$OUT/"
+done

--- a/projects/rust-base64/project.yaml
+++ b/projects/rust-base64/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://crates.io/crates/base64"
+language: rust
+primary_contact: "marshall@mpierce.org"
+main_repo: "https://github.com/marshallpierce/rust-base64"
+file_github_issue: true
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer


### PR DESCRIPTION
The project uses cargo fuzz already, which makes onboarding straight- forward.
Fuzzers are currently built in circleci to prevent breakage.

Passes `python3 infra/helper.py check_build rust-base64`.