### PR TITLE
jackson-dataformats-binary: Add loops to parser method calling

### DIFF
--- a/projects/jackson-dataformats-binary/AvroParserFuzzer.java
+++ b/projects/jackson-dataformats-binary/AvroParserFuzzer.java
@@ -25,8 +25,7 @@ import java.util.EnumSet;
 public class AvroParserFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     try {
-      Integer choice = data.consumeInt(1, 19);
-      Integer iteration = data.consumeInt(1, 100);
+      int[] choices = data.consumeInts(data.consumeInt(1, 100));
 
       // Retrieve set of AvroMapper.Feature
       EnumSet<AvroParser.Feature> featureSet = EnumSet.allOf(AvroParser.Feature.class);
@@ -55,8 +54,8 @@ public class AvroParserFuzzer {
           ((AvroMapper) mapper).getFactory().createParser(data.consumeRemainingAsBytes());
 
       // Fuzz methods of AvroParser
-      while (iteration-- > 0) {
-        switch (choice) {
+      for (Integer choice : choices) {
+        switch (choice % 19) {
           case 1:
             parser.currentName();
             break;
@@ -111,7 +110,7 @@ public class AvroParserFuzzer {
           case 18:
             parser.getDoubleValue();
             break;
-          case 19:
+          default:
             parser.getDecimalValue();
             break;
         }

--- a/projects/jackson-dataformats-binary/AvroParserFuzzer.java
+++ b/projects/jackson-dataformats-binary/AvroParserFuzzer.java
@@ -26,6 +26,7 @@ public class AvroParserFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     try {
       Integer choice = data.consumeInt(1, 19);
+      Integer iteration = data.consumeInt(1, 100);
 
       // Retrieve set of AvroMapper.Feature
       EnumSet<AvroParser.Feature> featureSet = EnumSet.allOf(AvroParser.Feature.class);
@@ -54,64 +55,66 @@ public class AvroParserFuzzer {
           ((AvroMapper) mapper).getFactory().createParser(data.consumeRemainingAsBytes());
 
       // Fuzz methods of AvroParser
-      switch (choice) {
-        case 1:
-          parser.currentName();
-          break;
-        case 2:
-          parser.currentTokenLocation();
-          break;
-        case 3:
-          parser.currentLocation();
-          break;
-        case 4:
-          parser.isExpectedStartArrayToken();
-          break;
-        case 5:
-          parser.isExpectedNumberIntToken();
-          break;
-        case 6:
-          parser.nextToken();
-          break;
-        case 7:
-          parser.nextTextValue();
-          break;
-        case 8:
-          parser.getText();
-          break;
-        case 9:
-          parser.getTextCharacters();
-          break;
-        case 10:
-          parser.getTextLength();
-          break;
-        case 11:
-          parser.getTextOffset();
-          break;
-        case 12:
-          parser.getNumberType();
-          break;
-        case 13:
-          parser.getNumberValue();
-          break;
-        case 14:
-          parser.getIntValue();
-          break;
-        case 15:
-          parser.getLongValue();
-          break;
-        case 16:
-          parser.getBigIntegerValue();
-          break;
-        case 17:
-          parser.getFloatValue();
-          break;
-        case 18:
-          parser.getDoubleValue();
-          break;
-        case 19:
-          parser.getDecimalValue();
-          break;
+      while (iteration-- > 0) {
+        switch (choice) {
+          case 1:
+            parser.currentName();
+            break;
+          case 2:
+            parser.currentTokenLocation();
+            break;
+          case 3:
+            parser.currentLocation();
+            break;
+          case 4:
+            parser.isExpectedStartArrayToken();
+            break;
+          case 5:
+            parser.isExpectedNumberIntToken();
+            break;
+          case 6:
+            parser.nextToken();
+            break;
+          case 7:
+            parser.nextTextValue();
+            break;
+          case 8:
+            parser.getText();
+            break;
+          case 9:
+            parser.getTextCharacters();
+            break;
+          case 10:
+            parser.getTextLength();
+            break;
+          case 11:
+            parser.getTextOffset();
+            break;
+          case 12:
+            parser.getNumberType();
+            break;
+          case 13:
+            parser.getNumberValue();
+            break;
+          case 14:
+            parser.getIntValue();
+            break;
+          case 15:
+            parser.getLongValue();
+            break;
+          case 16:
+            parser.getBigIntegerValue();
+            break;
+          case 17:
+            parser.getFloatValue();
+            break;
+          case 18:
+            parser.getDoubleValue();
+            break;
+          case 19:
+            parser.getDecimalValue();
+            break;
+        }
       }
 
       parser.close();

--- a/projects/jackson-dataformats-binary/CborParserFuzzer.java
+++ b/projects/jackson-dataformats-binary/CborParserFuzzer.java
@@ -24,8 +24,7 @@ import java.util.EnumSet;
 public class CborParserFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     try {
-      Integer choice = data.consumeInt(1, 19);
-      Integer iteration = data.consumeInt(1, 100);
+      int[] choices = data.consumeInts(data.consumeInt(1, 100));
 
       // Retrieve set of CBORParser.Feature
       EnumSet<CBORParser.Feature> featureSet = EnumSet.allOf(CBORParser.Feature.class);
@@ -48,8 +47,8 @@ public class CborParserFuzzer {
           ((CBORMapper) mapper).getFactory().createParser(data.consumeRemainingAsBytes());
 
       // Fuzz methods of CBORParser
-      while (iteration-- > 0) {
-        switch (choice) {
+      for (Integer choice : choices) {
+        switch (choice % 19) {
           case 1:
             parser.currentName();
             break;
@@ -104,7 +103,7 @@ public class CborParserFuzzer {
           case 18:
             parser.getDoubleValue();
             break;
-          case 19:
+          default:
             parser.getDecimalValue();
             break;
         }

--- a/projects/jackson-dataformats-binary/CborParserFuzzer.java
+++ b/projects/jackson-dataformats-binary/CborParserFuzzer.java
@@ -25,6 +25,7 @@ public class CborParserFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     try {
       Integer choice = data.consumeInt(1, 19);
+      Integer iteration = data.consumeInt(1, 100);
 
       // Retrieve set of CBORParser.Feature
       EnumSet<CBORParser.Feature> featureSet = EnumSet.allOf(CBORParser.Feature.class);
@@ -47,64 +48,66 @@ public class CborParserFuzzer {
           ((CBORMapper) mapper).getFactory().createParser(data.consumeRemainingAsBytes());
 
       // Fuzz methods of CBORParser
-      switch (choice) {
-        case 1:
-          parser.currentName();
-          break;
-        case 2:
-          parser.currentTokenLocation();
-          break;
-        case 3:
-          parser.currentLocation();
-          break;
-        case 4:
-          parser.isExpectedStartArrayToken();
-          break;
-        case 5:
-          parser.isExpectedNumberIntToken();
-          break;
-        case 6:
-          parser.nextToken();
-          break;
-        case 7:
-          parser.nextTextValue();
-          break;
-        case 8:
-          parser.getText();
-          break;
-        case 9:
-          parser.getTextCharacters();
-          break;
-        case 10:
-          parser.getTextLength();
-          break;
-        case 11:
-          parser.getTextOffset();
-          break;
-        case 12:
-          parser.getNumberType();
-          break;
-        case 13:
-          parser.getNumberValue();
-          break;
-        case 14:
-          parser.getIntValue();
-          break;
-        case 15:
-          parser.getLongValue();
-          break;
-        case 16:
-          parser.getBigIntegerValue();
-          break;
-        case 17:
-          parser.getFloatValue();
-          break;
-        case 18:
-          parser.getDoubleValue();
-          break;
-        case 19:
-          parser.getDecimalValue();
-          break;
+      while (iteration-- > 0) {
+        switch (choice) {
+          case 1:
+            parser.currentName();
+            break;
+          case 2:
+            parser.currentTokenLocation();
+            break;
+          case 3:
+            parser.currentLocation();
+            break;
+          case 4:
+            parser.isExpectedStartArrayToken();
+            break;
+          case 5:
+            parser.isExpectedNumberIntToken();
+            break;
+          case 6:
+            parser.nextToken();
+            break;
+          case 7:
+            parser.nextTextValue();
+            break;
+          case 8:
+            parser.getText();
+            break;
+          case 9:
+            parser.getTextCharacters();
+            break;
+          case 10:
+            parser.getTextLength();
+            break;
+          case 11:
+            parser.getTextOffset();
+            break;
+          case 12:
+            parser.getNumberType();
+            break;
+          case 13:
+            parser.getNumberValue();
+            break;
+          case 14:
+            parser.getIntValue();
+            break;
+          case 15:
+            parser.getLongValue();
+            break;
+          case 16:
+            parser.getBigIntegerValue();
+            break;
+          case 17:
+            parser.getFloatValue();
+            break;
+          case 18:
+            parser.getDoubleValue();
+            break;
+          case 19:
+            parser.getDecimalValue();
+            break;
+        }
       }
 
       parser.close();

--- a/projects/jackson-dataformats-binary/IonParserFuzzer.java
+++ b/projects/jackson-dataformats-binary/IonParserFuzzer.java
@@ -27,6 +27,7 @@ public class IonParserFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     try {
       Integer choice = data.consumeInt(1, 19);
+      Integer iteration = data.consumeInt(1, 100);
 
       // Retrieve set of IonParser.Feature
       EnumSet<IonParser.Feature> featureSet = EnumSet.allOf(IonParser.Feature.class);
@@ -58,64 +59,66 @@ public class IonParserFuzzer {
       JsonParser parser = ((IonObjectMapper) mapper).getFactory().createParser(byteArray);
 
       // Fuzz methods of IonParser
-      switch (choice) {
-        case 1:
-          parser.currentName();
-          break;
-        case 2:
-          parser.currentTokenLocation();
-          break;
-        case 3:
-          parser.currentLocation();
-          break;
-        case 4:
-          parser.isExpectedStartArrayToken();
-          break;
-        case 5:
-          parser.isExpectedNumberIntToken();
-          break;
-        case 6:
-          parser.nextToken();
-          break;
-        case 7:
-          parser.nextTextValue();
-          break;
-        case 8:
-          parser.getText();
-          break;
-        case 9:
-          parser.getTextCharacters();
-          break;
-        case 10:
-          parser.getTextLength();
-          break;
-        case 11:
-          parser.getTextOffset();
-          break;
-        case 12:
-          parser.getNumberType();
-          break;
-        case 13:
-          parser.getNumberValue();
-          break;
-        case 14:
-          parser.getIntValue();
-          break;
-        case 15:
-          parser.getLongValue();
-          break;
-        case 16:
-          parser.getBigIntegerValue();
-          break;
-        case 17:
-          parser.getFloatValue();
-          break;
-        case 18:
-          parser.getDoubleValue();
-          break;
-        case 19:
-          parser.getDecimalValue();
-          break;
+      while (iteration-- > 0) {
+        switch (choice) {
+          case 1:
+            parser.currentName();
+            break;
+          case 2:
+            parser.currentTokenLocation();
+            break;
+          case 3:
+            parser.currentLocation();
+            break;
+          case 4:
+            parser.isExpectedStartArrayToken();
+            break;
+          case 5:
+            parser.isExpectedNumberIntToken();
+            break;
+          case 6:
+            parser.nextToken();
+            break;
+          case 7:
+            parser.nextTextValue();
+            break;
+          case 8:
+            parser.getText();
+            break;
+          case 9:
+            parser.getTextCharacters();
+            break;
+          case 10:
+            parser.getTextLength();
+            break;
+          case 11:
+            parser.getTextOffset();
+            break;
+          case 12:
+            parser.getNumberType();
+            break;
+          case 13:
+            parser.getNumberValue();
+            break;
+          case 14:
+            parser.getIntValue();
+            break;
+          case 15:
+            parser.getLongValue();
+            break;
+          case 16:
+            parser.getBigIntegerValue();
+            break;
+          case 17:
+            parser.getFloatValue();
+            break;
+          case 18:
+            parser.getDoubleValue();
+            break;
+          case 19:
+            parser.getDecimalValue();
+            break;
+        }
       }
 
       parser.close();

--- a/projects/jackson-dataformats-binary/IonParserFuzzer.java
+++ b/projects/jackson-dataformats-binary/IonParserFuzzer.java
@@ -26,8 +26,7 @@ import java.util.EnumSet;
 public class IonParserFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     try {
-      Integer choice = data.consumeInt(1, 19);
-      Integer iteration = data.consumeInt(1, 100);
+      int[] choices = data.consumeInts(data.consumeInt(1, 100));
 
       // Retrieve set of IonParser.Feature
       EnumSet<IonParser.Feature> featureSet = EnumSet.allOf(IonParser.Feature.class);
@@ -59,8 +58,8 @@ public class IonParserFuzzer {
       JsonParser parser = ((IonObjectMapper) mapper).getFactory().createParser(byteArray);
 
       // Fuzz methods of IonParser
-      while (iteration-- > 0) {
-        switch (choice) {
+      for (Integer choice : choices) {
+        switch (choice % 19) {
           case 1:
             parser.currentName();
             break;
@@ -115,7 +114,7 @@ public class IonParserFuzzer {
           case 18:
             parser.getDoubleValue();
             break;
-          case 19:
+          default:
             parser.getDecimalValue();
             break;
         }

--- a/projects/jackson-dataformats-binary/ProtobufParserFuzzer.java
+++ b/projects/jackson-dataformats-binary/ProtobufParserFuzzer.java
@@ -24,6 +24,7 @@ public class ProtobufParserFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     try {
       Integer choice = data.consumeInt(1, 19);
+      Integer iteration = data.consumeInt(1, 100);
 
       ProtobufMapper mapper = ProtobufMapper.builder(ProtobufFactory.builder().build()).build();
 
@@ -37,64 +38,66 @@ public class ProtobufParserFuzzer {
           ((ProtobufMapper) mapper).getFactory().createParser(data.consumeRemainingAsBytes());
 
       // Fuzz methods of ProtobufParser
-      switch (choice) {
-        case 1:
-          parser.currentName();
-          break;
-        case 2:
-          parser.currentTokenLocation();
-          break;
-        case 3:
-          parser.currentLocation();
-          break;
-        case 4:
-          parser.isExpectedStartArrayToken();
-          break;
-        case 5:
-          parser.isExpectedNumberIntToken();
-          break;
-        case 6:
-          parser.nextToken();
-          break;
-        case 7:
-          parser.nextTextValue();
-          break;
-        case 8:
-          parser.getText();
-          break;
-        case 9:
-          parser.getTextCharacters();
-          break;
-        case 10:
-          parser.getTextLength();
-          break;
-        case 11:
-          parser.getTextOffset();
-          break;
-        case 12:
-          parser.getNumberType();
-          break;
-        case 13:
-          parser.getNumberValue();
-          break;
-        case 14:
-          parser.getIntValue();
-          break;
-        case 15:
-          parser.getLongValue();
-          break;
-        case 16:
-          parser.getBigIntegerValue();
-          break;
-        case 17:
-          parser.getFloatValue();
-          break;
-        case 18:
-          parser.getDoubleValue();
-          break;
-        case 19:
-          parser.getDecimalValue();
-          break;
+      while (iteration-- > 0) {
+        switch (choice) {
+          case 1:
+            parser.currentName();
+            break;
+          case 2:
+            parser.currentTokenLocation();
+            break;
+          case 3:
+            parser.currentLocation();
+            break;
+          case 4:
+            parser.isExpectedStartArrayToken();
+            break;
+          case 5:
+            parser.isExpectedNumberIntToken();
+            break;
+          case 6:
+            parser.nextToken();
+            break;
+          case 7:
+            parser.nextTextValue();
+            break;
+          case 8:
+            parser.getText();
+            break;
+          case 9:
+            parser.getTextCharacters();
+            break;
+          case 10:
+            parser.getTextLength();
+            break;
+          case 11:
+            parser.getTextOffset();
+            break;
+          case 12:
+            parser.getNumberType();
+            break;
+          case 13:
+            parser.getNumberValue();
+            break;
+          case 14:
+            parser.getIntValue();
+            break;
+          case 15:
+            parser.getLongValue();
+            break;
+          case 16:
+            parser.getBigIntegerValue();
+            break;
+          case 17:
+            parser.getFloatValue();
+            break;
+          case 18:
+            parser.getDoubleValue();
+            break;
+          case 19:
+            parser.getDecimalValue();
+            break;
+        }
       }
 
       parser.close();

--- a/projects/jackson-dataformats-binary/ProtobufParserFuzzer.java
+++ b/projects/jackson-dataformats-binary/ProtobufParserFuzzer.java
@@ -23,8 +23,7 @@ import java.io.IOException;
 public class ProtobufParserFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     try {
-      Integer choice = data.consumeInt(1, 19);
-      Integer iteration = data.consumeInt(1, 100);
+      int[] choices = data.consumeInts(data.consumeInt(1, 100));
 
       ProtobufMapper mapper = ProtobufMapper.builder(ProtobufFactory.builder().build()).build();
 
@@ -38,8 +37,8 @@ public class ProtobufParserFuzzer {
           ((ProtobufMapper) mapper).getFactory().createParser(data.consumeRemainingAsBytes());
 
       // Fuzz methods of ProtobufParser
-      while (iteration-- > 0) {
-        switch (choice) {
+      for (Integer choice : choices) {
+        switch (choice % 19) {
           case 1:
             parser.currentName();
             break;
@@ -94,7 +93,7 @@ public class ProtobufParserFuzzer {
           case 18:
             parser.getDoubleValue();
             break;
-          case 19:
+          default:
             parser.getDecimalValue();
             break;
         }

--- a/projects/jackson-dataformats-binary/SmileParserFuzzer.java
+++ b/projects/jackson-dataformats-binary/SmileParserFuzzer.java
@@ -25,6 +25,7 @@ public class SmileParserFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     try {
       Integer choice = data.consumeInt(1, 19);
+      Integer iteration = data.consumeInt(1, 100);
 
       // Retrieve set of SmileParser.Feature
       EnumSet<SmileParser.Feature> featureSet = EnumSet.allOf(SmileParser.Feature.class);
@@ -47,64 +48,66 @@ public class SmileParserFuzzer {
           ((SmileMapper) mapper).getFactory().createParser(data.consumeRemainingAsBytes());
 
       // Fuzz methods of SmileParser
-      switch (choice) {
-        case 1:
-          parser.currentName();
-          break;
-        case 2:
-          parser.currentTokenLocation();
-          break;
-        case 3:
-          parser.currentLocation();
-          break;
-        case 4:
-          parser.isExpectedStartArrayToken();
-          break;
-        case 5:
-          parser.isExpectedNumberIntToken();
-          break;
-        case 6:
-          parser.nextToken();
-          break;
-        case 7:
-          parser.nextTextValue();
-          break;
-        case 8:
-          parser.getText();
-          break;
-        case 9:
-          parser.getTextCharacters();
-          break;
-        case 10:
-          parser.getTextLength();
-          break;
-        case 11:
-          parser.getTextOffset();
-          break;
-        case 12:
-          parser.getNumberType();
-          break;
-        case 13:
-          parser.getNumberValue();
-          break;
-        case 14:
-          parser.getIntValue();
-          break;
-        case 15:
-          parser.getLongValue();
-          break;
-        case 16:
-          parser.getBigIntegerValue();
-          break;
-        case 17:
-          parser.getFloatValue();
-          break;
-        case 18:
-          parser.getDoubleValue();
-          break;
-        case 19:
-          parser.getDecimalValue();
-          break;
+      while (iteration-- > 0) {
+        switch (choice) {
+          case 1:
+            parser.currentName();
+            break;
+          case 2:
+            parser.currentTokenLocation();
+            break;
+          case 3:
+            parser.currentLocation();
+            break;
+          case 4:
+            parser.isExpectedStartArrayToken();
+            break;
+          case 5:
+            parser.isExpectedNumberIntToken();
+            break;
+          case 6:
+            parser.nextToken();
+            break;
+          case 7:
+            parser.nextTextValue();
+            break;
+          case 8:
+            parser.getText();
+            break;
+          case 9:
+            parser.getTextCharacters();
+            break;
+          case 10:
+            parser.getTextLength();
+            break;
+          case 11:
+            parser.getTextOffset();
+            break;
+          case 12:
+            parser.getNumberType();
+            break;
+          case 13:
+            parser.getNumberValue();
+            break;
+          case 14:
+            parser.getIntValue();
+            break;
+          case 15:
+            parser.getLongValue();
+            break;
+          case 16:
+            parser.getBigIntegerValue();
+            break;
+          case 17:
+            parser.getFloatValue();
+            break;
+          case 18:
+            parser.getDoubleValue();
+            break;
+          case 19:
+            parser.getDecimalValue();
+            break;
+        }
       }
 
       parser.close();

--- a/projects/jackson-dataformats-binary/SmileParserFuzzer.java
+++ b/projects/jackson-dataformats-binary/SmileParserFuzzer.java
@@ -24,8 +24,7 @@ import java.util.EnumSet;
 public class SmileParserFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     try {
-      Integer choice = data.consumeInt(1, 19);
-      Integer iteration = data.consumeInt(1, 100);
+      int[] choices = data.consumeInts(data.consumeInt(1, 100));
 
       // Retrieve set of SmileParser.Feature
       EnumSet<SmileParser.Feature> featureSet = EnumSet.allOf(SmileParser.Feature.class);
@@ -48,8 +47,8 @@ public class SmileParserFuzzer {
           ((SmileMapper) mapper).getFactory().createParser(data.consumeRemainingAsBytes());
 
       // Fuzz methods of SmileParser
-      while (iteration-- > 0) {
-        switch (choice) {
+      for (Integer choice : choices) {
+        switch (choice % 19) {
           case 1:
             parser.currentName();
             break;
@@ -104,7 +103,7 @@ public class SmileParserFuzzer {
           case 18:
             parser.getDoubleValue();
             break;
-          case 19:
+          default:
             parser.getDecimalValue();
             break;
         }


### PR DESCRIPTION
This PR adds looping for calling methods of different parsers in the jackson-dataformats-binary project to simulate multiple method calling for the same initialized parser.