### PR TITLE
vscode: add comparison of local vs remote coverage

### DIFF
--- a/tools/vscode-extension/package.json
+++ b/tools/vscode-extension/package.json
@@ -98,7 +98,7 @@
       {
         "command": "oss-fuzz.Template",
         "title": "OSS-Fuzz: Template fuzzer creation"
-      }      
+      }
     ]
   },
   "scripts": {

--- a/tools/vscode-extension/src/commands/cmdEndToEndCoverage.ts
+++ b/tools/vscode-extension/src/commands/cmdEndToEndCoverage.ts
@@ -20,7 +20,7 @@ import {println} from '../logger';
 import {commandHistory} from '../commandUtils';
 import {buildFuzzersFromWorkspace, runFuzzerHandler} from '../ossfuzzWrappers';
 import {listFuzzersForProject, systemSync} from '../utils';
-import {loadCoverageIntoWorkspace} from '../coverageHelper';
+import {compareLocalToRemoteCoverage, loadSummaryJsonCoverage, loadCoverageIntoWorkspace} from '../coverageHelper';
 import {extensionConfig} from '../config';
 
 /**
@@ -157,4 +157,6 @@ async function endToEndRun(
     const generatedCodeCoverageFile = vscode.Uri.file(allCovPath);
     await loadCoverageIntoWorkspace(context, generatedCodeCoverageFile);
   }
+
+  await compareLocalToRemoteCoverage(context, ossFuzzProjectNameInput.toString());
 }

--- a/tools/vscode-extension/src/commands/cmdEndToEndCoverage.ts
+++ b/tools/vscode-extension/src/commands/cmdEndToEndCoverage.ts
@@ -20,7 +20,11 @@ import {println} from '../logger';
 import {commandHistory} from '../commandUtils';
 import {buildFuzzersFromWorkspace, runFuzzerHandler} from '../ossfuzzWrappers';
 import {listFuzzersForProject, systemSync} from '../utils';
-import {compareLocalToRemoteCoverage, loadSummaryJsonCoverage, loadCoverageIntoWorkspace} from '../coverageHelper';
+import {
+  compareLocalToRemoteCoverage,
+  loadSummaryJsonCoverage,
+  loadCoverageIntoWorkspace,
+} from '../coverageHelper';
 import {extensionConfig} from '../config';
 
 /**
@@ -85,8 +89,14 @@ async function endToEndRun(
   vscode.window.showInformationMessage(
     'Building project: ' + ossFuzzProjectNameInput.toString()
   );
-  if (await buildFuzzersFromWorkspace(ossFuzzProjectNameInput.toString(), '', true) == false) {
-    println("Failed to build project");
+  if (
+    (await buildFuzzersFromWorkspace(
+      ossFuzzProjectNameInput.toString(),
+      '',
+      true
+    )) === false
+  ) {
+    println('Failed to build project');
     return;
   }
   println('Build projects');
@@ -158,5 +168,8 @@ async function endToEndRun(
     await loadCoverageIntoWorkspace(context, generatedCodeCoverageFile);
   }
 
-  await compareLocalToRemoteCoverage(context, ossFuzzProjectNameInput.toString());
+  await compareLocalToRemoteCoverage(
+    context,
+    ossFuzzProjectNameInput.toString()
+  );
 }

--- a/tools/vscode-extension/src/coverageHelper.ts
+++ b/tools/vscode-extension/src/coverageHelper.ts
@@ -18,7 +18,8 @@ import * as vscode from 'vscode';
 import {Uri} from 'vscode';
 import {println} from './logger';
 import {getApi, FileDownloader} from '@microsoft/vscode-file-downloader-api';
-import {extensionConfig} from './config';
+import {extensionConfig} from './config'
+import {getOSSFuzzCloudURL, getLocalOutBuildDir, downloadRemoteURL} from './utils';
 
 const path = require('path');
 let isCodeCoverageEnabled = false;
@@ -69,44 +70,13 @@ export async function compareLocalToRemoteCoverage(
   println("Checking the file matching");
   /* Get the coverage from the remote server */
   const fileDownloader: FileDownloader = await getApi();
-
-  const currentDate = new Date();
-  const yesterday = new Date(currentDate);
-  yesterday.setDate(yesterday.getDate() - 1);
-
-  const day = yesterday.getDate();
-  const month = yesterday.getMonth();
-  const year = yesterday.getFullYear();
-
-  var urlString = 'https://storage.googleapis.com/oss-fuzz-coverage/' +
-  projectName +
-  '/reports/' +
-  year.toString();
-
-  if (month < 10) {
-    urlString += "0";
-  }
-  urlString += month.toString();
-  if (day < 10) {
-    urlString += "0";
-  }
-  urlString += day.toString();
-  urlString += '/linux/summary.json';
+  var urlString = await getOSSFuzzCloudURL(projectName) + '/linux/summary.json';
 
   println("URL: " + urlString);
-  var codeCoverageFile: vscode.Uri;
-  try {
-    codeCoverageFile = await fileDownloader.downloadFile(
-      vscode.Uri.parse(
-        urlString
-      ),
-      'summary.json',
-      context
-    );
-
-  } catch (err) {
+  var codeCoverageFile: false | vscode.Uri = await downloadRemoteURL(urlString, 'summary.json', context);
+  if (!codeCoverageFile) {
     println(
-      'Could not get the URL. Currently, this feature is only supported for Python projects'
+      'Could not get the coverage summary file'
     );
     return;
   }
@@ -114,22 +84,23 @@ export async function compareLocalToRemoteCoverage(
 
   /* Get the local coverage report */
   // Compare the local coverage to the upstream coverage
-  const summaryCovPath =
-    extensionConfig.ossFuzzPepositoryWorkPath +
-    '/build/out/' +
-    projectName +
-    '/report/linux/summary.json';
-  const localCodeCoverage = await loadSummaryJsonCoverage(context, vscode.Uri.file(summaryCovPath));
+  const localSummaryCovPath = await getLocalOutBuildDir(projectName) + '/report/linux/summary.json';
+  const localCodeCoverage = await loadSummaryJsonCoverage(context, vscode.Uri.file(localSummaryCovPath));
 
   for (var i = 0; i < localCodeCoverage.data[0].files.length; i++) {
     for (var j = 0; j < remoteCoverage.data[0].files.length; j++) {
-      if (localCodeCoverage.data[0].files[i].filename == remoteCoverage.data[0].files[j].filename) {
-        const remoteFuncCount = remoteCoverage.data[0].files[j].summary.functions.count;
-        const localFuncCount = localCodeCoverage.data[0].files[i].summary.functions.count;
+      // Get the file dictionary
+      const localFileData = localCodeCoverage.data[0].files[i];
+      const remoteFileData = remoteCoverage.data[0].files[j];
+
+      // If the filepaths are the same, then we match coverage data
+      if (localFileData.filename == remoteFileData.filename) {
+        const remoteFuncCount = remoteFileData.summary.functions.count;
+        const localFuncCount = localFileData.summary.functions.count;
 
         if (localFuncCount > remoteFuncCount) {
           println("Coverage improved in :" +
-            localCodeCoverage.data[0].files[i].filename +
+          localFileData.filename +
             " [" + localFuncCount + " : " + remoteFuncCount + "]");
         }
       }

--- a/tools/vscode-extension/src/coverageHelper.ts
+++ b/tools/vscode-extension/src/coverageHelper.ts
@@ -18,8 +18,12 @@ import * as vscode from 'vscode';
 import {Uri} from 'vscode';
 import {println} from './logger';
 import {getApi, FileDownloader} from '@microsoft/vscode-file-downloader-api';
-import {extensionConfig} from './config'
-import {getOSSFuzzCloudURL, getLocalOutBuildDir, downloadRemoteURL} from './utils';
+import {extensionConfig} from './config';
+import {
+  getOSSFuzzCloudURL,
+  getLocalOutBuildDir,
+  downloadRemoteURL,
+} from './utils';
 
 const path = require('path');
 let isCodeCoverageEnabled = false;
@@ -58,7 +62,9 @@ export async function loadSummaryJsonCoverage(
   context: vscode.ExtensionContext,
   codeCoverageFile: Uri
 ) {
-  const coverageSummaryRawJson = await vscode.workspace.openTextDocument(codeCoverageFile);
+  const coverageSummaryRawJson = await vscode.workspace.openTextDocument(
+    codeCoverageFile
+  );
   const jsonCodeCoverage = JSON.parse(coverageSummaryRawJson.getText());
   return jsonCodeCoverage;
 }
@@ -66,42 +72,57 @@ export async function loadSummaryJsonCoverage(
 export async function compareLocalToRemoteCoverage(
   context: vscode.ExtensionContext,
   projectName: string
-){
-  println("Checking the file matching");
+) {
+  println('Checking the file matching');
   /* Get the coverage from the remote server */
-  const fileDownloader: FileDownloader = await getApi();
-  var urlString = await getOSSFuzzCloudURL(projectName) + '/linux/summary.json';
+  const urlString =
+    (await getOSSFuzzCloudURL(projectName)) + '/linux/summary.json';
 
-  println("URL: " + urlString);
-  var codeCoverageFile: false | vscode.Uri = await downloadRemoteURL(urlString, 'summary.json', context);
+  println('URL: ' + urlString);
+  const codeCoverageFile: false | vscode.Uri = await downloadRemoteURL(
+    urlString,
+    'summary.json',
+    context
+  );
   if (!codeCoverageFile) {
-    println(
-      'Could not get the coverage summary file'
-    );
+    println('Could not get the coverage summary file');
     return;
   }
-  const remoteCoverage = await loadSummaryJsonCoverage(context, codeCoverageFile);
+  const remoteCoverage = await loadSummaryJsonCoverage(
+    context,
+    codeCoverageFile
+  );
 
   /* Get the local coverage report */
   // Compare the local coverage to the upstream coverage
-  const localSummaryCovPath = await getLocalOutBuildDir(projectName) + '/report/linux/summary.json';
-  const localCodeCoverage = await loadSummaryJsonCoverage(context, vscode.Uri.file(localSummaryCovPath));
+  const localSummaryCovPath =
+    (await getLocalOutBuildDir(projectName)) + '/report/linux/summary.json';
+  const localCodeCoverage = await loadSummaryJsonCoverage(
+    context,
+    vscode.Uri.file(localSummaryCovPath)
+  );
 
-  for (var i = 0; i < localCodeCoverage.data[0].files.length; i++) {
-    for (var j = 0; j < remoteCoverage.data[0].files.length; j++) {
+  for (let i = 0; i < localCodeCoverage.data[0].files.length; i++) {
+    for (let j = 0; j < remoteCoverage.data[0].files.length; j++) {
       // Get the file dictionary
       const localFileData = localCodeCoverage.data[0].files[i];
       const remoteFileData = remoteCoverage.data[0].files[j];
 
       // If the filepaths are the same, then we match coverage data
-      if (localFileData.filename == remoteFileData.filename) {
+      if (localFileData.filename === remoteFileData.filename) {
         const remoteFuncCount = remoteFileData.summary.functions.count;
         const localFuncCount = localFileData.summary.functions.count;
 
         if (localFuncCount > remoteFuncCount) {
-          println("Coverage improved in :" +
-          localFileData.filename +
-            " [" + localFuncCount + " : " + remoteFuncCount + "]");
+          println(
+            'Coverage improved in :' +
+              localFileData.filename +
+              ' [' +
+              localFuncCount +
+              ' : ' +
+              remoteFuncCount +
+              ']'
+          );
         }
       }
     }

--- a/tools/vscode-extension/src/extension.ts
+++ b/tools/vscode-extension/src/extension.ts
@@ -33,6 +33,7 @@ import {cmdInputCollectorReproduceTestcase} from './commands/cmdReproduceTestcas
 import {cmdDispatcherTemplate} from './commands/cmdTemplate';
 import {setUpOssFuzzHandler} from './commands/cmdSetupOSSFuzz';
 import {setOssFuzzPath} from './commands/cmdSetOSSFuzzPath';
+import {getSummaryRemoteCoverage} from './commands/cmdRemoteSummaryCoverage';
 import {extensionConfig} from './config';
 
 /**

--- a/tools/vscode-extension/src/extension.ts
+++ b/tools/vscode-extension/src/extension.ts
@@ -33,7 +33,6 @@ import {cmdInputCollectorReproduceTestcase} from './commands/cmdReproduceTestcas
 import {cmdDispatcherTemplate} from './commands/cmdTemplate';
 import {setUpOssFuzzHandler} from './commands/cmdSetupOSSFuzz';
 import {setOssFuzzPath} from './commands/cmdSetOSSFuzzPath';
-import {getSummaryRemoteCoverage} from './commands/cmdRemoteSummaryCoverage';
 import {extensionConfig} from './config';
 
 /**

--- a/tools/vscode-extension/src/utils.ts
+++ b/tools/vscode-extension/src/utils.ts
@@ -15,10 +15,71 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 import * as vscode from 'vscode';
+import {extensionConfig} from './config'
+import {getApi, FileDownloader} from '@microsoft/vscode-file-downloader-api';
+
 const fs = require('fs');
 const {spawn} = require('node:child_process');
 
 import {println, printRaw, debugPrintln} from './logger';
+
+export async function downloadRemoteURL(urlString: string, targetFile: string, context: vscode.ExtensionContext,) {
+  const fileDownloader: FileDownloader = await getApi();
+  //var urlString = await getOSSFuzzCloudURL(projectName) + '/linux/summary.json';
+
+  println("URL: " + urlString);
+  var codeCoverageFile: vscode.Uri;
+  try {
+    codeCoverageFile = await fileDownloader.downloadFile(
+      vscode.Uri.parse(
+        urlString
+      ),
+      targetFile,
+      context
+    );
+
+  } catch (err) {
+    println(
+      'Could not get the coverage summary file'
+    );
+    return false;
+  }
+  return codeCoverageFile;
+}
+
+export async function getLocalOutBuildDir(projectName: string) {
+  const summaryCovPath =
+    extensionConfig.ossFuzzPepositoryWorkPath +
+    '/build/out/' +
+    projectName;
+    return summaryCovPath;
+}
+
+export async function getOSSFuzzCloudURL(projectName: string) {
+  const currentDate = new Date();
+  const yesterday = new Date(currentDate);
+  yesterday.setDate(yesterday.getDate() - 1);
+
+  const day = yesterday.getDate();
+  const month = yesterday.getMonth();
+  const year = yesterday.getFullYear();
+
+  var urlString = 'https://storage.googleapis.com/oss-fuzz-coverage/' +
+  projectName +
+  '/reports/' +
+  year.toString();
+
+  if (month < 10) {
+    urlString += "0";
+  }
+  urlString += month.toString();
+  if (day < 10) {
+    urlString += "0";
+  }
+  urlString += day.toString();
+
+  return urlString;
+}
 
 /**
  * Checks if the current workspace has a generated OSS-Fuzz folder. This is the

--- a/tools/vscode-extension/src/utils.ts
+++ b/tools/vscode-extension/src/utils.ts
@@ -15,7 +15,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 import * as vscode from 'vscode';
-import {extensionConfig} from './config'
+import {extensionConfig} from './config';
 import {getApi, FileDownloader} from '@microsoft/vscode-file-downloader-api';
 
 const fs = require('fs');
@@ -23,25 +23,24 @@ const {spawn} = require('node:child_process');
 
 import {println, printRaw, debugPrintln} from './logger';
 
-export async function downloadRemoteURL(urlString: string, targetFile: string, context: vscode.ExtensionContext,) {
+export async function downloadRemoteURL(
+  urlString: string,
+  targetFile: string,
+  context: vscode.ExtensionContext
+) {
   const fileDownloader: FileDownloader = await getApi();
   //var urlString = await getOSSFuzzCloudURL(projectName) + '/linux/summary.json';
 
-  println("URL: " + urlString);
-  var codeCoverageFile: vscode.Uri;
+  println('URL: ' + urlString);
+  let codeCoverageFile: vscode.Uri;
   try {
     codeCoverageFile = await fileDownloader.downloadFile(
-      vscode.Uri.parse(
-        urlString
-      ),
+      vscode.Uri.parse(urlString),
       targetFile,
       context
     );
-
   } catch (err) {
-    println(
-      'Could not get the coverage summary file'
-    );
+    println('Could not get the coverage summary file');
     return false;
   }
   return codeCoverageFile;
@@ -49,10 +48,8 @@ export async function downloadRemoteURL(urlString: string, targetFile: string, c
 
 export async function getLocalOutBuildDir(projectName: string) {
   const summaryCovPath =
-    extensionConfig.ossFuzzPepositoryWorkPath +
-    '/build/out/' +
-    projectName;
-    return summaryCovPath;
+    extensionConfig.ossFuzzPepositoryWorkPath + '/build/out/' + projectName;
+  return summaryCovPath;
 }
 
 export async function getOSSFuzzCloudURL(projectName: string) {
@@ -64,17 +61,18 @@ export async function getOSSFuzzCloudURL(projectName: string) {
   const month = yesterday.getMonth();
   const year = yesterday.getFullYear();
 
-  var urlString = 'https://storage.googleapis.com/oss-fuzz-coverage/' +
-  projectName +
-  '/reports/' +
-  year.toString();
+  let urlString =
+    'https://storage.googleapis.com/oss-fuzz-coverage/' +
+    projectName +
+    '/reports/' +
+    year.toString();
 
   if (month < 10) {
-    urlString += "0";
+    urlString += '0';
   }
   urlString += month.toString();
   if (day < 10) {
-    urlString += "0";
+    urlString += '0';
   }
   urlString += day.toString();
 


### PR DESCRIPTION
Extends the command that runs a full build-fuzzers; run-fuzzers; collect code coverage; to also now do a comparison of the local code coverage to the code coverage by Clusterfuzz. Any gains are highlighted.