### PR TITLE
containerd: move clone instrumentation to oss_fuzz_build.sh

### DIFF
--- a/projects/containerd/Dockerfile
+++ b/projects/containerd/Dockerfile
@@ -17,6 +17,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN apt-get update && apt-get install -y btrfs-progs libc-dev pkg-config libseccomp-dev gcc wget libbtrfs-dev
 RUN git clone --depth 1 https://github.com/containerd/containerd
-RUN git clone --depth=1 https://github.com/AdamKorcz/instrumentation
+#RUN git clone --depth=1 https://github.com/AdamKorcz/instrumentation
 COPY build.sh $SRC/
 WORKDIR $SRC/containerd


### PR DESCRIPTION
https://github.com/containerd/containerd/pull/10348
The above PR clones the instrumentation repo in oss_fuzz_build.sh