### PR TITLE
jcc: append stdlib to newArgs instead of original args

### DIFF
--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -382,7 +382,7 @@ func main() {
 	var bin string
 	if isCPP {
 		bin = "clang++"
-		newArgs = append(args, "-stdlib=libc++")
+		newArgs = append(newArgs, "-stdlib=libc++")
 	} else {
 		bin = "clang"
 	}


### PR DESCRIPTION
Fix `-w` flag dropped unintentionally for clang++