### PR TITLE
[libcups] Init integration

### DIFF
--- a/projects/libcups/Dockerfile
+++ b/projects/libcups/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool build-essential libavahi-client-dev libgnutls28-dev libnss-mdns zlib1g-dev libsystemd-dev
+RUN git clone --depth 1 https://github.com/OpenPrinting/libcups.git
+RUN git clone --depth 1 https://github.com/OpenPrinting/fuzzing.git
+
+COPY build.sh $SRC/
+WORKDIR $SRC/libcups

--- a/projects/libcups/build.sh
+++ b/projects/libcups/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+$SRC/fuzzing/projects/libcups/oss_fuzz_build.sh

--- a/projects/libcups/project.yaml
+++ b/projects/libcups/project.yaml
@@ -16,16 +16,16 @@ auto_ccs:
 
 architectures:
   - x86_64
-  - i386
+  # - i386
 
 sanitizers:
   - address
   - memory
-  - undefined
+  # - undefined
 
 fuzzing_engines:
   - libfuzzer
-  - honggfuzz
-  - afl
+  # - honggfuzz
+  # - afl
 
 # builds_per_day: 2

--- a/projects/libcups/project.yaml
+++ b/projects/libcups/project.yaml
@@ -1,0 +1,31 @@
+homepage: "https://github.com/OpenPrinting/libcups"
+main_repo: "https://github.com/OpenPrinting/libcups.git"
+# help_url:
+language: c++
+
+primary_contact: "jiongchiyu@gmail.com"
+auto_ccs:
+  - "till.kamppeter@gmail.com"
+  - "ossfuzz@iosifache.me"
+  # - "msweet@msweet.org"
+  # - "jsmeix@suse.de"
+  # - "debian@alteholz.de"
+  # - "zdohnal@redhat.com"
+  # - "basu.aveek@gmail.com"
+# vendor_ccs:
+
+architectures:
+  - x86_64
+  - i386
+
+sanitizers:
+  - address
+  - memory
+  - undefined
+
+fuzzing_engines:
+  - libfuzzer
+  - honggfuzz
+  - afl
+
+# builds_per_day: 2


### PR DESCRIPTION
The OpenPrinting Team is integrating C-based projects into the OSS-Fuzz Framework. The maintaining fuzz harnesses locate in OpenPrinting project [fuzzing](https://github.com/OpenPrinting/fuzzing). 

This PR contains the initial integration config for OpenPrinting project libcups.

CC: @tillkamppeter @iosifache