### PR TITLE
Minor fix `project_experiment.py`

### DIFF
--- a/infra/build/functions/project_experiment.py
+++ b/infra/build/functions/project_experiment.py
@@ -84,8 +84,7 @@ def run_experiment(project_name, command, output_path, experiment_name):
           'args': [
               '-m',
               'cp',
-              '-r',
-              '/workspace/out',
+              '/workspace/out/*',
               output_path,
           ]
       },


### PR DESCRIPTION
Copy the content in `/workspace/out/` only.
No need to copy the parent `out` directory level.