### PR TITLE
use `apt` boost package to build libtorrent

### DIFF
--- a/projects/libtorrent/Dockerfile
+++ b/projects/libtorrent/Dockerfile
@@ -15,9 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y wget libssl-dev
-
-RUN git clone --depth 1 --single-branch --branch boost-1.73.0 --recurse-submodules https://github.com/boostorg/boost.git
+RUN apt-get update && apt-get install -y wget libssl-dev libboost-tools-dev libboost-dev libboost-system-dev
 
 RUN git clone --depth 1 --single-branch --branch RC_2_0 --recurse-submodules https://github.com/arvidn/libtorrent.git
 WORKDIR libtorrent

--- a/projects/libtorrent/build.sh
+++ b/projects/libtorrent/build.sh
@@ -15,13 +15,6 @@
 #
 ################################################################################
 
-export PATH=${PATH}:${PWD}/../boost
-export BOOST_ROOT=${PWD}/../boost
-export BOOST_BUILD_PATH=${PWD}/../boost/tools/build
-# when building b2, we don't want sanitizers enabled
-ASAN_OPTIONS=detect_leaks=0
-(cd ${PWD}/../boost && ./bootstrap.sh && ./b2 headers)
-
 echo "CXX=$CXX"
 echo "CXXFLAGS=$CXXFLAGS"
 


### PR DESCRIPTION
as newer compilers have deprecated some features used by old boost. Specifically:

```
/src/boost/boost/container_hash/hash.hpp:131:33: error: no template named 'unary_function' in namespace 'std'; did you mean '__unary_function'?
  131 |         struct hash_base : std::unary_function<T, std::size_t> {};
      |                            ~~~~~^~~~~~~~~~~~~~
      |                                 __unary_function
```