### PR TITLE
Generate AST of the target file while building project.

### DIFF
--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -182,6 +182,7 @@ func GenerateAST(bin string, args []string, targetFile string) {
 
 func GenerateASTs(bin string, args []string) {
 	// Generates an AST for each C/CPP file in the command.
+	// Target file suffixes.
 	suffixes := []string{".cpp", ".cc", ".cxx", ".c++", ".c", ".h", ".hpp"}
 	// C/CPP targets in the command.
 	targets := []string{}
@@ -213,8 +214,10 @@ func ExecBuildCommand(bin string, args []string) (int, string, string) {
 }
 
 func Compile(bin string, args []string) (int, string, string) {
-	// Generate AST.
-	GenerateASTs(bin, args)
+	// Generate ASTs f we define this ENV var.
+	if os.Getenv("JCC_GENERATE_AST") == "1" {
+		GenerateASTs(bin, args)
+	}
 	// Run the actual command.
 	return ExecBuildCommand(bin, args)
 }

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -65,7 +65,7 @@ func TryFixCCompilation(cmdline []string) (int, string, string) {
 	newCmdline := []string{"-stdlib=libc++"}
 	newCmdline = append(cmdline, newCmdline...)
 
-	retcode, out, err := compile("clang++", newCmdline)
+	retcode, out, err := Compile("clang++", newCmdline)
 	if retcode == 0 {
 		return retcode, out, err
 	}
@@ -149,7 +149,7 @@ func GetHeaderCorrectedCmd(cmd []string, compilerErr string) ([]string, string, 
 
 func CorrectMissingHeaders(bin string, cmd []string) (bool, error) {
 
-	_, _, stderr := compile(bin, cmd)
+	_, _, stderr := Compile(bin, cmd)
 	cmd, correctedFilename, err := GetHeaderCorrectedCmd(cmd, stderr)
 	if err != nil {
 		return false, err
@@ -211,7 +211,7 @@ func ExecBuildCommand(bin string, args []string) (int, string, string) {
 	return cmd.ProcessState.ExitCode(), outb.String(), errb.String()
 }
 
-func compile(bin string, args []string) (int, string, string) {
+func Compile(bin string, args []string) (int, string, string) {
 	// Generate AST.
 	GenerateASTs(bin, args)
 	// Run the actual command.
@@ -219,7 +219,7 @@ func compile(bin string, args []string) (int, string, string) {
 }
 
 func TryCompileAndFixHeadersOnce(bin string, cmd []string, filename string) (fixed, hasBrokenHeaders bool) {
-	retcode, _, err := compile(bin, cmd)
+	retcode, _, err := Compile(bin, cmd)
 	if retcode == 0 {
 		fixed = true
 		hasBrokenHeaders = false
@@ -337,10 +337,10 @@ func main() {
 	var bin string
 	if isCPP {
 		bin = "clang++"
-		retcode, out, err = compile(bin, newArgs)
+		retcode, out, err = Compile(bin, newArgs)
 	} else {
 		bin = "clang"
-		retcode, out, err = compile(bin, newArgs)
+		retcode, out, err = Compile(bin, newArgs)
 	}
 	if retcode == 0 {
 		fmt.Println(out)

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -214,7 +214,7 @@ func GenerateAST(bin string, args []string) (int, string, string) {
 	newArgs := append(args, "-Xclang", "-ast-dump=json", "-fsyntax-only")
 
 	targetFile := FindTargetFile(args)
-	filePath := filepath.Join("/tmp", fmt.Sprintf("%s.txt", targetFile))
+	filePath := filepath.Join("/out", fmt.Sprintf("%s.ast", targetFile))
 
 	cmdStr := fmt.Sprintf("%s %s > %s", bin, strings.Join(newArgs, " "), filePath)
 	cmd := exec.Command("sh", "-c", cmdStr)

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -195,7 +195,8 @@ func GenerateASTs(bin string, args []string) {
 		}
 		flags = append(flags, arg)
 	}
-	// Generate an AST for each target.
+	// Generate an AST for each target. Skips AST generation when a command
+	// has no target file (e.g., during linking).
 	for _, target := range targets {
 		GenerateAST(bin, append(flags, target), filepath.Base(target))
 	}

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -168,25 +168,18 @@ func CorrectMissingHeaders(bin string, cmd []string) (bool, error) {
 
 func EnsureDir(dirPath string) {
 	// Checks if a path is an existing directory, otherwise create one.
-	pathInfo, err := os.Stat(dirPath)
-	if err == nil {
-		isDir := pathInfo.IsDir()
-		if !isDir {
+	if pathInfo, err := os.Stat(dirPath); err == nil {
+		if isDir := pathInfo.IsDir(); !isDir {
 			panic(dirPath + "exists but is not a directory.")
 		}
-		return
-	}
-
-	if !errors.Is(err, fs.ErrNotExist) {
+	} else if errors.Is(err, fs.ErrNotExist) {
+		if err := os.MkdirAll(dirPath, 0755); err != nil {
+			panic("Failed to create directory" + dirPath + ".")
+		}
+		fmt.Println("Created directory" + dirPath + ".")
+	} else {
 		panic("An error occurred in os.Stat(" + dirPath + "): ", err)
-		return
 	}
-
-	if err := os.MkdirAll(dirPath, 0755); err != nil {
-		panic("Failed to create directory" + dirPath + ".")
-		return
-	}
-	fmt.Println("Created directory" + dirPath + ".")
 }
 
 func GenerateAST(bin string, args []string, filePath string) {

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -179,7 +179,7 @@ func ExecOriginalCommand(bin string, args []string) (int, string, string) {
 
 func FindTargetFile(args []string) string {
 	// Finds the fuzz target file by file extension.
-	suffixes := []string{".cpp", ".cc", ".cxx", ".c++", ".c"}
+	suffixes := []string{".cpp", ".cc", ".cxx", ".c++", ".c", ".h", ".hpp"}
 	for _, arg := range args {
 		if slices.Contains(suffixes, strings.ToLower(filepath.Ext(arg))) {
 			return filepath.Base(arg)

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -25,6 +25,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 )
@@ -181,21 +182,11 @@ func ExecOriginalCommand(bin string, args []string) (int, string, string) {
 	return RunCommand(cmd)
 }
 
-func Contains(slice []string, item string) bool {
-	// Checks if the slice contains item.
-	for _, s := range slice {
-		if strings.EqualFold(s, item) {
-			return true
-		}
-	}
-	return false
-}
-
 func FindTargetFile(args []string) string {
 	// Finds the fuzz target file by file extension.
 	suffixes := []string{".cpp", ".cc", ".cxx", ".c++", ".c"}
 	for _, arg := range args {
-		if Contains(suffixes, filepath.Ext(arg)) {
+		if slices.Contains(suffixes, strings.ToLower(filepath.Ext(arg))) {
 			return filepath.Base(arg)
 		}
 	}

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -201,7 +201,7 @@ func GenerateASTs(bin string, args []string) {
 	}
 }
 
-func ExecOriginalCommand(bin string, args []string) (int, string, string) {
+func ExecBuildCommand(bin string, args []string) (int, string, string) {
 	// Executes the original command.
 	cmd := exec.Command(bin, args...)
 	var outb, errb bytes.Buffer
@@ -215,7 +215,7 @@ func compile(bin string, args []string) (int, string, string) {
 	// Generate AST.
 	GenerateASTs(bin, args)
 	// Run the actual command.
-	return ExecOriginalCommand(bin, args)
+	return ExecBuildCommand(bin, args)
 }
 
 func TryCompileAndFixHeadersOnce(bin string, cmd []string, filename string) (fixed, hasBrokenHeaders bool) {

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -178,7 +178,7 @@ func EnsureDir(dirPath string) {
 		}
 		fmt.Println("Created directory: " + dirPath + ".")
 	} else {
-		panic("An error occurred in os.Stat(" + dirPath + "): ", err)
+		panic("An error occurred in os.Stat(" + dirPath + "): " + err.Error())
 	}
 }
 

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -170,13 +170,13 @@ func EnsureDir(dirPath string) {
 	// Checks if a path is an existing directory, otherwise create one.
 	if pathInfo, err := os.Stat(dirPath); err == nil {
 		if isDir := pathInfo.IsDir(); !isDir {
-			panic(dirPath + "exists but is not a directory.")
+			panic(dirPath + " exists but is not a directory.")
 		}
 	} else if errors.Is(err, fs.ErrNotExist) {
 		if err := os.MkdirAll(dirPath, 0755); err != nil {
-			panic("Failed to create directory" + dirPath + ".")
+			panic("Failed to create directory: " + dirPath + ".")
 		}
-		fmt.Println("Created directory" + dirPath + ".")
+		fmt.Println("Created directory: " + dirPath + ".")
 	} else {
 		panic("An error occurred in os.Stat(" + dirPath + "): ", err)
 	}

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -204,7 +204,7 @@ func GenerateAST(bin string, args []string, filePath string) {
 
 func GenerateASTs(bin string, args []string, astDir string) {
 	// Generates an AST for each C/CPP file in the command.
-	// Cannot save AST when astDir does not exist.
+	// Cannot save AST when astDir is not available.
 	if !EnsureDir(astDir) { return }
 
 	// Target file suffixes.

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -166,28 +166,27 @@ func CorrectMissingHeaders(bin string, cmd []string) (bool, error) {
 	return false, nil
 }
 
-func EnsureDir(dirPath string) bool {
+func EnsureDir(dirPath string) {
 	// Checks if a path is an existing directory, otherwise create one.
 	pathInfo, err := os.Stat(dirPath)
 	if err == nil {
 		isDir := pathInfo.IsDir()
 		if !isDir {
-			fmt.Println(dirPath, "exists but is not a directory.")
+			panic(dirPath + "exists but is not a directory.")
 		}
-		return isDir
+		return
 	}
 
 	if !os.IsNotExist(err) {
-		fmt.Println("An error occurred in os.Stat(" + dirPath + "): ", err)
-		return false
+		panic("An error occurred in os.Stat(" + dirPath + "): ", err)
+		return
 	}
 
 	if err := os.MkdirAll(dirPath, 0755); err != nil {
-		fmt.Println("Failed to create directory" + dirPath + ".")
-		return false
+		panic("Failed to create directory" + dirPath + ".")
+		return
 	}
 	fmt.Println("Created directory" + dirPath + ".")
-	return true
 }
 
 func GenerateAST(bin string, args []string, filePath string) {
@@ -206,7 +205,7 @@ func GenerateAST(bin string, args []string, filePath string) {
 func GenerateASTs(bin string, args []string, astDir string) {
 	// Generates an AST for each C/CPP file in the command.
 	// Cannot save AST when astDir is not available.
-	if !EnsureDir(astDir) { return }
+	EnsureDir(astDir)
 
 	// Target file suffixes.
 	suffixes := []string{".cpp", ".cc", ".cxx", ".c++", ".c", ".h", ".hpp"}

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -177,7 +177,7 @@ func EnsureDir(dirPath string) {
 		return
 	}
 
-	if !os.IsNotExist(err) {
+	if !errors.Is(err, fs.ErrNotExist) {
 		panic("An error occurred in os.Stat(" + dirPath + "): ", err)
 		return
 	}

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -215,8 +215,8 @@ func GenerateASTs(bin string, args []string, astDir string) {
 	// Flags to generate AST.
 	flags := []string{"-Xclang", "-ast-dump=json", "-fsyntax-only"}
 	for _, arg := range args {
-		targetFile_ext := strings.ToLower(filepath.Ext(arg))
-		if slices.Contains(suffixes, targetFile_ext) {
+		targetFileExt := strings.ToLower(filepath.Ext(arg))
+		if slices.Contains(suffixes, targetFileExt) {
 			targetFiles = append(targetFiles, arg)
 			continue
 		}

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -177,16 +177,17 @@ func EnsureDir(dirPath string) bool {
 		return isDir
 	}
 
-	if os.IsNotExist(err) {
-		if err := os.MkdirAll(dirPath, 0755); err != nil {
-			fmt.Println("Failed to create directory" + dirPath + ".")
-			return false
-		}
-		fmt.Println("Created directory" + dirPath + ".")
-		return true
+	if !os.IsNotExist(err) {
+		fmt.Println("An error occurred in os.Stat(" + dirPath + "): ", err)
+		return false
 	}
-	fmt.Println("An error occurred in os.Stat(" + dirPath + "): ", err)
-	return false
+
+	if err := os.MkdirAll(dirPath, 0755); err != nil {
+		fmt.Println("Failed to create directory" + dirPath + ".")
+		return false
+	}
+	fmt.Println("Created directory" + dirPath + ".")
+	return true
 }
 
 func GenerateAST(bin string, args []string, filePath string) {


### PR DESCRIPTION
Tested on `ada-url`.
Does not work on `bzl` projects (e.g. `abseil-cpp` for now.