### PR TITLE
libwebp: restrict fuzzers to libfuzzer

### DIFF
--- a/projects/libwebp/project.yaml
+++ b/projects/libwebp/project.yaml
@@ -3,9 +3,6 @@ language: c++
 primary_contact: "jzern@google.com"
 fuzzing_engines:
   - libfuzzer
-  - afl
-  - honggfuzz
-  - centipede
 sanitizers:
   - address
   - undefined


### PR DESCRIPTION
This is because tests have been migrated to fuzztest