### PR TITLE
vscode: add CFLite helper for C++

### DIFF
--- a/tools/vscode-extension/package-lock.json
+++ b/tools/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "OSS-Fuzz",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "OSS-Fuzz",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "dependencies": {
         "@microsoft/vscode-file-downloader-api": "^1.0.1"
       },

--- a/tools/vscode-extension/package.json
+++ b/tools/vscode-extension/package.json
@@ -95,6 +95,21 @@
         "command": "oss-fuzz.Template",
         "title": "OSS-Fuzz: Fuzzer Creation Using Templates",
         "description": "Creates a template fuzzer file using a catalogue of templates available."
+      },
+      {
+        "command": "oss-fuzz.GenerateClusterfuzzLite",
+        "title": "OSS-Fuzz: Generate ClusterfuzzLite setup",
+        "description": "Creates the files needed for ClusterfuzzLite integration."
+      },
+      {
+        "command": "oss-fuzz.WSBuildFuzzersCFLite",
+        "title": "OSS-Fuzz: [CFLite] Build Fuzzers In Workspace",
+        "description": "Builds the ClusterfuzzLite fuzzers from the project in the current VSCode workspace."
+      },
+      {
+        "command": "oss-fuzz.testFuzzerCFLite",
+        "title": "OSS-Fuzz: [CFLite] Test running a specific fuzzer.",
+        "description": "Builds the CFLite setup and runs a fuzzer for a short period of time."
       }
     ],
     "walkthroughs":[

--- a/tools/vscode-extension/src/commands/cmdBuildFuzzerFromWorkspaceCFLite.ts
+++ b/tools/vscode-extension/src/commands/cmdBuildFuzzerFromWorkspaceCFLite.ts
@@ -1,0 +1,49 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import {commandHistory} from '../commandUtils';
+import {setStatusText} from '../utils';
+import {buildFuzzersFromWorkspaceClusterfuzzLite} from '../ossfuzzWrappers';
+
+export async function cmdInputCollectorBuildFuzzersFromWorkspaceCFLite() {
+  // Create an history object
+  const args = new Object({
+    toClean: false,
+  });
+
+  const commandObject = new Object({
+    commandType: 'oss-fuzz.WSBuildFuzzers',
+    Arguments: args,
+    dispatcherFunc: cmdDispatchbuildFuzzersFromWorkspaceClusterfuzzLite,
+  });
+  console.log('L1: ' + commandHistory.length);
+  commandHistory.push(commandObject);
+
+  await cmdDispatchbuildFuzzersFromWorkspaceClusterfuzzLite(args);
+  return true;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+async function cmdDispatchbuildFuzzersFromWorkspaceClusterfuzzLite(_args: any) {
+  await setStatusText('[CFLite] Building fuzzers: starting');
+  const res = await buildFuzzersFromWorkspaceClusterfuzzLite();
+  if (res) {
+    await setStatusText('[CFLite] Building fuzzers: finished');
+  } else {
+    await setStatusText('[CFLite] Building fuzzers: failed');
+  }
+}

--- a/tools/vscode-extension/src/commands/cmdDispatcherGenerateClusterfuzzLite.ts
+++ b/tools/vscode-extension/src/commands/cmdDispatcherGenerateClusterfuzzLite.ts
@@ -14,15 +14,25 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-import {setupProjectInitialFiles} from '../projectIntegrationHelper';
+/**
+ * Command for generating template fuzzers. This is a short-cut for rapid
+ * prototyping as well as an archive for inspiration.
+ */
+import * as vscode from 'vscode';
 import {setStatusText} from '../utils';
 
-export async function createOssFuzzSetup() {
+import {setupProjectInitialFiles} from '../projectIntegrationHelper';
+
+export async function cmdDispatcherGenerateClusterfuzzLite(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _context: vscode.ExtensionContext
+) {
   await setStatusText('Creating OSS-Fuzz setup: starting');
-  const res = await setupProjectInitialFiles(false);
+  const res = await setupProjectInitialFiles(true);
   if (res) {
     await setStatusText('Creating OSS-Fuzz setup: finished');
   } else {
     await setStatusText('Creating OSS-Fuzz setup: failed');
   }
+  return;
 }

--- a/tools/vscode-extension/src/commands/cmdTestFuzzerCFLite.ts
+++ b/tools/vscode-extension/src/commands/cmdTestFuzzerCFLite.ts
@@ -1,0 +1,89 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import path = require('path');
+import * as vscode from 'vscode';
+import {println} from '../logger';
+import {
+  runFuzzerHandlerCFLite,
+  buildFuzzersFromWorkspaceClusterfuzzLite,
+} from '../ossfuzzWrappers';
+import {setStatusText} from '../utils';
+import {commandHistory} from '../commandUtils';
+import {extensionConfig} from '../config';
+
+/**
+ * Does an end-to-end test of a project/fuzzer. This is done by
+ * first building the project and then running the fuzzer.
+ * @param context
+ * @returns
+ */
+
+export async function cmdInputCollectorTestFuzzerCFLite() {
+  setStatusText('Testing specific fuzzer: getting input');
+  // Get the fuzzer to run
+  const fuzzerNameInput = await vscode.window.showInputBox({
+    value: '',
+    placeHolder: 'Type a fuzzer name',
+  });
+  if (!fuzzerNameInput) {
+    println('Failed to get fuzzer name');
+    return;
+  }
+
+  // Create the args object for the dispatcher
+  const args = new Object({
+    fuzzerName: fuzzerNameInput.toString(),
+  });
+
+  // Create a dispatcher object.
+  const commandObject = new Object({
+    commandType: 'oss-fuzz.TestFuzzerCFLite',
+    Arguments: args,
+    dispatcherFunc: cmdDispatchTestFuzzerHandlerCFLite,
+  });
+  commandHistory.push(commandObject);
+
+  await cmdDispatchTestFuzzerHandlerCFLite(args);
+}
+
+async function cmdDispatchTestFuzzerHandlerCFLite(args: any) {
+  // Build the project
+  setStatusText('Test specific fuzzer: building fuzzers in workspace');
+  if (!(await buildFuzzersFromWorkspaceClusterfuzzLite())) {
+    println('Build projects');
+    return;
+  }
+
+  const workspaceFolder = vscode.workspace.workspaceFolders;
+  if (!workspaceFolder) {
+    return;
+  }
+
+  const pathOfLocal = workspaceFolder[0].uri.path;
+  println('path of local: ' + pathOfLocal);
+
+  // Run the fuzzer for 10 seconds
+  println('Running fuzzer');
+  setStatusText('Test specific fuzzer: running fuzzer ' + args.fuzzerName);
+  await runFuzzerHandlerCFLite(
+    pathOfLocal,
+    args.fuzzerName,
+    extensionConfig.numberOfSecondsForTestRuns.toString()
+  );
+  setStatusText('Test specific fuzzer: test completed of ' + args.fuzzerName);
+  return;
+}

--- a/tools/vscode-extension/src/extension.ts
+++ b/tools/vscode-extension/src/extension.ts
@@ -22,6 +22,8 @@ import {println} from './logger';
 // Import the command dispatcher functions
 import {cmdInputCollectorRunSpecificFuzzer} from './commands/cmdRunFuzzer';
 import {cmdInputCollectorBuildFuzzersFromWorkspace} from './commands/cmdBuildFuzzerFromWorkspace';
+import {cmdInputCollectorBuildFuzzersFromWorkspaceCFLite} from './commands/cmdBuildFuzzerFromWorkspaceCFLite';
+import {cmdInputCollectorTestFuzzerCFLite} from './commands/cmdTestFuzzerCFLite';
 import {cmdDispatcherRe} from './commands/cmdRedo';
 import {setupCIFuzzHandler} from './commands/cmdSetupCIFuzz';
 import {cmdInputCollectorTestFuzzer} from './commands/cmdTestFuzzer';
@@ -31,6 +33,7 @@ import {runEndToEndAndGetCoverage} from './commands/cmdEndToEndCoverage';
 import {listFuzzersHandler} from './commands/cmdListFuzzers';
 import {cmdInputCollectorReproduceTestcase} from './commands/cmdReproduceTestcase';
 import {cmdDispatcherTemplate} from './commands/cmdTemplate';
+import {cmdDispatcherGenerateClusterfuzzLite} from './commands/cmdDispatcherGenerateClusterfuzzLite';
 import {setUpOssFuzzHandler} from './commands/cmdSetupOSSFuzz';
 import {setOssFuzzPath} from './commands/cmdSetOSSFuzzPath';
 import {extensionConfig} from './config';
@@ -154,6 +157,36 @@ export function activate(context: vscode.ExtensionContext) {
       println('CMD start: remplate');
       await cmdDispatcherTemplate(context);
       println('CMD end: template');
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'oss-fuzz.GenerateClusterfuzzLite',
+      async () => {
+        println('CMD start: GenerateClusterfuzzLite');
+        await cmdDispatcherGenerateClusterfuzzLite(context);
+        println('CMD end: GenerateClusterfuzzLite');
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'oss-fuzz.WSBuildFuzzersCFLite',
+      async () => {
+        println('CMD start: WSBuildFuzzersCFLite');
+        await cmdInputCollectorBuildFuzzersFromWorkspaceCFLite();
+        println('CMD end: WSBuildFuzzersCFLite');
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('oss-fuzz.testFuzzerCFLite', async () => {
+      println('CMD start: testFuzzerCFLite');
+      await cmdInputCollectorTestFuzzerCFLite();
+      println('CMD end: testFuzzerCFLite');
     })
   );
 }


### PR DESCRIPTION
Adds helpers to:
- Generate files needed for a CFLite set up (the content of `.clusterfuzzlite`, not the GH workflow)
- Test fuzzers in a CFLite set up

Only CPP support for now.

Follow-up PRs will:
- Add support for the rest of the languages
- Add support for code coverage generation
- Add support for yaml generation.