### PR TITLE
POC: Speed up compilation by freezing container during compilation.

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -170,8 +170,10 @@ COPY bazel_build_fuzz_tests \
 
 # TODO: Build this as part of a multi-stage build.
 ADD https://commondatastorage.googleapis.com/clusterfuzz-builds/jcc/clang-jcc /usr/local/bin/
-ADD https://commondatastorage.googleapis.com/clusterfuzz-builds/jcc/clang++-jcc /usr/local/bin/
-RUN chmod +x /usr/local/bin/clang-jcc && chmod +x /usr/local/bin/clang++-jcc
+ADD https://commondatastorage.googleapis.com/clusterfuzz-builds/jcc/clang++-jcc /usr/local/bi
+ADD https://commondatastorage.googleapis.com/clusterfuzz-builds/jcc/clang-jcc2 /usr/local/bin/
+ADD https://commondatastorage.googleapis.com/clusterfuzz-builds/jcc/clang++-jcc2 /usr/local/bin/n/
+RUN chmod +x /usr/local/bin/clang-jcc /usr/local/bin/clang++-jcc /usr/local/bin/clang-jcc2 /usr/local/bin/clang++-jcc2
 
 COPY llvmsymbol.diff $SRC
 COPY detect_repo.py /opt/cifuzz/

--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -170,9 +170,9 @@ COPY bazel_build_fuzz_tests \
 
 # TODO: Build this as part of a multi-stage build.
 ADD https://commondatastorage.googleapis.com/clusterfuzz-builds/jcc/clang-jcc /usr/local/bin/
-ADD https://commondatastorage.googleapis.com/clusterfuzz-builds/jcc/clang++-jcc /usr/local/bi
+ADD https://commondatastorage.googleapis.com/clusterfuzz-builds/jcc/clang++-jcc /usr/local/bin
 ADD https://commondatastorage.googleapis.com/clusterfuzz-builds/jcc/clang-jcc2 /usr/local/bin/
-ADD https://commondatastorage.googleapis.com/clusterfuzz-builds/jcc/clang++-jcc2 /usr/local/bin/n/
+ADD https://commondatastorage.googleapis.com/clusterfuzz-builds/jcc/clang++-jcc2 /usr/local/bin
 RUN chmod +x /usr/local/bin/clang-jcc /usr/local/bin/clang++-jcc /usr/local/bin/clang-jcc2 /usr/local/bin/clang++-jcc2
 
 COPY llvmsymbol.diff $SRC

--- a/infra/base-images/base-builder/jcc/build_jcc.bash
+++ b/infra/base-images/base-builder/jcc/build_jcc.bash
@@ -17,7 +17,9 @@
 ################################################################################
 
 go build jcc.go
-cp jcc clang
-cp jcc clang++
+go build jcc2.go
 gsutil cp jcc gs://clusterfuzz-builds/jcc/clang++-jcc
 gsutil cp jcc gs://clusterfuzz-builds/jcc/clang-jcc
