### PR TITLE
[bignum-fuzzer] Update mpdecimal to version 4.0.0

### DIFF
--- a/projects/bignum-fuzzer/Dockerfile
+++ b/projects/bignum-fuzzer/Dockerfile
@@ -31,7 +31,7 @@ RUN git clone --depth 1 -b development https://github.com/Mbed-TLS/mbedtls
 # Install Python packages from PyPI
 RUN pip3 install -r $SRC/mbedtls/scripts/basic.requirements.txt
 
-RUN wget https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.5.1.tar.gz
+RUN wget https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-4.0.0.tar.gz
 RUN git clone --depth 1 https://github.com/guidovranken/bignum-fuzzer
 RUN git clone --depth 1 https://github.com/openssl/openssl
 RUN git clone https://boringssl.googlesource.com/boringssl

--- a/projects/bignum-fuzzer/build.sh
+++ b/projects/bignum-fuzzer/build.sh
@@ -20,8 +20,8 @@
 #source $HOME/.cargo/env
 
 # Build libmpdec
-tar zxf mpdecimal-2.5.1.tar.gz
-cd mpdecimal-2.5.1
+tar zxf mpdecimal-4.0.0.tar.gz
+cd mpdecimal-4.0.0
 ./configure && make -j$(nproc)
 
 cd $SRC/openssl
@@ -60,7 +60,7 @@ LIBGMP_INCLUDE_PATH=$SRC/libgmp LIBGMP_A_PATH=$SRC/libgmp/.libs/libgmp.a make
 
 # Build libmpdec module
 cd $SRC/bignum-fuzzer/modules/libmpdec
-LIBMPDEC_A_PATH=$SRC/mpdecimal-2.5.1/libmpdec/libmpdec.a LIBMPDEC_INCLUDE_PATH=$SRC/mpdecimal-2.5.1/libmpdec make
+LIBMPDEC_A_PATH=$SRC/mpdecimal-4.0.0/libmpdec/libmpdec.a LIBMPDEC_INCLUDE_PATH=$SRC/mpdecimal-4.0.0/libmpdec make
 
 BASE_CXXFLAGS=$CXXFLAGS
 

--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -48,7 +48,7 @@ RUN git clone --depth 1 https://github.com/libtom/libtomcrypt.git
 RUN git clone --depth 1 https://github.com/microsoft/SymCrypt.git
 RUN hg clone https://gmplib.org/repo/gmp/ libgmp/ || \
     (wget 'https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz' && tar xf gmp-6.2.1.tar.lz && mv $SRC/gmp-6.2.1/ $SRC/libgmp/)
-RUN wget https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.5.1.tar.gz
+RUN wget https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-4.0.0.tar.gz
 RUN git clone --depth 1 https://github.com/indutny/bn.js.git
 RUN git clone --depth 1 https://github.com/MikeMcl/bignumber.js.git
 RUN git clone --depth 1 https://github.com/guidovranken/libfuzzer-js.git

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -322,8 +322,8 @@ make -B
 
 # Compile mpdecimal
 cd $SRC/
-tar zxf mpdecimal-2.5.1.tar.gz
-cd mpdecimal-2.5.1/
+tar zxf mpdecimal-4.0.0.tar.gz
+cd mpdecimal-4.0.0/
 ./configure
 cd libmpdec/
 make libmpdec.a -j$(nproc)


### PR DESCRIPTION
mpdecimal-4.0.0 has been released:

https://www.bytereef.org/mpdecimal/changelog.html

It would be nice to update the fuzzer.