### PR TITLE
Fix Patched vulnerable to authorization bypass due to inconsistent HTTP request handling (HTTP Request Smuggling)

### DIFF
--- a/projects/jetty/project-parent/fuzz-targets/pom.xml
+++ b/projects/jetty/project-parent/fuzz-targets/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>Fuzzing-SNAPSHOT</version>
+            <version>9.4.51.v20230217</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Details
Eclipse Jetty Server versions 9.2.x and older, 9.3.x (all non HTTP/1.x configurations), and 9.4.x (all HTTP/1.x configurations), are vulnerable to HTTP Request Smuggling when presented with two content-lengths headers, allowing authorization bypass. When presented with a content-length and a chunked encoding header, the content-length was ignored (as per RFC 2616). If an intermediary decides on the shorter length, but still passes on the longer body, then body content could be interpreted by Jetty as a pipelined request. If the intermediary is imposing authorization, the fake pipelined request bypasses that authorization.

CVE-2017-7658
CWE-444
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`