+
+gsutil cp jcc2 gs://clusterfuzz-builds/jcc/clang++-jcc2
+gsutil cp jcc2 gs://clusterfuzz-builds/jcc/clang-jcc2

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -360,16 +360,23 @@ func WriteStdErrOut(args []string, outstr string, errstr string) {
 	fmt.Print(outstr)
 	fmt.Fprint(os.Stderr, errstr)
 	// Record what compile args produced the error and the error itself in log file.
-	AppendStringToFile("/workspace/err.log", fmt.Sprintf("%s\n", args) + errstr)
+	AppendStringToFile("/workspace/err.log", fmt.Sprintf("%s\n", args)+errstr)
 }
 
 func main() {
+	fmt.Println("MAAAAIN")
 	f, err := os.OpenFile("/tmp/jcc.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-
 	if err != nil {
 		log.Println(err)
 	}
 	defer f.Close()
+	if _, err := os.Stat("/out/statefile"); !errors.Is(err, os.ErrNotExist) {
+		log.Println(err)
+		fmt.Println(err)
+		fmt.Println("EEXXIT")
+		os.Exit(0)
+	}
+	fmt.Println("MAAAAIN")
 	if _, err := f.WriteString(fmt.Sprintf("%s\n", os.Args)); err != nil {
 		log.Println(err)
 	}
@@ -377,6 +384,7 @@ func main() {
 	args := os.Args[1:]
 	basename := filepath.Base(os.Args[0])
 	isCPP := basename == "clang++-jcc"
+	fmt.Println(isCPP)
 	newArgs := append(args, "-w")
 
 	var bin string
@@ -387,44 +395,76 @@ func main() {
 		bin = "clang"
 	}
 	fullCmdArgs := append([]string{bin}, newArgs...)
+	if IsCompilingTarget(fullCmdArgs) {
+		WriteTargetArgsAndCommitImage(fullCmdArgs)
+		os.Exit(0)
+	}
 	retcode, out, errstr := Compile(bin, newArgs)
-	if retcode == 0 {
-		WriteStdErrOut(fullCmdArgs, out, errstr)
-		os.Exit(0)
-	}
-
-	// Note that on failures or when we succeed on the first try, we should
-	// try to write the first out/err to stdout/stderr.
-	// When we fail we should try to write the original out/err and one from
-	// the corrected.
-
-	headersFixArgs, headersFixed, _ := CorrectMissingHeaders(bin, newArgs)
-	if headersFixed {
-		// We succeeded here but it's kind of complicated to get out and
-		// err from TryCompileAndFixHeadersOnce. The output and err is
-		// not so important on success so just be silent.
-		WriteStdErrOut(append([]string{bin}, headersFixArgs...), "", "")
-		os.Exit(0)
-	}
-
-	if isCPP {
-		// Nothing else we can do. Just write the error and exit.
-		// Just print the original error for debugging purposes and
-		//  to make build systems happy.
-		WriteStdErrOut(fullCmdArgs, out, errstr)
-		os.Exit(retcode)
-	}
-	fixargs, fixret, fixout, fixerr := TryFixCCompilation(newArgs)
-	if fixret != 0 {
-		// We failed, write stdout and stderr from the first failure and
-		// from fix failures so we can know what the code did wrong and
-		// how to improve jcc to fix more issues.
-		WriteStdErrOut(fullCmdArgs, out, errstr)
-		fmt.Println("\nFix failure")
-		// Print error back to stderr so tooling that relies on this can proceed
-		WriteStdErrOut(fixargs, fixout, fixerr)
-		os.Exit(retcode)
-	}
-	// The fix suceeded, write its out and err.
-	WriteStdErrOut(fixargs, fixout, fixerr)
+	WriteStdErrOut(fullCmdArgs, out, errstr)
+	os.Exit(retcode)
 }
+
+func WriteTargetArgsAndCommitImage(cmdline []string) {
+	fmt.Println("WRITTE")
+	f, _ := os.OpenFile("/out/statefile", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f.WriteString(strings.Join(cmdline, " "))
+	f.Close()
+	hostname, _ := os.Hostname()
+	dockerArgs := []string{"commit", hostname, "frozen"}
+	cmd := exec.Command("docker", dockerArgs...)
+	var outb, errb bytes.Buffer
+	cmd.Stdout = &outb
+	cmd.Stderr = &errb
+	cmd.Stdin = os.Stdin
+	cmd.Run()
+	fmt.Println(outb.String(), errb.String())
+	fmt.Println("COMMIT")
+}
+
+func IsCompilingTarget(cmdline []string) bool {
+	for _, arg := range cmdline {
+		// This can fail if people do crazy things they aren't supposed to e.g.
+		if arg == "-fsanitize=fuzzer" {
+			fmt.Println(true)
+			return true
+		}
+	}
+	fmt.Println(false)
+	return false
+}
+
+// 	// Note that on failures or when we succeed on the first try, we should
+// 	// try to write the first out/err to stdout/stderr.
+// 	// When we fail we should try to write the original out/err and one from
+// 	// the corrected.
+
+// 	headersFixArgs, headersFixed, _ := CorrectMissingHeaders(bin, newArgs)
+// 	if headersFixed {
+// 		// We succeeded here but it's kind of complicated to get out and
+// 		// err from TryCompileAndFixHeadersOnce. The output and err is
+// 		// not so important on success so just be silent.
+// 		WriteStdErrOut(append([]string{bin}, headersFixArgs...), "", "")
+// 		os.Exit(0)
+// 	}
+
+// 	if isCPP {
+// 		// Nothing else we can do. Just write the error and exit.
+// 		// Just print the original error for debugging purposes and
+// 		//  to make build systems happy.
+// 		WriteStdErrOut(fullCmdArgs, out, errstr)
+// 		os.Exit(retcode)
+// 	}
+// 	fixargs, fixret, fixout, fixerr := TryFixCCompilation(newArgs)
+// 	if fixret != 0 {
+// 		// We failed, write stdout and stderr from the first failure and
+// 		// from fix failures so we can know what the code did wrong and
+// 		// how to improve jcc to fix more issues.
+// 		WriteStdErrOut(fullCmdArgs, out, errstr)
+// 		fmt.Println("\nFix failure")
+// 		// Print error back to stderr so tooling that relies on this can proceed
+// 		WriteStdErrOut(fixargs, fixout, fixerr)
+// 		os.Exit(retcode)
+// 	}
+// 	// The fix suceeded, write its out and err.
+// 	WriteStdErrOut(fixargs, fixout, fixerr)
+// }

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -377,13 +377,12 @@ func main() {
 	args := os.Args[1:]
 	basename := filepath.Base(os.Args[0])
 	isCPP := basename == "clang++-jcc"
-	newArgs := []string{"-w", "-stdlib=libc++"}
-	newArgs = append(args, newArgs...)
+	newArgs := append(args, "-w")
 
 	var bin string
 	if isCPP {
 		bin = "clang++"
-		// TODO: Should `-stdlib=libc++` be added only here?
+		newArgs = append(args, "-stdlib=libc++")
 	} else {
 		bin = "clang"
 	}

--- a/infra/base-images/base-builder/jcc/jcc2.go
+++ b/infra/base-images/base-builder/jcc/jcc2.go
@@ -26,7 +26,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"slices"
 	"strings"
 )
 
@@ -170,63 +169,6 @@ func CorrectMissingHeaders(bin string, cmd []string) ([]string, bool, error) {
 	return cmd, false, nil
 }
 
-func EnsureDir(dirPath string) {
-	// Checks if a path is an existing directory, otherwise create one.
-	if pathInfo, err := os.Stat(dirPath); err == nil {
-		if isDir := pathInfo.IsDir(); !isDir {
-			panic(dirPath + " exists but is not a directory.")
-		}
-	} else if errors.Is(err, fs.ErrNotExist) {
-		if err := os.MkdirAll(dirPath, 0755); err != nil {
-			panic("Failed to create directory: " + dirPath + ".")
-		}
-		fmt.Println("Created directory: " + dirPath + ".")
-	} else {
-		panic("An error occurred in os.Stat(" + dirPath + "): " + err.Error())
-	}
-}
-
-func GenerateAST(bin string, args []string, filePath string) {
-	// Generates AST.
-	outFile, err := os.Create(filePath)
-	if err != nil {
-		fmt.Println(err)
-	}
-	defer outFile.Close()
-
-	cmd := exec.Command(bin, args...)
-	cmd.Stdout = outFile
-	cmd.Run()
-}
-
-func GenerateASTs(bin string, args []string, astDir string) {
-	// Generates an AST for each C/CPP file in the command.
-	// Cannot save AST when astDir is not available.
-	EnsureDir(astDir)
-
-	// Target file suffixes.
-	suffixes := []string{".cpp", ".cc", ".cxx", ".c++", ".c", ".h", ".hpp"}
-	// C/CPP targets in the command.
-	targetFiles := []string{}
-	// Flags to generate AST.
-	flags := []string{"-Xclang", "-ast-dump=json", "-fsyntax-only"}
-	for _, arg := range args {
-		targetFileExt := strings.ToLower(filepath.Ext(arg))
-		if slices.Contains(suffixes, targetFileExt) {
-			targetFiles = append(targetFiles, arg)
-			continue
-		}
-		flags = append(flags, arg)
-	}
-
-	// Generate an AST for each target file. Skips AST generation when a
-	// command has no target file (e.g., during linking).
-	for _, targetFile := range targetFiles {
-		filePath := filepath.Join(astDir, fmt.Sprintf("%s.ast", filepath.Base(targetFile)))
-		GenerateAST(bin, append(flags, targetFile), filePath)
-	}
-}
-
 func ExecBuildCommand(bin string, args []string) (int, string, string) {
 	// Executes the original command.
 	cmd := exec.Command(bin, args...)
@@ -239,10 +181,6 @@ func ExecBuildCommand(bin string, args []string) (int, string, string) {
 }
 
 func Compile(bin string, args []string) (int, string, string) {
-	// Generate ASTs f we define this ENV var.
-	if astDir := os.Getenv("JCC_GENERATE_AST_DIR"); astDir != "" {
-		GenerateASTs(bin, args, astDir)
-	}
 	// Run the actual command.
 	return ExecBuildCommand(bin, args)
 }

--- a/infra/base-images/base-builder/jcc/jcc2.go
+++ b/infra/base-images/base-builder/jcc/jcc2.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -365,7 +365,6 @@ func WriteStdErrOut(args []string, outstr string, errstr string) {
 }
 
 func main() {
-	// fmt.Println("MAAAAIN")
 	f, err := os.OpenFile("/tmp/jcc.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		log.Println(err)
@@ -382,7 +381,6 @@ func main() {
         }
 	basename := filepath.Base(os.Args[0])
 	isCPP := basename == "clang++-jcc"
-	// fmt.Println(isCPP)
 	newArgs := append(args, "-w")
 
 	var bin string
@@ -408,7 +406,7 @@ type BuildCommand struct {
 }
 
 func WriteTargetArgsAndCommitImage(cmdline []string) {
-	fmt.Println("WRITTE")
+	fmt.Println("WRITE COMMAND")
 	f, _ := os.OpenFile("/out/statefile.json", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
         wd, _ := os.Getwd()
         buildcmd := BuildCommand{
@@ -427,18 +425,16 @@ func WriteTargetArgsAndCommitImage(cmdline []string) {
 	cmd.Stdin = os.Stdin
 	cmd.Run()
 	fmt.Println(outb.String(), errb.String())
-	fmt.Println("COMMIT")
+	fmt.Println("COMMIT IMAGE")
 }
 
 func IsCompilingTarget(cmdline []string) bool {
 	for _, arg := range cmdline {
 		// This can fail if people do crazy things they aren't supposed to e.g.
 		if arg == "-fsanitize=fuzzer" {
-			fmt.Println(true)
 			return true
 		}
                 if arg == "-lFuzzingEngine" {
-			fmt.Println(true)
 			return true
 		}
 	}
@@ -453,26 +449,14 @@ func parseCommand(command string) (string, []string) {
 }
 
 func unfreeze() {
-fmt.Println("un")
-       // if _, err := os.Stat("/out/statefile.json"); !errors.Is(err, os.ErrNotExist) {
-       // fmt.Println("DNE")
-       //         log.Println(err)
-       //         os.Exit(1)
-       // }
-       fmt.Println("stated")
        content, err := ioutil.ReadFile("/out/statefile.json")
        if err != nil {
                log.Fatal(err)
        }
-       fmt.Println("read")
-
        var command BuildCommand
        json.Unmarshal(content, &command)
-       fmt.Println(command.CMD)
        bin, args := parseCommand(strings.Join(command.CMD, " "))
        os.Chdir(command.CWD)
-       fmt.Println(bin)
-       fmt.Println(args)
        ExecBuildCommand(bin, args)
        os.Exit(0)
 }

--- a/infra/base-images/base-builder/jcc/jcc2.go
+++ b/infra/base-images/base-builder/jcc/jcc2.go
@@ -16,7 +16,7 @@ package main
 
 import (
 	"bytes"
-        "encoding/json"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -375,10 +375,10 @@ func main() {
 	}
 
 	args := os.Args[1:]
-        if args[0] == "unfreeze" {
-           fmt.Println("unfreeze")
-           unfreeze()
-        }
+	if args[0] == "unfreeze" {
+		fmt.Println("unfreeze")
+		unfreeze()
+	}
 	basename := filepath.Base(os.Args[0])
 	isCPP := basename == "clang++-jcc"
 	newArgs := append(args, "-w")
@@ -401,19 +401,19 @@ func main() {
 }
 
 type BuildCommand struct {
-    CWD  string        `json:"CWD"`
-    CMD  []string      `json:"CMD"`
+	CWD string   `json:"CWD"`
+	CMD []string `json:"CMD"`
 }
 
 func WriteTargetArgsAndCommitImage(cmdline []string) {
 	fmt.Println("WRITE COMMAND")
 	f, _ := os.OpenFile("/out/statefile.json", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-        wd, _ := os.Getwd()
-        buildcmd := BuildCommand{
-        CWD: wd,
-        CMD: cmdline,
-        }
-        jsonData, _ := json.Marshal(buildcmd)
+	wd, _ := os.Getwd()
+	buildcmd := BuildCommand{
+		CWD: wd,
+		CMD: cmdline,
+	}
+	jsonData, _ := json.Marshal(buildcmd)
 	f.Write(jsonData)
 	f.Close()
 	hostname, _ := os.Hostname()
@@ -434,7 +434,7 @@ func IsCompilingTarget(cmdline []string) bool {
 		if arg == "-fsanitize=fuzzer" {
 			return true
 		}
-                if arg == "-lFuzzingEngine" {
+		if arg == "-lFuzzingEngine" {
 			return true
 		}
 	}
@@ -442,21 +442,21 @@ func IsCompilingTarget(cmdline []string) bool {
 }
 
 func parseCommand(command string) (string, []string) {
-       args := strings.Fields(command)
-       commandBin := args[0]
-       commandArgs := args[1:]
-       return commandBin, commandArgs
+	args := strings.Fields(command)
+	commandBin := args[0]
+	commandArgs := args[1:]
+	return commandBin, commandArgs
 }
 
 func unfreeze() {
-       content, err := ioutil.ReadFile("/out/statefile.json")
-       if err != nil {
-               log.Fatal(err)
-       }
-       var command BuildCommand
-       json.Unmarshal(content, &command)
-       bin, args := parseCommand(strings.Join(command.CMD, " "))
-       os.Chdir(command.CWD)
-       ExecBuildCommand(bin, args)
-       os.Exit(0)
+	content, err := ioutil.ReadFile("/out/statefile.json")
+	if err != nil {
+		log.Fatal(err)
+	}
+	var command BuildCommand
+	json.Unmarshal(content, &command)
+	bin, args := parseCommand(strings.Join(command.CMD, " "))
+	os.Chdir(command.CWD)
+	ExecBuildCommand(bin, args)
+	os.Exit(0)
 }

--- a/infra/base-images/base-builder/jcc/jcc2.go
+++ b/infra/base-images/base-builder/jcc/jcc2.go
@@ -344,8 +344,8 @@ type BuildCommand struct {
 }
 
 func WriteTargetArgsAndCommitImage(cmdline []string) {
-	fmt.Println("WRITE COMMAND")
-	f, _ := os.OpenFile("/out/statefile.json", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	log.Println("WRITE COMMAND")
+	f, _ := os.OpenFile("/out/statefile.json", os.O_CREATE|os.O_WRONLY, 0644)
 	wd, _ := os.Getwd()
 	buildcmd := BuildCommand{
 		CWD: wd,
@@ -368,7 +368,8 @@ func WriteTargetArgsAndCommitImage(cmdline []string) {
 
 func IsCompilingTarget(cmdline []string) bool {
 	for _, arg := range cmdline {
-		// This can fail if people do crazy things they aren't supposed to e.g.
+		// This can fail if people do crazy things they aren't supposed
+		// to such as using some other means to link in libFuzzer.
 		if arg == "-fsanitize=fuzzer" {
 			return true
 		}

--- a/infra/base-images/base-builder/jcc/jcc2.go
+++ b/infra/base-images/base-builder/jcc/jcc2.go
@@ -364,7 +364,7 @@ func WriteStdErrOut(args []string, outstr string, errstr string) {
 }
 
 func main() {
-	fmt.Println("MAAAAIN")
+	// fmt.Println("MAAAAIN")
 	f, err := os.OpenFile("/tmp/jcc.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		log.Println(err)
@@ -376,7 +376,7 @@ func main() {
 		fmt.Println("EEXXIT")
 		os.Exit(0)
 	}
-	fmt.Println("MAAAAIN")
+	// fmt.Println("MAAAAIN")
 	if _, err := f.WriteString(fmt.Sprintf("%s\n", os.Args)); err != nil {
 		log.Println(err)
 	}
@@ -384,7 +384,7 @@ func main() {
 	args := os.Args[1:]
 	basename := filepath.Base(os.Args[0])
 	isCPP := basename == "clang++-jcc"
-	fmt.Println(isCPP)
+	// fmt.Println(isCPP)
 	newArgs := append(args, "-w")
 
 	var bin string
@@ -428,7 +428,11 @@ func IsCompilingTarget(cmdline []string) bool {
 			fmt.Println(true)
 			return true
 		}
+                if arg == "-lFuzzingEngine" {
+			fmt.Println(true)
+			return true
+		}
 	}
-	fmt.Println(false)
+	// fmt.Println(false)
 	return false
 }

--- a/infra/base-images/base-builder/jcc/jcc2.go
+++ b/infra/base-images/base-builder/jcc/jcc2.go
@@ -346,7 +346,7 @@ func CppifyHeaderIncludes(contents string) (string, error) {
 
 func AppendStringToFile(filepath, new_content string) error {
 	// Appends |new_content| to the content of |filepath|.
-	file, err := os.OpenFile(filepath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	file, err := os.OpenFile(filepath, os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return err
 	}
@@ -403,15 +403,16 @@ func main() {
 }
 
 type BuildCommand struct {
-    CWD  string        `json:"cwd"`
-    CMD  []string      `json:"cmd"`
+    CWD  string        `json:"CWD"`
+    CMD  []string      `json:"CMD"`
 }
 
 func WriteTargetArgsAndCommitImage(cmdline []string) {
 	fmt.Println("WRITTE")
 	f, _ := os.OpenFile("/out/statefile.json", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+        wd, _ := os.Getwd()
         buildcmd := BuildCommand{
-        CWD:"",
+        CWD: wd,
         CMD: cmdline,
         }
         jsonData, _ := json.Marshal(buildcmd)
@@ -452,18 +453,26 @@ func parseCommand(command string) (string, []string) {
 }
 
 func unfreeze() {
-       if _, err := os.Stat("/out/statefile.json"); !errors.Is(err, os.ErrNotExist) {
-               log.Println(err)
-               os.Exit(1)
-       }
+fmt.Println("un")
+       // if _, err := os.Stat("/out/statefile.json"); !errors.Is(err, os.ErrNotExist) {
+       // fmt.Println("DNE")
+       //         log.Println(err)
+       //         os.Exit(1)
+       // }
+       fmt.Println("stated")
        content, err := ioutil.ReadFile("/out/statefile.json")
        if err != nil {
                log.Fatal(err)
        }
+       fmt.Println("read")
 
        var command BuildCommand
        json.Unmarshal(content, &command)
+       fmt.Println(command.CMD)
        bin, args := parseCommand(strings.Join(command.CMD, " "))
        os.Chdir(command.CWD)
+       fmt.Println(bin)
+       fmt.Println(args)
        ExecBuildCommand(bin, args)
+       os.Exit(0)
 }

--- a/infra/base-images/base-builder/jcc/jcc2.go
+++ b/infra/base-images/base-builder/jcc/jcc2.go
@@ -346,7 +346,7 @@ func CppifyHeaderIncludes(contents string) (string, error) {
 
 func AppendStringToFile(filepath, new_content string) error {
 	// Appends |new_content| to the content of |filepath|.
-	file, err := os.OpenFile(filepath, os.O_CREATE|os.O_WRONLY, 0644)
+	file, err := os.OpenFile(filepath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return err
 	}
@@ -365,7 +365,7 @@ func WriteStdErrOut(args []string, outstr string, errstr string) {
 }
 
 func main() {
-	f, err := os.OpenFile("/tmp/jcc.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile("/tmp/jcc.log", os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		log.Println(err)
 	}

--- a/projects/skcms/Dockerfile
+++ b/projects/skcms/Dockerfile
@@ -24,6 +24,12 @@ RUN wget -O $SRC/skcms/iccprofile_seed_corpus.zip https://storage.googleapis.com
 # current directory for build script
 WORKDIR skcms
 
+RUN apt-get update && \
+    apt-get install -y systemd && \
+    wget https://download.docker.com/linux/ubuntu/dists/focal/pool/stable/amd64/docker-ce-cli_20.10.8~3-0~ubuntu-focal_amd64.deb -O /tmp/docker-ce.deb && \
+    dpkg -i /tmp/docker-ce.deb && \
+    rm /tmp/docker-ce.deb
+
 COPY build.sh $SRC/
 
 COPY iccprofile.options iccprofile.dict $SRC/skcms/


### PR DESCRIPTION
Instead of rebuilding the entire project every time we want to compile a single fuzz target, a better workflow is to build the project once and somehow compile the target against the already compiled project code.
This POC does that by interrupting building in when it detects it is compiling the fuzz target.
On detection it does the following:
1. Writes the command to /out/statefile TODO: write the cwd.
2. Commits the current container as "frozen" for use later. TODO: make this changeable.
3. Returns 1 so compilation stops. TODO: It would be better to exit the container.
This step may be important to prevent clean up of the environment.

Then the frozen container can be used to compile fuzz targets against the project without recompiling the project in its entirety.

TODO:
1. Support this in oss-fuzz-gen
2. Install docker command line tool in base-builder (or use sneaky inheritance) because it must be used within the container.
3. Automate the compilation of the new fuzz target