### PR TITLE
suricata: remove temporary workarounds for suricata

### DIFF
--- a/projects/suricata/Dockerfile
+++ b/projects/suricata/Dockerfile
@@ -29,10 +29,6 @@ RUN git clone --depth=1 https://github.com/catenacyber/fuzzpcap
 
 ADD https://rules.emergingthreats.net/open/suricata/emerging.rules.zip emerging.rules.zip
 
-# until clang 16 is used for C cf https://github.com/rust-lang/rust/issues/107149#issuecomment-1492637779
-RUN rustup install nightly-2023-03-24
-RUN rustup component add rust-src --toolchain nightly-2023-03-24-x86_64-unknown-linux-gnu
-RUN rustup default nightly-2023-03-24
 RUN cargo install --force cbindgen
 
 RUN git clone --depth 1 https://github.com/OISF/suricata.git suricata

--- a/projects/suricata/build.sh
+++ b/projects/suricata/build.sh
@@ -25,9 +25,6 @@ then
     make -j$(nproc) all
     make -j$(nproc) install
     )
-    # Temporary workaround for https://github.com/rust-lang/rust/issues/107149
-    # until oss-fuzz clang is up to rustc clang (15.0.6).
-    export RUSTFLAGS="$RUSTFLAGS -Zsanitizer-memory-track-origins -Cllvm-args=-msan-eager-checks=0"
 fi
 
 (


### PR DESCRIPTION
after clang update in https://github.com/google/oss-fuzz/pull/11714

Let's see how CI goes...