### PR TITLE
[quickjs] Set max stack limit.

### DIFF
--- a/projects/quickjs/fuzz_compile.c
+++ b/projects/quickjs/fuzz_compile.c
@@ -13,6 +13,7 @@
  limitations under the License.
  */
 
+#include "quickjs.h"
 #include "quickjs-libc.h"
 #include "cutils.h"
 
@@ -36,7 +37,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         rt = JS_NewRuntime();
         // 64 Mo
         JS_SetMemoryLimit(rt, 0x4000000);
-        //TODO JS_SetMaxStackSize ?
+        // 64 Kb
+        JS_SetMaxStackSize(rt, 0x10000);
         ctx = JS_NewContextRaw(rt);
         JS_SetModuleLoaderFunc(rt, NULL, js_module_loader, NULL);
         JS_AddIntrinsicBaseObjects(ctx);

--- a/projects/quickjs/fuzz_eval.c
+++ b/projects/quickjs/fuzz_eval.c
@@ -13,6 +13,7 @@
  limitations under the License.
  */
 
+#include "quickjs.h"
 #include "quickjs-libc.h"
 
 #include <stdint.h>
@@ -35,7 +36,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         rt = JS_NewRuntime();
         // 64 Mo
         JS_SetMemoryLimit(rt, 0x4000000);
-        //TODO JS_SetMaxStackSize ?
+        // 64 Kb
+        JS_SetMaxStackSize(rt, 0x10000);
         ctx = JS_NewContextRaw(rt);
         JS_SetModuleLoaderFunc(rt, NULL, js_module_loader, NULL);
         JS_AddIntrinsicBaseObjects(ctx);

--- a/projects/quickjs/fuzz_regexp.c
+++ b/projects/quickjs/fuzz_regexp.c
@@ -14,6 +14,7 @@
  */
 
 #include "libregexp.h"
+#include "quickjs.h"
 #include "quickjs-libc.h"
 
 #include <stdint.h>
@@ -31,7 +32,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         rt = JS_NewRuntime();
         // 64 Mo
         JS_SetMemoryLimit(rt, 0x4000000);
-        //TODO JS_SetMaxStackSize ?
+        // 64 Kb
+        JS_SetMaxStackSize(rt, 0x10000);
         ctx = JS_NewContextRaw(rt);
     }
     int len, ret, i;


### PR DESCRIPTION
Google's internal fuzzers found tests that make `fuzz_regexp.c` exceed stack memory. Turns out, QuickJS already has built-in mechanism for tracking that stack size doesn't exceed a given limit - it's just that limit isn't set for fuzzer tests by default

Setting the limit to 64kb as a reasonable default setting