### PR TITLE
memcached: initial fuzzer integration

### DIFF
--- a/projects/memcached/Dockerfile
+++ b/projects/memcached/Dockerfile
@@ -1,0 +1,29 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool pkgconf libevent-dev
+
+RUN git clone https://github.com/libevent/libevent.git && \
+    cd libevent && \
+    mkdir build && \
+    cd build && \
+    cmake -DEVENT__DISABLE_MBEDTLS=ON -DEVENT__DISABLE_OPENSSL=ON -DEVENT__LIBRARY_TYPE=STATIC ../ && \
+    make && make install
+
+RUN git clone --depth 1 https://github.com/memcached/memcached memcached
+WORKDIR memcached
+COPY build.sh generate_corpus.py *.c *.diff *.options $SRC/

--- a/projects/memcached/build.sh
+++ b/projects/memcached/build.sh
@@ -1,0 +1,48 @@
+#!/bin/bash -eu
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+cd vendor && ./fetch.sh && cd ../
+git apply $SRC/patch.diff
+./autogen.sh
+./configure --enable-proxy
+make
+
+mv $SRC/fuzzer_proxy.c $SRC/memcached/
+cd $SRC/memcached
+
+$CC $CFLAGS $LIB_FUZZING_ENGINE -Ivendor/liburing/src/include \
+    -Ivendor/lua/src \
+    -L /usr/local/lib \
+    -DHAVE_CONFIG_H -L ./vendor/lua/src \
+    -g -O2 -pthread -levent -lm -ldl fuzzer_proxy.c \
+    memcached-memcached.o memcached-hash.o memcached-jenkins_hash.o \
+    memcached-murmur3_hash.o memcached-slabs.o memcached-items.o \
+    memcached-assoc.o memcached-thread.o memcached-daemon.o memcached-stats_prefix.o \
+    memcached-util.o memcached-cache.o memcached-bipbuffer.o memcached-base64.o \
+    memcached-logger.o memcached-crawler.o memcached-itoa_ljust.o memcached-slab_automove.o \
+    memcached-authfile.o memcached-restart.o memcached-proto_text.o memcached-proto_bin.o \
+    memcached-proto_proxy.o memcached-proxy_xxhash.o memcached-proxy_await.o \
+    memcached-proxy_ustats.o memcached-proxy_jump_hash.o memcached-proxy_request.o \
+    memcached-proxy_network.o memcached-proxy_lua.o memcached-proxy_config.o \
+    memcached-proxy_ring_hash.o memcached-proxy_internal.o memcached-md5.o \
+    memcached-extstore.o memcached-crc32c.o memcached-storage.o memcached-slab_automove_extstore.o \
+    vendor/lua/src/liblua.a /usr/local/lib/libevent.a vendor/mcmc/mcmc.o -o fuzzer_proxy
+
+python3 $SRC/generate_corpus.py
+
+cp $SRC/memcached/fuzzer_proxy $OUT/
+cp $SRC/*.options $OUT/
+cp *seed_corpus.zip $OUT/

--- a/projects/memcached/fuzzer_proxy.c
+++ b/projects/memcached/fuzzer_proxy.c
@@ -1,3 +1,15 @@
+/* Copyright 2023 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/projects/memcached/fuzzer_proxy.c
+++ b/projects/memcached/fuzzer_proxy.c
@@ -1,0 +1,76 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "memcached.h"
+#include "proto_proxy.h"
+#include "cache.h"
+#include <sys/eventfd.h>
+
+static struct event_base *main_base;
+static conn *fconn;
+
+#define PROXY 1
+#define READ_BUFFER_SIZE 16384 // memcached.h
+
+extern int LLVMFuzzerInitialize(int *argc, char **argv)
+{
+    // allocate cons
+    conns = calloc(10, sizeof(conn *));
+
+    // init eventfd
+    int dfd = eventfd(0, EFD_NONBLOCK);
+    struct event_config *ev_config;
+    ev_config = event_config_new();
+    event_config_set_flag(ev_config, EVENT_BASE_FLAG_NOLOCK);
+    main_base = event_base_new_with_config(ev_config);
+
+    memcached_thread_init(1, NULL);
+    // get the first, and only, worker thread, and manually attach to the conn
+    LIBEVENT_THREAD *mthread = get_worker_thread(0); 
+
+    // init proxy config
+    settings.proxy_ctx = proxy_init(false);
+    settings.proxy_enabled = true;
+    settings.binding_protocol = proxy_prot;
+
+    // generate connection
+    fconn = conn_new(dfd, conn_parse_cmd,
+                EV_READ|EV_PERSIST,
+                4096, local_transport,
+                main_base, NULL, 0,
+                settings.binding_protocol);
+
+    // assign worker thread
+    fconn->thread = mthread;
+
+    // initialize proxy thread
+    proxy_thread_init(settings.proxy_ctx, fconn->thread);
+    
+    // setup hashing
+    assoc_init(HASHPOWER_DEFAULT);
+    hash_init(MURMUR3_HASH);
+
+    return 0;
+}
+
+extern int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
+{
+    if(len < 4) return -1;
+    if(len > READ_BUFFER_SIZE) return -1;
+
+    int rval = 0;
+
+    fconn->rbuf = do_cache_alloc(fconn->thread->rbuf_cache);
+    fconn->rcurr = fconn->rbuf;
+    fconn->rsize = READ_BUFFER_SIZE;
+
+    fconn->rbytes = len;
+    memcpy(fconn->rbuf, buf, len);
+
+    rval = try_read_command_proxy(fconn);
+    do_cache_free(fconn->thread->rbuf_cache, fconn->rbuf);
+    fconn->rbuf = NULL;
+    fconn->rcurr = NULL;
+    
+    return rval;
+}

--- a/projects/memcached/fuzzer_proxy.options
+++ b/projects/memcached/fuzzer_proxy.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+detect_leaks=0

--- a/projects/memcached/generate_corpus.py
+++ b/projects/memcached/generate_corpus.py
@@ -1,0 +1,50 @@
+import zipfile
+from hashlib import md5
+
+"""
+simple, temporary script to dynamically generate a text protocol corpus
+for fuzzing memcached text protocol
+"""
+
+commands = ["ms $PATH$ $PAYLEN$ $FLAG$ $PAYLOAD$", 
+            "mg $PATH$ $FLAG$", 
+            "md $PATH$ $FLAG$",
+            "ma $PATH$ $FLAG$", 
+            "mn ", 
+            "set $PATH$ 2 0 2 $PAYLOAD$", 
+            "get $PATH$", 
+            "add $PATH$ 2 0 2 $PAYLOAD$", 
+            "replace $PATH$ 2 0 2 $PAYLOAD$", 
+            "append $PATH$ $PAYLEN$ $PAYLOAD$", 
+            "prepend $PATH$ $PAYLEN$ $PAYLOAD$", 
+            "gets $PATH$", 
+            "delete $PATH$", 
+            "incr $PATH$ 1",
+            "decr $PATH$ 1", 
+            "touch $PATH$ 0", 
+            "gat 0 $PATH$", 
+            "gats 0 $PATH$", 
+            "watch", 
+            "version", 
+            "stats"]
+
+# hardcode these for now
+PATH="/foo/test"
+PAYLOAD="hi"
+PAYLEN="2"
+FLAG="c k"
+
+# generate fuzzer_proxy corpus
+fproxy_corpus = "fuzzer_proxy_seed_corpus.zip"
+with zipfile.ZipFile(fproxy_corpus, "w") as zfile:
+    for command in commands:
+        data = (command.replace
+            ("$PATH$", PATH)
+            .replace
+            ("$FLAG$", FLAG)
+            .replace
+            ("$PAYLEN$", PAYLEN)
+            .replace
+            ("$PAYLOAD$", "\r\n{0}".format(PAYLOAD))) 
+        
+        zfile.writestr(md5(data.encode("utf-8")).hexdigest(), data)

--- a/projects/memcached/generate_corpus.py
+++ b/projects/memcached/generate_corpus.py
@@ -1,3 +1,19 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+##########################################################################
+
 import zipfile
 from hashlib import md5
 

--- a/projects/memcached/patch.diff
+++ b/projects/memcached/patch.diff
@@ -1,0 +1,26 @@
+diff --git a/Makefile.am b/Makefile.am
+index 4208331..11c3e1b 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,6 +1,7 @@
+ bin_PROGRAMS = memcached
+ pkginclude_HEADERS = protocol_binary.h xxhash.h
+-noinst_PROGRAMS = memcached-debug sizes testapp timedrun
++#noinst_PROGRAMS = memcached-debug sizes testapp timedrun
++memcached_LINK = true
+ 
+ BUILT_SOURCES=
+ 
+diff --git a/memcached.c b/memcached.c
+index 306a952..4520bdb 100644
+--- a/memcached.c
++++ b/memcached.c
+@@ -4730,7 +4730,7 @@ static int _mc_meta_load_cb(const char *tag, void *ctx, void *data) {
+     return reuse_mmap;
+ }
+ 
+-int main (int argc, char **argv) {
++int main2 (int argc, char **argv) {
+     int c;
+     bool lock_memory = false;
+     bool do_daemonize = false;


### PR DESCRIPTION
Initial memcached integration. This currently only targets the proxy with a minimal corpus, but this will change and be expanded. Tested successfully locally. 