### PR TITLE
Revert "dropbear: fix broken build (#8183)"

### DIFF
--- a/projects/dropbear/Dockerfile
+++ b/projects/dropbear/Dockerfile
@@ -16,6 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y libz-dev autoconf mercurial
+RUN hg clone https://hg.ucc.asn.au/dropbear-fuzzcorpus dropbear-corpus
 RUN git clone https://github.com/mkj/dropbear dropbear
 WORKDIR dropbear
 COPY build.sh *.options $SRC/

--- a/projects/dropbear/build.sh
+++ b/projects/dropbear/build.sh
@@ -22,6 +22,9 @@ make -j$(nproc) fuzz-targets FUZZLIB=$LIB_FUZZING_ENGINE
 
 TARGETS="$(make list-fuzz-targets)"
 
+make -C $SRC/dropbear-corpus
 
 cp -v $TARGETS $OUT/
 cp -v *.options $OUT/
+cp -v $SRC/dropbear-corpus/*.zip $OUT/
+cp -v $SRC/dropbear-corpus/*.dict $OUT/


### PR DESCRIPTION
hg.ucc.asn.au was intermittently unavailable it's available now.

This reverts commit 10b8aeddd7380fe6f10927fffb495ea020f9b867.

It would be good to CC project maintainers when merging something like #8183 (I didn't realise the corpus had been removed, I could have moved the server if needed)
