### PR TITLE
[avahi] switch to the avahi organization

### DIFF
--- a/projects/avahi/Dockerfile
+++ b/projects/avahi/Dockerfile
@@ -17,6 +17,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && \
     apt-get install -y autoconf gettext libtool m4 automake pkg-config libexpat-dev libexpat-dev:i386
-RUN git clone --depth 1 https://github.com/lathiat/avahi
+RUN git clone --depth 1 https://github.com/avahi/avahi
 WORKDIR avahi
 COPY build.sh $SRC/

--- a/projects/avahi/project.yaml
+++ b/projects/avahi/project.yaml
@@ -13,7 +13,7 @@ sanitizers:
 architectures:
   - x86_64
   - i386
-main_repo: 'https://github.com/lathiat/avahi'
+main_repo: 'https://github.com/avahi/avahi'
 fuzzing_engines:
   - afl
   - honggfuzz


### PR DESCRIPTION
It was moved: https://github.com/avahi/avahi/commit/94e1ffdfbe7a1b7036b9902bab15ea0ef8b24eb4