### PR TITLE
Report matio issues to primary contact of hdf5 group

### DIFF
--- a/projects/matio/project.yaml
+++ b/projects/matio/project.yaml
@@ -1,16 +1,16 @@
 homepage: "https://github.com/tbeu/matio"
 language: c++
 primary_contact: "t-beu@users.sourceforge.net"
+auto_ccs:
+  - "derobins@hdfgroup.org"
 sanitizers:
   - address
   - memory
   - undefined
 architectures:
   - x86_64
-main_repo: 'https://github.com/tbeu/matio'
-
+main_repo: "https://github.com/tbeu/matio"
 fuzzing_engines:
   - afl
   - honggfuzz
   - libfuzzer
-


### PR DESCRIPTION
This is due to https://github.com/HDFGroup/hdf5/issues/272 and the recently disclosed issues https://github.com/HDFGroup/hdf5/issues/4350 and https://github.com/HDFGroup/hdf5/issues/4351. Many of the found issues actually address libhdf5. I know that libhdf5 has its own oss-fuzz setup, but I cannot be sure if the reported issues for libmatio are also found there.

@derobins Being primary contact for hdf5 fuzzing report, do you approve?