### PR TITLE
immer: install pkg-config & Catch2

### DIFF
--- a/projects/immer/Dockerfile
+++ b/projects/immer/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y cmake libgc-dev
+RUN apt-get update && apt-get install -y cmake libgc-dev pkg-config
 # install Catch2 from sources, since Ubuntu 20.04 (currently the base for
 # this image) does not ship it
 RUN git clone -b v2.x --depth 1 https://github.com/catchorg/Catch2.git && \

--- a/projects/immer/Dockerfile
+++ b/projects/immer/Dockerfile
@@ -16,6 +16,13 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y cmake libgc-dev
+# install Catch2 from sources, since Ubuntu 20.04 (currently the base for
+# this image) does not ship it
+RUN git clone -b v2.x --depth 1 https://github.com/catchorg/Catch2.git && \
+    cd Catch2 && \
+    cmake -DCATCH_BUILD_TESTING=OFF -DCATCH_BUILD_EXAMPLES=OFF -DCATCH_ENABLE_COVERAGE=OFF -DCATCH_ENABLE_WERROR=OFF -DCATCH_INSTALL_DOCS=OFF -DCATCH_INSTALL_HELPERS=OFF -Bbuild && \
+    cmake --build build && \
+    cmake --build build --target install
 RUN git clone --depth 1 https://github.com/arximboldi/immer.git immer
 WORKDIR immer
 COPY build.sh $SRC/


### PR DESCRIPTION
- install pkg-config, available as distro package
- install Catch2 from sources, as it is not available in Ubuntu 20.04