### PR TITLE
Apache poi more fuzz targets

### DIFF
--- a/projects/apache-poi/pom.xml
+++ b/projects/apache-poi/pom.xml
@@ -41,6 +41,16 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>
+			<artifactId>poi-ooxml</artifactId>
+			<version>${fuzzedLibaryVersion}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.poi</groupId>
+			<artifactId>poi-scratchpad</artifactId>
+			<version>${fuzzedLibaryVersion}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-examples</artifactId>
 			<version>${fuzzedLibaryVersion}</version>
 		</dependency>

--- a/projects/apache-poi/project.yaml
+++ b/projects/apache-poi/project.yaml
@@ -14,4 +14,4 @@ vendor_ccs:
   - "schaich@code-intelligence.com"
   - "bug-disclosure@code-intelligence.com"
   - "centic@apache.org"
-  - "dominik.stadler@gmx.at"
+  - "dominik.stadler@gmail.com"

--- a/projects/apache-poi/src/main/java/org/apache/poi/EncryptDecryptFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/EncryptDecryptFuzzer.java
@@ -1,0 +1,99 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package org.apache.poi;
+
+import static org.apache.poi.poifs.crypt.Decryptor.DEFAULT_POIFS_ENTRY;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.GeneralSecurityException;
+import java.util.Arrays;
+
+import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
+import org.apache.poi.poifs.crypt.Decryptor;
+import org.apache.poi.poifs.crypt.EncryptionInfo;
+import org.apache.poi.poifs.crypt.EncryptionMode;
+import org.apache.poi.poifs.crypt.Encryptor;
+import org.apache.poi.poifs.filesystem.DocumentInputStream;
+import org.apache.poi.poifs.filesystem.POIFSFileSystem;
+import org.apache.poi.util.HexDump;
+import org.apache.poi.util.IOUtils;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+public class EncryptDecryptFuzzer {
+	public static void fuzzerTestOneInput(FuzzedDataProvider data) throws IOException, GeneralSecurityException {
+		try {
+			EncryptionMode encryptionMode = EncryptionMode.values()[(data.consumeInt(0, EncryptionMode.values().length - 1))];
+			String password = data.consumeString(20);
+			byte[] testData = data.consumeRemainingAsBytes();
+
+			EncryptionInfo infoEnc = new EncryptionInfo(encryptionMode);
+			Encryptor enc = infoEnc.getEncryptor();
+			enc.confirmPassword(password);
+
+			byte[] encData;
+			byte[] encDocument;
+			try (POIFSFileSystem fsEnc = new POIFSFileSystem()) {
+				try (OutputStream os = enc.getDataStream(fsEnc)) {
+					os.write(testData);
+				}
+
+				UnsynchronizedByteArrayOutputStream bos = UnsynchronizedByteArrayOutputStream.builder().get();
+				fsEnc.writeFilesystem(bos);
+
+				bos.close();
+				encData = bos.toByteArray();
+
+				DocumentInputStream dis = fsEnc.getRoot().createDocumentInputStream(DEFAULT_POIFS_ENTRY);
+				/*long _length =*/
+				dis.readLong();
+				encDocument = IOUtils.toByteArray(dis);
+			}
+
+			byte[] actualData;
+			try (POIFSFileSystem fsDec = new POIFSFileSystem(new ByteArrayInputStream(encData))) {
+				EncryptionInfo infoDec = new EncryptionInfo(fsDec);
+				Decryptor dec = infoDec.getDecryptor();
+				if (!dec.verifyPassword(password)) {
+					throw new IllegalStateException("Could not verify password when decrypting " + password + "\n" +
+							HexDump.dump(testData, 0, 0) + " and encrypted \n" +
+							HexDump.dump(encDocument, 0, 0) + " full encrypted \n" +
+							HexDump.dump(encData, 0, 0));
+				}
+				InputStream is = dec.getDataStream(fsDec);
+
+				actualData = IOUtils.toByteArray(is);
+				is.close();
+			}
+
+			// input-data and resulting decrypted data should be equal
+			if (!Arrays.equals(testData, actualData)) {
+				throw new IllegalStateException("Resulting array was not equal to input-array, "
+						+ "having " + testData.length + " bytes, had actual length " + actualData.length + " and expected \n" +
+						HexDump.dump(testData, 0, 0) + " and actual \n" +
+						HexDump.dump(actualData, 0, 0) + " encrypted \n" +
+						HexDump.dump(encDocument, 0, 0) + " full encrypted \n" +
+						HexDump.dump(encData, 0, 0));
+			}
+		} catch (IOException | EncryptedDocumentException e) {
+			// expected, e.g. when something is not supported
+		}
+	}
+}

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIFuzzer.java
@@ -1,0 +1,157 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package org.apache.poi;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.BufferUnderflowException;
+import java.util.NoSuchElementException;
+
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.poi.extractor.ExtractorFactory;
+import org.apache.poi.extractor.POIOLE2TextExtractor;
+import org.apache.poi.extractor.POITextExtractor;
+import org.apache.poi.hslf.exceptions.HSLFException;
+import org.apache.poi.hssf.record.RecordInputStream;
+import org.apache.poi.ooxml.POIXMLException;
+import org.apache.poi.ooxml.extractor.POIXMLPropertiesTextExtractor;
+import org.apache.poi.ooxml.extractor.POIXMLTextExtractor;
+import org.apache.poi.openxml4j.exceptions.OpenXML4JRuntimeException;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.apache.poi.util.DocumentFormatException;
+import org.apache.poi.util.RecordFormatException;
+
+/**
+ * This class provides a simple target for fuzzing Apache POI with Jazzer.
+ *
+ * It uses the byte-array to call various method which parse the various
+ * supported file-formats.
+ *
+ * It catches all exceptions that are currently expected.
+ *
+ * Some are marked as to-do where Apache POI should actually do
+ * exception handling differently, e.g. wrapping internal exceptions
+ * or providing more explicit exceptions instead of general RuntimeExceptions
+ */
+public class POIFuzzer {
+	public static void fuzzerTestOneInput(byte[] input) {
+		// try to invoke various methods which parse documents/workbooks/slide-shows/...
+
+		fuzzAny(input);
+
+		POIHDGFFuzzer.fuzzerTestOneInput(input);
+
+		POIHMEFFuzzer.fuzzerTestOneInput(input);
+
+		POIHPBFFuzzer.fuzzerTestOneInput(input);
+
+		POIHPSFFuzzer.fuzzerTestOneInput(input);
+
+		POIHSLFFuzzer.fuzzerTestOneInput(input);
+
+		POIHSSFFuzzer.fuzzerTestOneInput(input);
+
+		POIHWPFFuzzer.fuzzerTestOneInput(input);
+
+		POIOldExcelFuzzer.fuzzerTestOneInput(input);
+
+		POIVisioFuzzer.fuzzerTestOneInput(input);
+
+		//XLSX2CSVFuzzer.fuzzerTestOneInput(input);
+
+		POIXSLFFuzzer.fuzzerTestOneInput(input);
+
+		POIXSSFFuzzer.fuzzerTestOneInput(input);
+
+		POIXWPFFuzzer.fuzzerTestOneInput(input);
+	}
+
+	public static void fuzzAny(byte[] input) {
+		try (Workbook wb = WorkbookFactory.create(new ByteArrayInputStream(input))) {
+			for (Sheet sheet : wb) {
+				for (Row row : sheet) {
+					for (Cell cell : row) {
+						cell.getAddress();
+						cell.getCellType();
+					}
+				}
+			}
+
+			wb.write(NullOutputStream.INSTANCE);
+		} catch (IOException | POIXMLException | IllegalArgumentException | RecordFormatException |
+				 IndexOutOfBoundsException | HSLFException | RecordInputStream.LeftoverDataException |
+				 IllegalStateException | BufferUnderflowException | OpenXML4JRuntimeException |
+				UnsupportedOperationException | NoSuchElementException | NegativeArraySizeException e) {
+			// expected here
+		}
+
+		ExtractorFactory.setThreadPrefersEventExtractors(true);
+		checkExtractor(input);
+		ExtractorFactory.setAllThreadsPreferEventExtractors(false);
+		checkExtractor(input);
+	}
+
+	public static void checkExtractor(byte[] input) {
+		try (POITextExtractor extractor = ExtractorFactory.createExtractor(new ByteArrayInputStream(input))) {
+			checkExtractor(extractor);
+		} catch (IOException | POIXMLException | IllegalArgumentException | RecordFormatException |
+				 IndexOutOfBoundsException | HSLFException | RecordInputStream.LeftoverDataException |
+				 NoSuchElementException | IllegalStateException | ArithmeticException |
+				 BufferUnderflowException | UnsupportedOperationException | DocumentFormatException |
+				NegativeArraySizeException e) {
+			// expected here
+		}
+	}
+
+	public static void checkExtractor(POITextExtractor extractor) throws IOException {
+		extractor.getDocument();
+		extractor.getFilesystem();
+		extractor.getMetadataTextExtractor();
+		extractor.getText();
+
+		if (extractor instanceof POIOLE2TextExtractor) {
+			POIOLE2TextExtractor ole2Extractor = (POIOLE2TextExtractor) extractor;
+			ole2Extractor.getRoot();
+			ole2Extractor.getSummaryInformation();
+			ole2Extractor.getDocSummaryInformation();
+
+			POITextExtractor[] embedded = ExtractorFactory.getEmbeddedDocsTextExtractors(ole2Extractor);
+			for (POITextExtractor poiTextExtractor : embedded) {
+				poiTextExtractor.getText();
+				poiTextExtractor.getDocument();
+				poiTextExtractor.getFilesystem();
+				POITextExtractor metaData = poiTextExtractor.getMetadataTextExtractor();
+				metaData.getFilesystem();
+				metaData.getText();
+			}
+		} else if (extractor instanceof POIXMLTextExtractor) {
+			POIXMLTextExtractor xmlExtractor = (POIXMLTextExtractor) extractor;
+			xmlExtractor.getCoreProperties();
+			xmlExtractor.getCustomProperties();
+			xmlExtractor.getExtendedProperties();
+			POIXMLPropertiesTextExtractor metaData = xmlExtractor.getMetadataTextExtractor();
+			metaData.getFilesystem();
+			metaData.getText();
+
+			xmlExtractor.getPackage();
+		}
+	}
+}

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIFuzzer.java
@@ -39,18 +39,6 @@ import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.apache.poi.util.DocumentFormatException;
 import org.apache.poi.util.RecordFormatException;
 
