### PR TITLE
haproxy: Add missing includes

### DIFF
--- a/projects/haproxy/fuzz_cfg_parser.c
+++ b/projects/haproxy/fuzz_cfg_parser.c
@@ -15,9 +15,13 @@
 #
 ################################################################################
 */
-#include <stdlib.h>
-#include <stdio.h>
+
+#include <haproxy/cfgparse.h>
+
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
 
 int
 LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)


### PR DESCRIPTION
Needed for clang-18:

```
fuzz_cfg_parser.c:29:41: error: call to undeclared function 'getpid'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   29 |         sprintf(filename, "/tmp/libfuzzer.%d", getpid());
      |                                                ^
fuzz_cfg_parser.c:38:2: error: call to undeclared function 'readcfgfile'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   38 |         readcfgfile(filename);
      |         ^
fuzz_cfg_parser.c:40:2: error: call to undeclared function 'unlink'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   40 |         unlink(filename);
      |         ^
3 errors generated.
ERROR:__main__:Building fuzzers failed.
