### PR TITLE
ecc-diff-fuzzer: only build botan libs

### DIFF
--- a/projects/ecc-diff-fuzzer/build.sh
+++ b/projects/ecc-diff-fuzzer/build.sh
@@ -113,7 +113,7 @@ else
                --disable-shared --disable-modules=locking_allocator --disable-shared-library \
                --without-os-features=getrandom,getentropy
 fi
-make -j$(nproc)
+make -j$(nproc) libs
 make install
 )
 


### PR DESCRIPTION
so that compile error in tests do not bother fuzzing

Meant to fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=63198