### PR TITLE
Update Clang toolchain from 18.0.0 to 18.1.8

### DIFF
--- a/infra/base-images/base-builder-rust/Dockerfile
+++ b/infra/base-images/base-builder-rust/Dockerfile
@@ -26,7 +26,7 @@ ENV OSSFUZZ_RUSTPATH /rust
 # manually specifying what toolchain to use. Note that this environment variable
 # is additionally used by `install_rust.sh` as the toolchain to install.
 # cf https://rust-lang.github.io/rustup/overrides.html
-ENV RUSTUP_TOOLCHAIN nightly-2024-02-12
+ENV RUSTUP_TOOLCHAIN nightly-2024-07-12
 
 # Configure the linker used by default for x86_64 linux to be `clang` instead of
 # rustc's default of `cc` which is able to find custom-built libraries like

--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -60,8 +60,19 @@ ENV CCC "clang++"
 # warning, to allow compiling legacy code.
 # See https://releases.llvm.org/16.0.0/tools/clang/docs/ReleaseNotes.html#potentially-breaking-changes
 # Same for deprecated-declarations, int-conversion,
-# incompatible-function-pointer-types, enum-constexpr-conversion
+# incompatible-function-pointer-types, enum-constexpr-conversion,
+# vla-cxx-extension
 
-ENV CFLAGS "-O1 -fno-omit-frame-pointer -gline-tables-only -Wno-error=enum-constexpr-conversion -Wno-error=incompatible-function-pointer-types -Wno-error=int-conversion -Wno-error=deprecated-declarations -Wno-error=implicit-function-declaration -Wno-error=implicit-int -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"
+ENV CFLAGS -O1 \
+  -fno-omit-frame-pointer \
+  -gline-tables-only \
+  -Wno-error=enum-constexpr-conversion \
+  -Wno-error=incompatible-function-pointer-types \
+  -Wno-error=int-conversion \
+  -Wno-error=deprecated-declarations \
+  -Wno-error=implicit-function-declaration \
+  -Wno-error=implicit-int \
+  -Wno-error=vla-cxx-extension \
+  -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 ENV CXXFLAGS_EXTRA "-stdlib=libc++"
 ENV CXXFLAGS "$CFLAGS $CXXFLAGS_EXTRA"

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -54,7 +54,7 @@ apt-get update && apt-get install -y $LLVM_DEP_PACKAGES --no-install-recommends
 # languages, projects, ...) is needed.
 # Check CMAKE_VERSION infra/base-images/base-clang/Dockerfile was released
 # recently enough to fully support this clang version.
-OUR_LLVM_REVISION=llvmorg-18-init-4631-gd50b56d1
+OUR_LLVM_REVISION=llvmorg-18.1.8
 
 mkdir $SRC/chromium_tools
 cd $SRC/chromium_tools
@@ -116,6 +116,7 @@ cmake -G "Ninja" \
   -DLLVM_TARGETS_TO_BUILD="$TARGET_TO_BUILD" \
   -DLLVM_ENABLE_PROJECTS="clang;lld" \
   -DLLVM_BINUTILS_INCDIR="/usr/include/" \
+  -DLIBCXXABI_USE_LLVM_UNWINDER=OFF \
   $LLVM_SRC/llvm
 
 ninja -j $NPROC
