### PR TITLE
powerdns: Go back to the correct working directory on old branches

### DIFF
--- a/projects/powerdns/build.sh
+++ b/projects/powerdns/build.sh
@@ -62,9 +62,12 @@ if [ -f dnsdistdist/fuzz_dnsdistcache.cc ]; then
     # copy the fuzzing target binaries
     cp fuzz_target_* "${OUT}/"
 
-    # back to the checkout directory
-    cd ../..
+    # back to the pdns/ directory
+    cd ..
 fi
+
+# back to the checkout directory
+cd ..
 
 # copy the zones used in the regression tests to the "zones" corpus
 cp regression-tests/zones/* fuzzing/corpus/zones/


### PR DESCRIPTION
96b8b80172c6bc333919cac4422f88e4ac1b9eb8 did not properly fix the issue because on older branches, where dnsdist does not have its own fuzzing targets, we do not properly go back to the checkout directory and thus the next step fails.