### PR TITLE
Fix mbedtls build

### DIFF
--- a/projects/bignum-fuzzer/Dockerfile
+++ b/projects/bignum-fuzzer/Dockerfile
@@ -36,6 +36,6 @@ RUN git clone --depth 1 https://github.com/guidovranken/bignum-fuzzer
 RUN git clone --depth 1 https://github.com/openssl/openssl
 RUN git clone https://boringssl.googlesource.com/boringssl
 RUN hg clone https://gmplib.org/repo/gmp/ libgmp/ || \
-    (wget --no-check-certificate 'https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz' && tar xf gmp-6.2.1.tar.lz && mv $SRC/gmp-6.2.1/ $SRC/libgmp/)
+    (wget --no-check-certificate 'https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz' && tar xf gmp-6.2.1.tar.lz && mv $SRC/gmp-6.2.1/ $SRC/libgmp/)
 
 COPY build.sh $SRC/

--- a/projects/bignum-fuzzer/Dockerfile
+++ b/projects/bignum-fuzzer/Dockerfile
@@ -23,6 +23,9 @@ RUN apt-get update && apt-get install -y \
     python-all-dev \
     python3-all-dev \
     python3-pip
+# mbedtls needs jsonschema which needs rpds-py which needs pip>=20
+# or a Rust toolchain.
+RUN pip3 install 'pip>=20'
 
 RUN git clone --depth 1 -b development https://github.com/Mbed-TLS/mbedtls
 # Install Python packages from PyPI

--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -19,6 +19,10 @@ FROM gcr.io/oss-fuzz-base/base-builder-rust
 RUN apt-get update && \
     apt-get install -y software-properties-common wget make autoconf automake libtool build-essential cmake mercurial gyp ninja-build zlib1g-dev libsqlite3-dev bison flex texinfo lzip bsdmainutils
 
+# mbedtls needs jsonschema which needs rpds-py which needs pip>=20
+# or a Rust toolchain.
+RUN pip3 install 'pip>=20'
+
 RUN wget https://go.dev/dl/go1.20.5.linux-amd64.tar.gz
 RUN wget https://go.dev/dl/go1.19.10.linux-amd64.tar.gz
 RUN git clone --depth 1 https://github.com/golang/go go-dev

--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -46,7 +46,7 @@ RUN git clone --depth 1 https://github.com/jedisct1/libsodium.git
 RUN git clone --depth 1 https://github.com/libtom/libtomcrypt.git
 RUN git clone --depth 1 https://github.com/microsoft/SymCrypt.git
 RUN hg clone https://gmplib.org/repo/gmp/ libgmp/ || \
-    (wget --no-check-certificate 'https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz' && tar xf gmp-6.2.1.tar.lz && mv $SRC/gmp-6.2.1/ $SRC/libgmp/)
+    (wget --no-check-certificate 'https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz' && tar xf gmp-6.2.1.tar.lz && mv $SRC/gmp-6.2.1/ $SRC/libgmp/)
 RUN wget https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.5.1.tar.gz
 RUN git clone --depth 1 https://github.com/indutny/bn.js.git
 RUN git clone --depth 1 https://github.com/MikeMcl/bignumber.js.git

--- a/projects/ecc-diff-fuzzer/Dockerfile
+++ b/projects/ecc-diff-fuzzer/Dockerfile
@@ -26,6 +26,10 @@ RUN bash nodesource_setup.sh
 RUN apt install -y nodejs
 RUN npm install -g browserify
 RUN npm install elliptic
+# mbedtls needs jsonschema which needs rpds-py which needs pip>=20
+# or a Rust toolchain.
+RUN pip3 install 'pip>=20'
+
 RUN git clone --depth 1 https://github.com/bellard/quickjs quickjs
 RUN git clone --depth 1 https://github.com/catenacyber/elliptic-curve-differential-fuzzer.git ecfuzzer
 RUN git clone --recursive --depth 1 -b development https://github.com/Mbed-TLS/mbedtls.git mbedtls

--- a/projects/ecc-diff-fuzzer/Dockerfile
+++ b/projects/ecc-diff-fuzzer/Dockerfile
@@ -40,7 +40,7 @@ RUN git clone --depth 1 https://github.com/openssl/openssl.git openssl
 RUN git clone --depth 1 git://git.gnupg.org/libgpg-error.git libgpg-error
 RUN git clone --depth 1 git://git.gnupg.org/libgcrypt.git gcrypt
 RUN git clone --depth 1 https://github.com/weidai11/cryptopp cryptopp
-ADD https://gmplib.org/download/gmp/gmp-6.2.1.tar.bz2 gmp-6.2.1.tar.bz2
+ADD https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.bz2 gmp-6.2.1.tar.bz2
 RUN git clone --depth 1 https://github.com/gnutls/nettle.git nettle
 RUN git clone --depth 1 https://github.com/randombit/botan.git botan
 WORKDIR $SRC/

--- a/projects/libressl/Dockerfile
+++ b/projects/libressl/Dockerfile
@@ -23,7 +23,7 @@ RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora
 RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 RUN git clone --depth 1 https://github.com/randombit/botan.git
-RUN wget --no-check-certificate https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz
+RUN wget --no-check-certificate https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz
 RUN test "$(sha256sum gmp-6.2.1.tar.lz)" = "2c7f4f0d370801b2849c48c9ef3f59553b5f1d3791d070cffb04599f9fc67b41  gmp-6.2.1.tar.lz"
 WORKDIR libressl
 RUN ./update.sh

--- a/projects/mbedtls/Dockerfile
+++ b/projects/mbedtls/Dockerfile
@@ -20,6 +20,10 @@ RUN apt-get update && apt-get install -y \
     python-all-dev \
     python3-all-dev \
     python3-pip
+# mbedtls needs jsonschema which needs rpds-py which needs pip>=20
+# or a Rust toolchain.
+RUN pip3 install 'pip>=20'
+
 RUN git clone --recursive --depth 1 -b development https://github.com/Mbed-TLS/mbedtls.git mbedtls
 RUN pip3 install -r $SRC/mbedtls/scripts/basic.requirements.txt
 

--- a/projects/nettle/Dockerfile
+++ b/projects/nettle/Dockerfile
@@ -21,7 +21,7 @@ RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora
 RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
-RUN wget --no-check-certificate https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz
+RUN wget --no-check-certificate https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz
 RUN test "$(sha256sum gmp-6.2.1.tar.lz)" = "2c7f4f0d370801b2849c48c9ef3f59553b5f1d3791d070cffb04599f9fc67b41  gmp-6.2.1.tar.lz"
 COPY build.sh $SRC/
 # This is to fix Fuzz Introspector build by using LLVM old pass manager


### PR DESCRIPTION
mbedtls needs jsonschema which needs rpds-py which needs pip>=20 or a Rust toolchain. The base oss-fuzz image has pip 19, resulting in an error when installing rpds-py:
```
ERROR: Could not build wheels for rpds-py which use PEP 517 and cannot be installed directly
```

Fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=60485, https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=60492, https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=60429