### PR TITLE
Add additional CC emails to the Wt project

### DIFF
--- a/projects/wt/project.yaml
+++ b/projects/wt/project.yaml
@@ -2,6 +2,8 @@ homepage: "https://www.webtoolkit.eu/wt"
 language: c++
 primary_contact: "wt-security@emweb.be"
 auto_ccs:
+  - "matthias@emweb.be"
+  - "wim@emweb.be"
   - "ajsinghyadav00@gmail.com"
 fuzzing_engines:
   - libfuzzer


### PR DESCRIPTION
The auto_cc emails can also be used to access the oss-fuzz.com dashboard. This will grant access to the current maintainer of Wt and the head of the emweb organization.