### PR TITLE
Avoid openssl build errors due to out of disk space

### DIFF
--- a/projects/openssl/build.sh
+++ b/projects/openssl/build.sh
@@ -62,6 +62,9 @@ function build_fuzzers() {
     done
     cp fuzz/oids.txt $OUT/asn1${SUFFIX}.dict
     cp fuzz/oids.txt $OUT/x509${SUFFIX}.dict
+    df
+    rm -rf *
+    df
 }
 
 cd $SRC/openssl/


### PR DESCRIPTION
The docker image that runs the openssl build goes
quickly out of disk space, because 4 different versions are built and since a while all CIFuzz builds started to fail, since the disk space is used up when the last openssl version is built.

Mitigate that problem by deleting the source directory after the fuzzer build is complete, since that source tree is no longer needed at this time.