### PR TITLE
lua: enable Leakanitizer debug mode

### DIFF
--- a/projects/lua/build.sh
+++ b/projects/lua/build.sh
@@ -63,6 +63,8 @@ case $SANITIZER in
   *) SANITIZERS_ARGS="" ;;
 esac
 
+export LSAN_OPTIONS="verbosity=1:log_threads=1"
+
 : ${LD:="${CXX}"}
 : ${LDFLAGS:="${CXXFLAGS}"}  # to make sure we link with sanitizer runtime
 


### PR DESCRIPTION
Building `luaL_loadbuffer_proto` on AArch64 has failed with unclear error:

```
[31mFAILED: �[0mtests/capi/luaL_loadbuffer_proto/preamble.lua.c /src/testdir/build/tests/capi/luaL_loadbuffer_proto/preamble.lua.c
cd /src/testdir/build/tests/capi/luaL_loadbuffer_proto && /usr/bin/echo 'const char preamble_lua[] =' > /src/testdir/build/tests/capi/luaL_loadbuffer_proto/preamble.lua.new.c && /src/testdir/build/extra/txt2c /src/testdir/tests/capi/luaL_loadbuffer_proto/preamble.lua >> /src/testdir/build/tests/capi/luaL_loadbuffer_proto/preamble.lua.new.c && /usr/bin/echo ';' >> /src/testdir/build/tests/capi/luaL_loadbuffer_proto/preamble.lua.new.c && /usr/local/bin/cmake -E copy_if_different /src/testdir/build/tests/capi/luaL_loadbuffer_proto/preamble.lua.new.c /src/testdir/build/tests/capi/luaL_loadbuffer_proto/preamble.lua.c && /usr/local/bin/cmake -E remove /src/testdir/build/tests/capi/luaL_loadbuffer_proto/preamble.lua.new.c
==2425==LeakSanitizer has encountered a fatal error.
==2425==HINT: For debugging, try setting environment variable LSAN_OPTIONS=verbosity=1:log_threads=1
==2425==HINT: LeakSanitizer does not work under ptrace (strace, gdb, etc)
```

The patch set an environment variable enabling debug mode in LeakSanitizer.

Needed for https://github.com/ligurio/lua-c-api-tests/issues/72