### PR TITLE
libldac: Use corpus-replicator to generate seed corpus

### DIFF
--- a/projects/libldac/Dockerfile
+++ b/projects/libldac/Dockerfile
@@ -16,9 +16,10 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 
-RUN apt-get update && apt-get install -y automake libtool
+RUN apt-get update && apt-get install -y automake ffmpeg libtool
 RUN git clone --depth 1 -b master https://android.googlesource.com/platform/external/libldac
-RUN svn export https://github.com/mozillasecurity/fuzzdata.git/trunk/samples/wav corpora
+RUN python3 -m pip install corpus-replicator
+RUN corpus-replicator -o corpora audio_pcm_wav_ffmpeg.yml audio
 
 WORKDIR libldac
 


### PR DESCRIPTION
Fuzzdata is no longer available. See https://github.com/google/oss-fuzz/issues/10610 for more context.