### PR TITLE
Update `homepage` and `main_repo` for RE2.

### DIFF
--- a/projects/re2/project.yaml
+++ b/projects/re2/project.yaml
@@ -1,6 +1,7 @@
-homepage: "https://code.googlesource.com/re2"
-language: c++
+homepage: "https://github.com/google/re2"
+main_repo: "https://github.com/google/re2"
 primary_contact: "junyer@google.com"
+language: c++
 sanitizers:
   - address
   - memory
@@ -8,10 +9,7 @@ sanitizers:
 architectures:
   - x86_64
   - i386
-main_repo: 'https://code.googlesource.com/re2'
-
 fuzzing_engines:
   - afl
   - honggfuzz
   - libfuzzer
-


### PR DESCRIPTION
Currently, https://deps.dev/project/github/google%2Fre2 indicates that RE2 isn't fuzzed. I'm guessing that this configuration is the reason for that.