### PR TITLE
libyaml: Improve buffer efficiency

### DIFF
--- a/projects/libyaml/libyaml_deconstructor_alt_fuzzer.c
+++ b/projects/libyaml/libyaml_deconstructor_alt_fuzzer.c
@@ -58,7 +58,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   yaml_parser_set_input_string(&parser, data, size);
 
   /* Set the emitter parameters. */
-  yaml_output_buffer_t out = {/*buf=*/NULL, /*size=*/0};
+  yaml_output_buffer_t out = {/*buf=*/NULL, /*size=*/0, /*capacity=*/1000};
   yaml_emitter_set_output(&emitter, yaml_write_handler, &out);
 
   yaml_emitter_set_canonical(&emitter, is_canonical);

--- a/projects/libyaml/libyaml_deconstructor_fuzzer.c
+++ b/projects/libyaml/libyaml_deconstructor_fuzzer.c
@@ -56,7 +56,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   yaml_parser_set_input_string(&parser, data, size);
 
   /* Set the emitter parameters. */
-  yaml_output_buffer_t out = {/*buf=*/NULL, /*size=*/0};
+  yaml_output_buffer_t out = {/*buf=*/NULL, /*size=*/0, /*capacity=*/1000};
   yaml_emitter_set_output(&emitter, yaml_write_handler, &out);
 
   yaml_emitter_set_canonical(&emitter, is_canonical);

--- a/projects/libyaml/libyaml_dumper_fuzzer.c
+++ b/projects/libyaml/libyaml_dumper_fuzzer.c
@@ -229,7 +229,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   yaml_emitter_set_canonical(&emitter, is_canonical);
   yaml_emitter_set_unicode(&emitter, is_unicode);
 
-  yaml_output_buffer_t out = {/*buf=*/NULL, /*size=*/0};
+  yaml_output_buffer_t out = {/*buf=*/NULL, /*size=*/0, /*capacity=*/1000};
   yaml_emitter_set_output(&emitter, yaml_write_handler, &out);
   yaml_emitter_open(&emitter);
 

--- a/projects/libyaml/libyaml_emitter_fuzzer.c
+++ b/projects/libyaml/libyaml_emitter_fuzzer.c
@@ -233,7 +233,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   yaml_emitter_set_canonical(&emitter, is_canonical);
   yaml_emitter_set_unicode(&emitter, is_unicode);
 
-  yaml_output_buffer_t out = {/*buf=*/NULL, /*size=*/0};
+  yaml_output_buffer_t out = {/*buf=*/NULL, /*size=*/0, /*capacity=*/1000};
   yaml_emitter_set_output(&emitter, yaml_write_handler, &out);
 
   while (!done) {

--- a/projects/libyaml/libyaml_reformatter_alt_fuzzer.c
+++ b/projects/libyaml/libyaml_reformatter_alt_fuzzer.c
@@ -52,7 +52,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   yaml_parser_set_input_string(&parser, data, size);
 
   /* Set the emitter parameters. */
-  yaml_output_buffer_t out = {/*buf=*/NULL, /*size=*/0};
+  yaml_output_buffer_t out = {/*buf=*/NULL, /*size=*/0, /*capacity=*/1000};
   yaml_emitter_set_output(&emitter, yaml_write_handler, &out);
 
   yaml_emitter_set_canonical(&emitter, is_canonical);

--- a/projects/libyaml/libyaml_reformatter_fuzzer.c
+++ b/projects/libyaml/libyaml_reformatter_fuzzer.c
@@ -52,7 +52,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   yaml_parser_set_input_string(&parser, data, size);
 
   /* Set the emitter parameters. */
-  yaml_output_buffer_t out = {/*buf=*/NULL, /*size=*/0};
+  yaml_output_buffer_t out = {/*buf=*/NULL, /*size=*/0, /*capacity=*/1000};
   yaml_emitter_set_output(&emitter, yaml_write_handler, &out);
 
   yaml_emitter_set_canonical(&emitter, is_canonical);

--- a/projects/libyaml/yaml_write_handler.h
+++ b/projects/libyaml/yaml_write_handler.h
@@ -18,12 +18,22 @@
 typedef struct yaml_output_buffer {
   unsigned char *buf;
   size_t size;
+  size_t capacity;
 } yaml_output_buffer_t;
 
 static int yaml_write_handler(void *data, unsigned char *buffer, size_t size) {
+  size_t newsize;
   yaml_output_buffer_t *out = (yaml_output_buffer_t *)data;
 
-  out->buf = (unsigned char *)realloc(out->buf, out->size + size);
+  /* Double buffer size whenever necessary */
+  if (out->size + size >= out->capacity) {
+    newsize = out->capacity << 1;
+    if (newsize < out->size + size) {
+      newsize = out->size + size;
+    }
+    out->buf = (unsigned char *)realloc(out->buf, newsize);
+    out->capacity = newsize;
+  }
   if (!out->buf) {
     out->size = 0;
     return 0;


### PR DESCRIPTION
This is about https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=68147 and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=68320

In some testcases, the resulting output can be large.

When the output buffer is only increased by the smallest necessary amount (16384 for libyaml), that can cause a lot of calls to realloc, which gets expensive the bigger the buffer gets.

This commit will double the allocated space when it's too small, resulting in much faster processing, where previously the fuzzer ran into a 25s timeout (e.g. only 1.5s now for issue 68147).