### PR TITLE
kyverno: temporarily clone fork

### DIFF
--- a/projects/kyverno/Dockerfile
+++ b/projects/kyverno/Dockerfile
@@ -15,7 +15,8 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
-RUN git clone --depth 1 https://github.com/kyverno/kyverno
+# Temporarily point to a fork
+RUN git clone --depth 1 https://github.com/AdamKorcz/kyverno --branch=more-fuzzing
 RUN wget https://go.dev/dl/go1.20.6.linux-amd64.tar.gz \ 
     && mkdir temp-go \ 
     && rm -rf /root/.go/* \ 


### PR DESCRIPTION
My fork of Kyverno contains two new fuzzers that should run for a bit on OSS-Fuzz before they are merged upstream.

This PR temporarily points Kyvernos OSS-Fuzz integration to my fork to collect runtime and performance metrics over the next few days.