### PR TITLE
alembic: Bump OpenEXR

### DIFF
--- a/projects/alembic/Dockerfile
+++ b/projects/alembic/Dockerfile
@@ -21,9 +21,8 @@ RUN apt-get update && apt-get install -y build-essential zlib1g-dev zlib1g-dev:i
 RUN git clone --depth 1 https://github.com/alembic/alembic
 
 # Ubuntu's libilmbase-dev package doesn't include static libraries, so we have
-# to build OpenEXR from source.  The v2.4.2 release is the most recent as of
-# 2020-07-29.
-RUN git clone -b v2.4.2 --depth 1 https://github.com/AcademySoftwareFoundation/openexr
+# to build OpenEXR from source.
+RUN git clone -b v2.5.9 --depth 1 https://github.com/AcademySoftwareFoundation/openexr
 
 COPY build.sh *.h *.cc $SRC/
 WORKDIR $WORK/


### PR DESCRIPTION
This is required to allow newer compilers, such as clang-18.