### PR TITLE
s2opc: Bump mbedtls

### DIFF
--- a/projects/s2opc/Dockerfile
+++ b/projects/s2opc/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y make cmake git curl
 # Sources and dependencies
 RUN git clone --depth 1 https://gitlab.com/systerel/S2OPC
 RUN git clone --depth 1 https://gitlab.com/systerel/S2OPC-fuzzing-data
-RUN curl -L https://github.com/Mbed-TLS/mbedtls/archive/v2.28.0.tar.gz -o $SRC/mbedtls.tgz
+RUN curl -L https://github.com/Mbed-TLS/mbedtls/releases/download/v2.28.8/mbedtls-2.28.8.tar.bz2 -o $SRC/mbedtls.tbz2
 RUN curl -L https://github.com/libcheck/check/releases/download/0.14.0/check-0.14.0.tar.gz -o $SRC/check.tgz
 RUN curl -L https://github.com/libexpat/libexpat/releases/download/R_2_4_3/expat-2.4.3.tar.gz -o $SRC/expat.tgz
 

--- a/projects/s2opc/build.sh
+++ b/projects/s2opc/build.sh
@@ -24,7 +24,7 @@ SAMPLES=$SRC/S2OPC-fuzzing-data
 # Build the dependencies
 
 ## Configure mbedtls to disable support of the AES-NI instructions, known to cause error with some sanitizers
-tar xzf $SRC/mbedtls.tgz -C $WORK
+tar xjf $SRC/mbedtls.tbz2 -C $WORK
 sed 's,#define MBEDTLS_AESNI_C,//#define MBEDTLS_AESNI_C,' -i $WORK/mbedtls-2.*/include/mbedtls/config.h
 
 mkdir -p $MBEDTLS_BUILD


### PR DESCRIPTION
To fix clang-18 errors:

```
/work/mbedtls-2.28.0/library/bignum.c:1395:29: error: variable 't' set but not used [-Werror,-Wunused-but-set-variable]
 1395 |     mbedtls_mpi_uint c = 0, t = 0;
      |                             ^
1 error generated.
make[2]: *** [library/CMakeFiles/mbedcrypto.dir/build.make:174: library/CMakeFiles/mbedcrypto.dir/bignum.c.o] Error 1
