### PR TITLE
[scapy] actually fuzz protocol dissectors

### DIFF
--- a/projects/scapy/pcap_fuzzer.py
+++ b/projects/scapy/pcap_fuzzer.py
@@ -21,6 +21,7 @@ with atheris.instrument_imports():
   import io
   import scapy
   import scapy.error
+  import scapy.layers.all
   import scapy.utils
 
 

--- a/projects/scapy/pcap_fuzzer.py
+++ b/projects/scapy/pcap_fuzzer.py
@@ -18,24 +18,24 @@ import sys
 import atheris
 
 with atheris.instrument_imports():
-  import io
-  import scapy
-  import scapy.error
-  import scapy.layers.all
-  import scapy.utils
+    import io
+    import scapy
+    import scapy.error
+    import scapy.layers.all
+    import scapy.utils
 
 
 def TestOneInput(input_bytes):
-  try:
-    scapy.utils.rdpcap(io.BytesIO(input_bytes))
-  except scapy.error.Scapy_Exception:
-    pass
+    try:
+        scapy.utils.rdpcap(io.BytesIO(input_bytes))
+    except scapy.error.Scapy_Exception:
+        pass
 
 
 def main():
-  atheris.Setup(sys.argv, TestOneInput)
-  atheris.Fuzz()
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
 
 
 if __name__ == "__main__":
-  main()
+    main()

--- a/projects/scapy/project.yaml
+++ b/projects/scapy/project.yaml
@@ -5,6 +5,7 @@ primary_contact: "guedou@gmail.com"
 auto_ccs:
   - "julien.voisin@dustri.org"
   - "ipudney@google.com"
+  - "evverx@gmail.com"
 fuzzing_engines:
   - libfuzzer
 sanitizers:


### PR DESCRIPTION
When scapy reads pcap/pcapng files it extracts link layer types from
headers and tries to match them with classes representing those layers.
Those classes are registered in conf.l2types.num2layer when they are
imported so if no layers are imported the only known layer is Raw and it
isn't very interesting in terms of fuzzing because it just wraps bytes
without parsing anything. Apart from populating l2types when the layers
are imported they are bound to make it possible for scapy to guess
payloads and move from lower layers all the way up.

The coverage went from 24% to 39%. It can be bumped further but I think
it would be better to roll out those changes gradually.

* [scapy] fix indentation

Fixes:
```sh
projects/scapy/pcap_fuzzer.py:21:3: E111 indentation is not a multiple of 4
projects/scapy/pcap_fuzzer.py:36:3: E111 indentation is not a multiple of 4
projects/scapy/pcap_fuzzer.py:37:3: E111 indentation is not a multiple of 4
projects/scapy/pcap_fuzzer.py:41:3: E111 indentation is not a multiple of 4
...
```
and makes it easier to change the code using editors expecting Python
code to be compliant with PEP 8.

[scapy] update the CC list

It was discussed in https://github.com/secdev/scapy/pull/4373#issuecomment-2088964303