### PR TITLE
More fuzz introspector webapp build fixes

### DIFF
--- a/infra/build/fuzz-introspector-webapp/cloudbuild.yaml
+++ b/infra/build/fuzz-introspector-webapp/cloudbuild.yaml
@@ -27,7 +27,10 @@ steps:
     - '1'
     - '--max-instances'
     - '10'
+    - '--cpu'
+    - '4'
     - '--memory'
-    - '10Gi'
+    - '16Gi'
 options:
   machineType: 'E2_HIGHCPU_32'
+timeout: 21600s  # 6 hours


### PR DESCRIPTION
Explicitly set CPUs. 4 CPUs are required for > 8 GiB. Also bump memory to 16GiB just in case for now. 

Also increase build timeout to 6 hours.