### PR TITLE
[avahi] build the fuzz targets more often

### DIFF
--- a/projects/avahi/project.yaml
+++ b/projects/avahi/project.yaml
@@ -13,9 +13,9 @@ architectures:
   - x86_64
   - i386
 main_repo: 'https://github.com/lathiat/avahi'
-
 fuzzing_engines:
   - afl
   - honggfuzz
   - libfuzzer
 file_github_issue: True
+builds_per_day: 4


### PR DESCRIPTION
to make it possible to start testing patches like
https://github.com/lathiat/avahi/commit/b448c9f771bada14ae8de175695a9729f8646797 as soon as possible.