### PR TITLE
opencv: set pixel limit for imread

### DIFF
--- a/projects/opencv/Dockerfile
+++ b/projects/opencv/Dockerfile
@@ -24,3 +24,5 @@ COPY *.cc *.h $SRC/
 # This is to fix Fuzz Introspector build by using LLVM old pass manager
 # re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS 1
+# Runner have memory limit 2048Mb, set imread pixel limit 712Mpix ~ 2037Mb (BGR)
+ENV OPENCV_IO_MAX_IMAGE_PIXELS=712000000


### PR DESCRIPTION
Trying to fix OOM issues in `imread`/`imdecode` tests.

OpenCV has mechanism for input image size limiting controlled via environment variables:
https://github.com/opencv/opencv/blob/b2593427376f75fc70eaf6b79c4d4a3082da6aad/modules/imgcodecs/src/loadsave.cpp#L67-L81

In this PR we set lower than default (`1<<30` ~ 1Gpix ~ 3072Mb) total pixel limit since runner has its own limits (2048Mb?).

**cc** @vrabaud , @opencv-alalek