### PR TITLE
keycloak: Install JDK 17 for keycloak project

### DIFF
--- a/projects/keycloak/Dockerfile
+++ b/projects/keycloak/Dockerfile
@@ -16,11 +16,14 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 
+RUN apt install openjdk-17-jdk -y
+
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \
     rm -rf maven.zip
 
 ENV MVN $SRC/maven/apache-maven-3.6.3/bin/mvn
+ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64
 
 RUN git clone --depth 1 https://github.com/cncf/cncf-fuzzing cncf-fuzzing
 RUN git clone --depth 1 https://github.com/keycloak/keycloak keycloak


### PR DESCRIPTION
Add jdk 17 installation in the dockerfile for keycloak project which depends on JDK 17. The new approach uses apt install instead of plain download of JDK-17 to avoid missing native dependencies.