### PR TITLE
rdf4j: Fix exception handling for ParserFuzzer

### DIFF
--- a/projects/rdf4j/ParserFuzzer.java
+++ b/projects/rdf4j/ParserFuzzer.java
@@ -28,7 +28,7 @@ public class ParserFuzzer {
       SPARQLParser obj = new SPARQLParser();
       obj.parseQuery(
           data.consumeString(data.remainingBytes() / 2), data.consumeRemainingAsString());
-    } catch (MalformedQueryException e1) {
+    } catch (MalformedQueryException | IllegalArgumentException e1) {
     }
   }
 }


### PR DESCRIPTION
In https://github.com/eclipse/rdf4j/blob/main/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/BaseDeclProcessor.java#L73, the method throws an IllegalArgumentException when the input does not fulfil some of the conditions which could happen when we fuzz the project. This PR fixes the fuzzer by capturing the exception.