### PR TITLE
Apache POI: Improve coverage counting and add a few more expected exceptions

### DIFF
--- a/projects/apache-poi/build.sh
+++ b/projects/apache-poi/build.sh
@@ -79,8 +79,10 @@ popd
 
 pushd "${SRC}"
 	${MVN} package -DfuzzedLibaryVersion="${CURRENT_VERSION}" ${MVN_FLAGS}
-	install -v target/${LIBRARY_NAME}-fuzzer-${CURRENT_VERSION}.jar ${OUT}/${LIBRARY_NAME}-fuzzer-${CURRENT_VERSION}.jar
-	ALL_JARS="${ALL_JARS} ${LIBRARY_NAME}-fuzzer-${CURRENT_VERSION}.jar"
+	mkdir -p ${OUT}/dependency
+	install -v target/assembly/${LIBRARY_NAME}-fuzzer-${CURRENT_VERSION}.jar ${OUT}/${LIBRARY_NAME}-fuzzer-${CURRENT_VERSION}.jar
+	install -v target/assembly/${LIBRARY_NAME}-fuzzer-libs-${CURRENT_VERSION}.jar ${OUT}/dependency/${LIBRARY_NAME}-fuzzer-libs-${CURRENT_VERSION}.jar
+	ALL_JARS="${ALL_JARS} ${LIBRARY_NAME}-fuzzer-${CURRENT_VERSION}.jar dependency/${LIBRARY_NAME}-fuzzer-libs-${CURRENT_VERSION}.jar"
 popd
 
 # The classpath at build-time includes the project jars in $OUT as well as the

--- a/projects/apache-poi/pom.xml
+++ b/projects/apache-poi/pom.xml
@@ -81,10 +81,38 @@
 				</configuration>
 				<executions>
 					<execution>
+						<id>shade-poi</id>
 						<phase>package</phase>
 						<goals>
 							<goal>shade</goal>
 						</goals>
+						<configuration>
+							<outputFile>target/assembly/${project.artifactId}-${fuzzedLibaryVersion}.jar</outputFile>
+							<artifactSet>
+								<includes>
+									<includes>org.apache.poi:poi</includes>
+									<includes>org.apache.poi:poi-ooxml</includes>
+									<includes>org.apache.poi:poi-scratchpad</includes>
+								</includes>
+							</artifactSet>
+						</configuration>
+					</execution>
+					<execution>
+						<id>shade-non-poi</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<outputFile>target/assembly/${project.artifactId}-libs-${fuzzedLibaryVersion}.jar</outputFile>
+							<artifactSet>
+								<excludes>
+									<excludes>org.apache.poi:poi</excludes>
+									<excludes>org.apache.poi:poi-ooxml</excludes>
+									<excludes>org.apache.poi:poi-scratchpad</excludes>
+								</excludes>
+							</artifactSet>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIFuzzer.java
@@ -26,6 +26,7 @@ import org.apache.poi.extractor.ExtractorFactory;
 import org.apache.poi.extractor.POIOLE2TextExtractor;
 import org.apache.poi.extractor.POITextExtractor;
 import org.apache.poi.hslf.exceptions.HSLFException;
+import org.apache.poi.hssf.record.RecordFactory;
 import org.apache.poi.hssf.record.RecordInputStream;
 import org.apache.poi.ooxml.POIXMLException;
 import org.apache.poi.ooxml.extractor.POIXMLPropertiesTextExtractor;
@@ -152,5 +153,11 @@ public class POIFuzzer {
 
 			xmlExtractor.getPackage();
 		}
