### PR TITLE
[Infra] base-images: do build `openmp` runtime too

### DIFF
--- a/infra/base-images/base-builder/bisect_clang.py
+++ b/infra/base-images/base-builder/bisect_clang.py
@@ -166,7 +166,7 @@ def prepare_build(llvm_project_path):
       'cmake', '-G', 'Ninja', '-DLIBCXX_ENABLE_SHARED=OFF',
       '-DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON', '-DLIBCXXABI_ENABLE_SHARED=OFF',
       '-DCMAKE_BUILD_TYPE=Release',
-      '-DLLVM_ENABLE_PROJECTS=libcxx;libcxxabi;compiler-rt;clang',
+      '-DLLVM_ENABLE_PROJECTS=libcxx;libcxxabi;compiler-rt;openmp;clang',
       '-DLLVM_TARGETS_TO_BUILD=' + get_clang_target_arch(),
       os.path.join(llvm_project_path, 'llvm')
   ],

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -91,13 +91,15 @@ function clone_with_retries {
 }
 clone_with_retries https://github.com/llvm/llvm-project.git $LLVM_SRC
 
-PROJECTS_TO_BUILD="libcxx;libcxxabi;compiler-rt;clang;lld"
+PROJECTS_TO_BUILD="libcxx;libcxxabi;compiler-rt;openmp;clang;lld"
 function cmake_llvm {
   extra_args="$@"
   cmake -G "Ninja" \
       -DLIBCXX_ENABLE_SHARED=OFF \
       -DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON \
       -DLIBCXXABI_ENABLE_SHARED=OFF \
+      -DLIBOMP_ENABLE_SHARED=OFF \
+      -DOPENMP_ENABLE_LIBOMPTARGET=OFF \
       -DCMAKE_BUILD_TYPE=Release \
       -DLLVM_TARGETS_TO_BUILD="$TARGET_TO_BUILD" \
       -DLLVM_ENABLE_PROJECTS="$PROJECTS_TO_BUILD" \


### PR DESCRIPTION
I'm guessing this needs tests?

See https://github.com/google/oss-fuzz/issues/11547
X-Ref: https://github.com/darktable-org/rawspeed/pull/631