### PR TITLE
askama: ignore 'rust' from coverage

### DIFF
--- a/projects/askama/project.yaml
+++ b/projects/askama/project.yaml
@@ -10,3 +10,4 @@ fuzzing_engines:
   - libfuzzer
 coverage_extra_args: >
   -ignore-filename-regex=.*/rustc/.*
+  -ignore-filename-regex=.*/rust/.*


### PR DESCRIPTION
Ignores `'/rust/'` from coverage report, as i'm not sure how to cover crates like `nom-7.1.3` or `once_cell-1.19.0`  which is used by askama_parser and which already has  `90%` of its line covered.