### PR TITLE
hdf5: Use latest builder / Temp disable afl

### DIFF
--- a/projects/hdf5/Dockerfile
+++ b/projects/hdf5/Dockerfile
@@ -14,8 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
   pkg-config cmake zlib1g-dev
 RUN git clone --depth 1 https://github.com/HDFGroup/hdf5

--- a/projects/hdf5/project.yaml
+++ b/projects/hdf5/project.yaml
@@ -11,3 +11,7 @@ sanitizers:
   - address
   - undefined
   - memory
+fuzzing_engines:
+# - afl  # Temporarily disabled after a clang-18 bump, to avoid link errors "undefined reference to [...]"
+  - honggfuzz
+  - libfuzzer


### PR DESCRIPTION
Work around:

```
+ /src/aflplusplus/afl-clang-fast++ -O1 -fno-omit-frame-pointer -gline-tables-only -Wno-error=enum-constexpr-conversion -Wno-error=incompatible-function-pointer-types -Wno-error=int-conversion -Wno-error=deprecated-declarations -Wno-error=implicit-function-declaration -Wno-error=implicit-int -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=address -fsanitize-address-use-after-scope -stdlib=libc++ /usr/lib/libFuzzingEngine.a h5_read_fuzzer.o ./build-dir/bin/libhdf5.a -lz -o /out/h5_read_fuzzer
/usr/bin/ld: /usr/bin/ld: DWARF error: invalid or unhandled FORM value: 0x25
./build-dir/bin/libhdf5.a(H5Tconv_integer.c.o): in function `H5T__conv_schar__Float16':
H5Tconv_integer.c:(.text.H5T__conv_schar__Float16[H5T__conv_schar__Float16]+0xe77): undefined reference to `__truncsfhf2'
/usr/bin/ld: H5Tconv_integer.c:(.text.H5T__conv_schar__Float16[H5T__conv_schar__Float16]+0xf9a): undefined reference to `__truncsfhf2'
/usr/bin/ld: H5Tconv_integer.c:(.text.H5T__conv_schar__Float16[H5T__conv_schar__Float16]+0x117d): undefined reference to `__truncsfhf2'
/usr/bin/ld: H5Tconv_integer.c:(.text.H5T__conv_schar__Float16[H5T__conv_schar__Float16]+0x121d): undefined reference to `__truncsfhf2'
/usr/bin/ld: H5Tconv_integer.c:(.text.H5T__conv_schar__Float16[H5T__conv_schar__Float16]+0x12dc): undefined reference to `__truncsfhf2'
/usr/bin/ld: ./build-dir/bin/libhdf5.a(H5Tconv_integer.c.o):H5Tconv_integer.c:(.text.H5T__conv_schar__Float16[H5T__conv_schar__Float16]+0x137d): more undefined references to `__truncsfhf2' follow