### PR TITLE
apache-commons-lang: Fix ClassCastException for wrong return type

### DIFF
--- a/projects/apache-commons-lang/SerializationUtilsFuzzer.java
+++ b/projects/apache-commons-lang/SerializationUtilsFuzzer.java
@@ -26,16 +26,16 @@ public class SerializationUtilsFuzzer {
 
       switch (choice) {
         case 1:
-          byteArray = SerializationUtils.clone(byteArray);
+          SerializationUtils.clone(byteArray);
           break;
         case 2:
-          byteArray = SerializationUtils.roundtrip(byteArray);
+          SerializationUtils.roundtrip(byteArray);
           break;
         case 3:
-          byteArray = SerializationUtils.serialize(byteArray);
+          SerializationUtils.serialize(byteArray);
           break;
         case 4:
-          byteArray = SerializationUtils.deserialize(byteArray);
+          SerializationUtils.deserialize(byteArray);
           break;
       }
     } catch (SerializationException e) {


### PR DESCRIPTION
This PR removes the storing of return values to avoid ClassCastException. This PR fixes a false positive issues reported in https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64486.