### PR TITLE
jackson-dataformats-binary: fix fuzzer blockage

### DIFF
--- a/projects/jackson-dataformats-binary/AvroGeneratorFuzzer.java
+++ b/projects/jackson-dataformats-binary/AvroGeneratorFuzzer.java
@@ -27,14 +27,10 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.HashMap;
 
 /** This fuzzer targets the methods of AvroGenerator */
 public class AvroGeneratorFuzzer {
-  private static final String[] fieldNameChoice = {
-    "string", "i", "bo", "b", "c", "d", "f", "s", "l",
-    "bd", "ba", "da", "la", "ia", "obj"
-  };
-
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     try {
       // Retrieve set of AvroGenerator.Feature
@@ -75,23 +71,27 @@ public class AvroGeneratorFuzzer {
       // Fuzz methods of CBORGenerator
       String value = null;
       byte[] byteArray = null;
-      generator.writeFieldName(data.pickValue(fieldNameChoice));
       switch (data.consumeInt(1, 18)) {
         case 1:
+          generator.writeFieldName("bo");
           generator.writeBoolean(data.consumeBoolean());
           break;
         case 2:
+          generator.writeFieldName("obj");
           generator.writeNull();
           break;
         case 3:
+          generator.writeFieldName("ia");
           int[] intArray = data.consumeInts(data.consumeInt(1, 5));
           generator.writeArray(intArray, 0, intArray.length);
           break;
         case 4:
+          generator.writeFieldName("la");
           long[] longArray = data.consumeLongs(data.consumeInt(1, 5));
           generator.writeArray(longArray, 0, longArray.length);
           break;
         case 5:
+          generator.writeFieldName("da");
           double[] doubleArray = new double[data.consumeInt(1, 5)];
           for (int i = 0; i < doubleArray.length; i++) {
             doubleArray[i] = data.consumeDouble();
@@ -99,53 +99,66 @@ public class AvroGeneratorFuzzer {
           generator.writeArray(doubleArray, 0, doubleArray.length);
           break;
         case 6:
+          generator.writeFieldName("string");
           generator.writeString(data.consumeRemainingAsString());
           break;
         case 7:
+          generator.writeFieldName("string");
           value = data.consumeRemainingAsString();
           generator.writeString(value.toCharArray(), 0, value.length());
           break;
         case 8:
+          generator.writeFieldName("string");
           generator.writeString(new SerializedString(data.consumeRemainingAsString()));
           break;
         case 9:
+          generator.writeFieldName("string");
           byteArray = data.consumeRemainingAsBytes();
           generator.writeRawUTF8String(byteArray, 0, byteArray.length);
           break;
         case 10:
+          generator.writeFieldName("ba");
           byteArray = data.consumeRemainingAsBytes();
           generator.writeUTF8String(byteArray, 0, byteArray.length);
           break;
         case 11:
+          generator.writeFieldName("ba");
           byteArray = data.consumeRemainingAsBytes();
           generator.writeBinary(new ByteArrayInputStream(byteArray), byteArray.length);
           break;
         case 12:
+          generator.writeFieldName("i");
           generator.writeNumber(data.consumeInt());
           break;
         case 13:
+          generator.writeFieldName("l");
           generator.writeNumber(data.consumeLong());
           break;
         case 14:
+          generator.writeFieldName("d");
           generator.writeNumber(data.consumeDouble());
           break;
         case 15:
+          generator.writeFieldName("f");
           generator.writeNumber(data.consumeFloat());
           break;
         case 16:
+          generator.writeFieldName("bd");
           generator.writeNumber(new BigDecimal(data.consumeLong()));
           break;
         case 17:
+          generator.writeFieldName("bi");
           generator.writeNumber(BigInteger.valueOf(data.consumeLong()));
           break;
         case 18:
+          generator.writeFieldName("obj");
           generator.writeNumber(data.consumeRemainingAsString());
           break;
       }
 
       generator.flush();
       generator.close();
-    } catch (IOException | IllegalArgumentException | IllegalStateException e) {
+    } catch (IOException | IllegalArgumentException | IllegalStateException | UnsupportedOperationException e) {
       // Known exception
     }
   }
@@ -154,13 +167,12 @@ public class AvroGeneratorFuzzer {
     public String string;
     public int i;
     public boolean bo;
-    public byte b;
-    public char c;
     public double d;
     public float f;
     public short s;
     public long l;
     public BigDecimal bd;
+    public BigInteger bi;
     public byte[] ba;
     public double[] da;
     public long[] la;

--- a/projects/jackson-dataformats-binary/AvroParserFuzzer.java
+++ b/projects/jackson-dataformats-binary/AvroParserFuzzer.java
@@ -14,12 +14,15 @@
 //
 ///////////////////////////////////////////////////////////////////////////
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.dataformat.avro.AvroFactory;
 import com.fasterxml.jackson.dataformat.avro.AvroFactoryBuilder;
 import com.fasterxml.jackson.dataformat.avro.AvroMapper;
 import com.fasterxml.jackson.dataformat.avro.AvroParser;
+import com.fasterxml.jackson.dataformat.avro.schema.AvroSchemaGenerator;
 import java.io.IOException;
 import java.util.EnumSet;
+import java.util.List;
 
 /** This fuzzer targets the methods of AvroParser */
 public class AvroParserFuzzer {
@@ -52,6 +55,11 @@ public class AvroParserFuzzer {
       // Create and configure AvroParser
       AvroParser parser =
           ((AvroMapper) mapper).getFactory().createParser(data.consumeRemainingAsBytes());
+
+      AvroSchemaGenerator schemaGenerator = new AvroSchemaGenerator();
+      mapper.acceptJsonFormatVisitor(RootType.class, schemaGenerator);
+
+      parser.setSchema(schemaGenerator.getGeneratedSchema());
 
       // Fuzz methods of AvroParser
       for (Integer choice : choices) {
@@ -120,5 +128,14 @@ public class AvroParserFuzzer {
     } catch (IOException | IllegalArgumentException | IllegalStateException e) {
       // Known exception
     }
+  }
+
+  private static class RootType {
+    @JsonAlias({"nm", "Name"})
+    public String name;
+
+    public int value;
+
+    List<String> other;
   }
 }

--- a/projects/jackson-dataformats-binary/CborGeneratorFuzzer.java
+++ b/projects/jackson-dataformats-binary/CborGeneratorFuzzer.java
@@ -56,6 +56,7 @@ public class CborGeneratorFuzzer {
       // Fuzz methods of CBORGenerator
       String value = null;
       byte[] byteArray = null;
+      generator.writeFieldName("OSS-Fuzz");
       switch (data.consumeInt(1, 18)) {
         case 1:
           generator.writeBoolean(data.consumeBoolean());

--- a/projects/jackson-dataformats-binary/CborParserFuzzer.java
+++ b/projects/jackson-dataformats-binary/CborParserFuzzer.java
@@ -26,16 +26,9 @@ public class CborParserFuzzer {
     try {
       int[] choices = data.consumeInts(data.consumeInt(1, 100));
 
-      // Retrieve set of CBORParser.Feature
-      EnumSet<CBORParser.Feature> featureSet = EnumSet.allOf(CBORParser.Feature.class);
-
       // Create and configure CBORParser
       CBORMapper mapper =
-          new CBORMapper(
-              CBORFactory.builder()
-                  .enable(data.pickValue(featureSet))
-                  .disable(data.pickValue(featureSet))
-                  .build());
+          new CBORMapper(CBORFactory.builder().build());
 
       // Failsafe logic
       if (mapper == null) {

--- a/projects/jackson-dataformats-binary/IonGeneratorFuzzer.java
+++ b/projects/jackson-dataformats-binary/IonGeneratorFuzzer.java
@@ -66,6 +66,7 @@ public class IonGeneratorFuzzer {
       // Fuzz methods of ProtobufGenerator
       String value = null;
       byte[] byteArray = null;
+      generator.writeFieldName("OSS-Fuzz");
       switch (data.consumeInt(1, 18)) {
         case 1:
           generator.writeBoolean(data.consumeBoolean());

--- a/projects/jackson-dataformats-binary/ProtobufParserFuzzer.java
+++ b/projects/jackson-dataformats-binary/ProtobufParserFuzzer.java
@@ -36,6 +36,8 @@ public class ProtobufParserFuzzer {
       ProtobufParser parser =
           ((ProtobufMapper) mapper).getFactory().createParser(data.consumeRemainingAsBytes());
 
+      parser.setSchema(mapper.generateSchemaFor(ProtobufParserFuzzer.class));
+
       // Fuzz methods of ProtobufParser
       for (Integer choice : choices) {
         switch (Math.abs(choice) % 19) {

--- a/projects/jackson-dataformats-binary/SmileGeneratorFuzzer.java
+++ b/projects/jackson-dataformats-binary/SmileGeneratorFuzzer.java
@@ -37,7 +37,6 @@ public class SmileGeneratorFuzzer {
           new SmileMapper(
               SmileFactory.builder()
                   .enable(data.pickValue(featureSet))
-                  .disable(data.pickValue(featureSet))
                   .build());
 
       // Failsafe logic
@@ -56,6 +55,7 @@ public class SmileGeneratorFuzzer {
       // Fuzz methods of SmileGenerator
       String value = null;
       byte[] byteArray = null;
+      generator.writeFieldName("OSS-Fuzz");
       switch (data.consumeInt(1, 20)) {
         case 1:
           generator.writeRaw(data.consumeByte());
@@ -133,7 +133,7 @@ public class SmileGeneratorFuzzer {
       generator.writeEndObject();
       generator.flush();
       generator.close();
-    } catch (IOException | IllegalArgumentException | IllegalStateException e) {
+    } catch (IOException | IllegalArgumentException | IllegalStateException | UnsupportedOperationException e) {
       // Known exception
     }
   }


### PR DESCRIPTION
This PR fixes multiple fuzzers in project jackson-dataformats-binary. The fixes majorly focus on some exception blockers of fuzzers due to insufficient initialisation of the objects.