### PR TITLE
infra: bazel_build_fuzz_tests: do not force O0 (second try)

### DIFF
--- a/infra/base-images/base-builder/bazel_build_fuzz_tests
+++ b/infra/base-images/base-builder/bazel_build_fuzz_tests
@@ -48,7 +48,6 @@ for oss_fuzz_test in "${OSS_FUZZ_TESTS[@]}"; do
 done
 
 declare -r BAZEL_BUILD_FLAGS=(
-    "-c" "opt"
     "--@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing_oss_fuzz//:oss_fuzz_engine" \
     "--@rules_fuzzing//fuzzing:java_engine=@rules_fuzzing_oss_fuzz//:oss_fuzz_java_engine" \
     "--@rules_fuzzing//fuzzing:cc_engine_instrumentation=oss-fuzz" \


### PR DESCRIPTION
This does the same as https://github.com/google/oss-fuzz/pull/11715 which seems to be stuck in the CI