### PR TITLE
Update several github action to node20 verisons

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/infra_tests.yml
+++ b/.github/workflows/infra_tests.yml
@@ -25,7 +25,7 @@ jobs:
           git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master
 
       - name: Setup python environment
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
 

--- a/.github/workflows/infra_tests.yml
+++ b/.github/workflows/infra_tests.yml
@@ -18,7 +18,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:  # Needed for git diff to work. (get_changed_files)
           fetch-depth: 0
       - run: |

--- a/.github/workflows/pr_helper.yml
+++ b/.github/workflows/pr_helper.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup python environment
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/pr_helper.yml
+++ b/.github/workflows/pr_helper.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup python environment
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
           cache: pip

--- a/.github/workflows/pr_helper.yml
+++ b/.github/workflows/pr_helper.yml
@@ -31,7 +31,7 @@ jobs:
           pip install -r infra/ci/requirements.txt
 
       - name: setup go environment
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 'stable'
       - run: go install github.com/ossf/criticality_score/cmd/criticality_score@latest

--- a/.github/workflows/pr_helper.yml
+++ b/.github/workflows/pr_helper.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Leave comments
         if: env.IS_INTERNAL == 'FALSE'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -59,7 +59,7 @@ jobs:
 
       - name: Add labels for valid PR
         if: env.IS_READY_FOR_MERGE == 'True'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             github.rest.issues.addLabels({

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -18,14 +18,14 @@ jobs:
       cancel-in-progress: true
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:  # Needed for git diff to work. (get_changed_files)
           fetch-depth: 0
       - run: |
           git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master
 
       - name: Setup python environment
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
           cache: pip

--- a/.github/workflows/project_tests.yml
+++ b/.github/workflows/project_tests.yml
@@ -56,7 +56,7 @@ jobs:
       ARCHITECTURE: ${{ matrix.architecture }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:  # Needed for git diff to work. (get_changed_files)
           fetch-depth: 0
       - run: |

--- a/.github/workflows/project_tests.yml
+++ b/.github/workflows/project_tests.yml
@@ -74,7 +74,7 @@ jobs:
           sudo bash -c '(ionice -c 3 nice -n 19 rm -rf /usr/share/dotnet/ /usr/local/graalvm/ /usr/local/.ghcup/ /usr/local/share/powershell /usr/local/share/chromium /usr/local/lib/android /usr/local/lib/node_modules)&'
 
       - name: Setup python environment
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
           cache: pip


### PR DESCRIPTION
When my other pr was running i noticed 

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v3, actions/setup-go@v4, actions/github-script@v6. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```
At the end of the Summary.  I have updated those actions in all workflows using them.