### PR TITLE
Handle BrokenPipeError in wait_for_build

### DIFF
--- a/infra/build/functions/build_lib.py
+++ b/infra/build/functions/build_lib.py
@@ -629,7 +629,7 @@ def wait_for_build(build_id, credentials, cloud_project):
                                   'INTERNAL_ERROR', 'EXPIRED', 'CANCELLED'):
         # Build done.
         return
-    except googleapiclient.errors.HttpError:
+    except (googleapiclient.errors.HttpError, BrokenPipeError):
       pass
 
     time.sleep(15)  # Avoid rate limiting.


### PR DESCRIPTION
The GCE metadata server can be unresponsive sometimes, resulting in this exception.

This should address the  root cause of the stack trace pointed out in https://github.com/google/oss-fuzz/pull/11727