### PR TITLE
[Django] Force python3 to point to python3.10.

### DIFF
--- a/projects/django/Dockerfile
+++ b/projects/django/Dockerfile
@@ -20,8 +20,9 @@ RUN apt-get update -y \
     && apt-get install -y libgdal26 software-properties-common \
     && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt-get install -y python3.10 python3.10-dev \
-    && curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10 \
-    && python3.10 -m pip install -v --no-cache-dir "atheris>=2.1.1" "pyinstaller==5.0.1" "coverage==6.3.2" \
+    && ln --force -s /usr/bin/python3.10 /usr/local/bin/python3 \
+    && curl -sS https://bootstrap.pypa.io/get-pip.py | python3 \
+    && python3 -m pip install -v --no-cache-dir "atheris>=2.1.1" "pyinstaller==5.0.1" "coverage==6.3.2" \
     && rm -rf /var/lib/apt/lists/*
 
 RUN git clone --depth 1 https://github.com/django/django.git

--- a/projects/django/build.sh
+++ b/projects/django/build.sh
@@ -17,7 +17,7 @@
 
 # Build and install project (using current CFLAGS, CXXFLAGS). This is required
 # for projects with C extensions so that they're built with the proper flags.
-python3.10 -m pip install .
+python3 -m pip install .
 
 export DJANGO_SETTINGS_MODULE=fuzzer_project.settings
 


### PR DESCRIPTION
This seems to be required otherwise the coverage helper scripts will use python 3.8 leading to syntax errors.