### PR TITLE
graphicsmagick: Re-add ubsan

### DIFF
--- a/projects/graphicsmagick/project.yaml
+++ b/projects/graphicsmagick/project.yaml
@@ -9,8 +9,7 @@ auto_ccs:
 sanitizers:
     - address
     - memory
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
-# - memory
+    - undefined
 architectures:
     - x86_64
     - i386


### PR DESCRIPTION
Looks like this was accidentally removed in https://github.com/google/oss-fuzz/commit/806d1a06206a5f6d81d5f1dc4949682dbcee30ad#diff-13a77fec79966170f568afd947cc722e3ac35a76f5159e96e051cc5eb3f24cde about three years ago.