### PR TITLE
powerdns: Fix the build on old branches

### DIFF
--- a/projects/powerdns/build.sh
+++ b/projects/powerdns/build.sh
@@ -34,7 +34,10 @@ autoreconf -vi
     --enable-fuzz-targets \
     --disable-dependency-tracking \
     --disable-silent-rules || /bin/bash
-make -j$(nproc) -C ext/arc4random/
+
+if [ -d ext/arc4random/ ]; then
+    make -j$(nproc) -C ext/arc4random/
+fi
 make -j$(nproc) -C ext/yahttp/
 cd pdns
 make -j$(nproc) fuzz_targets


### PR DESCRIPTION
Branches for stable versions do not have the ext/arc4random directory so they no longer build properly.