### PR TITLE
[g-api-python-tasks] Update Project Repo to Fix Build

### DIFF
--- a/projects/g-api-python-tasks/Dockerfile
+++ b/projects/g-api-python-tasks/Dockerfile
@@ -15,8 +15,10 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder-python
-RUN apt-get update && apt-get install -y make autoconf automake libtool
-RUN pip3 install --upgrade pip && pip install google-api-core google-cloud-core mock
-RUN git clone --depth 1 https://github.com/googleapis/python-tasks
-WORKDIR python-tasks
+RUN apt-get update && \
+    apt-get install -y libre2-dev zlib1g-dev libssl-dev
+RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip install --upgrade  mock
+RUN git clone --depth 1 https://github.com/googleapis/google-cloud-python $SRC/google-cloud-python
+WORKDIR $SRC/google-cloud-python/packages/google-cloud-tasks
 COPY build.sh *.py $SRC/

--- a/projects/g-api-python-tasks/build.sh
+++ b/projects/g-api-python-tasks/build.sh
@@ -15,7 +15,13 @@
 #
 ################################################################################
 
-GRPC_PYTHON_CFLAGS="${CFLAGS}" GRPC_PYTHON_BUILD_SYSTEM_RE2=true GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=true GRPC_PYTHON_BUILD_SYSTEM_ZLIB=true pip3 install .
+GRPC_PYTHON_CFLAGS="${CFLAGS}" \
+GRPC_PYTHON_BUILD_SYSTEM_RE2=true \
+GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=true \
+GRPC_PYTHON_BUILD_SYSTEM_ZLIB=true \
+MAX_JOBS=$(nproc) \
+python3 -m pip install -v . --no-binary :all:
+
 for fuzzer in $(find $SRC -name 'fuzz_*.py'); do
   compile_python_fuzzer $fuzzer
 done

--- a/projects/g-api-python-tasks/fuzz_cloudtask_client.py
+++ b/projects/g-api-python-tasks/fuzz_cloudtask_client.py
@@ -13,15 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import sys
 import mock
 import atheris
 
-from google.auth import credentials as ga_credentials
-from google.cloud.tasks_v2.services.cloud_tasks import CloudTasksClient
-from google.cloud.tasks_v2.types import queue
-from google.cloud.tasks_v2.types import cloudtasks
+with atheris.instrument_imports():
+    from google.auth import credentials as ga_credentials
+    from google.cloud.tasks_v2.services.cloud_tasks import CloudTasksClient
+    from google.cloud.tasks_v2.types import queue
+    from google.cloud.tasks_v2.types import cloudtasks
 
 
 def get_request_queue(fdp, client):
@@ -68,8 +68,7 @@ def TestOneInput(data):
 
 
 def main():
-    atheris.instrument_all()
-    atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
+    atheris.Setup(sys.argv, TestOneInput)
     atheris.Fuzz()
 
 

--- a/projects/g-api-python-tasks/project.yaml
+++ b/projects/g-api-python-tasks/project.yaml
@@ -1,8 +1,8 @@
 fuzzing_engines:
 - libfuzzer
-homepage: https://github.com/googleapis/python-tasks
+homepage: https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-tasks
 language: python
-main_repo: https://github.com/googleapis/python-tasks
+main_repo: https://github.com/googleapis/google-cloud-python
 sanitizers:
 - address
 - undefined


### PR DESCRIPTION
Fixes [Monorail Issue 62914][Monorail-issue]. The
https://github.com/googleapis/python-tasks repository was archived on
2024-02-01 and the project was moved to the `google-cloud-tasks` package
in the https://github.com/googleapis/google-cloud-python repository.
The upstream migration removed the source code from the original repo,
resulting in the broken build.

[Monorail-issue]: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62914

## Other Changes Introduced Here

### Fixes for Missing Instrumentation of Native Extension Code

See a3f475e91fcd730b889d5f6204751a5ca813897b

### Fuzzer Update

See 275368c90813e33e5e2c8bd4d78ed5394d4a7da6

## Related PRs Fixing Similar Issues

- #12014
- #12015