### PR TITLE
fastify: initial integration

### DIFF
--- a/projects/fastify/Dockerfile
+++ b/projects/fastify/Dockerfile
@@ -1,0 +1,30 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-javascript
+
+COPY build.sh $SRC/
+
+RUN git clone --depth 1 https://github.com/fastify/fastify fastify
+RUN git clone --depth 1 https://github.com/fastify/fast-json-stringify fast-json-stringify
+RUN git clone --depth 1 https://github.com/fastify/fastify-jwt fastify-jwt
+RUN git clone --depth 1 https://github.com/fastify/fastify-response-validation fastify-response-validation
+RUN git clone --depth 1 https://github.com/fastify/fastify-auth fastify-auth
+RUN git clone --depth 1 https://github.com/fastify/fastify-basic-auth fastify-basic-auth
+RUN git clone --depth 1 https://github.com/fastify/fastify-bearer-auth fastify-bearer-auth
+RUN git clone --depth 1 https://github.com/AdaLogics/ada-fuzzers fuzzers
+
+WORKDIR $SRC/fastify

--- a/projects/fastify/build.sh
+++ b/projects/fastify/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+cp $SRC/fuzzers/projects/fastify/*.js $SRC/fastify
+$SRC/fuzzers/projects/fastify/build.sh

--- a/projects/fastify/project.yaml
+++ b/projects/fastify/project.yaml
@@ -1,0 +1,12 @@
+homepage: https://www.fastify.dev
+language: javascript
+main_repo: https://github.com/fastify/fastify
+fuzzing_engines:
+- libfuzzer
+sanitizers:
+- none
+primary_contact: "matteo.collina@gmail.com"
+auto_ccs:
+- david@adalogics.com
+- adam@adalogics.com
+- arthur.chan@adalogics.com


### PR DESCRIPTION
Fastify is a javascript web framework and it's a foundation project from [OpenJS](https://openjsf.org/). It's used by a lot of [organisations](https://fastify.dev/organisations/) (50+ listed on its website), including:
- Microsoft
-  [Net-a-porter](https://www.net-a-porter.com/en-gb/) (fyi, this is a large UK e-commerce website with 1.8 billion in revenue)
- [Amerisave](https://www.amerisave.com/)

Maintainers are happy to integrate this and is listed as primary contact.