### PR TITLE
Draft: Kimageformats JXR test

### DIFF
--- a/projects/kimageformats/Dockerfile
+++ b/projects/kimageformats/Dockerfile
@@ -23,8 +23,7 @@ RUN git clone --depth 1 --branch=RB-3.2 https://github.com/AcademySoftwareFounda
 RUN git clone --depth 1 -b kf5 https://invent.kde.org/frameworks/extra-cmake-modules.git
 RUN git clone --depth 1 --branch=5.15 git://code.qt.io/qt/qtbase.git
 RUN git clone --depth 1 -b kf5 https://invent.kde.org/frameworks/karchive.git
-#RUN git clone --depth 1 -b kf5 https://invent.kde.org/frameworks/kimageformats.git
-RUN git clone --depth 1 -b jxr_support_kf5 https://invent.kde.org/mircomir/kimageformats.git
+RUN git clone --depth 1 -b kf5 https://invent.kde.org/frameworks/kimageformats.git
 RUN git clone --depth 1 -b v3.8.1 https://aomedia.googlesource.com/aom
 RUN git clone --depth 1 -b v1.0.4 https://github.com/AOMediaCodec/libavif.git
 RUN git clone --depth 1 https://github.com/strukturag/libde265.git

--- a/projects/kimageformats/Dockerfile
+++ b/projects/kimageformats/Dockerfile
@@ -23,7 +23,8 @@ RUN git clone --depth 1 --branch=RB-3.2 https://github.com/AcademySoftwareFounda
 RUN git clone --depth 1 -b kf5 https://invent.kde.org/frameworks/extra-cmake-modules.git
 RUN git clone --depth 1 --branch=5.15 git://code.qt.io/qt/qtbase.git
 RUN git clone --depth 1 -b kf5 https://invent.kde.org/frameworks/karchive.git
-RUN git clone --depth 1 -b kf5 https://invent.kde.org/frameworks/kimageformats.git
+#RUN git clone --depth 1 -b kf5 https://invent.kde.org/frameworks/kimageformats.git
+RUN git clone --depth 1 -b jxr_support_kf5 https://invent.kde.org/mircomir/kimageformats.git
 RUN git clone --depth 1 -b v3.8.1 https://aomedia.googlesource.com/aom
 RUN git clone --depth 1 -b v1.0.4 https://github.com/AOMediaCodec/libavif.git
 RUN git clone --depth 1 https://github.com/strukturag/libde265.git
@@ -31,6 +32,7 @@ RUN git clone --depth 1 -b v2.5.0 https://github.com/uclouvain/openjpeg.git
 RUN git clone --depth 1 https://github.com/strukturag/libheif.git
 RUN git clone --depth=1 --branch v0.10.x --recursive --shallow-submodules https://github.com/libjxl/libjxl.git
 RUN git clone --depth 1 https://github.com/LibRaw/LibRaw
+RUN git clone --depth 1 https://github.com/4creators/jxrlib.git
 COPY build.sh $SRC
 COPY kimgio_fuzzer.cc $SRC
 WORKDIR kimageformats

--- a/projects/kimageformats/build.sh
+++ b/projects/kimageformats/build.sh
@@ -16,6 +16,10 @@
 ################################################################################
 
 cd $SRC
+cd jxrlib
+make -j$(nproc)
+
+cd $SRC
 cd LibRaw
 TMP_CFLAGS=$CFLAGS
 TMP_CXXFLAGS=$CXXFLAGS
@@ -133,6 +137,7 @@ HANDLER_TYPES="ANIHandler ani
         HDRHandler hdr
         HEIFHandler heif
         QJpegXLHandler jxl
+        JXRHandler jxr
         KraHandler kra
         OraHandler ora
         PCXHandler pcx
@@ -152,8 +157,7 @@ echo "$HANDLER_TYPES" | while read class format; do
   $SRC/qtbase/bin/moc $SRC/kimageformats/src/imageformats/$format.cpp -o $format.moc
   header=`ls $SRC/kimageformats/src/imageformats/$format*.h`
   $SRC/qtbase/bin/moc $header -o moc_`basename $header .h`.cpp
