### PR TITLE
Fix bs4 build

### DIFF
--- a/projects/bs4/Dockerfile
+++ b/projects/bs4/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-python
 
-RUN apt-get install -y bzr python-lxml python-html5lib
+RUN apt-get install -y bzr python-lxml python-html5lib libxslt-dev libxml2-dev zlib1g-dev
 RUN pip3 install soupsieve html5lib lxml
 RUN pip3 install bzr+lp:beautifulsoup
 


### PR DESCRIPTION
```
Step #1: Step 3/5 : RUN pip3 install soupsieve html5lib lxml
Step #1:  ---> Running in 95c0ff529f3c
Step #1: Collecting soupsieve
Step #1:   Downloading https://files.pythonhosted.org/packages/4c/f3/038b302fdfbe3be7da016777069f26ceefe11a681055ea1f7817546508e3/soupsieve-2.5-py3-none-any.whl
Step #1: Collecting html5lib
Step #1:   Downloading https://files.pythonhosted.org/packages/6c/dd/a834df6482147d48e225a49515aabc28974ad5a4ca3215c18a882565b028/html5lib-1.1-py2.py3-none-any.whl (112kB)
Step #1: Collecting lxml
Step #1:   Downloading https://files.pythonhosted.org/packages/2b/b4/bbccb250adbee490553b6a52712c46c20ea1ba533a643f1424b27ffc6845/lxml-5.1.0.tar.gz (3.8MB)
Step #1:   Installing build dependencies: started
Step #1:   Installing build dependencies: finished with status 'done'
Step #1:   Getting requirements to build wheel: started
Step #1:   Getting requirements to build wheel: finished with status 'error'
Step #1: [91m  ERROR: Command errored out with exit status 1:
Step #1:    command: /usr/local/bin/python3.8 /usr/local/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /tmp/tmpffkvuryp
Step #1:        cwd: /tmp/pip-install-kbqwq5f7/lxml
Step #1:   Complete output (4 lines):
Step #1:   <string>:67: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
Step #1:   Building lxml version 5.1.0.
Step #1:   Building without Cython.
Step #1:   Error: Please make sure the libxml2 and libxslt development packages are installed.
```