### PR TITLE
jackson-dataformats-{binary, text}: fix exception blockers for fuzzers

### DIFF
--- a/projects/jackson-dataformats-binary/DeserializerFuzzer.java
+++ b/projects/jackson-dataformats-binary/DeserializerFuzzer.java
@@ -38,6 +38,7 @@ import com.fasterxml.jackson.dataformat.protobuf.ProtobufMapper;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 import com.fasterxml.jackson.dataformat.smile.SmileParser;
 import com.fasterxml.jackson.dataformat.smile.databind.SmileMapper;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -125,13 +126,13 @@ public class DeserializerFuzzer {
 
       // Fuzz the deserialize methods for different Avro/Cbor/Ion/Protobuf/Smile objects
       if (data.consumeBoolean()) {
-        byte[] output = new byte[data.remainingBytes()];
-        parser = mapper.getFactory().createParser(output);
+        byte[] output = data.consumeRemainingAsBytes();
+        parser = mapper.getFactory().createParser(new ByteArrayInputStream(output));
         mapper.readTree(parser);
       } else {
         Class type = data.pickValue(choice);
         String value = data.consumeRemainingAsString();
-        if (value == null) {
+        if ((value == null) || (value.isEmpty())) {
           return;
         }
         mapper.readValue(value, type);
@@ -159,7 +160,6 @@ public class DeserializerFuzzer {
     choice = new ArrayList<Class>();
     choice.add(ByteArrayContainer.class);
     choice.add(ByteArrayOutputStream.class);
-    choice.add(Byte[].class);
     choice.add(ModelContainer.class);
     choice.add(DelegateContainer.class);
     choice.add(RawContainer.class);

--- a/projects/jackson-dataformats-binary/SerializerFuzzer.java
+++ b/projects/jackson-dataformats-binary/SerializerFuzzer.java
@@ -140,20 +140,12 @@ public class SerializerFuzzer {
       // Initialize ObjectNode object
       ObjectNode node = mapper.createObjectNode();
 
-      // Initialize JsonGenerator object
-      generator = factory.createGenerator(new StringWriter());
-
       // Randomize writer options
       if (data.consumeBoolean()) {
         writer = writer.withDefaultPrettyPrinter();
       }
       if (feature != null) {
         writer = writer.with(feature);
-      }
-
-      // Failsafe logic
-      if (generator == null) {
-        return;
       }
 
       // Object to write
@@ -166,11 +158,13 @@ public class SerializerFuzzer {
           object = node;
           break;
         case 2:
+          generator = factory.createGenerator(new StringWriter());
           generator.writeStartObject();
           generator.writeBinaryField("data", data.consumeRemainingAsBytes());
           generator.writeEndObject();
           break;
         case 3:
+          generator = factory.createGenerator(new StringWriter());
           generator.writeStartObject();
           generator.writeString(data.consumeRemainingAsString());
           generator.writeEndObject();

--- a/projects/jackson-dataformats-text/DeserializerFuzzer.java
+++ b/projects/jackson-dataformats-text/DeserializerFuzzer.java
@@ -102,6 +102,9 @@ public class DeserializerFuzzer {
       } else {
         Class type = data.pickValue(choice);
         String value = data.consumeRemainingAsString();
+        if ((value == null) || (value.isEmpty())) {
+          return;
+        }
         mapper.readValue(value, type);
       }
     } catch (IOException | IllegalArgumentException | DateTimeException e) {
@@ -121,7 +124,6 @@ public class DeserializerFuzzer {
     choice = new ArrayList<Class>();
     choice.add(ByteArrayContainer.class);
     choice.add(ByteArrayOutputStream.class);
-    choice.add(Byte[].class);
     choice.add(ModelContainer.class);
     choice.add(DelegateContainer.class);
     choice.add(RawContainer.class);
@@ -152,6 +154,7 @@ public class DeserializerFuzzer {
   private static class ByteArrayContainer {
     public byte[] value;
 
+    @JsonCreator
     public ByteArrayContainer(byte[] value) {
       this.value = value;
     }


### PR DESCRIPTION
This PR fixes the fuzzer problem for https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64729 which is deserialising an unsupported type. This PR also fixes some logic in the fuzzers to increase coverage in project jackson-dataformats-binary and jackson-dataformats-text.