### PR TITLE
Link "fixed" C to C++ targets with libc++.

### DIFF
--- a/infra/base-images/base-builder/build_jcc.bash
+++ b/infra/base-images/base-builder/build_jcc.bash
@@ -19,3 +19,5 @@
 go build jcc.go
 cp jcc clang
 cp jcc clang++
+gsutil cp jcc gs://clusterfuzz-builds/jcc/clang++
+gsutil cp jcc gs://clusterfuzz-builds/jcc/clang

--- a/infra/base-images/base-builder/jcc.go
+++ b/infra/base-images/base-builder/jcc.go
@@ -54,7 +54,9 @@ func TryFixCCompilation(cmdline []string) bool {
 	if newFile == "" {
 		return false
 	}
-	cmd := exec.Command("clang++", cmdline...)
+	newCmdline := []string{"-stdlib=libc++"}
+	newCmdline = append(cmdline, newCmdline...)
+	cmd := exec.Command("clang++", newCmdline...)
 	var outb, errb bytes.Buffer
 	cmd.Stdout = &outb
 	cmd.Stderr = &errb


### PR DESCRIPTION
Otherwise results in a linking error.