### PR TITLE
lua: update introspector paths

### DIFF
--- a/projects/lua/build.sh
+++ b/projects/lua/build.sh
@@ -39,8 +39,8 @@ apt-get install -y $PACKAGES
 export FUZZ_INTROSPECTOR_CONFIG=$SRC/fuzz_introspector_exclusion.config
 cat > $FUZZ_INTROSPECTOR_CONFIG <<EOF
 FILES_TO_AVOID
-testdir/build/tests/external.protobuf_mutator
-testdir/build/tests/luaL_loadbuffer_proto/
+testdir/build/tests/capi/external.protobuf_mutator
+testdir/build/tests/capi/luaL_loadbuffer_proto/
 EOF
 
 cd $SRC/testdir
@@ -51,7 +51,7 @@ if [[ $FUZZING_ENGINE == centipede ]]
 then
     sed -i \
         '/$ENV{LIB_FUZZING_ENGINE}/a \ \ \ \ \ \ \ \ -lc++' \
-        tests/CMakeLists.txt
+        tests/capi/CMakeLists.txt
 fi
 
 # Clean up potentially persistent build directory.


### PR DESCRIPTION
Paths were changed after reorganization in tests [1]

1. https://github.com/ligurio/lua-c-api-tests/commit/e0216377d7502230e76d572f9344109406b1a95c