### PR TITLE
Add timeout for `target_experiment.py`

### DIFF
--- a/infra/build/functions/target_experiment.py
+++ b/infra/build/functions/target_experiment.py
@@ -220,11 +220,17 @@ def run_experiment(project_name, target_name, args, output_path, errlog_path,
       f'COVERAGE_EXTRA_ARGS={project.coverage_extra_args.strip()}',
   ])
   steps.append({
-      'name': build_lib.get_runner_image_name(''),
-      'env': env,
+      'name':
+          build_lib.get_runner_image_name(''),
+      'env':
+          env,
+      'entrypoint':
+          '/bin/bash',
       'args': [
-          'coverage',
-          target_name,
+          '-c',
+          (f'timeout 30m coverage {target_name}; ret=$?; [ $ret -eq 124 ] '
+           '&& echo "coverage a timed out after 30 minutes" '
+           '|| echo "coverage a completed with exit status $EXIT_STATUS"'),
       ],
   })
 
@@ -268,6 +274,8 @@ def run_experiment(project_name, target_name, args, output_path, errlog_path,
   })
 
   credentials, _ = google.auth.default()
+  # Empirically, 3 hours is more than enough for 30-minute fuzzing cloud builds.
+  build_lib.BUILD_TIMEOUT = 3 * 60 * 60
   build_id = build_project.run_build(project_name,
                                      steps,
                                      credentials,

--- a/infra/build/functions/target_experiment.py
+++ b/infra/build/functions/target_experiment.py
@@ -230,9 +230,10 @@ def run_experiment(project_name, target_name, args, output_path, errlog_path,
           '-c',
           (
               f'timeout 30m coverage {target_name}; ret=$?; '
-              '[ $ret -eq 124 ] '  # Return code 124 indicates a time out.
-              '&& echo "coverage a timed out after 30 minutes" '
-              '|| echo "coverage a completed with exit status $EXIT_STATUS"'),
+              '[ $ret -eq 124 ] '  # Exit code 124 indicates a time out.
+              f'&& echo "coverage {target_name} timed out after 30 minutes" '
+              f'|| echo "coverage {target_name} completed with exit code $ret"'
+          ),
       ],
   })
 

--- a/infra/build/functions/target_experiment.py
+++ b/infra/build/functions/target_experiment.py
@@ -228,9 +228,11 @@ def run_experiment(project_name, target_name, args, output_path, errlog_path,
           '/bin/bash',
       'args': [
           '-c',
-          (f'timeout 30m coverage {target_name}; ret=$?; [ $ret -eq 124 ] '
-           '&& echo "coverage a timed out after 30 minutes" '
-           '|| echo "coverage a completed with exit status $EXIT_STATUS"'),
+          (
+              f'timeout 30m coverage {target_name}; ret=$?; '
+              '[ $ret -eq 124 ] '  # Return code 124 indicates a time out.
+              '&& echo "coverage a timed out after 30 minutes" '
+              '|| echo "coverage a completed with exit status $EXIT_STATUS"'),
       ],
   })
 


### PR DESCRIPTION
Add a 3-hour timeout to `target_experiment.py`, which should be more than enough given fuzzing timeout is 30 minutes and most successful cloud builds finish in 2.5 hours empirically.