### PR TITLE
Write build command before error messages in jcc err.log

### DIFF
--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -43,7 +43,7 @@ func CopyFile(src string, dst string) {
 	}
 }
 
-func TryFixCCompilation(cmdline []string) (int, string, string) {
+func TryFixCCompilation(cmdline []string) (string, []string, int, string, string) {
 	var newFile string = ""
 	for i, arg := range cmdline {
 		if !strings.HasSuffix(arg, ".c") {
@@ -60,20 +60,21 @@ func TryFixCCompilation(cmdline []string) (int, string, string) {
 		break
 	}
 	if newFile == "" {
-		return 1, "", ""
+		return "", []string{}, 1, "", ""
 	}
+	bin := "clang++"
 	newCmdline := []string{"-stdlib=libc++"}
 	newCmdline = append(cmdline, newCmdline...)
 
-	retcode, out, err := Compile("clang++", newCmdline)
+	retcode, out, err := Compile(bin, newCmdline)
 	if retcode == 0 {
-		return retcode, out, err
+		return bin, newCmdline, retcode, out, err
 	}
-	corrected, _ := CorrectMissingHeaders("clang++", newCmdline)
+	correctedCmdline, corrected, _ := CorrectMissingHeaders(bin, newCmdline)
 	if corrected {
-		return 0, "", ""
+		return bin, correctedCmdline, 0, "", ""
 	}
-	return retcode, out, err
+	return bin, newCmdline, retcode, out, err
 }
 
 func ExtractMissingHeader(compilerOutput string) (string, bool) {
@@ -148,23 +149,23 @@ func GetHeaderCorrectedCmd(cmd []string, compilerErr string) ([]string, string, 
 	return cmd, "", errors.New("Couldn't find file")
 }
 
-func CorrectMissingHeaders(bin string, cmd []string) (bool, error) {
+func CorrectMissingHeaders(bin string, cmd []string) ([]string, bool, error) {
 
 	_, _, stderr := Compile(bin, cmd)
 	cmd, correctedFilename, err := GetHeaderCorrectedCmd(cmd, stderr)
 	if err != nil {
-		return false, err
+		return cmd, false, err
 	}
 	for i := 0; i < MaxMissingHeaderFiles; i++ {
 		fixed, hasBrokenHeaders := TryCompileAndFixHeadersOnce(bin, cmd, correctedFilename)
 		if fixed {
-			return true, nil
+			return cmd, true, nil
 		}
 		if !hasBrokenHeaders {
-			return false, nil
+			return cmd, false, nil
 		}
 	}
-	return false, nil
+	return cmd, false, nil
 }
 
 func EnsureDir(dirPath string) {
@@ -353,13 +354,13 @@ func AppendStringToFile(filepath, new_content string) error {
 	return err
 }
 
-func WriteStdErrOut(outstr string, errstr string) {
+func WriteStdErrOut(bin string, args []string, outstr string, errstr string) {
 	// Prints |outstr| to stdout, prints |errstr| to stderr, and saves |errstr| to err.log.
 	fmt.Print(outstr)
 	fmt.Fprint(os.Stderr, errstr)
 	// Record what source file produced the error.
-	// TODO: Should we write the actual flags used instead?
-	AppendStringToFile("/workspace/err.log", fmt.Sprintf("%s\n", os.Args))
+	fullargs := append([]string{bin}, args...)
+	AppendStringToFile("/workspace/err.log", fmt.Sprintf("%s\n", fullargs))
 	AppendStringToFile("/workspace/err.log", errstr)
 }
 
@@ -389,7 +390,7 @@ func main() {
 	}
 	retcode, out, errstr := Compile(bin, newArgs)
 	if retcode == 0 {
-		WriteStdErrOut(out, errstr)
+		WriteStdErrOut(bin, newArgs, out, errstr)
 		os.Exit(0)
 	}
 
@@ -398,7 +399,7 @@ func main() {
 	// When we fail we should try to write the original out/err and one from
 	// the corrected.
 
-	headersFixed, _ := CorrectMissingHeaders(bin, newArgs)
+	_, headersFixed, _ := CorrectMissingHeaders(bin, newArgs)
 	if headersFixed {
 		// We succeeded here but it's kind of complicated to get out and
 		// err from TryCompileAndFixHeadersOnce. The output and err is
@@ -410,20 +411,20 @@ func main() {
 		// Nothing else we can do. Just write the error and exit.
 		// Just print the original error for debugging purposes and
 		//  to make build systems happy.
-		WriteStdErrOut(out, errstr)
+		WriteStdErrOut(bin, newArgs, out, errstr)
 		os.Exit(retcode)
 	}
-	fixret, fixout, fixerr := TryFixCCompilation(newArgs)
+	fixbin, fixargs, fixret, fixout, fixerr := TryFixCCompilation(newArgs)
 	if fixret != 0 {
 		// We failed, write stdout and stderr from the first failure and
 		// from fix failures so we can know what the code did wrong and
 		// how to improve jcc to fix more issues.
-		WriteStdErrOut(out, errstr)
+		WriteStdErrOut(bin, newArgs, out, errstr)
 		fmt.Println("\nFix failure")
 		// Print error back to stderr so tooling that relies on this can proceed
-		WriteStdErrOut(fixout, fixerr)
+		WriteStdErrOut(fixbin, fixargs, fixout, fixerr)
 		os.Exit(retcode)
 	}
 	// The fix suceeded, write its out and err.
-	WriteStdErrOut(fixout, fixerr)
+	WriteStdErrOut(fixbin, fixargs, fixout, fixerr)
 }

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -357,6 +357,9 @@ func WriteStdErrOut(outstr string, errstr string) {
 	// Prints |outstr| to stdout, prints |errstr| to stderr, and saves |errstr| to err.log.
 	fmt.Print(outstr)
 	fmt.Fprint(os.Stderr, errstr)
+	// Record what source file produced the error.
+	// TODO: Should we write the actual flags used instead?
+	AppendStringToFile("/workspace/err.log", os.Args)
 	AppendStringToFile("/workspace/err.log", errstr)
 }
 

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -359,9 +359,8 @@ func WriteStdErrOut(args []string, outstr string, errstr string) {
 	// Prints |outstr| to stdout, prints |errstr| to stderr, and saves |errstr| to err.log.
 	fmt.Print(outstr)
 	fmt.Fprint(os.Stderr, errstr)
-	// Record what compile args produced the error.
-	AppendStringToFile("/workspace/err.log", fmt.Sprintf("%s\n", args))
-	AppendStringToFile("/workspace/err.log", errstr)
+	// Record what compile args produced the error and the error itself in log file.
+	AppendStringToFile("/workspace/err.log", fmt.Sprintf("%s\n", args) + errstr)
 }
 
 func main() {

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -62,18 +62,18 @@ func TryFixCCompilation(cmdline []string) ([]string, int, string, string) {
 	if newFile == "" {
 		return []string{}, 1, "", ""
 	}
-	bin := "clang++"
+	cppBin := "clang++"
 	newCmdline := []string{"-stdlib=libc++"}
 	newCmdline = append(cmdline, newCmdline...)
-	newFullArgs := append([]string{bin}, newCmdline...)
+	newFullArgs := append([]string{cppBin}, newCmdline...)
 
-	retcode, out, err := Compile(bin, newCmdline)
+	retcode, out, err := Compile(cppBin, newCmdline)
 	if retcode == 0 {
 		return newFullArgs, retcode, out, err
 	}
-	correctedCmdline, corrected, _ := CorrectMissingHeaders(bin, newCmdline)
+	correctedCmdline, corrected, _ := CorrectMissingHeaders(cppBin, newCmdline)
 	if corrected {
-		return append([]string{bin}, correctedCmdline...), 0, "", ""
+		return append([]string{cppBin}, correctedCmdline...), 0, "", ""
 	}
 	return newFullArgs, retcode, out, err
 }

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -359,7 +359,7 @@ func WriteStdErrOut(outstr string, errstr string) {
 	fmt.Fprint(os.Stderr, errstr)
 	// Record what source file produced the error.
 	// TODO: Should we write the actual flags used instead?
-	AppendStringToFile("/workspace/err.log", os.Args)
+	AppendStringToFile("/workspace/err.log", fmt.Sprintf("%s\n", os.Args))
 	AppendStringToFile("/workspace/err.log", errstr)
 }
 

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -399,11 +399,12 @@ func main() {
 	// When we fail we should try to write the original out/err and one from
 	// the corrected.
 
-	_, headersFixed, _ := CorrectMissingHeaders(bin, newArgs)
+	headersFixArgs, headersFixed, _ := CorrectMissingHeaders(bin, newArgs)
 	if headersFixed {
 		// We succeeded here but it's kind of complicated to get out and
 		// err from TryCompileAndFixHeadersOnce. The output and err is
 		// not so important on success so just be silent.
+		WriteStdErrOut(append([]string{bin}, headersFixArgs...), "", "")
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
This pr prints out the command executed with `jcc` right before the relevant error lines, if there are any, into `err.log`.
Having this extra info will help:
- oss-fuzz-gen code fixer precisely extract target error messages
- debug compile failure in more general cases
