### PR TITLE
Add Emilio to CC list for rust-cssparser

### DIFF
--- a/projects/servo/project.yaml
+++ b/projects/servo/project.yaml
@@ -9,5 +9,5 @@ auto_ccs:
   - "mrlachatte@gmail.com"
   - "vgosu@mozilla.com"
   - "david@adalogics.com"
-  - "emilio@mozilla.com"
+  - "ealvarez@mozilla.com"
 main_repo: 'https://github.com/servo/servo'

--- a/projects/servo/project.yaml
+++ b/projects/servo/project.yaml
@@ -9,4 +9,5 @@ auto_ccs:
   - "mrlachatte@gmail.com"
   - "vgosu@mozilla.com"
   - "david@adalogics.com"
+  - "emilio@mozilla.com"
 main_repo: 'https://github.com/servo/servo'


### PR DESCRIPTION
@emilio is the primary maintainer of rust-cssparser, so he should have access to the issues reported for it.