### PR TITLE
All the cert-manager security contacts are alerted and can log into oss-fuzz.com

### DIFF
--- a/projects/cert-manager/project.yaml
+++ b/projects/cert-manager/project.yaml
@@ -1,10 +1,21 @@
 homepage: "https://cert-manager.io"
-primary_contact: "tim.ramlot@venafi.com"
+# Send reports to the cert-manager-security distribution list.
+# - https://cert-manager.io/docs/contributing/security/
+# - https://github.com/cert-manager/community/blob/main/SECURITY.md#reporting-process
+primary_contact: "cert-manager-security@googlegroups.com"
+# Allow people listed in maintainers.csv file to sign in to https://oss-fuzz.com/
+# - https://github.com/cert-manager/community/blob/main/maintainers.csv
 auto_ccs:
-  - "ashley.davis@venafi.com"
-  - "mael.valais@gmail.com"
+  - "ashley.davis@venafi.com" # Ashley Davis,sgtcodfish,Venafi
+  - "i@am.so-aweso.me"        # Jake Sanders,jakexks,G-Research
+  - "irbekrm@gmail.com"       # Irbe Krumina,irbekrm,Tailscale
+  - "jmunnelly@apple.com"     # James Munnelly,munnerz,Apple
+  - "mael.valais@gmail.com"   # Maël Valais,maelvls,Venafi
+  - "me@joshvanl.dev"         # Josh van Leeuwen,joshvanl,Diagrid
+  - "richard.wall@venafi.com" # Richard Wall,wallrj,Venafi
+  - "tim.ramlot@venafi.com"   # Tim Ramlot,inteon,Venafi
 vendor_ccs :
-  - "adam@adalogics.com"
+  - "adam@adalogics.com"      # Adam Korczynski,AdamKorcz,ADALogics
 language: go
 fuzzing_engines:
   - libfuzzer


### PR DESCRIPTION
I've updated the primary email to be cert-manager's official security distribution list,
which behind the scenes will copy the email to all the appropriate maintainers:
 * https://cert-manager.io/docs/contributing/security/
 * https://github.com/cert-manager/community/blob/main/maintainers.csv

And I've added the email addresses of all the maintainers so that we can all log into https://oss-fuzz.com/ if we have a Google account:  
 * https://github.com/cert-manager/community/blob/main/maintainers.csv

xref:
 * https://github.com/google/oss-fuzz/pull/11261

/cc @AdamKorcz @oliverchang @jonathanmetzman @DonggeLiu PTAL