### PR TITLE
[cairo] Use SVG seeds/dict for svg-render-fuzzer

### DIFF
--- a/projects/cairo/Dockerfile
+++ b/projects/cairo/Dockerfile
@@ -21,9 +21,11 @@ RUN pip3 install -U meson==1.3.0 ninja packaging
 RUN git clone --depth 1 git://git.sv.nongnu.org/freetype/freetype2.git
 RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/glib
 RUN git clone --depth 1 https://gitlab.freedesktop.org/cairo/cairo.git && \
-    zip -q $SRC/cairo_seed_corpus.zip $SRC/cairo/test/reference/*
+    zip -q $SRC/cairo_seed_corpus.zip $SRC/cairo/test/reference/* && \
+    zip -q $SRC/svg-render-fuzzer_seed_corpus.zip $SRC/cairo/test/svg/*.svg
 
 ADD https://raw.githubusercontent.com/google/fuzzing/master/dictionaries/png.dict $SRC/cairo.dict
+ADD https://raw.githubusercontent.com/google/fuzzing/master/dictionaries/svg.dict $SRC/svg-render-fuzzer.dict
 
 WORKDIR $SRC/cairo
 COPY targets $SRC/fuzz

--- a/projects/cairo/build.sh
+++ b/projects/cairo/build.sh
@@ -78,7 +78,7 @@ BUILD_CFLAGS="$CFLAGS `pkg-config --static --cflags $DEPS`"
 BUILD_LDFLAGS="-Wl,-static `pkg-config --static --libs $DEPS`"
 
 fuzzers=$(find $SRC/fuzz/ -name "*_fuzzer.c")
-for f in $fuzzers $SRC/cairo/test/svg/fuzzer/svg-render-fuzzer.c; do
+for f in $fuzzers ; do
   fuzzer_name=$(basename $f .c)
   $CC $CFLAGS $BUILD_CFLAGS \
     -c $f -o $WORK/${fuzzer_name}.o
@@ -90,4 +90,17 @@ for f in $fuzzers $SRC/cairo/test/svg/fuzzer/svg-render-fuzzer.c; do
     -Wl,-Bdynamic
   cd $OUT; ln -sf cairo_seed_corpus.zip ${fuzzer_name}_seed_corpus.zip
   cd $OUT; ln -sf cairo.dict ${fuzzer_name}.dict
+done
+
+# Fuzzers with non-PNG dict/seed corpus.
+for f in $SRC/cairo/test/svg/fuzzer/svg-render-fuzzer.c ; do
+  fuzzer_name=$(basename $f .c)
+  $CC $CFLAGS $BUILD_CFLAGS \
+    -c $f -o $WORK/${fuzzer_name}.o
+  $CXX $CXXFLAGS \
+    $WORK/${fuzzer_name}.o -o $OUT/${fuzzer_name} \
+    $PREDEPS_LDFLAGS \
+    $BUILD_LDFLAGS \
+    $LIB_FUZZING_ENGINE \
+    -Wl,-Bdynamic
 done


### PR DESCRIPTION
The cairo project has several fuzzers which parse PNG files. It also has one SVG renderer fuzzer that is hosted in the cairo project. This SVG fuzzer currently does no actual testing as it's given the same PNG seeds and dictionaries as the other fuzzers.

Some short testing shows that the fuzzer currently reaches about 340 edges (as reported by AFL++), while with actual SVG seeds/dict reaching 5000+ edges immediately. The usual fuzzer tricks for bypassing any of the early parser checks also fail (which is another story), so the coverage with PNG seeds/dict doesn't catch up to the fuzzer with the SVG seeds.

This patch gives the SVG fuzzer the standard SVG dict and the SVG test files from the cairo test folder.

Note that the cairo build also fails because of an outdated meson install, but this is another patch.