### PR TITLE
Update AdamKorcz/instrumentation branch for containerd

### DIFF
--- a/projects/containerd/Dockerfile
+++ b/projects/containerd/Dockerfile
@@ -17,6 +17,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN apt-get update && apt-get install -y btrfs-progs libc-dev pkg-config libseccomp-dev gcc wget libbtrfs-dev
 RUN git clone --depth 1 https://github.com/containerd/containerd
-RUN git clone --depth=1 --branch=dev https://github.com/AdamKorcz/instrumentation
+RUN git clone --depth=1 https://github.com/AdamKorcz/instrumentation
 COPY build.sh $SRC/
 WORKDIR $SRC/containerd


### PR DESCRIPTION
Move branch back to main now that all changes (and required add'l change for Go 1.22 build fix) are in main