### PR TITLE
[g-api-resource-manager] Update Project Repo to Fix Build

### DIFF
--- a/projects/g-api-resource-manager/Dockerfile
+++ b/projects/g-api-resource-manager/Dockerfile
@@ -15,8 +15,10 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder-python
-RUN apt-get update && apt-get install -y make autoconf automake libtool
-RUN pip3 install --upgrade pip && pip install google-api-core google-cloud-core mock
-RUN git clone --depth 1 https://github.com/googleapis/python-resource-manager
-WORKDIR python-resource-manager
+RUN apt-get update && \
+    apt-get install -y libre2-dev zlib1g-dev libssl-dev
+RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip install --upgrade mock
+RUN git clone --depth 1 https://github.com/googleapis/google-cloud-python $SRC/google-cloud-python
+WORKDIR $SRC/google-cloud-python/packages/google-cloud-resource-manager
 COPY build.sh *.py $SRC/

--- a/projects/g-api-resource-manager/build.sh
+++ b/projects/g-api-resource-manager/build.sh
@@ -15,7 +15,12 @@
 #
 ################################################################################
 
-GRPC_PYTHON_CFLAGS="${CFLAGS}" GRPC_PYTHON_BUILD_SYSTEM_RE2=true GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=true GRPC_PYTHON_BUILD_SYSTEM_ZLIB=true  pip3 install -v .
+GRPC_PYTHON_CFLAGS="${CFLAGS}" \
+GRPC_PYTHON_BUILD_SYSTEM_RE2=true \
+GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=true \
+GRPC_PYTHON_BUILD_SYSTEM_ZLIB=true \
+MAX_JOBS=$(nproc) \
+python3 -m pip install -v . --no-binary :all:
 
 for fuzzer in $(find $SRC -name 'fuzz_*.py'); do
   compile_python_fuzzer $fuzzer

--- a/projects/g-api-resource-manager/fuzz_tag_values_client.py
+++ b/projects/g-api-resource-manager/fuzz_tag_values_client.py
@@ -14,23 +14,22 @@
 # limitations under the License.
 """Fuzzer for google/cloud/resourcemanager_v3/services/tag_values/client.py"""
 
-import os
 import sys
+import mock
 import atheris
 
-import mock
-
-from google.auth import credentials as ga_credentials
-from google.longrunning import operations_pb2
-from google.iam.v1 import iam_policy_pb2
-from google.iam.v1 import policy_pb2 
-from google.cloud.resourcemanager_v3.services.tag_values import (
-    TagValuesAsyncClient,
-    TagValuesClient,
-    pagers,
-    transports,
-)
-from google.cloud.resourcemanager_v3.types import tag_values
+with atheris.instrument_imports():
+    from google.auth import credentials as ga_credentials
+    from google.longrunning import operations_pb2
+    from google.iam.v1 import iam_policy_pb2
+    from google.iam.v1 import policy_pb2
+    from google.cloud.resourcemanager_v3.services.tag_values import (
+        TagValuesAsyncClient,
+        TagValuesClient,
+        pagers,
+        transports,
+    )
+    from google.cloud.resourcemanager_v3.types import tag_values
 
 
 def test_get_tag_value(fdp, client):
@@ -133,8 +132,7 @@ def TestOneInput(data):
         target(fdp, client)
 
 def main():
-    atheris.instrument_all()
-    atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
+    atheris.Setup(sys.argv, TestOneInput)
     atheris.Fuzz()
 
 if __name__ == "__main__":

--- a/projects/g-api-resource-manager/project.yaml
+++ b/projects/g-api-resource-manager/project.yaml
@@ -1,8 +1,8 @@
 fuzzing_engines:
 - libfuzzer
-homepage: https://github.com/googleapis/python-resource-manager
+homepage: https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-resource-manager
 language: python
-main_repo: https://github.com/googleapis/python-resource-manager
+main_repo: https://github.com/googleapis/google-cloud-python
 sanitizers:
 - address
 - undefined


### PR DESCRIPTION
Fixes [Monorail Issue 59721][Monorail-issue]. The
https://github.com/googleapis/python-resource-manager repository was archived on
2023-09-05 and the project was moved to the `google-cloud-resource-manager` package
in the https://github.com/googleapis/google-cloud-python repository.
The upstream migration removed the source code from the original repo,
resulting in the broken build.

[Monorail-issue]: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=59721

## Other Changes Introduced Here

### Fixes for Missing Instrumentation of Native Extension Code

See 9a8989bf73899b232ac16f970dfa9bf72a8904bb

### Fuzzer Update

See d33e0a4156132bbc4293f8169aba415cd21bd075

## Related PRs Fixing Similar Issues

- #12014
- #12016