### PR TITLE
Overhaul `abseil-cpp`... and get it working again.

### DIFF
--- a/projects/abseil-cpp/BUILD
+++ b/projects/abseil-cpp/BUILD
@@ -14,18 +14,20 @@
 #
 ################################################################################
 
-cc_binary(
-	name = "string_escape_fuzzer",
-	deps = ["@com_google_absl//absl/strings"],
-	srcs = ["string_escape_fuzzer.cc"],
+load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
+
+cc_fuzz_test(
+    name = "string_escape_fuzzer",
+    srcs = ["string_escape_fuzzer.cc"],
+    deps = ["@com_google_absl//absl/strings"],
 )
 
-cc_binary(
-	name = "string_utilities_fuzzer",
-	deps = [
-		"@com_google_absl//absl/strings",
-		"@com_google_absl//absl/strings:cord",
-                "@com_google_absl//absl/strings:str_format"
-		],
-	srcs = ["string_utilities_fuzzer.cc"],
+cc_fuzz_test(
+    name = "string_utilities_fuzzer",
+    srcs = ["string_utilities_fuzzer.cc"],
+    deps = [
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:cord",
+        "@com_google_absl//absl/strings:str_format",
+    ],
 )

--- a/projects/abseil-cpp/Dockerfile
+++ b/projects/abseil-cpp/Dockerfile
@@ -15,16 +15,5 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get --no-install-recommends install -y build-essential make curl wget rsync
-
-RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
-RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
-RUN apt-get update && apt-get install -y bazel
-RUN curl -Lo /usr/bin/bazel \
-        https://github.com/bazelbuild/bazelisk/releases/download/v1.1.0/bazelisk-linux-amd64 \
-        && \
-    chmod +x /usr/bin/bazel
-
 RUN git clone --depth 1 https://github.com/abseil/abseil-cpp.git
-
-COPY BUILD WORKSPACE build.sh string_escape_fuzzer.cc string_utilities_fuzzer.cc $SRC/
+COPY BUILD WORKSPACE build.sh *_fuzzer.cc $SRC/

--- a/projects/abseil-cpp/WORKSPACE
+++ b/projects/abseil-cpp/WORKSPACE
@@ -16,13 +16,41 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive(
-    name = "bazel_skylib",
-    sha256 = "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz"],
-)
-
 local_repository(
     name = "com_google_absl",
     path = "abseil-cpp/",
 )
+
+# released on 2023-11-07
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "cd55a062e763b9349921f0f5db8c3933288dc8ba4f76dd9416aac68acee3cb94",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
+    ],
+)
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+# released on 2023-10-19
+http_archive(
+    name = "rules_fuzzing",
+    sha256 = "ff52ef4845ab00e95d29c02a9e32e9eff4e0a4c9c8a6bcf8407a2f19eb3f9190",
+    strip_prefix = "rules_fuzzing-0.4.1",
+    urls = ["https://github.com/bazelbuild/rules_fuzzing/releases/download/v0.4.1/rules_fuzzing-0.4.1.zip"],
+)
+
+load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
+
+rules_fuzzing_dependencies()
+
+load("@rules_fuzzing//fuzzing:init.bzl", "rules_fuzzing_init")
+
+rules_fuzzing_init()
+
+load("@fuzzing_py_deps//:requirements.bzl", "install_deps")
+
+install_deps()

--- a/projects/abseil-cpp/build.sh
+++ b/projects/abseil-cpp/build.sh
@@ -14,57 +14,12 @@
 #
 ################################################################################
 
-export CXXFLAGS="$CXXFLAGS -std=c++14"
-
-readonly EXTRA_BAZEL_FLAGS="$(
-for f in ${CFLAGS}; do
-  echo "--conlyopt=${f}" "--linkopt=${f}"
-done
-for f in ${CXXFLAGS}; do
-  echo "--cxxopt=${f}" "--linkopt=${f}"
-done
-
-if [ "$SANITIZER" = "undefined" ]
-then
-  # Bazel uses clang to link binary, which does not link clang_rt ubsan library for C++ automatically.
-  # See issue: https://github.com/bazelbuild/bazel/issues/8777
-  echo "--linkopt=\"$(find $(llvm-config --libdir) -name libclang_rt.ubsan_standalone_cxx-x86_64.a | head -1)\""
-fi
-)"
-
-declare FUZZ_TARGETS=("string_escape_fuzzer" "string_utilities_fuzzer")
-
-bazel build \
-	--verbose_failures \
-	--dynamic_mode=off \
-	--spawn_strategy=standalone \
-	--genrule_strategy=standalone \
-	--strip=never \
-	--linkopt=-pthread \
-	--copt=${LIB_FUZZING_ENGINE} \
-	--linkopt=${LIB_FUZZING_ENGINE} \
-	--linkopt=-lc++ \
-	${EXTRA_BAZEL_FLAGS} \
-	${FUZZ_TARGETS[*]}
-
-
-if [ "$SANITIZER" = "coverage" ]
-then
-  # The build invoker looks for sources in $SRC, but it turns out that we need
-  # to not be buried under src/, paths are expected at out/proc/self/cwd by
-  # the profiler.
-  declare -r REMAP_PATH="${OUT}/proc/self/cwd"
-  mkdir -p "${REMAP_PATH}"
-  mkdir -p "${REMAP_PATH}/external/com_google_absl"
-  rsync -av "${SRC}"/abseil-cpp/absl "${REMAP_PATH}/external/com_google_absl"
-
-  declare -r RSYNC_FILTER_ARGS=("--include" "*.h" "--include" "*.cc" "--include" \
-    "*.hpp" "--include" "*.cpp" "--include" "*.c" "--include" "*/" "--exclude" "*")
-  rsync -avLk "${RSYNC_FILTER_ARGS[@]}" "${SRC}"/bazel-out "${REMAP_PATH}"
-  rsync -avLkR "${RSYNC_FILTER_ARGS[@]}" "${HOME}" "${OUT}"
-  rsync -avLkR "${RSYNC_FILTER_ARGS[@]}" /tmp "${OUT}"
-
-  cp *fuzzer.cc "${OUT}/proc/self/cwd"
-fi
-
-cp "./bazel-bin/"*fuzzer "${OUT}/"
+# Disable `layering_check` feature.
+# As per https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=63223, it breaks
+# the build. Someone could figure out exactly why it breaks the build, but just
+# disabling it suffices because it doesn't actually matter for our purposes. ;)
+export BAZEL_EXTRA_BUILD_FLAGS='--features=-layering_check'
+# The default query is complex and requires additional dependencies in order to
+# work (due to its use of `//...`) whereas this query is simple and sufficient.
+export BAZEL_FUZZ_TEST_QUERY='filter("_fuzzer$", //:all)'
+exec bazel_build_fuzz_tests


### PR DESCRIPTION
In `Dockerfile`, remove cruft that probably wasn't needed before and certainly isn't needed now.

In `WORKSPACE`, take a dependency on `rules_fuzzing` and, while I'm here, update the dependency on `bazel_skylib`.

In `BUILD`, use `cc_fuzz_test()`.

In `build.sh`, replace cruft that was complex (and unmaintained) and simply use `bazel_build_fuzz_tests` instead.