### PR TITLE
ntopng: Bump dependecies

### DIFF
--- a/projects/ntopng/Dockerfile
+++ b/projects/ntopng/Dockerfile
@@ -36,10 +36,10 @@ RUN mkdir libprotobuf-mutator/build; cd libprotobuf-mutator/build; \
 
 ADD https://www.tcpdump.org/release/libpcap-1.9.1.tar.gz libpcap-1.9.1.tar.gz
 RUN tar -xvzf libpcap-1.9.1.tar.gz
-ADD https://github.com/zeromq/libzmq/releases/download/v4.3.4/zeromq-4.3.4.tar.gz zeromq-4.3.4.tar.gz
-RUN tar -xvzf zeromq-4.3.4.tar.gz
-ADD https://github.com/json-c/json-c/archive/refs/tags/json-c-0.16-20220414.tar.gz json-c-0.16-20220414.tar.gz
-RUN tar -xvzf json-c-0.16-20220414.tar.gz
+ADD https://github.com/zeromq/libzmq/releases/download/v4.3.5/zeromq-4.3.5.tar.gz zeromq-4.3.5.tar.gz
+RUN tar -xvzf zeromq-4.3.5.tar.gz
+ADD https://github.com/json-c/json-c/archive/refs/tags/json-c-0.17-20230812.tar.gz json-c-0.17-20230812.tar.gz
+RUN tar -xvzf json-c-0.17-20230812.tar.gz
 ADD https://github.com/maxmind/libmaxminddb/releases/download/1.7.1/libmaxminddb-1.7.1.tar.gz libmaxminddb-1.7.1.tar.gz
 RUN tar -xvzf libmaxminddb-1.7.1.tar.gz;
 

--- a/projects/ntopng/build.sh
+++ b/projects/ntopng/build.sh
@@ -33,14 +33,17 @@ make -j$(nproc)
 make install
 
 # zeromq
-cd $SRC/zeromq-4.3.4
+cd $SRC/zeromq-4.3.5
 ./autogen.sh
+(
+export CXXFLAGS="-Wno-error=missing-braces -stdlib=libc++"
 ./configure --without-documentation --without-libsodium --enable-static --disable-shared
 make -j$(nproc)
 make install
+)
 
 # json-c
-cd $SRC/json-c-json-c-0.16-20220414
+cd $SRC/json-c-json-c-0.17-20230812
 mkdir build
 cd build
 cmake -DBUILD_SHARED_LIBS=OFF ..


### PR DESCRIPTION
Also, suppress the missing-braces error. Both are done to fix issues with clang-18.