### PR TITLE
Few fixes to infra/cifuzz/example_cifuzz.yml.

### DIFF
--- a/infra/cifuzz/example_cifuzz.yml
+++ b/infra/cifuzz/example_cifuzz.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         oss-fuzz-project-name: 'example'
         fuzz-seconds: 600
+        output-sarif: true
     - name: Upload Crash
       uses: actions/upload-artifact@v3
       if: failure() && steps.build.outcome == 'success'

--- a/infra/cifuzz/example_cifuzz.yml
+++ b/infra/cifuzz/example_cifuzz.yml
@@ -23,10 +23,10 @@ jobs:
       with:
         name: artifacts
         path: ./out/artifacts   
-   - name: Upload Sarif
-    if: always() && steps.build.outcome == 'success'
-    uses: github/codeql-action/upload-sarif@v2
-    with:
-      # Path to SARIF file relative to the root of the repository
-      sarif_file: cifuzz-sarif/results.sarif
-      checkout_path: cifuzz-sarif
+    - name: Upload Sarif
+      if: always() && steps.build.outcome == 'success'
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        # Path to SARIF file relative to the root of the repository
+        sarif_file: cifuzz-sarif/results.sarif
+        checkout_path: cifuzz-sarif


### PR DESCRIPTION
When tried to enable CI fuzzing for md4c project as described at https://google.github.io/oss-fuzz/getting-started/continuous-integration/, encountered some issues:

- Broken indentation.
- The step "Upload Sarif" fails (and I'm not the 1st one to encounter it: See #10915)

These changes seem to fix it for me.
