### PR TITLE
Disable wycheproof for libcue

### DIFF
--- a/projects/libcue/project.yaml
+++ b/projects/libcue/project.yaml
@@ -5,8 +5,7 @@ primary_contact: "ilya.lipnitskiy@gmail.com"
 auto_ccs:
   - "aleksandrosansan@gmail.com"
 fuzzing_engines:
-    - libfuzzer
-    - honggfuzz
-    - afl
-    - wycheproof
-    # - centipede disabled until https://github.com/lipnitsk/libcue/pull/31/
+  - libfuzzer
+  - honggfuzz
+  - afl
+  # - centipede disabled until https://github.com/lipnitsk/libcue/pull/31/


### PR DESCRIPTION
Wycheproof causes [build break](https://oss-fuzz-build-logs.storage.googleapis.com/log-760a7a28-01ef-4046-88fe-5003a4a99fbf.txt). Disabling it unless someone knows what is missing for it to work.
Edit: Also just learned wycheproof purpose is to fuzz cryptography, so it is irrelevant for this project.