### PR TITLE
pugixml: Disable float-divide-by-zero

### DIFF
--- a/projects/pugixml/build.sh
+++ b/projects/pugixml/build.sh
@@ -16,6 +16,10 @@
 ################################################################################
 cd pugixml
 
+# Fix float-divide-by-zero false positives during XPath evaluation
+# This is disabled by default in clang but oss-fuzz reenables it, so we need to disable it again; see https://github.com/google/oss-fuzz/issues/10564
+CXXFLAGS="${CXXFLAGS} -fno-sanitize=float-divide-by-zero"
+
 $CXX $CXXFLAGS -c src/pugixml.cpp -o src/pugixml.o
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE tests/fuzz_parse.cpp src/pugixml.o -o ${OUT}/fuzz_parse
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE tests/fuzz_xpath.cpp src/pugixml.o -o ${OUT}/fuzz_xpath


### PR DESCRIPTION
This is defined as valid by clang and by IEEE-754; XPath evaluation requires a IEEE conformant floating point division operator.