### PR TITLE
Update from tendermint to new cosmos-sdk dependency cometbft

### DIFF
--- a/projects/tendermint/Dockerfile
+++ b/projects/tendermint/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
-RUN git clone https://github.com/tendermint/tendermint
+RUN git clone https://github.com/cometbft/cometbft
 
 COPY build.sh $SRC
-WORKDIR $SRC/tendermint
+WORKDIR $SRC/cometbft

--- a/projects/tendermint/project.yaml
+++ b/projects/tendermint/project.yaml
@@ -1,4 +1,4 @@
-homepage: "https://github.com/tendermint/tendermint"
+homepage: "https://github.com/cometbft/cometbft"
 primary_contact: "security@interchain.io"
 auto_ccs:
   - fuzzing@orijtech.com
@@ -12,4 +12,4 @@ fuzzing_engines:
   - libfuzzer
 sanitizers:
   - address
-main_repo: "https://github.com/tendermint/tendermint"
+main_repo: "https://github.com/cometbft/cometbft"


### PR DESCRIPTION
We maintain security for cometbft which forked off from tendermint and cometbft is maintained by the teams that use the cosmos-sdk and that powers the Cosmos/Interchain ecosystem.