### PR TITLE
Fix apache poi

### DIFF
--- a/projects/apache-poi/Dockerfile
+++ b/projects/apache-poi/Dockerfile
@@ -22,6 +22,18 @@ rm -rf maven.zip
 
 ENV MVN $SRC/maven-3.6.3/apache-maven-3.6.3/bin/mvn
 
+RUN wget https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u382-b05/OpenJDK8U-jdk_x64_linux_hotspot_8u382b05.tar.gz && \
+  tar xvf OpenJDK8U-jdk_x64_linux_hotspot_8u382b05.tar.gz && \
+  rm -rf OpenJDK8U-jdk_x64_linux_hotspot_8u382b05.tar.gz
+
+ENV JAVA_HOME_8 $SRC/jdk8u382-b05
+
+RUN wget https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20%2B8/OpenJDK11U-jdk_x64_linux_hotspot_11.0.20_8.tar.gz && \
+  tar xvf OpenJDK11U-jdk_x64_linux_hotspot_11.0.20_8.tar.gz && \
+  rm -rf OpenJDK11U-jdk_x64_linux_hotspot_11.0.20_8.tar.gz
+
+ENV JAVA_HOME_11 $SRC/jdk-11.0.20+8
+
 WORKDIR ${SRC}
 #
 # clone repository

--- a/projects/apache-poi/Dockerfile
+++ b/projects/apache-poi/Dockerfile
@@ -38,7 +38,7 @@ WORKDIR ${SRC}
 #
 # clone repository
 #
-RUN git clone https://github.com/apache/poi.git
+RUN git clone --depth 1 https://github.com/apache/poi.git
 
 ADD pom.xml build.sh ${SRC}/
 ADD src/ ${SRC}/src/

--- a/projects/apache-poi/build.sh
+++ b/projects/apache-poi/build.sh
@@ -40,7 +40,7 @@ popd
 
 pushd "${SRC}/${LIBRARY_NAME}"
 	./gradlew publishToMavenLocal ${GRADLE_FLAGS}
-	CURRENT_VERSION=$(./gradlew properties --console=plain | sed -nr "s/^version:\ (.*)/\1/p")
+	CURRENT_VERSION=$(./gradlew properties --console=plain ${GRADLE_FLAGS} | sed -nr "s/^version:\ (.*)/\1/p")
 popd
 
 pushd "${SRC}"

--- a/projects/apache-poi/build.sh
+++ b/projects/apache-poi/build.sh
@@ -18,7 +18,16 @@
 MVN_FLAGS="-DskipTests"
 ALL_JARS=""
 LIBRARY_NAME="poi"
-GRADLE_FLAGS="-x javadoc -x test -Dfile.encoding=UTF-8"
+GRADLE_FLAGS="-x javadoc -x test -Dfile.encoding=UTF-8 -Porg.gradle.java.installations.fromEnv=JAVA_HOME_8,JAVA_HOME_11"
+
+echo Main Java
+${JAVA_HOME}/bin/java -version
+
+echo Java 8
+${JAVA_HOME_8}/bin/java -version
+
+echo Java 11
+${JAVA_HOME_11}/bin/java -version
 
 # Install the build servers' jazzer-api into the maven repository.
 pushd "/tmp"
@@ -61,12 +70,12 @@ for fuzzer in $(find ${SRC} -name '*Fuzzer.java'); do
 	if (echo ${stripped_path} | grep ".java$"); then
 		continue;
 	fi
-	
+
 	fuzzer_basename=$(basename -s .java $fuzzer)
 	fuzzer_classname=$(echo ${stripped_path} | sed 's|/|.|g');
-	
+
 	# Create an execution wrapper that executes Jazzer with the correct arguments.
-	
+
 	echo "#!/bin/sh
 # LLVMFuzzerTestOneInput Magic String required for infra/base-images/base-runner/test_all.py. DO NOT REMOVE
 

--- a/projects/apache-poi/src/main/java/org/apache/poi/XLSX2CSVFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/XLSX2CSVFuzzer.java
@@ -11,8 +11,8 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.poi.openxml4j.exceptions.OpenXML4JException;
 import org.apache.poi.openxml4j.opc.OPCPackage;
-import org.apache.commons.compress.archivers.dump.InvalidFormatException;
 import org.apache.poi.examples.xssf.eventusermodel.XLSX2CSV;
+import org.apache.poi.util.RecordFormatException;
 import org.xml.sax.SAXException;
 
 public class XLSX2CSVFuzzer {
@@ -32,18 +32,10 @@ public class XLSX2CSVFuzzer {
             OPCPackage p = OPCPackage.open(in);
             XLSX2CSV xlsx2csv = new XLSX2CSV(p, out, 5);
             xlsx2csv.process();
-        } catch (OpenXML4JException ex) {
+        } catch (IOException | OpenXML4JException | SAXException ex) {
             /* documented, ignore. */
-        } catch (SAXException ex) {
-            /* documented, ignore. */
-        } catch (InvalidFormatException ex) {
-            /* documented, ignore. */
-        } catch (UnsupportedFileFormatException ex) {
+        } catch (UnsupportedFileFormatException | RecordFormatException | EmptyFileException ex) {
             /* not so documented ... */
-        } catch (IOException ex) {
-
-        } catch (EmptyFileException ex) {
-
         }
 
     }

--- a/projects/apache-poi/src/main/java/org/apache/poi/XLSX2CSVFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/XLSX2CSVFuzzer.java
@@ -1,3 +1,19 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
 package org.apache.poi;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -17,7 +33,7 @@ import org.xml.sax.SAXException;
 
 public class XLSX2CSVFuzzer {
 
-    private FuzzedDataProvider fuzzedDataProvider;
+    private final FuzzedDataProvider fuzzedDataProvider;
 
     public XLSX2CSVFuzzer(FuzzedDataProvider fuzzedDataProvider) {
         this.fuzzedDataProvider = fuzzedDataProvider;
@@ -28,7 +44,7 @@ public class XLSX2CSVFuzzer {
             final ByteArrayOutputStream baos = new ByteArrayOutputStream();
             PrintStream out = new PrintStream(baos, true, StandardCharsets.UTF_8.name());
             String string = fuzzedDataProvider.consumeRemainingAsString();
-            InputStream in = new ByteArrayInputStream(string.getBytes("UTF-8"));
+            InputStream in = new ByteArrayInputStream(string.getBytes(StandardCharsets.UTF_8));
             OPCPackage p = OPCPackage.open(in);
             XLSX2CSV xlsx2csv = new XLSX2CSV(p, out, 5);
             xlsx2csv.process();


### PR DESCRIPTION
The initial fuzzing of Apache POI seems to be broken (or did not work at all until now).

This PR adds the necessary versions of JDK 8 and 11 for building Apache POI.

They also adjust the fuzz-target slightly to not quickly fail during fuzzing due to another type of
"expected" exception.

Also the checkout can be done shallow to reduce the amount of downloaded data.

This hopefully closes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=56337&can=1&q=poi (and maybe https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=54562&can=1&q=poi as well)