### PR TITLE
apache-commons-compress: Adding more coverage (COMPRESS-632)

### DIFF
--- a/projects/apache-commons-compress/ArchiverArFuzzer.java
+++ b/projects/apache-commons-compress/ArchiverArFuzzer.java
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,23 +14,15 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarFile;
+import org.apache.commons.compress.archivers.ar.ArArchiveInputStream;
 
-import java.io.InputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-// Keeping class name the same so corpus doesn't change
-// See: https://google.github.io/oss-fuzz/faq/#what-happens-when-i-rename-a-fuzz-target-
-public class CompressTarFuzzer extends BaseTests {
+public class ArchiverArFuzzer extends BaseTests {
     public static void fuzzerTestOneInput(byte[] data) {
         try {
-            TarFile tf = new TarFile(data);
-            for (TarArchiveEntry entry : tf.getEntries()) {
-                InputStream is = tf.getInputStream(entry);
-                is.read(new byte[1024]);
-            }
-            tf.close();
+            fuzzArchiveInputStream(new ArArchiveInputStream(new ByteArrayInputStream(data)));
         } catch (IOException ignored) {
         }
     }

--- a/projects/apache-commons-compress/ArchiverArjFuzzer.java
+++ b/projects/apache-commons-compress/ArchiverArjFuzzer.java
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,24 +14,17 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarFile;
+import org.apache.commons.compress.archivers.ArchiveException;
+import org.apache.commons.compress.archivers.arj.ArjArchiveInputStream;
 
-import java.io.InputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-// Keeping class name the same so corpus doesn't change
-// See: https://google.github.io/oss-fuzz/faq/#what-happens-when-i-rename-a-fuzz-target-
-public class CompressTarFuzzer extends BaseTests {
+public class ArchiverArjFuzzer extends BaseTests {
     public static void fuzzerTestOneInput(byte[] data) {
         try {
-            TarFile tf = new TarFile(data);
-            for (TarArchiveEntry entry : tf.getEntries()) {
-                InputStream is = tf.getInputStream(entry);
-                is.read(new byte[1024]);
-            }
-            tf.close();
-        } catch (IOException ignored) {
+            fuzzArchiveInputStream(new ArjArchiveInputStream(new ByteArrayInputStream(data)));
+        } catch (ArchiveException | IOException ignored) {
         }
     }
 }

--- a/projects/apache-commons-compress/ArchiverCpioFuzzer.java
+++ b/projects/apache-commons-compress/ArchiverCpioFuzzer.java
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,24 +14,16 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarFile;
+import org.apache.commons.compress.archivers.cpio.CpioArchiveInputStream;
 
-import java.io.InputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-// Keeping class name the same so corpus doesn't change
-// See: https://google.github.io/oss-fuzz/faq/#what-happens-when-i-rename-a-fuzz-target-
-public class CompressTarFuzzer extends BaseTests {
+public class ArchiverCpioFuzzer extends BaseTests {
     public static void fuzzerTestOneInput(byte[] data) {
         try {
-            TarFile tf = new TarFile(data);
-            for (TarArchiveEntry entry : tf.getEntries()) {
-                InputStream is = tf.getInputStream(entry);
-                is.read(new byte[1024]);
-            }
-            tf.close();
-        } catch (IOException ignored) {
+            fuzzArchiveInputStream(new CpioArchiveInputStream(new ByteArrayInputStream(data)));
+        } catch (IllegalArgumentException | IOException ignored) {
         }
     }
 }

--- a/projects/apache-commons-compress/ArchiverTarStreamFuzzer.java
+++ b/projects/apache-commons-compress/ArchiverTarStreamFuzzer.java
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,23 +14,15 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarFile;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 
-import java.io.InputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-// Keeping class name the same so corpus doesn't change
-// See: https://google.github.io/oss-fuzz/faq/#what-happens-when-i-rename-a-fuzz-target-
-public class CompressTarFuzzer extends BaseTests {
+public class ArchiverTarStreamFuzzer extends BaseTests {
     public static void fuzzerTestOneInput(byte[] data) {
         try {
-            TarFile tf = new TarFile(data);
-            for (TarArchiveEntry entry : tf.getEntries()) {
-                InputStream is = tf.getInputStream(entry);
-                is.read(new byte[1024]);
-            }
-            tf.close();
+            fuzzArchiveInputStream(new TarArchiveInputStream(new ByteArrayInputStream(data)));
         } catch (IOException ignored) {
         }
     }

--- a/projects/apache-commons-compress/ArchiverZipStreamFuzzer.java
+++ b/projects/apache-commons-compress/ArchiverZipStreamFuzzer.java
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,23 +14,15 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarFile;
+import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 
-import java.io.InputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-// Keeping class name the same so corpus doesn't change
-// See: https://google.github.io/oss-fuzz/faq/#what-happens-when-i-rename-a-fuzz-target-
-public class CompressTarFuzzer extends BaseTests {
+public class ArchiverZipStreamFuzzer extends BaseTests {
     public static void fuzzerTestOneInput(byte[] data) {
         try {
-            TarFile tf = new TarFile(data);
-            for (TarArchiveEntry entry : tf.getEntries()) {
-                InputStream is = tf.getInputStream(entry);
-                is.read(new byte[1024]);
-            }
-            tf.close();
+            fuzzArchiveInputStream(new ZipArchiveInputStream(new ByteArrayInputStream(data)));
         } catch (IOException ignored) {
         }
     }

--- a/projects/apache-commons-compress/BaseTests.java
+++ b/projects/apache-commons-compress/BaseTests.java
@@ -1,0 +1,44 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import org.apache.commons.compress.archivers.ArchiveEntry;
+import org.apache.commons.compress.archivers.ArchiveInputStream;
+import org.apache.commons.compress.compressors.CompressorInputStream;
+
+import java.io.IOException;
+import java.util.logging.LogManager;
+
+// Class with common functionality shared among fuzzing harnesses
+public class BaseTests {
+    public static void fuzzerInitialize() {
+        LogManager.getLogManager().reset();
+    }
+
+    // Fuzz archiver streams by reading every entry
+    public static void fuzzArchiveInputStream(ArchiveInputStream is) throws IOException {
+        ArchiveEntry entry;
+        while ((entry = is.getNextEntry()) != null) {
+            is.read(new byte[1024]);
+        }
+        is.close();
+    }
+
+    // Fuzz compressor streams by reading them
+    public static void fuzzCompressorInputStream(CompressorInputStream is) throws IOException {
+        is.read(new byte[1024]);
+        is.close();
+    }
+}

--- a/projects/apache-commons-compress/CompressSevenZFuzzer.java
+++ b/projects/apache-commons-compress/CompressSevenZFuzzer.java
@@ -14,25 +14,30 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+import org.apache.commons.compress.archivers.sevenz.SevenZArchiveEntry;
 import org.apache.commons.compress.archivers.sevenz.SevenZFile;
 import org.apache.commons.compress.archivers.sevenz.SevenZFileOptions;
 import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
 
+import java.io.InputStream;
 import java.io.IOException;
-import java.util.logging.LogManager;
 
-public class CompressSevenZFuzzer {
+// Keeping class name the same so corpus doesn't change
+// See: https://google.github.io/oss-fuzz/faq/#what-happens-when-i-rename-a-fuzz-target-
+public class CompressSevenZFuzzer extends BaseTests {
     private static final SevenZFileOptions options = new SevenZFileOptions.Builder()
         .withMaxMemoryLimitInKb(1_000_000)
         .build();
 
-    public static void fuzzerInitialize() {
-        LogManager.getLogManager().reset();
-    }
-
     public static void fuzzerTestOneInput(byte[] data) {
         try {
-            new SevenZFile(new SeekableInMemoryByteChannel(data), options).close();
+            SevenZFile sf = new SevenZFile(new SeekableInMemoryByteChannel(data), options);
+            SevenZArchiveEntry entry;
+            while((entry = sf.getNextEntry()) != null) {
+                InputStream is = sf.getInputStream(entry);
+                is.read(new byte[1024]);
+            }
+            sf.close();
         } catch (IOException ignored) {
         }
     }

--- a/projects/apache-commons-compress/CompressorBZip2Fuzzer.java
+++ b/projects/apache-commons-compress/CompressorBZip2Fuzzer.java
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,23 +14,15 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarFile;
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 
-import java.io.InputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-// Keeping class name the same so corpus doesn't change
-// See: https://google.github.io/oss-fuzz/faq/#what-happens-when-i-rename-a-fuzz-target-
-public class CompressTarFuzzer extends BaseTests {
+public class CompressorBZip2Fuzzer extends BaseTests {
     public static void fuzzerTestOneInput(byte[] data) {
         try {
-            TarFile tf = new TarFile(data);
-            for (TarArchiveEntry entry : tf.getEntries()) {
-                InputStream is = tf.getInputStream(entry);
-                is.read(new byte[1024]);
-            }
-            tf.close();
+            fuzzCompressorInputStream(new BZip2CompressorInputStream(new ByteArrayInputStream(data)));
         } catch (IOException ignored) {
         }
     }

--- a/projects/apache-commons-compress/CompressorDeflate64Fuzzer.java
+++ b/projects/apache-commons-compress/CompressorDeflate64Fuzzer.java
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,23 +14,15 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarFile;
+import org.apache.commons.compress.compressors.deflate64.Deflate64CompressorInputStream;
 
-import java.io.InputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-// Keeping class name the same so corpus doesn't change
-// See: https://google.github.io/oss-fuzz/faq/#what-happens-when-i-rename-a-fuzz-target-
-public class CompressTarFuzzer extends BaseTests {
+public class CompressorDeflate64Fuzzer extends BaseTests {
     public static void fuzzerTestOneInput(byte[] data) {
         try {
-            TarFile tf = new TarFile(data);
-            for (TarArchiveEntry entry : tf.getEntries()) {
-                InputStream is = tf.getInputStream(entry);
-                is.read(new byte[1024]);
-            }
-            tf.close();
+            fuzzCompressorInputStream(new Deflate64CompressorInputStream(new ByteArrayInputStream(data)));
         } catch (IOException ignored) {
         }
     }

--- a/projects/apache-commons-compress/CompressorGzipFuzzer.java
+++ b/projects/apache-commons-compress/CompressorGzipFuzzer.java
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,23 +14,15 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarFile;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 
-import java.io.InputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-// Keeping class name the same so corpus doesn't change
-// See: https://google.github.io/oss-fuzz/faq/#what-happens-when-i-rename-a-fuzz-target-
-public class CompressTarFuzzer extends BaseTests {
+public class CompressorGzipFuzzer extends BaseTests {
     public static void fuzzerTestOneInput(byte[] data) {
         try {
-            TarFile tf = new TarFile(data);
-            for (TarArchiveEntry entry : tf.getEntries()) {
-                InputStream is = tf.getInputStream(entry);
-                is.read(new byte[1024]);
-            }
-            tf.close();
+            fuzzCompressorInputStream(new GzipCompressorInputStream(new ByteArrayInputStream(data)));
         } catch (IOException ignored) {
         }
     }

--- a/projects/apache-commons-compress/CompressorLZ4Fuzzer.java
+++ b/projects/apache-commons-compress/CompressorLZ4Fuzzer.java
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,23 +14,22 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarFile;
+import org.apache.commons.compress.compressors.lz4.BlockLZ4CompressorInputStream;
+import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorInputStream;
 
-import java.io.InputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-// Keeping class name the same so corpus doesn't change
-// See: https://google.github.io/oss-fuzz/faq/#what-happens-when-i-rename-a-fuzz-target-
-public class CompressTarFuzzer extends BaseTests {
+public class CompressorLZ4Fuzzer extends BaseTests {
+    // Test both LZ4 classes
     public static void fuzzerTestOneInput(byte[] data) {
         try {
-            TarFile tf = new TarFile(data);
-            for (TarArchiveEntry entry : tf.getEntries()) {
-                InputStream is = tf.getInputStream(entry);
-                is.read(new byte[1024]);
-            }
-            tf.close();
+            fuzzCompressorInputStream(new BlockLZ4CompressorInputStream(new ByteArrayInputStream(data)));
+        } catch (IOException ignored) {
+        }
+
+        try {
+            fuzzCompressorInputStream(new FramedLZ4CompressorInputStream(new ByteArrayInputStream(data)));
         } catch (IOException ignored) {
         }
     }

--- a/projects/apache-commons-compress/CompressorSnappyFuzzer.java
+++ b/projects/apache-commons-compress/CompressorSnappyFuzzer.java
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,23 +14,22 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarFile;
+import org.apache.commons.compress.compressors.snappy.FramedSnappyCompressorInputStream;
+import org.apache.commons.compress.compressors.snappy.SnappyCompressorInputStream;
 
-import java.io.InputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-// Keeping class name the same so corpus doesn't change
-// See: https://google.github.io/oss-fuzz/faq/#what-happens-when-i-rename-a-fuzz-target-
-public class CompressTarFuzzer extends BaseTests {
+public class CompressorSnappyFuzzer extends BaseTests {
+    // Test both Snappy classes
     public static void fuzzerTestOneInput(byte[] data) {
         try {
-            TarFile tf = new TarFile(data);
-            for (TarArchiveEntry entry : tf.getEntries()) {
-                InputStream is = tf.getInputStream(entry);
-                is.read(new byte[1024]);
-            }
-            tf.close();
+            fuzzCompressorInputStream(new FramedSnappyCompressorInputStream(new ByteArrayInputStream(data)));
+        } catch (IOException ignored) {
+        }
+
+        try {
+            fuzzCompressorInputStream(new SnappyCompressorInputStream(new ByteArrayInputStream(data)));
         } catch (IOException ignored) {
         }
     }

--- a/projects/apache-commons-compress/CompressorZFuzzer.java
+++ b/projects/apache-commons-compress/CompressorZFuzzer.java
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,24 +14,17 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarFile;
+import org.apache.commons.compress.compressors.z.ZCompressorInputStream;
 
-import java.io.InputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-// Keeping class name the same so corpus doesn't change
-// See: https://google.github.io/oss-fuzz/faq/#what-happens-when-i-rename-a-fuzz-target-
-public class CompressTarFuzzer extends BaseTests {
+public class CompressorZFuzzer extends BaseTests {
     public static void fuzzerTestOneInput(byte[] data) {
         try {
-            TarFile tf = new TarFile(data);
-            for (TarArchiveEntry entry : tf.getEntries()) {
-                InputStream is = tf.getInputStream(entry);
-                is.read(new byte[1024]);
-            }
-            tf.close();
-        } catch (IOException ignored) {
+            // Setting limit to avoid out of memory errors
+            fuzzCompressorInputStream(new ZCompressorInputStream(new ByteArrayInputStream(data), 1024*1024));
+        } catch (IllegalArgumentException | IOException ignored) {
         }
     }
 }

--- a/projects/apache-commons-compress/Dockerfile
+++ b/projects/apache-commons-compress/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/apache-commons-compress/Dockerfile
+++ b/projects/apache-commons-compress/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,31 +16,59 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 
-RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip -o maven.zip && \
+RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.9.5/binaries/apache-maven-3.9.5-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \
     rm -rf maven.zip
 
-ENV MVN $SRC/maven/apache-maven-3.6.3/bin/mvn
+ENV MVN $SRC/maven/apache-maven-3.9.5/bin/mvn
 
 # Dictionaries
 RUN git clone --depth 1 https://github.com/google/fuzzing && \
     mv fuzzing/dictionaries/zip.dict $SRC/CompressZipFuzzer.dict && \
+    mv fuzzing/dictionaries/bz2.dict $SRC/CompressorBZip2Fuzzer.dict && \
     rm -rf fuzzing
 
 # Seed corpus (go-fuzz-corpus)
 RUN git clone --depth 1 https://github.com/dvyukov/go-fuzz-corpus && \
-    zip -j $SRC/CompressTarFuzzer_seed_corpus.zip go-fuzz-corpus/tar/corpus/* && \
-    zip -j $SRC/CompressZipFuzzer_seed_corpus.zip go-fuzz-corpus/zip/corpus/* && \
+    zip -j0 $SRC/CompressTarFuzzer_seed_corpus.zip go-fuzz-corpus/tar/corpus/* && \
+    zip -j0 $SRC/CompressZipFuzzer_seed_corpus.zip go-fuzz-corpus/zip/corpus/* && \
+    zip -j0 $SRC/CompressorBZip2Fuzzer_seed_corpus.zip go-fuzz-corpus/bzip2/corpus/* && \
+    zip -j0 $SRC/CompressorGzipFuzzer_seed_corpus.zip go-fuzz-corpus/gzip/corpus/* && \
+    zip -j0 $SRC/CompressorSnappyFuzzer_seed_corpus.zip go-fuzz-corpus/snappy/corpus/* && \
     rm -rf go-fuzz-corpus
 
-# Compress
+# Checkout out Compress source code
 RUN git clone --depth 1 https://gitbox.apache.org/repos/asf/commons-compress.git
 
-RUN zip -uj $SRC/CompressTarFuzzer_seed_corpus.zip commons-compress/src/test/resources/*.tar && \
-    zip -uj $SRC/CompressZipFuzzer_seed_corpus.zip commons-compress/src/test/resources/*.zip && \
-    zip -j $SRC/CompressSevenZFuzzer_seed_corpus.zip commons-compress/src/test/resources/bla.7z
+# Seed corpus (Compress source code)
+RUN \
+    zip -j0  $SRC/ArchiverArFuzzer_seed_corpus.zip commons-compress/src/test/resources/*.ar && \
+    zip -uj0 $SRC/ArchiverArFuzzer_seed_corpus.zip commons-compress/src/test/resources/archives/*.ar && \
+    zip -j0  $SRC/ArchiverArjFuzzer_seed_corpus.zip commons-compress/src/test/resources/*.arj && \
+    zip -j0  $SRC/ArchiverCpioFuzzer_seed_corpus.zip commons-compress/src/test/resources/*.cpio && \
+    zip -uj0 $SRC/ArchiverCpioFuzzer_seed_corpus.zip commons-compress/src/test/resources/archives/*.cpio && \
+    zip -j0  $SRC/CompressSevenZFuzzer_seed_corpus.zip commons-compress/src/test/resources/*.7z && \
+    zip -uj0 $SRC/CompressTarFuzzer_seed_corpus.zip commons-compress/src/test/resources/*.tar && \
+    zip -uj0 $SRC/CompressTarFuzzer_seed_corpus.zip commons-compress/src/test/resources/archives/*.tar && \
+    zip -uj0 $SRC/CompressTarFuzzer_seed_corpus.zip commons-compress/src/test/resources/longpath/*.tar && \
+    zip -uj0 $SRC/CompressTarFuzzer_seed_corpus.zip commons-compress/src/test/resources/longsymlink/*.tar && \
+    zip -uj0 $SRC/CompressZipFuzzer_seed_corpus.zip commons-compress/src/test/resources/*.zip
 
-# Copy build script and all fuzzers
+RUN \
+    zip -uj0 $SRC/CompressorBZip2Fuzzer_seed_corpus.zip commons-compress/src/test/resources/*.bz2 && \
+    zip -j0  $SRC/CompressorDeflate64Fuzzer_seed_corpus.zip commons-compress/src/test/resources/*.deflate && \
+    zip -uj0 $SRC/CompressorGzipFuzzer_seed_corpus.zip commons-compress/src/test/resources/*.gz && \
+    zip -j0  $SRC/CompressorLZ4Fuzzer_seed_corpus.zip commons-compress/src/test/resources/*lz4 && \
+    zip -uj0 $SRC/CompressorSnappyFuzzer_seed_corpus.zip commons-compress/src/test/resources/*.sz && \
+    zip -j0  $SRC/CompressorZFuzzer_seed_corpus.zip commons-compress/src/test/resources/*.Z
+
+# Copy some corpuses and dictionaries
+RUN \
+    cp $SRC/CompressTarFuzzer_seed_corpus.zip $SRC/ArchiverTarStreamFuzzer_seed_corpus.zip && \
+    cp $SRC/CompressZipFuzzer.dict $SRC/ArchiverZipStreamFuzzer.dict && \
+    cp $SRC/CompressZipFuzzer_seed_corpus.zip $SRC/ArchiverZipStreamFuzzer_seed_corpus.zip
+
+# Copy build script, all fuzzers and supporting files
 COPY build.sh $SRC/
-COPY *Fuzzer.java $SRC/
+COPY *.java $SRC/
 WORKDIR $SRC/

--- a/projects/apache-commons-compress/README.md
+++ b/projects/apache-commons-compress/README.md
@@ -1,0 +1,8 @@
+Note that classes that use third party libraries are excluded.
+These are either being already fuzzed by oss-fuzz or cannot be
+fuzzed effectively. These include:
+* BrotliCompressorInputStream - uses Google's Brotli
+* DeflateCompressorInputStream - uses JDK's Inflater
+* LZMACompressorInputStream - uses XZ for Java
+* XZCompressorInputStream - uses XZ for Java
+* ZstdCompressorInputStream - uses zstd-jni

--- a/projects/apache-commons-compress/build.sh
+++ b/projects/apache-commons-compress/build.sh
@@ -20,8 +20,8 @@ mv $SRC/{*.zip,*.dict} $OUT
 
 pushd "$SRC/commons-compress"
   MAVEN_ARGS="-Dmaven.test.skip=true -Djavac.src.version=15 -Djavac.target.version=15"
-  $MVN package org.apache.maven.plugins:maven-shade-plugin:3.2.4:shade $MAVEN_ARGS
-  CURRENT_VERSION=$($MVN org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate \
+  $MVN package org.apache.maven.plugins:maven-shade-plugin:3.5.1:shade $MAVEN_ARGS
+  CURRENT_VERSION=$($MVN org.apache.maven.plugins:maven-help-plugin:3.4.0:evaluate \
    -Dexpression=project.version -q -DforceStdout)
   cp "target/commons-compress-$CURRENT_VERSION.jar" $OUT/commons-compress.jar
 popd
@@ -39,6 +39,7 @@ for fuzzer in $(find $SRC -name '*Fuzzer.java'); do
   fuzzer_basename=$(basename -s .java $fuzzer)
   javac -cp $BUILD_CLASSPATH $fuzzer
   cp $SRC/$fuzzer_basename.class $OUT/
+  cp $SRC/Base*.class $OUT/
 
   # Create an execution wrapper that executes Jazzer with the correct arguments.
   echo "#!/bin/bash


### PR DESCRIPTION
This PR expands coverage for more compression types in this library as well as trying to read all of the files in archivers. This work is being tracked on the project side here:
https://issues.apache.org/jira/browse/COMPRESS-632
