### PR TITLE
ion-java: fix build

### DIFF
--- a/projects/ion-java/project-parent/fuzz-targets/src/test/java/com/example/IonReaderFuzzer.java
+++ b/projects/ion-java/project-parent/fuzz-targets/src/test/java/com/example/IonReaderFuzzer.java
@@ -31,12 +31,11 @@ class IonReaderFuzzer {
         try {
             IonReader reader = IonReaderBuilder
                                 .standard()
-                                .withAnnotationIteratorReuseEnabled(data.consumeBoolean())
                                 .withIncrementalReadingEnabled(data.consumeBoolean())
                                 .build(data.consumeRemainingAsString());
             read(reader);
             reader.close();
-        } catch (IOException | NullPointerException | IllegalStateException | IllegalArgumentException | ArrayIndexOutOfBoundsException | IonException | AssertionError e) {
+        } catch (IOException | IllegalStateException | IllegalArgumentException | IonException e) {
             // Need to be caught to get more interesting findings.
         }
     }


### PR DESCRIPTION
Fixes build failure for `ion-java`: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=63457

`withAnnotationIteratorReuseEnabled` was removed from `IonReaderBuilder`. Removing this will cause the build to succeed.

`NullPointerException`, `ArrayIndexOutOfBoundsException`, and `AssertionError` should not leak from the library; such leaks would be useful to find during fuzzing.