### PR TITLE
freerdp: fix building

### DIFF
--- a/projects/freerdp/build.sh
+++ b/projects/freerdp/build.sh
@@ -45,6 +45,8 @@ cmake_args=(
     -DWITH_LIBSYSTEMD=OFF
     -DWITH_FUSE=OFF
     -DWITH_AAD=OFF
+    -DWITH_FFMPEG=OFF
+    -DWITH_SWSCALE=OFF
 
     # clang-15 segfaults on linking binaries when LTO is enabled,
     # see https://github.com/google/oss-fuzz/pull/10448#issuecomment-1578160436


### PR DESCRIPTION
Enabling SWSCALE by default broke a build.
Broken by commit 67bc4565 ("[cmake] default to require FFMPEG and SWCALE").

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=60211#c33