### PR TITLE
libzip: disable memory sanitizer

### DIFF
--- a/projects/libzip/Dockerfile
+++ b/projects/libzip/Dockerfile
@@ -18,7 +18,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 
 
-RUN apt-get update && apt-get install -y cmake pkg-config zlib1g-dev liblzma-dev
+RUN apt-get update && apt-get install -y cmake pkg-config zlib1g-dev libbz2-dev liblzma-dev libzstd-dev
 
 RUN git clone --depth 1 https://github.com/nih-at/libzip.git
 

--- a/projects/libzip/build.sh
+++ b/projects/libzip/build.sh
@@ -15,4 +15,4 @@
 #
 ################################################################################
 # Run the OSS-Fuzz script in the project
-$SRC/libzip/regress/ossfuzz.sh
+$SRC/libzip/ossfuzz/ossfuzz.sh

--- a/projects/libzip/project.yaml
+++ b/projects/libzip/project.yaml
@@ -7,7 +7,8 @@ auto_ccs:
 sanitizers:
   - address
   - undefined
-  - memory
+# Disable MSAN because it does not support using other libraries (openssl, zlib) correctly
+#  - memory
 main_repo: 'https://github.com/nih-at/libzip.git'
 fuzzing_engines:
   - afl


### PR DESCRIPTION
Disable MSAN because it does not support using other libraries (openssl, zlib) correctly
