### PR TITLE
Add `llvm-readelf` to clang base image.

### DIFF
--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -152,6 +152,8 @@ function free_disk_space {
       /usr/local/bin/llvm-nm \
       /usr/local/bin/llvm-profdata \
       /usr/local/bin/llvm-ranlib \
+      /usr/local/bin/llvm-readelf \
+      /usr/local/bin/llvm-readobj \
       /usr/local/bin/llvm-symbolizer \
       /usr/local/bin/llvm-undname \
       $LLVM_TOOLS_TMPDIR


### PR DESCRIPTION
After building clang, a lot of the binaries are removed from the build.

One of them is `llvm-readelf`, which is be useful to interact with elf files in the images, as it allows for exporting information in JSON format.