### PR TITLE
lua: enable fuzz introspector

### DIFF
--- a/projects/lua/build.sh
+++ b/projects/lua/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+# For some reason the linker will complain if address sanitizer is not used
+# in introspector builds.
+if [ "$SANITIZER" == "introspector" ]; then
+  export CFLAGS="${CFLAGS} -fsanitize=address"
+  export CXXFLAGS="${CXXFLAGS} -fsanitize=address"
+fi
+
 PACKAGES="build-essential ninja-build cmake make"
 if [ "$ARCHITECTURE" = "i386" ]; then
     PACKAGES="$PACKAGES zlib1g-dev:i386 libreadline-dev:i386 libunwind-dev:i386"


### PR DESCRIPTION
This enables fuzz introspector for lua.

The [current build](https://oss-fuzz-build-logs.storage.googleapis.com/log-95e09fbf-701e-4adf-ad25-8629c7dd5f8a.txt) fails with:
```
Step #6 - "compile-libfuzzer-introspector-x86_64": [Log level 1] : 10:13:22 : This means a main function is in the source code rather in the libfuzzer library, and thus we do not care about it. We only want to study the actual fuzzers. Exiting this run.
Step #6 - "compile-libfuzzer-introspector-x86_64": /usr/bin/ld.gold: internal error in read_header_prolog, at ../../gold/dwarf_reader.cc:1678
Step #6 - "compile-libfuzzer-introspector-x86_64": clang-15: fatal error: linker command failed with exit code 1 (use -v to see invocation)
Step #6 - "compile-libfuzzer-introspector-x86_64": make: *** [makefile:119: lua] Error 1
Step #6 - "compile-libfuzzer-introspector-x86_64": 
```
At first I thought this was an issue of multiple-definitions since the error is the same as: https://github.com/google/oss-fuzz/issues/8629 However, allowing multiple definitions didn't work.

I'm not entirely sure why this fixes the problem. It was through trial and error I came up with the fix. I assume it may be some ASAN gets compiled in somehow during non-ASAN builds and this causes issues for the gold linker (but not in non-gold linkers, i.e. coverage and other sanitizers are fine).

This fixes the introspector build, but also adds ASAN instrumentation which bloats the calltrees, but the function table is good.

I tried setting LDFLAGS=-fsanitizer=address but this didn't work in the case of Lua. I have some ideas, however, to fix this. Will pursue that at a later stage.

Ref: https://github.com/google/oss-fuzz/issues/10882
