### PR TITLE
abseil-cpp: Make myself the primary contact

### DIFF
--- a/projects/abseil-cpp/project.yaml
+++ b/projects/abseil-cpp/project.yaml
@@ -1,4 +1,4 @@
 homepage: "abseil.io"
 language: c++
-primary_contact: "abseil-io@googlegroups.com"
+primary_contact: "dmauro@google.com"
 main_repo: 'https://github.com/abseil/abseil-cpp.git'


### PR DESCRIPTION
I was alerted via b/323340435 that the current primary contact is a public Google Group. Changing the contact to myself to prevent early disclosure of detected vulnerabilities.