### PR TITLE
apache-commons-compress: Adding coverage for DUMP and Pack200 formats (COMPRESS-632)

### DIFF
--- a/projects/apache-commons-compress/ArchiverDumpFuzzer.java
+++ b/projects/apache-commons-compress/ArchiverDumpFuzzer.java
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/apache-commons-compress/ArchiverDumpFuzzer.java
+++ b/projects/apache-commons-compress/ArchiverDumpFuzzer.java
@@ -14,6 +14,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.compress.archivers.dump.DumpArchiveInputStream;
 
 import java.io.ByteArrayInputStream;
@@ -23,7 +24,7 @@ public class ArchiverDumpFuzzer extends BaseTests {
     public static void fuzzerTestOneInput(byte[] data) {
         try {
             fuzzArchiveInputStream(new DumpArchiveInputStream(new ByteArrayInputStream(data)));
-        } catch (IOException ignored) {
+        } catch (ArchiveException|IOException ignored) {
         }
     }
 }

--- a/projects/apache-commons-compress/ArchiverDumpFuzzer.java
+++ b/projects/apache-commons-compress/ArchiverDumpFuzzer.java
@@ -1,0 +1,29 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import org.apache.commons.compress.archivers.dump.DumpArchiveInputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class ArchiverDumpFuzzer extends BaseTests {
+    public static void fuzzerTestOneInput(byte[] data) {
+        try {
+            fuzzArchiveInputStream(new DumpArchiveInputStream(new ByteArrayInputStream(data)));
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/projects/apache-commons-compress/CompressorPack200Fuzzer.java
+++ b/projects/apache-commons-compress/CompressorPack200Fuzzer.java
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/apache-commons-compress/CompressorPack200Fuzzer.java
+++ b/projects/apache-commons-compress/CompressorPack200Fuzzer.java
@@ -1,0 +1,29 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import org.apache.commons.compress.compressors.pack200.Pack200CompressorInputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class CompressorPack200Fuzzer extends BaseTests {
+    public static void fuzzerTestOneInput(byte[] data) {
+        try {
+            fuzzCompressorInputStream(new Pack200CompressorInputStream(new ByteArrayInputStream(data)));
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/projects/apache-commons-compress/Dockerfile
+++ b/projects/apache-commons-compress/Dockerfile
@@ -47,6 +47,8 @@ RUN \
     zip -j0  $SRC/ArchiverArjFuzzer_seed_corpus.zip commons-compress/src/test/resources/*.arj && \
     zip -j0  $SRC/ArchiverCpioFuzzer_seed_corpus.zip commons-compress/src/test/resources/*.cpio && \
     zip -uj0 $SRC/ArchiverCpioFuzzer_seed_corpus.zip commons-compress/src/test/resources/archives/*.cpio && \
+    zip -j0  $SRC/ArchiverDumpFuzzer_seed_corpus.zip commons-compress/src/test/resources/*.dump && \
+    zip -uj0 $SRC/ArchiverDumpFuzzer_seed_corpus.zip commons-compress/src/test/resources/org/apache/commons/compress/dump/*.dump && \
     zip -j0  $SRC/CompressSevenZFuzzer_seed_corpus.zip commons-compress/src/test/resources/*.7z && \
     zip -uj0 $SRC/CompressTarFuzzer_seed_corpus.zip commons-compress/src/test/resources/*.tar && \
     zip -uj0 $SRC/CompressTarFuzzer_seed_corpus.zip commons-compress/src/test/resources/archives/*.tar && \
@@ -59,6 +61,8 @@ RUN \
     zip -j0  $SRC/CompressorDeflate64Fuzzer_seed_corpus.zip commons-compress/src/test/resources/*.deflate && \
     zip -uj0 $SRC/CompressorGzipFuzzer_seed_corpus.zip commons-compress/src/test/resources/*.gz && \
     zip -j0  $SRC/CompressorLZ4Fuzzer_seed_corpus.zip commons-compress/src/test/resources/*lz4 && \
+    zip -j0  $SRC/CompressorPack200Fuzzer_seed_corpus.zip commons-compress/src/test/resources/*.pack && \
+    zip -uj0 $SRC/CompressorPack200Fuzzer_seed_corpus.zip commons-compress/src/test/resources/pack200/*.pack && \
     zip -uj0 $SRC/CompressorSnappyFuzzer_seed_corpus.zip commons-compress/src/test/resources/*.sz && \
     zip -j0  $SRC/CompressorZFuzzer_seed_corpus.zip commons-compress/src/test/resources/*.Z
 


### PR DESCRIPTION
This PR adds support for DUMP and COMPRESS formats. This work is being tracked on the project side here:
https://issues.apache.org/jira/browse/COMPRESS-632