### PR TITLE
Allow timeout and OOMs options in GH Action (#12003)

### DIFF
--- a/infra/cifuzz/actions/run_fuzzers/action.yml
+++ b/infra/cifuzz/actions/run_fuzzers/action.yml
@@ -52,6 +52,14 @@ inputs:
     description: "Whether to output fuzzing results to SARIF."
     required: false
     default: false
+  report-timeouts:
+    description: "Whether to report fails due to timeout."
+    required: false
+    default: true
+  report-ooms:
+    description: "Whether to report fails due to OOM."
+    required: false
+    default: true
 runs:
   using: 'docker'
   image: '../../../run_fuzzers.Dockerfile'
@@ -70,3 +78,5 @@ runs:
     CFL_PLATFORM: 'github'
     PARALLEL_FUZZING: ${{ inputs.parallel-fuzzing }}
     OUTPUT_SARIF: ${{ inputs.output-sarif }}
+    REPORT_TIMEOUTS: ${{ inputs.report-timeouts }}
+    REPORT_OOMS: ${{ inputs.report-ooms}}


### PR DESCRIPTION
With disabled option `report-oom` in GH Action Github reports a warning:

"Unexpected input(s) 'report_ooms', valid inputs are ['entryPoint', 'args', 'language', 'fuzz-seconds', 'dry-run', 'sanitizer', 'mode', 'github-token', 'storage-repo', 'storage-repo-branch', 'storage-repo-branch-coverage', 'report-unreproducible-crashes', 'minimize-crashes', 'parallel-fuzzing', 'output-sarif']".

The patch follows up commit a7c524dca08b ("Fix doc timeouts and ooms and allow these options in GH Action (#12003)").