### PR TITLE
util-linux: use all fuzzers

### DIFF
--- a/projects/util-linux/project.yaml
+++ b/projects/util-linux/project.yaml
@@ -23,4 +23,4 @@ fuzzing_engines:
   - afl
   - honggfuzz
   - libfuzzer
-
+  - centipede


### PR DESCRIPTION
By removing the explicit list of fuzzers the project falls back to the default configuration which is all fuzzers.
Especially this enables the centipede fuzzer today.

Cc @karelzak 