### PR TITLE
Replace xz contributor with project owner.

### DIFF
--- a/projects/xz-java/project.yaml
+++ b/projects/xz-java/project.yaml
@@ -1,8 +1,6 @@
 homepage: "https://xz.tukaani.org/xz-for-java/"
 language: jvm
-primary_contact: "jiat0218@gmail.com"
-auto_ccs:
-  - "lasse.collin@tukaani.org"
+primary_contact: "lasse.collin@tukaani.org"
 fuzzing_engines:
   - libfuzzer
 main_repo: "https://github.com/tukaani-project/xz-java"

--- a/projects/xz/project.yaml
+++ b/projects/xz/project.yaml
@@ -1,8 +1,7 @@
 homepage: "https://xz.tukaani.org/xz-utils/"
 language: c++
-primary_contact: "jiat0218@gmail.com"
+primary_contact: "lasse.collin@tukaani.org"
 auto_ccs:
-  - "lasse.collin@tukaani.org"
   - "bshas3@gmail.com"
 fuzzing_engines:
   - libfuzzer


### PR DESCRIPTION
In light of https://www.openwall.com/lists/oss-security/2024/03/29/4 we will change the contact of the xz projects back to the original maintainer.

Related:
https://github.com/google/oss-fuzz/issues/11760