### PR TITLE
projects/cras: Remove unused deps

### DIFF
--- a/projects/cras/Dockerfile
+++ b/projects/cras/Dockerfile
@@ -28,13 +28,11 @@ RUN apt-get -y update && \
       cmake \
       g++ \
       git \
-      ladspa-sdk \
       libasound-dev \
       libdbus-1-dev \
       libgtest-dev \
       libncurses5-dev \
       libsbc-dev \
-      libsndfile-dev \
       libspeexdsp-dev \
       libsystemd-dev \
       libclang1 \


### PR DESCRIPTION
ladspa-sdk support removed in https://crrev.com/c/5369016.