### PR TITLE
[FFmpeg] disable libdrm

### DIFF
--- a/projects/ffmpeg/build.sh
+++ b/projects/ffmpeg/build.sh
@@ -169,6 +169,7 @@ PKG_CONFIG_PATH="$FFMPEG_DEPS_PATH/lib/pkgconfig" ./configure \
         --enable-libvpx \
         --enable-libxml2 \
         --enable-nonfree \
+        --disable-libdrm \
         --disable-muxers \
         --disable-protocols \
         --disable-demuxer=rtp,rtsp,sdp \
@@ -256,6 +257,7 @@ PKG_CONFIG_PATH="$FFMPEG_DEPS_PATH/lib/pkgconfig" ./configure \
         --optflags=-O1 \
         --enable-gpl \
         --enable-libxml2 \
+        --disable-libdrm \
         --disable-muxers \
         --disable-protocols \
         --disable-devices \


### PR DESCRIPTION
because of "error while loading shared libraries: libdrm.so.2: cannot
open shared object file: No such file or directory"

Alternatively we can copy that to the lib directory like it seems done with libz/bz2

https://github.com/google/oss-fuzz/pull/11629 depends on this but it seems even on its own some things seem to fail without this