### PR TITLE
[scapy] build it more often

### DIFF
--- a/projects/scapy/project.yaml
+++ b/projects/scapy/project.yaml
@@ -6,6 +6,7 @@ auto_ccs:
   - "julien.voisin@dustri.org"
   - "ipudney@google.com"
   - "evverx@gmail.com"
+builds_per_day: 4
 fuzzing_engines:
   - libfuzzer
 sanitizers:


### PR DESCRIPTION
to let the latest builds be more or less in sync with the upstream repository. It should help CIFuzz to detect known issues better among other things.