### PR TITLE
Apache POI: install libraries for awt and adjust xmx

### DIFF
--- a/projects/apache-poi/Dockerfile
+++ b/projects/apache-poi/Dockerfile
@@ -41,6 +41,9 @@ WORKDIR ${SRC}
 #
 RUN git clone --depth 1 https://github.com/apache/poi.git
 
+# install packages required for font-handling and other code in java.awt.*
+RUN apt-get install -y libxext6 libx11-6 libxrender1 libxtst6 libxi6 libxcb1 libxau6 libxdmcp6
+
 ADD pom.xml build.sh ${SRC}/
 ADD src/ ${SRC}/src/
 WORKDIR ${SRC}/poi

--- a/projects/apache-poi/build.sh
+++ b/projects/apache-poi/build.sh
@@ -20,6 +20,18 @@ ALL_JARS=""
 LIBRARY_NAME="poi"
 GRADLE_FLAGS="-x javadoc -x test -Dfile.encoding=UTF-8 -Porg.gradle.java.installations.fromEnv=JAVA_HOME_8,JAVA_HOME_11 --console=plain"
 
+echo Copy libraries for java.awt in place
+ls /usr/lib/x86_64-linux-gnu/
+cp /usr/lib/x86_64-linux-gnu/libXext.so.6* \
+  /usr/lib/x86_64-linux-gnu/libX11.so.6* \
+  /usr/lib/x86_64-linux-gnu/libXrender.so.1* \
+  /usr/lib/x86_64-linux-gnu/libXtst.so.6* \
+  /usr/lib/x86_64-linux-gnu/libXi.so.6* \
+  /usr/lib/x86_64-linux-gnu/libxcb.so.1* \
+  /usr/lib/x86_64-linux-gnu/libXau.so.6* \
+  /usr/lib/x86_64-linux-gnu/libXdmcp.so.6* \
+  ${OUT}/
+
 echo Main Java
 ${JAVA_HOME}/bin/java -version
 
@@ -70,8 +82,6 @@ pushd "${SRC}"
 	install -v target/${LIBRARY_NAME}-fuzzer-${CURRENT_VERSION}.jar ${OUT}/${LIBRARY_NAME}-fuzzer-${CURRENT_VERSION}.jar
 	ALL_JARS="${ALL_JARS} ${LIBRARY_NAME}-fuzzer-${CURRENT_VERSION}.jar"
 popd
-
-
 
 # The classpath at build-time includes the project jars in $OUT as well as the
 # Jazzer API.

