### PR TITLE
lua: use common Lua library by tests

### DIFF
--- a/projects/lua/Dockerfile
+++ b/projects/lua/Dockerfile
@@ -15,7 +15,6 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN git clone https://github.com/lua/lua
 RUN git clone https://github.com/ligurio/lua-c-api-tests testdir
 WORKDIR testdir
 RUN git clone --depth 1 --jobs $(nproc) https://github.com/ligurio/lua-c-api-corpus corpus_dir


### PR DESCRIPTION
Commit 0736b5b08f61be9ff9f62f885912f934c7df5aed ("[Lua]initial integration. (#4653)") introduces a test that used a Lua library built from source code. Tests [1] added later builds its own Lua library and as a result we have two directories with the same source code and code coverage report (and probably Fuzz Introspector) accounts overall code coverage separately.

The patch switches fuzz_lua test to using Lua library build by additional tests [1].

1. https://github.com/ligurio/lua-c-api-tests
2. https://storage.googleapis.com/oss-fuzz-coverage/lua/reports/20230911/linux/src/testdir/build/lua-master/source/report.html
3. https://storage.googleapis.com/oss-fuzz-coverage/lua/reports/20230911/linux/src/lua/report.html