### PR TITLE
nokogiri: add steve checkoway to the project

### DIFF
--- a/projects/nokogiri/project.yaml
+++ b/projects/nokogiri/project.yaml
@@ -2,6 +2,7 @@ homepage: "nokogiri.org"
 language: c
 primary_contact: "mike.dalessio@gmail.com"
 auto_ccs:
+  - "scheckoway@gmail.com"
   - "fuzzy.boiiii23a@gmail.com"
   - "nokogiri-oss-fuzz@googlegroups.com"
 main_repo: "https://github.com/sparklemotion/nokogiri.git"


### PR DESCRIPTION
@stevecheckoway is a co-maintainer of Nokogiri and the libgumbo fork.