### PR TITLE
Fix bazel invocations with jcc

### DIFF
--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -342,14 +342,14 @@ func CppifyHeaderIncludes(contents string) (string, error) {
 }
 
 func main() {
-	f, err2 := os.OpenFile("/tmp/jcc.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile("/tmp/jcc.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 
-	if err2 != nil {
-		log.Println(err2)
+	if err != nil {
+		log.Println(err)
 	}
 	defer f.Close()
-	if _, err2 := f.WriteString(fmt.Sprintf("%s\no", os.Args)); err2 != nil {
-		log.Println(err2)
+	if _, err := f.WriteString(fmt.Sprintf("%s\n", os.Args)); err != nil {
+		log.Println(err)
 	}
 
 	args := os.Args[1:]

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -369,6 +369,8 @@ func main() {
 	if retcode == 0 {
 		fmt.Print(out)
 		fmt.Print(errstr)
+		// Print error back to stderr so tooling that relies on this can proceed
+		fmt.Fprint(os.Stderr, errstr)
 		os.Exit(0)
 	}
 

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -390,6 +390,8 @@ func main() {
 		fmt.Println("\nFix failure")
 		fmt.Print(fixout)
 		fmt.Print(fixerr)
+		// Print error back to stderr so tooling that relies on this can proceed
+		fmt.Fprint(os.Stderr, errstr)
 		os.Exit(retcode)
 	}
 }

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -357,20 +357,18 @@ func main() {
 	isCPP := basename == "clang++-jcc"
 	newArgs := []string{"-w", "-stdlib=libc++"}
 	newArgs = append(args, newArgs...)
-	var retcode int
-	var out string
-	var err string
+
 	var bin string
 	if isCPP {
 		bin = "clang++"
-		retcode, out, err = Compile(bin, newArgs)
+		// TODO: Should `-stdlib=libc++` be added only here?
 	} else {
 		bin = "clang"
-		retcode, out, err = Compile(bin, newArgs)
 	}
+	retcode, out, errstr := Compile(bin, newArgs)
 	if retcode == 0 {
 		fmt.Print(out)
-		fmt.Print(err)
+		fmt.Print(errstr)
 		os.Exit(0)
 	}
 
@@ -388,7 +386,7 @@ func main() {
 	fixret, fixout, fixerr := TryFixCCompilation(newArgs)
 	if fixret != 0 {
 		fmt.Print(out)
-		fmt.Print(err)
+		fmt.Print(errstr)
 		fmt.Println("\nFix failure")
 		fmt.Print(fixout)
 		fmt.Print(fixerr)


### PR DESCRIPTION
We only need to make sure that if the wrapped compiler (clang) prints something to stderr, we report that to stderr in the wrapper, __even if__ the compiler exits with 0. This is because when starting up, Bazel invokes the compiler with various flags to detect what features are available and what flags to pass during regular compilation. The detection is based on the stderr of the compiler invocation, so we need to make sure we are properly printing out stderr. Finally, Bazel uses stderr to determine if the compiler is clang / gcc or a third option. If we don't report stderr, then Bazel considers we are using a generic compiler and then gets confused about what to generate in the toolchain.

Currently, this is the diff from the toolchain autoconfig when Bazel starts up:

```diff
--- w-clang/bazel-w-clang/external/bazel_tools~cc_configure_extension~local_config_cc/BUILD     2023-09-15 16:54:56.131676995 +0000
+++ w-jcc/bazel-w-jcc/external/bazel_tools~cc_configure_extension~local_config_cc/BUILD 2023-09-15 18:17:24.486499047 +0000
@@ -85,16 +85,13 @@
     "/usr/include/x86_64-linux-gnu",
     "/usr/include",
     "/usr/local/lib/clang/15.0.0/share",
-    "/usr/include/c++/9",
-    "/usr/include/x86_64-linux-gnu/c++/9",
-    "/usr/include/c++/9/backward",
     "/usr/local/include/c++/v1"],
     tool_paths = {"ar": "/usr/bin/ar",
         "ld": "/usr/bin/ld",
         "llvm-cov": "/usr/local/bin/llvm-cov",
         "llvm-profdata": "/usr/local/bin/llvm-profdata",
         "cpp": "/usr/bin/cpp",
-        "gcc": "/usr/local/bin/clang-15",
+        "gcc": "/usr/local/bin/clang-jcc",
         "dwp": "/usr/bin/dwp",
         "gcov": "/usr/bin/gcov",
         "nm": "/usr/bin/nm",
```

The 3 missing header files could be because of https://github.com/bazelbuild/bazel/blob/7a4eefa869d370a19b0704d4995ebf00c2cd0ddf/tools/cpp/unix_cc_configure.bzl#L316-L321 but I could not find a way to force this. So far, it didn't look like it was causing problems though.