### PR TITLE
Fix fuzz introspector config

### DIFF
--- a/projects/lua/build.sh
+++ b/projects/lua/build.sh
@@ -39,7 +39,6 @@ cat > $FUZZ_INTROSPECTOR_CONFIG <<EOF
 FILES_TO_AVOID
 testdir/build/tests/external.protobuf_mutator
 testdir/build/tests/luaL_loadbuffer_proto/
-testdir/tests
 EOF
 
 cd $SRC/testdir

--- a/projects/tarantool/build.sh
+++ b/projects/tarantool/build.sh
@@ -33,7 +33,6 @@ export FUZZ_INTROSPECTOR_CONFIG=$SRC/fuzz_introspector_exclusion.config
 cat > $FUZZ_INTROSPECTOR_CONFIG <<EOF
 FILES_TO_AVOID
 icu/
-tarantool/test
 tarantool/build/test
 EOF
 


### PR DESCRIPTION
Tarantool's Fuzz Introspector report is not generated at all, see [^1]
Lua's Fuzz Introspector config is missed all tests except `fuzz_lua`, see [^2].
Proposed patches fixes that.

[^1]: https://introspector.oss-fuzz.com/project-profile?project=tarantool
[^2]: https://storage.googleapis.com/oss-fuzz-introspector/lua/inspector-report/20230930/fuzz_report.html

Follows up https://github.com/google/oss-fuzz/pull/11040
Follows up https://github.com/google/oss-fuzz/pull/11041