### PR TITLE
feign: Fix missing exception handling

### DIFF
--- a/projects/feign/BodyTemplateFuzzer.java
+++ b/projects/feign/BodyTemplateFuzzer.java
@@ -24,7 +24,7 @@ import java.util.regex.PatternSyntaxException
 public class BodyTemplateFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     try {
-      BodyTemplate.create(Pattern.quote(data.consumeRemainingAsString()));
+      BodyTemplate.create(data.consumeRemainingAsString());
     } catch (IllegalArgumentException | PatternSyntaxException e1) {}
   }
 }

--- a/projects/feign/BodyTemplateFuzzer.java
+++ b/projects/feign/BodyTemplateFuzzer.java
@@ -16,6 +16,7 @@
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import feign.template.BodyTemplate;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException
 
 // Generated with https://github.com/ossf/fuzz-introspector/tree/main/tools/auto-fuzz
 // Heuristic name: jvm-autofuzz-heuristics-1
@@ -24,6 +25,6 @@ public class BodyTemplateFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     try {
       BodyTemplate.create(Pattern.quote(data.consumeRemainingAsString()));
-    } catch (IllegalArgumentException e1) {}
+    } catch (IllegalArgumentException | PatternSyntaxException e1) {}
   }
 }


### PR DESCRIPTION
Passing random string to regex parser and matcher could result in PatternSyntaxException and it is not caught by the fuzzer. This PR adds the catching for this expected PatternSyntaxException.