### PR TITLE
infra: bump fuzz-introspector

### DIFF
--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -272,7 +272,7 @@ if [ "$SANITIZER" = "introspector" ]; then
   mkdir -p $SRC/inspector
   find $SRC/ -name "fuzzerLogFile-*.data" -exec cp {} $SRC/inspector/ \;
   find $SRC/ -name "fuzzerLogFile-*.data.yaml" -exec cp {} $SRC/inspector/ \;
-  find $SRC/ -name "fuzzerLogFile-*.data.debug_info" -exec cp {} $SRC/inspector/ \;
+  find $SRC/ -name "fuzzerLogFile-*.data.debug_*" -exec cp {} $SRC/inspector/ \;
   find $SRC/ -name "allFunctionsWithMain-*.yaml" -exec cp {} $SRC/inspector/ \;
 
   # Move coverage report.

--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y wget sudo && \
 RUN apt-get update && apt-get install -y git && \
     git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
     cd fuzz-introspector && \
-    git checkout acc32a7ecfca4dc0446ca6aa3604adb01ee8ea7b && \
+    git checkout 45c66f0bd1fa53674a990c39ecd712e9b02cf66b && \
     git submodule init && \
     git submodule update && \
     apt-get autoremove --purge -y git && \

--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y wget sudo && \
 RUN apt-get update && apt-get install -y git && \
     git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
     cd fuzz-introspector && \
-    git checkout 45c66f0bd1fa53674a990c39ecd712e9b02cf66b && \
+    git checkout 04011ff3b0bff1ab1b7a2745688ca31b03c8db38 && \
     git submodule init && \
     git submodule update && \
     apt-get autoremove --purge -y git && \


### PR DESCRIPTION
- Contains improvements in debug information handling
  - function signature improvements
  - more raw type-related data
  - fix for providing source code for e.g. header files
- The version of Fuzz Introspector is compatible with LLVM18 so the soon-to-occur bump should be more painfree with this version of Introspector.