### PR TITLE
Remove workaround for gmp download

### DIFF
--- a/projects/bignum-fuzzer/Dockerfile
+++ b/projects/bignum-fuzzer/Dockerfile
@@ -36,6 +36,6 @@ RUN git clone --depth 1 https://github.com/guidovranken/bignum-fuzzer
 RUN git clone --depth 1 https://github.com/openssl/openssl
 RUN git clone https://boringssl.googlesource.com/boringssl
 RUN hg clone https://gmplib.org/repo/gmp/ libgmp/ || \
-    (wget --no-check-certificate 'https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz' && tar xf gmp-6.2.1.tar.lz && mv $SRC/gmp-6.2.1/ $SRC/libgmp/)
+    (wget 'https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz' && tar xf gmp-6.2.1.tar.lz && mv $SRC/gmp-6.2.1/ $SRC/libgmp/)
 
 COPY build.sh $SRC/

--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -46,7 +46,7 @@ RUN git clone --depth 1 https://github.com/jedisct1/libsodium.git
 RUN git clone --depth 1 https://github.com/libtom/libtomcrypt.git
 RUN git clone --depth 1 https://github.com/microsoft/SymCrypt.git
 RUN hg clone https://gmplib.org/repo/gmp/ libgmp/ || \
-    (wget --no-check-certificate 'https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz' && tar xf gmp-6.2.1.tar.lz && mv $SRC/gmp-6.2.1/ $SRC/libgmp/)
+    (wget 'https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz' && tar xf gmp-6.2.1.tar.lz && mv $SRC/gmp-6.2.1/ $SRC/libgmp/)
 RUN wget https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.5.1.tar.gz
 RUN git clone --depth 1 https://github.com/indutny/bn.js.git
 RUN git clone --depth 1 https://github.com/MikeMcl/bignumber.js.git

--- a/projects/libressl/Dockerfile
+++ b/projects/libressl/Dockerfile
@@ -23,7 +23,7 @@ RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora
 RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
 RUN git clone --depth 1 https://github.com/randombit/botan.git
-RUN wget --no-check-certificate https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz
+RUN wget https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz
 RUN test "$(sha256sum gmp-6.2.1.tar.lz)" = "2c7f4f0d370801b2849c48c9ef3f59553b5f1d3791d070cffb04599f9fc67b41  gmp-6.2.1.tar.lz"
 WORKDIR libressl
 RUN ./update.sh

--- a/projects/nettle/Dockerfile
+++ b/projects/nettle/Dockerfile
@@ -21,7 +21,7 @@ RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora
 RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2
-RUN wget --no-check-certificate https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz
+RUN wget https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz
 RUN test "$(sha256sum gmp-6.2.1.tar.lz)" = "2c7f4f0d370801b2849c48c9ef3f59553b5f1d3791d070cffb04599f9fc67b41  gmp-6.2.1.tar.lz"
 COPY build.sh $SRC/
 # This is to fix Fuzz Introspector build by using LLVM old pass manager


### PR DESCRIPTION
At some point we downloaded gmp from gmplib.org which had expired certificates for a while. Now that we're not downloading from gmplib.org, this is no longer needed.