### PR TITLE
Adding Ruby Support into OSS-Fuzz via Ruzzy

### DIFF
--- a/infra/base-images/all.sh
+++ b/infra/base-images/all.sh
@@ -22,6 +22,7 @@ docker build -t gcr.io/oss-fuzz-base/base-builder-go "$@" infra/base-images/base
 docker build -t gcr.io/oss-fuzz-base/base-builder-jvm "$@" infra/base-images/base-builder-jvm
 docker build -t gcr.io/oss-fuzz-base/base-builder-python "$@" infra/base-images/base-builder-python
 docker build -t gcr.io/oss-fuzz-base/base-builder-rust "$@" infra/base-images/base-builder-rust
+docker build -t gcr.io/oss-fuzz-base/base-builder-ruby "$@" infra/base-images/base-builder-ruby
 docker build -t gcr.io/oss-fuzz-base/base-builder-swift "$@" infra/base-images/base-builder-swift
 docker build -t gcr.io/oss-fuzz-base/base-runner "$@" infra/base-images/base-runner
 docker build -t gcr.io/oss-fuzz-base/base-runner-debug "$@" infra/base-images/base-runner-debug

--- a/infra/base-images/base-builder-ruby/Dockerfile
+++ b/infra/base-images/base-builder-ruby/Dockerfile
@@ -16,9 +16,6 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 
-# TODO: I think it's not used.
-ENV ASAN_OPTIONS="allocator_may_return_null=1:detect_leaks=0:use_sigaltstack=0"
-
 RUN git clone https://github.com/trailofbits/ruzzy.git $SRC/ruzzy
 
 RUN install_ruby.sh

--- a/infra/base-images/base-builder-ruby/Dockerfile
+++ b/infra/base-images/base-builder-ruby/Dockerfile
@@ -1,0 +1,58 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+# TODO: I think it's not used.
+ENV ASAN_OPTIONS="allocator_may_return_null=1:detect_leaks=0:use_sigaltstack=0"
+
+RUN git clone https://github.com/trailofbits/ruzzy.git $SRC/ruzzy
+
+RUN install_ruby.sh
+ENV PATH="$PATH:/usr/local/rvm/rubies/ruby-3.3.1/bin"
+
+RUN gem update --system 3.5.11
+
+# Install ruzzy
+WORKDIR $SRC/ruzzy
+
+# The MAKE variable allows overwriting the make command at runtime. This forces the
+# Ruby C extension to respect ENV variables when compiling, like CC, CFLAGS, etc.
+ENV MAKE="make --environment-overrides V=1"
+
+RUN CC="clang" \
+CXX="clang++" \
+LDSHARED="clang -shared" \
+LDSHAREDXX="clang++ -shared" \
+gem build
+
+RUN MAKE="make --environment-overrides V=1" \
+CC="clang" \
+CXX="clang++" \
+LDSHARED="clang -shared" \
+LDSHAREDXX="clang++ -shared" \
+CXXFLAGS="-fPIC" \
+CFLAGS="-fPIC" \
+RUZZY_DEBUG=1 gem install --install-dir /install/ruzzy --development --verbose ruzzy-*.gem
+
+
+ENV LDSHARED="$CC -shared"
+ENV LDSHAREDXX="$CXX -shared"
+
+ENV GEM_HOME="$OUT/fuzz-gem"
+ENV GEM_PATH="/install/ruzzy"
+
+COPY ruzzy-build /usr/bin/ruzzy-build

--- a/infra/base-images/base-builder-ruby/ruzzy-build
+++ b/infra/base-images/base-builder-ruby/ruzzy-build
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash -e
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+fuzz_target=$(basename "$1")
+echo "BASENAME: $fuzz_target ---"
+harness_sh=${fuzz_target::-3}
+
+cp $1 $OUT/$fuzz_target
+
+echo """#!/usr/bin/env bash
+
+ruzzy $fuzz_target
+""" > $OUT/$harness_sh
+chmod +x $OUT/$harness_sh

--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -161,6 +161,7 @@ COPY bazel_build_fuzz_tests \
     install_javascript.sh \
     install_java.sh \
     install_python.sh \
+    install_ruby.sh \
     install_rust.sh \
     install_swift.sh \
     python_coverage_helper.py \

