### PR TITLE
mpv: enable MSAN

### DIFF
--- a/projects/mpv/Dockerfile
+++ b/projects/mpv/Dockerfile
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y nasm libass-dev libass-dev:i386 && pip3 install meson ninja
+RUN apt-get update && apt-get install -y nasm pkg-config gperf && pip3 install meson ninja
 RUN git clone --depth 1 https://github.com/mpv-player/mpv mpv
 RUN git clone --depth 1 https://github.com/FFmpeg/FFmpeg ffmpeg
-RUN git clone --depth 1 --recursive https://github.com/haasn/libplacebo libplacebo
 WORKDIR mpv
 COPY build.sh $SRC/

--- a/projects/mpv/build.sh
+++ b/projects/mpv/build.sh
@@ -31,22 +31,39 @@ make -j`nproc`
 make install
 popd
 
-pushd $SRC/libplacebo
-meson setup build -Ddefault_library=static -Dprefer_static=true --libdir $LIBDIR
-meson install -C build
-popd
-
 pushd $SRC/mpv
 sed -i -e "/^\s*flags += \['-fsanitize=address,undefined,fuzzer', '-fno-omit-frame-pointer'\]/d; \
           s|^\s*link_flags += \['-fsanitize=address,undefined,fuzzer', '-fno-omit-frame-pointer'\]| \
           link_flags += \['$LIB_FUZZING_ENGINE'\]|" meson.build
+mkdir subprojects
+meson wrap update-db
+# Explicitly download wraps as nested projects have older versions of them.
+meson wrap install expat
+meson wrap install harfbuzz
+meson wrap install libpng
+meson wrap install zlib
+cat <<EOF > subprojects/libplacebo.wrap
+[wrap-git]
+url = https://github.com/haasn/libplacebo
+revision = master
+depth = 1
+clone-recursive = true
+EOF
+cat <<EOF > subprojects/libass.wrap
+[wrap-git]
+url = https://github.com/libass/libass
+revision = master
+depth = 1
+EOF
 meson setup build -Ddefault_library=static -Dprefer_static=true \
-                  -Dfuzzers=true -Dlibmpv=true -Dcplayer=false \
-                  -Dc_link_args="$CXXFLAGS -lc++ -Wl,-rpath,'\$ORIGIN/lib'" \
+                  -Dfuzzers=true -Dlibmpv=true -Dcplayer=false -Dgpl=true \
+                  -Dlibplacebo:lcms=enabled -Dlcms2=enabled \
+                  -Dlcms2:jpeg=disabled -Dlcms2:tiff=disabled -Dlibplacebo:demos=false \
+                  -Dlibass:asm=disabled -Dlibass:libunibreak=enabled -Dlibass:fontconfig=enabled \
+                  -Dc_link_args="$CXXFLAGS -lc++" -Dcpp_link_args="$CXXFLAGS" \
+                  -Dlibarchive=disabled -Drubberband=disabled -Ddrm=disabled -Dwayland=disabled \
+                  -Dlua=disabled -Djavascript=enabled -Duchardet=enabled \
                   --libdir $LIBDIR
 meson compile -C build
 
 cp ./build/fuzzers/fuzzer_*  $OUT/ || true
-# Static lib not available, requirement pulled by libass
-mkdir -p $OUT/lib/
-cp /usr/$LIBDIR/libgraphite2.so.3 $OUT/lib/

--- a/projects/mpv/build.sh
+++ b/projects/mpv/build.sh
@@ -26,6 +26,7 @@ pushd $SRC/ffmpeg
 ./configure --cc=$CC --cxx=$CXX --ld="$CXX $CXXFLAGS" \
             --disable-shared --enable-gpl --enable-nonfree \
             --disable-programs --disable-asm --pkg-config-flags="--static" \
+            --disable-protocol=rtp,srtp \
             $FFMPEG_BUILD_ARGS
 make -j`nproc`
 make install

--- a/projects/mpv/project.yaml
+++ b/projects/mpv/project.yaml
@@ -1,6 +1,8 @@
 homepage: "https://github.com/mpv-player/mpv"
 language: c
 primary_contact: "kasper93@gmail.com"
+auto_ccs:
+  - "jeebjp@gmail.com"
 architectures:
   - x86_64
   - i386

--- a/projects/mpv/project.yaml
+++ b/projects/mpv/project.yaml
@@ -2,9 +2,11 @@ homepage: "https://github.com/mpv-player/mpv"
 language: c
 primary_contact: "kasper93@gmail.com"
 architectures:
- - x86_64
- - i386
+  - x86_64
+  - i386
 sanitizers:
   - address
+  - memory:
+      experimental: true
   - undefined
 main_repo: 'https://github.com/mpv-player/mpv'


### PR DESCRIPTION
Build all dependencies and enable memory sanitizer. With experimental flag for now, in case there are false-positives.