### PR TITLE
[libstdc++] initial integration

### DIFF
--- a/projects/libstdcpp/Dockerfile
+++ b/projects/libstdcpp/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN sed -i -e 's/^# deb-src/deb-src/g' /etc/apt/sources.list
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN apt build-dep -y g++-10
+RUN git clone --depth 1 git://gcc.gnu.org/git/gcc.git libstdcpp
+WORKDIR libstdcpp
+COPY build.sh $SRC/
+ADD https://raw.githubusercontent.com/pauldreik/stdfuzz/main/format/one-arg.cpp $SRC/

--- a/projects/libstdcpp/build.sh
+++ b/projects/libstdcpp/build.sh
@@ -1,0 +1,45 @@
+#!/bin/bash -eu
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+SRCDIR=$SRC/libstdcpp
+BUILDDIR=$OUT/build.d
+INSTALLDIR=$OUT/install.d
+mkdir -p $BUILDDIR $INSTALLDIR
+
+(
+    cd $BUILDDIR
+    CXX= CC= CXXFLAGS= CFLAGS= $SRCDIR/configure \
+       --disable-bootstrap \
+       --prefix=$INSTALLDIR \
+       --enable-languages=c++
+    make -j$(nproc)
+    make -j$(nproc) install-target-libstdc++-v3
+)
+
+for fuzzsrcfile in /src/*.cpp; do
+    targetfile=$(basename $fuzzsrcfile .cpp)
+    $CXX \
+	$CXXFLAGS \
+	-std=c++20 \
+	-nostdinc++ \
+	-cxx-isystem $INSTALLDIR/include/c++/14.0.0/ \
+	-cxx-isystem $INSTALLDIR/include/c++/14.0.0/x86_64-pc-linux-gnu \
+	$fuzzsrcfile \
+	-o $OUT/$targetfile \
+	$LIB_FUZZING_ENGINE \
+	$INSTALLDIR/lib64/libstdc++.a
+done
+

--- a/projects/libstdcpp/project.yaml
+++ b/projects/libstdcpp/project.yaml
@@ -1,0 +1,17 @@
+homepage: "https://gcc.gnu.org/"
+language: c++
+primary_contact: "pauldreikossfuzz@gmail.com"
+auto_ccs:
+ - "jwakely.gcc@gmail.com"
+main_repo: "git://gcc.gnu.org/git/gcc.git"
+file_github_issue: false
+architectures:
+ - x86_64
+sanitizers:
+ - address
+ - undefined
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+# - centipede


### PR DESCRIPTION
this adds a fuzzer for format in the gnu standard C++ library

this particular fuzzer has found several bugs which have been reported upstream and fixed. ([110860](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110860), [110862](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110862) and [110868](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110868))

the code is partially based on the fuzzers I made for the {fmt} library already on oss-fuzz.

I have contacted Jonathan Wakely @jwakely from upstream who has agreed to be a mail cc and is OK with this work taking place.

since fuzzing a standard library while using another one is a bit weird, I am not sure I got everything right but this is a place to start and improve from. in particular, memory sanitizer does not work so I disabled it.