### PR TITLE
apache-commons-lang: Wrap ClassCastException thrown from SerializationUtils

### DIFF
--- a/projects/apache-commons-lang/SerializationUtilsFuzzer.java
+++ b/projects/apache-commons-lang/SerializationUtilsFuzzer.java
@@ -38,7 +38,7 @@ public class SerializationUtilsFuzzer {
           SerializationUtils.deserialize(byteArray);
           break;
       }
-    } catch (SerializationException | NullPointerException e) {
+    } catch (SerializationException | NullPointerException | ClassCastException e) {
       // Known exception
     }
   }


### PR DESCRIPTION
This PR wraps expected ClassCastException thrown when calling deserialize method of SerializationUtils.