### PR TITLE
QuickJS: Switch to a corpus optimized for fuzzing

### DIFF
--- a/projects/quickjs/Dockerfile
+++ b/projects/quickjs/Dockerfile
@@ -17,5 +17,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make
 RUN git clone --depth 1 https://github.com/bellard/quickjs quickjs
+RUN git clone --depth 1 https://github.com/renatahodovan/quickjs-corpus
 WORKDIR $SRC/quickjs
 COPY build.sh $SRC/

--- a/projects/quickjs/build.sh
+++ b/projects/quickjs/build.sh
@@ -19,10 +19,8 @@
 # Makefile should not override CFLAGS
 sed -i -e 's/CFLAGS=/CFLAGS+=/' Makefile
 CONFIG_CLANG=y make libquickjs.fuzz.a .obj/fuzz_common.o .obj/libregexp.fuzz.o .obj/cutils.fuzz.o .obj/libunicode.fuzz.o
-zip -r $OUT/fuzz_eval_seed_corpus.zip tests/*.js
-zip -r $OUT/fuzz_eval_seed_corpus.zip examples/*.js
-zip -r $OUT/fuzz_compile_seed_corpus.zip tests/*.js
-zip -r $OUT/fuzz_compile_seed_corpus.zip examples/*.js
+zip -r $OUT/fuzz_eval_seed_corpus.zip $SRC/quickjs-corpus/js/*.js
+zip -r $OUT/fuzz_compile_seed_corpus.zip $SRC/quickjs-corpus/js/*.js
 
 build_fuzz_target () {
     local target=$1


### PR DESCRIPTION
The original corpus of QuickJS consisted of a few large files that were too complex; some contained benchmarks, others had tests spread across multiple files or were scattered with assertions. The new corpus was created by breaking down and transforming these tests into smaller, fuzzing-optimized pieces.