### PR TITLE
Kyverno: Clone upstream repo

### DIFF
--- a/projects/kyverno/Dockerfile
+++ b/projects/kyverno/Dockerfile
@@ -15,7 +15,6 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
-# Temporarily point to a fork
-RUN git clone --depth 1 https://github.com/AdamKorcz/kyverno --branch=more-fuzzing
+RUN git clone --depth 1 https://github.com/kyverno/kyverno
 COPY build.sh $SRC/
 WORKDIR $SRC/kyverno


### PR DESCRIPTION
We temporarily used a fork for Kyverno while testing out some new fuzzers. These fuzzers are now merged upstream, so reverting the repo to clone as well.