### PR TITLE
kyverno: build upstream fuzzers

### DIFF
--- a/projects/kyverno/Dockerfile
+++ b/projects/kyverno/Dockerfile
@@ -21,6 +21,5 @@ RUN wget https://go.dev/dl/go1.20.6.linux-amd64.tar.gz \
     && rm -rf /root/.go/* \ 
     && tar -C temp-go/ -xzf go1.20.6.linux-amd64.tar.gz \ 
     && mv temp-go/go/* /root/.go/ 
-RUN git clone --depth 1 https://github.com/cncf/cncf-fuzzing
 COPY build.sh $SRC/
 WORKDIR $SRC/kyverno

--- a/projects/kyverno/build.sh
+++ b/projects/kyverno/build.sh
@@ -18,4 +18,4 @@
 # required by Go 1.20
 export CXX="${CXX} -lresolv"
 
-$SRC/cncf-fuzzing/projects/kyverno/build.sh
+$SRC/kyverno/test/fuzz/oss_fuzz_build.sh


### PR DESCRIPTION
I have recently moved the fuzzers upstream. This PR builds them from there instead of cncf-fuzzing.