### PR TITLE
Don't specify the branch for mutagen

### DIFF
--- a/projects/mutagen/Dockerfile
+++ b/projects/mutagen/Dockerfile
@@ -18,7 +18,6 @@ FROM gcr.io/oss-fuzz-base/base-builder-python
 
 RUN git clone \
 	--depth 1 \
-	--branch master \
 	https://github.com/quodlibet/mutagen
 
 WORKDIR mutagen


### PR DESCRIPTION
This should fix the following issue:

```
Step #1:  ---> 22f958f99cac
Step #1: Step 2/4 : RUN git clone 	--depth 1 	--branch master 	https://github.com/quodlibet/mutagen
Step #1:  ---> Running in 77c762382f3f
Step #1: [91mCloning into 'mutagen'...
Step #1: [0m[91mwarning: Could not find remote branch master to clone.
Step #1: fatal: Remote branch master not found in upstream origin
Step #1: The command '/bin/sh -c git clone 	--depth 1 	--branch master 	https://github.com/quodlibet/mutagen' returned a non-zero code: 128
Finished Step #1
ERROR
ERROR: build step 1 "gcr.io/cloud-builders/docker" failed: step exited with non-zero status: 128
Step #1: [0m
```