### PR TITLE
Apache POI: more expected exceptions

### DIFF
--- a/projects/apache-poi/src/main/java/org/apache/poi/POIHSSFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIHSSFFuzzer.java
@@ -45,6 +45,13 @@ public class POIHSSFFuzzer {
 							new POIFSFileSystem(new ByteArrayInputStream(input)).getRoot())) {
 				POIFuzzer.checkExtractor(extractor);
 			}
+		} catch (UnsatisfiedLinkError e) {
+			// only allow one missing library related to Font-handling
+			// we cannot install JDK font packages in oss-fuzz images currently
+			// see https://github.com/google/oss-fuzz/issues/7380
+			if (!e.getMessage().contains("libawt_xawt.so")) {
+				throw e;
+			}
 		} catch (IOException | IllegalArgumentException | RecordFormatException | IllegalStateException |
 				 IndexOutOfBoundsException | RecordInputStream.LeftoverDataException |
 				 BufferUnderflowException | UnsupportedOperationException | NoSuchElementException |

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIVisioFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIVisioFuzzer.java
@@ -22,8 +22,6 @@ import java.nio.BufferUnderflowException;
 import java.util.NoSuchElementException;
 
 import org.apache.commons.io.output.NullOutputStream;
-import org.apache.poi.EmptyFileException;
-import org.apache.poi.UnsupportedFileFormatException;
 import org.apache.poi.hdgf.extractor.VisioTextExtractor;
 import org.apache.poi.ooxml.POIXMLException;
 import org.apache.poi.openxml4j.exceptions.OpenXML4JRuntimeException;
@@ -35,9 +33,9 @@ public class POIVisioFuzzer {
 	public static void fuzzerTestOneInput(byte[] input) {
 		try (XmlVisioDocument visio = new XmlVisioDocument(new ByteArrayInputStream(input))) {
 			visio.write(NullOutputStream.INSTANCE);
-		} catch (IOException | POIXMLException | EmptyFileException | UnsupportedFileFormatException |
+		} catch (IOException | POIXMLException |
 				 BufferUnderflowException | RecordFormatException | OpenXML4JRuntimeException |
-				 XmlValueOutOfRangeException | NumberFormatException e) {
+				 IllegalArgumentException e) {
 			// expected here
 		}
 

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIXSSFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIXSSFFuzzer.java
@@ -36,6 +36,13 @@ public class POIXSSFFuzzer {
 			try (SXSSFWorkbook swb = new SXSSFWorkbook(wb)) {
 				swb.write(NullOutputStream.INSTANCE);
 			}
+		} catch (NoClassDefFoundError e) {
+			// only allow one missing class related to Font-handling
+			// we cannot install JDK font packages in oss-fuzz images currently
+			// see https://github.com/google/oss-fuzz/issues/7380
+			if (!e.getMessage().contains("java.awt.Font")) {
+				throw e;
+			}
 		} catch (IOException | POIXMLException | RecordFormatException | IllegalStateException |
 				 OpenXML4JRuntimeException | IllegalArgumentException | IndexOutOfBoundsException e) {
 			// expected here


### PR DESCRIPTION
The new fuzz-targets for Apache POI combined with the seed-corpus now lead to a number of interesting new exceptions!

But some of them are actually expected. Partly because the Docker image does not provide a full font-setup for the JDK.

See also previous discussion at #7380 

This PR should resolve bugs 61247, 61244, 61253.
