### PR TITLE
libxml2: Don't install i386 packages on aarch64

### DIFF
--- a/projects/libxml2/Dockerfile
+++ b/projects/libxml2/Dockerfile
@@ -15,11 +15,17 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
+ARG TARGETPLATFORM
 
 RUN apt-get update && \
+    case "$TARGETPLATFORM" in \
+        'linux/arm64') EXTRA_PACKAGES='' ;; \
+        *)             EXTRA_PACKAGES='zlib1g-dev:i386 liblzma-dev:i386' ;; \
+    esac && \
     apt-get install -y --no-install-recommends \
         make autoconf libtool pkg-config \
-        zlib1g-dev zlib1g-dev:i386 liblzma-dev liblzma-dev:i386
+        zlib1g-dev liblzma-dev \
+        $EXTRA_PACKAGES
 # Build requires automake 1.16.3
 RUN curl -LO http://mirrors.kernel.org/ubuntu/pool/main/a/automake-1.16/automake_1.16.5-1.3_all.deb && \
     apt install ./automake_1.16.5-1.3_all.deb


### PR DESCRIPTION
Try to fix build failure on aarch64.