### PR TITLE
[golang] restrict access to golang issues

### DIFF
--- a/projects/golang/project.yaml
+++ b/projects/golang/project.yaml
@@ -1,13 +1,13 @@
 homepage: "https://golang.org/"
 main_repo: "https://github.com/golang/go"
-primary_contact: "golang-fuzz@googlegroups.com"
+primary_contact: "security@golang.org"
 auto_ccs:
- - "emmanuel@orijtech.com"
+ - "bracewell@google.com"
+ - "dneil@google.com"
+ - "tatianabradley@google.com"
  - "Adam@adalogics.com"
- - "cuong.manhle.vn@gmail.com"
 language: go
 sanitizers:
  - address
 fuzzing_engines:
  - libfuzzer
-view_restrictions: none


### PR DESCRIPTION
We've had multiple security reports originating from crashes discovered by oss-fuzz. I was unaware that the results were entirely public.

Restrict access to issues to the Go Security team.

**Note:** It's unclear to me if this actually accomplishes what I want. `view_restrictions` seems entirely undocumented. From contextual clues from other projects it _seems_ that removing the field causes restriction, but that is entirely a guess.