### PR TITLE
mp4san: project moved to Signal org

### DIFF
--- a/projects/mp4san/Dockerfile
+++ b/projects/mp4san/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-rust
 
-RUN git clone --depth 1 https://github.com/privacyresearchgroup/mp4san mp4san
+RUN git clone --depth 1 https://github.com/signalapp/mp4san mp4san
 WORKDIR mp4san
 
 COPY build.sh $SRC/

--- a/projects/mp4san/project.yaml
+++ b/projects/mp4san/project.yaml
@@ -1,7 +1,10 @@
-homepage: "https://github.com/privacyresearchgroup/mp4san"
+homepage: "https://github.com/signalapp/mp4san"
 language: rust
 primary_contact: "usual.beach5937@jessacake.com"
-main_repo: "https://github.com/privacyresearchgroup/mp4san"
+main_repo: "https://github.com/signalapp/mp4san"
+auto_ccs:
+  - "jrose@signal.org"
+  - "ehren@signal.org"
 vendor_ccs:
   - "security@signal.org"
 sanitizers:


### PR DESCRIPTION
The mp4san project has been moved to the Signal Messenger organization (signalapp on github).

- Updated repo URLs: repo was moved to `signalapp` organization on github
- Added Signal employees to `auto_ccs`