### PR TITLE
opencv: fix build error - link with quirc

### DIFF
--- a/projects/opencv/build.sh
+++ b/projects/opencv/build.sh
@@ -41,7 +41,7 @@ $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer.cc -std=c++11 \
 -lopencv_stitching -lopencv_video -lopencv_calib3d -lopencv_features2d \
 -lopencv_highgui -lopencv_videoio -lopencv_imgcodecs -lopencv_imgproc \
 -lopencv_flann -lopencv_core -llibjpeg-turbo -llibwebp -llibpng -llibtiff \
--llibopenjp2 -lIlmImf -llibprotobuf -lquirc -lzlib -littnotify -lippiw \
+-llibopenjp2 -lIlmImf -llibprotobuf -lzlib -littnotify -lippiw \
 -lippicv -lade -ldl -lm -lpthread -lrt \
 -o $OUT/$fuzzer
 done


### PR DESCRIPTION
OpenCV library now doesn't build QUIRC by default - it uses own QR decoder.

Build error:
```
Step #3 - "compile-afl-address-x86_64": + for fuzzer in core_fuzzer filestorage_read_file_fuzzer filestorage_read_filename_fuzzer filestorage_read_string_fuzzer generateusergallerycollage_fuzzer imdecode_fuzzer imencode_fuzzer imread_fuzzer readnetfromtensorflow_fuzzer
Step #3 - "compile-afl-address-x86_64": + /src/aflplusplus/afl-clang-fast++ -O1 -fno-omit-frame-pointer -gline-tables-only -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=address -fsanitize-address-use-after-scope -stdlib=libc++ /usr/lib/libFuzzingEngine.a core_fuzzer.cc -std=c++11 -I/work/install-address/include/opencv4 -L/work/install-address/lib -L/work/install-address/lib/opencv4/3rdparty -lopencv_dnn -lopencv_objdetect -lopencv_photo -lopencv_ml -lopencv_gapi -lopencv_stitching -lopencv_video -lopencv_calib3d -lopencv_features2d -lopencv_highgui -lopencv_videoio -lopencv_imgcodecs -lopencv_imgproc -lopencv_flann -lopencv_core -llibjpeg-turbo -llibwebp -llibpng -llibtiff -llibopenjp2 -lIlmImf -llibprotobuf -lquirc -lzlib -littnotify -lippiw -lippicv -lade -ldl -lm -lpthread -lrt -o /workspace/out/afl-address-x86_64/core_fuzzer
Step #3 - "compile-afl-address-x86_64": /usr/bin/ld: cannot find -lquirc
Step #3 - "compile-afl-address-x86_64": clang-15: [0;1;31merror: [0m[1mlinker command failed with exit code 1 (use -v to see invocation)[0m
```

**cc** @vrabaud , @opencv-alalek