### PR TITLE
apache-poi: expect 2 more exceptions

### DIFF
--- a/projects/apache-poi/src/main/java/org/apache/poi/POIXWPFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIXWPFFuzzer.java
@@ -54,7 +54,7 @@ public class POIXWPFFuzzer {
 				POIFuzzer.checkExtractor(extractor);
 			}
 		} catch (IOException | POIXMLException | RecordFormatException | OpenXML4JRuntimeException |
-				 IllegalArgumentException | IllegalStateException e) {
+				 IllegalArgumentException | IllegalStateException | IndexOutOfBoundsException e) {
 			// expected
 		}
 	}

--- a/projects/apache-poi/src/main/java/org/apache/poi/XLSX2CSVFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/XLSX2CSVFuzzer.java
@@ -34,6 +34,13 @@ public class XLSX2CSVFuzzer {
 			OPCPackage p = OPCPackage.open(in);
 			XLSX2CSV xlsx2csv = new XLSX2CSV(p, NullPrintStream.INSTANCE, 5);
 			xlsx2csv.process();
+		} catch (UnsatisfiedLinkError e) {
+			// only allow one missing library related to Font/Color-handling
+			// we cannot install additional libraries in oss-fuzz images currently
+			// see https://github.com/google/oss-fuzz/issues/7380
+			if (!e.getMessage().contains("libawt_xawt.so")) {
+				throw e;
+			}
 		} catch (IOException | OpenXML4JException | SAXException |
 				 POIXMLException | RecordFormatException |
 				IllegalStateException | IllegalArgumentException |


### PR DESCRIPTION
Add two more Exceptions which popped up when running fuzzing at large scale.

There is one more place where font-handling is triggered, but not available
on the VMs that run fuzzing