### PR TITLE
infra: bump introspector

### DIFF
--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y wget sudo && \
 RUN apt-get update && apt-get install -y git && \
     git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
     cd fuzz-introspector && \
-    git checkout 2188913aac0f423ec2aa6f4efdd5de6df0752376 && \
+    git checkout 2e1462803b3f391ce0f414e766f1b2442dcf4260 && \
     git submodule init && \
     git submodule update && \
     apt-get autoremove --purge -y git && \


### PR DESCRIPTION
Bumps introspector. The primary update is that we now expose all debug information in an index file where each type is indexed by its address. The address is the key used by LLVM, which is unique for each type. There are additional helped features to make debug information look prettier as it's quite verbose.

The goal is to assist making it easier to extract full type contexts.