### PR TITLE
Fix openssl coverage build failure

### DIFF
--- a/projects/openssl/build.sh
+++ b/projects/openssl/build.sh
@@ -62,8 +62,17 @@ function build_fuzzers() {
     done
     cp fuzz/oids.txt $OUT/asn1${SUFFIX}.dict
     cp fuzz/oids.txt $OUT/x509${SUFFIX}.dict
+    if [ "$SANITIZER" == coverage ]; then
+      DESTDIR=$OUT/src/openssl${SUFFIX#_}
+      SOURCES="include crypto ssl providers engines fuzz"
+      mkdir -p $DESTDIR
+      if [ -f e_os.h ]; then
+        cp e_os.h $DESTDIR/
+      fi
+      find $SOURCES -type f -a \( -name '*.[ch]' -o -name '*.inc' \) -exec cp --parents '{}' $DESTDIR/ \;
+    fi
     df
-    rm -rf *
+    rm -rf * .git*
     df
 }
 


### PR DESCRIPTION
My previous commit apparently broke the oss-fuzz coverage build where it is necessary to save various source files, otherwise the coverage report generation fails.

Fixes: #11618