### PR TITLE
pillow: Updated script path

### DIFF
--- a/projects/pillow/build_depends.sh
+++ b/projects/pillow/build_depends.sh
@@ -23,7 +23,4 @@ export CPPFLAGS="-I$BUILD_PREFIX/include $CPPFLAGS"
 export LIBRARY_PATH="$BUILD_PREFIX/lib:$LIBRARY_PATH"
 export PKG_CONFIG_PATH="$BUILD_PREFIX/lib/pkgconfig/:$PKG_CONFIG_PATH"
 
-. wheels/multibuild/library_builders.sh
-. wheels/config.sh
-
-pre_build
+. .github/workflows/wheels-dependencies.sh


### PR DESCRIPTION
pillow has started using [cibuildwheel](https://github.com/pypa/cibuildwheel) - https://github.com/python-pillow/Pillow/pull/7552

This moved the script for building wheel dependencies from `wheels/config.sh`, a more natural location for [multibuild](https://github.com/multi-build/multibuild), to just under GitHub Actions instead, at [.github/workflows/wheel-dependencies.sh](https://github.com/python-pillow/Pillow/blob/main/.github/workflows/wheels-dependencies.sh)

It also now includes `wheels/multibuild/library_builders.sh` [by itself](https://github.com/python-pillow/Pillow/blob/e2ddd27500cdd4c8156bc0d5fe0bfa050408c707/.github/workflows/wheels-dependencies.sh#L10), and rearranged the code to run immediately, instead of needing `pre_build` to be called separately.

cc @hugovk