### PR TITLE
libavif: restrict fuzzers to libfuzzer

### DIFF
--- a/projects/libavif/project.yaml
+++ b/projects/libavif/project.yaml
@@ -1,6 +1,8 @@
 homepage: "https://github.com/AOMediaCodec/libavif"
 language: c++
 primary_contact: "wtc@google.com"
+fuzzing_engines:
+  - libfuzzer
 auto_ccs:
   - "fgalligan@google.com"
   - "joedrago@gmail.com"


### PR DESCRIPTION
This is because tests will be fully migrated to fuzztest