### PR TITLE
ostree: Build with stable glib

### DIFF
--- a/projects/ostree/Dockerfile
+++ b/projects/ostree/Dockerfile
@@ -15,6 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
+ARG glib_tag=2.78.4
 RUN apt-get update && apt-get install -y \
     make \
     autoconf \
@@ -30,7 +31,7 @@ RUN apt-get update && apt-get install -y \
     libtool \
     bison
 RUN unset CFLAGS CXXFLAGS && pip3 install -U meson ninja
-RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/glib
+RUN git clone --depth 1 --branch $glib_tag https://gitlab.gnome.org/GNOME/glib
 RUN git clone https://github.com/ostreedev/ostree && \
     cd ostree && \
     git submodule update --init


### PR DESCRIPTION
Recently glib's build process changed as it integrates parts of gobject-introspection. The only reason to build glib at all is because the version in the base image is a bit too old. Rather than building glib main, use a tagged version. 2.78.4 is a very recent stable release that satisfies ostree's 2.66.0 requirement.

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64890