### PR TITLE
Remove Catch2 dependency from `immer`'s fuzzers

### DIFF
--- a/projects/immer/Dockerfile
+++ b/projects/immer/Dockerfile
@@ -16,13 +16,6 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y cmake libgc-dev pkg-config
-# install Catch2 from sources, since Ubuntu 20.04 (currently the base for
-# this image) does not ship it
-RUN git clone -b v2.x --depth 1 https://github.com/catchorg/Catch2.git && \
-    cd Catch2 && \
-    cmake -DCATCH_BUILD_TESTING=OFF -DCATCH_BUILD_EXAMPLES=OFF -DCATCH_ENABLE_COVERAGE=OFF -DCATCH_ENABLE_WERROR=OFF -DCATCH_INSTALL_DOCS=OFF -DCATCH_INSTALL_HELPERS=OFF -Bbuild && \
-    cmake --build build && \
-    cmake --build build --target install
 RUN git clone --depth 1 https://github.com/arximboldi/immer.git immer
 WORKDIR immer
 COPY build.sh $SRC/

--- a/projects/immer/build.sh
+++ b/projects/immer/build.sh
@@ -20,7 +20,8 @@ mkdir build
 cd build
 cmake .. \
       -DBOEHM_GC_INCLUDE_DIR=/usr/include \
-      -DBOEHM_GC_LIBRARIES=/usr/lib/x86_64-linux-gnu/libgc.a
+      -DBOEHM_GC_LIBRARIES=/usr/lib/x86_64-linux-gnu/libgc.a \
+      -Dimmer_BUILD_TESTS=OFF
 make -j$(nproc) fuzzers
 
 for fuzzer in extra/fuzzer/*; do


### PR DESCRIPTION
immer's fuzzers do not depend on Catch2 anymore

This change is triggered by `immer` moving to use Catch2 v3, so the current build script will break.