### PR TITLE
infra: bump introspector

### DIFF
--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y wget sudo && \
 RUN apt-get update && apt-get install -y git && \
     git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
     cd fuzz-introspector && \
-    git checkout 051d91d586f4cfbe3ce11985706ea392b14a396b && \
+    git checkout f3df78ca617653ba663a2756c9b6c04450773bc0 && \
     git submodule init && \
     git submodule update && \
     apt-get autoremove --purge -y git && \


### PR DESCRIPTION
- adds a deeper recursion logic to introspector's python module, which fixes some of the broken builds
- fixes https://github.com/ossf/fuzz-introspector/issues/1192