### PR TITLE
Refactoring Build Logic and Updating 'auto_ccs' with New Contributors Aptos-Core

### DIFF
--- a/projects/aptos-core/build.sh
+++ b/projects/aptos-core/build.sh
@@ -15,12 +15,5 @@
 #
 ################################################################################
 
-NIGHTLY_VERSION="nightly"
-
-rustup install $NIGHTLY_VERSION
 cd testsuite/fuzzer
-
-RUSTFLAGS="$RUSTFLAGS --cfg tokio_unstable" cargo +$NIGHTLY_VERSION fuzz build -O -a
-for fuzzer in $(cat fuzz/Cargo.toml | grep "name = " | grep -v "fuzzer-fuzz" | cut -d'"' -f2); do
-  cp ../../target/x86_64-unknown-linux-gnu/release/$fuzzer $OUT/
-done
+bash fuzz.sh build-oss-fuzz $OUT

--- a/projects/aptos-core/project.yaml
+++ b/projects/aptos-core/project.yaml
@@ -5,6 +5,8 @@ main_repo: "https://github.com/aptos-labs/aptos-core"
 auto_ccs:
   - "oss-fuzz-notifications@aptoslabs.com"
   - "security@aptoslabs.com"
+  - "andrea.cappa@aptoslabs.com"
+  - "marco.ilardi@aptoslabs.com"
 sanitizers:
   - address
 fuzzing_engines:


### PR DESCRIPTION
This Pull Request introduces significant updates to our project's build process. The changes are twofold:

- Refactoring Build Process: In alignment with our internal design choices, this PR shifts the majority of the logic previously encapsulated within build.sh to our own fuzzer build script. This move is aimed at improving the modularity and maintainability of our build process.
- Updating 'auto_ccs': This PR includes an update to the auto_ccs section of our project, so we can sign in on the Dashboard.

Thanks.