### PR TITLE
nodejs: Attempt to fix broken coverage build

### DIFF
--- a/projects/nodejs/build.sh
+++ b/projects/nodejs/build.sh
@@ -25,7 +25,11 @@ fi
 export LDFLAGS="$CXXFLAGS"
 export LD="$CXX"
 ./configure --with-ossfuzz
-make -j$(nproc)
+if [[ "$SANITIZER" = coverage ]]; then
+	make
+else
+	make -j$(nproc)
+fi
 
 # Copy all fuzzers to OUT folder 
 cp out/Release/fuzz_* ${OUT}/


### PR DESCRIPTION
Nodejs's coverage build exhausts memory. Have tried building this on a 96GB RAM machine which also ran out of memory. Attempted to build with a single core which seems to have done the job. It takes a lot longer, but at least it completes. The coverage build consumes a lot of disk space as well, so this PR may not fix it entirely.

Doing this experimentally to see if it works out in the cloud infrastructure.