@@ -202,6 +203,7 @@ function cmake_libcxx {
       -DLIBCXX_ENABLE_SHARED=OFF \
       -DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON \
       -DLIBCXXABI_ENABLE_SHARED=OFF \
+      -DLIBCXXABI_USE_LLVM_UNWINDER=OFF \
       -DCMAKE_BUILD_TYPE=Release \
       -DLLVM_ENABLE_PIC=ON \
       -DLLVM_TARGETS_TO_BUILD="$TARGET_TO_BUILD" \

--- a/projects/ampproject/Dockerfile
+++ b/projects/ampproject/Dockerfile
@@ -14,8 +14,8 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
+FROM gcr.io/oss-fuzz-base/base-builder
+
 RUN apt-get update && apt-get install -y make autoconf automake libtool libomp-dev libgomp1 nodejs
 COPY build.sh *.diff $SRC/
 

--- a/projects/arrow/Dockerfile
+++ b/projects/arrow/Dockerfile
@@ -14,8 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
+FROM gcr.io/oss-fuzz-base/base-builder
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update -y -q && \

--- a/projects/bignum-fuzzer/Dockerfile
+++ b/projects/bignum-fuzzer/Dockerfile
@@ -14,8 +14,8 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! Project pinned after a clang update and an afl link error. Log: https://oss-fuzz-gcb-logs.storage.googleapis.com/log-6083635a-3f72-444d-80ef-3a0a26670cf7.txt
+FROM gcr.io/oss-fuzz-base/base-builder
+
 RUN apt-get update && apt-get install -y software-properties-common curl sudo mercurial autoconf bison texinfo libboost-all-dev cmake wget lzip
 RUN wget https://go.dev/dl/go1.17.5.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.17.5.linux-amd64.tar.gz && ldconfig
 ENV PATH=$PATH:/usr/local/go/bin

--- a/projects/boost-json/Dockerfile
+++ b/projects/boost-json/Dockerfile
@@ -14,8 +14,8 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
+FROM gcr.io/oss-fuzz-base/base-builder
+
 #RUN apt-get update && apt-get install -y g++
 
 RUN git clone --depth 1 --single-branch --branch master https://github.com/boostorg/boost.git

--- a/projects/boost/Dockerfile
+++ b/projects/boost/Dockerfile
@@ -14,8 +14,8 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
+FROM gcr.io/oss-fuzz-base/base-builder
+
 RUN apt-get update && apt-get install -y g++ python
 
 RUN git clone --recursive https://github.com/boostorg/boost.git

--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -14,8 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-rust@sha256:c5216a9896a598dced7ce6708bb3226e443473f567045b4f282595776cc641f1
-# ! Project pinned after a clang update and an afl link error. Log: https://oss-fuzz-gcb-logs.storage.googleapis.com/log-8bc8a5ea-9bfb-421d-bfe9-911828e88741.txt
+FROM gcr.io/oss-fuzz-base/base-builder-rust
 
 RUN apt-get update && \
     apt-get install -y software-properties-common wget make autoconf automake libtool build-essential cmake mercurial gyp ninja-build zlib1g-dev libsqlite3-dev bison flex texinfo lzip bsdmainutils

--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -52,9 +52,9 @@ fi
 # The Envoy build configuration may clobber CFLAGS/CXXFLAGS, so we use separate
 # environment variables that are understood by rules_fuzzing.
 export FUZZING_CFLAGS="$CFLAGS"
-export FUZZING_CXXFLAGS="$CXXFLAGS"
+export FUZZING_CXXFLAGS="$CXXFLAGS -Wno-error=thread-safety-reference-return"
 
-# Disable instrumentation in various external libraries. These 
+# Disable instrumentation in various external libraries. These
 # are fuzzed elsewhere.
 # The following disables both coverage-instrumentation and other sanitizer instrumentation.
 # We disable instrumentation in:

--- a/projects/ffmpeg/Dockerfile
+++ b/projects/ffmpeg/Dockerfile
@@ -14,8 +14,8 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
+FROM gcr.io/oss-fuzz-base/base-builder
+
 RUN apt-get update && apt-get install -y make autoconf libtool build-essential \
 	libass-dev:i386 libfreetype6-dev:i386 \
 	libvdpau-dev:i386 libxcb1-dev:i386 libxcb-shm0-dev:i386 libdrm-dev:i386 \

--- a/projects/immer/Dockerfile
+++ b/projects/immer/Dockerfile
@@ -14,8 +14,8 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
+FROM gcr.io/oss-fuzz-base/base-builder
+
 RUN apt-get update && apt-get install -y cmake libgc-dev pkg-config
 RUN git clone --depth 1 https://github.com/arximboldi/immer.git immer
 WORKDIR immer

--- a/projects/libecc/Dockerfile
+++ b/projects/libecc/Dockerfile
@@ -14,8 +14,8 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! Project pinned after a clang update and an afl link error. Log: https://oss-fuzz-gcb-logs.storage.googleapis.com/log-bca72181-cfb2-4b2f-98f1-c2addee0aa4b.txt
+FROM gcr.io/oss-fuzz-base/base-builder
+
 RUN apt-get update && apt-get install -y make autoconf automake libtool wget python bison flex texinfo lzip bsdmainutils
 RUN git clone --depth 1 --branch cryptofuzz https://github.com/libecc/libecc.git
 RUN git clone --depth 1 https://github.com/randombit/botan.git

--- a/projects/libressl/Dockerfile
+++ b/projects/libressl/Dockerfile
@@ -14,8 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! Project pinned after a clang update and an afl link error. Log: https://oss-fuzz-gcb-logs.storage.googleapis.com/log-db180642-1ff0-4223-91e6-3bf060adb174.txt
+FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN apt-get update && apt-get install -y make cmake wget autoconf automake libtool bison flex texinfo lzip
 RUN git clone --depth 1 https://github.com/libressl/portable.git libressl

--- a/projects/nettle/Dockerfile
+++ b/projects/nettle/Dockerfile
@@ -14,8 +14,8 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! Project pinned after a clang update and an afl link error. Log: https://oss-fuzz-gcb-logs.storage.googleapis.com/log-e701b6fa-f3a0-414e-ad6e-0223e6d42ebd.txt
+FROM gcr.io/oss-fuzz-base/base-builder
+
 RUN apt-get update && apt-get install -y software-properties-common make autoconf build-essential wget lzip libtool python
 RUN git clone --depth 1 https://git.lysator.liu.se/nettle/nettle
 RUN git clone --depth 1 https://github.com/randombit/botan.git

--- a/projects/opencv/Dockerfile
+++ b/projects/opencv/Dockerfile
@@ -14,8 +14,8 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors. A compiler bug is the suspected cause, and it may be fixed on the next oss-fuzz clang roll
+FROM gcr.io/oss-fuzz-base/base-builder
+
 RUN apt-get update && apt-get install -y build-essential cmake pkg-config
 RUN git clone --depth 1 https://github.com/opencv/opencv.git opencv
 WORKDIR opencv/

--- a/projects/orbit/Dockerfile
+++ b/projects/orbit/Dockerfile
@@ -14,8 +14,8 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
+FROM gcr.io/oss-fuzz-base/base-builder
+
 RUN apt-get update && apt-get install -y m4 libglu1-mesa-dev mesa-common-dev \
   libxmu-dev libxi-dev pkg-config libxxf86vm-dev patchelf
 

--- a/projects/pcl/Dockerfile
+++ b/projects/pcl/Dockerfile
@@ -14,12 +14,12 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
+FROM gcr.io/oss-fuzz-base/base-builder
+
 RUN apt-get update && apt-get install -y make cmake autoconf \
     automake libtool gettext pkg-config build-essential \
-    mercurial wget libeigen3-dev libflann-dev python python-dev 
-    
+    mercurial wget libeigen3-dev libflann-dev python python-dev
+
 # VTK deps
 RUN apt-get update && apt-get install -y \
     libavcodec-dev libavformat-dev libavutil-dev libboost-dev \

--- a/projects/poco/Dockerfile
+++ b/projects/poco/Dockerfile
@@ -14,9 +14,9 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
-RUN apt-get update && apt-get install -y openssl libssl-dev git make cmake libssl-dev 
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN apt-get update && apt-get install -y openssl libssl-dev git make cmake libssl-dev
 RUN git clone --depth 1 https://github.com/pocoproject/poco
 WORKDIR $SRC/poco
 COPY build.sh \

--- a/projects/quiche/Dockerfile
+++ b/projects/quiche/Dockerfile
@@ -14,8 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
+FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN apt-get update && apt-get install -y zlib1g-dev libicu-dev
 RUN git clone --depth 1 https://github.com/google/quiche

--- a/projects/rustcrypto/Dockerfile
+++ b/projects/rustcrypto/Dockerfile
@@ -14,10 +14,8 @@
 #
 ################################################################################
 
-# Held back because of github.com/google/oss-fuzz/pull/8313
-# Please fix failure and upgrade.
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:111d6b9d3a52bd3392602c71dc8936c628607a7a9bc86d381db7586f9b1e840f
-# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
+FROM gcr.io/oss-fuzz-base/base-builder
+
 RUN apt-get update && apt-get install -y make autoconf automake libtool wget python
 RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
 RUN git clone --depth 1 https://github.com/randombit/botan.git

--- a/projects/samba/build.sh
+++ b/projects/samba/build.sh
@@ -15,6 +15,6 @@
 #
 ################################################################################
 
-export CFLAGS="$CFLAGS -Wno-error=strict-prototypes"
+export CFLAGS="$CFLAGS -Wno-error=strict-prototypes -Wno-error=format-truncation"
 # The real script is maintained in the Samba repo
 exec lib/fuzzing/oss-fuzz/build_samba.sh

--- a/projects/solidity/Dockerfile
+++ b/projects/solidity/Dockerfile
@@ -14,8 +14,8 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
+FROM gcr.io/oss-fuzz-base/base-builder
+
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
     build-essential libbz2-dev ninja-build zlib1g-dev wget python python-dev \
     liblzma-dev uuid-dev pkg-config openjdk-8-jdk unzip mlton bison texinfo

--- a/projects/tensorflow-serving/Dockerfile
+++ b/projects/tensorflow-serving/Dockerfile
@@ -14,8 +14,8 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
+FROM gcr.io/oss-fuzz-base/base-builder
+
 RUN apt-get update && apt-get install -y make autoconf automake libtool default-jdk bison m4 \
     build-essential\
     curl \
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool default-
     mcpp \
     sqlite \
     uuid-runtime \
-    zlib1g-dev 
+    zlib1g-dev
 RUN python3 -m pip install numpy
 RUN wget https://github.com/bazelbuild/buildtools/releases/download/4.2.5/buildifier-linux-amd64 \
     -O /usr/local/bin/buildifier && chmod a+x /usr/local/bin/buildifier

--- a/projects/tensorflow/Dockerfile
+++ b/projects/tensorflow/Dockerfile
@@ -14,8 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
+FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \

--- a/projects/xnu/Dockerfile
+++ b/projects/xnu/Dockerfile
@@ -14,8 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
+FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN apt-get update && apt-get install -y \
   autoconf \

--- a/projects/zeek/Dockerfile
+++ b/projects/zeek/Dockerfile
@@ -14,8 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
+FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         patchelf \


### PR DESCRIPTION
This is done in the interest of assisting #12075 and #11626. Currently the Rust toolchain cannot be updated because the latest nightly uses LLVM 18.1.7 and coverage information breaks. This breakage is because LLVM 18.1.7 records coverage information with version "9" but LLVM 18.0.0 recorded coverage information with version "8". This means that the recordings created by Rust binaries use version "9" which are unreadable by the processing that OSS-Fuzz does with the 18.0.0-based toolchain using version "8".

This commit updates the Clang toolchain to the latest 18.x.x release to get the two in sync so the same coverage recording version is used.