### PR TITLE
Change JCC error log location and upload

### DIFF
--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -357,7 +357,7 @@ func WriteStdErrOut(outstr string, errstr string) {
 	// Prints |outstr| to stdout, prints |errstr| to stderr, and saves |errstr| to err.log.
 	fmt.Print(outstr)
 	fmt.Fprint(os.Stderr, errstr)
-	AppendStringToFile("/out/err.log", errstr)
+	AppendStringToFile("/workspace/err.log", errstr)
 }
 
 func main() {

--- a/infra/build/functions/target_experiment.py
+++ b/infra/build/functions/target_experiment.py
@@ -91,9 +91,9 @@ def run_experiment(project_name, target_name, args, output_path, errlog_path,
     else:
       # Insert the upload step right after compile step.
       steps.insert(compile_step_index + 1, {
-        'name': 'gcr.io/cloud-builders/gsutil',
-        'args': ['-m', 'cp', local_err_path, errlog_path],
-        'allowFailure': True
+          'name': 'gcr.io/cloud-builders/gsutil',
+          'args': ['-m', 'cp', local_err_path, errlog_path],
+          'allowFailure': True
       })
 
   env = build_project.get_env(project_yaml['language'], build)

--- a/infra/build/functions/target_experiment.py
+++ b/infra/build/functions/target_experiment.py
@@ -88,13 +88,13 @@ def run_experiment(project_name, target_name, args, output_path, errlog_path,
                                if '&& compile' in ' '.join(d['args'])), -1)
     if compile_step_index == -1:
       print('Cannot find compile step')
-
-    # Insert the upload step right after compile step.
-    steps.insert(compile_step_index + 1, {
-      'name': 'gcr.io/cloud-builders/gsutil',
-      'args': ['-m', 'cp', local_err_path, errlog_path],
-      'allowFailure': True
-    })
+    else:
+      # Insert the upload step right after compile step.
+      steps.insert(compile_step_index + 1, {
+        'name': 'gcr.io/cloud-builders/gsutil',
+        'args': ['-m', 'cp', local_err_path, errlog_path],
+        'allowFailure': True
+      })
 
   env = build_project.get_env(project_yaml['language'], build)
   env.append('RUN_FUZZER_MODE=batch')

--- a/infra/build/functions/target_experiment.py
+++ b/infra/build/functions/target_experiment.py
@@ -72,7 +72,7 @@ def run_experiment(project_name, target_name, args, output_path, errlog_path,
 
   build = build_project.Build('libfuzzer', 'address', 'x86_64')
   local_output_path = '/workspace/output.log'
-  local_jcc_err_path = '/workspace/err.log'  # From jcc.go:360
+  local_jcc_err_path = '/workspace/err.log'  # From jcc.go:360.
   local_corpus_path_base = '/workspace/corpus'
   local_corpus_path = os.path.join(local_corpus_path_base, target_name)
   default_target_path = os.path.join(build.out, target_name)
@@ -87,8 +87,6 @@ def run_experiment(project_name, target_name, args, output_path, errlog_path,
     compile_step_index = -1
     for i, step in enumerate(steps):
       step_args = step.get('args', [])
-      if not step_args:
-        continue
       if '&& compile' in ' '.join(step_args):
         compile_step_index = i
         break


### PR DESCRIPTION
Upload `JCC`'s error log to assist `OSS-Fuzz-Gen` analyzing and classifying build errors:
1. Change JCC `err.log` location, because`/out` was removed before `compile` by default and `err.log` cannot be saved there.
2. Add a step in `target_experiment.py` to upload `err.log` to gcloud bucket.