### PR TITLE
Update projects/icu/build.sh

### DIFF
--- a/projects/icu/build.sh
+++ b/projects/icu/build.sh
@@ -34,6 +34,7 @@ export UBSAN_OPTIONS="detect_leaks=0"
 make -j$(nproc)
 
 $CXX $CXXFLAGS -std=c++11 -c $SRC/icu/icu4c/source/test/fuzzer/locale_util.cpp \
+     -I$SRC/icu/icu4c/source/common \
      -I$SRC/icu4c/source/test/fuzzer
 
 FUZZER_PATH=$SRC/icu/icu4c/source/test/fuzzer


### PR DESCRIPTION
Fix build problem
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=63289

Add include of icu/common to the include path to build locale_utill

unicode-org/icu#2672 add a new includer header for locale_util and break the fuzzer