### PR TITLE
Draft: Update karchive to use KF6 and Qt6

### DIFF
--- a/projects/karchive/Dockerfile
+++ b/projects/karchive/Dockerfile
@@ -15,8 +15,9 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install --yes cmake make autoconf automake autopoint libtool wget po4a ninja-build pkgconf libzstd-dev
+RUN apt-get update && apt-get install --yes cmake make autoconf automake autopoint libtool wget po4a ninja-build pkgconf
 RUN git clone --depth 1 https://github.com/madler/zlib.git
+RUN git clone --depth 1 https://github.com/facebook/zstd.git
 RUN git clone --depth 1 https://github.com/nih-at/libzip.git
 RUN wget https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz
 RUN git clone https://git.tukaani.org/xz.git

--- a/projects/karchive/Dockerfile
+++ b/projects/karchive/Dockerfile
@@ -15,16 +15,14 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install --yes cmake make autoconf automake autopoint libtool wget po4a
+RUN apt-get update && apt-get install --yes cmake make autoconf automake autopoint libtool wget po4a ninja-build pkgconf libzstd-dev
 RUN git clone --depth 1 https://github.com/madler/zlib.git
 RUN git clone --depth 1 https://github.com/nih-at/libzip.git
 RUN wget https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz
 RUN git clone https://git.tukaani.org/xz.git
-RUN git clone --depth 1 --branch=5.15 git://code.qt.io/qt/qtbase.git
-RUN git clone --depth 1 -b kf5 https://invent.kde.org/frameworks/extra-cmake-modules.git
-RUN git clone --depth 1 -b kf5 https://invent.kde.org/frameworks/karchive.git
+RUN git clone --depth 1 --branch=dev git://code.qt.io/qt/qtbase.git
+RUN git clone --depth 1 -b master https://invent.kde.org/frameworks/extra-cmake-modules.git
+RUN git clone --depth 1 -b master https://invent.kde.org/frameworks/karchive.git
 COPY build.sh $SRC
 COPY karchive_fuzzer.cc $SRC
 WORKDIR karchive
-
-

--- a/projects/karchive/build.sh
+++ b/projects/karchive/build.sh
@@ -15,6 +15,12 @@
 #
 ################################################################################
 
+# build zstd
+cd $SRC
+cd zstd
+cmake -S build/cmake -DBUILD_SHARED_LIBS=OFF
+make install -j$(nproc)
+
 # Build zlib
 cd $SRC
 cd zlib
@@ -72,9 +78,7 @@ sed -i -e "s~QMAKE_CXXFLAGS    += -stdlib=libc++~QMAKE_CXXFLAGS    += -stdlib=li
 sed -i -e "s~QMAKE_LFLAGS      += -stdlib=libc++~QMAKE_LFLAGS      += -stdlib=libc++ -lpthread $CXXFLAGS~g" mkspecs/linux-clang-libc++/qmake.conf
 sed -i -e "s~QMAKE_CXX               = \$\${CROSS_COMPILE}clang++~QMAKE_CXX = $CXX~g" mkspecs/common/clang.conf
 sed -i -e "s~QMAKE_CC                = \$\${CROSS_COMPILE}clang~QMAKE_CC = $CC~g" mkspecs/common/clang.conf
-# make qmake compile faster
-sed -i -e "s/MAKE\")/MAKE\" -j$(nproc))/g" configure
-./configure -no-glib -qt-libpng -opensource -confirm-license -static -no-opengl -no-icu -platform linux-clang-libc++ -prefix /usr
+./configure -no-glib -qt-libpng -qt-pcre -opensource -confirm-license -static -no-opengl -no-icu -platform linux-clang-libc++ -debug -prefix /usr
 cmake --build . --parallel $(nproc)
 cmake --install .
 
@@ -87,7 +91,7 @@ cmake . -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=OFF
 make install -j$(nproc)
 
 # Build karchive_fuzzer
-$CXX $CXXFLAGS -fPIC -fsanitize=fuzzer -std=c++11 $SRC/karchive_fuzzer.cc -o $OUT/karchive_fuzzer -I $SRC/Qt6/include/QtCore/ -I $SRC/Qt6/include/ -I $SRC/Qt6/include/QtGui -I $SRC/Qt6/mkspecs/linux-clang-libc++/ -I /usr/local/include/KF5/KArchive -L $SRC/Qt6/lib -lQt6Core -lm -lqtpcre2 -ldl -lpthread $LIB_FUZZING_ENGINE /usr/local/lib/libzip.a /usr/local/lib/libz.a -lKF5Archive /usr/local/lib/libbz2.a -llzma -lQt6Core /usr/local/lib/libz.a
+$CXX $CXXFLAGS -fPIC -std=c++17 $SRC/karchive_fuzzer.cc -o $OUT/karchive_fuzzer -I $SRC/qtbase/include/QtCore/ -I $SRC/qtbase/include/ -I $SRC/qtbase/include/QtGui -I $SRC/qtbase/mkspecs/linux-clang-libc++/ -I /usr/local/include/KF6/KArchive -L $SRC/qtbase/lib -lQt6Core -lm -lqtpcre2 -ldl -lpthread $LIB_FUZZING_ENGINE /usr/local/lib/libzip.a /usr/local/lib/libz.a -lKF6Archive /usr/local/lib/libbz2.a -llzma /usr/local/lib/libzstd.a
 
 cd $SRC
 find . -name "*.gz" -o -name "*.zip" -o -name "*.xz" -o -name "*.tar" | zip -q $OUT/karchive_fuzzer_seed_corpus.zip -@

