### PR TITLE
HPN-SSH Initial Request for New Project

### DIFF
--- a/projects/hpn-ssh/project.yaml
+++ b/projects/hpn-ssh/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://www.psc.edu/home-hpn-ssh"
+language: c
+primary_contact: "rapier1@gmail.com"
+auto_ccs:
+  - "rapier@psc.edu"
+  - "mwd@psc.edu"
+sanitizers:
+  - address
+  - memory:
+     experimental: True
+  - undefined
+main_repo: 'https://github.com/rapier1/hpn-ssh.git'


### PR DESCRIPTION
Request to add the HPN-SSH project to CIFuzz. HPN-SSH is a soft fork of OpenSSH that provides significantly improved performance and functionality. It's relatively widely used and we'd like to make sure that our changes pass fuzz tests.