--- a/infra/base-images/base-builder/install_ruby.sh
+++ b/infra/base-images/base-builder/install_ruby.sh
@@ -16,7 +16,6 @@
 ################################################################################
 
 apt update
-# TODO: we should install a specific version of ruby
 apt install -y lsb-release software-properties-common gnupg2 binutils xz-utils libyaml-dev
 gpg2 --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 curl -sSL https://get.rvm.io | bash

--- a/infra/base-images/base-builder/install_ruby.sh
+++ b/infra/base-images/base-builder/install_ruby.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+apt update
+# TODO: we should install a specific version of ruby
+apt install -y lsb-release software-properties-common gnupg2 binutils xz-utils libyaml-dev
+gpg2 --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+curl -sSL https://get.rvm.io | bash
+
+. /etc/profile.d/rvm.sh
+
+rvm install ruby-3.3.1

--- a/infra/base-images/base-runner/Dockerfile
+++ b/infra/base-images/base-runner/Dockerfile
@@ -18,11 +18,12 @@
 # Keeping the rust toolchain in the image wastes 1 GB.
 FROM gcr.io/oss-fuzz-base/base-image as temp-runner-binary-builder
 
-RUN apt-get update && apt-get install -y cargo
+RUN apt-get update && apt-get install -y cargo libyaml-dev
 RUN cargo install rustfilt
 
 # Using multi-stage build to copy some LLVM binaries needed in the runner image.
 FROM gcr.io/oss-fuzz-base/base-clang AS base-clang
+FROM gcr.io/oss-fuzz-base/base-builder-ruby AS base-ruby
 
 # Real image that will be used later.
 FROM gcr.io/oss-fuzz-base/base-image
@@ -86,6 +87,15 @@ RUN wget https://repo1.maven.org/maven2/org/jacoco/org.jacoco.cli/0.8.7/org.jaco
 
 COPY install_javascript.sh /
 RUN /install_javascript.sh && rm /install_javascript.sh
+
+# Copy built ruby and ruzzy from builder
+COPY --from=base-ruby /usr/local/rvm /usr/local/rvm
+COPY --from=base-ruby /install/ruzzy /install/ruzzy
+COPY ruzzy /usr/bin/ruzzy
+ENV PATH="$PATH:/usr/local/rvm/rubies/ruby-3.3.1/bin"
+# RubyGems installation directory
+ENV GEM_HOME="$OUT/fuzz-gem"
+ENV GEM_PATH="/install/ruzzy"
 
 # Do this last to make developing these files easier/faster due to caching.
 COPY bad_build_check \

--- a/infra/base-images/base-runner/run_fuzzer
+++ b/infra/base-images/base-runner/run_fuzzer
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2016 Google Inc.
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/base-images/base-runner/ruzzy
+++ b/infra/base-images/base-runner/ruzzy
@@ -15,5 +15,5 @@
 #
 ################################################################################
 
-LD_PRELOAD=$(ruby -e 'require "ruzzy"; print Ruzzy::ASAN_PATH') \
+ASAN_OPTIONS="allocator_may_return_null=1:detect_leaks=0:use_sigaltstack=0" LD_PRELOAD=$(ruby -e 'require "ruzzy"; print Ruzzy::ASAN_PATH') \
 	ruby $@

--- a/infra/base-images/base-runner/ruzzy
+++ b/infra/base-images/base-runner/ruzzy
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+LD_PRELOAD=$(ruby -e 'require "ruzzy"; print Ruzzy::ASAN_PATH') \
+	ruby $@

