### PR TITLE
quickjs: Add missing include to fuzz_eval.c

### DIFF
--- a/projects/quickjs/fuzz_eval.c
+++ b/projects/quickjs/fuzz_eval.c
@@ -18,6 +18,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 
 static int initialized = 0;
 JSRuntime *rt;


### PR DESCRIPTION
This is required for modern compilers to be able to compile it. Otherwise:

```
fuzz_eval.c:61:9: error: call to undeclared library function 'memcpy' with type 'void *(void *, const void *, unsigned long)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   61 |         memcpy(NullTerminatedData, Data, Size);
      |         ^
fuzz_eval.c:61:9: note: include the header <string.h> or explicitly provide a declaration for 'memcpy'
1 error generated.
ERROR:__main__:Building fuzzers failed.
