### PR TITLE
cras: Dry run

### DIFF
--- a/projects/cras/build.sh
+++ b/projects/cras/build.sh
@@ -18,6 +18,6 @@
 # limitations under the License.
 #
 ################################################################################
-
+# dry run
 cd ${SRC}/adhd
 devtools/oss-fuzz-build.sh


### PR DESCRIPTION
oss-fuzz is failing downstream. Kick off a dry run to see what github actions says.