### PR TITLE
lxml: Update Known Exception Handling in Tests to Prevent False Positives

### DIFF
--- a/projects/lxml/fuzz_html_parse.py
+++ b/projects/lxml/fuzz_html_parse.py
@@ -16,16 +16,10 @@
 
 import atheris
 import sys
+from test_utils import is_expected_error
 
 with atheris.instrument_imports():
   from lxml import etree
-
-
-def is_expected_error(error_content_list, error_msg):
-  for error in error_content_list:
-    if error in error_msg:
-      return True
-  return False
 
 
 def TestOneInput(data):
@@ -41,7 +35,7 @@ def TestOneInput(data):
     ]
     if isinstance(e, etree.LxmlError) or (
         isinstance(e, (TypeError, ValueError)) and
-        is_expected_error(expected_error_message_content, str(e))):
+        is_expected_error(expected_error_message_content, e)):
       # Known exception raised by the source code are not interesting.
       return -1  # Reject so the input will not be added to the corpus.
     else:

--- a/projects/lxml/fuzz_schematron.py
+++ b/projects/lxml/fuzz_schematron.py
@@ -31,15 +31,9 @@ def TestOneInput(data):
 
     schematron = Schematron(schema_raw)
     schematron.validate(valid_tree)
-  except (etree.LxmlError, KeyError) as e:
-    if isinstance(e, etree.LxmlError) or (
-        isinstance(e, KeyError) and "None" in str(e)
-        # This possibility is tracked here: https://bugs.launchpad.net/lxml/+bug/2058177
-    ):
-      return -1  # Reject so the input will not be added to the corpus.
-    else:
-      # Unexpected exceptions might be a bug in the source or in our test.
-      raise e  # Alert a human to take a closer look at what caused this.
+  except (etree.LxmlError, KeyError):
+    # The `KeyError` possibility is tracked here: https://bugs.launchpad.net/lxml/+bug/2058177
+    return -1  # Reject so the input will not be added to the corpus.
 
 
 def main():

--- a/projects/lxml/fuzz_xmlschema.py
+++ b/projects/lxml/fuzz_xmlschema.py
@@ -17,6 +17,7 @@
 import atheris
 import sys
 import io
+from test_utils import is_expected_error
 
 with atheris.instrument_imports():
   from lxml import etree
@@ -32,6 +33,15 @@ def TestOneInput(data):
     schema.validate(valid_tree)
   except etree.LxmlError:
     return -1  # Reject so the input will not be added to the corpus.
+  except (ValueError, TypeError) as e:
+    expected_exceptions = [
+        "Input object has no document",
+        "Invalid input object",
+    ]
+    if is_expected_error(expected_exceptions, e):
+      return -1
+    else:
+      raise e
 
 
 def main():

--- a/projects/lxml/test_utils.py
+++ b/projects/lxml/test_utils.py
@@ -1,0 +1,26 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List  # pragma: no cover
+import atheris  # pragma: no cover
+
+
+@atheris.instrument_func
+def is_expected_error(error_message_list: List[str],
+                      exception: Exception):  # pragma: no cover
+  """Checks if the message of a given exception matches any of the expected error messages."""
+  for error in error_message_list:
+    if error in str(exception):
+      return True
+  return False


### PR DESCRIPTION
The fuzzer is crashing because of known exception cases which seems to be preventing Fuzz Introspector from running successfully, and making the tests less effective.

I hope the commit messages adequately describe the changes, but they should be pretty self evident from the diff regardless.