### PR TITLE
hdf5: Add mising include

### DIFF
--- a/projects/hdf5/h5_extended_fuzzer.c
+++ b/projects/hdf5/h5_extended_fuzzer.c
@@ -12,6 +12,8 @@ limitations under the License.
 
 #include "hdf5.h"
 
+#include <unistd.h>
+
 extern int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     char filename[256];

--- a/projects/hdf5/h5_read_fuzzer.c
+++ b/projects/hdf5/h5_read_fuzzer.c
@@ -12,6 +12,8 @@ limitations under the License.
 
 #include "hdf5.h"
 
+#include <unistd.h>
+
 extern int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     // Some old logic with regards to skipping first byte. Leaving it here


### PR DESCRIPTION
To fix a clang-18 error:

```
/src/h5_read_fuzzer.c:27:44: error: call to undeclared function 'getpid'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   27 |     sprintf(filename, "/tmp/libfuzzer.%d", getpid());
      |                                            ^
1 error generated.
ERROR:__main__:Building fuzzers failed.
