### PR TITLE
libxslt: fix quote in project.yaml

### DIFF
--- a/projects/libxslt/project.yaml
+++ b/projects/libxslt/project.yaml
@@ -11,7 +11,7 @@ vendor_ccs:
   - "ebanniettis@apple.com"
   - "jm.park@apple.com"
   - "james_e_kim@apple.com"
-  - "rding23@apple.com”
+  - "rding23@apple.com"
   - "albassam@apple.com"
 sanitizers:
   - address


### PR DESCRIPTION
This was causing issues when parsing the `project.yaml` files:

```sh
  File "/home/dav/code/2024/fuzz-introspector-14/fuzz-introspector/tools/web-fuzzing-introspection/.venv/lib/python3.10/site-packages/yaml/parser.py", line 98, in check_event
    self.current_event = self.state()
  File "/home/dav/code/2024/fuzz-introspector-14/fuzz-introspector/tools/web-fuzzing-introspection/.venv/lib/python3.10/site-packages/yaml/parser.py", line 392, in parse_block_sequence_entry
    raise ParserError("while parsing a block collection", self.marks[-1],
yaml.parser.ParserError: while parsing a block collection
  in "<unicode string>", line 5, column 3:
      - "ddkilzer@apple.com"
      ^
expected <block end>, but found '<scalar>'
  in "<unicode string>", line 15, column 6:
      - "albassam@apple.com"
         ^
```

fyi @oliverchang