### PR TITLE
[lua] read a list of files via stdin

### DIFF
--- a/projects/lua/build.sh
+++ b/projects/lua/build.sh
@@ -78,6 +78,8 @@ git config --global --add safe.directory '*'
 cmake "${cmake_args[@]}" -S . -B build -G Ninja
 cmake --build build --parallel
 
+cp corpus_dir/*.options $OUT/
+
 # Archive and copy to $OUT seed corpus if the build succeeded.
 for f in $(find build/tests/ -name '*_test' -type f);
 do

--- a/projects/lua/build.sh
+++ b/projects/lua/build.sh
@@ -90,5 +90,5 @@ do
   if [ -e "$dict_path" ]; then
     cp $dict_path "$OUT/$name.dict"
   fi
-  [[ -e $corpus_dir ]] && zip -j $OUT/"$name"_seed_corpus.zip $corpus_dir/*
+  [[ -e $corpus_dir ]] && find "$corpus_dir" -mindepth 1 -maxdepth 1 | zip -@ -j $OUT/"$name"_seed_corpus.zip
 done


### PR DESCRIPTION
Corpus for test lua_loadbuffer_proto is huge, it contains about 80k files and zip reports an error on compression: `/usr/bin/zip: Argument list too long`. The patch fixes that by passing a list of files via stdin.

Disable leak detection: 
- https://github.com/ligurio/lua-c-api-tests/issues/25
- https://github.com/ligurio/lua-c-api-tests/issues/28