### PR TITLE
llvm: fix coverage build

### DIFF
--- a/projects/llvm/build.sh
+++ b/projects/llvm/build.sh
@@ -21,24 +21,46 @@ if [ -n "${OSS_FUZZ_CI-}" ]; then
     llvm-dwarfdump-fuzzer \
   )
 else
-  readonly FUZZERS=( \
-    llvm-microsoft-demangle-fuzzer \
-    llvm-dwarfdump-fuzzer \
-    llvm-itanium-demangle-fuzzer \
-    llvm-yaml-numeric-parser-fuzzer \
-    llvm-yaml-parser-fuzzer \
-    llvm-dlang-demangle-fuzzer \
-    vfabi-demangler-fuzzer \
-    llvm-rust-demangle-fuzzer \
-    llvm-dis-fuzzer \
-    llvm-opt-fuzzer \
-    llvm-isel-fuzzer \
-    clang-objc-fuzzer \
-    clang-format-fuzzer \
-    clang-pseudo-fuzzer \
-    clang-fuzzer \
-    clangd-fuzzer \
-  )
+  # For coverage we skip "clangd-fuzzer" because it eats too much memory
+  # and the process gets killed.
+  if [[ "$SANITIZER" = coverage ]]; then
+    readonly FUZZERS=( \
+      llvm-microsoft-demangle-fuzzer \
+      llvm-dwarfdump-fuzzer \
+      llvm-itanium-demangle-fuzzer \
+      llvm-yaml-numeric-parser-fuzzer \
+      llvm-yaml-parser-fuzzer \
+      llvm-dlang-demangle-fuzzer \
+      vfabi-demangler-fuzzer \
+      llvm-rust-demangle-fuzzer \
+      llvm-dis-fuzzer \
+      llvm-opt-fuzzer \
+      llvm-isel-fuzzer \
+      clang-objc-fuzzer \
+      clang-format-fuzzer \
+      clang-pseudo-fuzzer \
+      clang-fuzzer \
+    )
+  else
+    readonly FUZZERS=( \
+      llvm-microsoft-demangle-fuzzer \
+      llvm-dwarfdump-fuzzer \
+      llvm-itanium-demangle-fuzzer \
+      llvm-yaml-numeric-parser-fuzzer \
+      llvm-yaml-parser-fuzzer \
+      llvm-dlang-demangle-fuzzer \
+      vfabi-demangler-fuzzer \
+      llvm-rust-demangle-fuzzer \
+      llvm-dis-fuzzer \
+      llvm-opt-fuzzer \
+      llvm-isel-fuzzer \
+      clang-objc-fuzzer \
+      clang-format-fuzzer \
+      clang-pseudo-fuzzer \
+      clang-fuzzer \
+      clangd-fuzzer \
+    )
+  fi
 fi
 # Fuzzers whose inputs are C-family source can use clang-fuzzer-dictionary.
 readonly CLANG_DICT_FUZZERS=( \


### PR DESCRIPTION
The most recent coverage build got close but got killed at the last fuzzer (clangd-fuzzer) [log](https://oss-fuzz-build-logs.storage.googleapis.com/log-5a5b1493-2f55-47cf-8c59-f13bd20ed59d.txt). Am disabling this fuzzer in coverage builds for now.