### PR TITLE
fix PR helper when commits have no author.

### DIFF
--- a/infra/pr_helper.py
+++ b/infra/pr_helper.py
@@ -243,6 +243,9 @@ class GithubHandler:
       if i >= COMMITS_LIMIT:
         break
 
+      if not commit['author'] or not commit['commit']:
+        continue
+
       login = commit['author']['login']
       verified = commit['commit']['verification']['verified']
       if login in self._maintainers:


### PR DESCRIPTION
PR helper fails when author information is null. Adding a check before get login name.
![image](https://github.com/google/oss-fuzz/assets/39108850/f4f3aaa8-3edb-4745-93e1-c6da047d0b7b)
https://github.com/google/oss-fuzz/issues/10955