### PR TITLE
[systemd] drop address confusing monorail

### DIFF
--- a/projects/systemd/project.yaml
+++ b/projects/systemd/project.yaml
@@ -13,7 +13,6 @@ fuzzing_engines:
 auto_ccs:
   - jonathan@titanous.com
   - zbyszek@in.waw.pl
-  - dimitri.ledkov@canonical.com
   - poettering@gmail.com
   - watanabe.yu@gmail.com
   - evvers@ya.ru


### PR DESCRIPTION
monorail keeps updating every open issue every other day and also keeps sending notifications to everyone.

To judge from https://github.com/google/oss-fuzz/issues/6825 it happens due to inactive addresses and the only way to fix it is to remove addresses like that.