-  $CXX $CXXFLAGS -fPIC -DHANDLER=$class -std=c++17 $SRC/kimgio_fuzzer.cc $SRC/kimageformats/src/imageformats/$format.cpp $SRC/kimageformats/src/imageformats/scanlineconverter.cpp -o $OUT/$fuzz_target_name -DJXL_STATIC_DEFINE -DJXL_THREADS_STATIC_DEFINE -DJXL_CMS_STATIC_DEFINE -I $SRC/qtbase/include/QtCore/ -I $SRC/qtbase/include/ -I $SRC/qtbase/include//QtGui -I $SRC/kimageformats/src/imageformats/ -I $SRC/karchive/src/ -I $SRC/qtbase/mkspecs/linux-clang-libc++/ -I $SRC/libavif/include/ -I $SRC/libjxl/build/lib/include/ -I $SRC/libjxl/lib/include/ -I /usr/local/include/OpenEXR/ -I /usr/local/include/Imath -I . -L $SRC/qtbase/lib $SRC/libavif/build/libavif.a /usr/local/lib/libheif.a /usr/local/lib/libde265.a $SRC/aom/build.libavif/libaom.a $SRC/libjxl/build/lib/libjxl_threads.a $SRC/libjxl/build/lib/libjxl.a $SRC/libjxl/build/lib/libjxl_cms.a $SRC/libjxl/build/third_party/highway/libhwy.a $SRC/libjxl/build/third_party/brotli/libbrotlidec.a $SRC/libjxl/build/third_party/brotli/libbrotlienc.a $SRC/libjxl/build/third_party/brotli/libbrotlicommon.a -lQt5Gui -lQt5Core -lqtlibpng -lqtharfbuzz -lm -lqtpcre2 -ldl -lpthread $LIB_FUZZING_ENGINE /usr/local/lib/libzip.a /usr/local/lib/libz.a -lKF5Archive /usr/local/lib/libz.a /usr/local/lib/libraw.a /usr/local/lib/libOpenEXR-3_2.a /usr/local/lib/libIex-3_2.a /usr/local/lib/libImath-3_1.a /usr/local/lib/libIlmThread-3_2.a /usr/local/lib/libOpenEXRCore-3_2.a /usr/local/lib/libOpenEXRUtil-3_2.a /usr/local/lib/libopenjp2.a
-
+  $CXX $CXXFLAGS -fPIC -DHANDLER=$class -std=c++17 $SRC/kimgio_fuzzer.cc $SRC/kimageformats/src/imageformats/$format.cpp $SRC/kimageformats/src/imageformats/scanlineconverter.cpp -o $OUT/$fuzz_target_name -DJXL_STATIC_DEFINE -DJXL_THREADS_STATIC_DEFINE -DJXL_CMS_STATIC_DEFINE -DINITGUID -I $SRC/qtbase/include/QtCore/ -I $SRC/qtbase/include/ -I $SRC/qtbase/include//QtGui -I $SRC/kimageformats/src/imageformats/ -I $SRC/karchive/src/ -I $SRC/qtbase/mkspecs/linux-clang-libc++/ -I $SRC/libavif/include/ -I $SRC/libjxl/build/lib/include/ -I $SRC/libjxl/lib/include/ -I /usr/local/include/OpenEXR/ -I /usr/local/include/Imath -I $SRC/jxrlib/common/include -I $SRC/jxrlib/jxrgluelib -I $SRC/jxrlib/image/sys -I . -L $SRC/qtbase/lib $SRC/libavif/build/libavif.a /usr/local/lib/libheif.a /usr/local/lib/libde265.a $SRC/aom/build.libavif/libaom.a $SRC/libjxl/build/lib/libjxl_threads.a $SRC/libjxl/build/lib/libjxl.a $SRC/libjxl/build/lib/libjxl_cms.a $SRC/libjxl/build/third_party/highway/libhwy.a $SRC/libjxl/build/third_party/brotli/libbrotlidec.a $SRC/libjxl/build/third_party/brotli/libbrotlienc.a $SRC/libjxl/build/third_party/brotli/libbrotlicommon.a -lQt5Gui -lQt5Core -lqtlibpng -lqtharfbuzz -lm -lqtpcre2 -ldl -lpthread $LIB_FUZZING_ENGINE /usr/local/lib/libzip.a /usr/local/lib/libz.a -lKF5Archive /usr/local/lib/libz.a /usr/local/lib/libraw.a /usr/local/lib/libOpenEXR-3_2.a /usr/local/lib/libIex-3_2.a /usr/local/lib/libImath-3_1.a /usr/local/lib/libIlmThread-3_2.a /usr/local/lib/libOpenEXRCore-3_2.a /usr/local/lib/libOpenEXRUtil-3_2.a /usr/local/lib/libopenjp2.a $SRC/jxrlib/build/libjxrglue.a $SRC/jxrlib/build/libjpegxr.a
   find . -name "*.${format}" | zip -q $OUT/${fuzz_target_name}_seed_corpus.zip -@
 )
 done

--- a/projects/kimageformats/kimgio_fuzzer.cc
+++ b/projects/kimageformats/kimgio_fuzzer.cc
@@ -20,7 +20,7 @@
   Usage:
     python infra/helper.py build_image kimageformats
     python infra/helper.py build_fuzzers --sanitizer undefined|address|memory kimageformats
-    python infra/helper.py run_fuzzer kimageformats kimgio_[ani|avif|exr|hdr|heif|jxl|kra|ora|pcx|pic|psd|qoi|ras|raw|rgb|tga|xcf]_fuzzer
+    python infra/helper.py run_fuzzer kimageformats kimgio_[ani|avif|exr|hdr|heif|jxl|jxr|kra|ora|pcx|pic|psd|qoi|ras|raw|rgb|tga|xcf]_fuzzer
 */
 
 
@@ -34,6 +34,7 @@
 #include "hdr_p.h"
 #include "heif_p.h"
 #include "jxl_p.h"
+#include "jxr_p.h"
 #include "kra.h"
 #include "ora.h"
 #include "qoi_p.h"


### PR DESCRIPTION
Requires merging of [JXR plugin for KF5](https://invent.kde.org/frameworks/kimageformats/-/merge_requests/219)

Adds the test for the JXR plugin to KImageFormats.