### PR TITLE
Updating how urllib3 is called to improve reachability

### DIFF
--- a/projects/urllib3/fuzz_requests.py
+++ b/projects/urllib3/fuzz_requests.py
@@ -61,7 +61,10 @@ def TestOneInput(data):
         formData[fdp.ConsumeString(sys.maxsize)] = fdp.ConsumeString(sys.maxsize)
     formData = None if fdp.ConsumeBool() else formData
 
-    response = urllib3.request(
+    timeout = urllib3.util.Timeout(connect=0.1, read=0.1)
+    urllib_pool = urllib3.poolmanager.PoolManager(timeout=timeout)
+
+    response = urllib_pool.request(
         requestType,
         "http://www.test.com",
         headers=requestHeaders,

--- a/projects/urllib3/fuzz_urlparse.py
+++ b/projects/urllib3/fuzz_urlparse.py
@@ -23,7 +23,9 @@ def TestOneInput(data):
     original = fdp.ConsumeUnicode(sys.maxsize)
 
     try:
-        response = urllib3.util.parse_url(original)
+        # We have to call this via .url because of limitations
+        # in PyCG analysis
+        response = urllib3.util.url.parse_url(original)
         response.hostname
         response.request_uri
         response.authority


### PR DESCRIPTION
Recent PR #11120 was successful in improving the runtime coverage, but changed how we call urllib3 no longer creating a `PoolManager` object, This removed a lot of code from the reachability analysis (introspector seems to struggle with urllib3s package structure).

This change reads the `PoolManager` returning this reachability.

This change also changes how `parse_url` is called. There's an issue with the introspector (PyCG more specifically) not mapping `urllib3.util.parse_url` correctly, but does map `urllib3.util.url.parse_url`. When I change to `urllib3.util.url.parse_url` and run PyCG I get a full callgraph from this method.

**Before**
```
Call tree
.........fuzz_urlparse.TestOneInput / -1
  atheris.FuzzedDataProvider .........fuzz_urlparse 22
  fdp.ConsumeUnicode .........fuzz_urlparse 23
  urllib3.util.parse_url .........fuzz_urlparse 28
```

**After**
```
..................projects.urllib3.fuzz_urlparse.TestOneInput / -1
  atheris.FuzzedDataProvider ..................projects.urllib3.fuzz_urlparse 22
  fdp.ConsumeUnicode ..................projects.urllib3.fuzz_urlparse 23
  urllib3.util.url.parse_url ..................projects.urllib3.fuzz_urlparse 28
    _SCHEME_RE.search urllib3.util.url 402
    _URI_RE.match urllib3.util.url 416
    scheme.lower urllib3.util.url 417
...
```