### PR TITLE
[libecc] Support SM2, SM3

### DIFF
--- a/projects/libecc/Dockerfile
+++ b/projects/libecc/Dockerfile
@@ -21,7 +21,7 @@ RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone https://github.com/wolfssl/wolfssl
 RUN git clone --depth 1 https://github.com/wolfssl/wolfsm
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
-RUN wget -q --no-check-certificate https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz
+RUN wget -q https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz
 RUN test "$(sha256sum gmp-6.2.1.tar.lz)" = "2c7f4f0d370801b2849c48c9ef3f59553b5f1d3791d070cffb04599f9fc67b41  gmp-6.2.1.tar.lz"
 RUN wget -q https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 COPY build.sh $SRC/

--- a/projects/libecc/Dockerfile
+++ b/projects/libecc/Dockerfile
@@ -19,10 +19,11 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool wget pyt
 RUN git clone --depth 1 --branch cryptofuzz https://github.com/libecc/libecc.git
 RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone https://github.com/wolfssl/wolfssl
+RUN git clone --depth 1 https://github.com/wolfssl/wolfsm
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
-RUN wget --no-check-certificate https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz
+RUN wget -q --no-check-certificate https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz
 RUN test "$(sha256sum gmp-6.2.1.tar.lz)" = "2c7f4f0d370801b2849c48c9ef3f59553b5f1d3791d070cffb04599f9fc67b41  gmp-6.2.1.tar.lz"
-RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
+RUN wget -q https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 COPY build.sh $SRC/
 # This is to fix Fuzz Introspector build by using LLVM old pass manager
 # re https://github.com/ossf/fuzz-introspector/issues/305

--- a/projects/libecc/build.sh
+++ b/projects/libecc/build.sh
@@ -66,15 +66,19 @@ export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_LIBGMP"
 export LIBGMP_INCLUDE_PATH=$(realpath .)
 export LIBGMP_A_PATH=$(realpath .libs/libgmp.a)
 
+# Install support for wolfCrypt SM algorithms
+cd $SRC/wolfsm/
+./install.sh
+
 # Compile wolfSSL
 cd $SRC/wolfssl/
 # Checkout at commit that's known to be bug-free
-git checkout 37aada031350a36143fcfdf188e0eeaa9b05366e
+git checkout a96983e6d38e8d093892dd9e5d58b72753bac3ac
 # Note (to self):
 # Compiling wolfCrypt with SP math instead of normal math due to symbol collisions (specifically fp_* functions) between libecc and wolfCrypt otherwise.
 export CFLAGS="$CFLAGS -DHAVE_AES_ECB -DWOLFSSL_DES_ECB -DHAVE_ECC_SECPR2 -DHAVE_ECC_SECPR3 -DHAVE_ECC_BRAINPOOL -DHAVE_ECC_KOBLITZ -DWOLFSSL_ECDSA_SET_K -DWOLFSSL_ECDSA_SET_K_ONE_LOOP -DWOLFSSL_SP_INT_NEGATIVE"
 autoreconf -ivf
-export WOLFCRYPT_CONFIGURE_PARAMS="--enable-static --enable-md2 --enable-md4 --enable-ripemd --enable-blake2 --enable-blake2s --enable-pwdbased --enable-scrypt --enable-hkdf --enable-cmac --enable-arc4 --enable-camellia --enable-aesccm --enable-aesctr --enable-xts --enable-des3 --enable-x963kdf --enable-harden --enable-aescfb --enable-aesofb --enable-aeskeywrap --enable-aessiv --enable-keygen --enable-curve25519 --enable-curve448 --enable-shake256 --disable-crypttests --disable-examples --enable-compkey --enable-ed448 --enable-ed25519 --enable-ecccustcurves --enable-xchacha --enable-cryptocb --enable-eccencrypt --enable-smallstack --enable-ed25519-stream --enable-ed448-stream --enable-sp-math-all --enable-aesgcm-stream --enable-shake128 --enable-siphash"
+export WOLFCRYPT_CONFIGURE_PARAMS="--enable-static --enable-md2 --enable-md4 --enable-ripemd --enable-blake2 --enable-blake2s --enable-pwdbased --enable-scrypt --enable-hkdf --enable-cmac --enable-arc4 --enable-camellia --enable-aesccm --enable-aesctr --enable-xts --enable-des3 --enable-x963kdf --enable-harden --enable-aescfb --enable-aesofb --enable-aeskeywrap --enable-aessiv --enable-keygen --enable-curve25519 --enable-curve448 --enable-shake256 --disable-crypttests --disable-examples --enable-compkey --enable-ed448 --enable-ed25519 --enable-ecccustcurves --enable-xchacha --enable-cryptocb --enable-eccencrypt --enable-smallstack --enable-ed25519-stream --enable-ed448-stream --enable-sp-math-all --enable-aesgcm-stream --enable-shake128 --enable-siphash --enable-sm2 --enable-sm3"
 if [[ $CFLAGS = *sanitize=memory* ]]
 then
     export WOLFCRYPT_CONFIGURE_PARAMS="$WOLFCRYPT_CONFIGURE_PARAMS -disable-asm"


### PR DESCRIPTION
Compile wolfCrypt (which serves as an oracle to libecc) with support for the SM2 and SM3 algorithms.

Also make wget quiet