### PR TITLE
 Update default Rust to nightly-2024-02-12 

### DIFF
--- a/infra/base-images/base-builder-rust/Dockerfile
+++ b/infra/base-images/base-builder-rust/Dockerfile
@@ -22,4 +22,15 @@ ENV PATH=$PATH:/rust/bin
 # Set up custom environment variable for source code copy for coverage reports
 ENV OSSFUZZ_RUSTPATH /rust
 
+# Force rustup to ignore `rust-toolchain` and `rust-toolchain.toml` files by
+# manually specifying what toolchain to use. Note that this environment variable
+# is additionally used by `install_rust.sh` as the toolchain to install.
+# cf https://rust-lang.github.io/rustup/overrides.html
+ENV RUSTUP_TOOLCHAIN nightly-2024-02-12
+
+# Configure the linker used by default for x86_64 linux to be `clang` instead of
+# rustc's default of `cc` which is able to find custom-built libraries like
+# `libc++` by default more easily.
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER clang
+
 RUN install_rust.sh

--- a/infra/base-images/base-builder/install_rust.sh
+++ b/infra/base-images/base-builder/install_rust.sh
@@ -15,8 +15,8 @@
 #
 ################################################################################
 
-curl https://sh.rustup.rs | sh -s -- -y --default-toolchain=nightly-2023-12-28 --profile=minimal
+curl https://sh.rustup.rs | sh -s -- -y --default-toolchain=$RUSTUP_TOOLCHAIN --profile=minimal
 cargo install cargo-fuzz && rm -rf /rust/registry
 # Needed to recompile rust std library for MSAN
-rustup component add rust-src --toolchain nightly-2023-12-28
+rustup component add rust-src
 cp -r /usr/local/lib/x86_64-unknown-linux-gnu/* /usr/local/lib/

--- a/projects/crosvm/build.sh
+++ b/projects/crosvm/build.sh
@@ -19,7 +19,7 @@ cd crosvm
 
 # Build crosvm fuzzers
 # Unset the SRC variable as it will interfere with minijail's common.mk framework.
-env -u SRC cargo +nightly-2023-12-28 fuzz build -O
+env -u SRC cargo fuzz build -O
 
 # Copy fuzzer binaries to $OUT
 FUZZ_TARGET_OUTPUT_DIR="target/x86_64-unknown-linux-gnu/release"

--- a/projects/gitoxide/build.sh
+++ b/projects/gitoxide/build.sh
@@ -25,19 +25,19 @@ for CRATE_DIR in ${FUZZ_CRATE_DIRS[@]};
 do
   echo "Building crate: $CRATE_DIR"
   cd $CRATE_DIR
-  cargo +nightly-2023-12-28 fuzz build -O --debug-assertions
+  cargo fuzz build -O --debug-assertions
   FUZZ_TARGET_OUTPUT_DIR=$CARGO_BUILD_TARGET_DIR/x86_64-unknown-linux-gnu/release
   for f in fuzz/fuzz_targets/*.rs
   do
       FUZZ_TARGET_NAME=$(basename ${f%.*})
       CRATE_NAME=$(basename $CRATE_DIR)
       OUT_FUZZER_NAME=$OUT/$CRATE_NAME-$FUZZ_TARGET_NAME
-      cp $FUZZ_TARGET_OUTPUT_DIR/$FUZZ_TARGET_NAME $OUT_FUZZER_NAME 
-      FUZZ_CORPUS_BUILDER=./fuzz/fuzz_targets/${FUZZ_TARGET_NAME}_corpus_builder.sh      
+      cp $FUZZ_TARGET_OUTPUT_DIR/$FUZZ_TARGET_NAME $OUT_FUZZER_NAME
+      FUZZ_CORPUS_BUILDER=./fuzz/fuzz_targets/${FUZZ_TARGET_NAME}_corpus_builder.sh
       if test -f "$FUZZ_CORPUS_BUILDER"; then
           $FUZZ_CORPUS_BUILDER $SRC/gitoxide ${OUT_FUZZER_NAME}_seed_corpus.zip
       fi
-      FUZZ_DICT=./fuzz/fuzz_targets/${FUZZ_TARGET_NAME}.dict      
+      FUZZ_DICT=./fuzz/fuzz_targets/${FUZZ_TARGET_NAME}.dict
       if test -f "$FUZZ_DICT"; then
             cp $FUZZ_DICT ${OUT_FUZZER_NAME}.dict
       fi

--- a/projects/linkerd2-proxy/build.sh
+++ b/projects/linkerd2-proxy/build.sh
@@ -23,7 +23,7 @@ then
   export CFLAGS=""
 fi
 
-BUILD_FUZZER="cargo +nightly-2023-12-28 fuzz build "
+BUILD_FUZZER="cargo fuzz build "
 TARGET_PATH="./fuzz/target/x86_64-unknown-linux-gnu/release"
 BASE="$SRC/linkerd2-proxy/linkerd"
 

--- a/projects/naga/build.sh
+++ b/projects/naga/build.sh
@@ -15,7 +15,7 @@
 #
 ################################################################################
 
-cargo +nightly-2023-12-28 fuzz build -O
+cargo fuzz build -O
 fuzz_release=$SRC/wgpu/target/x86_64-unknown-linux-gnu/release
 cp $fuzz_release/spv_parser $OUT/
 cp $fuzz_release/wgsl_parser $OUT/

--- a/projects/opendal/build.sh
+++ b/projects/opendal/build.sh
@@ -15,7 +15,7 @@
 
 # build fuzz targets
 cd $SRC/opendal/core
-cargo +nightly-2023-12-28 fuzz build -O --debug-assertions
+cargo fuzz build -O --debug-assertions
 
 # copy fuzz targets to $OUT
 targets=(

--- a/projects/opensk/build.sh
+++ b/projects/opensk/build.sh
@@ -17,10 +17,6 @@
 
 FUZZ_TARGET_OUTPUT_DIR=fuzz/target/x86_64-unknown-linux-gnu/release
 
-# do not use override toolchain
-# cf https://rust-lang.github.io/rustup/overrides.html
-export RUSTUP_TOOLCHAIN=nightly-2023-12-28
-
 build_and_copy() {
   pushd "$1"
   cargo fuzz build --release --debug-assertions

--- a/projects/wasmtime/build.sh
+++ b/projects/wasmtime/build.sh
@@ -20,11 +20,6 @@
 git submodule update --init --recursive
 git clone --depth 1 https://github.com/bytecodealliance/wasmtime-libfuzzer-corpus wasmtime-libfuzzer-corpus
 
-
-# Temporary workaround. Can be removed once OSS-Fuzz rust toolchain is bumped.
-export RUSTUP_TOOLCHAIN=nightly-2024-02-12
-
-
 # Note: This project creates Rust fuzz targets exclusively
 
 build() {


### PR DESCRIPTION
This commit updates the default version of Rust installed for fuzzing to
the last nightly of Rust that used LLVM 17. The next version uses LLVM
18.1.7 which is incompatible with the fuzz infrastructure's own LLVM
which is currently 18.0.0. This is intended to update the Rust toolchain
as far as possible without causing coverage incompatibilities.

This additionally updates a few pinned projects to all use this nightly
as well. Furthermore the containers are now configured to by-default
ignore `rust-toolchain` and `rust-toolchain.toml` files which will force
this particular toolchain to be used.