### PR TITLE
Upgrade capstone to use python3

### DIFF
--- a/projects/capstone/Dockerfile
+++ b/projects/capstone/Dockerfile
@@ -14,8 +14,8 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make cmake python python-setuptools
+FROM gcr.io/oss-fuzz-base/base-builder-python
+RUN apt-get update && apt-get install -y make cmake
 RUN git clone --depth 1 --branch v5 https://github.com/aquynh/capstone.git capstonev5
 RUN git clone --depth 1 --branch next https://github.com/aquynh/capstone.git capstonenext
 WORKDIR $SRC

--- a/projects/capstone/build.sh
+++ b/projects/capstone/build.sh
@@ -33,7 +33,7 @@ do
     (
     export CFLAGS=""
     export AFL_NOOPT=1
-    python setup.py install
+    python3 setup.py install
     )
     cd $SRC/capstone$branch/suite
     mkdir fuzz/corpus

--- a/projects/capstone/build.sh
+++ b/projects/capstone/build.sh
@@ -37,7 +37,7 @@ do
     )
     cd $SRC/capstone$branch/suite
     mkdir fuzz/corpus
-    find MC/ -name *.cs | ./test_corpus.py
+    find MC/ -name *.cs | ./test_corpus3.py
     cd fuzz
     zip -r fuzz_disasm"$branch"_seed_corpus.zip corpus/
     cp fuzz_disasm"$branch"_seed_corpus.zip $OUT/


### PR DESCRIPTION
Upstream has ended python2 support. When removing python2 compatibility code, it was noticed that oss-fuzz was still utilizing this support. This fixes that by moving to a supported version of python3.

See this PR: https://github.com/capstone-engine/capstone/pull/2378