### PR TITLE
llvm: try getting coverage to work

### DIFF
--- a/projects/llvm/Dockerfile
+++ b/projects/llvm/Dockerfile
@@ -23,4 +23,4 @@ RUN apt-get install -y autoconf automake libtool curl make g++ unzip wget git \
 # Get LLVM
 RUN git clone --depth 1 https://github.com/llvm/llvm-project.git
 
-COPY build.sh $SRC/
+COPY build.sh *.py $SRC/

--- a/projects/llvm/build.sh
+++ b/projects/llvm/build.sh
@@ -81,7 +81,9 @@ cmake -GNinja -DCMAKE_BUILD_TYPE=Release ../$LLVM \
 # Build some initial targest using only a single core, this is because otherwse
 # they get killed.
 if [[ "$SANITIZER" = coverage ]]; then
-  ninja lib/Target/AMDGPU/Utils/CMakeFiles/LLVMAMDGPUUtils.dir/AMDGPUBaseInfo.cpp.o -j 1
+  mv build.ninja ../
+  python3 $SRC/coverage_patcher.py ../build.ninja build.ninja
+  ninja lib/Target/AMDGPU/Utils/CMakeFiles/LLVMAMDGPUUtils.dir/AMDGPUBaseInfo.cpp.o -j 3
 fi
 
 for fuzzer in "${FUZZERS[@]}"; do

--- a/projects/llvm/build.sh
+++ b/projects/llvm/build.sh
@@ -78,12 +78,12 @@ cmake -GNinja -DCMAKE_BUILD_TYPE=Release ../$LLVM \
     -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly \
     -DCOMPILER_RT_INCLUDE_TESTS=OFF
 
-# Build some initial targest using only a single core, this is because otherwse
-# they get killed.
+# Patch certain build rules in code coverage mode, as otherwise the process is killed.
+# Verify we can build some of the troublesome rules by building them.
 if [[ "$SANITIZER" = coverage ]]; then
   mv build.ninja ../
   python3 $SRC/coverage_patcher.py ../build.ninja build.ninja
-  ninja lib/Target/AMDGPU/Utils/CMakeFiles/LLVMAMDGPUUtils.dir/AMDGPUBaseInfo.cpp.o -j 3
+  ninja lib/Target/AMDGPU/Utils/CMakeFiles/LLVMAMDGPUUtils.dir/AMDGPUBaseInfo.cpp.o -j $(( $(nproc) / 2))
 fi
 
 for fuzzer in "${FUZZERS[@]}"; do

--- a/projects/llvm/build.sh
+++ b/projects/llvm/build.sh
@@ -78,6 +78,12 @@ cmake -GNinja -DCMAKE_BUILD_TYPE=Release ../$LLVM \
     -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly \
     -DCOMPILER_RT_INCLUDE_TESTS=OFF
 
+# Build some initial targest using only a single core, this is because otherwse
+# they get killed.
+if [[ "$SANITIZER" = coverage ]]; then
+  ninja lib/Target/AMDGPU/Utils/CMakeFiles/LLVMAMDGPUUtils.dir/AMDGPUBaseInfo.cpp.o -j 1
+fi
+
 for fuzzer in "${FUZZERS[@]}"; do
   # Limit workload in CI
   if [ -n "${OSS_FUZZ_CI-}" ]; then

--- a/projects/llvm/coverage_patcher.py
+++ b/projects/llvm/coverage_patcher.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python3
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Module for patching out coverage instrumentation for specific files."""
+
+import os
+import sys
+
+with open(sys.argv[1], "r") as f:
+  content = f.read()
+
+patch_flag = False
+new_content = ""
+for line in content.split("\n"):
+  if patch_flag:
+    if "FLAGS =" in line:
+      print("Patching")
+      line = line.replace("-fprofile-instr-generate -fcoverage-mapping", "")
+      patch_flag = False
+
+  # Find the AMDGPUBaseInfo.cpp.o build
+  if "build" in line and "AMDGPUBaseInfo.cpp.o" in line:
+    # Find the next flag
+    patch_flag = True
+  new_content += line + "\n"
+
+with open(sys.argv[2], "w") as f:
+  f.write(new_content)


### PR DESCRIPTION
Coverage build are struggling to build as processes are being killed. This is another attempt to fix this.

If this doesn't work in the cloud builds then I think the next step is to try and limit coverage flags for certain files.