### PR TITLE
Apache poi more expected exceptions and reduce logging some more

### DIFF
--- a/projects/apache-poi/pom.xml
+++ b/projects/apache-poi/pom.xml
@@ -54,6 +54,11 @@
 			<artifactId>poi-examples</artifactId>
 			<version>${fuzzedLibaryVersion}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>2.20.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIFuzzer.java
@@ -110,6 +110,13 @@ public class POIFuzzer {
 	public static void checkExtractor(byte[] input) {
 		try (POITextExtractor extractor = ExtractorFactory.createExtractor(new ByteArrayInputStream(input))) {
 			checkExtractor(extractor);
+		} catch (UnsatisfiedLinkError e) {
+			// only allow one missing library related to Font/Color-handling
+			// we cannot install additional libraries in oss-fuzz images currently
+			// see https://github.com/google/oss-fuzz/issues/7380
+			if (!e.getMessage().contains("libawt_xawt.so")) {
+				throw e;
+			}
 		} catch (IOException | POIXMLException | IllegalArgumentException | RecordFormatException |
 				 IndexOutOfBoundsException | HSLFException | RecordInputStream.LeftoverDataException |
 				 NoSuchElementException | IllegalStateException | ArithmeticException |

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIXSLFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIXSLFFuzzer.java
@@ -38,7 +38,7 @@ public class POIXSLFFuzzer {
 		try (XMLSlideShow slides = new XMLSlideShow(new ByteArrayInputStream(input))) {
 			slides.write(NullOutputStream.INSTANCE);
 		} catch (IOException | EmptyFileException | UnsupportedFileFormatException | POIXMLException |
-				 RecordFormatException | OpenXML4JRuntimeException e) {
+				 RecordFormatException | OpenXML4JRuntimeException | IndexOutOfBoundsException e) {
 			// expected here
 		}
 
@@ -47,7 +47,7 @@ public class POIXSLFFuzzer {
 				slides.write(NullOutputStream.INSTANCE);
 			}
 		} catch (IOException | OpenXML4JException | XmlException | IllegalArgumentException | POIXMLException |
-				 RecordFormatException | IllegalStateException | OpenXML4JRuntimeException e) {
+				 RecordFormatException | IllegalStateException | OpenXML4JRuntimeException | IndexOutOfBoundsException e) {
 			// expected here
 		}
 
@@ -56,7 +56,7 @@ public class POIXSLFFuzzer {
 				POIFuzzer.checkExtractor(extractor);
 			}
 		} catch (IOException | InvalidFormatException | POIXMLException | IllegalArgumentException |
-				RecordFormatException | IllegalStateException e) {
+				RecordFormatException | IllegalStateException | IndexOutOfBoundsException e) {
 			// expected
 		}
 	}


### PR DESCRIPTION
A few new types of Exceptions popped up when fuzzing Apache POI. Let's ignore those as well.

Also add dependency to log4j-core to not have log4j log everything to stdout instead of suppressing log-output completely as intended.

Should fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=61363 and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=61446