### PR TITLE
Update Node.js setup for JavaScript projects

### DIFF
--- a/infra/base-images/base-builder/install_javascript.sh
+++ b/infra/base-images/base-builder/install_javascript.sh
@@ -14,9 +14,14 @@
 # limitations under the License.
 #
 ################################################################################
-# Install Node.js v19.x
-curl -fsSL https://deb.nodesource.com/setup_19.x | bash -
-apt-get update && apt-get install -y nodejs
+# see installation instructions: https://github.com/nodesource/distributions#available-architectures
+apt-get update
+apt-get install -y ca-certificates curl gnupg
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 
-# Install latest versions of npm
-npm install --global npm
+NODE_MAJOR=20
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+
+apt-get update
+apt-get install nodejs -y

--- a/infra/base-images/base-runner/install_javascript.sh
+++ b/infra/base-images/base-runner/install_javascript.sh
@@ -14,11 +14,17 @@
 # limitations under the License.
 #
 ################################################################################
-# Install Node.js v19.x.
-apt-get update && apt-get install -y curl
+# see installation instructions: https://github.com/nodesource/distributions#available-architectures
+apt-get update
+apt-get install -y ca-certificates curl gnupg
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 
-curl -fsSL https://deb.nodesource.com/setup_19.x | bash -
-apt-get update && apt-get install -y nodejs
+NODE_MAJOR=20
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+
+apt-get update
+apt-get install nodejs -y
 
 # Install latest versions of nyc for source-based coverage reporting
 npm install --global nyc


### PR DESCRIPTION
Migrate the Node.js setup to the currently recommended way and version. The previously used installation scripts are no longer maintained.

Fixes #10936 