### PR TITLE
mpv: explicitly enable Centipede

### DIFF
--- a/projects/mpv/project.yaml
+++ b/projects/mpv/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/mpv-player/mpv"
+main_repo: "https://github.com/mpv-player/mpv"
 language: c
 primary_contact: "kasper93@gmail.com"
 auto_ccs:
@@ -11,4 +12,8 @@ sanitizers:
   - memory:
       experimental: True
   - undefined
-main_repo: 'https://github.com/mpv-player/mpv'
+fuzzing_engines:
+  - afl
+  - centipede
+  - honggfuzz
+  - libfuzzer

--- a/projects/mpv/project.yaml
+++ b/projects/mpv/project.yaml
@@ -9,6 +9,6 @@ architectures:
 sanitizers:
   - address
   - memory:
-      experimental: true
+      experimental: True
   - undefined
 main_repo: 'https://github.com/mpv-player/mpv'


### PR DESCRIPTION
According to the documentation [1] and oss-fuzz source [2] it should be
enabled by default. But in fact it is not enabled by default on the
ClusterFuzz [3] and only projects that explicity enable Centipede are using
this engine.

[1] https://google.github.io/oss-fuzz/getting-started/new-project-guide/#fuzzing_engines
[2] https://github.com/google/oss-fuzz/blob/b07cc908abf97529a95a4dd9b3d152bf4f101e71/infra/build/functions/build_project.py#L47
[3] https://github.com/google/clusterfuzz/blob/22e11083b540518248d512141c45c25c7f560f2e/src/clusterfuzz/_internal/cron/project_setup.py#L204

See-Also: https://github.com/google/oss-fuzz/issues/11964