### PR TITLE
Revert "Disable liblzma (#11762)"

### DIFF
--- a/projects/lzma/Dockerfile
+++ b/projects/lzma/Dockerfile
@@ -1,0 +1,34 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+
+RUN apt-get update && apt-get install -y \
+	autoconf \
+	automake \
+	libtool \
+	make
+
+RUN git clone \
+	--depth 1 \
+	--branch master \
+	https://github.com/fancycode/lzma-fuzz.git \
+	lzma-fuzz
+
+WORKDIR lzma-fuzz
+
+COPY build.sh $SRC/

--- a/projects/lzma/build.sh
+++ b/projects/lzma/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -eu
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# build and install fuzzers
+make clean
+make -j$(nproc)
+make install DEST=$OUT

--- a/projects/lzma/project.yaml
+++ b/projects/lzma/project.yaml
@@ -1,0 +1,16 @@
+homepage: "https://www.7-zip.org/sdk.html"
+main_repo: 'https://github.com/fancycode/lzma-fuzz.git'
+language: c++
+primary_contact: "ipavlov@users.sourceforge.net"
+auto_ccs:
+  - "mail@joachim-bauch.de"
+sanitizers:
+  - address
+  - memory
+  - undefined
+
+fuzzing_engines:
+  - afl
+  - honggfuzz
+  - libfuzzer
+


### PR DESCRIPTION
This reverts commit ae9dd26d624ec2cd2ae1d277d62ce30e2a70e798.

There is no evidence that the LZMA SDK in 7zip was affected at all - the issue in xz was a rogue co-maintainer.

I have also fixed the copyright headers, per CI.

--

See also the discussion at https://github.com/google/oss-fuzz/pull/11805#discussion_r1565324089. I don't have an association with LZMA SDK, but noticed this when fixing up xz (for which I do have an association).