### PR TITLE
Fix xpdf fuzz_pdfload fuzzer

### DIFF
--- a/projects/xpdf/fuzz_pdfload.cc
+++ b/projects/xpdf/fuzz_pdfload.cc
@@ -111,7 +111,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             SplashOutputDev *splashOut = new SplashOutputDev(splashModeRGB8, 1, gFalse, paperColor);
             splashOut->setNoComposite(gTrue);
             splashOut->startDoc(doc.getXRef());
-            for (size_t i = 0; i <= doc.getNumPages(); ++i) {
+            for (size_t i = 1; i <= doc.getNumPages(); ++i) {
               doc.displayPage(splashOut, i, hdpi, vdpi, rotate, useMediaBox, crop, printing);
             }
             (void)splashOut->getBitmap();


### PR DESCRIPTION
Currently the xpdf fuzz_pdfload fuzzer fails because the harness tries to display page zero. 

Issue #11711 highlighted this but the merged fix #11716 only fixes the first of the two loops, when both need to start at 1.