--- a/projects/karchive/build.sh
+++ b/projects/karchive/build.sh
@@ -74,22 +74,20 @@ sed -i -e "s~QMAKE_CXX               = \$\${CROSS_COMPILE}clang++~QMAKE_CXX = $C
 sed -i -e "s~QMAKE_CC                = \$\${CROSS_COMPILE}clang~QMAKE_CC = $CC~g" mkspecs/common/clang.conf
 # make qmake compile faster
 sed -i -e "s/MAKE\")/MAKE\" -j$(nproc))/g" configure
-# add QT_NO_WARNING_OUTPUT to make the output a bit cleaner by not containing lots of QBuffer::seek: Invalid pos
-sed -i -e "s/DEFINES += QT_NO_USING_NAMESPACE QT_NO_FOREACH/DEFINES += QT_NO_USING_NAMESPACE QT_NO_FOREACH QT_NO_WARNING_OUTPUT/g" src/corelib/corelib.pro
-./configure --glib=no --libpng=qt -opensource -confirm-license -static -no-opengl -no-icu -platform linux-clang-libc++ -v
-cd src
-../bin/qmake -o Makefile src.pro
-make sub-corelib sub-rcc -j$(nproc)
+./configure -no-glib -qt-libpng -opensource -confirm-license -static -no-opengl -no-icu -platform linux-clang-libc++ -prefix /usr
+cmake --build . --parallel $(nproc)
+cmake --install .
+
 
 # Build karchive
 cd $SRC
 cd karchive
 rm -rf poqm
-cmake . -DBUILD_SHARED_LIBS=OFF -DQt5Core_DIR=$SRC/qtbase/lib/cmake/Qt5Core/ -DBUILD_TESTING=OFF
+cmake . -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=OFF
 make install -j$(nproc)
 
 # Build karchive_fuzzer
-$CXX $CXXFLAGS -fPIC -std=c++11 $SRC/karchive_fuzzer.cc -o $OUT/karchive_fuzzer -I $SRC/qtbase/include/QtCore/ -I $SRC/qtbase/include/ -I $SRC/qtbase/include//QtGui -I $SRC/qtbase/mkspecs/linux-clang-libc++/ -I /usr/local/include/KF5/KArchive -L $SRC/qtbase/lib -lQt5Core -lm -lqtpcre2 -ldl -lpthread $LIB_FUZZING_ENGINE /usr/local/lib/libzip.a /usr/local/lib/libz.a -lKF5Archive /usr/local/lib/libbz2.a -llzma -lQt5Core /usr/local/lib/libz.a
+$CXX $CXXFLAGS -fPIC -fsanitize=fuzzer -std=c++11 $SRC/karchive_fuzzer.cc -o $OUT/karchive_fuzzer -I $SRC/Qt6/include/QtCore/ -I $SRC/Qt6/include/ -I $SRC/Qt6/include/QtGui -I $SRC/Qt6/mkspecs/linux-clang-libc++/ -I /usr/local/include/KF5/KArchive -L $SRC/Qt6/lib -lQt6Core -lm -lqtpcre2 -ldl -lpthread $LIB_FUZZING_ENGINE /usr/local/lib/libzip.a /usr/local/lib/libz.a -lKF5Archive /usr/local/lib/libbz2.a -llzma -lQt6Core /usr/local/lib/libz.a
 
 cd $SRC
 find . -name "*.gz" -o -name "*.zip" -o -name "*.xz" -o -name "*.tar" | zip -q $OUT/karchive_fuzzer_seed_corpus.zip -@

--- a/projects/karchive/karchive_fuzzer.cc
+++ b/projects/karchive/karchive_fuzzer.cc
@@ -28,11 +28,11 @@
 #include <QCoreApplication>
 #include <QVector>
 
-#include <KF5/KArchive/k7zip.h>
-#include <KF5/KArchive/ktar.h>
-#include <KF5/KArchive/kzip.h>
-#include <KF5/KArchive/kar.h>
-#include <KF5/KArchive/kcompressiondevice.h>
+#include <KF6/KArchive/k7zip.h>
+#include <KF6/KArchive/ktar.h>
+#include <KF6/KArchive/kzip.h>
+#include <KF6/KArchive/kar.h>
+#include <KF6/KArchive/kcompressiondevice.h>
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {


### PR DESCRIPTION
 - Update KArchive to use Qt6 and KF6

Todo fix 
`clang++: error: no such file or directory: '/usr/lib/libFuzzingEngine.a' `
