### PR TITLE
Switch Mbed TLS to stable branch

### DIFF
--- a/projects/bignum-fuzzer/Dockerfile
+++ b/projects/bignum-fuzzer/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y \
 # or a Rust toolchain.
 RUN pip3 install 'pip>=20'
 
-RUN git clone --depth 1 --recurse-submodules -b development https://github.com/Mbed-TLS/mbedtls
+RUN git clone --depth 1 --recurse-submodules -b mbedtls-3.6 https://github.com/Mbed-TLS/mbedtls
 # Install Python packages from PyPI
 RUN pip3 install -r $SRC/mbedtls/scripts/basic.requirements.txt
 

--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -41,7 +41,7 @@ RUN git clone --depth 1 https://github.com/google/cityhash.git
 RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone --depth 1 https://github.com/wolfSSL/wolfssl.git
 RUN git clone --depth 1 https://github.com/wolfSSL/wolfsm
-RUN git clone --depth 1 --recurse-submodules -b development https://github.com/Mbed-TLS/mbedtls.git
+RUN git clone --depth 1 --recurse-submodules -b mbedtls-3.6 https://github.com/Mbed-TLS/mbedtls.git
 RUN hg clone https://hg.mozilla.org/projects/nspr
 RUN hg clone https://hg.mozilla.org/projects/nss
 RUN git clone --depth 1 https://github.com/jedisct1/libsodium.git

--- a/projects/mbedtls/Dockerfile
+++ b/projects/mbedtls/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y \
 # or a Rust toolchain.
 RUN pip3 install 'pip>=20'
 
-RUN git clone --recursive --depth 1 -b development https://github.com/Mbed-TLS/mbedtls.git mbedtls
+RUN git clone --recursive --depth 1 -b mbedtls-3.6 https://github.com/Mbed-TLS/mbedtls.git mbedtls
 RUN pip3 install -r $SRC/mbedtls/scripts/basic.requirements.txt
 
 RUN git clone --depth 1 https://github.com/google/boringssl.git boringssl


### PR DESCRIPTION
The `development` branch of Mbed TLS will have some API-breaking changes in the next few months, in preparation for the next major release (see
https://lists.trustedfirmware.org/archives/list/mbed-tls@lists.trustedfirmware.org/thread/RHZSQLKCBOPDXS7NFKY5FATMTBYV7D5J/). To avoid breaking fuzzers, temporarily point them at the `mbedtls-3.6` long-term support branch. We will go back to fuzzing the `development` branch before the 4.0 release (https://github.com/Mbed-TLS/mbedtls/issues/9071).

Do not change ecc-diff-fuzzer because https://oss-fuzz-build-logs.storage.googleapis.com/index.html#ecc-diff-fuzzer shows that its build has been broken since 2024-01-13.