### PR TITLE
Add additional CCs for accessing connectedhomeip reports

### DIFF
--- a/projects/connectedhomeip/project.yaml
+++ b/projects/connectedhomeip/project.yaml
@@ -3,6 +3,8 @@ language: c++
 primary_contact: "andreilitvin@google.com"
 auto_ccs:
   - "mboyington@google.com"
+  - "szewczyk@google.com"
+  - "tennessee@google.com"
 sanitizers:
   - address
   - undefined


### PR DESCRIPTION
Adding a few more CC e-mails to extend the team available to review/triage/fix these issues.

I also expect we may add a few more in time as folks responsible with matter fuzzing are ramping up.