### PR TITLE
reproduce: Test for a directory exists instead of a regular file

### DIFF
--- a/infra/base-images/base-runner/reproduce
+++ b/infra/base-images/base-runner/reproduce
@@ -22,7 +22,7 @@ if [ ! -v TESTCASE ]; then
     TESTCASE="/testcase"
 fi
 
-if [ ! -f $TESTCASE ]; then
+if [ ! -d $TESTCASE ]; then
   echo "Error: $TESTCASE not found, use: docker run -v <path>:$TESTCASE ..."
   exit 1
 fi


### PR DESCRIPTION
The `-f` flag checks for a file exists and is a regular file, while the `-d` checks for a directory exists.

Doc: https://www.gnu.org/software/coreutils/manual/html_node/File-type-tests.html