### PR TITLE
brpc: enable fuzz introspector

### DIFF
--- a/projects/brpc/build.sh
+++ b/projects/brpc/build.sh
@@ -27,7 +27,7 @@ cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_UNIT_TESTS=ON -DBUILD_SHARED_LIBS=OFF -DW
 -DLIB_FUZZING_ENGINE="$LIB_FUZZING_ENGINE" \
 ../
 
-make -j$(nproc)
+make -j$(nproc) Fuzz_json Fuzz_http
 
 pushd test/
 cp Fuzz_json $OUT/Fuzz_json


### PR DESCRIPTION
We only need to link the executables used for fuzzing. brpc has a lot of unit tests that need linking, and because of -j(nproc) the cloud builders are currently being killed due to resource exhaustion. This focuses the build more on what we need and enables fuzz introspector.