### PR TITLE
llvm: reorder fuzzer builds

### DIFF
--- a/projects/llvm/build.sh
+++ b/projects/llvm/build.sh
@@ -22,14 +22,14 @@ if [ -n "${OSS_FUZZ_CI-}" ]; then
   )
 else
   readonly FUZZERS=( \
-    clang-fuzzer \
-    clang-format-fuzzer \
-    clang-objc-fuzzer \
-    clangd-fuzzer \
-    clang-pseudo-fuzzer \
-    llvm-itanium-demangle-fuzzer \
     llvm-microsoft-demangle-fuzzer \
     llvm-dwarfdump-fuzzer \
+    llvm-itanium-demangle-fuzzer \
+    clang-objc-fuzzer \
+    clang-format-fuzzer \
+    clang-pseudo-fuzzer \
+    clang-fuzzer \
+    clangd-fuzzer \
   )
 fi
 # Fuzzers whose inputs are C-family source can use clang-fuzzer-dictionary.


### PR DESCRIPTION
The coverage build is still getting killed on the cloud server even when only 1 process is used. This commit tries to build the smaller fuzzers first in order to (1) verify at least some fuzzers can be built with coverage sanitizer; (2) see if having build some of the lighter fuzzers will make it easier to build the larger fuzzers later. A bit of a guess with respect to (2).