### PR TITLE
cras: Declare "language: rust"

### DIFF
--- a/projects/cras/project.yaml
+++ b/projects/cras/project.yaml
@@ -1,5 +1,5 @@
 homepage: "https://www.chromium.org"
-language: c++
+language: rust
 primary_contact: "paulhsia@chromium.org"
 auto_ccs:
   - "hychao@chromium.org"


### PR DESCRIPTION
The coverage builder complains that rust stdlib sources is missing.

```
Step #5: [0;31merror: /workspace/out/libfuzzer-coverage-x86_64/rustc/187b8131d4f760f856b214fce34534903276f2ef/library/core/src/panic.rs: No such file or directory
Step #5: [0m[0;31mwarning: The file '/rustc/187b8131d4f760f856b214fce34534903276f2ef/library/core/src/panic.rs' isn't covered.
Step #5: [0m[2023-10-04 06:50:42,764 DEBUG] Finished generating per-file code coverage summary.
Step #5: [2023-10-04 06:50:42,764 DEBUG] Generating file view html index file as: "/workspace/out/libfuzzer-coverage-x86_64/report/linux/file_view_index.html".
Step #5: Traceback (most recent call last):
Step #5:   File "/opt/code_coverage/coverage_utils.py", line 829, in <module>
Step #5:     sys.exit(Main())
Step #5:   File "/opt/code_coverage/coverage_utils.py", line 823, in Main
Step #5:     return _CmdPostProcess(args)
Step #5:   File "/opt/code_coverage/coverage_utils.py", line 780, in _CmdPostProcess
Step #5:     processor.PrepareHtmlReport()
Step #5:   File "/opt/code_coverage/coverage_utils.py", line 577, in PrepareHtmlReport
Step #5:     self.GenerateFileViewHtmlIndexFile(per_file_coverage_summary,
Step #5:   File "/opt/code_coverage/coverage_utils.py", line 450, in GenerateFileViewHtmlIndexFile
Step #5:     self.GetCoverageHtmlReportPathForFile(file_path),
Step #5:   File "/opt/code_coverage/coverage_utils.py", line 422, in GetCoverageHtmlReportPathForFile
Step #5:     assert os.path.isfile(
Step #5: AssertionError: "/rustc/187b8131d4f760f856b214fce34534903276f2ef/library/core/src/panic.rs" is not a file.
```

I think the sources would be copied in base-builder if we declare cras as a rust project:

https://github.com/google/oss-fuzz/blob/d514fac92686c656633aa8549fd6f239c964b2bc/infra/base-images/base-builder/compile#L226-L231

Fixes: https://crbug.com/oss-fuzz/62974