### PR TITLE
crosvm: Fix apt-get command

### DIFF
--- a/projects/crosvm/Dockerfile
+++ b/projects/crosvm/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder-rust
 
 RUN git clone --depth=1 --recursive https://chromium.googlesource.com/crosvm/crosvm $SRC/crosvm
 
-RUN apt-get upgrade && apt-get install --yes --no-install-recommends \
+RUN apt-get update && apt-get install --yes --no-install-recommends \
     libclang-dev \
     pkg-config \
     libcap-dev


### PR DESCRIPTION
Using `apt upgrade` without `-y` is problematic, because it may fail:

```
Step #17: Step 3/4 : RUN apt-get upgrade && apt-get install --yes --no-install-recommends     libclang-dev     pkg-config     libcap-dev
Step #17:  ---> Running in 4fd961f9329f
Step #17: Reading package lists...
Step #17: Building dependency tree...
Step #17: Reading state information...
Step #17: Calculating upgrade...
Step #17: The following packages will be upgraded:
Step #17:   bsdutils fdisk libblkid1 libfdisk1 libmount1 libsmartcols1 libuuid1 mount
Step #17:   util-linux
Step #17: 9 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Step #17: Need to get 1901 kB of archives.
Step #17: After this operation, 4096 B of additional disk space will be used.
Step #17: Do you want to continue? [Y/n] Abort.
Step #17: The command '/bin/sh -c apt-get upgrade && apt-get install --yes --no-install-recommends     libclang-dev     pkg-config     libcap-dev' returned a non-zero code: 1
Finished Step #17
ERROR
```

Also, an `apt-get update` is needed, anyway.

Fix both issues by replacing `upgrade` with `update`.