### PR TITLE
kcodecs: Avoid clang-18 error

### DIFF
--- a/projects/kcodecs/build.sh
+++ b/projects/kcodecs/build.sh
@@ -23,7 +23,7 @@ FUZZ_CXXFLAGS="${CXXFLAGS}"
 unset CFLAGS
 unset CXXFLAGS
 # gperf is a code generator, so no need to sanitize it
-./configure --prefix=/usr
+./configure --prefix=/usr CXX='clang++ -std=c++14'  # Avoid C++17 due to clang-18 error
 make -j$(nproc) install
 export CFLAGS="${FUZZ_CFLAGS}"
 export CXXFLAGS="${FUZZ_CXXFLAGS}"


### PR DESCRIPTION
As soon as selecting C++17, at least in clang-18, it will fail:

```
./getline.cc:58:7: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
   58 |       register int c = getc (stream);
      |       ^~~~~~~~
1 error generated.
