### PR TITLE
[memcached] Update fuzzer to support 1.6.22

### DIFF
--- a/projects/memcached/build.sh
+++ b/projects/memcached/build.sh
@@ -39,6 +39,7 @@ $CC $CFLAGS $LIB_FUZZING_ENGINE -Ivendor/liburing/src/include \
     memcached-proxy_network.o memcached-proxy_lua.o memcached-proxy_config.o \
     memcached-proxy_ring_hash.o memcached-proxy_internal.o memcached-md5.o \
     memcached-extstore.o memcached-crc32c.o memcached-storage.o memcached-slab_automove_extstore.o \
+    memcached-proxy_ratelim.o \
     vendor/lua/src/liblua.a /usr/local/lib/libevent.a vendor/mcmc/mcmc.o -o fuzzer_proxy
 
 python3 $SRC/generate_corpus.py

--- a/projects/memcached/fuzzer_proxy.c
+++ b/projects/memcached/fuzzer_proxy.c
@@ -41,7 +41,7 @@ extern int LLVMFuzzerInitialize(int *argc, char **argv)
     LIBEVENT_THREAD *mthread = get_worker_thread(0); 
 
     // init proxy config
-    settings.proxy_ctx = proxy_init(false);
+    settings.proxy_ctx = proxy_init(false, false);
     settings.proxy_enabled = true;
     settings.binding_protocol = proxy_prot;
 


### PR DESCRIPTION
Update memcached build script to link to `memcached-proxy_ratelim` and update fuzzer API to match the newly minted 1.6.22.