### PR TITLE
luajit: initial integration

### DIFF
--- a/projects/luajit/Dockerfile
+++ b/projects/luajit/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y \
+	build-essential ninja-build cmake make \
+	libreadline-dev libunwind-dev zlib1g-dev
+
+RUN git clone --recursive https://github.com/ligurio/lua-c-api-tests testdir
+WORKDIR $SRC/testdir
+RUN git clone --depth 1 --jobs $(nproc) https://github.com/ligurio/lua-c-api-corpus corpus_dir
+COPY build.sh $SRC

--- a/projects/luajit/build.sh
+++ b/projects/luajit/build.sh
@@ -1,0 +1,89 @@
+#!/bin/bash -eu
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Clean up potentially persistent build directory.
+[[ -e $SRC/testdir/build ]] && rm -rf $SRC/testdir/build
+
+cd $SRC/testdir
+
+# Avoid compilation issue due to some undefined references. They are defined in
+# libc++ and used by Centipede so -lc++ needs to come after centipede's lib.
+if [[ $FUZZING_ENGINE == centipede ]]
+then
+    sed -i \
+        '/$ENV{LIB_FUZZING_ENGINE}/a \ \ \ \ \ \ \ \ -lc++' \
+        tests/CMakeLists.txt
+fi
+
+# For some reason the linker will complain if address sanitizer is not used
+# in introspector builds.
+if [ "$SANITIZER" == "introspector" ]; then
+  export CFLAGS="${CFLAGS} -fsanitize=address"
+  export CXXFLAGS="${CXXFLAGS} -fsanitize=address"
+fi
+
+case $SANITIZER in
+  address) SANITIZERS_ARGS="-DENABLE_ASAN=ON" ;;
+  undefined) SANITIZERS_ARGS="-DENABLE_UBSAN=ON" ;;
+  *) SANITIZERS_ARGS="" ;;
+esac
+
+: ${LD:="${CXX}"}
+: ${LDFLAGS:="${CXXFLAGS}"}  # to make sure we link with sanitizer runtime
+
+cmake_args=(
+    -DUSE_LUAJIT=ON
+    -DOSS_FUZZ=ON
+    $SANITIZERS_ARGS
+
+    # C compiler
+    -DCMAKE_C_COMPILER="${CC}"
+    -DCMAKE_C_FLAGS="${CFLAGS}"
+
+    # C++ compiler
+    -DCMAKE_CXX_COMPILER="${CXX}"
+    -DCMAKE_CXX_FLAGS="${CXXFLAGS}"
+
+    # Linker
+    -DCMAKE_LINKER="${LD}"
+    -DCMAKE_EXE_LINKER_FLAGS="${LDFLAGS}"
+    -DCMAKE_MODULE_LINKER_FLAGS="${LDFLAGS}"
+    -DCMAKE_SHARED_LINKER_FLAGS="${LDFLAGS}"
+)
+
+# To deal with a host filesystem from inside of container.
+git config --global --add safe.directory '*'
+
+# Build the project and fuzzers.
+[[ -e build ]] && rm -rf build
+cmake "${cmake_args[@]}" -S . -B build -G Ninja
+cmake --build build --parallel
+
+# Archive and copy to $OUT seed corpus if the build succeeded.
+for f in $(find build/tests/ -name '*_test' -type f);
+do
+  name=$(basename $f);
+  module=$(echo $name | sed 's/_test//')
+  corpus_dir="corpus_dir/$module"
+  echo "Copying for $module";
+  cp $f $OUT/
+  dict_path="corpus_dir/$name.dict"
+  if [ -e "$dict_path" ]; then
+    cp "$dict_path" $OUT/"$module.dict"
+  fi
+  [[ -e $corpus_dir ]] && find "$corpus_dir" -mindepth 1 -maxdepth 1 | zip -@ -j $OUT/"$name"_seed_corpus.zip
+done

--- a/projects/luajit/project.yaml
+++ b/projects/luajit/project.yaml
@@ -1,0 +1,15 @@
+homepage: "https://luajit.org/"
+language: c
+builds_per_day: 4
+primary_contact: "estetus@gmail.com"
+fuzzing_engines:
+  - afl
+  - libfuzzer
+  - honggfuzz
+  - centipede
+sanitizers:
+  - address
+architectures:
+  # See https://luajit.org/luajit.html.
+  - x86_64
+main_repo: "https://github.com/LuaJIT/LuaJIT/"


### PR DESCRIPTION
Tarantool is a project that is based on it own LuaJIT fork, we do our best to test our fork and usually report bugs to upstream and backport patches to the fork back. Back in 2021 year we made (bf0720d322057c505eb462bab697d874e27e5e98) integration with OSS Fuzz and year ago added a test for Lua runtime, this test regularly finds bugs in our fork that are valid for upstream LuaJIT to (see examples in trophies [^1]). We are interested in regular fuzzing LuaJIT too because it helps to find bugs as soon as possible. LuaJIT maintainer Mike Pall has rejected integration with OSS Fuzz for unknown reasons (see LuaJIT 568), so I propose to make this integration, maintain it and process crashes by community.

The patches add initial integration with LuaJIT and uses fuzzing tests [^2] for Lua runtimes.

[^1]: https://github.com/tarantool/tarantool/wiki/Fuzzing
[^2]: https://github.com/ligurio/lua-c-api-tests