### PR TITLE
arrow: Add Felipe Oliveira Carvalho to ccs

### DIFF
--- a/projects/arrow/project.yaml
+++ b/projects/arrow/project.yaml
@@ -4,6 +4,7 @@ primary_contact: "antoine@python.org"
 auto_ccs:
   - "bengilgit@gmail.com"
   - "emkornfield@gmail.com"
+  - "felipekde@gmail.com"
   - "fsaintjacques@gmail.com"
   - "jinpengz@google.com"
   - "micahk@google.com"


### PR DESCRIPTION
Felipe Oliveira Carvalho is a committer on Apache Arrow and works actively on Arrow C++ maintenance. He would like to be involved in handling issues detected by OSS-Fuzz.