### PR TITLE
librsvg: add project.yaml

### DIFF
--- a/projects/librsvg/project.yaml
+++ b/projects/librsvg/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://gitlab.gnome.org/GNOME/librsvg/"
+language: rust
+primary_contact: "federico.mena@gmail.com"
+auto_ccs:
+  - "correctmost@gmail.com"
+main_repo: "https://gitlab.gnome.org/GNOME/librsvg.git"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer


### PR DESCRIPTION
#### Prominent users
- GNOME and GTK ([source](https://archlinux.org/packages/extra/x86_64/librsvg/))
- Wikipedia ([source](https://en.wikipedia.org/wiki/Librsvg#Adoption))

#### Verification
- I have received permission to integrate librsvg into OSS-Fuzz from a maintainer: https://gitlab.gnome.org/GNOME/librsvg/-/issues/1070#note_2078036
  - The maintainer's `primary_contact` email can be seen in the commit history: https://gitlab.gnome.org/GNOME/librsvg/-/commit/ed7b9fda3dd22b4a46723b3cae7a5c9e47bd9316.patch
- I have committed to the librsvg repository: https://gitlab.gnome.org/GNOME/librsvg/-/merge_requests/954