### PR TITLE
Get ntp-dev fuzzing again

### DIFF
--- a/projects/ntp/build.sh
+++ b/projects/ntp/build.sh
@@ -18,8 +18,9 @@
 cd ntp-dev
 git apply ../patch.diff
 #avoids https://bugs.llvm.org/show_bug.cgi?id=34636
-cp /usr/bin/ld.gold /usr/bin/ld
+#not a problem with binutils 2.36+
+#cp /usr/bin/ld.gold /usr/bin/ld
 ./bootstrap
-./configure --enable-fuzztargets
+./configure -C --enable-fuzztargets --disable-dependency-tracking
 make
 cp tests/fuzz/fuzz_ntpd_receive $OUT/

--- a/projects/ntp/patch.diff
+++ b/projects/ntp/patch.diff
@@ -39,7 +39,7 @@ index 7975d31..528861c 100644
 +
  NTP_UNITYBUILD
  
- dnl  gtest is needed for our tests subdirs. It would be nice if we could
+ NTP_PROBLEM_TESTS
 @@ -4459,6 +4490,7 @@ AC_CONFIG_FILES([tests/ntpd/Makefile])
  AC_CONFIG_FILES([tests/ntpq/Makefile])
  AC_CONFIG_FILES([tests/sandbox/Makefile])
@@ -99,7 +99,7 @@ new file mode 100644
 index 0000000..7cb8d99
 --- /dev/null
 +++ b/tests/fuzz/fuzz_ntpd_receive.c
-@@ -0,0 +1,94 @@
+@@ -0,0 +1,93 @@
 +#include <stddef.h>
 +#include <stdint.h>
 +#include <sys/types.h>
@@ -110,14 +110,13 @@ index 0000000..7cb8d99
 +#include "recvbuff.h"
 +#include "ntpd.h"
 +
-+const char *Version = "libntpq 0.3beta";
++const char *Version = "fuzz_ntpd_receive 0.2";
 +int listen_to_virtual_ips = TRUE;
 +int mdnstries = 5;
 +char const *progname = "fuzz_ntpd_receive";
 +#ifdef HAVE_WORKING_FORK
-+int    waitsync_fd_to_close = -1;    /* -w/--wait-sync */
++int    daemon_pipe[2] = {-1, -1};    /* -w/--wait-sync */
 +#endif
-+int yydebug=0;
 +
 +static int initialized = 0;
 +int sockfd;

--- a/projects/ntp/project.yaml
+++ b/projects/ntp/project.yaml
@@ -4,6 +4,8 @@ primary_contact: "security@ntp.org"
 main_repo: "https://bitbucket.nwtime.org/scm/websites/ntpwww.git"
 auto_ccs:
   - "p.antoine@catenacyber.fr"
+  - "hart@ntp.org"
+  - "stenn@nwtime.org"
 fuzzing_engines:
   - afl
   - libfuzzer


### PR DESCRIPTION
Update fuzz patch for ntp source changes. (issue 59213).
Speed one-shot build by sharing config.cache between our 4 configure scripts and disabling dependency tracking.
Add Dave Hart and Harlan Stenn to auto_ccs to enable authenticated access to gsutil.