### PR TITLE
[libjpeg-turbo] Re-add libjpeg-turbo test images to seed corpora

### DIFF
--- a/projects/libjpeg-turbo/Dockerfile
+++ b/projects/libjpeg-turbo/Dockerfile
@@ -23,8 +23,14 @@ RUN git clone --depth 1 https://github.com/libjpeg-turbo/fuzz && \
     done
 
 RUN git clone --depth 1 https://github.com/libjpeg-turbo/seed-corpora
-RUN cd seed-corpora && zip -r ../decompress_fuzzer_seed_corpus.zip afl-testcases/jpeg* bugs/decompress* $SRC/libjpeg-turbo/testimages/*.jpg
-RUN cd seed-corpora && zip -r ../compress_fuzzer_seed_corpus.zip afl-testcases/bmp afl-testcases/gif* afl-testcases/targa bugs/compress* $SRC/libjpeg-turbo/testimages/*.bmp $SRC/libjpeg-turbo/testimages/*.ppm
+RUN cd seed-corpora && zip -r ../decompress_fuzzer_seed_corpus.zip afl-testcases/jpeg* bugs/decompress*
+RUN cat fuzz/branches.txt | while read branch; do \
+      zip -r decompress_fuzzer_seed_corpus.zip libjpeg-turbo.$branch/testimages/*.jpg; \
+    done
+RUN cd seed-corpora && zip -r ../compress_fuzzer_seed_corpus.zip afl-testcases/bmp afl-testcases/gif* afl-testcases/targa bugs/compress*
+RUN cat fuzz/branches.txt | while read branch; do \
+      zip -r compress_fuzzer_seed_corpus.zip libjpeg-turbo.$branch/testimages/*.bmp libjpeg-turbo.$branch/testimages/*.ppm; \
+    done
 RUN rm -rf seed-corpora
 
 COPY build.sh $SRC/


### PR DESCRIPTION
Because of 5cc77a3fde7edc0b6fbb88636811185214d2d963, $SRC/libjpeg-turbo/ no longer exists, so the test images from the libjpeg-turbo source tree have not been added to the seed corpora .zip files since then.  This commit causes the test images from the source trees of all supported libjpeg-turbo branches to be added to the seed corpora .zip files.