### PR TITLE
Remove a cc for fuzz bugs for Wasmtime

### DIFF
--- a/projects/wasmtime/project.yaml
+++ b/projects/wasmtime/project.yaml
@@ -10,7 +10,6 @@ auto_ccs:
   - "peterhuene@gmail.com"
   - "jsharp@fastly.com"
   - "telliott@fastly.com"
-  - "rsinclair@fastly.com"
 sanitizers:
   - address
 fuzzing_engines:


### PR DESCRIPTION
I believe that Rainy is no longer looking to get cc'd on these issues.