### PR TITLE
aspectj: Fix target package prefix for aspectj

### DIFF
--- a/projects/aspectj/Dockerfile
+++ b/projects/aspectj/Dockerfile
@@ -21,6 +21,7 @@ unzip maven.zip -d $SRC/maven && \
 rm -rf maven.zip
 
 ENV MVN $SRC/maven/apache-maven-3.6.3/bin/mvn
+ENV TARGET_PACKAGE_PREFIX org.aspectj.*
 
 WORKDIR ${SRC}
 #


### PR DESCRIPTION
Add TARGET_PACKAGE_PREFIX environment variable for fuzz-introspector to ignore analysing on dependency classes.