### PR TITLE
[connectedhomeip] Update PIP to latest in Dockerfile

### DIFF
--- a/projects/connectedhomeip/Dockerfile
+++ b/projects/connectedhomeip/Dockerfile
@@ -38,6 +38,9 @@ RUN rustup default nightly
 
 RUN git clone --depth=1 https://github.com/project-chip/connectedhomeip.git connectedhomeip
 
+# Ensure global python has access to build requirements
+RUN pip3 install -r connectedhomeip/scripts/setup/requirements.build.txt
+
 # checkout submodules required for linux
 RUN cd $SRC/connectedhomeip && scripts/checkout_submodules.py --shallow --platform linux
 

--- a/projects/connectedhomeip/Dockerfile
+++ b/projects/connectedhomeip/Dockerfile
@@ -23,6 +23,9 @@ RUN apt-get update && \
 		libavahi-client-dev ninja-build python3-venv python3-dev python3-pip \
 		unzip libgirepository1.0-dev libcairo2-dev libreadline-dev
 
+# PIP517 needed for cryptography. Update pip
+RUN pip install --upgrade pip setuptools wheel
+
 # Install Rust for building `cryptography` python package when bootstraping pigweed
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/projects/connectedhomeip/Dockerfile
+++ b/projects/connectedhomeip/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
 		unzip libgirepository1.0-dev libcairo2-dev libreadline-dev
 
 # PEP-517 needed for cryptography. Update pip
-RUN pip install --upgrade pip setuptools wheel
+RUN pip3 install --upgrade pip setuptools wheel
 
 # Install Rust for building `cryptography` python package when bootstraping pigweed
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/projects/connectedhomeip/Dockerfile
+++ b/projects/connectedhomeip/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && \
 		libavahi-client-dev ninja-build python3-venv python3-dev python3-pip \
 		unzip libgirepository1.0-dev libcairo2-dev libreadline-dev
 
-# PIP517 needed for cryptography. Update pip
+# PEP-517 needed for cryptography. Update pip
 RUN pip install --upgrade pip setuptools wheel
 
 # Install Rust for building `cryptography` python package when bootstraping pigweed

--- a/projects/connectedhomeip/Dockerfile
+++ b/projects/connectedhomeip/Dockerfile
@@ -23,6 +23,10 @@ RUN apt-get update && \
 		libavahi-client-dev ninja-build python3-venv python3-dev python3-pip \
 		unzip libgirepository1.0-dev libcairo2-dev libreadline-dev
 
+# Ensure python that was just installed gets precedence over
+# the one already installed in /usr/local/bin
+ENV PATH="/usr/bin/:${PATH}"
+
 # PEP-517 needed for cryptography. Update pip
 RUN pip3 install --upgrade pip setuptools wheel
 


### PR DESCRIPTION
This fixes the CHIP build, since python cryptography requires PEP 517 which in turn requires a more recent pip. Several issues seem to have compounded here:

- cryptography requires PEP517, basically needing a newer pip
- oss-fuzz docker image has 2 pythons installed (/usr/bin and /usr/local/bin)
- oss-fuzz deactivates the build environment for the actual build, losing some python setup

Changes:
  - upgrade pip
  - ensure `/usr/bin` takes precedence over `/usr/local/bin` to use the right updated python
  - install build requirements since the build script seems to deactivate the chip build environment (and that breaks ninja build requirements)
