### PR TITLE
[gc-iam] Update Project Repo & Fix Build Issues

### DIFF
--- a/projects/gc-iam/Dockerfile
+++ b/projects/gc-iam/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-python
 RUN apt-get update && \
-    apt-get install libre2-dev zlib1g-dev libssl-dev --yes
+    apt-get install -y libre2-dev zlib1g-dev libssl-dev
 RUN python3 -m pip install --upgrade pip
 RUN git clone --depth 1 https://github.com/googleapis/google-cloud-python $SRC/google-cloud-python
 WORKDIR $SRC/google-cloud-python/packages/google-cloud-iam

--- a/projects/gc-iam/Dockerfile
+++ b/projects/gc-iam/Dockerfile
@@ -15,8 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder-python
-
-RUN git clone --depth=1 https://github.com/googleapis/python-iam
-WORKDIR python-iam
-
+RUN python3 -m pip install --upgrade pip
+RUN git clone --depth 1 https://github.com/googleapis/google-cloud-python
+WORKDIR google-cloud-python
 COPY build.sh fuzz_*.py $SRC/

--- a/projects/gc-iam/Dockerfile
+++ b/projects/gc-iam/Dockerfile
@@ -15,7 +15,9 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder-python
+RUN apt-get update && \
+    apt-get install libre2-dev zlib1g-dev libssl-dev --yes
 RUN python3 -m pip install --upgrade pip
-RUN git clone --depth 1 https://github.com/googleapis/google-cloud-python
-WORKDIR google-cloud-python
+RUN git clone --depth 1 https://github.com/googleapis/google-cloud-python $SRC/google-cloud-python
+WORKDIR $SRC/google-cloud-python/packages/google-cloud-iam
 COPY build.sh fuzz_*.py $SRC/

--- a/projects/gc-iam/build.sh
+++ b/projects/gc-iam/build.sh
@@ -15,10 +15,10 @@
 #
 ################################################################################
 
+cd packages/google-cloud-iam/
+
 # Build and install project (using current CFLAGS, CXXFLAGS).
-pip3 install --upgrade pip
-pip3 install google-cloud-core
-pip3 install .
+ python3 -m pip install .
 
 for fuzzer in $(find $SRC -name 'fuzz_*.py'); do
   compile_python_fuzzer $fuzzer

--- a/projects/gc-iam/build.sh
+++ b/projects/gc-iam/build.sh
@@ -15,10 +15,12 @@
 #
 ################################################################################
 
-cd packages/google-cloud-iam/
-
 # Build and install project (using current CFLAGS, CXXFLAGS).
- python3 -m pip install .
+GRPC_PYTHON_CFLAGS="${CFLAGS}" \
+GRPC_PYTHON_BUILD_SYSTEM_RE2=true \
+GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=true \
+GRPC_PYTHON_BUILD_SYSTEM_ZLIB=true \
+python3 -m pip install . --no-binary protobuf,grpcio
 
 for fuzzer in $(find $SRC -name 'fuzz_*.py'); do
   compile_python_fuzzer $fuzzer

--- a/projects/gc-iam/build.sh
+++ b/projects/gc-iam/build.sh
@@ -20,7 +20,7 @@ GRPC_PYTHON_CFLAGS="${CFLAGS}" \
 GRPC_PYTHON_BUILD_SYSTEM_RE2=true \
 GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=true \
 GRPC_PYTHON_BUILD_SYSTEM_ZLIB=true \
-python3 -m pip install . --no-binary protobuf,grpcio
+python3 -m pip install -v . --no-binary :all:
 
 for fuzzer in $(find $SRC -name 'fuzz_*.py'); do
   compile_python_fuzzer $fuzzer

--- a/projects/gc-iam/fuzz_credentials.py
+++ b/projects/gc-iam/fuzz_credentials.py
@@ -15,6 +15,7 @@
 
 import sys
 import atheris
+
 with atheris.instrument_imports():
     import google.cloud.iam_credentials_v1.services.iam_credentials as iam
 
@@ -70,7 +71,7 @@ def TestOneInput(data):
     )
 
 def main():
-    atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
+    atheris.Setup(sys.argv, TestOneInput)
     atheris.Fuzz()
 
 if __name__ == "__main__":

--- a/projects/gc-iam/project.yaml
+++ b/projects/gc-iam/project.yaml
@@ -1,8 +1,8 @@
 fuzzing_engines:
 - libfuzzer
-homepage: https://github.com/googleapis/python-iam
+homepage: https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-iam
 language: python
-main_repo: https://github.com/googleapis/python-iam
+main_repo: https://github.com/googleapis/google-cloud-python
 sanitizers:
 - address
 - undefined


### PR DESCRIPTION
Fixes [Monorail Issue 61581][Monorail-issue].

The https://github.com/googleapis/python-iam repository was archived on 2023-10-26 and the project was moved to the `google-cloud-iam` package in the https://github.com/googleapis/google-cloud-python repository.
The upstream migration removed the source code from the original repo, resulting in the broken build.

[Monorail-issue]: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=61581


## Related PRs Fixing Similar Issues

- #12015
- #12016

## Other Changes Introduced Here

### Fixes for Missing Instrumentation of Native Extension Code

Native extensions used by this project were not being instrumented despite the environment variables set in `build.sh` because `pip` was downloading prebuilt binaries instead of building them with appropriate flags. The result was reduced fuzzer efficacy for ASAN runs and little to no value for UBSAN runs.

This is fixed by building dependencies with instrumentation in `build.sh`:

Passing `--no-binary :all:` to `pip install` instructs pip to prefer building/compiling the required dependencies rather than downloading a pre-built binary. The result is a slower install, but enables more effective fuzzing by instrumenting native extensions shipped with dependencies.

`:all:` is used instead of specifying individual dependencies to make the build more resilient and adaptable to upstream dependency changes.

The `Dockerfile` was also updated to install the required build dependencies.

### Misc.

- Moves the `pip` upgrade into the `Dockerfile` so it is only done once
  when the image is built.
- Removes the `google-cloud-core` install step and instead relies on the
  `google-cloud-iam` package to specify its own dependencies.
- Removes deprecated `enable_python_coverage=True` argument from
  `atheris.Setup`.



