### PR TITLE
Limit libavif to libfuzzer.

### DIFF
--- a/projects/libavif/project.yaml
+++ b/projects/libavif/project.yaml
@@ -11,7 +11,4 @@ auto_ccs:
 main_repo: 'https://github.com/AOMediaCodec/libavif.git'
 
 fuzzing_engines:
-  - afl
-  - honggfuzz
   - libfuzzer
-


### PR DESCRIPTION
afl does not compile with fuzztest (because it uses afl-clang-fast which ends up creating errors like:
DWARF error: invalid or unhandled FORM value: 0x25 ).
And honggfuzz does not valid those tests as they are scripts.