### PR TITLE
libyaml: Fix error handling

### DIFF
--- a/projects/libyaml/libyaml_dumper_fuzzer.c
+++ b/projects/libyaml/libyaml_dumper_fuzzer.c
@@ -291,6 +291,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
       if (!done) {
         if (!documents_equal(documents + count, &document)) {
           yaml_parser_delete(&parser);
+          yaml_document_delete(&document);
           goto error;
         }
         count++;
@@ -300,12 +301,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     yaml_parser_delete(&parser);
   }
 
-  for (int k = 0; k < document_number; k++) {
-    yaml_document_delete(documents + k);
-  }
 
 error:
 
+  for (int k = 0; k < document_number; k++) {
+    yaml_document_delete(documents + k);
+  }
   free(out.buf);
   return 0;
 }


### PR DESCRIPTION
This is about https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=68171 and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=68178

In both cases we have a circular reference, e.g. `&a { *a: 1 }`, which leads to a missing cleanup.

In case documents_equal returns false, the current document needs to be deleted.

This is an issue when having cyclic documents, because documents_equal calls nodes_equal, and this will recurse until a level of 1000 and then just return false.
Instead it should detect that it is processing the same node(s) over and over again, but I don't know right now how to detect this in the fuzzer code. I guess one has to keep a list somewhere.

But the memory leak can be fixed by deleting the document.

Also I moved the deletion of the document list into the error handler, as it is just more convenient, and the error handler is called always anyway.