### PR TITLE
Add Open Navigation Surface BAG library

### DIFF
--- a/projects/opennavsurf-bag/project.yaml
+++ b/projects/opennavsurf-bag/project.yaml
@@ -1,0 +1,13 @@
+homepage: "https://github.com/OpenNavigationSurface/BAG"
+language: c++
+primary_contact: "selimnairb@gmail.com"
+auto_ccs:
+  - "bmiles@ccom.unh.edu"
+  - "brc@ccom.unh.edu"
+  - "glen.rice@noaa.gov"
+sanitizers:
+  - address
+  - memory:
+     experimental: True
+  - undefined
+main_repo: 'https://github.com/OpenNavigationSurface/BAG.git'


### PR DESCRIPTION
The Bathymetric Attributed Grid ([BAG](https://en.wikipedia.org/wiki/Bathymetric_attributed_grid)) is an open specification and C++/Python library for representing bathymetric data as grids of the best available characterization of the true depth of the seafloor.

The [BAG specification](https://bag.readthedocs.io/en/master/fsd/index.html) has been in use for conveying and archiving bathymetry, uncertainty, and metadata by [NOAA Office of Coast Survey](https://www.ngdc.noaa.gov/mgg/bathymetry/hydro.html) for close to 20 years. The BAG format was developed and is maintained by the [Open Navigation Surface Working Group](https://www.opennavsurf.org/), a collaboration between NOAA, [UNH JHC/CCOM](https://ccom.unh.edu) as well as other interested parties. The format is used by the US Navy as well as other hydrographic offices and academic partners around the world.

Participation in OSS-Fuzz will enhance automated testing for Open Navigation Surface BAG library, helping to ensure correctness for this reference implementation of the BAG specification while also uncovering potential security vulnerabilities in this important piece of global spatial data infrastructure.