### PR TITLE
mdbook-i18n-helpers: Initial integration

### DIFF
--- a/projects/mdbook-i18n-helpers/project.yaml
+++ b/projects/mdbook-i18n-helpers/project.yaml
@@ -1,0 +1,7 @@
+homepage: "https://github.com/google/mdbook-i18n-helpers"
+main_repo: "https://github.com/google/mdbook-i18n-helpers.git"
+language: rust
+primary_contact: "mgeisler@google.com"
+auto_ccs:
+  - "kdark@google.com"
+  - "darkhanu@gmail.com"


### PR DESCRIPTION
[mdbook-i18n-helpers](https://github.com/google/mdbook-i18n-helpers/) is a plugin for [mdbook](https://rust-lang.github.io/mdBook/) which enables localization support.
According to [crates](https://crates.io/crates/mdbook-i18n-helpers), it was downloaded ~100k times.

The project already defines [several fuzzers within its repo](https://github.com/google/mdbook-i18n-helpers/tree/main/fuzz).

I am one of the maintainers of the project. The main maintainer @mgeisler  approves of this request as can be seen from https://github.com/google/mdbook-i18n-helpers/issues/83.