### PR TITLE
jsonnet: Add myself as a second contact

### DIFF
--- a/projects/jsonnet/project.yaml
+++ b/projects/jsonnet/project.yaml
@@ -3,6 +3,8 @@ language: c++
 primary_contact: "dcunnin@google.com"
 auto_ccs:
   - "sparkprime@gmail.com"
+  - "jpa.bartholomew@gmail.com"
+  - "jpab@google.com"
 
 sanitizers:
   - address


### PR DESCRIPTION
Add @johnbartholomew (both corp and non-corp) addresses so I can get access to test cases. @sparkprime remains the primary contact/owner.