### PR TITLE
Changing urllib3 fuzzing to use httpretty

### DIFF
--- a/projects/urllib3/Dockerfile
+++ b/projects/urllib3/Dockerfile
@@ -15,6 +15,8 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder-python
+RUN pip3 install httpretty
+
 RUN git clone --depth 1 https://github.com/urllib3/urllib3
 
 COPY build.sh $SRC/

--- a/projects/urllib3/build.sh
+++ b/projects/urllib3/build.sh
@@ -17,6 +17,8 @@
 
 python3 -m pip install .
 
+export PYFUZZPACKAGE=$SRC/urllib3/src/urllib3
+
 # Build fuzzers in $OUT.
 for fuzzer in $(find $SRC -name 'fuzz_*.py'); do
   compile_python_fuzzer $fuzzer


### PR DESCRIPTION
I've been trying to use a Python `HTTPServer` on a seperate thread to drive coverage of urllib3. There are technical issues with it #10235 that mean it's not running properly.

I have created an alternative approach that uses a Python socket mocking framework `httpretty` to fuzz urllib3's request handling. I'd like to switch us over to this new approach to see if we can start fuzzing urllib3's request handling.