### PR TITLE
[skia] Try downloading less data

### DIFF
--- a/projects/skia/Dockerfile
+++ b/projects/skia/Dockerfile
@@ -27,7 +27,10 @@ RUN git clone https://skia.googlesource.com/skia.git --depth 1
 # current directory for build script
 WORKDIR skia
 
-RUN python3 bin/sync
+ENV GIT_SYNC_DEPS_SKIP_EMSDK=1
+ENV GIT_SYNC_DEPS_SHALLOW_CLONE=1
+ENV GIT_SYNC_DEPS_QUIET=0
+RUN python3 tools/git-sync-deps
 RUN python3 bin/fetch-gn
 RUN python3 bin/fetch-ninja
 


### PR DESCRIPTION
In https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64153, we are seeing the syncing of DEPS fail for mysterious reasons. One hypothesis is that we are overwhelming the server or otherwise running out of quota.

Thus, we are trying shallow clones and avoiding downloading emscripten to reduce unnecessary bandwidth.

See also:
https://skia-review.googlesource.com/c/skia/+/780137
https://skia-review.googlesource.com/c/skia/+/779916