### PR TITLE
Fix libjxl

### DIFF
--- a/projects/libjxl/Dockerfile
+++ b/projects/libjxl/Dockerfile
@@ -20,7 +20,10 @@ RUN apt-get update && apt-get install -y cmake ninja-build pkg-config \
 RUN git clone --depth 1 https://github.com/libjxl/libjxl.git
 # We only need these sub-projects for the fuzzers.
 RUN git -C libjxl submodule update --init --recommend-shallow \
-  third_party/highway third_party/skcms third_party/brotli
+  third_party/brotli \
+  third_party/highway \
+  third_party/libjpeg-turbo \
+  third_party/skcms
 RUN git clone --depth 1 https://github.com/libjpeg-turbo/seed-corpora
 
 WORKDIR libjxl


### PR DESCRIPTION
jpegli fuzzer target now depends on third_party/libjpeg-turbo files