### PR TITLE
Add Gavin Howard's bc/dc as bc-gh

### DIFF
--- a/projects/bc-gh/project.yaml
+++ b/projects/bc-gh/project.yaml
@@ -1,0 +1,4 @@
+homepage: https://git.gavinhoward.com/gavin/bc
+main_repo: https://github.com/gavinhoward/bc
+language: c
+primary_contact: gavin.d.howard@gmail.com


### PR DESCRIPTION
The FAQ [says][1] that projects can be accepted if they "have a critical impact on infrastructure and user security," with the following two explicit criteria:

* Exposure to remote attacks
* Number of users/other projects depending on this project.

This bc/dc is locked down, and the exposure to remote attacks should be extremely low. So I understand if this project is not accepted.

However, it is shipped by default in [Android][2], [FreeBSD][3], and [macOS][4], so it is critical to other projects that are used widely.

It is already [set up for fuzzing][5], but as a single maintainer, I do not have the resources to fuzz it all of the time and ask for Google's help since Google ships this bc/dc in Android.

[1]: https://google.github.io/oss-fuzz/faq/#what-kind-of-projects-are-you-accepting
[2]: https://android.googlesource.com/platform/external/bc/
[3]: https://forums.freebsd.org/threads/freebsd-13-3-whats-new-and-how-did-we-get-here.92596/
[4]: https://github.com/apple-oss-distributions/bc/tree/main/bc
[5]: https://github.com/gavinhoward/bc/blob/master/manuals/development.md#fuzzing-1