### PR TITLE
Add hint text when jcc err.log does not get created

### DIFF
--- a/infra/build/functions/target_experiment.py
+++ b/infra/build/functions/target_experiment.py
@@ -96,7 +96,15 @@ def run_experiment(project_name, target_name, args, output_path, errlog_path,
       # Insert the upload step right after compile step.
       upload_jcc_err_step = {
           'name': 'gcr.io/cloud-builders/gsutil',
-          'args': ['cp', local_jcc_err_path, errlog_path]
+          'entrypoint':
+              '/bin/bash',
+          'args': [
+              '-c',
+              (f'test -f {local_jcc_err_path} || '
+               f'echo "Failed to generate JCC error log." >> '
+               f'{local_jcc_err_path} && '
+               f'gsutil cp {local_jcc_err_path} {errlog_path}'),
+          ]
       }
       steps.insert(compile_step_index + 1, upload_jcc_err_step)
 

--- a/infra/build/functions/target_experiment.py
+++ b/infra/build/functions/target_experiment.py
@@ -95,7 +95,8 @@ def run_experiment(project_name, target_name, args, output_path, errlog_path,
     else:
       # Insert the upload step right after compile step.
       upload_jcc_err_step = {
-          'name': 'gcr.io/cloud-builders/gsutil',
+          'name':
+              'gcr.io/cloud-builders/gsutil',
           'entrypoint':
               '/bin/bash',
           'args': [

--- a/infra/build/functions/target_experiment.py
+++ b/infra/build/functions/target_experiment.py
@@ -102,8 +102,8 @@ def run_experiment(project_name, target_name, args, output_path, errlog_path,
           'args': [
               '-c',
               (f'test -f {local_jcc_err_path} || '
-               f'echo "Failed to generate JCC error log." >> '
-               f'{local_jcc_err_path} && '
+               f'echo "Failed to generate JCC error log." | '
+               f'tee -a {local_jcc_err_path} && '
                f'gsutil cp {local_jcc_err_path} {errlog_path}'),
           ]
       }


### PR DESCRIPTION
Some project (e.g. [civetweb)](https://github.com/civetweb/civetweb/blob/88dad2f6ef3857802b2aa09a3a2195d5571935bf/Makefile#L84) does not use jcc to build fuzz targets.
This pr:
1. Prevents cloud build fail at upload jcc err step.
2. Add hint text in err.log for uploading.