### PR TITLE
openssl: Additional team members to get the access

### DIFF
--- a/projects/openssl/project.yaml
+++ b/projects/openssl/project.yaml
@@ -5,6 +5,9 @@ auto_ccs:
  - "openssl-security@openssl.org"
  - "matt@openssl.org"
  - "richard@levitte.org"
+ - "tomas@openssl.org"
+ - "hlandau@openssl.org"
+ - "paulidale@openssl.org"
 sanitizers:
  - address
  - memory:


### PR DESCRIPTION
There are more team members who need access to work on the non-public issues.