### PR TITLE
infra: [NFC] Consolidate LLVM_REVISION and OUR_LLVM_REVISION

### DIFF
--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -23,6 +23,7 @@ ARG arch=x86_64
 ENV FUZZINTRO_OUTDIR=$SRC
 
 # Install newer cmake.
+# Many projects, as well as recent clang versions, need a newer cmake.
 ENV CMAKE_VERSION 3.29.2
 RUN apt-get update && apt-get install -y wget sudo && \
     wget -q https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-$arch.sh && \

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -50,6 +50,10 @@ LLVM_DEP_PACKAGES="build-essential make ninja-build git python3 python3-distutil
 apt-get update && apt-get install -y $LLVM_DEP_PACKAGES --no-install-recommends
 
 # For manual bumping.
+# On each bump a full trial run for everything (fuzzing engines, sanitizers,
+# languages, projects, ...) is needed.
+# Check CMAKE_VERSION infra/base-images/base-clang/Dockerfile was released
+# recently enough to fully support this clang version.
 OUR_LLVM_REVISION=llvmorg-18-init-4631-gd50b56d1
 
 mkdir $SRC/chromium_tools
@@ -58,13 +62,6 @@ git clone https://chromium.googlesource.com/chromium/src/tools/clang
 cd clang
 # Pin clang script due to https://github.com/google/oss-fuzz/issues/7617
 git checkout 9eb79319239629c1b23cf7a59e5ebb2bab319a34
-
-# To allow for manual downgrades. Set to 0 to use Chrome's clang version (i.e.
-# *not* force a manual downgrade). Set to 1 to force a manual downgrade.
-# DO NOT CHANGE THIS UNTIL https://github.com/google/oss-fuzz/issues/7273 is
-# RESOLVED.
-FORCE_OUR_REVISION=1
-LLVM_REVISION=$(grep -Po "CLANG_REVISION = '\K([^']+)" scripts/update.py)
 
 LLVM_SRC=$SRC/llvm-project
 # Checkout
@@ -107,19 +104,8 @@ function cmake_llvm {
       $LLVM_SRC/llvm
 }
 
-set +e
-git -C $LLVM_SRC merge-base --is-ancestor $OUR_LLVM_REVISION $LLVM_REVISION
-IS_OUR_REVISION_ANCESTOR_RETCODE=$?
-set -e
-
-# Use our revision if specified by FORCE_OUR_REVISION or if our revision is a
-# later revision than Chrome's (i.e. not an ancestor of Chrome's).
-if [ $IS_OUR_REVISION_ANCESTOR_RETCODE -ne 0 ] || [ $FORCE_OUR_REVISION -eq 1 ] ; then
-  LLVM_REVISION=$OUR_LLVM_REVISION
-fi
-
-git -C $LLVM_SRC checkout $LLVM_REVISION
-echo "Using LLVM revision: $LLVM_REVISION"
+git -C $LLVM_SRC checkout $OUR_LLVM_REVISION
+echo "Using LLVM revision: $OUR_LLVM_REVISION"
 
 # For fuzz introspector.
 echo "Applying introspector changes"


### PR DESCRIPTION
clang/llvm are only bumped on a manual basis, due to requiring a full infra build. Thus, remove the code to support the rolling chromium nightly clang.

Also, extend the docs around `CMAKE_VERSION`. The removal of the docs around `FORCE_OUR_REVISION` also remove the mention of https://github.com/google/oss-fuzz/issues/7273, so this also fixes https://github.com/google/oss-fuzz/issues/7273.