### PR TITLE
libheif: repository of x265 dependency changed

### DIFF
--- a/projects/libheif/Dockerfile
+++ b/projects/libheif/Dockerfile
@@ -34,9 +34,8 @@ RUN git clone \
     https://github.com/strukturag/libde265.git \
     libde265
 
-RUN hg clone \
-    --branch stable \
-    http://hg.videolan.org/x265 \
+RUN git clone \
+    https://bitbucket.org/multicoreware/x265_git/src/stable/ \
     x265
 
 RUN git clone \


### PR DESCRIPTION
The x265 project has changed their repository location, the old one is not accessible anymore.
Source: https://www.videolan.org/developers/x265.html

https://github.com/strukturag/libheif/pull/1099#issuecomment-1884035385
