### PR TITLE
Fix bug in coverage build for jvm

### DIFF
--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -469,7 +469,7 @@ elif [[ $FUZZING_LANGUAGE == "jvm" ]]; then
   find $classes_dir -type f -not -name "*.class" | xargs rm -f
   # Remove all class files which have a dot in their file name which are normally
   # used to name a duplication of the legitimate class file.
-  find $classes_dir -type f -name "*.*.class" | xargs rm -f
+  find $classes_dir/*/ -type f -name "*.*.class" | xargs rm -f
 
   # Heuristically determine source directories based on Maven structure.
   # Always include the $SRC root as it likely contains the fuzzer sources.


### PR DESCRIPTION
In #9658, all jar files of the project has been extracted and dumped in a directory. Then certain class duplication are removed. But the removing logic contains a bug. Those class files for fuzzers in the base of the dump directory are accidentally removed and because they don't have duplication from the jar files, they are missing from the resulting coverage report. This PR fixes the bug by ignoring the base directory of the class dump location when removing classes duplication to ensure the fuzzer classes existed in the final coverage report.
