### PR TITLE
[libavc, libhevc, libmpeg2]: Remove experimental tag on ubsan

### DIFF
--- a/projects/libavc/project.yaml
+++ b/projects/libavc/project.yaml
@@ -4,8 +4,7 @@ primary_contact: "harish.mahendrakar@ittiam.com"
 sanitizers:
   - address
   - memory
-  - undefined:
-     experimental: True
+  - undefined
 auto_ccs:
   - aadithya.kamath@ittiam.com
   - ashwin.natesan@ittiam.com

--- a/projects/libhevc/project.yaml
+++ b/projects/libhevc/project.yaml
@@ -4,8 +4,7 @@ primary_contact: "harish.mahendrakar@ittiam.com"
 sanitizers:
   - address
   - memory
-  - undefined:
-     experimental: True
+  - undefined
 auto_ccs:
   - aadithya.kamath@ittiam.com
   - harish.mahendrakar@ittiam.com

--- a/projects/libmpeg2/project.yaml
+++ b/projects/libmpeg2/project.yaml
@@ -4,8 +4,7 @@ primary_contact: "harish.mahendrakar@ittiam.com"
 sanitizers:
   - address
   - memory
-  - undefined:
-     experimental: True
+  - undefined
 auto_ccs:
   - aadithya.kamath@ittiam.com
   - harish.mahendrakar@ittiam.com


### PR DESCRIPTION
undefined sanitizer was so far marked experimental for libavc, libhevc and libmpeg2. 
That experimental tag is now removed in this.