### PR TITLE
fastcsv: Catch CsvParseException

### DIFF
--- a/projects/fastcsv/CsvReaderFuzzer.java
+++ b/projects/fastcsv/CsvReaderFuzzer.java
@@ -19,12 +19,16 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 
 import de.siegmar.fastcsv.reader.CsvReader;
+import de.siegmar.fastcsv.reader.CsvParseException;
 
 public class CsvReaderFuzzer {
   public static void fuzzerTestOneInput(byte[] input) {
-    CsvReader.builder()
-      .ofCsvRecord(new InputStreamReader(new ByteArrayInputStream(input), StandardCharsets.UTF_8))
-      .stream()
-      .toList();
+    try {
+      CsvReader.builder()
+        .ofCsvRecord(new InputStreamReader(new ByteArrayInputStream(input), StandardCharsets.UTF_8))
+        .stream()
+        .toList();
+    } catch (CsvParseException e) {
+    }
   }
 }


### PR DESCRIPTION
This PR fixes a false positive issues reported in https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=67386.