### PR TITLE
gdal: Remove temporary cmake workaround

### DIFF
--- a/projects/gdal/Dockerfile
+++ b/projects/gdal/Dockerfile
@@ -18,12 +18,6 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && \
     apt-get install -y make autoconf automake libtool g++ curl cmake sqlite3 pkg-config
 
-ENV CMAKE_VERSION 3.29.2
-RUN apt-get update && apt-get install -y wget sudo && \
-    wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
-    chmod +x cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
-    ./cmake-$CMAKE_VERSION-Linux-x86_64.sh --skip-license --prefix="/usr/local"
-
 RUN git clone --depth 1 https://github.com/OSGeo/gdal gdal
 
 RUN cp gdal/fuzzers/build.sh $SRC/


### PR DESCRIPTION
Not needed, as oss-fuzz ships with the current cmake