### PR TITLE
lua: work around LeakSanitizer internal errors

### DIFF
--- a/projects/lua/build.sh
+++ b/projects/lua/build.sh
@@ -65,6 +65,12 @@ esac
 
 export LSAN_OPTIONS="verbosity=1:log_threads=1"
 
+# Workaround for a LeakSanitizer crashes,
+# see https://github.com/google/oss-fuzz/issues/11798.
+if [ "$ARCHITECTURE" = "aarch64" ]; then
+    export ASAN_OPTIONS=detect_leaks=0
+fi
+
 : ${LD:="${CXX}"}
 : ${LDFLAGS:="${CXXFLAGS}"}  # to make sure we link with sanitizer runtime
 


### PR DESCRIPTION
When using `-fanitize=address`, we consistently get spurious build failures on ARM64 due to some issue with the leak detection pass at the end of execution:

```
==2413==AddressSanitizer: failed to intercept '__isoc99_printf'
==2413==AddressSanitizer: failed to intercept '__isoc99_sprintf'
==2413==AddressSanitizer: failed to intercept '__isoc99_snprintf'
==2413==AddressSanitizer: failed to intercept '__isoc99_fprintf'
==2413==AddressSanitizer: failed to intercept '__isoc99_vprintf'
==2413==AddressSanitizer: failed to intercept '__isoc99_vsprintf'
==2413==AddressSanitizer: failed to intercept '__isoc99_vsnprintf'
==2413==AddressSanitizer: failed to intercept '__isoc99_vfprintf'
==2413==AddressSanitizer: failed to intercept 'xdr_destroy'
==2413==AddressSanitizer: failed to intercept 'crypt'
==2413==AddressSanitizer: failed to intercept 'crypt_r'
==2413==AddressSanitizer: failed to intercept '__cxa_throw'
==2413==AddressSanitizer: failed to intercept '__cxa_rethrow_primary_exception'
==2413==AddressSanitizer: libc interceptors initialized
|| `[0x002000000000, 0x007fffffffff]` || HighMem    ||
|| `[0x001400000000, 0x001fffffffff]` || HighShadow ||
|| `[0x001200000000, 0x0013ffffffff]` || ShadowGap  ||
|| `[0x001000000000, 0x0011ffffffff]` || LowShadow  ||
|| `[0x000000000000, 0x000fffffffff]` || LowMem     ||
MemToShadow(shadow): 0x001200000000 0x00123fffffff 0x001280000000 0x0013ffffffff
redzone=16
max_redzone=2048
quarantine_size_mb=256M
thread_local_quarantine_size_kb=1024K
```

Note, it does not happen for me locally and on AWS Graviton 2 using the same build-with command line.

Related to google/oss-fuzz#11798
Related to google/sanitizers#723
Related to ligurio/lua-c-api-tests#72