### PR TITLE
[quickjs] Ensure input data is zero-terminated

### DIFF
--- a/projects/quickjs/fuzz_compile.c
+++ b/projects/quickjs/fuzz_compile.c
@@ -58,11 +58,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     }
 
     if (Size > 0) {
-        if (Data[Size-1] != 0) {
-            return 0;
-        }
+        uint8_t *NullTerminatedData = (uint8_t *)malloc(Size + 1);
+        memcpy(NullTerminatedData, Data, Size);
+        NullTerminatedData[Size] = 0;
         JSValue obj;
-        obj = JS_Eval(ctx, (const char *)Data, Size-1, "<none>", JS_EVAL_FLAG_COMPILE_ONLY | JS_EVAL_TYPE_GLOBAL | JS_EVAL_TYPE_MODULE);
+        obj = JS_Eval(ctx, (const char *)NullTerminatedData, Size, "<none>", JS_EVAL_FLAG_COMPILE_ONLY | JS_EVAL_TYPE_GLOBAL | JS_EVAL_TYPE_MODULE);
+        free(NullTerminatedData);
         //TODO target with JS_ParseJSON
         if (JS_IsException(obj)) {
             return 0;

--- a/projects/quickjs/fuzz_eval.c
+++ b/projects/quickjs/fuzz_eval.c
@@ -57,13 +57,13 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     }
 
     if (Size > 0) {
-        //is it more efficient to malloc(Size+1) and memcpy ?
-        if (Data[Size-1] != 0) {
-            return 0;
-        }
+        uint8_t *NullTerminatedData = (uint8_t *)malloc(Size + 1);
+        memcpy(NullTerminatedData, Data, Size);
+        NullTerminatedData[Size] = 0;
         nbinterrupts = 0;
         //the final 0 does not count (as in strlen)
-        JSValue val = JS_Eval(ctx, (const char *)Data, Size-1, "<none>", JS_EVAL_TYPE_GLOBAL);
+        JSValue val = JS_Eval(ctx, (const char *)NullTerminatedData, Size, "<none>", JS_EVAL_TYPE_GLOBAL);
+        free(NullTerminatedData);
         //TODO targets with JS_ParseJSON, JS_ReadObject
         if (!JS_IsException(val)) {
             js_std_loop(ctx);


### PR DESCRIPTION
LibFuzzer reads input corpus as binary data and it doesn't ensure it to be zero-terminated. Since quickjs expects receiving zero-terminated input, only those tests were enabled in the fuzz targets. However, this condition discards many useful tests, the whole input corpus among others. The patch ensures to zero-terminate all inputs properly.