### PR TITLE
qpid-proton: install python3.9 as it is required by the project

### DIFF
--- a/projects/qpid-proton/Dockerfile
+++ b/projects/qpid-proton/Dockerfile
@@ -19,6 +19,11 @@ RUN apt-get update && \
     apt-get install -y \
         cmake
 
+# Ensure we work from right python version
+RUN apt-get install -y python3.9 python3.9-dev && \
+    ln --force -s /usr/bin/python3.9 /usr/local/bin/python3 && \
+    apt-get install -y python3-pip
+
 RUN git clone https://github.com/apache/qpid-proton.git
 
 WORKDIR qpid-proton


### PR DESCRIPTION
This is to resolve

* https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=68175
* https://issues.apache.org/jira/browse/PROTON-2819

## Note to self

When trying this out locally, I noticed symptoms of https://github.com/google/oss-fuzz/issues/11698, so I also tried adding

```
# Use lld for linking as it is drop-in replacement more compatible with Clang
#  https://github.com/google/oss-fuzz/issues/11698
RUN apt-get install -y lld && \
    ln --force -s /usr/bin/lld /usr/local/bin/ld
```

In the end I noticed the following, which made me realize I am running out of disk space for docker. After redownloading docker images, the local build started working for me both with and without the above change, so for now I am not including that one

```
ld: error: /usr/local/lib/clang/15.0.0/lib/linux/libclang_rt.msan-x86_64.a: failed to parse archive: truncated or malformed archive (terminator characters in archive member "\000\000" not the correct "`\n" values for the archive member header for                 )
clang-15: error: linker command failed with exit code 1 (use -v to see invocation)
```