--- a/infra/constants.py
+++ b/infra/constants.py
@@ -30,9 +30,10 @@ LANGUAGES = [
     'python',
     'rust',
     'swift',
+    'ruby',
 ]
 LANGUAGES_WITH_COVERAGE_SUPPORT = [
-    'c', 'c++', 'go', 'jvm', 'python', 'rust', 'swift', 'javascript'
+    'c', 'c++', 'go', 'jvm', 'python', 'rust', 'swift', 'javascript', 'ruby'
 ]
 SANITIZERS = [
     'address',

--- a/projects/ox-ruby/Dockerfile
+++ b/projects/ox-ruby/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-ruby
+
+RUN git clone --depth 1 --single-branch https://github.com/ohler55/ox.git $SRC/ox-ruby
+
+ENV CFLAGS="$CFLAGS -fsanitize=fuzzer-no-link -fno-omit-frame-pointer -fno-common -fPIC -g"
+ENV CXXFLAGS="$XXFLAGS -fsanitize=fuzzer-no-link -fno-omit-frame-pointer -fno-common -fPIC -g"
+
+COPY build.sh $SRC/build.sh
+COPY fuzz_*.rb $SRC/harnesses/.
+
+WORKDIR $SRC

--- a/projects/ox-ruby/build.sh
+++ b/projects/ox-ruby/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -eu
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# setup
+BUILD=$WORK/Build
+
+cd $SRC/ox-ruby
+gem build
+RUZZY_DEBUG=1 gem install --development --verbose *.gem
+
+for fuzz_target_path in $SRC/harnesses/fuzz_*.rb; do
+	ruzzy-build "$fuzz_target_path"
+done

--- a/projects/ox-ruby/fuzz_parse.rb
+++ b/projects/ox-ruby/fuzz_parse.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+require 'ruzzy'
+require 'ox'
+
+test_one_input = lambda do |data|
+  begin
+    Ox.parse(data)
+  rescue Ox::ParseError, Ox::SyntaxError, EncodingError
+    # pass
+  end
+  return 0
+end
+
+Ruzzy.fuzz(test_one_input)

--- a/projects/ox-ruby/fuzz_sax_parse.rb
+++ b/projects/ox-ruby/fuzz_sax_parse.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+require 'ruzzy'
+require 'ox'
+
+class MyHandler < Ox::Sax
+  # Called for the opening of an element
+  def start_element(name)
+  end
+
+  # Called for the text content of an element
+  def text(value)
+  end
+
+  # Called for the closing of an element
+  def end_element(name)
+  end
+end
+
+test_one_input = lambda do |data|
+  begin
+    handler = MyHandler.new
+    Ox.sax_parse(handler, StringIO.new(data))
+  rescue Ox::ParseError, EncodingError
+    # pass
+  end
+  return 0
+end
+
+Ruzzy.fuzz(test_one_input)

--- a/projects/ox-ruby/project.yaml
+++ b/projects/ox-ruby/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://github.com/ohler55/ox"
+language: ruby
+primary_contact: "TODO@template.test"
+auto_ccs:
+  - "TODO@template.test"
+sanitizers:
+  - address
+  - undefined
+main_repo: 'https://github.com/ohler55/ox'
+
+fuzzing_engines:
+  - libfuzzer


### PR DESCRIPTION
This is a follow-up to the discussions held during our Monthly Fuzzing Collaboration meetings and directly relates to issue #11967.

This Pull Request integrates Ruzzy support for Ruby fuzzing into OSS-Fuzz. Ruzzy is a coverage-guided fuzzer for pure Ruby code and Ruby C extensions, developed by Matt (@mschwager) at Trail of Bits. More information on Ruzzy can be found in the blog post titled "[Introducing Ruzzy, a coverage-guided Ruby fuzzer](https://blog.trailofbits.com/2024/03/29/introducing-ruzzy-a-coverage-guided-ruby-fuzzer/)".

The first commit of this PR integrates Ruby support into the OSS-Fuzz project via Ruzzy, while the second one includes the Ox project as an example of its usage.

The first commit introduces changes in the infra directory, most notably by adding the base-builder-ruby docker and the ruby install script.

Two scripts, ruzzy-build and ruzzy, have been added to base-builder-ruby and base-runner respectively. The former creates scripts that start harnesses with the latter one, and the latter is simply a wrapper for ruby with LD_PRELOAD.
In order to prevent the duplication of many gigabytes of data, we use separate installation directories for RubyGem. Technically, Ruzzy can be installed in the default directory without any performance disadvantage, but having a separate directory may facilitate troubleshooting.

This implementation was arrived at through testing a few ideas. If you have suggestions for further improvements, please let me know. I am currently addressing my concerns in the related issue.

Using the provided scripts isn't necessary but it does simplify the process. Installation directories are set using environment variables in the Dockerfiles, making it transparent for users.

The second commit simply adds a project to illustrate how straightforward the integration process is. You can test it using the standard helper commands.

Fixes: #11967

Co-authored-by: mschwager <matt.schwager@trailofbits.com>

