### PR TITLE
[gitpython] Fix Broken Build

### DIFF
--- a/projects/gitpython/Dockerfile
+++ b/projects/gitpython/Dockerfile
@@ -16,5 +16,15 @@ FROM gcr.io/oss-fuzz-base/base-builder-python
 RUN git clone https://github.com/gitpython-developers/gitpython gitpython \
     && python3 -m pip install --upgrade pip;
 
+RUN mkdir -p $SRC/seed_data \
+    && git clone --depth 1 https://github.com/DaveLak/oss-fuzz-inputs.git oss-fuzz-inputs \
+    && rsync -avc oss-fuzz-inputs/gitpython/ $SRC/seed_data/ \
+    && rm -rf oss-fuzz-inputs;
+
+RUN git clone --depth 1 https://github.com/google/fuzzing fuzzing \
+    && cat fuzzing/dictionaries/utf8.dict \
+      >> $SRC/seed_data/__base.dict \
+    && rm -rf fuzzing;
+
 COPY *.sh *py $SRC/
 WORKDIR $SRC/gitpython

--- a/projects/gitpython/Dockerfile
+++ b/projects/gitpython/Dockerfile
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 FROM gcr.io/oss-fuzz-base/base-builder-python
-RUN git clone https://github.com/gitpython-developers/gitpython gitpython
+RUN git clone https://github.com/gitpython-developers/gitpython gitpython \
+    && python3 -m pip install --upgrade pip;
+
 COPY *.sh *py $SRC/
 WORKDIR $SRC/gitpython

--- a/projects/gitpython/build.sh
+++ b/projects/gitpython/build.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 ################################################################################
-pip3 install .
+python3 -m pip install .
 
 # Build fuzzers in $OUT.
 for fuzzer in $(find $SRC -name 'fuzz_*.py'); do

--- a/projects/gitpython/fuzz_tree.py
+++ b/projects/gitpython/fuzz_tree.py
@@ -12,13 +12,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import atheris
 import io
 import sys
+import os
 import shutil
-import atheris
 
-from git.objects import Tree
-from git import Repo
+with atheris.instrument_imports():
+  from git.objects import Tree
+  from git.repo import Repo
 
 
 def TestOneInput(data):
@@ -45,11 +47,10 @@ def TestOneInput(data):
   try:
     fuzz_tree._deserialize(io.BytesIO(data))
   except IndexError:
-    pass
+    return -1
 
 
 def main():
-  atheris.instrument_all()
   atheris.Setup(sys.argv, TestOneInput)
   atheris.Fuzz()
 


### PR DESCRIPTION
Fixes ClusterFuzz issues [67399][1] and [55299][2]

## [Issue 67399: gitpython: Fuzzing build failure][1]
Since: 2024-03-11

### The Problem
The pre-installed version of `pip` (19.2.3) was outdated and unable to parse the `pyproject.toml` syntax during the install step in `build.sh` causing the script to error out and crash.

### The Solution
Upgrading `pip` to the latest version in the project image resolves the issue and allows the installation to complete.

## [Issue 55299: gitpython: Coverage build failure][2]
Since: 2023-01-21

### The Problem 
_(my hypothesis at least)_

I believe the root of the issue here was caused by fuzzer initialization and execution taking too long for the actual run to generate a meaningful corpus. I suspect this because:
- The [build log posted in the CF issue](https://oss-fuzz-build-logs.storage.googleapis.com/log-851906cd-45e2-47d9-b51c-9917eaf961cf.txt) shows the coverage build fails after trying to unzip the corpus archives and warning the zipfiles are empty.
- I downloaded a backup of the corpus zips to confirm and they are in fact empty.
- This project has a deep dependency graph which caused the call to
`atheris.instrament_all()` to instrument 4,000+ functions before the fuzzer execution could begin which was causing a significant delay (on my local machine, at least) before actual test execution would start.


### The Solution(-ish)
The commit message on 908ba9c207aff00f1b580e6677bc0a56229fc471 should sum it up, but the TL;DR is I reduced the scope of instrumented functions to align closer with the APIs being fuzzed and added dictionaries and seed corpra which provided promising results locally.

`fuzz_tree.py` is still slow as far as average_exec_per_sec, but startup is quicker and with the seed data it gets close to its coverage depth fairly quickly as well.

- I believe this will fix the OSS-Fuzz coverage build at least.
- but I suspect the Introspector build will continue to timeout because I couldn't figure out how to get pycg to play nicely with the dependency graph 
  - (I think there's a circular dependency it gets stuck on, but that's a problem for another day.)

[1]: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=67399
[2]: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=55299