### PR TITLE
infra: bump fuzz introspector

### DIFF
--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y wget sudo && \
 RUN apt-get update && apt-get install -y git && \
     git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
     cd fuzz-introspector && \
-    git checkout f3f2d0ba6483cd97ad16cd4c233148dd7fae6b52 && \
+    git checkout 051d91d586f4cfbe3ce11985706ea392b14a396b && \
     git submodule init && \
     git submodule update && \
     apt-get autoremove --purge -y git && \

--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y wget sudo && \
 RUN apt-get update && apt-get install -y git && \
     git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
     cd fuzz-introspector && \
-    git checkout 6ca19c0035438fbc88c2e417b83c61596fa83fc1 && \
+    git checkout f3f2d0ba6483cd97ad16cd4c233148dd7fae6b52 && \
     git submodule init && \
     git submodule update && \
     apt-get autoremove --purge -y git && \


### PR DESCRIPTION
This contains a minor fix in accummulated code complexity for the annotated CFG feature, used by https://introspector.oss-fuzz.com/api/annotated-cfg -- in some cases the value would be 0 incorrectly.

Also includes:
- a refined definition of top-level API fra annotated-cfg extraction: 
  - PR: https://github.com/ossf/fuzz-introspector/pull/1191
  - fixes: https://github.com/ossf/fuzz-introspector/pull/1180#issuecomment-1667163532
- Extended type recognition for C/C++ projects:
  - PR: https://github.com/ossf/fuzz-introspector/pull/1190
  - fixes: https://github.com/ossf/fuzz-introspector/issues/1188
- Converts arg types to array of strings rather a string representation entirely:
  - PR: https://github.com/ossf/fuzz-introspector/pull/1189 
  - fixes: https://github.com/ossf/fuzz-introspector/issues/1187)