### PR TITLE
Bump Boost download URL in Cryptofuzz-related projects (part 2)

### DIFF
--- a/projects/bearssl/Dockerfile
+++ b/projects/bearssl/Dockerfile
@@ -20,7 +20,7 @@ RUN git clone --depth 1 https://www.bearssl.org/git/BearSSL
 RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora
-RUN wget https://archives.boost.io/release/1.74.0/source/boost_1_74_0.tar.bz2
+RUN wget https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.bz2
 COPY build.sh $SRC/
 # This is to fix Fuzz Introspector build by using LLVM old pass manager
 # re https://github.com/ossf/fuzz-introspector/issues/305

--- a/projects/bearssl/build.sh
+++ b/projects/bearssl/build.sh
@@ -20,8 +20,8 @@
 
 # Install Boost headers
     cd $SRC/
-    tar jxf boost_1_74_0.tar.bz2
-    cd boost_1_74_0/
+    tar jxf boost_1_84_0.tar.bz2
+    cd boost_1_84_0/
     CFLAGS="" CXXFLAGS="" ./bootstrap.sh
     CFLAGS="" CXXFLAGS="" ./b2 headers
     cp -R boost/ /usr/include/

--- a/projects/bitcoin-core/Dockerfile
+++ b/projects/bitcoin-core/Dockerfile
@@ -31,7 +31,7 @@ RUN git clone --depth 1 https://github.com/bitcoin-core/secp256k1.git
 RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone --depth 1 https://github.com/trezor/trezor-firmware.git
 RUN git clone --depth 1 https://github.com/google/wycheproof.git
-RUN wget https://archives.boost.io/release/1.74.0/source/boost_1_74_0.tar.bz2
+RUN wget https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.bz2
 WORKDIR bitcoin-core
 COPY build.sh $SRC/
 COPY build_cryptofuzz.sh $SRC/

--- a/projects/bitcoin-core/build_cryptofuzz.sh
+++ b/projects/bitcoin-core/build_cryptofuzz.sh
@@ -20,11 +20,11 @@ export LIBFUZZER_LINK="$LIB_FUZZING_ENGINE"
 
 # Install Boost headers
 cd $SRC/
-tar jxf boost_1_74_0.tar.bz2
-cd boost_1_74_0/
+tar jxf boost_1_84_0.tar.bz2
+cd boost_1_84_0/
 CFLAGS="" CXXFLAGS="" ./bootstrap.sh
 CFLAGS="" CXXFLAGS="" ./b2 headers
-export CXXFLAGS="$CXXFLAGS -I $SRC/boost_1_74_0/"
+export CXXFLAGS="$CXXFLAGS -I $SRC/boost_1_84_0/"
 
 # Preconfigure libsecp256k1
 cd $SRC/secp256k1/

--- a/projects/bls-signatures/Dockerfile
+++ b/projects/bls-signatures/Dockerfile
@@ -21,7 +21,7 @@ RUN git clone --depth 1 https://github.com/supranational/blst
 RUN git clone --depth 1 https://github.com/herumi/mcl.git
 RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone --depth 1 https://github.com/mratsim/constantine
-RUN wget -q https://archives.boost.io/release/1.74.0/source/boost_1_74_0.tar.bz2
+RUN wget -q https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.bz2
 RUN wget -q https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz
 RUN wget -q https://nim-lang.org/download/nim-1.6.12-linux_x64.tar.xz
 RUN wget -q https://nim-lang.org/download/nim-1.6.12-linux_x32.tar.xz

--- a/projects/bls-signatures/build.sh
+++ b/projects/bls-signatures/build.sh
@@ -25,8 +25,8 @@ export LINK_FLAGS=""
 
 # Install Boost headers
 cd $SRC/
-tar jxf boost_1_74_0.tar.bz2
-cd boost_1_74_0/
+tar jxf boost_1_84_0.tar.bz2
+cd boost_1_84_0/
 CFLAGS="" CXXFLAGS="" ./bootstrap.sh
 CFLAGS="" CXXFLAGS="" ./b2 headers
 cp -R boost/ /usr/include/


### PR DESCRIPTION
Split out from https://github.com/google/oss-fuzz/pull/11741 to allow CI to not timeout