### PR TITLE
[envoy] fix clang18 libclang_rt linkage issue

### DIFF
--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -41,7 +41,7 @@ if [ "$SANITIZER" = "undefined" ]
 then
   # Bazel uses clang to link binary, which does not link clang_rt ubsan library for C++ automatically.
   # See issue: https://github.com/bazelbuild/bazel/issues/8777
-  echo "--linkopt=$(find $(llvm-config --libdir) -name libclang_rt.ubsan_standalone_cxx.a | grep x86_64 | head -1)"
+  echo "--linkopt=$(clang -print-file-name=libclang_rt.ubsan_standalone_cxx.a)"
   echo "--linkopt=-fsanitize=undefined"
 elif [ "$SANITIZER" = "address" ]
 then

--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -41,7 +41,7 @@ if [ "$SANITIZER" = "undefined" ]
 then
   # Bazel uses clang to link binary, which does not link clang_rt ubsan library for C++ automatically.
   # See issue: https://github.com/bazelbuild/bazel/issues/8777
-  echo "--linkopt=$(find $(llvm-config --libdir) -name libclang_rt.ubsan_standalone_cxx-x86_64.a | head -1)"
+  echo "--linkopt=$(find $(llvm-config --libdir) -name libclang_rt.ubsan_standalone_cxx.a | grep x86_64 | head -1)"
   echo "--linkopt=-fsanitize=undefined"
 elif [ "$SANITIZER" = "address" ]
 then


