### PR TITLE
nodejs: temporarily use fork with fixes and new fuzzers

### DIFF
--- a/projects/nodejs/Dockerfile
+++ b/projects/nodejs/Dockerfile
@@ -17,6 +17,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make
 RUN apt-get install -y flex bison build-essential
-RUN git clone --recursive --depth 1 https://github.com/nodejs/node
+RUN git clone --recursive --depth 1 https://github.com/AdamKorcz/node --branch=all-new-fuzzers
 WORKDIR $SRC
 COPY build.sh $SRC/

--- a/projects/nodejs/build.sh
+++ b/projects/nodejs/build.sh
@@ -16,6 +16,11 @@
 ################################################################################
 cd $SRC/node
 
+# Coverage build takes very long and time outs in the CI which blocks changes. Ignore Coverage build in OSS-Fuzz CI for now:
+if [[ -n "${OSS_FUZZ_CI-}" && "$SANITIZER" = coverage ]]; then
+	exit 0
+fi
+
 # Build node
 export LDFLAGS="$CXXFLAGS"
 export LD="$CXX"

--- a/projects/nodejs/project.yaml
+++ b/projects/nodejs/project.yaml
@@ -7,4 +7,5 @@ sanitizers:
   - address
 auto_ccs:
   - "david@adalogics.com"
+  - "adam@adalogics.com"
 main_repo: 'https://github.com/nodejs/node'


### PR DESCRIPTION
Switches the node build to my fork which contains fixes for Nodes currently broken fuzzer and 2 new fuzzers. The PRs for the fix and the new fuzzers have been made upstream. This change in repo is temporary until Nodejs merges in the changes.