### PR TITLE
Revert "[CFL] Temporary work around MSAN issue."

### DIFF
--- a/infra/cifuzz/run_fuzzers.py
+++ b/infra/cifuzz/run_fuzzers.py
@@ -15,7 +15,6 @@
 import enum
 import logging
 import os
-import subprocess
 import sys
 import time
 
@@ -308,7 +307,6 @@ def run_fuzzers(config):  # pylint: disable=too-many-locals
   Returns:
     A RunFuzzersResult enum value indicating what happened during fuzzing.
   """
-  subprocess.run(['sysctl', '-w', 'vm.mmap_rnd_bits=28'], check=False)
   fuzz_target_runner = get_fuzz_target_runner(config)
   if not fuzz_target_runner.initialize():
     # We didn't fuzz at all because of internal (CIFuzz) errors. And we didn't


### PR DESCRIPTION
This reverts commit d9a8b112597c37e9fdb8a765c7f58f14e9a32f2d.

It should be safe to revert it now that
https://github.com/actions/runner-images/issues/9491 is closed.

That stopgap was also reverted in
https://github.com/systemd/systemd/commit/ae0e1cb989bcc43bd3e7e5729cbea7d33571fe65 and the CI confirmed that other workflows with sanitizers are fine so CIFuzz/CFLite should be fine as well.