### PR TITLE
doc: add rust to list of languages that support llvm-cov arguments

### DIFF
--- a/docs/advanced-topics/code_coverage.md
+++ b/docs/advanced-topics/code_coverage.md
@@ -99,7 +99,7 @@ $ python infra/helper.py coverage --fuzz-target=<fuzz_target_name> \
     --corpus-dir=<my_local_corpus_dir> $PROJECT_NAME
 ```
 
-### Additional arguments for `llvm-cov` (C/C++ only)
+### Additional arguments for `llvm-cov` (C/C++/Rust only)
 
 You may want to use some of the options provided by the [llvm-cov tool], like
 `-ignore-filename-regex=`. You can pass these to the helper script after `--`:


### PR DESCRIPTION
Some example Rust projects that are already using this functionality:

https://github.com/google/oss-fuzz/blob/7dc680836c9d99a5e1839ca07f60874654727bc8/projects/askama/project.yaml#L11-L13

https://github.com/google/oss-fuzz/blob/7dc680836c9d99a5e1839ca07f60874654727bc8/projects/gitoxide/project.yaml#L12-L13

https://github.com/google/oss-fuzz/blob/7dc680836c9d99a5e1839ca07f60874654727bc8/projects/wasmer/project.yaml#L15-L16