### PR TITLE
cras: Disable MSan

### DIFF
--- a/projects/cras/project.yaml
+++ b/projects/cras/project.yaml
@@ -23,7 +23,6 @@ auto_ccs:
   - "whalechang@google.com"
 sanitizers:
   - address
-  - memory
   - undefined
 fuzzing_engines:
   - afl


### PR DESCRIPTION
Our MSan fuzzers are falling apart. This is a result of our increased mix C + Rust usage, combined with potentially incompatible C + Rust toolchains from oss-fuzz's docker image:

> root@5d91b39ca4c8:/src# clang --version
> clang version 18.0.0 (https://github.com/llvm/llvm-project.git > d50b56d18c96e0ce462d7236eb268c54098cbaf9)
> Target: x86_64-unknown-linux-gnu
> Thread model: posix
> InstalledDir: /usr/local/bin
> root@5d91b39ca4c8:/src# rustc --version --verbose
> rustc 1.77.0-nightly (89e2160c4 2023-12-27)
> binary: rustc
> commit-hash: 89e2160c4ca5808657ed55392620ed1dbbce78d1
> commit-date: 2023-12-27
> host: x86_64-unknown-linux-gnu
> release: 1.77.0-nightly
> LLVM version: 17.0.6

Example of broken MSan builds include b/336202938 and https://crrev.com/c/5528486/4.

Let's disable MSan for now.