### PR TITLE
Reapply "target_experiment: don't use gcloud. (#11701)" (#11727)

### DIFF
--- a/infra/build/functions/build_lib.py
+++ b/infra/build/functions/build_lib.py
@@ -23,13 +23,16 @@ import six.moves.urllib.parse as urlparse
 import sys
 import time
 import subprocess
+import tarfile
 import tempfile
 import json
+import uuid
 
 from googleapiclient.discovery import build as cloud_build
 import googleapiclient.discovery
 import google.api_core.client_options
 import google.auth
+from google.cloud import storage
 from oauth2client import service_account as service_account_lib
 import requests
 import yaml
@@ -547,6 +550,15 @@ def get_build_body(steps,
   return build_body
 
 
+def _tgz_local_build(oss_fuzz_project, temp_tgz_path):
+  """Prepare a .tgz containing the files required to build `oss_fuzz_project`."""
+  # Just the projects/<project> dir should be sufficient.
+  project_rel_path = os.path.join('projects', oss_fuzz_project)
+  with tarfile.open(temp_tgz_path, 'w:gz') as tar:
+    tar.add(os.path.join(OSS_FUZZ_ROOT, project_rel_path),
+            arcname=project_rel_path)
+
+
 def run_build(  # pylint: disable=too-many-arguments
     oss_fuzz_project,
     steps,
@@ -566,23 +578,24 @@ def run_build(  # pylint: disable=too-many-arguments
                               use_build_pool=use_build_pool,
                               experiment=experiment)
   if experiment:
-    with tempfile.NamedTemporaryFile(suffix='build.json') as config_file:
-      config_file.write(bytes(json.dumps(build_body), 'utf-8'))
-      config_file.seek(0)
-      result = subprocess.run([
-          'gcloud',
-          'builds',
-          'submit',
-          '--project=oss-fuzz',
-          f'--config={config_file.name}',
-          '--async',
-          '--format=get(id)',
-      ],
-                              stdout=subprocess.PIPE,
-                              cwd=OSS_FUZZ_ROOT,
-                              encoding='utf-8',
-                              check=True)
-      return result.stdout.strip()
+    with tempfile.NamedTemporaryFile(suffix='source.tgz') as tgz_file:
+      # Archive the necessary files for the build.
+      _tgz_local_build(oss_fuzz_project, tgz_file.name)
+      gcs_client = storage.Client()
+      # This is the automatically created Cloud Build bucket for Cloud Build.
+      bucket_name = gcs_client.project + '_cloudbuild'
+      bucket = gcs_client.bucket(bucket_name)
+      blob_name = f'source/{str(uuid.uuid4())}.tgz'
+      blob = bucket.blob(blob_name)
+      logging.info(f'Uploading project to {bucket_name}/{blob_name}')
+      blob.upload_from_filename(tgz_file.name)
+
+      build_body['source'] = {
+          'storageSource': {
+              'bucket': bucket_name,
+              'object': blob_name,
+          }
+      }
 
   cloudbuild = cloud_build('cloudbuild',
                            'v1',


### PR DESCRIPTION
This reverts commit a80fd730e4b7ac89726055894c746b674fbe2370.

The investigation shows that the slowness issues and `BrokenPipe` error mentioned in https://github.com/google/oss-fuzz/pull/11727#issue-2205034022 are not caused by #11701, so this PR reverts #11727.

Queued cloud builds of a full experiment likely caused the slowness.
Specifically, some cloud builds' `BrokenPipe` error caused them to queue forever, which blocks other cloud builds and causes the slowness.
This should have been solved by #11729, I will start another full experiment shortly and verify that.