### PR TITLE
jackson-dataformats-binary: Catch expected IonException

### DIFF
--- a/projects/jackson-dataformats-binary/DeserializerFuzzer.java
+++ b/projects/jackson-dataformats-binary/DeserializerFuzzer.java
@@ -14,6 +14,7 @@
 //
 ///////////////////////////////////////////////////////////////////////////
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.amazon.ion.IonException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -138,7 +139,7 @@ public class DeserializerFuzzer {
           mapper.readerFor(type).with(((AvroMapper) mapper).schemaFrom(value)).readValue(value);
         }
       }
-    } catch (IOException | IllegalArgumentException | UnsupportedOperationException e) {
+    } catch (IOException | IllegalArgumentException | UnsupportedOperationException | IonException e) {
       // Known exception
     } finally {
       try {

--- a/projects/jackson-dataformats-binary/DeserializerFuzzer.java
+++ b/projects/jackson-dataformats-binary/DeserializerFuzzer.java
@@ -13,8 +13,8 @@
 // limitations under the License.
 //
 ///////////////////////////////////////////////////////////////////////////
-import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.amazon.ion.IonException;
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -139,7 +139,10 @@ public class DeserializerFuzzer {
           mapper.readerFor(type).with(((AvroMapper) mapper).schemaFrom(value)).readValue(value);
         }
       }
-    } catch (IOException | IllegalArgumentException | UnsupportedOperationException | IonException e) {
+    } catch (IOException
+        | IllegalArgumentException
+        | UnsupportedOperationException
+        | IonException e) {
       // Known exception
     } finally {
       try {


### PR DESCRIPTION
This PR catches the expected IonException during deserialization process. This PR solves https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64715.