### PR TITLE
Fastify: fix dockerfile to downgrade nodejs to version 19.2

### DIFF
--- a/projects/fastify/Dockerfile
+++ b/projects/fastify/Dockerfile
@@ -18,6 +18,8 @@ FROM gcr.io/oss-fuzz-base/base-builder-javascript
 
 COPY build.sh $SRC/
 
+RUN npm install -g n && n 19.2
+
 RUN git clone --depth 1 https://github.com/fastify/fastify fastify
 RUN git clone --depth 1 https://github.com/fastify/fast-json-stringify fast-json-stringify
 RUN git clone --depth 1 https://github.com/fastify/fastify-jwt fastify-jwt


### PR DESCRIPTION
This PR fixes the Dockerfile for project fastify by switching the default nodejs version to 19.2 to avoid a strange failing of npm build in Docker as mentioned in https://github.com/nodejs/docker-node/issues/1912.