### PR TITLE
Tiny-json integration

### DIFF
--- a/projects/tiny-json/Dockerfile
+++ b/projects/tiny-json/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN git clone --depth 1 https://github.com/rafagafe/tiny-json.git $SRC/tiny-json     # or use other version control
+COPY . $SRC/

--- a/projects/tiny-json/build.sh
+++ b/projects/tiny-json/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -eu
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+for fuzzer in $(find $SRC -name 'fuzz_*.c'); do
+    fuzzer_name=$(basename $fuzzer .c)
+    $CXX $CXXFLAGS $SRC/$fuzzer_name.c -c -o $fuzzer_name.o
+    $CXX $CXXFLAGS $SRC/tiny-json/tiny-json.c -c -o tiny-json.o
+    $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $fuzzer_name.o tiny-json.o -o $OUT/$fuzzer_name
+done
+

--- a/projects/tiny-json/fuzzTinyJson.c
+++ b/projects/tiny-json/fuzzTinyJson.c
@@ -1,0 +1,35 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <cstring>
+#include <cstdlib>
+#include "tiny-json/tiny-json.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    char* data_str = static_cast<char*>(malloc(size + 1));
+    if (data_str == nullptr) {
+        return -1;
+    }
+    memcpy(data_str, data, size);
+    data_str[size] = '\0';
+
+    json_t *mem = new json_t[size];
+    json_t const* json = json_create(data_str, mem, size);
+
+    free(data_str);
+    delete[] mem;
+
+    return 0;
+}

--- a/projects/tiny-json/fuzz_json-create.c
+++ b/projects/tiny-json/fuzz_json-create.c
@@ -1,0 +1,35 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <cstring>
+#include <cstdlib>
+#include "tiny-json/tiny-json.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    char* data_str = static_cast<char*>(malloc(size + 1));
+    if (data_str == nullptr) {
+        return -1;
+    }
+    memcpy(data_str, data, size);
+    data_str[size] = '\0';
+
+    json_t *mem = new json_t[size];
+    json_t const* json = json_create(data_str, mem, size);
+
+    free(data_str);
+    delete[] mem;
+
+    return 0;
+}

--- a/projects/tiny-json/fuzz_json-get-property.c
+++ b/projects/tiny-json/fuzz_json-get-property.c
@@ -1,0 +1,40 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <cstring>
+#include <cstdlib>
+#include "tiny-json/tiny-json.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    char* data_str = static_cast<char*>(malloc(size + 1));
+    if (data_str == nullptr) {
+        return -1;
+    }
+    memcpy(data_str, data, size);
+    data_str[size] = '\0';
+
+    enum { MAX_FIELDS = 4 };
+    json_t *pool = new json_t[MAX_FIELDS];
+
+    char str[] = "{ \"name\": \"peter\", \"age\": 32 }";	
+
+    json_t const* parent = json_create( str, pool, MAX_FIELDS );
+    json_t const* namefield = json_getProperty( parent, data_str );
+
+    free(data_str);
+    delete[] pool;
+
+    return 0;
+}

--- a/projects/tiny-json/fuzz_json-get-value.c
+++ b/projects/tiny-json/fuzz_json-get-value.c
@@ -1,0 +1,42 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <cstring>
+#include <cstdlib>
+#include "tiny-json/tiny-json.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    char* data_str = static_cast<char*>(malloc(size + 1));
+    if (data_str == nullptr) {
+        return -1;
+    }
+    memcpy(data_str, data, size);
+    data_str[size] = '\0';
+
+    enum { MAX_FIELDS = 4 };
+    json_t *pool = new json_t[MAX_FIELDS];
+
+    char str[] = "{ \"name\": \"peter\", \"age\": 32 }";	
+
+    json_t const* parent = json_create( str, pool, MAX_FIELDS );
+    json_t const* namefield = json_getProperty( parent, "name" );
+
+    
+
+    free(data_str);
+    delete[] pool;
+
+    return 0;
+}

--- a/projects/tiny-json/project.yaml
+++ b/projects/tiny-json/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/rafagafe/tiny-json"
+main_repo: https://github.com/rafagafe/tiny-json
+language: c
+primary_contact: "void@lessvoid.com"
+auto_ccs:
+  - "xhanzalikj@stuba.sk"


### PR DESCRIPTION
tiny-json is a versatile and easy to use json parser written in C and suitable for embedded systems. It is fast, robust and portable.

It is not only a tokenizer. You can access json data in string format or get primitive values directly as C type variables without any loss of performance.

You can access the JSON fields one on one or get their values by their names. This helps you to save a lot of source code lines and development time.