### PR TITLE
Bump Boost download URL in Cryptofuzz-related projects (part 3)

### DIFF
--- a/projects/circl/Dockerfile
+++ b/projects/circl/Dockerfile
@@ -23,7 +23,7 @@ RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone --depth 1 https://github.com/supranational/blst.git
 RUN cd $SRC/cryptofuzz/modules/circl && go get ./... || true
-RUN wget https://archives.boost.io/release/1.74.0/source/boost_1_74_0.tar.bz2
+RUN wget https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.bz2
 RUN wget https://storage.googleapis.com/pub/gsutil.tar.gz -O $SRC/gsutil.tar.gz
 RUN tar zxf $SRC/gsutil.tar.gz
 ENV PATH="${PATH}:$SRC/gsutil"

--- a/projects/circl/build.sh
+++ b/projects/circl/build.sh
@@ -21,8 +21,8 @@ export LINK_FLAGS=""
 
 # Install Boost headers
 cd $SRC/
-tar jxf boost_1_74_0.tar.bz2
-cd boost_1_74_0/
+tar jxf boost_1_84_0.tar.bz2
+cd boost_1_84_0/
 CFLAGS="" CXXFLAGS="" ./bootstrap.sh
 CFLAGS="" CXXFLAGS="" ./b2 headers
 cp -R boost/ /usr/include/

--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -62,7 +62,7 @@ RUN git clone --depth 1 https://github.com/supranational/blst.git
 RUN git clone --depth 1 https://github.com/bitcoin-core/secp256k1.git
 RUN apt-get remove -y libunwind8
 RUN apt-get install -y libssl-dev
-RUN wget https://archives.boost.io/release/1.74.0/source/boost_1_74_0.tar.bz2
+RUN wget https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.bz2
 RUN wget https://nodejs.org/dist/v14.17.1/node-v14.17.1-linux-x64.tar.xz
 RUN pip3 install -r $SRC/mbedtls/scripts/basic.requirements.txt
 RUN bash -c "wget $(curl https://ziglang.org/download/index.json | jq -r '.master."x86_64-linux".tarball') -O zig-latest.tar.xz"

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -83,8 +83,8 @@ cp -R $SRC/xxHash/ $SRC/cryptofuzz/modules/reference/
 
 # Install Boost headers
 cd $SRC/
-tar jxf boost_1_74_0.tar.bz2
-cd boost_1_74_0/
+tar jxf boost_1_84_0.tar.bz2
+cd boost_1_84_0/
 CFLAGS="" CXXFLAGS="" ./bootstrap.sh
 CFLAGS="" CXXFLAGS="" ./b2 headers
 cp -R boost/ /usr/include/


### PR DESCRIPTION
Split out from https://github.com/google/oss-fuzz/pull/11741 to allow CI to not timeout