### PR TITLE
Add additional reviewers for OSS-fuzz reports for CHIP

### DIFF
--- a/projects/connectedhomeip/project.yaml
+++ b/projects/connectedhomeip/project.yaml
@@ -2,6 +2,8 @@ homepage: "https://buildwithmatter.com/"
 language: c++
 primary_contact: "andreilitvin@google.com"
 auto_ccs:
+  - "asad_haque@comcast.com"
+  - "lalabdulkarim@csa-iot.org"
   - "mboyington@google.com"
   - "szewczyk@google.com"
   - "tennessee@google.com"


### PR DESCRIPTION
This adds folks that are in the security incident report team outside of google - they should also have access to fuzzing reports.