### PR TITLE
fix(nokogiri): pass CFLAGS and CXXFLAGS to the make command

### DIFF
--- a/projects/nokogiri/Dockerfile
+++ b/projects/nokogiri/Dockerfile
@@ -17,6 +17,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get --no-install-recommends install -y build-essential make curl wget
 
-RUN git clone https://github.com/sparklemotion/nokogiri.git
+RUN git clone --depth=1 https://github.com/sparklemotion/nokogiri.git
 
 COPY build.sh $SRC

--- a/projects/nokogiri/build.sh
+++ b/projects/nokogiri/build.sh
@@ -15,4 +15,4 @@
 ###############################################################################
 
 cd nokogiri/gumbo-parser
-make oss-fuzz
+make oss-fuzz CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS"


### PR DESCRIPTION
Without these flags being set properly, the build has been failing, see https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=65904

Also: use a shallow git clone when building the container

(Solves issue introduced in #11494 /cc @fuzzy-boiii23a)