### PR TITLE
libyaml: Fix yaml_write_handler return values

### DIFF
--- a/projects/libyaml/yaml_write_handler.h
+++ b/projects/libyaml/yaml_write_handler.h
@@ -26,12 +26,12 @@ static int yaml_write_handler(void *data, unsigned char *buffer, size_t size) {
   out->buf = (unsigned char *)realloc(out->buf, out->size + size);
   if (!out->buf) {
     out->size = 0;
-    return 1;
+    return 0;
   }
 
   memcpy(out->buf + out->size, buffer, size);
   out->size += size;
-  return 0;
+  return 1;
 }
 
 #endif // YAML_WRITE_HANDLER_H_


### PR DESCRIPTION
See #11811

libyaml expects 1 for success and 0 for failure.

https://github.com/yaml/libyaml/blob/master/src/writer.c#L53-L62

    if (emitter->write_handler(emitter->write_handler_data, ...) {
        ...
    }
    else {
        return yaml_emitter_set_writer_error(emitter, "write error");
    }

The logic is currently reverse, which (in combination of the failing check for the yaml_emitter_dump return value) caused several wrong bug reports and a CVE.

The fuzzer programs just ignore the failing yaml_emitter_dump, and so I assume it never appeared as a problem. Only in the cases where the wrongly called yaml_emitter_close ran into a case where it popped from an empty stack an overflow was detected.

The input YAML in question just had a lot of nested sequences in the form

    - - - - -

which in canonical output mode resulted in a large output because of the indentation, and so the buffer flush was triggered before the emitter finished:

    !!seq [
      !!seq [
        ...

In the most cases the YAML is simply too small to produce the error because the flush happened when the output was complete.

Note that this does not yet fix the missing error handling of `yaml_emitter_dump` in libyaml_dumper_fuzzer.c etc.