### PR TITLE
protobuf-python: Fix build

### DIFF
--- a/projects/protobuf-python/Dockerfile
+++ b/projects/protobuf-python/Dockerfile
@@ -17,5 +17,5 @@
 FROM gcr.io/oss-fuzz-base/base-builder-python
 RUN curl -L -O https://raw.githubusercontent.com/protobuf-c/protobuf-c/39cd58f5ff06048574ed5ce17ee602dc84006162/t/test-full.proto
 RUN git clone https://github.com/protocolbuffers/protobuf.git
-RUN cd protobuf && bazel build --nobuild //:protoc @upb//python/dist:binary_wheel
+RUN cd protobuf && bazel build --nobuild //:protoc //python/dist:binary_wheel
 COPY build.sh fuzz_* $SRC/

--- a/projects/protobuf-python/build.sh
+++ b/projects/protobuf-python/build.sh
@@ -30,7 +30,7 @@ cd $SRC/protobuf
   type -a python3
   /usr/bin/python3 --version
 )
-bazel build $BAZEL_FLAGS //:protoc @upb//python/dist:binary_wheel
+bazel build $BAZEL_FLAGS //:protoc //python/dist:binary_wheel
 PROTOC=$(realpath bazel-bin/protoc)
 
 # Install the protobuf python runtime.


### PR DESCRIPTION
We have merged the upb repo into the main protobuf repo, so the reference to `@upb` is no longer valid. This change should fix the protobuf-python build.