### PR TITLE
jackson-dataformats-binary: Catch expected IonException

### DIFF
--- a/projects/jackson-dataformats-binary/IonGeneratorFuzzer.java
+++ b/projects/jackson-dataformats-binary/IonGeneratorFuzzer.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 //
 ///////////////////////////////////////////////////////////////////////////
+import com.amazon.ion.IonException;
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.io.SerializedString;
@@ -138,6 +139,7 @@ public class IonGeneratorFuzzer {
     } catch (IOException
         | IllegalArgumentException
         | IllegalStateException
+        | IonException
         | UnsupportedOperationException e) {
       // Known exception
     }

--- a/projects/jackson-dataformats-binary/IonParserFuzzer.java
+++ b/projects/jackson-dataformats-binary/IonParserFuzzer.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 //
 ///////////////////////////////////////////////////////////////////////////
+import com.amazon.ion.IonException;
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.dataformat.ion.IonFactory;
@@ -121,7 +122,7 @@ public class IonParserFuzzer {
       }
 
       parser.close();
-    } catch (IOException | IllegalArgumentException | IllegalStateException e) {
+    } catch (IOException | IllegalArgumentException | IllegalStateException | IonException e) {
       // Known exception
     }
   }

--- a/projects/jackson-dataformats-binary/SerializerFuzzer.java
+++ b/projects/jackson-dataformats-binary/SerializerFuzzer.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 //
 ///////////////////////////////////////////////////////////////////////////
+import com.amazon.ion.IonException;
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonRawValue;
@@ -253,7 +254,10 @@ public class SerializerFuzzer {
 
       writer.writeValueAsString(object);
       writer.writeValueAsBytes(object);
-    } catch (IOException | IllegalArgumentException | UnsupportedOperationException e) {
+    } catch (IOException
+        | IllegalArgumentException
+        | UnsupportedOperationException
+        | IonException e) {
       // Known exception
     } finally {
       try {

--- a/projects/jackson-dataformats-binary/SmileGeneratorFuzzer.java
+++ b/projects/jackson-dataformats-binary/SmileGeneratorFuzzer.java
@@ -46,7 +46,8 @@ public class SmileGeneratorFuzzer {
       }
 
       // Create and configure SmileGenerator
-      SmileGenerator generator = ((SmileMapper)mapper).getFactory().createGenerator(new ByteArrayOutputStream());
+      SmileGenerator generator =
+          ((SmileMapper) mapper).getFactory().createGenerator(new ByteArrayOutputStream());
       for (SmileGenerator.Feature feature : featureSet) {
         generator.configure(feature, data.consumeBoolean());
       }


### PR DESCRIPTION
This PR catches an expected IonException from Ion-related parsers and also fixes some formating of fuzzers. This fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=65180 and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=65181.


