### PR TITLE
[inih] initial integration

### DIFF
--- a/projects/inih/Dockerfile
+++ b/projects/inih/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update
+RUN git clone https://github.com/0x34d/inih
+COPY build.sh $SRC/
+WORKDIR $SRC/inih/

--- a/projects/inih/build.sh
+++ b/projects/inih/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+pushd fuzzing/
+bash oss-fuzz.sh
+cp inihfuzz $OUT/
+popd
+
+zip -r inihfuzz_seed_corpus.zip tests/*.ini
+mv inihfuzz_seed_corpus.zip $OUT/

--- a/projects/inih/project.yaml
+++ b/projects/inih/project.yaml
@@ -1,0 +1,14 @@
+homepage: "https://github.com/benhoyt/inih"
+language: c
+primary_contact: "benhoyt@gmail.com"
+auto_ccs:
+  - "ajsinghyadav00@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+sanitizers:
+  - address
+  - memory
+  - undefined
+main_repo: 'https://github.com/benhoyt/inih'


### PR DESCRIPTION
Old PR: https://github.com/google/oss-fuzz/pull/1525
My inih PR: https://github.com/benhoyt/inih/pull/153


IniH is a default library for INI parsing in Red Hat based systems. It is installed by default in Fedora for parsing INI files. 
According to program, it is also used in embedded systems.


Can the OSS-Fuzz team accept this project for mainstream fuzzing?