### PR TITLE
[libstdcpp] fix updated install path

### DIFF
--- a/projects/libstdcpp/build.sh
+++ b/projects/libstdcpp/build.sh
@@ -35,8 +35,8 @@ for fuzzsrcfile in /src/*.cpp; do
 	$CXXFLAGS \
 	-std=c++20 \
 	-nostdinc++ \
-	-cxx-isystem $INSTALLDIR/include/c++/14.0.0/ \
-	-cxx-isystem $INSTALLDIR/include/c++/14.0.0/x86_64-pc-linux-gnu \
+	-cxx-isystem $INSTALLDIR/include/c++/14.0.1/ \
+	-cxx-isystem $INSTALLDIR/include/c++/14.0.1/x86_64-pc-linux-gnu \
 	$fuzzsrcfile \
 	-o $OUT/$targetfile \
 	$LIB_FUZZING_ENGINE \


### PR DESCRIPTION
this is a partial fix for the current build error for libstdc++.

it is a step in the right direction, but there is a more complicated error left to sort out.
UPDATE: the problem is that clang (clang-15) is too old, and can't handle concepts properly. The fuzzer builds properly with clang-17. I see there is work ongoing (?) with upgrading here: https://github.com/google/oss-fuzz/pull/8108 