--- a/projects/apache-poi/build.sh
+++ b/projects/apache-poi/build.sh
@@ -118,7 +118,7 @@ LD_LIBRARY_PATH=\"\$JVM_LD_LIBRARY_PATH\":\$this_dir \
 --cp=${RUNTIME_CLASSPATH} \
 --instrumentation_includes=org.apache.poi.**:org.apache.xmlbeans.** \
 --target_class=${fuzzer_classname} \
---jvm_args=\"-Xmx2048m\" \
+--jvm_args=\"-Xmx1024m\" \
 \$@" > $OUT/${fuzzer_basename}
 	chmod u+x $OUT/${fuzzer_basename}
 done

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIFuzzer.java
@@ -110,13 +110,6 @@ public class POIFuzzer {
 	public static void checkExtractor(byte[] input) {
 		try (POITextExtractor extractor = ExtractorFactory.createExtractor(new ByteArrayInputStream(input))) {
 			checkExtractor(extractor);
-		} catch (UnsatisfiedLinkError e) {
-			// only allow one missing library related to Font/Color-handling
-			// we cannot install additional libraries in oss-fuzz images currently
-			// see https://github.com/google/oss-fuzz/issues/7380
-			if (!e.getMessage().contains("libawt_xawt.so")) {
-				throw e;
-			}
 		} catch (IOException | POIXMLException | IllegalArgumentException | RecordFormatException |
 				 IndexOutOfBoundsException | HSLFException | RecordInputStream.LeftoverDataException |
 				 NoSuchElementException | IllegalStateException | ArithmeticException |

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIHSSFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIHSSFFuzzer.java
@@ -45,13 +45,6 @@ public class POIHSSFFuzzer {
 							new POIFSFileSystem(new ByteArrayInputStream(input)).getRoot())) {
 				POIFuzzer.checkExtractor(extractor);
 			}
-		} catch (UnsatisfiedLinkError e) {
-			// only allow one missing library related to Font-handling
-			// we cannot install JDK font packages in oss-fuzz images currently
-			// see https://github.com/google/oss-fuzz/issues/7380
-			if (!e.getMessage().contains("libawt_xawt.so")) {
-				throw e;
-			}
 		} catch (IOException | IllegalArgumentException | RecordFormatException | IllegalStateException |
 				 IndexOutOfBoundsException | RecordInputStream.LeftoverDataException |
 				 BufferUnderflowException | UnsupportedOperationException | NoSuchElementException |

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIXSSFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIXSSFFuzzer.java
@@ -36,15 +36,6 @@ public class POIXSSFFuzzer {
 			try (SXSSFWorkbook swb = new SXSSFWorkbook(wb)) {
 				swb.write(NullOutputStream.INSTANCE);
 			}
-		} catch (NoClassDefFoundError e) {
-			// only allow some missing classes related to Font-handling
-			// we cannot install JDK font packages in oss-fuzz images currently
-			// see https://github.com/google/oss-fuzz/issues/7380
-			if (!e.getMessage().contains("java.awt.Font") &&
-					!e.getMessage().contains("java.awt.Toolkit") &&
-					!e.getMessage().contains("sun.awt.X11FontManager")) {
-				throw e;
-			}
 		} catch (IOException | POIXMLException | RecordFormatException | IllegalStateException |
 				 OpenXML4JRuntimeException | IllegalArgumentException | IndexOutOfBoundsException e) {
 			// expected here
@@ -53,15 +44,6 @@ public class POIXSSFFuzzer {
 		try (OPCPackage pkg = OPCPackage.open(new ByteArrayInputStream(input))) {
 			try (XSSFEventBasedExcelExtractor extractor = new XSSFEventBasedExcelExtractor(pkg)) {
 				POIFuzzer.checkExtractor(extractor);
-			}
-		} catch (NoClassDefFoundError e) {
-			// only allow some missing classes related to Font-handling
-			// we cannot install JDK font packages in oss-fuzz images currently
-			// see https://github.com/google/oss-fuzz/issues/7380
-			if (!e.getMessage().contains("java.awt.Font") &&
-					!e.getMessage().contains("java.awt.Toolkit") &&
-					!e.getMessage().contains("sun.awt.X11FontManager")) {
-				throw e;
 			}
 		} catch (IOException | XmlException | OpenXML4JException | POIXMLException | RecordFormatException |
 				IllegalStateException | IllegalArgumentException | IndexOutOfBoundsException e) {

--- a/projects/apache-poi/src/main/java/org/apache/poi/XLSX2CSVFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/XLSX2CSVFuzzer.java
@@ -34,13 +34,6 @@ public class XLSX2CSVFuzzer {
 			OPCPackage p = OPCPackage.open(in);
 			XLSX2CSV xlsx2csv = new XLSX2CSV(p, NullPrintStream.INSTANCE, 5);
 			xlsx2csv.process();
-		} catch (UnsatisfiedLinkError e) {
-			// only allow one missing library related to Font/Color-handling
-			// we cannot install additional libraries in oss-fuzz images currently
-			// see https://github.com/google/oss-fuzz/issues/7380
-			if (!e.getMessage().contains("libawt_xawt.so")) {
-				throw e;
-			}
 		} catch (IOException | OpenXML4JException | SAXException |
 				 POIXMLException | RecordFormatException |
 				IllegalStateException | IllegalArgumentException |


### PR DESCRIPTION
These changes add some additional .so files to the container so that loading some classes from java.awt works.

See #10933 and #7380 for related discussions.

Also decrease "Xmx" as it seems we get native OOM in Jazzer-runs otherwise.