### PR TITLE
jackson-dataforamts-binary: Wrap expected exceptions

### DIFF
--- a/projects/jackson-dataformats-binary/CborParserFuzzer.java
+++ b/projects/jackson-dataformats-binary/CborParserFuzzer.java
@@ -105,6 +105,11 @@ public class CborParserFuzzer {
       parser.close();
     } catch (IOException | IllegalArgumentException | IllegalStateException e) {
       // Known exception
+    } catch (RuntimeException e) {
+      // Catch known internal exception
+      if (!e.getMessage().contains("Internal error")) {
+        throw e;
+      }
     }
   }
 }


### PR DESCRIPTION
This PR fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=65748 in `CborParserFuzzer` by wrapping an expected exception.