### PR TITLE
Proposing new project: Python cbor2

### DIFF
--- a/projects/cbor2/Dockerfile
+++ b/projects/cbor2/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/cbor2/Dockerfile
+++ b/projects/cbor2/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-python
+RUN git clone --depth 1 https://github.com/agronholm/cbor2.git
+WORKDIR cbor2
+COPY build.sh *.py $SRC/

--- a/projects/cbor2/build.sh
+++ b/projects/cbor2/build.sh
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/cbor2/build.sh
+++ b/projects/cbor2/build.sh
@@ -1,0 +1,27 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Ensure C extension gets built
+export CBOR2_BUILD_C_EXTENSION=1
+
+# Build and install project (using current CFLAGS, CXXFLAGS). This is required
+# for projects with C extensions so that they're built with the proper flags.
+pip3 install .
+
+# Build fuzzers in $OUT.
+for fuzzer in $(find $SRC -name '*_fuzzer.py'); do
+    compile_python_fuzzer $fuzzer
+done

--- a/projects/cbor2/loads_fuzzer.py
+++ b/projects/cbor2/loads_fuzzer.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/cbor2/loads_fuzzer.py
+++ b/projects/cbor2/loads_fuzzer.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python3
+
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+import sys
+import atheris
+
+# _cbor2 ensures the C library is imported
+from _cbor2 import loads
+
+
+def test_one_input(data: bytes):
+    try:
+        loads(data)
+    except Exception:
+        # We're searching for memory corruption, not Python exceptions
+        pass
+
+
+def main():
+    atheris.Setup(sys.argv, test_one_input)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/cbor2/project.yaml
+++ b/projects/cbor2/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/agronholm/cbor2"
+main_repo: "https://github.com/agronholm/cbor2"
+language: python
+primary_contact: "alex.gronholm@nextday.fi"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+  - undefined


### PR DESCRIPTION
`cbor2` is a Python CBOR (de)serializer with extensive tag support.

It has nearly [2,000 dependents](https://github.com/agronholm/cbor2/network/dependents) on GitHub. It's used by many large blockchain projects, such as:

- https://github.com/bitcoin-core/HWI
- https://github.com/Blockstream/Jade
- https://github.com/vyperlang/vyper
- https://github.com/lidofinance/lido-dao
- https://github.com/fetchai/cosmpy
- https://github.com/OpShin/opshin

And other non-blockchain projects, such as:

- https://github.com/project-chip/connectedhomeip
- https://github.com/pritunl/pritunl
- https://github.com/amazon-ion/ion-python

I received approval from this project here: https://github.com/agronholm/cbor2/pull/204#issuecomment-1874467670