### PR TITLE
`target_experiment.py`  uploads reproducer and binary in target_experiment.py 

### DIFF
--- a/infra/build/functions/target_experiment.py
+++ b/infra/build/functions/target_experiment.py
@@ -134,7 +134,7 @@ def run_experiment(project_name, target_name, args, output_path,
             '-c',
             (f'cp {default_target_path} {local_target_dir} 2>/dev/null || '
              f'find {build.out} -type f -name {target_name} -exec bash -c '
-             f'\'cp "$0" "${local_target_dir}/$(echo "$0" | sed "s@/@_@g")"\' '
+             f'\'cp "$0" "{local_target_dir}/$(echo "$0" | sed "s@/@_@g")"\' '
              f'{{}} \\; && gsutil cp -r {local_target_dir} '
              f'{upload_reproducer_path}/{target_name} || true'),
         ],

--- a/infra/build/functions/target_experiment.py
+++ b/infra/build/functions/target_experiment.py
@@ -165,11 +165,14 @@ def run_experiment(project_name, target_name, args, output_path,
             '-c',
             (f'if [ -f {local_target_dir}/{target_name} ]; then '
              f'{local_target_dir}/{target_name} {local_artifact_path}/* > '
-             f'{local_stacktrace_path}/{target_name}.st 2>&1; else '
-             f'for b in {local_target_dir}/*; do "$b" {local_artifact_path}/* >'
-             f' "{local_stacktrace_path}/$b.st" 2>&1; done'
-             f'gsutil -m cp -r {local_stacktrace_path} {upload_reproducer_path} '
-             '|| true'),
+             f'{local_stacktrace_path}/{target_name}.st 2>&1; '
+             'else '
+             f'for target in {local_target_dir}/*; do '
+             f'"$target" {local_artifact_path}/* > '
+             f'"{local_stacktrace_path}/$target.st" 2>&1; '
+             'done; fi; '
+             f'gsutil -m cp -r {local_stacktrace_path} {upload_reproducer_path}'
+             ' || true'),
         ],
     })
 

--- a/infra/build/functions/target_experiment.py
+++ b/infra/build/functions/target_experiment.py
@@ -134,7 +134,7 @@ def run_experiment(project_name, target_name, args, output_path,
             '-c',
             (f'cp {default_target_path} {local_target_dir} 2>/dev/null || '
              f'find {build.out} -type f -name {target_name} -exec bash -c '
-             f'\'cp "$0" "{local_target_dir}/$(basename "$0")_$(date +%s%N)"\' '
+             f'\'cp "$0" "${local_target_dir}/$(echo "$0" | sed "s@/@_@g")"\' '
              f'{{}} \\; && gsutil cp -r {local_target_dir} '
              f'{upload_reproducer_path}/{target_name} || true'),
         ],

--- a/infra/build/functions/target_experiment.py
+++ b/infra/build/functions/target_experiment.py
@@ -77,7 +77,7 @@ def run_experiment(project_name, target_name, args, output_path,
   default_target_path = os.path.join(build.out, target_name)
   local_target_dir = os.path.join(build.out, 'target')
   local_corpus_zip_path = '/workspace/corpus/corpus.zip'
-  local_artifact_path = os.path.join(build.out, 'artifacts')
+  local_artifact_path = os.path.join(build.out, 'artifacts/')
   fuzzer_args = ' '.join(args + [f'-artifact_prefix={local_artifact_path}'])
 
   env = build_project.get_env(project_yaml['language'], build)


### PR DESCRIPTION
Helps https://github.com/google/oss-fuzz-gen/issues/156:

1. `target_experiment.py` takes a new parameter, `upload_reproducer_path`.
2. `target_experiment.py` saves crash reproducer  to `local_artifect_path`.
3. `target_experiment.py` uploads the fuzz target binary, the crash reproducer, and stacktrace to bucket directory `upload_reproducer_path`.