### PR TITLE
infra: bump introspector

### DIFF
--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -245,7 +245,7 @@ if [ "$SANITIZER" = "introspector" ]; then
   unset CXXFLAGS
   unset CFLAGS
   export G_ANALYTICS_TAG="G-8WTFM1Y62J"
-  apt-get install -y libjpeg-dev zlib1g-dev
+  apt-get install -y libjpeg-dev zlib1g-dev libyaml-dev
   python3 -m pip install --upgrade setuptools
   python3 -m pip install cxxfilt pyyaml beautifulsoup4 lxml soupsieve
   python3 -m pip install --prefer-binary matplotlib

--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y wget sudo && \
 RUN apt-get update && apt-get install -y git && \
     git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
     cd fuzz-introspector && \
-    git checkout 4ee1cfaf28a61aec43462e520e32a4fceebe8858 && \
+    git checkout 54ade08f03b3144a67fa9da704b54093b36eabde && \
     git submodule init && \
     git submodule update && \
     apt-get autoremove --purge -y git && \


### PR DESCRIPTION
This has a set of performance improvements in Fuzz Introspector, the two changes with most impact are:
- removal of some expensive and unnecessary loops in the code
- switching parsing of large yaml files from pure python code to using a C backend.

Locally it makes OpenSSL builds take approximately 70 minutes whereas in the cloud build it seems to take 20+ hours. Similar impact happens across several large java projects.