### PR TITLE
igraph: ignore vendored code in coverage

### DIFF
--- a/projects/igraph/project.yaml
+++ b/projects/igraph/project.yaml
@@ -2,7 +2,7 @@ homepage: "https://github.com/igraph/igraph"
 main_repo: "https://github.com/igraph/igraph"
 language: c
 primary_contact: "szhorvat@gmail.com"
-coverage_extra_args: -ignore-filename-regex=.*libxml2-2.*/.*
+coverage_extra_args: -ignore-filename-regex=.*libxml2-2.*/.* -ignore-filename-regex=.*/vendor/.*
 auto_ccs:
   - "Adam@adalogics.com"
   - "ntamas@gmail.com"


### PR DESCRIPTION
Ignore vendored sources in igraph, as these are (mostly) used only when an external version of the respective library is not available.