### PR TITLE
[lxml] Fix Pyinstaller Bundling Error & Add More Graceful Handling for Shallow Errors

### DIFF
--- a/projects/lxml/build.sh
+++ b/projects/lxml/build.sh
@@ -53,7 +53,7 @@ find $SEED_DATA_DIR \( -name '*_seed_corpus.zip' -o -name '*.options' -o -name '
   -exec cp {} "$OUT" \;
 
 find "$SRC" -maxdepth 1 -name 'fuzz_*.py' -print0 | while IFS= read -r -d $'\0' fuzz_harness; do
-  compile_python_fuzzer "$fuzz_harness" \
+  LD_PRELOAD=$OUT/sanitizer_with_fuzzer.so ASAN_OPTIONS=detect_leaks=0 compile_python_fuzzer "$fuzz_harness" \
     --collect-all="lxml"
 
   common_base_dictionary_filename="$SEED_DATA_DIR/__base.dict"
@@ -71,5 +71,3 @@ find "$SRC" -maxdepth 1 -name 'fuzz_*.py' -print0 | while IFS= read -r -d $'\0' 
     cat "$common_base_dictionary_filename" >> "$output_file"
   fi
 done
-
-

--- a/projects/lxml/fuzz_schematron.py
+++ b/projects/lxml/fuzz_schematron.py
@@ -17,6 +17,7 @@
 import atheris
 import sys
 import io
+from test_utils import is_expected_error
 
 with atheris.instrument_imports():
   from lxml import etree
@@ -33,6 +34,11 @@ def TestOneInput(data):
     schematron.validate(valid_tree)
   except etree.LxmlError:
     return -1  # Reject so the input will not be added to the corpus.
+  except (ValueError, TypeError) as e:
+    if is_expected_error(["Empty tree", "None not allowed as a stylesheet parameter"], e):
+      return -1
+    else:
+      raise e
 
 
 def main():


### PR DESCRIPTION
#### In the Fuzz Harnesses

Adds additional handling for shallow errors that prematurely halt fuzzer runs.

#### In `build.sh`

Fixes an issue preventing Pyinstaller from properly bundling `lxml.isoschematron`. The issue fixed here can be seen in the build logs (e.g, [the most recent one](https://oss-fuzz-build-logs.storage.googleapis.com/log-c5377ff0-29ca-4541-bda2-1159016ec4a6.txt)) by `grep`ing for the string `Failed to collect submodules`

---

More details about these changes can be found in their respective commit messages.