### PR TITLE
cloud-custodian: initial integration

### DIFF
--- a/projects/cloud-custodian/Dockerfile
+++ b/projects/cloud-custodian/Dockerfile
@@ -1,0 +1,26 @@
+#!/usr/bin/python3
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-fuzz-base/base-builder-python
+RUN git clone https://github.com/cloud-custodian/cloud-custodian
+RUN apt-get install build-essential libssl-dev libffi-dev pkg-config python3-dev cargo -y
+RUN pip3 install --upgrade pip
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup install nightly
+RUN rustup default stable
+
+COPY *.sh *.py $SRC/
+WORKDIR $SRC/cloud-custodian

--- a/projects/cloud-custodian/build.sh
+++ b/projects/cloud-custodian/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -eu
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+python3 -m pip install .
+for fuzzer in $(find $SRC -name 'fuzz_*.py'); do
+  compile_python_fuzzer $fuzzer
+done

--- a/projects/cloud-custodian/fuzz_query_parser.py
+++ b/projects/cloud-custodian/fuzz_query_parser.py
@@ -1,0 +1,46 @@
+#!/usr/bin/python3
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import atheris
+
+from c7n import exceptions, utils
+
+
+
+def TestOneInput(data):
+    """Fuzz encode and decode"""
+    fdp = atheris.FuzzedDataProvider(data)
+    try:
+        qp = utils.QueryParser.parse(fdp.ConsumeUnicodeNoSurrogates(1024))
+    except exceptions.PolicyValidationError:
+        pass
+
+    c7njme = utils.C7NJMESPathParser()
+    try:
+        c7njme.parse(fdp.ConsumeUnicodeNoSurrogates(1024))
+    except:
+        pass
+
+
+def main():
+    atheris.instrument_all()
+    atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/cloud-custodian/fuzz_resources_parser.py
+++ b/projects/cloud-custodian/fuzz_resources_parser.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python3
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import atheris
+
+from c7n import exceptions
+from c7n.resources import ec2, aws, health, sagemaker, emr
+
+def TestOneInput(data):
+    """Fuzz encode and decode"""
+    fdp = atheris.FuzzedDataProvider(data)
+    choice = fdp.ConsumeIntInRange(1, 5)
+
+    try:
+        if choice == 1:
+            ec2.QueryFilter.parse(fdp.ConsumeUnicodeNoSurrogates(1024))
+        elif choice == 2:
+            aws.Arn.parse(fdp.ConsumeUnicodeNoSurrogates(1024))
+        elif choice == 3:
+            health.QueryFilter.parse(fdp.ConsumeUnicodeNoSurrogates(1024))
+        elif choice == 4:
+            sagemaker.QueryFilter.parse(fdp.ConsumeUnicodeNoSurrogates(1024))
+        elif choice == 5:
+            emr.QueryFilter.parse(fdp.ConsumeUnicodeNoSurrogates(1024))
+    except exceptions.PolicyValidationError:
+        pass
+    except ValueError as e:
+        if "Invalid structure" not in str(e):
+            raise e
+
+
+def main():
+    atheris.instrument_all()
+    atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/cloud-custodian/fuzz_resources_validate.py
+++ b/projects/cloud-custodian/fuzz_resources_validate.py
@@ -1,0 +1,79 @@
+#!/usr/bin/python3
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import atheris
+
+from c7n import exceptions
+from c7n.resources import health, kafka, sagemaker, ebs, emr, awslambda, securityhub, cw, ec2
+#from c7n.resources import secretsmanager, account, ebs, emr, ecr, servicecatalog
+#from c7n.resources import eks, redshift, awslambda, glue, asg, route53
+#from c7n.resources import securityhub, cloudtrail, ssm, rds, cw, efs
+#from c7n.resources import ec2, rdscluster, workspaces, vpc, iam, ami
+#from c7n.resources import elasticsearch, apigw, appelb, s3, sagemaker
+
+def TestOneInput(data):
+    """Fuzz encode and decode"""
+    fdp = atheris.FuzzedDataProvider(data)
+    choice = fdp.ConsumeIntInRange(1, 11)
+    data = _generate_random_dict(fdp)
+
+    try:
+        if choice == 1:
+            object = health.QueryFilter(data)
+        elif choice == 2:
+            object = kafka.SetMonitoring(data = data)
+        elif choice == 3:
+            object = sagemaker.QueryFilter(data)
+        elif choice == 4:
+            object = ebs.CopySnapshot(data = data)
+        elif choice == 5:
+            object = emr.QueryFilter(data = data)
+        elif choice == 6:
+            object = awslambda.SetConcurrency(data = data)
+        elif choice == 7:
+            object = securityhub.SetConcurrency(data = data)
+        elif choice == 8:
+            object = cw.EncryptLogGroup(data = data)
+        elif choice == 9:
+            object = ec2.DisableApiStop(data = data)
+        elif choice == 10:
+            object = ec2.Snapshot(data = data)
+        elif choice == 11:
+            object = ec2.QueryFilter(data = data)
+
+        object.validate()
+    except exceptions.PolicyValidationError:
+        pass
+
+
+def _generate_random_dict(fdp):
+    map = dict()
+
+    for count in range(fdp.ConsumeIntInRange(1, 5)):
+        map[fdp.ConsumeUnicodeNoSurrogates(128)] = fdp.ConsumeUnicodeNoSurrogates(128)
+
+    return map
+
+
+def main():
+    atheris.instrument_all()
+    atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/cloud-custodian/fuzz_resources_validate.py
+++ b/projects/cloud-custodian/fuzz_resources_validate.py
@@ -19,11 +19,6 @@ import atheris
 
 from c7n import exceptions
 from c7n.resources import health, kafka, sagemaker, ebs, emr, awslambda, securityhub, cw, ec2
