### PR TITLE
dropbear: Don't run autoconf

### DIFF
--- a/projects/dropbear/build.sh
+++ b/projects/dropbear/build.sh
@@ -16,11 +16,6 @@
 ################################################################################
 
 
-pushd $SRC/dropbear
-autoconf
-autoheader
-popd
-
 $SRC/dropbear/configure --enable-fuzz --disable-harden --disable-zlib
 
 make -j$(nproc) fuzz-targets FUZZLIB=$LIB_FUZZING_ENGINE


### PR DESCRIPTION
Dropbear now distributes a pre-built configure script in the repo (built with autoconf 2.71).  An intermittent failure seems to occur only using the older autoconf in Ubuntu 20.04 from oss-fuzz, it sometimes doesn't find src/install-sh which is in AC_CONFIG_AUX_DIR

Previously install-sh was in the top directory, changed in https://github.com/mkj/dropbear/commit/e49f2012adb3e062b0c2fb57ca575ceedb2eae58

```
/src/dropbear/configure --enable-fuzz --disable-harden --disable-zlib 
...
checking for _FILE_OFFSET_BITS value needed for large files... no 
configure: error: cannot find install-sh, install.sh, or shtool in "." "./.." "./../.."
```

Intermittent cifuzz:
Failure https://github.com/mkj/dropbear/actions/runs/7237504504/job/19717245388
Successful retry https://github.com/mkj/dropbear/actions/runs/7237504504