### PR TITLE
remove unused gflags dependency for libjxl

### DIFF
--- a/projects/libjxl/Dockerfile
+++ b/projects/libjxl/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y cmake ninja-build pkg-config \
-  libgflags-dev libjpeg-dev
+  libjpeg-dev
 RUN git clone --depth 1 https://github.com/libjxl/libjxl.git
 # We only need these sub-projects for the fuzzers.
 RUN git -C libjxl submodule update --init --recommend-shallow \


### PR DESCRIPTION
revert #7063, since it is no longer needed, see
https://github.com/libjxl/libjxl/pull/1588.