### PR TITLE
igraph: exclude external libxml2 from coverage measurements

### DIFF
--- a/projects/igraph/project.yaml
+++ b/projects/igraph/project.yaml
@@ -2,6 +2,7 @@ homepage: "https://github.com/igraph/igraph"
 main_repo: "https://github.com/igraph/igraph"
 language: c
 primary_contact: "szhorvat@gmail.com"
+coverage_extra_args: -ignore-filename-regex=.*libxml2-2.*/.*
 auto_ccs:
   - "Adam@adalogics.com"
   - "ntamas@gmail.com"


### PR DESCRIPTION
[We compile libxml2 together with igraph](https://github.com/igraph/igraph/blob/master/fuzzing/build.sh) for two reasons:

 - Disable ICU support in libxml2 to work around [a still-existing ICU crash bug](https://unicode-org.atlassian.net/browse/ICU-21932) that the igraph fuzzer was hitting
 - MSan support requires compiling all dependencies

This PR tries to ensure that coverage is only measured for igraph, not for libxml2.