### PR TITLE
fluent-bit: update lib deps

### DIFF
--- a/projects/fluent-bit/Dockerfile
+++ b/projects/fluent-bit/Dockerfile
@@ -17,5 +17,10 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make cmake flex bison libssl-dev libyaml-dev
 RUN git clone --depth 1 https://github.com/fluent/fluent-bit/ fluent-bit
 
+# Update the libs in fluent-bit to use the latest patches for optimizing fuzzing workflow
+RUN cd $SRC/fluent-bit/lib && \
+    rm -rf ./ctraces && \
+    git clone --depth 1 https://github.com/fluent/ctraces ctraces
+
 WORKDIR $SRC
 COPY build.sh $SRC/


### PR DESCRIPTION
This is to use the latest dependencies where patches are made to avoid having to wait for Fluent-bit's master branch to update.