### PR TITLE
mpv: disable network

### DIFF
--- a/projects/mpv/build.sh
+++ b/projects/mpv/build.sh
@@ -26,7 +26,7 @@ pushd $SRC/ffmpeg
 ./configure --cc=$CC --cxx=$CXX --ld="$CXX $CXXFLAGS" \
             --disable-shared --enable-gpl --enable-nonfree \
             --disable-programs --disable-asm --pkg-config-flags="--static" \
-            --disable-protocol=rtp,srtp \
+            --disable-network \
             $FFMPEG_BUILD_ARGS
 make -j`nproc`
 make install


### PR DESCRIPTION
Should fix arbitrary DNS resolutions.

I think this is the root cause of #11958, so let's fix it. Although I'm only guessing. Everything is stuck, even sanitizer that cannot trigger DNS doesn't run, so there might be more to it.

It wasn't clear that this error causes so much trouble. There is https://oss-fuzz.com/testcase-detail/6494370936193024, but on crash statistic it says
```
Time to crash: 5916.00s
Total count: 1 
```
but if we dig into the statistic table on the actual testcase-detail page, I can see a lot of crashes. Which make sense of course.

What is little bit puzzling is that on the one log that is there, I can see it gone all the way
```
INFO: fuzzed for 5916 seconds, wrapping up soon
```
and apparently reported error after doing whole 6000 seconds. There is no detail, no more logs saved. My current understanding is that we got stuck in this case.