### PR TITLE
llvm: limit coverage builds to 2 processes

### DIFF
--- a/projects/llvm/build.sh
+++ b/projects/llvm/build.sh
@@ -78,7 +78,7 @@ for fuzzer in "${FUZZERS[@]}"; do
     # Do not exhaust memory limitations on the cloud machine, coverage
     # takes more resources which causes processes to crash.
     if [[ "$SANITIZER" = coverage ]]; then
-      ninja $fuzzer -j $(( $(nproc) / 8))
+      ninja $fuzzer -j 2
     else
       ninja $fuzzer -j $(( $(nproc) / 4))
     fi


### PR DESCRIPTION
The coverage build is still failing, even when only four processes are used https://oss-fuzz-build-logs.storage.googleapis.com/log-b007c06a-278a-45e9-960b-7129f262586b.txt

Trying to limit and harden this.