### PR TITLE
Get -std=... from runConfigureICU instead of hardcoding it

### DIFF
--- a/projects/icu/build.sh
+++ b/projects/icu/build.sh
@@ -33,7 +33,10 @@ export UBSAN_OPTIONS="detect_leaks=0"
 
 make -j$(nproc)
 
-$CXX $CXXFLAGS -std=c++11 -c $SRC/icu/icu4c/source/test/fuzzer/locale_util.cpp \
+# Pick up additional flags (-std=...) added by runConfigureICU.
+CXXFLAGS="$CXXFLAGS $(config/icu-config --noverify --cxxflags)"
+
+$CXX $CXXFLAGS -c $SRC/icu/icu4c/source/test/fuzzer/locale_util.cpp \
      -I$SRC/icu/icu4c/source/common \
      -I$SRC/icu4c/source/test/fuzzer
 
@@ -43,7 +46,7 @@ FUZZERS=$FUZZER_PATH/*_fuzzer.cpp
 
 for fuzzer in $FUZZERS; do
   file=${fuzzer:${#FUZZER_PATH}+1}
-  $CXX $CXXFLAGS -std=c++11 \
+  $CXX $CXXFLAGS \
     $fuzzer -o $OUT/${file/.cpp/} locale_util.o \
     -I$SRC/icu/icu4c/source/common -I$SRC/icu/icu4c/source/i18n -L$WORK/icu/lib \
     $LIB_FUZZING_ENGINE -licui18n -licuuc -licutu -licudata


### PR DESCRIPTION
ICU4C nowadays requires C11 & C++17 so it'd be better if the oss-fuzz configuration didn't hardcode the standard versions required.