### PR TITLE
powerdns: Build the DNSDist fuzzing target again

### DIFF
--- a/projects/powerdns/build.sh
+++ b/projects/powerdns/build.sh
@@ -45,28 +45,47 @@ make -j$(nproc) fuzz_targets
 # copy the fuzzing target binaries
 cp fuzz_target_* "${OUT}/"
 
+# build the dnsdist fuzzing target
+cd dnsdistdist
+sed -i 's/AC_CC_PIE//' configure.ac
+autoreconf -vi
+./configure \
+    --enable-fuzz-targets \
+    --disable-dependency-tracking \
+    --disable-silent-rules || /bin/bash
+if [ -d ext/arc4random/ ]; then
+    make -j$(nproc) -C ext/arc4random/
+fi
+make -j$(nproc) fuzz_targets
+
+# copy the fuzzing target binaries
+cp fuzz_target_* "${OUT}/"
+
+# back to the checkout directory
+cd ../..
+
 # copy the zones used in the regression tests to the "zones" corpus
-cp ../regression-tests/zones/* ../fuzzing/corpus/zones/
+cp regression-tests/zones/* fuzzing/corpus/zones/
 
 # generate the corpus files
-if [ -d ../fuzzing/corpus/raw-dns-packets/ ]; then
-    zip -j "${OUT}/fuzz_target_dnsdistcache_seed_corpus.zip" ../fuzzing/corpus/raw-dns-packets/*
+if [ -d fuzzing/corpus/raw-dns-packets/ ]; then
+    zip -j "${OUT}/fuzz_target_dnsdistcache_seed_corpus.zip" fuzzing/corpus/raw-dns-packets/*
 fi
-if [ -d ../fuzzing/corpus/txt-records/ ]; then
-    zip -j "${OUT}/fuzz_target_dnslabeltext_parseRFC1035CharString_seed_corpus.zip" ../fuzzing/corpus/txt-records/*
+if [ -d fuzzing/corpus/txt-records/ ]; then
+    zip -j "${OUT}/fuzz_target_dnslabeltext_parseRFC1035CharString_seed_corpus.zip" fuzzing/corpus/txt-records/*
 fi
-if [ -d ../fuzzing/corpus/raw-dns-packets/ ]; then
-    zip -j "${OUT}/fuzz_target_moadnsparser_seed_corpus.zip" ../fuzzing/corpus/raw-dns-packets/*
+if [ -d fuzzing/corpus/raw-dns-packets/ ]; then
+    zip -j "${OUT}/fuzz_target_moadnsparser_seed_corpus.zip" fuzzing/corpus/raw-dns-packets/*
 fi
-if [ -d ../fuzzing/corpus/raw-dns-packets/ ]; then
-    zip -j "${OUT}/fuzz_target_packetcache_seed_corpus.zip" ../fuzzing/corpus/raw-dns-packets/*
+if [ -d fuzzing/corpus/raw-dns-packets/ ]; then
+    zip -j "${OUT}/fuzz_target_packetcache_seed_corpus.zip" fuzzing/corpus/raw-dns-packets/*
 fi
-if [ -d ../fuzzing/corpus/proxy-protocol-raw-packets/ ]; then
-    zip -j "${OUT}/fuzz_target_proxyprotocol_seed_corpus.zip" ../fuzzing/corpus/proxy-protocol-raw-packets/*
+if [ -d fuzzing/corpus/proxy-protocol-raw-packets/ ]; then
+    zip -j "${OUT}/fuzz_target_proxyprotocol_seed_corpus.zip" fuzzing/corpus/proxy-protocol-raw-packets/*
 fi
-if [ -d ../fuzzing/corpus/zones/ ]; then
-    zip -j "${OUT}/fuzz_target_zoneparsertng_seed_corpus.zip" ../fuzzing/corpus/zones/*
+if [ -d fuzzing/corpus/zones/ ]; then
+    zip -j "${OUT}/fuzz_target_zoneparsertng_seed_corpus.zip" fuzzing/corpus/zones/*
 fi
-if [ -d ../fuzzing/corpus/http-raw-payloads/ ]; then
-    zip -j "${OUT}/fuzz_target_yahttp_seed_corpus.zip" ../fuzzing/corpus/http-raw-payloads/*
+if [ -d fuzzing/corpus/http-raw-payloads/ ]; then
+    zip -j "${OUT}/fuzz_target_yahttp_seed_corpus.zip" fuzzing/corpus/http-raw-payloads/*
 fi


### PR DESCRIPTION
PowerDNS recently [1] refactored the way fuzzing targets were handled, and decided to split them per-product inside the monorepo. We thus now need to build the DNSDist targets separately from the Authoritative Server's ones.

[1]: https://github.com/PowerDNS/pdns/pull/13145