### PR TITLE
suricata: clean some disk space while building

### DIFF
--- a/projects/suricata/build.sh
+++ b/projects/suricata/build.sh
@@ -131,6 +131,11 @@ cat generic.dict >> $OUT/fuzz_applayerparserparse$branch.dict
 cat generic.dict >> $OUT/fuzz_sigpcap$branch.dict
 cat generic.dict >> $OUT/fuzz_sigpcap_aware$branch.dict
 
+df
+# clean to leave enough space for CIFuzz
+make clean
+df
+
 # build corpuses
 # default configuration file
 zip -r $OUT/fuzz_confyamlloadstring"$branch"_seed_corpus.zip suricata.yaml


### PR DESCRIPTION
As done by openssl in https://github.com/google/oss-fuzz/pull/11618

Is there a way from build.sh to know if we are built by CIFuzz ? Like environment variable `CFL_PLATFORM` ?
Because I do not think we want to build other branches than master for CIFuzz