### PR TITLE
hdf5: fix build

### DIFF
--- a/projects/hdf5/build.sh
+++ b/projects/hdf5/build.sh
@@ -47,4 +47,4 @@ $CC $CFLAGS  -std=c99 -c \
   $SRC/h5_extended_fuzzer.c
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE h5_extended_fuzzer.o ./build-dir/bin/libhdf5.a -lz -o $OUT/h5_extended_fuzzer
 
-zip -j $OUT/h5_extended_fuzzer_seed_corpus.zip $SRC/hdf5/test/*.h5
+zip -j $OUT/h5_extended_fuzzer_seed_corpus.zip $SRC/hdf5/test/testfiles/*.h5


### PR DESCRIPTION
Test files used for seed corpus are moved to a new folder