### PR TITLE
cert-manager: replace removed ParseSubjectStringToRawDERBytes function

### DIFF
--- a/projects/cert-manager/build.sh
+++ b/projects/cert-manager/build.sh
@@ -17,6 +17,6 @@
 
 cp -r $SRC/pki_fuzzer.go $SRC/cert-manager/pkg/util/pki/
 
-compile_go_fuzzer github.com/cert-manager/cert-manager/pkg/util/pki FuzzParseSubjectStringToRawDERBytes FuzzParseSubjectStringToRawDERBytes
+compile_go_fuzzer github.com/cert-manager/cert-manager/pkg/util/pki FuzzUnmarshalSubjectStringToRDNSequence FuzzUnmarshalSubjectStringToRDNSequence
 compile_go_fuzzer github.com/cert-manager/cert-manager/pkg/util/pki FuzzDecodePrivateKeyBytes FuzzDecodePrivateKeyBytes
 

--- a/projects/cert-manager/pki_fuzzer.go
+++ b/projects/cert-manager/pki_fuzzer.go
@@ -15,8 +15,8 @@
 
 package pki
 
-func FuzzParseSubjectStringToRawDERBytes(data []byte) int {
-	ParseSubjectStringToRawDERBytes(string(data))
+func FuzzUnmarshalSubjectStringToRDNSequence(data []byte) int {
+	UnmarshalSubjectStringToRDNSequence(string(data))
 	return 1
 }
 


### PR DESCRIPTION
This function was removed in https://github.com/cert-manager/cert-manager/pull/6994.