### PR TITLE
libstdcpp: Update build.sh for current GCC trunk

### DIFF
--- a/projects/libstdcpp/Dockerfile
+++ b/projects/libstdcpp/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder-testing-2403-roll-clang@sha256:0bc4e74ed3f5f2097980ed79cbef0f962fe1926d997ee581a44ccb0009c42a24
 RUN sed -i -e 's/^# deb-src/deb-src/g' /etc/apt/sources.list
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN apt build-dep -y g++-10

--- a/projects/libstdcpp/build.sh
+++ b/projects/libstdcpp/build.sh
@@ -35,8 +35,8 @@ for fuzzsrcfile in /src/*.cpp; do
 	$CXXFLAGS \
 	-std=c++20 \
 	-nostdinc++ \
-	-cxx-isystem $INSTALLDIR/include/c++/14.0.0/ \
-	-cxx-isystem $INSTALLDIR/include/c++/14.0.0/x86_64-pc-linux-gnu \
+	-cxx-isystem $INSTALLDIR/include/c++/14.0.1/ \
+	-cxx-isystem $INSTALLDIR/include/c++/14.0.1/x86_64-pc-linux-gnu \
 	$fuzzsrcfile \
 	-o $OUT/$targetfile \
 	$LIB_FUZZING_ENGINE \


### PR DESCRIPTION
The current version is 14.0.1 so the expected paths to the C++ headers need to be adjusted.

It might be better to just use `/*/` instead of `/14.0.1/` so it doesn't need to change again.

This should fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=65666