### PR TITLE
[pygments] Upgrade pip to fix broken build

### DIFF
--- a/projects/pygments/Dockerfile
+++ b/projects/pygments/Dockerfile
@@ -21,6 +21,8 @@ RUN git clone \
 	--branch master \
 	https://github.com/pygments/pygments.git
 
+RUN python3 -m pip install --upgrade pip
+
 WORKDIR pygments
 
 RUN git clone --depth 1 https://github.com/google/fuzzing

--- a/projects/pygments/build.sh
+++ b/projects/pygments/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 # Build and install project (using current CFLAGS, CXXFLAGS).
-pip3 install .
+python3 -m pip install .
 
 # Build fuzzers in $OUT.
 for fuzzer in $(find $SRC -name 'fuzz_*.py'); do


### PR DESCRIPTION
It looks like the `pygments` build has the same toml parsing issue as I described in c3bedd8ccc24468e9c414be96e9f7cb4746aed21, i.e. the outdated `pip` was unable to parse `pyproject.toml` syntax.

But curiously, the this hasn't been an issue until the most recent (at the time of writing) build on 2024-03-30 [log](https://oss-fuzz-build-logs.storage.googleapis.com/log-8bec1e41-343e-4d95-ae29-6341c23e27af.txt) and prior builds (e.g. 2024-03-29 [log](https://oss-fuzz-build-logs.storage.googleapis.com/log-9a057fc1-c280-44d3-808f-5069c35af146.txt)) listed on https://oss-fuzz-build-logs.storage.googleapis.com/index.html#pygments seem to have been fine?

I wonder if something changed somewhere and more projects that don't upgrade pip will begin failing?

In any case, this fixes the build. Tested locally with `python infra/helper.py check_build pygments`.