### PR TITLE
[cairo] Use meson 1.3 to fix build

### DIFF
--- a/projects/cairo/Dockerfile
+++ b/projects/cairo/Dockerfile
@@ -16,7 +16,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && \
     apt-get install -y python3-pip gtk-doc-tools libffi-dev autotools-dev libtool gperf
-RUN pip3 install -U meson==1.2.0 ninja packaging
+RUN pip3 install -U meson==1.3.0 ninja packaging
 
 RUN git clone --depth 1 git://git.sv.nongnu.org/freetype/freetype2.git
 RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/glib


### PR DESCRIPTION
The build currently fails with the following error:

```
+ meson setup --prefix=/work/prefix --libdir=lib --default-library=static _builddir
The Meson build system
Version: 1.2.0
Source dir: /src/cairo
Build dir: /src/cairo/_builddir
Build type: native build

meson.build:2:17: ERROR: Meson version is 1.2.0 but project requires >= 1.3.0

A full log can be found at /src/cairo/_builddir/meson-logs/meson-log.txt
```