### PR TITLE
vscode: refine various places

### DIFF
--- a/tools/vscode-extension/package.json
+++ b/tools/vscode-extension/package.json
@@ -98,7 +98,7 @@
       },
       {
         "command": "oss-fuzz.GenerateClusterfuzzLite",
-        "title": "OSS-Fuzz: Generate ClusterfuzzLite setup",
+        "title": "OSS-Fuzz: [CFLite] Generate ClusterfuzzLite setup",
         "description": "Creates the files needed for ClusterfuzzLite integration."
       },
       {


### PR DESCRIPTION
- prefixes CFLite generate command
- Removes licenses from Dockerfile/Build in CFLite mode -- the rational is that users will likely not want to use those license in their own code base, and they are not needed as the code won't be put in OSS-Fuzz's repo.
- Removes unused fields from `project.yaml` -- these are not relevant in CFLite