### PR TITLE
readstat: Use latest builder

### DIFF
--- a/projects/readstat/Dockerfile
+++ b/projects/readstat/Dockerfile
@@ -14,8 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake gettext libtool zip zlib1g-dev
 
 RUN git clone --depth 1 https://github.com/WizardMac/ReadStat readstat


### PR DESCRIPTION
This was fixed upstream