### PR TITLE
[golang] explicitly set toolchain version

### DIFF
--- a/projects/golang/build.sh
+++ b/projects/golang/build.sh
@@ -22,6 +22,8 @@ then
 
 fi
 
+export GOTOOLCHAIN="local"
+
 export FUZZ_ROOT="github.com/dvyukov/go-fuzz-corpus"
 
 cd $SRC/text


### PR DESCRIPTION
Since we're operating inside of the main Go tree, we end up using the tip go.mod file, which typically defines a Go toolchain version which is not available yet. Explicitly setting GOTOOLCHAIN to "local" tells the toolchain to use the right (available) version, instead of trying to download the tip version.

This should fix the build... I think.