### PR TITLE
target_experiment: Avoid rate limiting issues with cloudbuild get.

### DIFF
--- a/infra/build/functions/build_lib.py
+++ b/infra/build/functions/build_lib.py
@@ -619,7 +619,7 @@ def wait_for_build(build_id, credentials, cloud_project):
     except googleapiclient.errors.HttpError:
       pass
 
-    time.sleep(10)  # Avoid rate limiting.
+    time.sleep(15)  # Avoid rate limiting.
 
 
 def cancel_build(build_id, credentials, cloud_project):

--- a/infra/build/functions/build_lib.py
+++ b/infra/build/functions/build_lib.py
@@ -569,16 +569,20 @@ def run_build(  # pylint: disable=too-many-arguments
     with tempfile.NamedTemporaryFile(suffix='build.json') as config_file:
       config_file.write(bytes(json.dumps(build_body), 'utf-8'))
       config_file.seek(0)
-      subprocess.run([
+      result = subprocess.run([
           'gcloud',
           'builds',
           'submit',
           '--project=oss-fuzz',
           f'--config={config_file.name}',
+          '--async',
+          '--format=get(id)',
       ],
-                     cwd=OSS_FUZZ_ROOT)
-
-      return 'NO-ID'  # Doesn't matter, this is just printed to the user.
+                              stdout=subprocess.PIPE,
+                              cwd=OSS_FUZZ_ROOT,
+                              encoding='utf-8',
+                              check=True)
+      return result.stdout.strip()
 
   cloudbuild = cloud_build('cloudbuild',
                            'v1',
@@ -594,3 +598,37 @@ def run_build(  # pylint: disable=too-many-arguments
   logging.info(f'{oss_fuzz_project}. logs: {get_logs_url(build_id)}. '
                f'GCB page: {get_gcb_url(build_id, cloud_project)}')
   return build_id
+
+
+def wait_for_build(build_id, credentials, cloud_project):
+  """Wait for a GCB build."""
+  cloudbuild = cloud_build('cloudbuild',
+                           'v1',
+                           credentials=credentials,
+                           cache_discovery=False,
+                           client_options=US_CENTRAL_CLIENT_OPTIONS)
+
+  while True:
+    try:
+      status = cloudbuild.projects().builds().get(projectId=cloud_project,
+                                                  id=build_id).execute()
+      if status.get('status') in ('SUCCESS', 'FAILURE', 'TIMEOUT',
+                                  'INTERNAL_ERROR', 'EXPIRED', 'CANCELLED'):
+        # Build done.
+        return
+    except googleapiclient.errors.HttpError:
+      pass
+
+    time.sleep(10)  # Avoid rate limiting.
+
+
+def cancel_build(build_id, credentials, cloud_project):
+  """Cancel a GCB build"""
+  cloudbuild = cloud_build('cloudbuild',
+                           'v1',
+                           credentials=credentials,
+                           cache_discovery=False,
+                           client_options=US_CENTRAL_CLIENT_OPTIONS)
+  # TODO(ochang): Avoid hardcoding us-central1.
+  cloudbuild.projects().builds().cancel(projectId=cloud_project,
+                                        id=build_id).execute()

--- a/infra/build/functions/build_lib.py
+++ b/infra/build/functions/build_lib.py
@@ -629,6 +629,5 @@ def cancel_build(build_id, credentials, cloud_project):
                            credentials=credentials,
                            cache_discovery=False,
                            client_options=US_CENTRAL_CLIENT_OPTIONS)
-  # TODO(ochang): Avoid hardcoding us-central1.
   cloudbuild.projects().builds().cancel(projectId=cloud_project,
                                         id=build_id).execute()

--- a/infra/build/functions/target_experiment.py
+++ b/infra/build/functions/target_experiment.py
@@ -179,13 +179,22 @@ def run_experiment(project_name, target_name, args, output_path,
   })
 
   credentials, _ = google.auth.default()
-  return build_project.run_build(
-      project_name,
-      steps,
-      credentials,
-      'experiment',
-      experiment=True,
-      extra_tags=[f'experiment-{experiment_name}', f'experiment-{project_name}'])
+  build_id = build_project.run_build(project_name,
+                                     steps,
+                                     credentials,
+                                     'experiment',
+                                     experiment=True,
+                                     extra_tags=[
+                                         f'experiment-{experiment_name}',
+                                         f'experiment-{project_name}'
+                                     ])
+
+  print('Waiting for build', build_id)
+  try:
+    build_lib.wait_for_build(build_id, credentials, 'oss-fuzz')
+  except (KeyboardInterrupt, SystemExit):
+    # Cancel the build on exit, to avoid dangling builds.
+    build_lib.cancel_build(build_id, credentials, 'oss-fuzz')
 
 
 def main():


### PR DESCRIPTION
Instead of relying on `gcloud builds submit` to poll the status of the build for us, we poll ourselves.

This is because `gcloud builds submit` has a fixed poll interval of 1 second.