### PR TITLE
EDK2 oss-fuzz integration with HBFA

### DIFF
--- a/projects/edk2/Dockerfile
+++ b/projects/edk2/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/edk2/Dockerfile
+++ b/projects/edk2/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN apt-get update && apt-get install -y \
+    python3 nasm uuid-dev
+
+RUN git clone https://github.com/tianocore/edk2.git --recursive
+RUN git clone https://github.com/intel/hbfa-fl
+
+COPY build.sh $SRC/

--- a/projects/edk2/build.sh
+++ b/projects/edk2/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+hbfa-fl/oss-fuzz/build.sh

--- a/projects/edk2/build.sh
+++ b/projects/edk2/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2021 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/edk2/project.yaml
+++ b/projects/edk2/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://www.tianocore.org"
+language: c
+fuzzing_engines:
+   - libfuzzer
+sanitizers:
+   - address
+   - undefined
+primary_contact: "edk2-hbfa-ossfuzz@intel.com"
+main_repo: "https://github.com/tianocore/edk2"
+file_github_issue: false


### PR DESCRIPTION
EDK2 forms the bases of the TianoCore UEFI BIOS reference implementation. Host Based Firmware Analyser (HBFA) is a build-system extension to EDK2 to allow building select code-segments for user-space fuzzing via libfuzzer, available at https://github.com/intel/hbfa-fl. We are enabling all currently functional HBFA EDK2 harnesses in this oss-fuzz integration.