### PR TITLE
Dulwich: Initial integration

### DIFF
--- a/projects/dulwich/Dockerfile
+++ b/projects/dulwich/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM gcr.io/oss-fuzz-base/base-builder-python
+RUN git clone https://github.com/jelmer/dulwich.git dulwich
+RUN $SRC/dulwich/fuzzing/oss-fuzz-scripts/container-environment-bootstrap.sh
+
+COPY *.sh $SRC/
+WORKDIR $SRC/dulwich

--- a/projects/dulwich/build.sh
+++ b/projects/dulwich/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+. "$SRC/dulwich/fuzzing/oss-fuzz-scripts/build.sh"

--- a/projects/dulwich/project.yaml
+++ b/projects/dulwich/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/jelmer/dulwich"
+main_repo: "https://github.com/jelmer/dulwich"
+language: python
+primary_contact: "jvernooij@gmail.com"
+auto_ccs:
+  - "david.js.lakin@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
Dulwich is a Git implementation written in Python with native extensions written with Rust. From [the Dulwich README](https://github.com/jelmer/dulwich/blob/5f0497de9c37ac4f4e8f27bed8decce13765d3df/README.rst):

> It aims to provide an interface to git repos (both local and remote) that doesn't call out to git directly but instead uses pure Python.


### Maintainer's Approval

@jelmer is the project's maintainer and approved of this integration proposal here:  https://github.com/jelmer/dulwich/issues/1302#issuecomment-2093114061. My email is in the `auto_ccs` list so I can assist with bug triage as discussed in that same thread.


### Popularity in the Python Ecosystem

At the time of this PR, [pypistats.org](https://pypistats.org/packages/dulwich) lists the following:

- Downloads last day: 1,432,072
- Downloads last week: 7,864,024
- Downloads last month: 35,371,675

Dulwich is mentioned[^1] as one of the "most popular embeddable Git libraries"[^2] in the book _Pro Git 2nd Edition_ by Scott Chacon and Ben Straub, and is a dependency of other popular projects such as [magic-wormhole/magic-wormhole](https://github.com/magic-wormhole/magic-wormhole), [openstack/reno](https://opendev.org/openstack/reno/), [PrefectHQ/prefect](https://github.com/PrefectHQ/prefect), [tahoe-lafs/tahoe-lafs](https://github.com/tahoe-lafs/tahoe-lafs), and [many more](https://github.com/jelmer/dulwich/network/dependents).



[^2]: _Pro Git 2nd Edition_, [A2.1 Appendix B: Embedding Git in your Applications - Command-line Git](https://git-scm.com/book/en/v2/Appendix-B%3A-Embedding-Git-in-your-Applications-Command-line-Git)

[^1]: _Pro Git 2nd Edition_, [A2.5 Appendix B: Embedding Git in your Applications - Dulwich](https://git-scm.com/book/en/v2/Appendix-B%3A-Embedding-Git-in-your-Applications-Dulwich)