### PR TITLE
sharp: fix build

### DIFF
--- a/projects/sharp/build.sh
+++ b/projects/sharp/build.sh
@@ -16,6 +16,7 @@
 ################################################################################
 
 # Install dependencies.
+npm install --ignore-scripts --no-save emnapi
 npm install
 npm install --save-dev @jazzer.js/core
 


### PR DESCRIPTION
Manually installs the `emnapi` dependency without running scripts to workaround an upstream npm registry data problem.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=67706

Upstream report https://github.com/toyobayashi/emnapi/issues/112