### PR TITLE
Add Eduard Zingerman (eddyz87@gmail.com) to auto CC list for libbpf

### DIFF
--- a/projects/libbpf/project.yaml
+++ b/projects/libbpf/project.yaml
@@ -13,6 +13,7 @@ auto_ccs:
   - yulia.kartseva@gmail.com
   - evverx@gmail.com
   - shunghsiyu@gmail.com
+  - eddyz87@gmail.com
 main_repo: "https://github.com/libbpf/libbpf"
 builds_per_day: 4
 view_restrictions: none


### PR DESCRIPTION
Hello oss-fuzz maintainers,

My name is Eduard Zingerman, I'm one of the maintainers for libbpf (see [here](https://github.com/torvalds/linux/blob/0106679839f7c69632b3b9833c3268c316c0a9fc/MAINTAINERS#L3898)).
Could you please add me to `auto_cc` list for libbpf project, the reason I'm asking: need to see details for the following two reports: [1](https://github.com/libbpf/libbpf/issues/802), [2](https://github.com/libbpf/libbpf/issues/803). As-is I get an "Access denied" page from oss-fuzz.com when I try to open the "detailed report" links.

(I am following procedure suggested [here](https://github.com/google/oss-fuzz/issues/4511), apologies if this is not the correct way to ask for access).

Best regards,
Eduard