### PR TITLE
Apache POI: Add seed corpus, remove logging, add HSMF

### DIFF
--- a/projects/apache-poi/build.sh
+++ b/projects/apache-poi/build.sh
@@ -40,8 +40,29 @@ pushd "/tmp"
 popd
 
 pushd "${SRC}/${LIBRARY_NAME}"
+	# build and publish current binaries
 	./gradlew publishToMavenLocal ${GRADLE_FLAGS}
+
+	# determine current version-tag
 	CURRENT_VERSION=$(./gradlew properties ${GRADLE_FLAGS} | sed -nr "s/^version:\ (.*)/\1/p")
+
+	# prepare some seed-corpus archives
+	# To provide a corpus for my_fuzzer, put my_fuzzer_seed_corpus.zip file next to the fuzz target’s binary in $OUT during the build.
+	# cannot do this autoamtically as there is not a 1:1 match of fuzz targets and formats
+	zip -r $OUT/POIFuzzer_seed_corpus.zip test-data
+	zip -jr $OUT/POIHDGFFuzzer_seed_corpus.zip test-data/diagram/*.vsd
+	zip -jr $OUT/POIHMEFFuzzer_seed_corpus.zip test-data/hmef/*
+	zip -jr $OUT/POIHPBFFuzzer_seed_corpus.zip test-data/publisher/*
+	zip -jr $OUT/POIHPSFFuzzer_seed_corpus.zip test-data/hpsf/*
+	zip -jr $OUT/POIHSLFFuzzer_seed_corpus.zip test-data/slideshow/*.ppt
+	zip -jr $OUT/POIHSSFFuzzer_seed_corpus.zip test-data/spreadsheet/*.xls
+	zip -jr $OUT/POIHWPFFuzzer_seed_corpus.zip test-data/document/*.doc test-data/document/*.DOC
+	zip -jr $OUT/POIOldExcelFuzzer_seed_corpus.zip test-data/spreadsheet/*.xls test-data/spreadsheet/*.bin
+	zip -jr $OUT/POIVisioFuzzer_seed_corpus.zip test-data/diagram/*
+	zip -jr $OUT/POIXSLFFuzzer_seed_corpus.zip test-data/slideshow/* test-data/integration/*.pptx
+	zip -jr $OUT/POIXSSFFuzzer_seed_corpus.zip test-data/spreadsheet/* test-data/integration/*.xslx
+	zip -jr $OUT/POIXWPFFuzzer_seed_corpus.zip test-data/document/* test-data/integration/*.docx
+	zip -jr $OUT/XLSX2CSVFuzzer_seed_corpus.zip test-data/spreadsheet/*
 popd
 
 pushd "${SRC}"

--- a/projects/apache-poi/build.sh
+++ b/projects/apache-poi/build.sh
@@ -46,15 +46,15 @@ pushd "${SRC}/${LIBRARY_NAME}"
 	# determine current version-tag
 	CURRENT_VERSION=$(./gradlew properties ${GRADLE_FLAGS} | sed -nr "s/^version:\ (.*)/\1/p")
 
-	# prepare some seed-corpus archives
-	# To provide a corpus for my_fuzzer, put my_fuzzer_seed_corpus.zip file next to the fuzz target’s binary in $OUT during the build.
-	# cannot do this autoamtically as there is not a 1:1 match of fuzz targets and formats
+	# prepare some seed-corpus archives based on the test-data of Apache POI
+	# we cannot do this automatically as there is not a 1:1 match of fuzz targets and formats
 	zip -r $OUT/POIFuzzer_seed_corpus.zip test-data
 	zip -jr $OUT/POIHDGFFuzzer_seed_corpus.zip test-data/diagram/*.vsd
 	zip -jr $OUT/POIHMEFFuzzer_seed_corpus.zip test-data/hmef/*
 	zip -jr $OUT/POIHPBFFuzzer_seed_corpus.zip test-data/publisher/*
 	zip -jr $OUT/POIHPSFFuzzer_seed_corpus.zip test-data/hpsf/*
 	zip -jr $OUT/POIHSLFFuzzer_seed_corpus.zip test-data/slideshow/*.ppt
+	zip -jr $OUT/POIHSMFFuzzer_seed_corpus.zip test-data/hsmf/*
 	zip -jr $OUT/POIHSSFFuzzer_seed_corpus.zip test-data/spreadsheet/*.xls
 	zip -jr $OUT/POIHWPFFuzzer_seed_corpus.zip test-data/document/*.doc test-data/document/*.DOC
 	zip -jr $OUT/POIOldExcelFuzzer_seed_corpus.zip test-data/spreadsheet/*.xls test-data/spreadsheet/*.bin

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIFuzzer.java
@@ -39,6 +39,14 @@ import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.apache.poi.util.DocumentFormatException;
 import org.apache.poi.util.RecordFormatException;
 
+/**
+ * This class provides a simple target for fuzzing Apache POI with Jazzer.
+ *
+ * It uses the byte-array to call various method which parse the various
+ * supported file-formats.
+ *
+ * It catches all exceptions that are currently expected.
+ */
 public class POIFuzzer {
 	public static void fuzzerTestOneInput(byte[] input) {
 		// try to invoke various methods which parse documents/workbooks/slide-shows/...
@@ -54,6 +62,8 @@ public class POIFuzzer {
 		POIHPSFFuzzer.fuzzerTestOneInput(input);
 
 		POIHSLFFuzzer.fuzzerTestOneInput(input);
+
+		POIHSMFFuzzer.fuzzerTestOneInput(input);
 
 		POIHSSFFuzzer.fuzzerTestOneInput(input);
 
@@ -109,6 +119,7 @@ public class POIFuzzer {
 		}
 	}
 
+	@SuppressWarnings("DuplicatedCode")
 	public static void checkExtractor(POITextExtractor extractor) throws IOException {
 		extractor.getDocument();
 		extractor.getFilesystem();

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIHSMFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIHSMFFuzzer.java
@@ -1,0 +1,51 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package org.apache.poi;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.BufferUnderflowException;
+import java.util.NoSuchElementException;
+
+import org.apache.poi.hsmf.MAPIMessage;
+import org.apache.poi.hsmf.datatypes.AttachmentChunks;
+import org.apache.poi.hsmf.datatypes.DirectoryChunk;
+import org.apache.poi.hsmf.exceptions.ChunkNotFoundException;
+import org.apache.poi.util.RecordFormatException;
+
+public class POIHSMFFuzzer {
+	public static void fuzzerTestOneInput(byte[] input) {
+		try (MAPIMessage mapi = new MAPIMessage(new ByteArrayInputStream(input))) {
+			mapi.getAttachmentFiles();
+			mapi.getDisplayBCC();
+			mapi.getMessageDate();
+
+			AttachmentChunks[] attachments = mapi.getAttachmentFiles();
+			for (AttachmentChunks attachment : attachments) {
+				DirectoryChunk chunkDirectory = attachment.getAttachmentDirectory();
+				if (chunkDirectory != null) {
+					MAPIMessage attachmentMSG = chunkDirectory.getAsEmbeddedMessage();
+					attachmentMSG.getTextBody();
+				}
+			}
+		} catch (IOException | ChunkNotFoundException | IllegalArgumentException |
+				 RecordFormatException | IndexOutOfBoundsException | NoSuchElementException |
+				 BufferUnderflowException | IllegalStateException e) {
+			// expected here
+		}
+	}
+}

--- a/projects/apache-poi/src/main/java/org/apache/poi/XLSX2CSVFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/XLSX2CSVFuzzer.java
@@ -36,7 +36,8 @@ public class XLSX2CSVFuzzer {
 			xlsx2csv.process();
 		} catch (IOException | OpenXML4JException | SAXException |
 				 POIXMLException | RecordFormatException |
-				IllegalStateException | IllegalArgumentException e) {
+				IllegalStateException | IllegalArgumentException |
+				ArrayIndexOutOfBoundsException e) {
 			// expected here
 		}
 	}

--- a/projects/apache-poi/src/main/resources/log4j2.xml
+++ b/projects/apache-poi/src/main/resources/log4j2.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="warn">
+	<Loggers>
+		<Root level="off"/>
+	</Loggers>
+</Configuration>


### PR DESCRIPTION
Now that fuzzing and introspector is working again, we can improve the fuzzing itself by adding seed corpus archives for all the fuzzers.

Also let's reduce output during fuzzing and add/adjust fuzzers some more.