### PR TITLE
powerdns: Fix CI Fuzz on stable branches

### DIFF
--- a/projects/powerdns/build.sh
+++ b/projects/powerdns/build.sh
@@ -45,24 +45,26 @@ make -j$(nproc) fuzz_targets
 # copy the fuzzing target binaries
 cp fuzz_target_* "${OUT}/"
 
-# build the dnsdist fuzzing target
-cd dnsdistdist
-sed -i 's/AC_CC_PIE//' configure.ac
-autoreconf -vi
-./configure \
-    --enable-fuzz-targets \
-    --disable-dependency-tracking \
-    --disable-silent-rules || /bin/bash
-if [ -d ext/arc4random/ ]; then
-    make -j$(nproc) -C ext/arc4random/
+# build the dnsdist fuzzing target, if any
+if [ -f dnsdistdist/fuzz_dnsdistcache.cc ]; then
+    cd dnsdistdist
+    sed -i 's/AC_CC_PIE//' configure.ac
+    autoreconf -vi
+    ./configure \
+        --enable-fuzz-targets \
+        --disable-dependency-tracking \
+        --disable-silent-rules || /bin/bash
+    if [ -d ext/arc4random/ ]; then
+        make -j$(nproc) -C ext/arc4random/
+    fi
+    make -j$(nproc) fuzz_targets
+
+    # copy the fuzzing target binaries
+    cp fuzz_target_* "${OUT}/"
+
+    # back to the checkout directory
+    cd ../..
 fi
-make -j$(nproc) fuzz_targets
-
-# copy the fuzzing target binaries
-cp fuzz_target_* "${OUT}/"
-
-# back to the checkout directory
-cd ../..
 
 # copy the zones used in the regression tests to the "zones" corpus
 cp regression-tests/zones/* fuzzing/corpus/zones/


### PR DESCRIPTION
Stable branches do not have the recent per-product split that was introduced in #10926, and thus CI Fuzz fails on them. This commit checks that there actually is at least one fuzzing target in the `dnsdistdist/` directory before trying to build them, so that this step can be skipped on older branches.