### PR TITLE
Fix building git

### DIFF
--- a/projects/git/fuzz-cmd-base.c
+++ b/projects/git/fuzz-cmd-base.c
@@ -9,8 +9,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#include "cache.h"
 #include "builtin.h"
+#include "hex.h"
+#include "strbuf.h"
 #include "fuzz-cmd-base.h"
 
 

--- a/projects/git/fuzz-cmd-diff.c
+++ b/projects/git/fuzz-cmd-diff.c
@@ -9,6 +9,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+#include "git-compat-util.h"
 #include <ftw.h>
 #include <unistd.h>
 #include <sys/stat.h>

--- a/projects/git/fuzz-command.c
+++ b/projects/git/fuzz-command.c
@@ -10,7 +10,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #include "builtin.h"
+#include "hex.h"
 #include "repository.h"
+#include "strbuf.h"
 #include "fuzz-cmd-base.h"
 
 int cmd_add(int argc, const char **argv, const char *prefix);


### PR DESCRIPTION
Git fuzzer builds have been failing for almost half a year—https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=56533

The errors seem to be fixable by changing included header files. https://github.com/git/git/commit/8bff5ca030d314d613e1ab58f07b27914d6dfd33 and https://github.com/git/git/commit/a1264a08a1a6e0cd7e510c899cd0ba42dcf1045d affected fuzzer builds most likely.

Building with `python infra/helper.py build_fuzzers --sanitizer undefined --architecture x86_64 git` succeeds locally with the suggested changes.