### PR TITLE
apache-poi: Some more expected exceptions

### DIFF
--- a/projects/apache-poi/src/main/java/org/apache/poi/POIHWPFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIHWPFFuzzer.java
@@ -22,6 +22,7 @@ import java.nio.BufferUnderflowException;
 import java.util.NoSuchElementException;
 
 import org.apache.commons.io.output.NullOutputStream;
+import org.apache.poi.hssf.record.RecordInputStream;
 import org.apache.poi.hwpf.HWPFDocument;
 import org.apache.poi.hwpf.extractor.WordExtractor;
 import org.apache.poi.poifs.filesystem.POIFSFileSystem;
@@ -45,7 +46,8 @@ public class POIHWPFFuzzer {
 			}
 		} catch (IOException | IllegalArgumentException | IndexOutOfBoundsException | BufferUnderflowException |
 				NoSuchElementException | RecordFormatException | IllegalStateException |
-				DocumentFormatException | UnsupportedOperationException | NegativeArraySizeException e) {
+				DocumentFormatException | UnsupportedOperationException | NegativeArraySizeException |
+				RecordInputStream.LeftoverDataException e) {
 			// expected here
 		}
 	}

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIVisioFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIVisioFuzzer.java
@@ -32,6 +32,15 @@ public class POIVisioFuzzer {
 	public static void fuzzerTestOneInput(byte[] input) {
 		try (XmlVisioDocument visio = new XmlVisioDocument(new ByteArrayInputStream(input))) {
 			visio.write(NullOutputStream.INSTANCE);
+		} catch (NoClassDefFoundError e) {
+			// only allow some missing classes related to Font-handling
+			// we cannot install JDK font packages in oss-fuzz images currently
+			// see https://github.com/google/oss-fuzz/issues/7380
+			if (!e.getMessage().contains("java.awt.Font") &&
+					!e.getMessage().contains("java.awt.Toolkit") &&
+					!e.getMessage().contains("sun.awt.X11FontManager")) {
+				throw e;
+			}
 		} catch (IOException | POIXMLException |
 				 BufferUnderflowException | RecordFormatException | OpenXML4JRuntimeException |
 				 IllegalArgumentException | IndexOutOfBoundsException e) {

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIXSSFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIXSSFFuzzer.java
@@ -64,7 +64,7 @@ public class POIXSSFFuzzer {
 				throw e;
 			}
 		} catch (IOException | XmlException | OpenXML4JException | POIXMLException | RecordFormatException |
-				IllegalStateException | IllegalArgumentException e) {
+				IllegalStateException | IllegalArgumentException | IndexOutOfBoundsException e) {
 			// expected
 		}
 	}


### PR DESCRIPTION
Ignore one more case where java.awt is missing native libs and other expected exceptions

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62275 https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62333 https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62354