### PR TITLE
libxml2: Move build.sh to upstream repo

### DIFF
--- a/projects/libxml2/build.sh
+++ b/projects/libxml2/build.sh
@@ -16,35 +16,4 @@
 #
 ################################################################################
 
-if [ "$SANITIZER" = undefined ]; then
-    export CFLAGS="$CFLAGS -fsanitize=integer -fno-sanitize-recover=integer"
-    export CXXFLAGS="$CXXFLAGS -fsanitize=integer -fno-sanitize-recover=integer"
-fi
-
-export V=1
-
-./autogen.sh \
-    --disable-shared \
-    --without-debug \
-    --without-http \
-    --without-python
-make -j$(nproc)
-
-cd fuzz
-make clean-corpus
-make fuzz.o
-
-for fuzzer in html regexp schema uri valid xinclude xml xpath; do
-    make $fuzzer.o
-    # Link with $CXX
-    $CXX $CXXFLAGS \
-        $fuzzer.o fuzz.o \
-        -o $OUT/$fuzzer \
-        $LIB_FUZZING_ENGINE \
-        ../.libs/libxml2.a -Wl,-Bstatic -lz -llzma -Wl,-Bdynamic
-
-    [ -e seed/$fuzzer ] || make seed/$fuzzer.stamp
-    zip -j $OUT/${fuzzer}_seed_corpus.zip seed/$fuzzer/*
-done
-
-cp *.dict *.options $OUT/
+fuzz/oss-fuzz-build.sh


### PR DESCRIPTION
build.sh is now maintained in the upstream libxml2 repo to facilitate changes.