### PR TITLE
bc-gh: Add Dockerfile and build.sh

### DIFF
--- a/projects/bc-gh/Dockerfile
+++ b/projects/bc-gh/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make
+RUN git clone --depth 1 https://github.com/gavinhoward/bc.git bc-gh
+WORKDIR bc-gh
+COPY build.sh $SRC/

--- a/projects/bc-gh/build.sh
+++ b/projects/bc-gh/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -eu
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+./configure -Z
+make -j$(nproc) all
+
+cp bin/*_fuzzer_* $OUT/

--- a/projects/bc-gh/project.yaml
+++ b/projects/bc-gh/project.yaml
@@ -2,3 +2,9 @@ homepage: https://git.gavinhoward.com/gavin/bc
 main_repo: https://github.com/gavinhoward/bc
 language: c
 primary_contact: gavin.d.howard@gmail.com
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+  - centipede
+disabled: true


### PR DESCRIPTION
I set `disabled` to true because LeakSanitizer claims the fuzzers have leaks. However, this is not true because bc and dc run without leaks under Valgrind.

After some debugging, I can cause them to free the memory by putting an `assert(false);` after all of the frees [1] [2], and it trips. But if I remove it, LeakSanitizer sees leaks.

Whether it's PEBKAC (probably) or miscompilation (unlikely), I don't know, but I figured I'd commit the necessary stuff for the project.

I'll try to figure out the problem later.

[1]: https://github.com/gavinhoward/bc/blob/master/src/bc_fuzzer.c#L110
[2]: https://github.com/gavinhoward/bc/blob/master/src/dc_fuzzer.c#L110