### PR TITLE
libavif: unpin base builder

### DIFF
--- a/projects/libavif/Dockerfile
+++ b/projects/libavif/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
+FROM gcr.io/oss-fuzz-base/base-builder
 # ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
 RUN apt-get update && \
     apt-get install --no-install-recommends -y curl python3-pip python3-setuptools python3-wheel cmake git nasm && \


### PR DESCRIPTION
Fixed by https://github.com/AOMediaCodec/libavif/commit/3dee1bb26136a1327966fcf40034d53053b2d3b0 Fixes https://github.com/AOMediaCodec/libavif/issues/2207