### PR TITLE
Add c++ stdlib flag for clang++ only

### DIFF
--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -377,7 +377,7 @@ func main() {
 	args := os.Args[1:]
 	basename := filepath.Base(os.Args[0])
 	isCPP := basename == "clang++-jcc"
-	newArgs = append(args, "-w")
+	newArgs := append(args, "-w")
 
 	var bin string
 	if isCPP {

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -377,13 +377,12 @@ func main() {
 	args := os.Args[1:]
 	basename := filepath.Base(os.Args[0])
 	isCPP := basename == "clang++-jcc"
-	newArgs := []string{"-w", "-stdlib=libc++"}
-	newArgs = append(args, newArgs...)
+	newArgs = append(args, "-w")
 
 	var bin string
 	if isCPP {
 		bin = "clang++"
-		// TODO: Should `-stdlib=libc++` be added only here?
+		newArgs = append(args, "-stdlib=libc++")
 	} else {
 		bin = "clang"
 	}


### PR DESCRIPTION
Observing failure on building `libtasn1` with jcc, suspect this flag used in clang caused the issue.