### PR TITLE
apache-commons-codec: Catch expected IllegalArgumentException

### DIFF
--- a/projects/apache-commons-codec/LanguageStringEncoderFuzzer.java
+++ b/projects/apache-commons-codec/LanguageStringEncoderFuzzer.java
@@ -79,7 +79,7 @@ public class LanguageStringEncoderFuzzer {
       if (strEncoder != null) {
         strEncoder.encode(data.consumeRemainingAsString());
       }
-    } catch (EncoderException e) {
+    } catch (EncoderException | IllegalArgumentException e) {
       // Known exception
     }
   }


### PR DESCRIPTION
This PR adds an additional catch for an expected IllegalArgumentException thrown from the [Soundex](https://github.com/apache/commons-codec/blob/5bbb66994f8e6d04509cbd297c6bf5dc77d328bb/src/main/java/org/apache/commons/codec/language/Soundex.java#L287) class. This fixes a false positive issue reported in https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64513.