+	}
+
+	static void adjustLimits() {
+		// reduce limits so we do not get OOMs with the Xmx settings
+		// that are used for the fuzzing runs
+		RecordFactory.setMaxNumberOfRecords(100_000);
 	}
 }

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIHDGFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIHDGFFuzzer.java
@@ -28,6 +28,10 @@ import org.apache.poi.poifs.filesystem.POIFSFileSystem;
 import org.apache.poi.util.RecordFormatException;
 
 public class POIHDGFFuzzer {
+	public static void fuzzerInitialize() {
+		POIFuzzer.adjustLimits();
+	}
+
 	public static void fuzzerTestOneInput(byte[] input) {
 		try (HDGFDiagram visio = new HDGFDiagram(new POIFSFileSystem(new ByteArrayInputStream(input)))) {
 			visio.write(NullOutputStream.INSTANCE);

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIHMEFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIHMEFFuzzer.java
@@ -23,6 +23,10 @@ import org.apache.poi.hmef.HMEFMessage;
 import org.apache.poi.util.RecordFormatException;
 
 public class POIHMEFFuzzer {
+	public static void fuzzerInitialize() {
+		POIFuzzer.adjustLimits();
+	}
+
 	public static void fuzzerTestOneInput(byte[] input) {
 		try {
 			HMEFMessage msg = new HMEFMessage(new ByteArrayInputStream(input));

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIHPBFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIHPBFFuzzer.java
@@ -28,6 +28,10 @@ import org.apache.poi.poifs.filesystem.POIFSFileSystem;
 import org.apache.poi.util.RecordFormatException;
 
 public class POIHPBFFuzzer {
+	public static void fuzzerInitialize() {
+		POIFuzzer.adjustLimits();
+	}
+
 	public static void fuzzerTestOneInput(byte[] input) {
 		try (HPBFDocument wb = new HPBFDocument(new ByteArrayInputStream(input))) {
 			wb.write(NullOutputStream.INSTANCE);

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIHPSFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIHPSFFuzzer.java
@@ -29,6 +29,10 @@ import org.apache.poi.poifs.filesystem.POIFSFileSystem;
 import org.apache.poi.util.RecordFormatException;
 
 public class POIHPSFFuzzer {
+	public static void fuzzerInitialize() {
+		POIFuzzer.adjustLimits();
+	}
+
 	public static void fuzzerTestOneInput(byte[] input) {
 		try (POIFSFileSystem fs = new POIFSFileSystem(new ByteArrayInputStream(input))) {
 			String workbookName = HSSFWorkbook.getWorkbookDirEntryName(fs.getRoot());

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIHSLFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIHSLFFuzzer.java
@@ -34,6 +34,10 @@ import org.apache.poi.sl.usermodel.SlideShowFactory;
 import org.apache.poi.util.RecordFormatException;
 
 public class POIHSLFFuzzer {
+	public static void fuzzerInitialize() {
+		POIFuzzer.adjustLimits();
+	}
+
 	public static void fuzzerTestOneInput(byte[] input) {
 		try (HSLFSlideShow slides = new HSLFSlideShow(new ByteArrayInputStream(input))) {
 			slides.write(NullOutputStream.INSTANCE);

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIHSMFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIHSMFFuzzer.java
@@ -28,6 +28,10 @@ import org.apache.poi.hsmf.exceptions.ChunkNotFoundException;
 import org.apache.poi.util.RecordFormatException;
 
 public class POIHSMFFuzzer {
+	public static void fuzzerInitialize() {
+		POIFuzzer.adjustLimits();
+	}
+
 	public static void fuzzerTestOneInput(byte[] input) {
 		try (MAPIMessage mapi = new MAPIMessage(new ByteArrayInputStream(input))) {
 			mapi.getAttachmentFiles();

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIHSSFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIHSSFFuzzer.java
@@ -30,6 +30,10 @@ import org.apache.poi.poifs.filesystem.POIFSFileSystem;
 import org.apache.poi.util.RecordFormatException;
 
 public class POIHSSFFuzzer {
+	public static void fuzzerInitialize() {
+		POIFuzzer.adjustLimits();
+	}
+
 	public static void fuzzerTestOneInput(byte[] input) {
 		try (HSSFWorkbook wb = new HSSFWorkbook(new ByteArrayInputStream(input))) {
 			wb.write(NullOutputStream.INSTANCE);

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIHWPFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIHWPFFuzzer.java
@@ -30,6 +30,10 @@ import org.apache.poi.util.DocumentFormatException;
 import org.apache.poi.util.RecordFormatException;
 
 public class POIHWPFFuzzer {
+	public static void fuzzerInitialize() {
+		POIFuzzer.adjustLimits();
+	}
+
 	public static void fuzzerTestOneInput(byte[] input) {
 		try (HWPFDocument doc = new HWPFDocument(new ByteArrayInputStream(input))) {
 			doc.write(NullOutputStream.INSTANCE);

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIOldExcelFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIOldExcelFuzzer.java
@@ -27,6 +27,10 @@ import org.apache.poi.poifs.filesystem.POIFSFileSystem;
 import org.apache.poi.util.RecordFormatException;
 
 public class POIOldExcelFuzzer {
+	public static void fuzzerInitialize() {
+		POIFuzzer.adjustLimits();
+	}
+
 	public static void fuzzerTestOneInput(byte[] input) {
 		try {
 			try (OldExcelExtractor extractor = new OldExcelExtractor(

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIVisioFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIVisioFuzzer.java
@@ -29,6 +29,10 @@ import org.apache.poi.util.RecordFormatException;
 import org.apache.poi.xdgf.usermodel.XmlVisioDocument;
 
 public class POIVisioFuzzer {
+	public static void fuzzerInitialize() {
+		POIFuzzer.adjustLimits();
+	}
+
 	public static void fuzzerTestOneInput(byte[] input) {
 		try (XmlVisioDocument visio = new XmlVisioDocument(new ByteArrayInputStream(input))) {
 			visio.write(NullOutputStream.INSTANCE);

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIXSLFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIXSLFFuzzer.java
@@ -20,8 +20,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
 import org.apache.commons.io.output.NullOutputStream;
-import org.apache.poi.EmptyFileException;
-import org.apache.poi.UnsupportedFileFormatException;
 import org.apache.poi.ooxml.POIXMLException;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.openxml4j.exceptions.OpenXML4JException;
@@ -37,8 +35,8 @@ public class POIXSLFFuzzer {
 	public static void fuzzerTestOneInput(byte[] input) {
 		try (XMLSlideShow slides = new XMLSlideShow(new ByteArrayInputStream(input))) {
 			slides.write(NullOutputStream.INSTANCE);
-		} catch (IOException | EmptyFileException | UnsupportedFileFormatException | POIXMLException |
-				 RecordFormatException | OpenXML4JRuntimeException | IndexOutOfBoundsException e) {
+		} catch (IOException | POIXMLException | RecordFormatException | OpenXML4JRuntimeException |
+				 IndexOutOfBoundsException | IllegalArgumentException e) {
 			// expected here
 		}
 

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIXSLFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIXSLFFuzzer.java
@@ -32,6 +32,10 @@ import org.apache.poi.xslf.usermodel.XSLFSlideShow;
 import org.apache.xmlbeans.XmlException;
 
 public class POIXSLFFuzzer {
+	public static void fuzzerInitialize() {
+		POIFuzzer.adjustLimits();
+	}
+
 	public static void fuzzerTestOneInput(byte[] input) {
 		try (XMLSlideShow slides = new XMLSlideShow(new ByteArrayInputStream(input))) {
 			slides.write(NullOutputStream.INSTANCE);

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIXSSFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIXSSFFuzzer.java
@@ -31,6 +31,10 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.apache.xmlbeans.XmlException;
 
 public class POIXSSFFuzzer {
+	public static void fuzzerInitialize() {
+		POIFuzzer.adjustLimits();
+	}
+
 	public static void fuzzerTestOneInput(byte[] input) {
 		try (XSSFWorkbook wb = new XSSFWorkbook(new ByteArrayInputStream(input))) {
 			try (SXSSFWorkbook swb = new SXSSFWorkbook(wb)) {

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIXWPFFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIXWPFFuzzer.java
@@ -28,6 +28,10 @@ import org.apache.poi.xwpf.extractor.XWPFWordExtractor;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
 
 public class POIXWPFFuzzer {
+	public static void fuzzerInitialize() {
+		POIFuzzer.adjustLimits();
+	}
+
 	@SuppressWarnings("ResultOfMethodCallIgnored")
 	public static void fuzzerTestOneInput(byte[] input) {
 		try (XWPFDocument doc = new XWPFDocument(new ByteArrayInputStream(input))) {

--- a/projects/apache-poi/src/main/java/org/apache/poi/XLSX2CSVFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/XLSX2CSVFuzzer.java
@@ -30,6 +30,10 @@ import org.apache.poi.util.RecordFormatException;
 import org.xml.sax.SAXException;
 
 public class XLSX2CSVFuzzer {
+	public static void fuzzerInitialize() {
+		POIFuzzer.adjustLimits();
+	}
+
 	public static void fuzzerTestOneInput(byte[] input) {
 		try (InputStream in = new ByteArrayInputStream(input)) {
 			OPCPackage p = OPCPackage.open(in);

--- a/projects/apache-poi/src/main/java/org/apache/poi/XLSX2CSVFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/XLSX2CSVFuzzer.java
@@ -24,6 +24,7 @@ import org.apache.commons.io.output.NullPrintStream;
 import org.apache.poi.examples.xssf.eventusermodel.XLSX2CSV;
 import org.apache.poi.ooxml.POIXMLException;
 import org.apache.poi.openxml4j.exceptions.OpenXML4JException;
+import org.apache.poi.openxml4j.exceptions.OpenXML4JRuntimeException;
 import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.util.RecordFormatException;
 import org.xml.sax.SAXException;
@@ -36,8 +37,8 @@ public class XLSX2CSVFuzzer {
 			xlsx2csv.process();
 		} catch (IOException | OpenXML4JException | SAXException |
 				 POIXMLException | RecordFormatException |
-				IllegalStateException | IllegalArgumentException |
-				IndexOutOfBoundsException e) {
+				 IllegalStateException | IllegalArgumentException |
+				 IndexOutOfBoundsException | OpenXML4JRuntimeException e) {
 			// expected here
 		}
 	}


### PR DESCRIPTION
As a general solution for handling excluding classes from JaCoCo coverage counting was not merged (See #10860#issuecomment-1870891873 ), this PR tries to implement a different approach which separates the class-files into two jar-files and this way at least allows to exclude code of third-party libraries when reporting coverage of fuzzing.

Also add two expected exceptions and adjust one limit to match the amount of memory which oss-fuzz uses here.
