### PR TITLE
Temporary build workaround no longer required

### DIFF
--- a/projects/upx/build.sh
+++ b/projects/upx/build.sh
@@ -15,10 +15,6 @@
 #
 ################################################################################
 
-# Temporary fix for clang bug of upx
-sed -i 's/ \&\& __clang_major__ < 15//m' /src/upx/src/util/util.cpp
-git apply $SRC/upx/fuzzers/build.patch
-
 # build project
 # e.g.
 mkdir -p build/debug


### PR DESCRIPTION
The upx project itself already applied such a change in order to make its own CI work properly.  Also, a newer version of the default compilers obviated the change anyway.