### PR TITLE
add missing args.architecture to _check_fuzzer_exists

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -1364,7 +1364,7 @@ def run_fuzzer(args):
   if not check_project_exists(args.project):
     return False
 
-  if not _check_fuzzer_exists(args.project, args.fuzzer_name):
+  if not _check_fuzzer_exists(args.project, args.fuzzer_name, args.architecture):
     return False
 
   env = [
@@ -1502,7 +1502,7 @@ def reproduce_impl(  # pylint: disable=too-many-arguments
   if not check_project_exists(project):
     return err_result
 
-  if not _check_fuzzer_exists(project, fuzzer_name):
+  if not _check_fuzzer_exists(project, fuzzer_name, architecture):
     return err_result
 
   debugger = ''


### PR DESCRIPTION
Adds args.architecture to _check_fuzzer_exists calls.  Without this when you run on aarch64 `python3 infra/helper.py run_fuzzer <...>` pulls the x86_64 image and gives a exec format error.