### PR TITLE
Turn off ubsan enum check for ICU project

### DIFF
--- a/projects/icu/build.sh
+++ b/projects/icu/build.sh
@@ -30,7 +30,7 @@ CFLAGS=$CFLAGS CXXFLAGS=$CXXFLAGS CC=$CC CXX=$CXX \
    --with-library-bits=64 --with-data-packaging=static --enable-static --disable-shared
 
 export ASAN_OPTIONS="detect_leaks=0"
-export UBSAN_OPTIONS="detect_leaks=0"
+export UBSAN_OPTIONS="detect_leaks=0,enum=0"
 
 make -j$(nproc)
 


### PR DESCRIPTION
Our fuzzer try to use out of bound enum to make sure the API will not crash so we like to turn that enum check off to avoid noise.