### PR TITLE
add a fuzz driver of gin

### DIFF
--- a/projects/gin/Dockerfile
+++ b/projects/gin/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone https://github.com/gin-gonic/gin.git gin
+WORKDIR gin
+RUN git checkout 0c96a20209ca035964be126a745c167196fb6db3
+COPY build.sh fuzz_test.go $SRC/

--- a/projects/gin/build.sh
+++ b/projects/gin/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cp $SRC/fuzz_test.go ./
+go mod tidy
+printf "package gin\nimport _ \"github.com/AdamKorcz/go-118-fuzz-build/testing\"\n" > register.go
+go mod tidy
+compile_native_go_fuzzer github.com/gin-gonic/gin FuzzTestContextNegotiationFormatWithAccept fuzzTestContextNegotiationFormatWithAccept

--- a/projects/gin/fuzz_test.go
+++ b/projects/gin/fuzz_test.go
@@ -1,0 +1,23 @@
+package gin
+
+import (
+	"net/http"
+)
+import (
+	"net/http/httptest"
+)
+import (
+	"testing"
+)
+
+func FuzzTestContextNegotiationFormatWithAccept(f *testing.F) {
+	f.Add(MIMEJSON, MIMEXML, MIMEHTML)
+	f.Fuzz(func(t *testing.T, data1 string, data2 string, data3 string) {
+		c, _ := CreateTestContext(httptest.NewRecorder())
+		c.Request, _ = http.NewRequest("POST", "/", nil)
+		c.Request.Header.Add("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9;q=0.8")
+		c.NegotiateFormat(data1, data2)
+		c.NegotiateFormat(data2, data3)
+		c.NegotiateFormat(data1)
+	})
+}

--- a/projects/gin/fuzz_test.go
+++ b/projects/gin/fuzz_test.go
@@ -1,3 +1,18 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package gin
 
 import (

--- a/projects/gin/project.yaml
+++ b/projects/gin/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://github.com/gin-gonic/gin"
+primary_contact: "appleboy.tw@gmail.com"
+language: go
+main_repo: "https://github.com/gin-gonic/gin"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
Overview
This pull request introduces a fuzz driver of that used to find the bug https://github.com/gin-gonic/gin/issues/3241. The purpose of this fuzz driver is to rigorously test the NegotiateFormat API by injecting mutated data into its arguments. By doing so, we aim to enhance our continuous testing efforts and ensure the robustness of this API.

Details
The fuzz driver has been designed to thoroughly exercise the NegotiateFormat API.
It accomplishes this by systematically injecting various forms of mutated data into the API's arguments.
Through this approach, we identified potential vulnerabilities and edge cases that might otherwise go unnoticed.

