### PR TITLE
add a fuzz driver of fzf

### DIFF
--- a/projects/fzf/Dockerfile
+++ b/projects/fzf/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/junegunn/fzf.git fzf
+WORKDIR fzf
+COPY build.sh fuzz_test.go $SRC/

--- a/projects/fzf/build.sh
+++ b/projects/fzf/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+go env -w GOPROXY=https://goproxy.cn,direct
+go mod tidy
+printf "package main\nimport _ \"github.com/AdamKorcz/go-118-fuzz-build/testing\"\n" > register.go
+go mod tidy
+cp $SRC/fuzz_test.go src/.
+compile_native_go_fuzzer github.com/junegunn/fzf/src FuzzTestTokenize fuzz_test_tokenize

--- a/projects/fzf/build.sh
+++ b/projects/fzf/build.sh
@@ -15,7 +15,6 @@
 #
 ################################################################################
 
-go env -w GOPROXY=https://goproxy.cn,direct
 go mod tidy
 printf "package main\nimport _ \"github.com/AdamKorcz/go-118-fuzz-build/testing\"\n" > register.go
 go mod tidy

--- a/projects/fzf/fuzz_test.go
+++ b/projects/fzf/fuzz_test.go
@@ -1,0 +1,29 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package fzf
+
+import (
+         "testing"
+)
+
+func FuzzTestTokenize(f *testing.F) {
+	f.Add("  abc:  def:  ghi  ", ":")
+	f.Fuzz(func(t *testing.T, data1 string, data2 string) {
+        input := data1
+        Tokenize(input, Delimiter{})
+        Tokenize(input, delimiterRegexp(data2))
+	})
+}

--- a/projects/fzf/project.yaml
+++ b/projects/fzf/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://github.com/junegunn/fzf"
+language: go
+primary_contact: "secsys-go@hotmail.com"
+main_repo: "https://github.com/junegunn/fzf"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
Overview
The purpose of this fuzz driver is to rigorously test the Tokenize API in fzf project by injecting mutated data into its arguments. By doing so, we aim to enhance our continuous testing efforts and ensure the robustness of this API.

Details
The fuzz driver has been designed to thoroughly exercise the Tokenize API.
It accomplishes this by systematically injecting various forms of mutated data into the API's arguments.
Through this approach, we identified potential vulnerabilities and edge cases that might otherwise go unnoticed.