### PR TITLE
Fix building CPython after python/cpython#107026

### DIFF
--- a/projects/cpython3/build.sh
+++ b/projects/cpython3/build.sh
@@ -27,6 +27,9 @@ CFLAGS=${CFLAGS//"-pthread"/}
 # earlier if those fire.
 CFLAGS="${CFLAGS} -UNDEBUG"
 
+# We use some internal CPython API.
+CFLAGS="${CFLAGS} -IInclude/internal/"
+
 FLAGS=()
 case $SANITIZER in
   address)


### PR DESCRIPTION
`Modules/_xxtestfuzz/fuzzer.c` in CPython started using private API in https://github.com/python/cpython/commit/89f987544860d1360e6232b6f52b8ced92a4d690#diff-a22ac7579f23068e0c6bcacf1086ee962fdf8e68725cf0510b42d0a389cf1efd.

This made fuzzing builds fail https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=60831.

Including needed header files fixes the error.