### PR TITLE
Remove  nrunge@google.com from icu/project.yaml

### DIFF
--- a/projects/icu/project.yaml
+++ b/projects/icu/project.yaml
@@ -1,6 +1,6 @@
 homepage: "https://icu.unicode.org"
 language: c++
-primary_contact: "nrunge@google.com"
+primary_contact: "ftang@google.com"
 auto_ccs:
  - icu-security@unicode.org
  - andy.heninger@gmail.com
@@ -8,7 +8,6 @@ auto_ccs:
  - jefgen.msft@gmail.com
  - shane@unicode.org
  - srl295@gmail.com
- - nrunge@google.com
  - ftang@google.com
  - elango@unicode.org
 sanitizers:


### PR DESCRIPTION
nrunge is no longer working for google since Jan 2023. That email is no longer valid.

Replace with ftang@google.com