### PR TITLE
xz: Change Dockerfile clone URL to match project.yaml entry.

### DIFF
--- a/projects/xz/Dockerfile
+++ b/projects/xz/Dockerfile
@@ -16,6 +16,6 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf autopoint libtool zip
-RUN git clone https://git.tukaani.org/xz.git
+RUN git clone https://github.com/tukaani-project/xz.git
 COPY build.sh $SRC/
 WORKDIR xz


### PR DESCRIPTION
The old URL is still kept as a mirror, but it is not always up to date since the primary repository is on GitHub. This now matches the 'main_repo' entry in the corresponding project.yaml.