### PR TITLE
libressl: Bump Boost download URL

### DIFF
--- a/projects/libressl/Dockerfile
+++ b/projects/libressl/Dockerfile
@@ -21,7 +21,7 @@ RUN git clone --depth 1 https://github.com/libressl/portable.git libressl
 RUN git clone --depth 1 https://github.com/libressl/fuzz.git libressl.fuzzers
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora
-RUN wget https://archives.boost.io/release/1.74.0/source/boost_1_74_0.tar.bz2
+RUN wget https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.bz2
 RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN wget https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz
 RUN test "$(sha256sum gmp-6.2.1.tar.lz)" = "2c7f4f0d370801b2849c48c9ef3f59553b5f1d3791d070cffb04599f9fc67b41  gmp-6.2.1.tar.lz"

--- a/projects/libressl/build.sh
+++ b/projects/libressl/build.sh
@@ -18,8 +18,8 @@
 
 # Install Boost headers
 cd $SRC/
-tar jxf boost_1_74_0.tar.bz2
-cd boost_1_74_0/
+tar jxf boost_1_84_0.tar.bz2
+cd boost_1_84_0/
 CFLAGS="" CXXFLAGS="" ./bootstrap.sh
 CFLAGS="" CXXFLAGS="" ./b2 headers
 cp -R boost/ /usr/include/


### PR DESCRIPTION
Split out from https://github.com/google/oss-fuzz/pull/11741, to test the fix https://github.com/google/oss-fuzz/pull/11741#issuecomment-2024925131 independently.