### PR TITLE
Olivekl add project history

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -63,11 +63,7 @@ manual effort.
 Google created OSS-Fuzz to fill this gap: it's a free service that runs fuzzers
 for open source projects and privately alerts developers to the bugs detected.
 Since its launch, OSS-Fuzz has become a critical service for the open source
-community, helping get
-[more than 10,000 security vulnerabilities](https://bugs.chromium.org/p/oss-fuzz/issues/list?q=type%3Dbug-security%20-status%3Aduplicate%2Cwontfix%20label%3Aclusterfuzz&can=1)
-and more than
-[31,000 other bugs](https://bugs.chromium.org/p/oss-fuzz/issues/list?q=type%3Dbug%20status%3Averified%2Cfixed%20label%3Aclusterfuzz&can=1)
-in open source projects fixed. With time, OSS-Fuzz has grown beyond C/C++ to
+community, growing beyond C/C++ to
 detect problems in memory-safe languages such as Go, Rust, and Python.
 
 ## Learn more about fuzzing
@@ -82,8 +78,8 @@ other resources are listed on the [useful links] page.
 [useful links]: {{ site.baseurl }}/reference/useful-links/#tutorials
 
 ## Trophies
-As of February 2023, OSS-Fuzz has helped identify and fix over [8,900] vulnerabilities and [28,000] bugs across [850] projects.
+As of February 2023, OSS-Fuzz has helped identify and fix over [10,000] vulnerabilities and [31,000] bugs across [1,000] projects.
 
-[8,900]: https://bugs.chromium.org/p/oss-fuzz/issues/list?q=status%3AFixed%2CVerified%20Type%3DBug-Security&can=1
-[28,000]: https://bugs.chromium.org/p/oss-fuzz/issues/list?q=status%3AFixed%2CVerified%20Type%3DBug&can=1
-[850]: https://github.com/google/oss-fuzz/tree/master/projects
+[10,000]: https://bugs.chromium.org/p/oss-fuzz/issues/list?q=status%3AFixed%2CVerified%20Type%3DBug-Security&can=1
+[31,000]: https://bugs.chromium.org/p/oss-fuzz/issues/list?q=status%3AFixed%2CVerified%20Type%3DBug&can=1
+[1,000]: https://github.com/google/oss-fuzz/tree/master/projects

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,6 +83,6 @@ other resources are listed on the [useful links] page.
 ## Trophies
 As of August 2023, OSS-Fuzz has helped identify and fix over [10,000] vulnerabilities and [36,000] bugs across [1,000] projects.
 
-[10,000]: https://bugs.chromium.org/p/oss-fuzz/issues/list?q=Type%3DBug-Security%20label%3Aclusterfuzz&can=1
+[10,000]: https://bugs.chromium.org/p/oss-fuzz/issues/list?q=Type%3DBug-Security%20label%3Aclusterfuzz%20-status%3ADuplicate%2CWontFix&can=1
 [36,000]: https://bugs.chromium.org/p/oss-fuzz/issues/list?q=Type%3DBug%20label%3Aclusterfuzz%20-status%3ADuplicate%2CWontFix&can=1
 [1,000]: https://github.com/google/oss-fuzz/tree/master/projects

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,28 @@ and i386 builds.
 
 [LLVM]: https://llvm.org
 
+
+## Project history
+OSS-Fuzz was launched in 2016 in response to the
+[Heartbleed](https://heartbleed.com/) vulnerability, discovered in one of the
+most popular open source projects for encrypting web traffic. The vulnerability
+had the potential to affect almost every internet user, yet was caused by a
+relatively simple memory buffer overflow bug that could have been detected by
+fuzzing—that is, by running the code on randomized inputs to intentionally cause
+unexpected behaviors or crashes that signal bugs. At the time, though, fuzzing
+was not widely used and was cumbersome for developers, requiring extensive
+manual effort.
+
+Google created OSS-Fuzz to fill this gap: it's a free service that runs fuzzers
+for open source projects and privately alerts developers to the bugs detected.
+Since its launch, OSS-Fuzz has become a critical service for the open source
+community, helping get
+[more than 10,000 security vulnerabilities](https://bugs.chromium.org/p/oss-fuzz/issues/list?q=type%3Dbug-security%20-status%3Aduplicate%2Cwontfix%20label%3Aclusterfuzz&can=1)
+and more than
+[26,000 other bugs](https://bugs.chromium.org/p/oss-fuzz/issues/list?q=type%3Dbug%20status%3Averified%2Cfixed%20label%3Aclusterfuzz&can=1)
+in open source projects fixed. With time, OSS-Fuzz has grown beyond C/C++ to
+detect problems in memory-safe languages such as Go, Rust, and Python.
+
 ## Learn more about fuzzing
 
 This documentation describes how to use OSS-Fuzz service for your open source

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,7 +66,7 @@ Since its launch, OSS-Fuzz has become a critical service for the open source
 community, helping get
 [more than 10,000 security vulnerabilities](https://bugs.chromium.org/p/oss-fuzz/issues/list?q=type%3Dbug-security%20-status%3Aduplicate%2Cwontfix%20label%3Aclusterfuzz&can=1)
 and more than
-[26,000 other bugs](https://bugs.chromium.org/p/oss-fuzz/issues/list?q=type%3Dbug%20status%3Averified%2Cfixed%20label%3Aclusterfuzz&can=1)
+[31,000 other bugs](https://bugs.chromium.org/p/oss-fuzz/issues/list?q=type%3Dbug%20status%3Averified%2Cfixed%20label%3Aclusterfuzz&can=1)
 in open source projects fixed. With time, OSS-Fuzz has grown beyond C/C++ to
 detect problems in memory-safe languages such as Go, Rust, and Python.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,12 +51,12 @@ and i386 builds.
 
 ## Project history
 OSS-Fuzz was launched in 2016 in response to the
-[Heartbleed](https://heartbleed.com/) vulnerability, discovered in one of the
+[Heartbleed] vulnerability, discovered in [OpenSSL], one of the
 most popular open source projects for encrypting web traffic. The vulnerability
 had the potential to affect almost every internet user, yet was caused by a
 relatively simple memory buffer overflow bug that could have been detected by
 fuzzing—that is, by running the code on randomized inputs to intentionally cause
-unexpected behaviors or crashes that signal bugs. At the time, though, fuzzing
+unexpected behaviors or crashes. At the time, though, fuzzing
 was not widely used and was cumbersome for developers, requiring extensive
 manual effort.
 
@@ -65,6 +65,9 @@ for open source projects and privately alerts developers to the bugs detected.
 Since its launch, OSS-Fuzz has become a critical service for the open source
 community, growing beyond C/C++ to
 detect problems in memory-safe languages such as Go, Rust, and Python.
+
+[Heartbleed]: https://heartbleed.com/ 
+[OpenSSL]: https://www.openssl.org/
 
 ## Learn more about fuzzing
 
@@ -78,8 +81,8 @@ other resources are listed on the [useful links] page.
 [useful links]: {{ site.baseurl }}/reference/useful-links/#tutorials
 
 ## Trophies
-As of February 2023, OSS-Fuzz has helped identify and fix over [10,000] vulnerabilities and [31,000] bugs across [1,000] projects.
+As of August 2023, OSS-Fuzz has helped identify and fix over [10,000] vulnerabilities and [36,000] bugs across [1,000] projects.
 
-[10,000]: https://bugs.chromium.org/p/oss-fuzz/issues/list?q=status%3AFixed%2CVerified%20Type%3DBug-Security&can=1
-[31,000]: https://bugs.chromium.org/p/oss-fuzz/issues/list?q=status%3AFixed%2CVerified%20Type%3DBug&can=1
+[10,000]: https://bugs.chromium.org/p/oss-fuzz/issues/list?q=Type%3DBug-Security%20label%3Aclusterfuzz&can=1
+[36,000]: https://bugs.chromium.org/p/oss-fuzz/issues/list?q=Type%3DBug%20label%3Aclusterfuzz%20-status%3ADuplicate%2CWontFix&can=1
 [1,000]: https://github.com/google/oss-fuzz/tree/master/projects


### PR DESCRIPTION
Add two paragraphs from blog post (https://security.googleblog.com/2022/09/fuzzing-beyond-memory-corruption.html) explaining the project's history.