### PR TITLE
Apache POI: more expected exceptions

### DIFF
--- a/projects/apache-poi/Dockerfile
+++ b/projects/apache-poi/Dockerfile
@@ -42,7 +42,10 @@ WORKDIR ${SRC}
 RUN git clone --depth 1 https://github.com/apache/poi.git
 
 # install packages required for font-handling and other code in java.awt.*
-RUN apt-get install -y libxext6 libx11-6 libxrender1 libxtst6 libxi6 libxcb1 libxau6 libxdmcp6
+RUN apt-get install -y libxext6 libx11-6 libxrender1 libxtst6 libxi6 libxcb1 libxau6 libxdmcp6 \
+&& apt-get clean autoclean \
+&& apt-get autoremove --yes \
+&& rm -rf /var/lib/{apt,dpkg,cache,log}/
 
 ADD pom.xml build.sh ${SRC}/
 ADD src/ ${SRC}/src/

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIFuzzer.java
@@ -124,8 +124,16 @@ public class POIFuzzer {
 	public static void checkExtractor(POITextExtractor extractor) throws IOException {
 		extractor.getDocument();
 		extractor.getFilesystem();
-		extractor.getMetadataTextExtractor();
-		extractor.getText();
+		try {
+			extractor.getMetadataTextExtractor();
+		} catch (IllegalStateException e) {
+			// can happen here
+		}
+		try {
+			extractor.getText();
+		} catch (OpenXML4JRuntimeException e) {
+			// can happen here
+		}
 
 		if (extractor instanceof POIOLE2TextExtractor) {
 			POIOLE2TextExtractor ole2Extractor = (POIOLE2TextExtractor) extractor;

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIVisioFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIVisioFuzzer.java
@@ -38,7 +38,7 @@ public class POIVisioFuzzer {
 			visio.write(NullOutputStream.INSTANCE);
 		} catch (IOException | POIXMLException |
 				 BufferUnderflowException | RecordFormatException | OpenXML4JRuntimeException |
-				 IllegalArgumentException | IndexOutOfBoundsException e) {
+				 IllegalArgumentException | IndexOutOfBoundsException | IllegalStateException e) {
 			// expected here
 		}
 


### PR DESCRIPTION
Fuzzing encountered a few more exceptions which are expected, so update fuzz-targets a bit more.

For some methods it makes sense to catch expected exceptions directly to still cover other methods afterwards and not leave the fuzz-target immediately.

We can also reduce the size of the docker image slightly by removing unnecessary remnants from package installation.