### PR TITLE
surrealdb: update auto_ccs

### DIFF
--- a/projects/surrealdb/project.yaml
+++ b/projects/surrealdb/project.yaml
@@ -3,6 +3,7 @@ language: rust
 primary_contact: "tobie@surrealdb.com"
 main_repo: "https://github.com/surrealdb/surrealdb"
 auto_ccs:
+  - security@surrealdb.com
   - finn.bear@surrealdb.com
   - nathaniel.brough@gmail.com
 


### PR DESCRIPTION
Add the [official security contact for SurrealDB](https://surrealdb.com/.well-known/security.txt) to the `auto_ccs` recipients.