### PR TITLE
rust-brotli: builds targets with debug assertions

### DIFF
--- a/projects/rust-brotli/build.sh
+++ b/projects/rust-brotli/build.sh
@@ -13,6 +13,10 @@
 # limitations under the License.
 #
 ################################################################################
+
+# checks for integer overflows
+export RUSTFLAGS="$RUSTFLAGS -Cdebug-assertions=yes"
+
 cd $SRC/rust-brotli/fuzz
 cargo fuzz build
 cp $SRC/rust-brotli/fuzz/target/x86_64-unknown-linux-gnu/release/decompress $OUT/


### PR DESCRIPTION
So that it finds https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64164&q=label%3AProj-suricata before suricata does
 (or https://github.com/dropbox/rust-brotli-decompressor/commit/d82932e686d4a73c73b8aa3b96b01c8255e438ed )