### PR TITLE
mongo-go-driver: Add Steve and remove Kevin from CC list.

### DIFF
--- a/projects/mongo-go-driver/project.yaml
+++ b/projects/mongo-go-driver/project.yaml
@@ -9,7 +9,7 @@ primary_contact: "dbx-go@mongodb.com"
 auto_ccs:
   - qingyang.hu@mongodb.com
   - matt.dale@mongodb.com
-  - kevin.albertson@mongodb.com
   - preston.vasquez@mongodb.com
+  - steve.silvester@mongodb.com
 vendor_ccs:
   - maxnair.dev@gmail.com


### PR DESCRIPTION
Add Steve Silvester (@blink1073), the Go Driver lead. Remove Kevin Albertson (@kevinAlbs), who is now on a different team.