### PR TITLE
re-enable SSSE3 target for libjxl

### DIFF
--- a/projects/libjxl/build.sh
+++ b/projects/libjxl/build.sh
@@ -40,11 +40,7 @@ build_args=(
   rm -rf ${WORK}/libjxl-corpus
   mkdir -p ${WORK}/libjxl-corpus
   cd ${WORK}/libjxl-corpus
-  cmake \
-    "${build_args[@]}" \
-    -DCMAKE_C_FLAGS="-DHWY_DISABLED_TARGETS=HWY_SSSE3" \
-    -DCMAKE_CXX_FLAGS="-DHWY_DISABLED_TARGETS=HWY_SSSE3" \
-    "${SRC}/libjxl"
+  cmake "${build_args[@]}" "${SRC}/libjxl"
   ninja clean
   ninja djxl_fuzzer_corpus jpegli_dec_fuzzer_corpus
 
@@ -84,8 +80,6 @@ cd ${WORK}/libjxl-fuzzer
 cmake \
   "${build_args[@]}" \
   -DJPEGXL_FUZZER_LINK_FLAGS="${LIB_FUZZING_ENGINE}" \
-  -DCMAKE_C_FLAGS="-DHWY_DISABLED_TARGETS=HWY_SSSE3 ${CFLAGS}" \
-  -DCMAKE_CXX_FLAGS="-DHWY_DISABLED_TARGETS=HWY_SSSE3 ${CXXFLAGS}" \
   "${SRC}/libjxl"
 
 fuzzers=(


### PR DESCRIPTION
This reverts #6837, since it seems to have been fixed in the meantime, see also https://github.com/libjxl/libjxl/issues/858