### PR TITLE
jackson-datatypes-collections: Catch known exceptions

### DIFF
--- a/projects/jackson-datatypes-collections/EclipseCollectionsDeserializerFuzzer.java
+++ b/projects/jackson-datatypes-collections/EclipseCollectionsDeserializerFuzzer.java
@@ -38,7 +38,7 @@ public class EclipseCollectionsDeserializerFuzzer {
       String value = data.consumeRemainingAsString();
       mapper.readValue(value, type);
       mapper.readTree(value);
-    } catch (IOException e) {
+    } catch (IOException | IllegalArgumentException e) {
       // Known exception
     }
   }

--- a/projects/jackson-datatypes-collections/GuavaDeserializerFuzzer.java
+++ b/projects/jackson-datatypes-collections/GuavaDeserializerFuzzer.java
@@ -65,7 +65,7 @@ public class GuavaDeserializerFuzzer {
       TypeReference type = data.pickValue(choice);
       String value = data.consumeRemainingAsString();
       mapper.readValue(value, type);
-    } catch (IOException e) {
+    } catch (IOException | IllegalArgumentException e) {
       // Known exception
     }
   }


### PR DESCRIPTION
This PR catches some known exceptions which are missed before. This PR solves https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64612, https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64614, https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64640 and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64642.