### PR TITLE
Fix the xpdf fuzzer

### DIFF
--- a/projects/xpdf/fuzz_pdfload.cc
+++ b/projects/xpdf/fuzz_pdfload.cc
@@ -96,7 +96,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
                 xfa.free();
             }
 
-            for (size_t i = 0; i < doc.getNumPages(); i++) {
+            for (size_t i = 1; i <= doc.getNumPages(); i++) {
               doc.getLinks(i);
               auto page = doc.getCatalog()->getPage(i);
               if (!page->isOk()) {


### PR DESCRIPTION
The number of pages is starting at `1`, and not at `0`

This should fix #11711