### PR TITLE
jackson-dataformats-binary: Fix looping condition

### DIFF
--- a/projects/jackson-dataformats-binary/AvroParserFuzzer.java
+++ b/projects/jackson-dataformats-binary/AvroParserFuzzer.java
@@ -55,7 +55,7 @@ public class AvroParserFuzzer {
 
       // Fuzz methods of AvroParser
       for (Integer choice : choices) {
-        switch (choice % 19) {
+        switch (Math.abs(choice) % 19) {
           case 1:
             parser.currentName();
             break;

--- a/projects/jackson-dataformats-binary/CborParserFuzzer.java
+++ b/projects/jackson-dataformats-binary/CborParserFuzzer.java
@@ -48,7 +48,7 @@ public class CborParserFuzzer {
 
       // Fuzz methods of CBORParser
       for (Integer choice : choices) {
-        switch (choice % 19) {
+        switch (Math.abs(choice) % 19) {
           case 1:
             parser.currentName();
             break;

--- a/projects/jackson-dataformats-binary/IonParserFuzzer.java
+++ b/projects/jackson-dataformats-binary/IonParserFuzzer.java
@@ -59,7 +59,7 @@ public class IonParserFuzzer {
 
       // Fuzz methods of IonParser
       for (Integer choice : choices) {
-        switch (choice % 19) {
+        switch (Math.abs(choice) % 19) {
           case 1:
             parser.currentName();
             break;

--- a/projects/jackson-dataformats-binary/ProtobufParserFuzzer.java
+++ b/projects/jackson-dataformats-binary/ProtobufParserFuzzer.java
@@ -38,7 +38,7 @@ public class ProtobufParserFuzzer {
 
       // Fuzz methods of ProtobufParser
       for (Integer choice : choices) {
-        switch (choice % 19) {
+        switch (Math.abs(choice) % 19) {
           case 1:
             parser.currentName();
             break;

--- a/projects/jackson-dataformats-binary/SmileParserFuzzer.java
+++ b/projects/jackson-dataformats-binary/SmileParserFuzzer.java
@@ -48,7 +48,7 @@ public class SmileParserFuzzer {
 
       // Fuzz methods of SmileParser
       for (Integer choice : choices) {
-        switch (choice % 19) {
+        switch (Math.abs(choice) % 19) {
           case 1:
             parser.currentName();
             break;


### PR DESCRIPTION
In Java, modulo operations are done with absolute value first, then the negative sign will be added to the modulo result if either of the left or right operands is negative. Thus if the choice is negative, the modulo result will always be negative and it automatically goes to the default branch for all the fuzzers. This makes the choice very unbalance and there are less than half chances to execute the other 18 branches. This PR fixes the bias problem by taking the absolute value of the integer choice before the modulo operation to ensure the result must be 0~18 inclusively.