### PR TITLE
tinyusb: Use latest builder

### DIFF
--- a/projects/tinyusb/Dockerfile
+++ b/projects/tinyusb/Dockerfile
@@ -14,8 +14,8 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
+FROM gcr.io/oss-fuzz-base/base-builder
+
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 
 # TODO: Update this to use hathath instead of this fork.

--- a/projects/tinyusb/build.sh
+++ b/projects/tinyusb/build.sh
@@ -16,6 +16,8 @@
 ################################################################################
 set -euxo pipefail
 
+export CXXFLAGS="$CXXFLAGS -Wno-error=missing-field-initializers"
+
 fuzz_harness=$(ls -d test/fuzz/device/*/)
 for h in $fuzz_harness
 do


### PR DESCRIPTION
After https://github.com/hathach/tinyusb/commit/40319ccf9de0e2981b1714c2925ca7657aecec7b