### PR TITLE
apache-commons-lang: Fix class list size

### DIFF
--- a/projects/apache-commons-lang/ClassFuzzerBase.java
+++ b/projects/apache-commons-lang/ClassFuzzerBase.java
@@ -24,11 +24,28 @@ import java.util.stream.Collectors;
 
 /** This is the base class for fuzzers requiring random class type objects */
 public abstract class ClassFuzzerBase {
-  private static final Integer MAX_CLASS = 1024;
+  private static final Integer MAX_CLASS = 64;
   public static Set<Class> classSet;
 
   public static void fuzzerInitialize() throws IOException {
-    classSet = getAllClasses();
+    Set<Class> all = getAllClasses();
+
+    classSet = new HashSet<Class>();
+    classSet.add(Object.class);
+    classSet.add(Throwable.class);
+    classSet.add(String.class);
+    classSet.add(Integer.class);
+    classSet.add(ArrayList.class);
+    classSet.add(Collections.class);
+    classSet.add(HashSet.class);
+    classSet.add(List.class);
+    classSet.add(Set.class);
+    classSet.add(Collectors.class);
+    classSet.add(ClassPath.class);
+
+    if (all != null) {
+      classSet.addAll(all);
+    }
   }
 
   public static void fuzzerTearDown() {
@@ -40,7 +57,8 @@ public abstract class ClassFuzzerBase {
     ClassLoader loader = ClassLoader.getSystemClassLoader();
     Set<Class> set = new HashSet<Class>();
 
-    List<ClassPath.ClassInfo> classInfoList = ClassPath.from(loader).getAllClasses().stream().collect(Collectors.toList());
+    List<ClassPath.ClassInfo> classInfoList =
+        ClassPath.from(loader).getAllClasses().stream().collect(Collectors.toList());
     Collections.shuffle(classInfoList);
 
     for (ClassPath.ClassInfo c : classInfoList) {
@@ -48,10 +66,15 @@ public abstract class ClassFuzzerBase {
         break;
       }
 
+      Class cls = null;
       try {
-        set.add(c.load());
+        cls = c.load();
       } catch (LinkageError e) {
         // Ignore
+      }
+
+      if (cls != null) {
+        set.add(cls);
       }
     }
 


### PR DESCRIPTION
This PR fixes the class list size for the `ClassFuzzerBase` which is used for both `AnnotationUtilsFuzzer` and `RelfectUtilsFuzzer` to possibly solve a class list loading problem.