### PR DESCRIPTION
Envoy's UBSAN build current fails with the following error:
```
[1A[K[31m[1mERROR: [0m/src/envoy/test/common/router/BUILD:233:21: Linking test/common/router/config_impl_test_static failed: (Exit 1): clang-18 failed: error executing command (from target //test/common/router:config_impl_test_static) 
Step #23 - "compile-libfuzzer-undefined-x86_64":   (cd /root/.cache/bazel/_bazel_root/4e9824db8e7d11820cfa25090ed4ed10/execroot/envoy && \
Step #23 - "compile-libfuzzer-undefined-x86_64":   exec env - \
Step #23 - "compile-libfuzzer-undefined-x86_64":     BAZEL_COMPILER=clang \
Step #23 - "compile-libfuzzer-undefined-x86_64":     BAZEL_CXXOPTS='-stdlib=libc++' \
Step #23 - "compile-libfuzzer-undefined-x86_64":     BAZEL_LINKLIBS=-l%:libc++.a:-l%:libc++abi.a \
Step #23 - "compile-libfuzzer-undefined-x86_64":     BAZEL_LINKOPTS=-lm:-pthread \
Step #23 - "compile-libfuzzer-undefined-x86_64":     CC=clang \
Step #23 - "compile-libfuzzer-undefined-x86_64":     CXX=clang++ \
Step #23 - "compile-libfuzzer-undefined-x86_64":     CXXFLAGS='-stdlib=libc++' \
Step #23 - "compile-libfuzzer-undefined-x86_64":     FUZZINTRO_OUTDIR=/src \
Step #23 - "compile-libfuzzer-undefined-x86_64":     LDFLAGS='-stdlib=libc++' \
Step #23 - "compile-libfuzzer-undefined-x86_64":     PATH=/bin:/usr/bin:/usr/local/bin \
Step #23 - "compile-libfuzzer-undefined-x86_64":     PWD=/proc/self/cwd \
Step #23 - "compile-libfuzzer-undefined-x86_64":   /usr/local/bin/clang-18 @bazel-out/k8-fastbuild-ST-0a6de8256f3b/bin/test/common/router/config_impl_test_static-2.params)
Step #23 - "compile-libfuzzer-undefined-x86_64": # Configuration: bcd0434cd1f68317f811560892076634a5706878d94e6459b56108eb78a3a66e
Step #23 - "compile-libfuzzer-undefined-x86_64": # Execution platform: @local_config_platform//:host
Step #23 - "compile-libfuzzer-undefined-x86_64": ld.lld: error: undefined symbol: __ubsan_vptr_type_cache
Step #23 - "compile-libfuzzer-undefined-x86_64": >>> referenced by socket_interface.h:69 (./envoy/network/socket_interface.h:69)
Step #23 - "compile-libfuzzer-undefined-x86_64": >>>               bazel-out/k8-fastbuild-ST-0a6de8256f3b/bin/test/common/router/_objs/config_impl_test_lib/config_impl_test.pic.o:(Envoy::Network::ioHandleForAddr(Envoy::Network::Socket::Type, std::__1::shared_ptr<Envoy::Network::Address::Instance const>, Envoy::Network::SocketCreationOptions const&))
Step #23 - "compile-libfuzzer-undefined-x86_64": >>> referenced by shared_ptr.h:772 (/usr/local/bin/../include/c++/v1/__memory/shared_ptr.h:772)
Step #23 - "compile-libfuzzer-undefined-x86_64": >>>               bazel-out/k8-fastbuild-ST-0a6de8256f3b/bin/test/common/router/_objs/config_impl_test_lib/config_impl_test.pic.o:(Envoy::Network::ioHandleForAddr(Envoy::Network::Socket::Type, std::__1::shared_ptr<Envoy::Network::Address::Instance const>, Envoy::Network::SocketCreationOptions const&))
Step #23 - "compile-libfuzzer-undefined-x86_64": >>> referenced by gtest-internal.h:532 (external/com_google_googletest/googletest/include/gtest/internal/gtest-internal.h:532)
Step #23 - "compile-libfuzzer-undefined-x86_64": >>>               bazel-out/k8-fastbuild-ST-0a6de8256f3b/bin/test/common/router/_objs/config_impl_test_lib/config_impl_test.pic.o:(testing::internal::SuiteApiResolver<Envoy::Router::(anonymous namespace)::RouteMatcherTest>::GetSetUpCaseOrSuite(char const*, int))
Step #23 - "compile-libfuzzer-undefined-x86_64": >>> referenced 174998 more times
Step #23 - "compile-libfuzzer-undefined-x86_64": 
Step #23 - "compile-libfuzzer-undefined-x86_64": ld.lld: error: undefined symbol: __ubsan_handle_dynamic_type_cache_miss_abort
Step #23 - "compile-libfuzzer-undefined-x86_64": >>> referenced by socket_interface.h:69 (./envoy/network/socket_interface.h:69)
Step #23 - "compile-libfuzzer-undefined-x86_64": >>>               bazel-out/k8-fastbuild-ST-0a6de8256f3b/bin/test/common/router/_objs/config_impl_test_lib/config_impl_test.pic.o:(Envoy::Network::ioHandleForAddr(Envoy::Network::Socket::Type, std::__1::shared_ptr<Envoy::Network::Address::Instance const>, Envoy::Network::SocketCreationOptions const&))
Step #23 - "compile-libfuzzer-undefined-x86_64": >>> referenced by socket_interface.h:69 (./envoy/network/socket_interface.h:69)
Step #23 - "compile-libfuzzer-undefined-x86_64": >>>               bazel-out/k8-fastbuild-ST-0a6de8256f3b/bin/test/common/router/_objs/config_impl_test_lib/config_impl_test.pic.o:(Envoy::Network::ioHandleForAddr(Envoy::Network::Socket::Type, std::__1::shared_ptr<Envoy::Network::Address::Instance const>, Envoy::Network::SocketCreationOptions const&))
Step #23 - "compile-libfuzzer-undefined-x86_64": >>> referenced by shared_ptr.h:772 (/usr/local/bin/../include/c++/v1/__memory/shared_ptr.h:772)
Step #23 - "compile-libfuzzer-undefined-x86_64": >>>               bazel-out/k8-fastbuild-ST-0a6de8256f3b/bin/test/common/router/_objs/config_impl_test_lib/config_impl_test.pic.o:(Envoy::Network::ioHandleForAddr(Envoy::Network::Socket::Type, std::__1::shared_ptr<Envoy::Network::Address::Instance const>, Envoy::Network::SocketCreationOptions const&))
Step #23 - "compile-libfuzzer-undefined-x86_64": >>> referenced 244906 more times
```

Further debugging revealed that the upgrade to clang18 caused the breakage, due to different libclang_rt library file name. This PR fixes this issue.