### PR TITLE
mpv: ignore third-party dependencies in the coverage report

### DIFF
--- a/projects/mpv/project.yaml
+++ b/projects/mpv/project.yaml
@@ -9,11 +9,13 @@ architectures:
   - i386
 sanitizers:
   - address
-  - memory:
-      experimental: True
+  - memory
   - undefined
 fuzzing_engines:
   - afl
   - centipede
   - honggfuzz
   - libfuzzer
+coverage_extra_args: >
+  -ignore-filename-regex=mpv/subprojects/.*
+  -ignore-filename-regex=ffmpeg/.*


### PR DESCRIPTION
Also remove experimental flag for MSAN.