-/**
- * This class provides a simple target for fuzzing Apache POI with Jazzer.
- *
- * It uses the byte-array to call various method which parse the various
- * supported file-formats.
- *
- * It catches all exceptions that are currently expected.
- *
- * Some are marked as to-do where Apache POI should actually do
- * exception handling differently, e.g. wrapping internal exceptions
- * or providing more explicit exceptions instead of general RuntimeExceptions
- */
 public class POIFuzzer {
 	public static void fuzzerTestOneInput(byte[] input) {
 		// try to invoke various methods which parse documents/workbooks/slide-shows/...
@@ -75,7 +63,7 @@ public class POIFuzzer {
 
 		POIVisioFuzzer.fuzzerTestOneInput(input);
 
-		//XLSX2CSVFuzzer.fuzzerTestOneInput(input);
+		XLSX2CSVFuzzer.fuzzerTestOneInput(input);
 
 		POIXSLFFuzzer.fuzzerTestOneInput(input);
 

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIHDGFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIHDGFFuzzer.java
@@ -1,0 +1,44 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package org.apache.poi;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.BufferUnderflowException;
+import java.util.NoSuchElementException;
+
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.poi.hdgf.HDGFDiagram;
+import org.apache.poi.hdgf.extractor.VisioTextExtractor;
+import org.apache.poi.poifs.filesystem.POIFSFileSystem;
+import org.apache.poi.util.RecordFormatException;
+
+public class POIHDGFFuzzer {
+	public static void fuzzerTestOneInput(byte[] input) {
+		try (HDGFDiagram visio = new HDGFDiagram(new POIFSFileSystem(new ByteArrayInputStream(input)))) {
+			visio.write(NullOutputStream.INSTANCE);
+
+			try (VisioTextExtractor extractor = new VisioTextExtractor(visio)) {
+				POIFuzzer.checkExtractor(extractor);
+			}
+		} catch (IOException | IllegalArgumentException | IllegalStateException | RecordFormatException |
+				 IndexOutOfBoundsException | BufferUnderflowException | ArithmeticException |
+				 NoSuchElementException e) {
+			// expected here
+		}
+	}
+}

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIHMEFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIHMEFFuzzer.java
@@ -1,0 +1,42 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package org.apache.poi;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.apache.poi.hmef.HMEFMessage;
+import org.apache.poi.util.RecordFormatException;
+
+public class POIHMEFFuzzer {
+	public static void fuzzerTestOneInput(byte[] input) {
+		try {
+			HMEFMessage msg = new HMEFMessage(new ByteArrayInputStream(input));
+			//noinspection ResultOfMethodCallIgnored
+			msg.getAttachments();
+			msg.getBody();
+			//noinspection ResultOfMethodCallIgnored
+			msg.getMessageAttributes();
+			msg.getSubject();
+			//noinspection ResultOfMethodCallIgnored
+			msg.getMessageMAPIAttributes();
+		} catch (IOException | IllegalArgumentException | IllegalStateException | RecordFormatException |
+				ArrayIndexOutOfBoundsException e) {
+			// expected here
+		}
+	}
+}

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIHPBFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIHPBFFuzzer.java
@@ -1,0 +1,49 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package org.apache.poi;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.BufferUnderflowException;
+import java.util.NoSuchElementException;
+
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.poi.hpbf.HPBFDocument;
+import org.apache.poi.hpbf.extractor.PublisherTextExtractor;
+import org.apache.poi.poifs.filesystem.POIFSFileSystem;
+import org.apache.poi.util.RecordFormatException;
+
+public class POIHPBFFuzzer {
+	public static void fuzzerTestOneInput(byte[] input) {
+		try (HPBFDocument wb = new HPBFDocument(new ByteArrayInputStream(input))) {
+			wb.write(NullOutputStream.INSTANCE);
+		} catch (IOException | IllegalArgumentException | RecordFormatException | IndexOutOfBoundsException |
+				 BufferUnderflowException | IllegalStateException | NoSuchElementException e) {
+			// expected here
+		}
+
+		try {
+			try (PublisherTextExtractor extractor = new PublisherTextExtractor (
+					new POIFSFileSystem(new ByteArrayInputStream(input)).getRoot())) {
+				POIFuzzer.checkExtractor(extractor);
+			}
+		} catch (IOException | IllegalArgumentException | RecordFormatException | IndexOutOfBoundsException |
+				BufferUnderflowException | IllegalStateException | NoSuchElementException e) {
+			// expected here
+		}
+	}
+}

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIHPSFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIHPSFFuzzer.java
@@ -1,0 +1,54 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package org.apache.poi;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.BufferUnderflowException;
+import java.util.NoSuchElementException;
+
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.poi.hpsf.HPSFPropertiesOnlyDocument;
+import org.apache.poi.hpsf.extractor.HPSFPropertiesExtractor;
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.poifs.filesystem.POIFSFileSystem;
+import org.apache.poi.util.RecordFormatException;
+
+public class POIHPSFFuzzer {
+	public static void fuzzerTestOneInput(byte[] input) {
+		try (POIFSFileSystem fs = new POIFSFileSystem(new ByteArrayInputStream(input))) {
+			String workbookName = HSSFWorkbook.getWorkbookDirEntryName(fs.getRoot());
+			fs.createDocumentInputStream(workbookName);
+
+			try (HPSFPropertiesOnlyDocument document = new HPSFPropertiesOnlyDocument(fs)) {
+				document.write(NullOutputStream.INSTANCE);
+			}
+
+			fs.writeFilesystem(NullOutputStream.INSTANCE);
+		} catch (IOException | IllegalArgumentException | IllegalStateException | RecordFormatException |
+				 IndexOutOfBoundsException | BufferUnderflowException | NoSuchElementException e) {
+			// expected here
+		}
+
+		try (HPSFPropertiesExtractor extractor = new HPSFPropertiesExtractor(new POIFSFileSystem(new ByteArrayInputStream(input)))) {
+			POIFuzzer.checkExtractor(extractor);
+		} catch (IOException | IllegalArgumentException | IllegalStateException | RecordFormatException |
+				 IndexOutOfBoundsException | BufferUnderflowException | NoSuchElementException e) {
+			// expected
+		}
+	}
+}

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIHSLFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIHSLFFuzzer.java
@@ -1,0 +1,66 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package org.apache.poi;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.BufferUnderflowException;
+import java.util.NoSuchElementException;
+
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.poi.hslf.exceptions.HSLFException;
+import org.apache.poi.hslf.usermodel.HSLFShape;
+import org.apache.poi.hslf.usermodel.HSLFSlideShow;
+import org.apache.poi.hslf.usermodel.HSLFSlideShowImpl;
+import org.apache.poi.hslf.usermodel.HSLFTextParagraph;
+import org.apache.poi.ooxml.POIXMLException;
+import org.apache.poi.poifs.filesystem.POIFSFileSystem;
+import org.apache.poi.sl.extractor.SlideShowExtractor;
+import org.apache.poi.sl.usermodel.SlideShowFactory;
+import org.apache.poi.util.RecordFormatException;
+
+public class POIHSLFFuzzer {
+	public static void fuzzerTestOneInput(byte[] input) {
+		try (HSLFSlideShow slides = new HSLFSlideShow(new ByteArrayInputStream(input))) {
+			slides.write(NullOutputStream.INSTANCE);
+		} catch (IOException | IllegalArgumentException | RecordFormatException |
+				 IllegalStateException | HSLFException | IndexOutOfBoundsException |
+				 BufferUnderflowException | POIXMLException | NoSuchElementException e) {
+			// expected here
+		}
+
+		try (HSLFSlideShowImpl slides = new HSLFSlideShowImpl(new ByteArrayInputStream(input))) {
+			slides.write(NullOutputStream.INSTANCE);
+		} catch (IOException | IllegalArgumentException | RecordFormatException |
+				 IllegalStateException | HSLFException | IndexOutOfBoundsException |
+				 BufferUnderflowException | POIXMLException | NoSuchElementException e) {
+			// expected here
+		}
+
+		try {
+			try (SlideShowExtractor<HSLFShape, HSLFTextParagraph> extractor =
+					new SlideShowExtractor<>((HSLFSlideShow) SlideShowFactory.create(
+							new POIFSFileSystem(new ByteArrayInputStream(input)).getRoot()))) {
+				POIFuzzer.checkExtractor(extractor);
+			}
+		} catch (IOException | IllegalArgumentException | RecordFormatException |
+				 IllegalStateException | HSLFException | IndexOutOfBoundsException |
+				 BufferUnderflowException | POIXMLException | NoSuchElementException e) {
+			// expected here
+		}
+	}
+}

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIHSSFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIHSSFFuzzer.java
@@ -1,0 +1,55 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package org.apache.poi;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.BufferUnderflowException;
+import java.util.NoSuchElementException;
+
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.poi.hslf.exceptions.HSLFException;
+import org.apache.poi.hssf.extractor.ExcelExtractor;
+import org.apache.poi.hssf.record.RecordInputStream;
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.poifs.filesystem.POIFSFileSystem;
+import org.apache.poi.util.RecordFormatException;
+
+public class POIHSSFFuzzer {
+	public static void fuzzerTestOneInput(byte[] input) {
+		try (HSSFWorkbook wb = new HSSFWorkbook(new ByteArrayInputStream(input))) {
+			wb.write(NullOutputStream.INSTANCE);
+		} catch (IOException | IllegalArgumentException | RecordFormatException | IllegalStateException |
+				 IndexOutOfBoundsException | RecordInputStream.LeftoverDataException |
+				 BufferUnderflowException | UnsupportedOperationException | NoSuchElementException |
+				NegativeArraySizeException e) {
+			// expected here
+		}
+
+		try {
+			try (ExcelExtractor extractor = new ExcelExtractor(
+							new POIFSFileSystem(new ByteArrayInputStream(input)).getRoot())) {
+				POIFuzzer.checkExtractor(extractor);
+			}
+		} catch (IOException | IllegalArgumentException | RecordFormatException | IllegalStateException |
+				 IndexOutOfBoundsException | RecordInputStream.LeftoverDataException |
+				 BufferUnderflowException | UnsupportedOperationException | NoSuchElementException |
+				 NegativeArraySizeException | HSLFException e) {
+			// expected here
+		}
+	}
+}

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIHWPFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIHWPFFuzzer.java
@@ -1,0 +1,52 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package org.apache.poi;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.BufferUnderflowException;
+import java.util.NoSuchElementException;
+
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.poi.hwpf.HWPFDocument;
+import org.apache.poi.hwpf.extractor.WordExtractor;
+import org.apache.poi.poifs.filesystem.POIFSFileSystem;
+import org.apache.poi.util.DocumentFormatException;
+import org.apache.poi.util.RecordFormatException;
+
+public class POIHWPFFuzzer {
+	public static void fuzzerTestOneInput(byte[] input) {
+		try (HWPFDocument doc = new HWPFDocument(new ByteArrayInputStream(input))) {
+			doc.write(NullOutputStream.INSTANCE);
+		} catch (IOException | IllegalArgumentException | IndexOutOfBoundsException | BufferUnderflowException |
+				NoSuchElementException | RecordFormatException | IllegalStateException |
+				UnsupportedOperationException | NegativeArraySizeException e) {
+			// expected here
+		}
+
+		try {
+			try (WordExtractor extractor = new WordExtractor(
+							new POIFSFileSystem(new ByteArrayInputStream(input)).getRoot())) {
+				POIFuzzer.checkExtractor(extractor);
+			}
+		} catch (IOException | IllegalArgumentException | IndexOutOfBoundsException | BufferUnderflowException |
+				NoSuchElementException | RecordFormatException | IllegalStateException |
+				DocumentFormatException | UnsupportedOperationException | NegativeArraySizeException e) {
+			// expected here
+		}
+	}
+}

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIOldExcelFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIOldExcelFuzzer.java
@@ -1,0 +1,42 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package org.apache.poi;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.BufferUnderflowException;
+import java.util.NoSuchElementException;
+
+import org.apache.poi.hssf.extractor.OldExcelExtractor;
+import org.apache.poi.hssf.record.RecordInputStream;
+import org.apache.poi.poifs.filesystem.POIFSFileSystem;
+import org.apache.poi.util.RecordFormatException;
+
+public class POIOldExcelFuzzer {
+	public static void fuzzerTestOneInput(byte[] input) {
+		try {
+			try (OldExcelExtractor extractor = new OldExcelExtractor(
+							new POIFSFileSystem(new ByteArrayInputStream(input)).getRoot())) {
+				POIFuzzer.checkExtractor(extractor);
+			}
+		} catch (IOException | IllegalArgumentException | RecordFormatException | IndexOutOfBoundsException |
+				 RecordInputStream.LeftoverDataException | IllegalStateException | BufferUnderflowException |
+				 NoSuchElementException e) {
+			// expected here
+		}
+	}
+}

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIVisioFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIVisioFuzzer.java
@@ -1,0 +1,52 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package org.apache.poi;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.BufferUnderflowException;
+import java.util.NoSuchElementException;
+
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.poi.EmptyFileException;
+import org.apache.poi.UnsupportedFileFormatException;
+import org.apache.poi.hdgf.extractor.VisioTextExtractor;
+import org.apache.poi.ooxml.POIXMLException;
+import org.apache.poi.openxml4j.exceptions.OpenXML4JRuntimeException;
+import org.apache.poi.util.RecordFormatException;
+import org.apache.poi.xdgf.usermodel.XmlVisioDocument;
+import org.apache.xmlbeans.impl.values.XmlValueOutOfRangeException;
+
+public class POIVisioFuzzer {
+	public static void fuzzerTestOneInput(byte[] input) {
+		try (XmlVisioDocument visio = new XmlVisioDocument(new ByteArrayInputStream(input))) {
+			visio.write(NullOutputStream.INSTANCE);
+		} catch (IOException | POIXMLException | EmptyFileException | UnsupportedFileFormatException |
+				 BufferUnderflowException | RecordFormatException | OpenXML4JRuntimeException |
+				 XmlValueOutOfRangeException | NumberFormatException e) {
+			// expected here
+		}
+
+		try (VisioTextExtractor extractor = new VisioTextExtractor(new ByteArrayInputStream(input))) {
+			POIFuzzer.checkExtractor(extractor);
+		} catch (IOException | POIXMLException | IllegalArgumentException | BufferUnderflowException |
+				 RecordFormatException | IndexOutOfBoundsException | ArithmeticException | IllegalStateException |
+				 NoSuchElementException e) {
+			// expected
+		}
+	}
+}

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIXSLFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIXSLFFuzzer.java
@@ -1,0 +1,63 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package org.apache.poi;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.poi.EmptyFileException;
+import org.apache.poi.UnsupportedFileFormatException;
+import org.apache.poi.ooxml.POIXMLException;
+import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
+import org.apache.poi.openxml4j.exceptions.OpenXML4JException;
+import org.apache.poi.openxml4j.exceptions.OpenXML4JRuntimeException;
+import org.apache.poi.openxml4j.opc.OPCPackage;
+import org.apache.poi.util.RecordFormatException;
+import org.apache.poi.xslf.extractor.XSLFExtractor;
+import org.apache.poi.xslf.usermodel.XMLSlideShow;
+import org.apache.poi.xslf.usermodel.XSLFSlideShow;
+import org.apache.xmlbeans.XmlException;
+
+public class POIXSLFFuzzer {
+	public static void fuzzerTestOneInput(byte[] input) {
+		try (XMLSlideShow slides = new XMLSlideShow(new ByteArrayInputStream(input))) {
+			slides.write(NullOutputStream.INSTANCE);
+		} catch (IOException | EmptyFileException | UnsupportedFileFormatException | POIXMLException |
+				 RecordFormatException | OpenXML4JRuntimeException e) {
+			// expected here
+		}
+
+		try (OPCPackage pkg = OPCPackage.open(new ByteArrayInputStream(input))) {
+			try (XSLFSlideShow slides = new XSLFSlideShow(pkg)) {
+				slides.write(NullOutputStream.INSTANCE);
+			}
+		} catch (IOException | OpenXML4JException | XmlException | IllegalArgumentException | POIXMLException |
+				 RecordFormatException | IllegalStateException | OpenXML4JRuntimeException e) {
+			// expected here
+		}
+
+		try (OPCPackage pkg = OPCPackage.open(new ByteArrayInputStream(input))) {
+			try (XSLFExtractor extractor = new XSLFExtractor(new XMLSlideShow(pkg))) {
+				POIFuzzer.checkExtractor(extractor);
+			}
+		} catch (IOException | InvalidFormatException | POIXMLException | IllegalArgumentException |
+				RecordFormatException | IllegalStateException e) {
+			// expected
+		}
+	}
+}

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIXSSFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIXSSFFuzzer.java
@@ -1,0 +1,53 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package org.apache.poi;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.poi.ooxml.POIXMLException;
+import org.apache.poi.openxml4j.exceptions.OpenXML4JException;
+import org.apache.poi.openxml4j.exceptions.OpenXML4JRuntimeException;
+import org.apache.poi.openxml4j.opc.OPCPackage;
+import org.apache.poi.util.RecordFormatException;
+import org.apache.poi.xssf.extractor.XSSFEventBasedExcelExtractor;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.apache.xmlbeans.XmlException;
+
+public class POIXSSFFuzzer {
+	public static void fuzzerTestOneInput(byte[] input) {
+		try (XSSFWorkbook wb = new XSSFWorkbook(new ByteArrayInputStream(input))) {
+			try (SXSSFWorkbook swb = new SXSSFWorkbook(wb)) {
+				swb.write(NullOutputStream.INSTANCE);
+			}
+		} catch (IOException | POIXMLException | RecordFormatException | IllegalStateException |
+				 OpenXML4JRuntimeException | IllegalArgumentException | IndexOutOfBoundsException e) {
+			// expected here
+		}
+
+		try (OPCPackage pkg = OPCPackage.open(new ByteArrayInputStream(input))) {
+			try (XSSFEventBasedExcelExtractor extractor = new XSSFEventBasedExcelExtractor(pkg)) {
+				POIFuzzer.checkExtractor(extractor);
+			}
+		} catch (IOException | XmlException | OpenXML4JException | POIXMLException | RecordFormatException |
+				IllegalStateException | IllegalArgumentException e) {
+			// expected
+		}
+	}
+}

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIXWPFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIXWPFFuzzer.java
@@ -1,0 +1,42 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package org.apache.poi;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.poi.ooxml.POIXMLException;
+import org.apache.poi.openxml4j.exceptions.OpenXML4JRuntimeException;
+import org.apache.poi.util.RecordFormatException;
+import org.apache.poi.xwpf.extractor.XWPFWordExtractor;
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
+
+public class POIXWPFFuzzer {
+	public static void fuzzerTestOneInput(byte[] input) {
+		try (XWPFDocument doc = new XWPFDocument(new ByteArrayInputStream(input))) {
+			doc.write(NullOutputStream.INSTANCE);
+
+			try (XWPFWordExtractor extractor = new XWPFWordExtractor(doc)) {
+				POIFuzzer.checkExtractor(extractor);
+			}
+		} catch (IOException | POIXMLException | RecordFormatException | OpenXML4JRuntimeException |
+				 IllegalArgumentException | IllegalStateException e) {
+			// expected
+		}
+	}
+}

--- a/projects/apache-poi/src/main/java/org/apache/poi/XLSX2CSVFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/XLSX2CSVFuzzer.java
@@ -16,49 +16,28 @@
 
 package org.apache.poi;
 
-import com.code_intelligence.jazzer.api.FuzzedDataProvider;
-
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
 
+import org.apache.commons.io.output.NullPrintStream;
+import org.apache.poi.examples.xssf.eventusermodel.XLSX2CSV;
+import org.apache.poi.ooxml.POIXMLException;
 import org.apache.poi.openxml4j.exceptions.OpenXML4JException;
 import org.apache.poi.openxml4j.opc.OPCPackage;
-import org.apache.poi.examples.xssf.eventusermodel.XLSX2CSV;
 import org.apache.poi.util.RecordFormatException;
 import org.xml.sax.SAXException;
 
 public class XLSX2CSVFuzzer {
-
-    private final FuzzedDataProvider fuzzedDataProvider;
-
-    public XLSX2CSVFuzzer(FuzzedDataProvider fuzzedDataProvider) {
-        this.fuzzedDataProvider = fuzzedDataProvider;
-    }
-
-    void test() {
-        try {
-            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            PrintStream out = new PrintStream(baos, true, StandardCharsets.UTF_8.name());
-            String string = fuzzedDataProvider.consumeRemainingAsString();
-            InputStream in = new ByteArrayInputStream(string.getBytes(StandardCharsets.UTF_8));
-            OPCPackage p = OPCPackage.open(in);
-            XLSX2CSV xlsx2csv = new XLSX2CSV(p, out, 5);
-            xlsx2csv.process();
-        } catch (IOException | OpenXML4JException | SAXException ex) {
-            /* documented, ignore. */
-        } catch (UnsupportedFileFormatException | RecordFormatException | EmptyFileException |
-				 ArrayIndexOutOfBoundsException ex) {
-            /* not so documented ... */
-        }
-
-    }
-
-    public static void fuzzerTestOneInput(FuzzedDataProvider fuzzedDataProvider) {
-        XLSX2CSVFuzzer fixture = new XLSX2CSVFuzzer(fuzzedDataProvider);
-        fixture.test();
-    }
+	public static void fuzzerTestOneInput(byte[] input) {
+		try (InputStream in = new ByteArrayInputStream(input)) {
+			OPCPackage p = OPCPackage.open(in);
+			XLSX2CSV xlsx2csv = new XLSX2CSV(p, NullPrintStream.INSTANCE, 5);
+			xlsx2csv.process();
+		} catch (IOException | OpenXML4JException | SAXException |
+				 POIXMLException | RecordFormatException |
+				IllegalStateException | IllegalArgumentException e) {
+			// expected here
+		}
+	}
 }


### PR DESCRIPTION
After getting project apache-poi to mostly build fine, we can add more
fuzz targets to cover much more of the library.

The currently used `XLSX2CSV` is only a small example usage of Apache POI 
and does not cover much actual functionality.

Therefore this PR adds a number of fuzz targets which will trigger fuzzing of the various 
supported formats of Apache POI. 

Many expected exceptions are already handled so that we should only get very 
few additional ones which we can either fix in the library or in the fuzz targets.

Also rework XLSX2CSVFuzzer as it is strange that it uses an string input
when the expected data is actually binary.

Finally move from @gmx.at to @gmail.com in CCS to be able to open bug-reports
for Apache POI