### PR TITLE
openslide: add project definition

### DIFF
--- a/projects/openslide/project.yaml
+++ b/projects/openslide/project.yaml
@@ -1,0 +1,4 @@
+homepage: https://openslide.org/
+language: c
+main_repo: https://github.com/openslide/openslide
+primary_contact: bgilbert@andrew.cmu.edu


### PR DESCRIPTION
[OpenSlide](https://openslide.org/) is a C library that provides a simple interface to read whole-slide images (also known as virtual slides) used in digital pathology.  It implements support for a [variety of file formats](https://openslide.org/#about-openslide) and is sometimes deployed in multi-user slide management systems where it is exposed to untrusted data.  OpenSlide is used by multiple image-processing frameworks, including [libvips](https://www.libvips.org/), [MONAI](https://monai.io/), [QuPath](https://qupath.github.io/), and [VTK](https://vtk.org/), and has language bindings to [C](https://github.com/j-hudecek/OpenslideCs)[#](https://github.com/yigolden/OpenSlideNET), [Java](https://github.com/openslide/openslide-java), [MATLAB](https://github.com/fordanic/openslide-matlab), and [Python](https://github.com/openslide/openslide-python/).

Integration work is in progress, and will be submitted later if the project is accepted.