### PR TITLE
igraph: disable aarch64

### DIFF
--- a/projects/igraph/project.yaml
+++ b/projects/igraph/project.yaml
@@ -15,7 +15,6 @@ sanitizers:
 architectures:
   - x86_64
   - i386
-  - aarch64
 fuzzing_engines:
   - afl
   - honggfuzz


### PR DESCRIPTION
I originally added this to make it easier to reproduce issues with Docker on Apple Silicon machines, but it broke the build. It seems OSS-Fuzz uses cross-compilation? It's possible to make this work for igraph, but I'm not ready to do it now given that aarch64 support is not even finalized in OSS-Fuzz.