### PR TITLE
xmldom: fix build by copying corpus to OUT

### DIFF
--- a/projects/xmldom/build.sh
+++ b/projects/xmldom/build.sh
@@ -19,6 +19,9 @@
 npm ci
 unzip node_modules/xmltest/xmltest.zip
 
+# Copy corpus out
+cp -rf $SRC/xmldom/xmltest $OUT/xmltest
+
 # build fuzzers
 compile_javascript_fuzzer xmldom fuzz/dom-parser.xml.target.js --sync --timeout=10 xmltest
 compile_javascript_fuzzer xmldom fuzz/dom-parser.html.target.js --sync --timeout=10 xmltest


### PR DESCRIPTION
Fixes: https://github.com/google/oss-fuzz/pull/11036#issuecomment-1759249910

CC @karfau 

To test this from outside the containers:

```
python3 infra/helper.py build_fuzzers xmldom
python3 infra/helper.py run_fuzzer xmldom dom-parser.xml.target
python3 infra/helper.py run_fuzzer xmldom dom-parser.html.target
```