### PR TITLE
libwebp: do not use afl and honggfuzz

### DIFF
--- a/projects/libwebp/project.yaml
+++ b/projects/libwebp/project.yaml
@@ -3,8 +3,6 @@ language: c++
 primary_contact: "jzern@google.com"
 fuzzing_engines:
   - libfuzzer
-  - afl
-  - honggfuzz
   - centipede
 sanitizers:
   - address


### PR DESCRIPTION
By switching the tests to fuzztest, only libfuzzer and centipede are supported now