### PR TITLE
[spdm-rs]: add initial integration for spdm-rs

### DIFF
--- a/projects/spdm-rs/Dockerfile
+++ b/projects/spdm-rs/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+RUN git clone --depth 1 --recursive https://github.com/ccc-spdm-tools/spdm-rs.git
+COPY build.sh $SRC/
+WORKDIR $SRC

--- a/projects/spdm-rs/build.sh
+++ b/projects/spdm-rs/build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -eu
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+set -eox pipefail
+pushd $SRC/spdm-rs
+
+export CARGO_TARGET_DIR=$SRC/spdm-rs/target
+FUZZ_TARGET_OUTPUT_DIR=${CARGO_TARGET_DIR}/x86_64-unknown-linux-gnu/release
+
+bash sh_script/pre-build.sh
+
+pushd spdmlib
+cargo fuzz build --release
+for f in fuzz/fuzz_targets/*.rs
+do
+    FUZZ_TARGET_NAME=$(basename ${f%.*})
+    cp $FUZZ_TARGET_OUTPUT_DIR/$FUZZ_TARGET_NAME $OUT/
+done
+popd # spdmlib
+
+popd # $SRC/spdm-rs

--- a/projects/spdm-rs/project.yml
+++ b/projects/spdm-rs/project.yml
@@ -1,0 +1,11 @@
+homepage: "https://github.com/ccc-spdm-tools/spdm-rs"
+language: rust
+primary_contact: "xiaoyu1.lu@intel.com"
+auto_ccs:
+  - "jiewen.yao@intel.com"
+  - "longlong.yang@intel.com"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+main_repo: 'https://github.com/ccc-spdm-tools/spdm-rs.git'


### PR DESCRIPTION
The `spdm-rs` provides a Rust language implementation of [SPDM](https://www.dmtf.org/standards/spdm) which is used to for Trusted Execution Environment I/O (TEE-I/O) in Confidential Computing.

Project repo: https://github.com/ccc-spdm-tools/spdm-rs