### PR TITLE
Update primary contact email of edk2

### DIFF
--- a/projects/edk2/project.yaml
+++ b/projects/edk2/project.yaml
@@ -5,6 +5,10 @@ fuzzing_engines:
 sanitizers:
    - address
    - undefined
-primary_contact: "edk2-hbfa-ossfuzz@intel.com"
+primary_contact: "tamas.k.lengyel@gmail.com"
+auto_ccs:
+   - "rowanbhart@gmail.com"
+vendor_ccs:
+   - "edk2-hbfa-ossfuzz@intel.com"
 main_repo: "https://github.com/tianocore/edk2"
 file_github_issue: false


### PR DESCRIPTION
To be able to access clusterfuzz reports fully and not just see summary emails.