### PR TITLE
llvm: limit resources for build

### DIFF
--- a/projects/llvm/build.sh
+++ b/projects/llvm/build.sh
@@ -81,7 +81,8 @@ for fuzzer in "${FUZZERS[@]}"; do
   if [ -n "${OSS_FUZZ_CI-}" ]; then
     ninja $fuzzer -j 3
   else
-    ninja $fuzzer
+    # Do not exhaust memory limitations on the cloud machine
+    ninja $fuzzer -j $(( $(nproc) / 4))
   fi
   cp bin/$fuzzer $OUT
 done


### PR DESCRIPTION
The build is not succeeding on the cloud machines, and it's likely due to memory exhaustion