### PR TITLE
burntsushi-toml: remove input limit

### DIFF
--- a/projects/burntsushi-toml/fuzz.go
+++ b/projects/burntsushi-toml/fuzz.go
@@ -4,10 +4,6 @@ import "bytes"
 
 func FuzzToml(data []byte) int {
 
-	if len(data) >= 10240 {
-		return 0
-	}
-
 	buf := make([]byte, 0, 2048)
 
 	var m interface{}

--- a/projects/burntsushi-toml/fuzz.go
+++ b/projects/burntsushi-toml/fuzz.go
@@ -1,4 +1,3 @@
-// !/bin/bash -eu
 //  Copyright 2022 Google LLC
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");

--- a/projects/burntsushi-toml/fuzz.go
+++ b/projects/burntsushi-toml/fuzz.go
@@ -1,3 +1,18 @@
+// !/bin/bash -eu
+//  Copyright 2022 Google LLC
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 package toml
 
 import "bytes"


### PR DESCRIPTION
Removing input limit as this target have not found anything notable yet, mostly because of large cap.