### PR TITLE
fix: add gofuzz tags to build

### DIFF
--- a/infra/base-images/base-builder/compile_native_go_fuzzer
+++ b/infra/base-images/base-builder/compile_native_go_fuzzer
@@ -29,7 +29,7 @@ function build_native_go_fuzzer() {
 		cp "${fuzzer_filename}" "${OUT}/rawfuzzers/${fuzzer}"
 		cd $current_dir
 	else
-		go-118-fuzz-build -o $fuzzer.a -func $function $abs_file_dir
+		go-118-fuzz-build $tags -o $fuzzer.a -func $function $abs_file_dir
 		$CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.a -o $OUT/$fuzzer
 	fi
 }


### PR DESCRIPTION
It appears that `gofuzz` was removed from the default tagspec in the main branch of go-118-fuzz-build [^1] to `gofuzz_libfuzzer` and `libfuzzer`.  To keep compatibility with the go build scripts, this change adds the gofuzz tag to the go-118-fuzz-build invocation. 

[^1]: https://github.com/AdamKorcz/go-118-fuzz-build/pull/9/files#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L35