### PR TITLE
envoy: enable sanitization of Cel code

### DIFF
--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -92,7 +92,6 @@ then
   echo " --per_file_copt=^.*com_googlesource_code_re2.*\.cc\$@-fsanitize-coverage=0,-fno-sanitize=all"
   echo " --per_file_copt=^.*upb.*\.cpp\$@-fsanitize-coverage=0,-fno-sanitize=all"
   echo " --per_file_copt=^.*org_brotli.*\.cpp\$@-fsanitize-coverage=0,-fno-sanitize=all"
-  echo " --per_file_copt=^.*com_google_cel_cpp.*\.cpp\$@-fsanitize-coverage=0,-fno-sanitize=all"
   echo " --per_file_copt=^.*com_github_jbeder_yaml_cpp.*\.cpp\$@-fsanitize-coverage=0,-fno-sanitize=all"
   echo " --per_file_copt=^.*proxy_wasm_cpp_host/.*\.cc\$@-fsanitize-coverage=0,-fno-sanitize=all"
   echo " --per_file_copt=^.*com_github_google_libprotobuf_mutator/.*\.cc\$@-fsanitize-coverage=0,-fno-sanitize=all"
@@ -101,6 +100,7 @@ then
 
 # External dependency which needs to be compiled with sanitizers. Disable
 # coverage instrumentation.
+  echo " --per_file_copt=^.*com_google_cel_cpp.*\.cpp\$@-fsanitize-coverage=0"
   echo " --per_file_copt=^.*antlr4_runtimes.*\.cpp\$@-fsanitize-coverage=0"
   echo " --per_file_copt=^.*googletest.*\.cc\$@-fsanitize-coverage=0"
 


### PR DESCRIPTION
A recent code-change executes CEL code, and the fuzzer detect false positives.
Enabling CEL sanitization to solve the issue.