### PR TITLE
pest: remove +nightly from cargo fuzz build

### DIFF
--- a/projects/pest/build.sh
+++ b/projects/pest/build.sh
@@ -15,9 +15,9 @@
 ################################################################################
 cd $SRC/pest/meta
 RUSTFLAGS="" cargo bootstrap
-cargo +nightly fuzz build
+cargo fuzz build
 cd $SRC/pest/grammars
-cargo +nightly fuzz build
+cargo fuzz build
 cp $SRC/pest/meta/fuzz/target/x86_64-unknown-linux-gnu/release/parser $OUT/
 cp $SRC/pest/grammars/fuzz/target/x86_64-unknown-linux-gnu/release/toml $OUT/
 cp $SRC/pest/grammars/fuzz/target/x86_64-unknown-linux-gnu/release/json $OUT/


### PR DESCRIPTION
this should hopefully resolve the recent build issue:
```
Step #5: warning: /workspace/out/libfuzzer-coverage-x86_64/dumps/parser.14845295624977050394_0.profraw: unsupported instrumentation profile format version
Step #5: error: no profile can be merged
Step #5: [2024-02-28 06:09:14,766 INFO] Finding shared libraries for targets (if any).
Step #5: [2024-02-28 06:09:14,775 INFO] Finished finding shared libraries for targets.
Step #5: error: parser: Failed to load coverage: No such file or directory
Step #5: error: Could not load coverage information
Step #5: error: No such file or directory: Could not read profile data!
Step #5: Traceback (most recent call last):
Step #5:   File "/usr/local/bin/profraw_update.py", line 129, in <module>
Step #5:     sys.exit(main())
Step #5:   File "/usr/local/bin/profraw_update.py", line 120, in main
Step #5:     profraw_latest = upgrade(profraw_base, sect_prf_cnts, sect_prf_data)
Step #5:   File "/usr/local/bin/profraw_update.py", line 87, in upgrade
Step #5:     relativize_address(data, offset + 16, dataref, sect_prf_cnts, sect_prf_data)
Step #5:   File "/usr/local/bin/profraw_update.py", line 35, in relativize_address
Step #5:     value = struct.unpack('Q', data[offset:offset + 8])[0]
Step #5: struct.error: unpack requires a buffer of 8 bytes
```