### PR TITLE
[lxml] Update Known Exception Handling to Unblock Fuzzing

### DIFF
--- a/projects/lxml/fuzz_sax.py
+++ b/projects/lxml/fuzz_sax.py
@@ -29,10 +29,15 @@ def TestOneInput(data):
 
     handler = sax.ElementTreeContentHandler()
     sax.ElementTreeProducer(parsed, handler).saxify()
-  except (etree.LxmlError, ValueError) as e:
+  except (etree.LxmlError, ValueError, IndexError) as e:
     if isinstance(e, etree.LxmlError) or (isinstance(e, ValueError) and
                                           "Invalid" in str(e)):
       return -1  # Reject so the input will not be added to the corpus.
+    elif isinstance(
+        e, IndexError
+    ) and "lxml.sax.ElementTreeContentHandler.processingInstruction" in str(e):
+      # This possibility is a bug and tracked here: https://bugs.launchpad.net/lxml/+bug/2011542
+      return 0  # Accept the input in the corpus to enable regression testing when fixed.
     else:
       raise e
 

--- a/projects/lxml/fuzz_schematron.py
+++ b/projects/lxml/fuzz_schematron.py
@@ -31,8 +31,7 @@ def TestOneInput(data):
 
     schematron = Schematron(schema_raw)
     schematron.validate(valid_tree)
-  except (etree.LxmlError, KeyError):
-    # The `KeyError` possibility is tracked here: https://bugs.launchpad.net/lxml/+bug/2058177
+  except etree.LxmlError:
     return -1  # Reject so the input will not be added to the corpus.
 
 


### PR DESCRIPTION
The changes here update the `fuzz_sax` test harness to gracefully handle a documented exception so the fuzzer will not exit when the exception is raised. This PR also removes the special case handling in `fuzz_schematron.py` for a bug in `lxml.isoschematron.Schematron` that has been fixed.

## Changes to `fuzz_sax.py`

The `IndexError` raised in `src/lxml/sax.py` is a known bug with an issue marked as low priority in lxml's bug tracker since  2023-03-14: https://bugs.launchpad.net/lxml/+bug/2011542

## Changes to `fuzz_schematron.py`

The unhandled `KeyError`  bug in the `lxml.isoschematron.Schematron` class that was previously identified by fuzzing has been fixed upstream via: https://github.com/lxml/lxml/pull/423.