### PR TITLE
openh264: Use corpus-replicator to create seed corpus

### DIFF
--- a/projects/openh264/Dockerfile
+++ b/projects/openh264/Dockerfile
@@ -16,7 +16,11 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && \
-    apt-get install -y libstdc++-9-dev libstdc++-9-dev:i386 nasm subversion
+    apt-get install -y ffmpeg libstdc++-9-dev libstdc++-9-dev:i386 nasm subversion
 RUN git clone --depth 1 https://github.com/cisco/openh264.git openh264
+RUN python3 -m pip install corpus-replicator
+RUN corpus-replicator -o corpus video_h264_264_libx264.yml video
+RUN mv openh264/res/*.264 corpus/
+RUN zip -j0r decoder_fuzzer_seed_corpus.zip corpus/
 WORKDIR openh264
 COPY build.sh decoder_fuzzer.cpp $SRC/

--- a/projects/openh264/build.sh
+++ b/projects/openh264/build.sh
@@ -15,12 +15,7 @@
 #
 ################################################################################
 
-# prepare corpus
-svn export https://github.com/mozillasecurity/fuzzdata.git/trunk/samples/h264 corpus/
-mv ./res/*.264 ./corpus/
-zip -j0r ${OUT}/decoder_fuzzer_seed_corpus.zip ./corpus/
-
-# build 
+# build
 if [[ $CXXFLAGS = *sanitize=memory* ]]; then
   ASM_BUILD=No
 else


### PR DESCRIPTION
The fuzzdata repository is no longer available.
Use corpus-replicator instead (https://github.com/MozillaSecurity/corpus-replicator)