### PR TITLE
new project: gnucobol

### DIFF
--- a/projects/gnucobol/project.yaml
+++ b/projects/gnucobol/project.yaml
@@ -1,0 +1,20 @@
+homepage: "https://www.gnu.org/software/gnucobol/"
+language: c
+
+primary_contact: "simonsobisch@gmail.com"
+auto_ccs:
+  - "simonsobisch@gnu.org"
+
+sanitizers:
+  - address
+  - memory:
+     experimental: True
+  - undefined
+
+architectures:
+ - x86_64
+ - i386
+
+# 'https://svn.code.sf.net/p/gnucobol/code/trunk' is the "next big version" (unstable),
+# code installed in OS package managers is found in 3.x branch
+main_repo: 'https://svn.code.sf.net/p/gnucobol/code/branches/gnucobol-3.x'


### PR DESCRIPTION
Note: previous fuzzing to GnuCOBOL was on invalid COBOL source files (that did found some issues that crash the parser/lexer)
That is already useful, but because the only thing that happens is that instead of a compile error the compiler crashes I didn't see a security issue there.

Much more interesting would be using input files to a COBOL program and by that either create a crash (potential denial of service) or overflow in the runtime (that would be likely a real problem).

... but in both cases I'd have no idea how to setup that for fuzzing; the only thing that is "easy" to do is to run the internal testsuite with a bunch of sanitizers.