### PR TITLE
libstdcpp: Use -cxx-isystem wildcard

### DIFF
--- a/projects/libstdcpp/build.sh
+++ b/projects/libstdcpp/build.sh
@@ -35,8 +35,8 @@ for fuzzsrcfile in /src/*.cpp; do
 	$CXXFLAGS \
 	-std=c++20 \
 	-nostdinc++ \
-	-cxx-isystem $INSTALLDIR/include/c++/14.0.0/ \
-	-cxx-isystem $INSTALLDIR/include/c++/14.0.0/x86_64-pc-linux-gnu \
+	-cxx-isystem $( echo $INSTALLDIR/include/c++/*/ ) \
+	-cxx-isystem $( echo $INSTALLDIR/include/c++/*/x86_64-pc-linux-gnu ) \
 	$fuzzsrcfile \
 	-o $OUT/$targetfile \
 	$LIB_FUZZING_ENGINE \


### PR DESCRIPTION
Closes #11827
Closes #11546
Closes #11731 