### PR TITLE
Initial project skeleteon for pymupdf

### DIFF
--- a/projects/pymupdf/project.yaml
+++ b/projects/pymupdf/project.yaml
@@ -1,0 +1,11 @@
+homepage: "https://pymupdf.readthedocs.io/en/latest/the-basics.html#supported-file-types"
+language: python
+primary_contact: "support@artifex.com"
+auto_ccs: 
+  - "ennamarie19@gmail.com"
+fuzzing_engines: 
+  - libfuzzer
+sanitizers: 
+  - address
+  - undefined
+main_repo: "https://github.com/pymupdf/PyMuPDF.git"


### PR DESCRIPTION
PyMuPDF is a high performance Python library for data extraction, analysis, conversion & manipulation of PDF (and other) documents. This library is used by over 21,900 repositories and nearly 600 packages, most notably langchain (86000+ stars and 13,500 forks), h2ogpt (10,800+ stars), paper-qa (3.7k stars), uptrain (2000+ stars), and bisheng (7000+ stars). 

Approval from upstream can be found here: https://github.com/pymupdf/PyMuPDF/issues/3556 