### PR TITLE
infra: bump fuzz-introspector

### DIFF
--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y wget sudo && \
 RUN apt-get update && apt-get install -y git && \
     git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
     cd fuzz-introspector && \
-    git checkout 1ea3a0d2ef5dc5bcb6e5fc8b278f4ee9ffb84d9a && \
+    git checkout 6ca19c0035438fbc88c2e417b83c61596fa83fc1 && \
     git submodule init && \
     git submodule update && \
     apt-get autoremove --purge -y git && \


### PR DESCRIPTION
Two updates since last:
- Argument name extraction has improved for all functions, and it's added to `summary.json` files.
- All function names as they are in the binaries are saved. This has effect only for C++ where the underlying function name is a mangled function name. Having the raw makes it possible to e.g. demangle it and get a better-looking name than what currently exists in the reports.