### PR TITLE
apache-poi: Allow missing fonts

### DIFF
--- a/projects/apache-poi/build.sh
+++ b/projects/apache-poi/build.sh
@@ -118,7 +118,7 @@ LD_LIBRARY_PATH=\"\$JVM_LD_LIBRARY_PATH\":\$this_dir \
 --cp=${RUNTIME_CLASSPATH} \
 --instrumentation_includes=org.apache.poi.**:org.apache.xmlbeans.** \
 --target_class=${fuzzer_classname} \
---jvm_args=\"-Xmx1024m\" \
+--jvm_args=\"-Xmx1024m:-Dorg.apache.poi.ss.ignoreMissingFontSystem=true\" \
 \$@" > $OUT/${fuzzer_basename}
 	chmod u+x $OUT/${fuzzer_basename}
 done

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIVisioFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIVisioFuzzer.java
@@ -32,15 +32,6 @@ public class POIVisioFuzzer {
 	public static void fuzzerTestOneInput(byte[] input) {
 		try (XmlVisioDocument visio = new XmlVisioDocument(new ByteArrayInputStream(input))) {
 			visio.write(NullOutputStream.INSTANCE);
-		} catch (NoClassDefFoundError e) {
-			// only allow some missing classes related to Font-handling
-			// we cannot install JDK font packages in oss-fuzz images currently
-			// see https://github.com/google/oss-fuzz/issues/7380
-			if (!e.getMessage().contains("java.awt.Font") &&
-					!e.getMessage().contains("java.awt.Toolkit") &&
-					!e.getMessage().contains("sun.awt.X11FontManager")) {
-				throw e;
-			}
 		} catch (IOException | POIXMLException |
 				 BufferUnderflowException | RecordFormatException | OpenXML4JRuntimeException |
 				 IllegalArgumentException | IndexOutOfBoundsException e) {


### PR DESCRIPTION
After removing some other "roadblocks" by providing some additional .so-files, fuzzing now hits some code which is missing installed fonts. 

Apache POI already provides a system property to handle this gracefully where possible. 

So let's add this property.

We can also remove one leftover exception handling which should not appear now.