### PR TITLE
[Pillow] pillow-wheels has been incorporated into Pillow

### DIFF
--- a/projects/pillow/Dockerfile
+++ b/projects/pillow/Dockerfile
@@ -39,6 +39,8 @@ RUN ln -s /usr/local/bin/python3 /usr/local/bin/python \
 # install extra test images for a better starting corpus
 RUN cd Pillow/depends && ./install_extra_test_images.sh
 
+RUN python3 -m pip install --upgrade pip
+
 COPY build.sh $SRC/
 
 # pillow optional runtime dependencies

--- a/projects/pillow/Dockerfile
+++ b/projects/pillow/Dockerfile
@@ -24,7 +24,6 @@ RUN apt-get update && \
       rsync
 
 RUN git clone --depth 1 https://github.com/python-pillow/Pillow
-RUN git clone --depth 1 https://github.com/python-pillow/pillow-wheels
 
 RUN $SRC/Pillow/Tests/oss-fuzz/build_dictionaries.sh
 
@@ -33,8 +32,8 @@ COPY build_depends.sh $SRC
 RUN ln -s /usr/local/bin/python3 /usr/local/bin/python \
     && ln -s /bin/true /usr/local/bin/yum_install \
     && ln -s /bin/true /usr/local/bin/yum \
-    && cd $SRC/pillow-wheels \
-    && git submodule update --init multibuild \
+    && cd $SRC/Pillow \
+    && git submodule update --init wheels/multibuild \
     && bash $SRC/build_depends.sh
 
 # install extra test images for a better starting corpus

--- a/projects/pillow/build_depends.sh
+++ b/projects/pillow/build_depends.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 
-. multibuild/common_utils.sh
+. wheels/multibuild/common_utils.sh
 
 export CONFIGURE_BUILD_SOURCED=1
 BUILD_PREFIX="${BUILD_PREFIX:-/usr/local}"
@@ -23,7 +23,7 @@ export CPPFLAGS="-I$BUILD_PREFIX/include $CPPFLAGS"
 export LIBRARY_PATH="$BUILD_PREFIX/lib:$LIBRARY_PATH"
 export PKG_CONFIG_PATH="$BUILD_PREFIX/lib/pkgconfig/:$PKG_CONFIG_PATH"
 
-. multibuild/library_builders.sh
-. config.sh
+. wheels/multibuild/library_builders.sh
+. wheels/config.sh
 
 pre_build


### PR DESCRIPTION
Two changes for the pillow project.

1. Pillow previously had a separate repository for wheel building scripts - https://github.com/python-pillow/pillow-wheels

However, that has been incorporated into the main repository for simplicity - https://github.com/python-pillow/Pillow/pull/7418

So this PR updates the project here to use the new location.

2. Pillow's oss-fuzz CI job is [currently failing because pip is too old](https://github.com/python-pillow/Pillow/actions/runs/6666944851/job/18119459590#step:4:9947). So this PR updates it.

cc @hugovk