### PR TITLE
Bump Boost download URL in Cryptofuzz-related projects (part 1)

### DIFF
--- a/projects/libecc/Dockerfile
+++ b/projects/libecc/Dockerfile
@@ -23,7 +23,7 @@ RUN git clone --depth 1 https://github.com/wolfssl/wolfsm
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN wget -q https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz
 RUN test "$(sha256sum gmp-6.2.1.tar.lz)" = "2c7f4f0d370801b2849c48c9ef3f59553b5f1d3791d070cffb04599f9fc67b41  gmp-6.2.1.tar.lz"
-RUN wget -q https://archives.boost.io/release/1.74.0/source/boost_1_74_0.tar.bz2
+RUN wget -q https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.bz2
 COPY build.sh $SRC/
 # This is to fix Fuzz Introspector build by using LLVM old pass manager
 # re https://github.com/ossf/fuzz-introspector/issues/305

--- a/projects/libecc/build.sh
+++ b/projects/libecc/build.sh
@@ -20,8 +20,8 @@ export LIBFUZZER_LINK="$LIB_FUZZING_ENGINE"
 
 # Install Boost headers
 cd $SRC/
-tar jxf boost_1_74_0.tar.bz2
-cd boost_1_74_0/
+tar jxf boost_1_84_0.tar.bz2
+cd boost_1_84_0/
 CFLAGS="" CXXFLAGS="" ./bootstrap.sh
 CFLAGS="" CXXFLAGS="" ./b2 headers
 cp -R boost/ /usr/include/

--- a/projects/nettle/Dockerfile
+++ b/projects/nettle/Dockerfile
@@ -20,7 +20,7 @@ RUN git clone --depth 1 https://git.lysator.liu.se/nettle/nettle
 RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora
-RUN wget https://archives.boost.io/release/1.74.0/source/boost_1_74_0.tar.bz2
+RUN wget https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.bz2
 RUN wget https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz
 RUN test "$(sha256sum gmp-6.2.1.tar.lz)" = "2c7f4f0d370801b2849c48c9ef3f59553b5f1d3791d070cffb04599f9fc67b41  gmp-6.2.1.tar.lz"
 COPY build.sh $SRC/

--- a/projects/nettle/build.sh
+++ b/projects/nettle/build.sh
@@ -22,8 +22,8 @@ export LINK_FLAGS=""
 
 # Install Boost headers
     cd $SRC/
-    tar jxf boost_1_74_0.tar.bz2
-    cd boost_1_74_0/
+    tar jxf boost_1_84_0.tar.bz2
+    cd boost_1_84_0/
     CFLAGS="" CXXFLAGS="" ./bootstrap.sh
     CFLAGS="" CXXFLAGS="" ./b2 headers
     cp -R boost/ /usr/include/

--- a/projects/num-bigint/Dockerfile
+++ b/projects/num-bigint/Dockerfile
@@ -18,5 +18,5 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool wget python
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/randombit/botan.git
-RUN wget https://archives.boost.io/release/1.74.0/source/boost_1_74_0.tar.bz2
+RUN wget https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.bz2
 COPY build.sh $SRC/

--- a/projects/num-bigint/build.sh
+++ b/projects/num-bigint/build.sh
@@ -25,8 +25,8 @@ source $HOME/.cargo/env
 
 # Install Boost headers
 cd $SRC/
-tar jxf boost_1_74_0.tar.bz2
-cd boost_1_74_0/
+tar jxf boost_1_84_0.tar.bz2
+cd boost_1_84_0/
 CFLAGS="" CXXFLAGS="" ./bootstrap.sh
 CFLAGS="" CXXFLAGS="" ./b2 headers
 cp -R boost/ /usr/include/

--- a/projects/relic/Dockerfile
+++ b/projects/relic/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool wget pyt
 RUN git clone --depth 1 https://github.com/relic-toolkit/relic.git
 RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
-RUN wget https://archives.boost.io/release/1.74.0/source/boost_1_74_0.tar.bz2
+RUN wget https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.bz2
 COPY build.sh $SRC/
 # This is to fix Fuzz Introspector build by using LLVM old pass manager
 # re https://github.com/ossf/fuzz-introspector/issues/305

--- a/projects/relic/build.sh
+++ b/projects/relic/build.sh
@@ -20,8 +20,8 @@ export LIBFUZZER_LINK="$LIB_FUZZING_ENGINE"
 
 # Install Boost headers
 cd $SRC/
-tar jxf boost_1_74_0.tar.bz2
-cd boost_1_74_0/
+tar jxf boost_1_84_0.tar.bz2
+cd boost_1_84_0/
 CFLAGS="" CXXFLAGS="" ./bootstrap.sh
 CFLAGS="" CXXFLAGS="" ./b2 headers
 cp -R boost/ /usr/include/


### PR DESCRIPTION
For some reason GitHub closed  #11741 without merge. So this is the same changes, reopened.