### PR TITLE
apache-commons-codec: Catch new IllegalArgumentException

### DIFF
--- a/projects/apache-commons-codec/NetCodecFuzzer.java
+++ b/projects/apache-commons-codec/NetCodecFuzzer.java
@@ -86,7 +86,7 @@ public class NetCodecFuzzer {
       if (strDecoder != null) {
         strDecoder.decode(data.consumeRemainingAsString());
       }
-    } catch (EncoderException | DecoderException e) {
+    } catch (EncoderException | DecoderException | IllegalArgumentException e) {
       // Known exception
     }
   }


### PR DESCRIPTION
In https://issues.apache.org/jira/browse/CODEC-314, we push a fix upstream to capture an unexpected IndexOutOfBoundException. The new logic will wrap the unexpected IndexOutOfBoundException and throw an IllegalArgumentException instead. This PR fixes the original fuzzer to capture the new IllegalArgumentException to meet the new logic. This PR should close https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64362.