### PR TITLE
igraph: provide access for an additional team member

### DIFF
--- a/projects/igraph/project.yaml
+++ b/projects/igraph/project.yaml
@@ -7,6 +7,7 @@ auto_ccs:
   - "Adam@adalogics.com"
   - "ntamas@gmail.com"
   - "vtraag@gmail.com"
+  - "igraphossfuzz@gmail.com"
 sanitizers:
   - address
   - undefined


### PR DESCRIPTION
This is to give @GroteGnoom access to igraph crash reports, as they'll be helping with fixing issues and adding new fuzz targets.