### PR TITLE
Enable memory sanitizer for libcue

### DIFF
--- a/projects/libcue/project.yaml
+++ b/projects/libcue/project.yaml
@@ -9,8 +9,8 @@ sanitizers:
   - memory
   - undefined
 fuzzing_engines:
-    - libfuzzer
-    - honggfuzz
-    - afl
-    - wycheproof
-    # - centipede disabled until https://github.com/lipnitsk/libcue/pull/31/
+  - libfuzzer
+  - honggfuzz
+  - afl
+  - wycheproof
+  # - centipede disabled until https://github.com/lipnitsk/libcue/pull/31/

--- a/projects/libcue/project.yaml
+++ b/projects/libcue/project.yaml
@@ -4,6 +4,10 @@ language: c
 primary_contact: "ilya.lipnitskiy@gmail.com"
 auto_ccs:
   - "aleksandrosansan@gmail.com"
+sanitizers:
+  - address
+  - memory
+  - undefined
 fuzzing_engines:
     - libfuzzer
     - honggfuzz


### PR DESCRIPTION
Just noticed that the memory sanitizer is not enabled by default.