### PR TITLE
glib: Install packaging Python module

### DIFF
--- a/projects/glib/Dockerfile
+++ b/projects/glib/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y python3-pip
-RUN unset CFLAGS CXXFLAGS && pip3 install -U meson ninja
+RUN unset CFLAGS CXXFLAGS && pip3 install -U meson ninja packaging
 RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/glib
 WORKDIR glib
 COPY build.sh $SRC/


### PR DESCRIPTION
It’s now a dependency of GLib.

See https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3740