### PR TITLE
p11-kit: install python3 in the base image

### DIFF
--- a/projects/p11-kit/Dockerfile
+++ b/projects/p11-kit/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config libtasn1-6-dev libffi-dev gettext autopoint
+RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config libtasn1-6-dev libffi-dev gettext autopoint python3
 RUN git clone --depth 1 https://github.com/p11-glue/p11-kit.git p11-kit
 WORKDIR p11-kit
 COPY build.sh $SRC/


### PR DESCRIPTION
p11-kit build infrastructure will require Python for code generation: https://github.com/p11-glue/p11-kit/pull/537