### PR TITLE
cert-manager: initial integration

### DIFF
--- a/projects/cert-manager/Dockerfile
+++ b/projects/cert-manager/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone https://github.com/cert-manager/cert-manager --depth=1
+COPY build.sh pki_fuzzer.go $SRC/
+WORKDIR $SRC/cert-manager

--- a/projects/cert-manager/build.sh
+++ b/projects/cert-manager/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cp -r $SRC/pki_fuzzer.go $SRC/cert-manager/pkg/util/pki/
+
+compile_go_fuzzer github.com/cert-manager/cert-manager/pkg/util/pki FuzzParseSubjectStringToRawDERBytes FuzzParseSubjectStringToRawDERBytes
+compile_go_fuzzer github.com/cert-manager/cert-manager/pkg/util/pki FuzzDecodePrivateKeyBytes FuzzDecodePrivateKeyBytes
+

--- a/projects/cert-manager/pki_fuzzer.go
+++ b/projects/cert-manager/pki_fuzzer.go
@@ -1,0 +1,26 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package pki
+
+func FuzzParseSubjectStringToRawDERBytes(data []byte) int {
+	ParseSubjectStringToRawDERBytes(string(data))
+	return 1
+}
+
+func FuzzDecodePrivateKeyBytes(data []byte) int {
+	DecodePrivateKeyBytes(data)
+	return 1
+}

--- a/projects/cert-manager/project.yaml
+++ b/projects/cert-manager/project.yaml
@@ -1,0 +1,13 @@
+homepage: "https://cert-manager.io"
+primary_contact: "tim.ramlot@venafi.com"
+auto_ccs:
+  - "ashley.davis@venafi.com"
+  - "mael.valais@gmail.com"
+vendor_ccs :
+  - "adam@adalogics.com"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+main_repo: 'https://github.com/cert-manager/cert-manager'


### PR DESCRIPTION
Cert-Manager is a cloud-native tool for provisioning and maintaining certficates in an automatic manner. Cert-Manager is often used to secure ingress cluster traffic, but is at its core a more general tool to secure traffic between any cluster asset.

Its users include the following companies:
- JFrog: https://jfrog.com/
- URSSAF (A provider to Frances national health system): https://www.urssaf.fr/portail/home.html
- Diagrid: https://www.diagrid.io/

Source: https://github.com/cert-manager/community/blob/main/USERS.md