### PR TITLE
Project Request: iverilog

### DIFF
--- a/projects/iverilog/project.yaml
+++ b/projects/iverilog/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://steveicarus.github.io/iverilog"
+language: c++
+primary_contact: "steve@icarus.com"
+auto_ccs:
+  - "capuanobailey@gmail.com"
+main_repo: "https://github.com/steveicarus/iverilog"


### PR DESCRIPTION
I am requesting permission to integrate [iverilog](https://github.com/steveicarus/iverilog) into OSSFuzz. I believe that this project is a good candidate for OSS-Fuzz integration as it serves as a preeminent compiler for Verilog HDL. As such, it directly preprocesses, parses, and compiles user-inputted VHDL programs, opening it up to a wide array of edge cases in capturing a complex language grammar and the potential for memory vulnerabilities (being written in C++). 