### PR TITLE
[typescript]: remove fuzz blockers and cleanup harnesses

### DIFF
--- a/projects/typescript/Dockerfile
+++ b/projects/typescript/Dockerfile
@@ -19,10 +19,12 @@ FROM gcr.io/oss-fuzz-base/base-builder-javascript
 RUN  git clone --depth 1 https://github.com/microsoft/TypeScript.git
 
 COPY build.sh $SRC/
+COPY fuzz_util.js $SRC/TypeScript
 COPY fuzz_ast.js $SRC/TypeScript
 COPY fuzz_compiler.js $SRC/TypeScript
 COPY fuzz_scanner.js $SRC/TypeScript
 COPY fuzz_json_parser.js $SRC/TypeScript
 COPY fuzz_transpile_module.js $SRC/TypeScript
+
 
 WORKDIR $SRC/TypeScript

--- a/projects/typescript/fuzz_json_parser.js
+++ b/projects/typescript/fuzz_json_parser.js
@@ -75,6 +75,8 @@ function createExistingOptions(provider) {
 }
 
 const ignored = [
+  // TypeScript not interested: https://github.com/microsoft/TypeScript/issues/55480
+  "maximum call stack size exceeded",
   "cannot read",
   "cannot create",
   "expected",

--- a/projects/typescript/fuzz_scanner.js
+++ b/projects/typescript/fuzz_scanner.js
@@ -53,6 +53,8 @@ function ignoredError(error) {
 }
 
 const ignored = [
+  // TypeScript not interested: https://github.com/microsoft/TypeScript/issues/55480
+  "maximum call stack size exceeded",
   "expected",
   "unexpected",
   "invalid",

--- a/projects/typescript/fuzz_transpile_module.js
+++ b/projects/typescript/fuzz_transpile_module.js
@@ -15,6 +15,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 const { FuzzedDataProvider } = require('@jazzer.js/core');
+const { getCompilerOptions } = require("./fuzz_util");
 const ts = require('typescript');
 
 module.exports.fuzz = function(data) {
@@ -35,130 +36,9 @@ function ignoredError(error) {
   return !!ignored.find((message) => error.message.toLowerCase().indexOf(message) !== -1);
 }
 
-function getCompilerOptions(provider) {
-  return {
-    allowJs: provider.consumeBoolean(),
-    allowSyntheticDefaultImports: provider.consumeBoolean(),
-    allowUnreachableCode: provider.consumeBoolean(),
-    allowUnusedLabels: provider.consumeBoolean(),
-    alwaysStrict: provider.consumeBoolean(),
-    baseUrl: provider.consumeString(provider.consumeIntegralInRange(0, 100)),
-    charset: provider.consumeString(provider.consumeIntegralInRange(0, 100)),
-    checkJs: provider.consumeBoolean(),
-    declaration: provider.consumeBoolean(),
-    declarationDir: provider.consumeString(provider.consumeIntegralInRange(0, 100)),
-    disableSizeLimit: provider.consumeBoolean(),
-    downlevelIteration: provider.consumeBoolean(),
-    emitBOM: provider.consumeBoolean(),
-    emitDecoratorMetadata: provider.consumeBoolean(),
-    experimentalDecorators: provider.consumeBoolean(),
-    forceConsistentCasingInFileNames: provider.consumeBoolean(),
-    importHelpers: provider.consumeBoolean(),
-    inlineSourceMap: provider.consumeBoolean(),
-    inlineSources: provider.consumeBoolean(),
-    isolatedModules: provider.consumeBoolean(),
-    jsx: getJsx(provider),
-    lib: [],
-    locale: provider.consumeString(provider.consumeIntegralInRange(0, 8)),
-    mapRoot: provider.consumeString(provider.consumeIntegralInRange(0, 100)),
-    maxNodeModuleJsDepth: provider.consumeIntegralInRange(0, 100),
-    module: getModuleKind(provider),
-    moduleResolution: getModuleResolutionKind(provider),
-    newLine: provider.consumeBoolean() ? ts.NewLineKind.LineFeed : ts.NewLineKind.CarriageReturnLineFeed,
-    noEmit: provider.consumeBoolean(),
-    noEmitHelpers: provider.consumeBoolean(),
-    noEmitOnError: provider.consumeBoolean(),
-    noErrorTruncation: provider.consumeBoolean(),
-    noFallthroughCasesInSwitch: provider.consumeBoolean(),
-    noImplicitAny: provider.consumeBoolean(),
-    noImplicitReturns: provider.consumeBoolean(),
-    noImplicitThis: provider.consumeBoolean(),
-    noUnusedLocals: provider.consumeBoolean(),
-    noUnusedParameters: provider.consumeBoolean(),
-    noImplicitUseStrict: provider.consumeBoolean(),
-    noLib: provider.consumeBoolean(),
-    noResolve: provider.consumeBoolean(),
-    out: provider.consumeString(provider.consumeIntegralInRange(0, 100)),
-    outDir: provider.consumeString(provider.consumeIntegralInRange(0, 100)),
-    outFile: provider.consumeString(provider.consumeIntegralInRange(0, 100)),
-    paths: {},
-    plugins: [],
-    preserveConstEnums: provider.consumeBoolean(),
-    preserveSymlinks: provider.consumeBoolean(),
-    project: provider.consumeString(provider.consumeIntegralInRange(0, 100)),
-    reactNamespace: provider.consumeString(provider.consumeIntegralInRange(0, 100)),
-    removeComments: provider.consumeBoolean(),
-    references: [],
-    rootDir: provider.consumeString(provider.consumeIntegralInRange(0, 100)),
-    rootDirs: [],
-    skipLibCheck: provider.consumeBoolean(),
-    skipDefaultLibCheck: provider.consumeBoolean(),
-    sourceMap: provider.consumeBoolean(),
-    sourceRoot: provider.consumeString(provider.consumeIntegralInRange(0, 100)),
-    strict: provider.consumeBoolean(),
-    strictNullChecks: provider.consumeBoolean(),
-    suppressExcessPropertyErrors: provider.consumeBoolean(),
-    suppressImplicitAnyIndexErrors: provider.consumeBoolean(),
-    useDefineForClassFields: provider.consumeBoolean(),
-    target: getScriptTarget(provider),
-    traceResolution: provider.consumeBoolean(),
-    resolveJsonModule: provider.consumeBoolean(),
-    types: [],
-    typeRoots: []
-  }
-}
-
-function getJsx(provider) {
-  switch (provider.consumeIntegralInRange(0, 3)) {
-    case 0: return ts.JsxEmit.None;
-    case 1: return ts.JsxEmit.Preserve;
-    case 2: return ts.JsxEmit.ReactNative;
-    case 3: return ts.JsxEmit.React;
-  }
-}
-
-function getModuleKind(provider) {
-  switch (provider.consumeIntegralInRange(0, 10)) {
-    case 0: return ts.ModuleKind.None;
-    case 1: return ts.ModuleKind.CommonJS;
-    case 2: return ts.ModuleKind.AMD;
-    case 3: return ts.ModuleKind.UMD;
-    case 4: return ts.ModuleKind.System;
-    case 5: return ts.ModuleKind.ES2015;
-    case 6: return ts.ModuleKind.ES2020;
-    case 7: return ts.ModuleKind.ES2022;
-    case 8: return ts.ModuleKind.ESNext;
-    case 9: return ts.ModuleKind.Node16;
-    case 10: return ts.ModuleKind.NodeNext;
-  }
-}
-
-function getModuleResolutionKind(provider) {
-  switch (provider.consumeIntegralInRange(0, 5)) {
-    case 0: return ts.ModuleResolutionKind.Classic;
-    case 1: return ts.ModuleResolutionKind.NodeNext;
-    case 2: return ts.ModuleResolutionKind.Node16
-    case 3: return ts.ModuleResolutionKind.Node10;
-    case 4: return ts.ModuleResolutionKind.Bundler;
-  }
-}
-
-function getScriptTarget(provider) {
-  switch (provider.consumeIntegralInRange(0, 10)) {
-    case 0: return ts.ScriptTarget.ESNext;
-    case 1: return ts.ScriptTarget.ES2022;
-    case 2: return ts.ScriptTarget.Latest;
-    case 3: return ts.ScriptTarget.ES3;
-    case 4: return ts.ScriptTarget.ES5;
-    case 5: return ts.ScriptTarget.ESNext;
-    case 6: return ts.ScriptTarget.JSON;
-    case 7: return ts.ScriptTarget.ES2015;
-    case 8: return ts.ScriptTarget.ES2016;
-    case 9: return ts.ScriptTarget.ES2017;
-  }
-}
-
 const ignored = [
+  // TypeScript not interested: https://github.com/microsoft/TypeScript/issues/55480
+  "maximum call stack size exceeded",
   "expected",
   "unexpected",
   "invalid",
@@ -170,4 +50,3 @@ const ignored = [
   "duplicate",
   "the value"
 ];
-

--- a/projects/typescript/fuzz_util.js
+++ b/projects/typescript/fuzz_util.js
@@ -1,0 +1,146 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+const ts = require("typescript");
+
+module.exports = { getCompilerOptions };
+function getCompilerOptions(provider) {
+  return {
+    allowJs: provider.consumeBoolean(),
+    allowSyntheticDefaultImports: provider.consumeBoolean(),
+    allowUnreachableCode: provider.consumeBoolean(),
+    allowUnusedLabels: provider.consumeBoolean(),
+    alwaysStrict: provider.consumeBoolean(),
+    baseUrl: provider.consumeString(provider.consumeIntegralInRange(0, 100)),
+    charset: provider.consumeString(provider.consumeIntegralInRange(0, 100)),
+    checkJs: provider.consumeBoolean(),
+    declaration: provider.consumeBoolean(),
+    declarationDir: provider.consumeString(provider.consumeIntegralInRange(0, 100)),
+    disableSizeLimit: provider.consumeBoolean(),
+    downlevelIteration: provider.consumeBoolean(),
+    emitBOM: provider.consumeBoolean(),
+    emitDecoratorMetadata: provider.consumeBoolean(),
+    experimentalDecorators: provider.consumeBoolean(),
+    forceConsistentCasingInFileNames: provider.consumeBoolean(),
+    importHelpers: provider.consumeBoolean(),
+    inlineSourceMap: provider.consumeBoolean(),
+    inlineSources: provider.consumeBoolean(),
+    isolatedModules: provider.consumeBoolean(),
+    jsx: getJsx(provider),
+    lib: [],
+    locale: provider.consumeString(provider.consumeIntegralInRange(0, 8)),
+    mapRoot: provider.consumeString(provider.consumeIntegralInRange(0, 100)),
+    maxNodeModuleJsDepth: provider.consumeIntegralInRange(0, 100),
+    module: getModuleKind(provider),
+    moduleResolution: getModuleResolutionKind(provider),
+    newLine: provider.consumeBoolean() ? ts.NewLineKind.LineFeed : ts.NewLineKind.CarriageReturnLineFeed,
+    noEmit: provider.consumeBoolean(),
+    noEmitHelpers: provider.consumeBoolean(),
+    noEmitOnError: provider.consumeBoolean(),
+    noErrorTruncation: provider.consumeBoolean(),
+    noFallthroughCasesInSwitch: provider.consumeBoolean(),
+    noImplicitAny: provider.consumeBoolean(),
+    noImplicitReturns: provider.consumeBoolean(),
+    noImplicitThis: provider.consumeBoolean(),
+    noUnusedLocals: provider.consumeBoolean(),
+    noUnusedParameters: provider.consumeBoolean(),
+    noImplicitUseStrict: provider.consumeBoolean(),
+    noLib: provider.consumeBoolean(),
+    noResolve: provider.consumeBoolean(),
+    out: provider.consumeString(provider.consumeIntegralInRange(0, 100)),
+    outDir: provider.consumeString(provider.consumeIntegralInRange(0, 100)),
+    outFile: provider.consumeString(provider.consumeIntegralInRange(0, 100)),
+    paths: {},
+    plugins: [],
+    preserveConstEnums: provider.consumeBoolean(),
+    preserveSymlinks: provider.consumeBoolean(),
+    project: provider.consumeString(provider.consumeIntegralInRange(0, 100)),
+    reactNamespace: provider.consumeString(provider.consumeIntegralInRange(0, 100)),
+    removeComments: provider.consumeBoolean(),
+    references: [],
+    rootDir: provider.consumeString(provider.consumeIntegralInRange(0, 100)),
+    rootDirs: [],
+    skipLibCheck: provider.consumeBoolean(),
+    skipDefaultLibCheck: provider.consumeBoolean(),
+    sourceMap: provider.consumeBoolean(),
+    sourceRoot: provider.consumeString(provider.consumeIntegralInRange(0, 100)),
+    strict: provider.consumeBoolean(),
+    strictNullChecks: provider.consumeBoolean(),
+    suppressExcessPropertyErrors: provider.consumeBoolean(),
+    suppressImplicitAnyIndexErrors: provider.consumeBoolean(),
+    useDefineForClassFields: provider.consumeBoolean(),
+    target: getScriptTarget(provider),
+    traceResolution: provider.consumeBoolean(),
+    resolveJsonModule: provider.consumeBoolean(),
+    types: [],
+    typeRoots: []
+  }
+}
+
+function getJsx(provider) {
+  switch (provider.consumeIntegralInRange(0, 4)) {
+    case 0: return ts.JsxEmit.None;
+    case 1: return ts.JsxEmit.Preserve;
+    case 2: return ts.JsxEmit.ReactNative;
+    case 3: return ts.JsxEmit.React;
+    case 4: return provider.consumeString(provider.consumeIntegralInRange(0, 100));
+  }
+}
+
+function getModuleKind(provider) {
+  switch (provider.consumeIntegralInRange(0, 11)) {
+    case 0: return ts.ModuleKind.None;
+    case 1: return ts.ModuleKind.CommonJS;
+    case 2: return ts.ModuleKind.AMD;
+    case 3: return ts.ModuleKind.UMD;
+    case 4: return ts.ModuleKind.System;
+    case 5: return ts.ModuleKind.ES2015;
+    case 6: return ts.ModuleKind.ES2020;
+    case 7: return ts.ModuleKind.ES2022;
+    case 8: return ts.ModuleKind.ESNext;
+    case 9: return ts.ModuleKind.Node16;
+    case 10: return ts.ModuleKind.NodeNext;
+    case 11: return provider.consumeString(provider.consumeIntegralInRange(0, 100));
+  }
+}
+
+function getModuleResolutionKind(provider) {
+  switch (provider.consumeIntegralInRange(0, 5)) {
+    case 0: return ts.ModuleResolutionKind.Classic;
+    case 1: return ts.ModuleResolutionKind.NodeNext;
+    case 2: return ts.ModuleResolutionKind.Node16
+    case 3: return ts.ModuleResolutionKind.Node10;
+    case 4: return ts.ModuleResolutionKind.Bundler;
+    case 5: return provider.consumeString(provider.consumeIntegralInRange(0, 100));
+  }
+}
+
+function getScriptTarget(provider) {
+  switch (provider.consumeIntegralInRange(0, 10)) {
+    case 0: return ts.ScriptTarget.ESNext;
+    case 1: return ts.ScriptTarget.ES2022;
+    case 2: return ts.ScriptTarget.Latest;
+    case 3: return ts.ScriptTarget.ES3;
+    case 4: return ts.ScriptTarget.ES5;
+    case 5: return ts.ScriptTarget.ESNext;
+    case 6: return ts.ScriptTarget.JSON;
+    case 7: return ts.ScriptTarget.ES2015;
+    case 8: return ts.ScriptTarget.ES2016;
+    case 9: return ts.ScriptTarget.ES2017;
+    case 10: return provider.consumeString(provider.consumeIntegralInRange(0, 100));
+  }
+}
+


### PR DESCRIPTION
This cleans up the harnesses some more and refactors some common helper functions in a `fuzz_utils.js` while also ignoring a certain bug class that, after discussion with the TypeScript team, is not interesting, so we treat it as a blocker and will ignore those now.