### PR TITLE
[Litmus]: Added initial integration 

### DIFF
--- a/projects/litmuschaos/Dockerfile
+++ b/projects/litmuschaos/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone https://github.com/litmuschaos/litmus.git
+RUN cp $SRC/litmus/chaoscenter/fuzz_build.sh $SRC/build.sh
+WORKDIR $SRC/litmus

--- a/projects/litmuschaos/project.yaml
+++ b/projects/litmuschaos/project.yaml
@@ -1,0 +1,14 @@
+homepage: "https://litmuschaos.io/"
+main_repo: "https://github.com/litmuschaos/litmus.git"
+primary_contact: "saranya.jena@harness.io"
+auto_ccs :
+  - "karthik.s@harness.io"
+  - "rajbabu.das@harness.io"
+  - "vedant.shrotria@harness.io"
+  - "sarthak.jain@harness.io"
+  - "shubham.chaudhary@harness.io"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
[Litmus](https://litmuschaos.io/) is an open source Chaos Engineering platform that enables teams to identify weaknesses & potential outages in infrastructures by inducing chaos tests in a controlled way.

Developers & SREs can simply execute Chaos Engineering with Litmus as it is easy to use, based on modern chaos engineering practices & community collaborated. Litmus is 100% open source & CNCF-incubated.

Github repo: https://github.com/litmuschaos/litmus
Documentation: https://docs.litmuschaos.io/