### PR TITLE
Java-coverage: Add logic to exclude dependencies in JVM coverage report

### DIFF
--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -459,6 +459,60 @@ elif [[ $FUZZING_LANGUAGE == "jvm" ]]; then
     fi
   done
 
+  # Check if TARGET_PACKAGE_PREFIX has been set and remove classes not
+  # in the target package prefix to exclude them in the resulting HTML
+  # report. By default, Jacoco includes all classes in the classes dump
+  # directory to the resulting HTML report. Removing classes not in target
+  # package could concentrate the result on small subset of class and
+  # decrease the noise from project dependencies.
+  dir_to_remove=
+  have_target_package="NO"
+  # Duplicate classes_dir for dependency classes removal
+  reduced_classes_dir=$DUMPS_DIR/classes_reduced
+  cp -r $classes_dir $reduced_classes_dir
+  if [[ -n ${TARGET_PACKAGE_PREFIX:-} ]]
+  then
+    # Translate the colon separated target package prefix environment
+    # variable to space separated directories for deciding which
+    # classes directory needed to be removed.
+    package_prefix=$(echo $TARGET_PACKAGE_PREFIX | sed "s#:# #g" | sed "s#\.#/#g" | sed "s#/\*##g")
+    for dir in $(find $reduced_classes_dir -mindepth 1 -type d)
+    do
+      # Check if each directory matches one of the target package prefix. If
+      # not, mark them as candidate for removal with a space separated variable.
+      # As the directory structure of java classes follow their package name,
+      # then directories that do not match the provided list of package prefix
+      # can be removed and exclude from the HTML report.
+      need_remove="YES"
+      for prefix in $package_prefix
+      do
+        if [[ "./$prefix" == "$dir"* ]]
+        then
+          have_target_package="YES"
+          need_remove="NO"
+        fi
+      done
+      if [[ "$need_remove" == "YES" ]]
+      then
+        # Mark the directory for removal with a space separated variable
+        dir_to_remove="$dir_to_remove$dir "
+      fi
+    done
+  fi
+
+  # Remove unwanted directory for Jacoco HTML report if
+  # at least one target package prefix does exist
+  if [[ "$have_target_package" == "YES" ]]
+  then
+    for dir in $dir_to_remove
+    do
+      rm -rf $dir
+    done
+   # Point classes_dir to reduced_classes_dir if at least one target package
+   # prefix does exist.
+   classes_dir=$reduced_classes_dir
+  fi
+
   # Clean up files that can create duplicate class names which breaks Jacoco.
   # Remove META-INF folder because some jar may store duplications of the same
   # class file in the META-INF for other java versions.

--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -459,17 +459,28 @@ elif [[ $FUZZING_LANGUAGE == "jvm" ]]; then
     fi
   done
 
+
   # Check if TARGET_PACKAGE_PREFIX has been set and remove classes not
   # in the target package prefix to exclude them in the resulting HTML
   # report. By default, Jacoco includes all classes in the classes dump
   # directory to the resulting HTML report. Removing classes not in target
   # package could concentrate the result on small subset of class and
   # decrease the noise from project dependencies.
+  for arg in $COVERAGE_EXTRA_ARGS
+  do
+    if [[ $arg == "TARGET_PACKAGE_PREFIX="* ]]
+    then
+      TARGET_PACKAGE_PREFIX=`echo $arg | cut -d= -f2`
+    fi
+  done
+
   dir_to_remove=
   have_target_package="NO"
   # Duplicate classes_dir for dependency classes removal
   reduced_classes_dir=$DUMPS_DIR/classes_reduced
+  rm -rf $reduced_classes_dir
   cp -r $classes_dir $reduced_classes_dir
+
   if [[ -n ${TARGET_PACKAGE_PREFIX:-} ]]
   then
     # Translate the colon separated target package prefix environment
@@ -486,10 +497,22 @@ elif [[ $FUZZING_LANGUAGE == "jvm" ]]; then
       need_remove="YES"
       for prefix in $package_prefix
       do
-        if [[ "./$prefix" == "$dir"* ]]
+	prefix=$reduced_classes_dir/$prefix
+        if [[ "$dir" == "$prefix"* ]]
         then
           have_target_package="YES"
           need_remove="NO"
+        else
+          while [[ "$prefix" != "$reduced_classes_dir" ]]
+          do
+            if [[ "$dir" == "$prefix" ]]
+            then
+              have_target_package="YES"
+              need_remove="NO"
+              break
+            fi
+            prefix=$(dirname $prefix)
+          done
         fi
       done
       if [[ "$need_remove" == "YES" ]]


### PR DESCRIPTION
This PR resolves #10826 by using the COVERAGE_EXTRA_ARGS from project.yaml or helper.py script to retrieve a TARGET_PACKAGE_PREFIX list to specify what class packages to be included in the Jacoco HTML report for JVM projects.

Sample result for project Joni before the PR
<img width="1136" alt="Screenshot 2023-11-10 at 10 20 49 PM" src="https://github.com/google/oss-fuzz/assets/33429318/da79ee95-05ed-4d5d-b010-872d8b552e75">

Sample result after the PR is applied
<img width="1037" alt="Screenshot 2023-11-10 at 10 20 19 PM" src="https://github.com/google/oss-fuzz/assets/33429318/1a155aa1-5148-48a9-831e-7b59ae91afff">

The additional field added to project.yaml
coverage_extra_args: TARGET_PACKAGE_PREFIX=org.joni.*