### PR TITLE
Change to `WORKDIR` before running commands in cloud project experiments.

### DIFF
--- a/infra/build/functions/project_experiment.py
+++ b/infra/build/functions/project_experiment.py
@@ -17,12 +17,12 @@
 
 import argparse
 import logging
-import os
 import sys
+
+import google.auth
 
 import build_lib
 import build_project
-import google.auth
 
 
 def run_experiment(project_name, command, output_path, experiment_name):

--- a/infra/build/functions/project_experiment.py
+++ b/infra/build/functions/project_experiment.py
@@ -72,7 +72,8 @@ def run_experiment(project_name, command, output_path, experiment_name):
           ]
       },
       {
-          'name': project.image,
+          'name':
+              project.image,
           'args': [
               'bash',
               '-c',

--- a/infra/build/functions/project_experiment.py
+++ b/infra/build/functions/project_experiment.py
@@ -17,12 +17,17 @@
 
 import argparse
 import logging
+import os
 import sys
-
-import google.auth
 
 import build_lib
 import build_project
+import google.auth
+
+sys.path.append(
+    os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+import helper
 
 
 def run_experiment(project_name, command, output_path, experiment_name):
@@ -51,6 +56,7 @@ def run_experiment(project_name, command, output_path, experiment_name):
   project_yaml['sanitizers'] = ['address']
   project_yaml['fuzzing_engines'] = ['libfuzzer']
   project_yaml['architectures'] = ['x86_64']
+  workdir = helper._workdir_from_dockerfile(helper.Project(project_name, False))
 
   # Don't do bad build checks.
   project_yaml['run_tests'] = False
@@ -76,7 +82,7 @@ def run_experiment(project_name, command, output_path, experiment_name):
           'args': [
               'bash',
               '-c',
-              command,
+              f'(cd {workdir}; {command})',
           ]
       },
       {

--- a/infra/build/functions/project_experiment.py
+++ b/infra/build/functions/project_experiment.py
@@ -77,7 +77,7 @@ def run_experiment(project_name, command, output_path, experiment_name):
           'args': [
               'bash',
               '-c',
-              f'(cd {os.path.join("/src", project.workdir)}; {command})',
+              f'(cd "/src"; cd {project.workdir}; {command})',
           ]
       },
       {

--- a/infra/build/functions/project_experiment.py
+++ b/infra/build/functions/project_experiment.py
@@ -24,11 +24,6 @@ import build_lib
 import build_project
 import google.auth
 
-sys.path.append(
-    os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
-
-import helper
-
 
 def run_experiment(project_name, command, output_path, experiment_name):
   config = build_project.Config(testing=True,
@@ -56,7 +51,6 @@ def run_experiment(project_name, command, output_path, experiment_name):
   project_yaml['sanitizers'] = ['address']
   project_yaml['fuzzing_engines'] = ['libfuzzer']
   project_yaml['architectures'] = ['x86_64']
-  workdir = helper._workdir_from_dockerfile(helper.Project(project_name, False))
 
   # Don't do bad build checks.
   project_yaml['run_tests'] = False
@@ -82,7 +76,7 @@ def run_experiment(project_name, command, output_path, experiment_name):
           'args': [
               'bash',
               '-c',
-              f'(cd {workdir}; {command})',
+              f'(cd {os.path.join("/src", project.workdir)}; {command})',
           ]
       },
       {


### PR DESCRIPTION
Mitigates the known issue where we don't automatically change to the `WORKDIR` defined in `Dockerfile` when running cloud experiments.

Question:
Would it be preferred if I introduce a flag for this?
(e.g., `--use_workdir` or `--workdir=/src/<project>`)
While this gives more flexibility, I feel `cd` to `WORKDIR` should always be preferred if we want the cloud experiments to behave the same as local ones.