### PR TITLE
[suricata] update project homepage

### DIFF
--- a/projects/suricata/project.yaml
+++ b/projects/suricata/project.yaml
@@ -1,4 +1,4 @@
-homepage: "https://suricata-ids.org"
+homepage: "https://suricata.io"
 language: rust
 primary_contact: "vjulien@openinfosecfoundation.org"
 auto_ccs:


### PR DESCRIPTION
Suricata's homepage was updated a while ago to https://suricata.io/

