### PR TITLE
apache-commons-lang: Catch known NullPointerException

### DIFF
--- a/projects/apache-commons-lang/SerializationUtilsFuzzer.java
+++ b/projects/apache-commons-lang/SerializationUtilsFuzzer.java
@@ -38,7 +38,7 @@ public class SerializationUtilsFuzzer {
           SerializationUtils.deserialize(byteArray);
           break;
       }
-    } catch (SerializationException e) {
+    } catch (SerializationException | NullPointerException e) {
       // Known exception
     }
   }


### PR DESCRIPTION
Some methods in [SerializationUtils](https://github.com/apache/commons-lang/blob/4fc2ab4d1474b77b63b646631b38893fbb4ff411/src/main/java/org/apache/commons/lang3/SerializationUtils.java#L200) will throw NullPointerException and it is documented in the Javadoc. Thus this PR aims to capture this known exception which is reported in https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64491.