-#from c7n.resources import secretsmanager, account, ebs, emr, ecr, servicecatalog
-#from c7n.resources import eks, redshift, awslambda, glue, asg, route53
-#from c7n.resources import securityhub, cloudtrail, ssm, rds, cw, efs
-#from c7n.resources import ec2, rdscluster, workspaces, vpc, iam, ami
-#from c7n.resources import elasticsearch, apigw, appelb, s3, sagemaker
 
 def TestOneInput(data):
     """Fuzz encode and decode"""

--- a/projects/cloud-custodian/project.yaml
+++ b/projects/cloud-custodian/project.yaml
@@ -8,3 +8,5 @@ sanitizers:
 - undefined
 vendor_ccs:
 - david@adalogics.com
+- adam@adalogics.com
+- arthur.chan@adalogics.com

--- a/projects/cloud-custodian/project.yaml
+++ b/projects/cloud-custodian/project.yaml
@@ -1,0 +1,10 @@
+fuzzing_engines:
+- libfuzzer
+homepage: https://github.com/cloud-custodian/cloud-custodian
+language: python
+main_repo: https://github.com/cloud-custodian/cloud-custodian
+sanitizers:
+- address
+- undefined
+vendor_ccs:
+- david@adalogics.com

--- a/projects/cloud-custodian/project.yaml
+++ b/projects/cloud-custodian/project.yaml
@@ -6,6 +6,7 @@ main_repo: https://github.com/cloud-custodian/cloud-custodian
 sanitizers:
 - address
 - undefined
+primary_contact: "kapil@stacklet.io"
 vendor_ccs:
 - david@adalogics.com
 - adam@adalogics.com


### PR DESCRIPTION
Initial integration of Cloud Custodian, a rules engine for cloud platforms such as Google Cloud, AWS, Azure and Kubernetes. Users write YAML-based policies to query, filter and take actions on cloud resources. It is used in production by companies such as:

1. HBO Max
2. JP Morgan
3. Capital One
4. Siemens
5. Zapier

And [others](https://github.com/cloud-custodian/cloud-custodian/blob/main/ADOPTERS.md).

Cloud Custodian is a Cloud Native Computing Foundation project.