### PR TITLE
mbedtls now has a submodule (again)

### DIFF
--- a/projects/bignum-fuzzer/Dockerfile
+++ b/projects/bignum-fuzzer/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -y \
 # or a Rust toolchain.
 RUN pip3 install 'pip>=20'
 
-RUN git clone --depth 1 -b development https://github.com/Mbed-TLS/mbedtls
+RUN git clone --depth 1 --recurse-submodules -b development https://github.com/Mbed-TLS/mbedtls
 # Install Python packages from PyPI
 RUN pip3 install -r $SRC/mbedtls/scripts/basic.requirements.txt
 

--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -40,7 +40,7 @@ RUN git clone --depth 1 https://github.com/google/cityhash.git
 RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone --depth 1 https://github.com/wolfSSL/wolfssl.git
 RUN git clone --depth 1 https://github.com/wolfSSL/wolfsm
-RUN git clone --depth 1 -b development https://github.com/Mbed-TLS/mbedtls.git
+RUN git clone --depth 1 --recurse-submodules -b development https://github.com/Mbed-TLS/mbedtls.git
 RUN hg clone https://hg.mozilla.org/projects/nspr
 RUN hg clone https://hg.mozilla.org/projects/nss
 RUN git clone --depth 1 https://github.com/jedisct1/libsodium.git


### PR DESCRIPTION
Fix the mbedtls build in bignum-fuzzer and cryptofuzz. (mbedtls and ecc-diff-fuzzer still had `--recursive` from earlier days.)