### PR TITLE
librsvg: bump libxml2 to 2.13.1

### DIFF
--- a/projects/librsvg/Dockerfile
+++ b/projects/librsvg/Dockerfile
@@ -34,6 +34,8 @@ RUN pip3 install --no-cache-dir \
 RUN git clone --depth=1 --no-tags https://gitlab.gnome.org/GNOME/librsvg.git
 RUN git clone --depth=1 --branch=2.78.5 https://gitlab.gnome.org/GNOME/glib.git
 RUN git clone --depth=1 --branch=VER-2-13-2 https://gitlab.freedesktop.org/freetype/freetype.git
+RUN git clone --depth=1 --branch=v2.13.1 https://gitlab.gnome.org/GNOME/libxml2.git
+RUN git clone --depth=1 --branch=2.15.0 https://gitlab.freedesktop.org/fontconfig/fontconfig.git
 RUN git clone --depth=1 --branch=1.18.0 https://gitlab.freedesktop.org/cairo/cairo.git
 RUN git clone --depth=1 --branch=8.4.0 https://github.com/harfbuzz/harfbuzz.git
 RUN git clone --depth=1 --branch=1.52.2 https://gitlab.gnome.org/GNOME/pango.git

--- a/projects/librsvg/build.sh
+++ b/projects/librsvg/build.sh
@@ -39,9 +39,21 @@ meson setup --prefix="$PREFIX" --buildtype=plain --default-library=static buildd
 ninja -C builddir
 ninja -C builddir install
 
+# Compile and install libxml2
+cd "$SRC/libxml2"
+meson setup --prefix="$PREFIX" --buildtype=plain --default-library=static builddir
+ninja -C builddir
+ninja -C builddir install
+
+# Compile and install Fontconfig
+cd "$SRC/fontconfig"
+meson setup --prefix="$PREFIX" --buildtype=plain --default-library=static builddir -Dtests=disabled -Dtools=disabled
+ninja -C builddir
+ninja -C builddir install
+
 # Compile and install Cairo
 cd "$SRC/cairo"
-meson setup --prefix="$PREFIX" --buildtype=plain --default-library=static builddir -Dfontconfig:tests=disabled -Dfontconfig:tools=disabled -Dpixman:tests=disabled
+meson setup --prefix="$PREFIX" --buildtype=plain --default-library=static builddir -Dpixman:tests=disabled -Dtests=disabled
 ninja -C builddir
 ninja -C builddir install
 


### PR DESCRIPTION
This bump fixes the leak reported in OSS-Fuzz issue 69700.

Previously, libxml2 2.12.6 was being pulled in as a subproject of Fontconfig (via Cairo).