### PR TITLE
infra: bazel_build_fuzz_tests: do not force O0

### DIFF
--- a/infra/base-images/base-builder/bazel_build_fuzz_tests
+++ b/infra/base-images/base-builder/bazel_build_fuzz_tests
@@ -57,7 +57,6 @@ declare -r BAZEL_BUILD_FLAGS=(
     "--verbose_failures" \
     "--spawn_strategy=standalone" \
     "--action_env=CC=${CC}" "--action_env=CXX=${CXX}" \
-
     ${BAZEL_EXTRA_BUILD_FLAGS[*]}
 )
 

--- a/infra/base-images/base-builder/bazel_build_fuzz_tests
+++ b/infra/base-images/base-builder/bazel_build_fuzz_tests
@@ -48,7 +48,6 @@ for oss_fuzz_test in "${OSS_FUZZ_TESTS[@]}"; do
 done
 
 declare -r BAZEL_BUILD_FLAGS=(
-    "-c" "opt"
     "--@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing_oss_fuzz//:oss_fuzz_engine" \
     "--@rules_fuzzing//fuzzing:java_engine=@rules_fuzzing_oss_fuzz//:oss_fuzz_java_engine" \
     "--@rules_fuzzing//fuzzing:cc_engine_instrumentation=oss-fuzz" \
@@ -58,6 +57,7 @@ declare -r BAZEL_BUILD_FLAGS=(
     "--verbose_failures" \
     "--spawn_strategy=standalone" \
     "--action_env=CC=${CC}" "--action_env=CXX=${CXX}" \
+
     ${BAZEL_EXTRA_BUILD_FLAGS[*]}
 )
 


### PR DESCRIPTION
This is causing issues for e.g. Fuzz Introspector where some data, e.g. mapping of binary to source, is optimized out.

We don't need to sets the flags in the first place, considering the `oss-fuzz` rule applies the `CFLAGS` https://github.com/bazelbuild/rules_fuzzing/blob/master/docs/guide.md#configuration-flags