### PR TITLE
libvips: remove OLD_LLVMPASS variable

### DIFF
--- a/projects/libvips/Dockerfile
+++ b/projects/libvips/Dockerfile
@@ -50,6 +50,3 @@ RUN git clone --depth 1 https://github.com/google/highway.git
 
 WORKDIR libvips
 COPY build.sh $SRC/
-# This is to fix Fuzz Introspector build by using LLVM old pass manager
-# re https://github.com/ossf/fuzz-introspector/issues/305
-ENV OLD_LLVMPASS 1


### PR DESCRIPTION
This became redundant after a2c60af93357f2053a45816fcdefdfc02206b64f.

---
Note that the failing introspector build was fixed via these commits:
https://github.com/libvips/libvips/commit/ee482ca49caafba89abe60fd8d361d0a00355096
https://github.com/libvips/libvips/commit/a9e161f04aae213e113e6ea551c704d5420cfd90
https://github.com/libvips/libvips/commit/18031970f70c00fe1ed56d85270ff80b454dfd71
6e1045e09968c5b45c08656bc669d5a20d205ea1