### PR TITLE
apache-httpd: Add missing includes

### DIFF
--- a/projects/apache-httpd/build.sh
+++ b/projects/apache-httpd/build.sh
@@ -26,7 +26,7 @@ svn checkout https://svn.apache.org/repos/asf/apr/apr/trunk/ srclib/apr
 # Build httpd
 ./buildconf
 ./configure --with-included-apr --enable-pool-debug
-make
+make -j$( nproc )
 
 static_pcre=($(find /src/pcre2 -name "libpcre2-8.a"))
 

--- a/projects/apache-httpd/fuzz_request.c
+++ b/projects/apache-httpd/fuzz_request.c
@@ -108,7 +108,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
       apr_bucket_brigade *tmp_bb = apr_brigade_create(r->pool, r->connection->bucket_alloc);
       conn.keepalive = AP_CONN_UNKNOWN;
 
-      ap_run_pre_read_request(r, conn);
+      ap_run_pre_read_request(r, &conn);
 
       core_server_config conf_mod;
       conf_mod.http_conformance   = (char)af_get_short(&data2, &size2);

--- a/projects/apache-httpd/fuzz_request.c
+++ b/projects/apache-httpd/fuzz_request.c
@@ -34,6 +34,9 @@ limitations under the License.
 #include "ap_provider.h"
 #include "ap_regex.h"
 
+#include "http_log.h"
+#include "http_protocol.h"
+
 #include "ada_fuzz_header.h"
 
 static const char *http_scheme2(const request_rec *r) {


### PR DESCRIPTION
This is needed for compilers after clang-16. Otherwise, there are errors, such as:

```
/src/fuzz_request.c:59:3: error: call to undeclared function 'ap_hook_http_scheme'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   59 |   ap_hook_http_scheme(http_scheme2, NULL, NULL, APR_HOOK_REALLY_LAST);
      |   ^
/src/fuzz_request.c:92:5: error: call to undeclared function 'ap_method_registry_init'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   92 |     ap_method_registry_init(conn.pool);
      |     ^
