### PR TITLE
add a fuzz driver of minio

### DIFF
--- a/projects/minio/Dockerfile
+++ b/projects/minio/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/minio/minio.git minio     # or use other version control
+WORKDIR minio
+COPY build.sh fuzz_test.go $SRC/

--- a/projects/minio/build.sh
+++ b/projects/minio/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+go mod tidy
+printf "package main\nimport _ \"github.com/AdamKorcz/go-118-fuzz-build/testing\"\n" > register.go
+go mod tidy
+cp $SRC/fuzz_test.go internal/s3select/csv/.
+compile_native_go_fuzzer github.com/minio/minio/internal/s3select/csv FuzzTestRead fuzz_test_read

--- a/projects/minio/fuzz_test.go
+++ b/projects/minio/fuzz_test.go
@@ -1,3 +1,18 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package csv
 
 import (

--- a/projects/minio/fuzz_test.go
+++ b/projects/minio/fuzz_test.go
@@ -1,0 +1,49 @@
+package csv
+
+import (
+	"bytes"
+	"github.com/minio/minio/internal/s3select/sql"
+	"io/ioutil"
+	"strings"
+	"testing"
+)
+
+func FuzzTestRead(f *testing.F) {
+	f.Add("1,2,3\na,b,c\n", "\n", ",")
+	f.Add("1,2,3\ta,b,c\t", "\t", ",")
+	f.Add("1,2,3\r\na,b,c\r\n", "\r\n", ",")
+	f.Fuzz(func(t *testing.T, data1 string, data2 string, data3 string) {
+		var err error
+		var record sql.Record
+		var result bytes.Buffer
+
+		r, _ := NewReader(ioutil.NopCloser(strings.NewReader(data1)), &ReaderArgs{
+			FileHeaderInfo:             none,
+			RecordDelimiter:            data2,
+			FieldDelimiter:             data3,
+			QuoteCharacter:             defaultQuoteCharacter,
+			QuoteEscapeCharacter:       defaultQuoteEscapeCharacter,
+			CommentCharacter:           defaultCommentCharacter,
+			AllowQuotedRecordDelimiter: false,
+			unmarshaled:                true,
+		})
+
+		for {
+			record, err = r.Read(record)
+			if err != nil {
+				break
+			}
+			opts := sql.WriteCSVOpts{
+				FieldDelimiter: []rune(data3)[0],
+				Quote:          '"',
+				QuoteEscape:    '"',
+				AlwaysQuote:    false,
+			}
+			record.WriteCSV(&result, opts)
+			result.Truncate(result.Len() - 1)
+			result.WriteString(data2)
+		}
+		r.Close()
+
+	})
+}

--- a/projects/minio/project.yaml
+++ b/projects/minio/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://github.com/minio/minio"
+language: go
+primary_contact: "secsys-go@hotmail.com"
+main_repo: "https://github.com/minio/minio"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
Overview
The purpose of this fuzz driver is to rigorously test the NewReader API in minio project by injecting mutated data into its arguments. By doing so, we aim to enhance our continuous testing efforts and ensure the robustness of this API.

Details
The fuzz driver has been designed to thoroughly exercise the NewReader API.
It accomplishes this by systematically injecting various forms of mutated data into the API's arguments.
Through this approach, we identified potential vulnerabilities and edge cases that might otherwise go unnoticed.