### PR TITLE
JCC writes build errors to a file for reliable future access.

### DIFF
--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -341,8 +341,8 @@ func CppifyHeaderIncludes(contents string) (string, error) {
 	return contents, nil
 }
 
-func appendStringToFile(filepath, new_content string) error {
-    // Appends |new_content| to the content of |filepath|.
+func AppendStringToFile(filepath, new_content string) error {
+	// Appends |new_content| to the content of |filepath|.
 	file, err := os.OpenFile(filepath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return err
@@ -350,7 +350,13 @@ func appendStringToFile(filepath, new_content string) error {
 	defer file.Close()
 
 	_, err = file.WriteString(new_content)
-    return err
+	return err
+}
+
+func RecordError(errstr string) {
+	// Prints |errstr| to stderr, and saves it to err log.
+	fmt.Fprint(os.Stderr, errstr)
+	AppendStringToFile("/out/err.log", errstr)
 }
 
 func main() {
@@ -380,7 +386,7 @@ func main() {
 	retcode, out, errstr := Compile(bin, newArgs)
 	if retcode == 0 {
 		fmt.Print(out)
-		fmt.Fprint(os.Stderr, errstr)
+		RecordError(errstr)
 		os.Exit(0)
 	}
 
@@ -402,8 +408,7 @@ func main() {
 		// Just print the original error for debugging purposes and
 		//  to make build systems happy.
 		fmt.Print(out)
-		fmt.Fprint(os.Stderr, errstr)
-               appendStringToFile("/out/err.log", errstr)
+		RecordError(errstr)
 		os.Exit(retcode)
 	}
 	fixret, fixout, fixerr := TryFixCCompilation(newArgs)
@@ -412,14 +417,14 @@ func main() {
 		// from fix failures so we can know what the code did wrong and
 		// how to improve jcc to fix more issues.
 		fmt.Print(out)
-		fmt.Fprint(os.Stderr, errstr)
+		RecordError(errstr)
 		fmt.Println("\nFix failure")
 		fmt.Print(fixout)
 		// Print error back to stderr so tooling that relies on this can proceed
-		fmt.Fprint(os.Stderr, fixerr)
+		RecordError(fixerr)
 		os.Exit(retcode)
 	}
 	// The fix suceeded, write its out and err.
 	fmt.Print(fixout)
-	fmt.Fprint(os.Stderr, fixerr)
+	RecordError(fixerr)
 }

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -353,8 +353,9 @@ func AppendStringToFile(filepath, new_content string) error {
 	return err
 }
 
-func RecordError(errstr string) {
-	// Prints |errstr| to stderr, and saves it to err log.
+func WriteStdErrOut(outstr string, errstr string) {
+	// Prints |outstr| to stdout, prints |errstr| to stderr, and saves |errstr| to err.log.
+	fmt.Print(outstr)
 	fmt.Fprint(os.Stderr, errstr)
 	AppendStringToFile("/out/err.log", errstr)
 }
@@ -385,8 +386,7 @@ func main() {
 	}
 	retcode, out, errstr := Compile(bin, newArgs)
 	if retcode == 0 {
-		fmt.Print(out)
-		RecordError(errstr)
+		WriteStdErrOut(out, errstr)
 		os.Exit(0)
 	}
 
@@ -407,8 +407,7 @@ func main() {
 		// Nothing else we can do. Just write the error and exit.
 		// Just print the original error for debugging purposes and
 		//  to make build systems happy.
-		fmt.Print(out)
-		RecordError(errstr)
+		WriteStdErrOut(out, errstr)
 		os.Exit(retcode)
 	}
 	fixret, fixout, fixerr := TryFixCCompilation(newArgs)
@@ -416,15 +415,12 @@ func main() {
 		// We failed, write stdout and stderr from the first failure and
 		// from fix failures so we can know what the code did wrong and
 		// how to improve jcc to fix more issues.
-		fmt.Print(out)
-		RecordError(errstr)
+		WriteStdErrOut(out, errstr)
 		fmt.Println("\nFix failure")
-		fmt.Print(fixout)
 		// Print error back to stderr so tooling that relies on this can proceed
-		RecordError(fixerr)
+		WriteStdErrOut(fixout, fixerr)
 		os.Exit(retcode)
 	}
 	// The fix suceeded, write its out and err.
-	fmt.Print(fixout)
-	RecordError(fixerr)
+	WriteStdErrOut(fixout, fixerr)
 }

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -341,6 +341,18 @@ func CppifyHeaderIncludes(contents string) (string, error) {
 	return contents, nil
 }
 
+func appendStringToFile(filepath, new_content string) error {
+    // Appends |new_content| to the content of |filepath|.
+	file, err := os.OpenFile(filepath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = file.WriteString(new_content)
+    return err
+}
+
 func main() {
 	f, err := os.OpenFile("/tmp/jcc.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 
@@ -391,6 +403,7 @@ func main() {
 		//  to make build systems happy.
 		fmt.Print(out)
 		fmt.Fprint(os.Stderr, errstr)
+               appendStringToFile("/out/err.log", errstr)
 		os.Exit(retcode)
 	}
 	fixret, fixout, fixerr := TryFixCCompilation(newArgs)


### PR DESCRIPTION
Some projects (e.g., `mosh`) do not report the root build error sent to `stderr`.
Saving the errors to a file so that we won't miss any and can always access them later.

Reproduce:
```bash
# In OSS-Fuzz repo:
PROJECT=mosh; \
echo -e "\nENV CC=/usr/local/bin/clang-jcc\nENV CXX=/usr/local/bin/clang++-jcc\nENV FUZZING_LANGUAGE=c++\nENV JCC_GENERATE_AST_DIR=/workspace/out/$PROJECT" >> "projects/$PROJECT/Dockerfile"; \
python infra/helper.py build_image "$PROJECT" --pull && \
docker run -ti gcr.io/oss-fuzz/$PROJECT /bin/bash
```

```bash
# In docker container:
wget https://storage.googleapis.com/clusterfuzz-builds/jcc/clang-jcc -O /usr/local/bin/clang-jcc && wget https://storage.googleapis.com/clusterfuzz-builds/jcc/clang++-jcc -O /usr/local/bin/clang++-jcc && compile
```

With this change, we can see errors like:
```
conftest.cpp:12:10: fatal error: 'ac_nonexistent.h' file not found
#include <ac_nonexistent.h>
         ^~~~~~~~~~~~~~~~~~
1 error generated.
/usr/bin/ld: cannot find -lutempter
clang-15: error: linker command failed with exit code 1 (use -v to see invocation)
conftest.cpp:76:10: fatal error: 'libutil.h' file not found
#include <libutil.h>
         ^~~~~~~~~~~
1 error generated.
conftest.cpp:78:10: fatal error: 'sys/endian.h' file not found
#include <sys/endian.h>
         ^~~~~~~~~~~~~~
1 error generated.
/usr/bin/ld: /tmp/conftest-18d81d.o: in function `main':
conftest.cpp:(.text+0x10): undefined reference to `pledge'
clang-15: error: linker command failed with exit code 1 (use -v to see invocation)
conftest.cpp:89:10: fatal error: 'CommonCrypto/CommonCrypto.h' file not found
#include <CommonCrypto/CommonCrypto.h>
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
/usr/bin/ld: /tmp/conftest-552a22.o: in function `main':
conftest.cpp:(.text+0x10): undefined reference to `forkpty'
clang-15: error: linker command failed with exit code 1 (use -v to see invocation)
conftest.cpp:60:10: fatal error: 'tr1/memory' file not found
#include <tr1/memory>
         ^~~~~~~~~~~~
1 error generated.
conftest.cpp:78:10: error: builtin functions must be directly called
  (void) __builtin_bswap64;
         ^
1 error generated.
```