### PR TITLE
graphicsmagick: Remove outdated comment

### DIFF
--- a/projects/graphicsmagick/project.yaml
+++ b/projects/graphicsmagick/project.yaml
@@ -9,8 +9,6 @@ auto_ccs:
 sanitizers:
     - address
     - memory
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
-# - memory
 architectures:
     - x86_64
     - i386


### PR DESCRIPTION
msan *is* enabled. ubsan was removed in commit https://github.com/google/oss-fuzz/commit/806d1a06206a5f6d81d5f1dc4949682dbcee30ad#diff-13a77fec79966170f568afd947cc722e3ac35a76f5159e96e051cc5eb3f24cde about three years ago.