### PR TITLE
typst: Change primary author email

### DIFF
--- a/projects/typst/project.yaml
+++ b/projects/typst/project.yaml
@@ -1,6 +1,6 @@
 homepage: "https://typst.app/"
 language: rust
-primary_contact: "laurmaedje@gmail.com"
+primary_contact: "laurmaedje@googlemail.com"
 main_repo: "https://github.com/typst/typst.git"
 auto_ccs:
   - nathaniel.brough@gmail.com


### PR DESCRIPTION
It looks like when Google switch over from googlemail.com to gmail.com they didn't do this across the board i.e. with bugs.chromium.com, this means that @laurmaedje currently can't access the bug tracker.