### PR TITLE
gstreamer: Bump meson requirement to 1.2.3

### DIFF
--- a/projects/gstreamer/Dockerfile
+++ b/projects/gstreamer/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && \
    apt-get install -y make autoconf automake libtool build-essential pkg-config bison flex patchelf \
     python3-pip ninja-build && \
-   pip3 install meson==0.63.2
+   pip3 install meson==1.2.3
 
 RUN git clone --depth 1 https://gitlab.xiph.org/xiph/vorbis.git vorbis
 RUN git clone --depth 1 https://gitlab.xiph.org/xiph/ogg.git ogg


### PR DESCRIPTION
We need at least 1.1 to build gstreamer as of this weekend.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=63487