### PR TITLE
[proton-bridge] initial integration

### DIFF
--- a/projects/proton-bridge/Dockerfile
+++ b/projects/proton-bridge/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/ProtonMail/proton-bridge.git
+RUN go install github.com/AdamKorcz/go-118-fuzz-build@latest
+COPY build.sh $SRC/
+WORKDIR $SRC/proton-bridge

--- a/projects/proton-bridge/build.sh
+++ b/projects/proton-bridge/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -eu
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+go get github.com/AdamKorcz/go-118-fuzz-build/testing
+
+compile_native_go_fuzzer   $PWD/internal/legacy/credentials     FuzzUnmarshal               fuzz_unmarshal   
+compile_native_go_fuzzer   $PWD/pkg/message/parser              FuzzNewParser               fuzz_new_parser
+compile_native_go_fuzzer   $PWD/pkg/message                     FuzzReadHeaderBody          fuzz_read_header_body
+compile_native_go_fuzzer   $PWD/pkg/mime                        FuzzDecodeHeader            fuzz_decode_header
+compile_native_go_fuzzer   $PWD/pkg/mime                        FuzzDecodeCharset           fuzz_decode_charset

--- a/projects/proton-bridge/project.yaml
+++ b/projects/proton-bridge/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://proton.me"
+language: go
+primary_contact: "security@proton.me"
+auto_ccs:
+  - "ajsinghyadav00@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+main_repo: "https://github.com/ProtonMail/proton-bridge"


### PR DESCRIPTION
[proton-bridge](https://github.com/ProtonMail/proton-bridge) use by [protonMail](https://proton.me/mail) e-mail clients.

@LBeernaertProton Ping, Dose this look good?
