### PR TITLE
Remove flags that may escalate warnings to errors

### DIFF
--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -42,6 +42,22 @@ func CopyFile(src string, dst string) {
 	}
 }
 
+func RemoveFailureCausingFlags(cmd []string) []string {
+    // Skip arguments that convert warnings to errors or make the command fail.
+    var newCmd []string
+    for _, arg := range cmd {
+        // Skip arguments that convert warnings to errors
+		if strings.HasPrefix(arg, "-Werror") ||
+			arg == "-pedantic-errors" ||
+			arg == "-Wfatal-errors" ||
+			arg == "-Weverything" {
+			continue
+		}
+        newCmd = append(newCmd, arg)
+    }
+    return newCmd
+}
+
 func TryFixCCompilation(cmdline []string) ([]string, int, string, string) {
 	var newFile string = ""
 	for i, arg := range cmdline {
@@ -316,6 +332,8 @@ func main() {
 	basename := filepath.Base(os.Args[0])
 	isCPP := basename == "clang++-jcc"
 	newArgs := append(args, "-w")
+
+    newArgs = RemoveFailureCausingFlags(newArgs)
 
 	var bin string
 	if isCPP {

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -383,8 +383,6 @@ func main() {
 		// how to improve jcc to fix more issues.
 		WriteStdErrOut(fullCmdArgs, out, errstr)
 		fmt.Println("\nFix failure")
-		// Print error back to stderr so tooling that relies on this can proceed
-		WriteStdErrOut(fixargs, fixout, fixerr)
 		os.Exit(retcode)
 	}
 	// The fix suceeded, write its out and err.

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -49,8 +49,7 @@ func RemoveFailureCausingFlags(cmd []string) []string {
         // Skip arguments that convert warnings to errors
 		if strings.HasPrefix(arg, "-Werror") ||
 			arg == "-pedantic-errors" ||
-			arg == "-Wfatal-errors" ||
-			arg == "-Weverything" {
+			arg == "-Wfatal-errors" {
 			continue
 		}
         newCmd = append(newCmd, arg)

--- a/infra/base-images/base-builder/jcc/jcc.go
+++ b/infra/base-images/base-builder/jcc/jcc.go
@@ -332,8 +332,6 @@ func main() {
 	isCPP := basename == "clang++-jcc"
 	newArgs := append(args, "-w")
 
-    newArgs = RemoveFailureCausingFlags(newArgs)
-
 	var bin string
 	if isCPP {
 		bin = "clang++"
@@ -341,12 +339,21 @@ func main() {
 	} else {
 		bin = "clang"
 	}
-	fullCmdArgs := append([]string{bin}, newArgs...)
-	retcode, out, errstr := Compile(bin, newArgs)
-	if retcode == 0 {
-		WriteStdErrOut(fullCmdArgs, out, errstr)
-		os.Exit(0)
-	}
+ 	fullCmdArgs := append([]string{bin}, newArgs...)
+ 	retcode, out, errstr := Compile(bin, newArgs)
+ 	if retcode == 0 {
+ 	 	WriteStdErrOut(fullCmdArgs, out, errstr)
+ 	 	os.Exit(0)
+ 	}
+
+ 	// Some projects convert warnings to errors, undo this and try again.
+ 	newArgs = RemoveFailureCausingFlags(newArgs)
+ 	retcode, out, errstr = Compile(bin, newArgs)
+ 	fullCmdArgs = append([]string{bin}, newArgs...)
+ 	if retcode == 0 {
+ 	 	WriteStdErrOut(fullCmdArgs, out, errstr)
+ 	 	os.Exit(0)
+ 	}
 
 	// Note that on failures or when we succeed on the first try, we should
 	// try to write the first out/err to stdout/stderr.


### PR DESCRIPTION
Some projects failed to compile because its compilation command escalates warnings into errors (e.g., [`bind9`](https://llm-exp.oss-fuzz.com/Result-reports/scheduled/2024-06-21-weekly-all/benchmark/output-bind9-dns_view_asyncload/index.html)). This is particularly problematic for C projects because `JCC` assumes these errors are due to C/C++ compatibility issues and then compiles these projects with `clang++`, which causes different failures that LLM cannot fix (e.g., in `bind9`, the error is caused by other files using C symbols that are not available in C++).

This PR removes all flags that may cause this problem in all compilation commands.
When tested locally, it fixed the compilation error in `bind9` (with some manual fix on the fuzz target).

----
Here is the command that contains `-Werror*` and causes this problem in `bind9`:
```shell
clang -DHAVE_CONFIG_H -I. -I..  -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -DISC_MEM_DEFAULTFILL=1 -DISC_MEM_TRACKLINES=1 -DISC_LIST_CHECKINIT=1 -DISC_STATS_CHECKUNDERFLOW=1 -DDNS_RBTDB_STRONG_RWLOCK_CHECK=1 -DISC_MUTEX_ERROR_CHECK=1 -include ../config.h -I./include -I../include -I../lib/isc/include -I../lib/isc/include -I../lib/dns/include -I../lib/dns/include -I/usr/include/x86_64-linux-gnu  -DFUZZDIR=\"/src/bind9/fuzz\" -I../lib/dns -I../lib/isc -I../tests/include  -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wno-missing-field-initializers -Wformat -Wshadow -Werror=implicit-function-declaration -Werror=missing-prototypes -Werror=format-security -Werror=parentheses -Werror=implicit -Werror=strict-prototypes -Werror=vla -fno-strict-aliasing -fno-delete-null-pointer-checks -fdiagnostics-show-option -Werror -Wno-vla -O1 -fno-omit-frame-pointer -gline-tables-only -Wno-error=enum-constexpr-conversion -Wno-error=incompatible-function-pointer-types -Wno-error=int-conversion -Wno-error=deprecated-declarations -Wno-error=implicit-function-declaration -Wno-error=implicit-int -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=address -fsanitize-address-use-after-scope -fsanitize=fuzzer-no-link -I/usr/include/x86_64-linux-gnu -pthread -MT isc_lex_gettoken.o -MD -MP -MF $depbase.Tpo -c -o isc_lex_gettoken.o isc_lex_gettoken.c
```

