### PR TITLE
halide: Remove broken builds

### DIFF
--- a/projects/halide/build.sh
+++ b/projects/halide/build.sh
@@ -43,6 +43,9 @@ cmake -DCMAKE_BUILD_TYPE=Release \
 cmake --build $WORK/llvm-build -j$(nproc)
 cmake --install $WORK/llvm-build --prefix $WORK/llvm-install
 
+# Cleanup space so github runners don't run out of disk space.
+rm -rf $WORK/llvm-build $SRC/llvm-project
+
 export LLVM_DIR=$WORK/llvm-install
 
 cmake -G Ninja  -S . -B build -DCMAKE_BUILD_TYPE=Release \

--- a/projects/halide/project.yaml
+++ b/projects/halide/project.yaml
@@ -8,10 +8,8 @@ auto_ccs:
   - nathaniel.brough@gmail.com
 
 fuzzing_engines:
- - afl
  - honggfuzz
  - libfuzzer
- - centipede
 
 sanitizers:
  - address


### PR DESCRIPTION
A few of the builds that where originally working locally had gone out of sync for sometime and are now breaking. I've just removed these fuzzing engines/sanitizers for now.