### PR TITLE
librsvg: exclude third-party code from coverage reports

### DIFF
--- a/projects/librsvg/project.yaml
+++ b/projects/librsvg/project.yaml
@@ -8,3 +8,6 @@ sanitizers:
   - address
 fuzzing_engines:
   - libfuzzer
+coverage_extra_args: >
+  -ignore-filename-regex=rust/.*
+  -ignore-filename-regex=rustc/.*


### PR DESCRIPTION
Example report that would be improved:
https://storage.googleapis.com/oss-fuzz-coverage/librsvg/reports/20240625/linux/report.html