### PR TITLE
[go-dhcp] initial integration

### DIFF
--- a/projects/go-dhcp/Dockerfile
+++ b/projects/go-dhcp/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/insomniacslk/dhcp.git
+RUN go install github.com/AdamKorcz/go-118-fuzz-build@latest
+COPY build.sh $SRC/
+WORKDIR $SRC/dhcp

--- a/projects/go-dhcp/build.sh
+++ b/projects/go-dhcp/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -eu
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+go get github.com/AdamKorcz/go-118-fuzz-build/testing
+
+go get github.com/stretchr/testify/assert@v1.6.1
+sed -i '58s/^/\/\//g' dhcpv6/dhcpv6_test.go
+
+compile_native_go_fuzzer github.com/insomniacslk/dhcp/dhcpv4       FuzzDHCPv4    fuzz_DHCPv4
+compile_native_go_fuzzer github.com/insomniacslk/dhcp/dhcpv6       FuzzDHCPv6    fuzz_DHCPv6
+compile_native_go_fuzzer github.com/insomniacslk/dhcp/rfc1035label FuzzLabel     fuzz_Label

--- a/projects/go-dhcp/project.yaml
+++ b/projects/go-dhcp/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/insomniacslk/dhcp"
+language: go
+primary_contact: "insomniac@slackware.it"
+auto_ccs:
+  - "ajsinghyadav00@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+main_repo: "https://github.com/insomniacslk/dhcp.git"


### PR DESCRIPTION
The DHCP library is used by many [PublicProjects](https://github.com/insomniacslk/dhcp#public-projects-that-use-it).

Merged PR : https://github.com/insomniacslk/dhcp/pull/508


My Proposal https://github.com/insomniacslk/dhcp/pull/508#discussion_r1268886577