### PR TITLE
OpenVPN:fix leak in fuzzer

### DIFF
--- a/projects/openvpn/fuzz_route.c
+++ b/projects/openvpn/fuzz_route.c
@@ -139,6 +139,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
         init_route_ipv6_list(&rl6, opt6, remote_endpoint, 0, &remote_host, c.es,
                              &c);
+        gc_free(&rl6.gc);
         route_list_ipv6_inited = 1;
       }
       break;


### PR DESCRIPTION
**In case 6 of fuzz_route.c, I noticed that the `function init_route_ipv6_list(&rl6, opt6, remote_endpoint, 0, &remote_host, c.es, &c) `initializes memory space for rl6. gc, but fails to release the allocated memory after the test ends.**