### PR TITLE
Submit IronRDP project

### DIFF
--- a/projects/ironrdp/project.yaml
+++ b/projects/ironrdp/project.yaml
@@ -1,0 +1,8 @@
+homepage: https://github.com/Devolutions/IronRDP
+main_repo: https://github.com/Devolutions/IronRDP
+language: rust
+primary_contact: oss-fuzz@devolutions.net
+auto_ccs:
+  - oss-fuzz@goteleport.com
+sanitizers:
+  - address


### PR DESCRIPTION
IronRDP is a pure Rust implementation of the Microsoft RDP protocol. The whole stack is open source and dual-licensed under the MIT and Apache v2 licenses. It is portable and versatile: it can be compiled for the WASM target and run in the browser.

The stack is currently used by Devolutions Inc. in the browser (WASM target) and GoTeleport on proxy side (native target). There is also an ongoing experiment to build an out-of-process display server in the QEMU project:

- https://github.com/Devolutions/IronRDP/issues/49#issuecomment-1410391444