### PR TITLE
sound-open-firmware: SOF integration has bitrotten.  Revive it.

### DIFF
--- a/projects/sound-open-firmware/Dockerfile
+++ b/projects/sound-open-firmware/Dockerfile
@@ -21,22 +21,15 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 
 # Base packages
-RUN apt-get -y update
-RUN apt-get install -y \
+RUN apt-get -y update && apt-get -y install \
       gettext git libc6-dev-i386 libglib2.0-dev libncurses5-dev \
       libtool ninja-build python3-pip
 RUN pip3 install west
 
 # Zephyr SDK:
-#
-# Zephyr doesn't provide a clean "get the latest version" URL, but
-# note that the use of the /latest/ path component at least ensures
-# this will fail on a new release.
-ARG SDK_VER=0.16.1
-WORKDIR /root
-RUN curl -L -o sdktmp.tar.xz https://github.com/zephyrproject-rtos/sdk-ng/releases/latest/download/zephyr-sdk-${SDK_VER}_linux-x86_64_minimal.tar.xz
-RUN tar xf sdktmp.tar.xz; rm sdktmp.tar.xz
-RUN zephyr-sdk-*/setup.sh -h
+COPY fetch-sdk.sh /root
+WORKDIR /root/
+RUN ./fetch-sdk.sh
 
 WORKDIR $SRC
 

--- a/projects/sound-open-firmware/build.sh
+++ b/projects/sound-open-firmware/build.sh
@@ -30,19 +30,10 @@ unset CXX
 unset CFLAGS
 unset CXXFLAGS
 
-BASE_CFG=(
--DCONFIG_ASSERT=y
--DCONFIG_SYS_HEAP_BIG_ONLY=y
--DCONFIG_ZEPHYR_NATIVE_DRIVERS=y
--DCONFIG_ARCH_POSIX_LIBFUZZER=y
--DCONFIG_ARCH_POSIX_FUZZ_TICKS=100
--DCONFIG_ASAN=y
-)
-
 cd $SRC/sof/sof
 
-west build -p -b native_posix ./app -- "${BASE_CFG[@]}"
-cp build/zephyr/zephyr.exe $OUT/sof-ipc3
+scripts/fuzz.sh -b -- -DEXTRA_CONF_FILE=stub_build_all_ipc3.conf
+cp build-fuzz/zephyr/zephyr.exe $OUT/sof-ipc3
 
-west build -p -b native_posix ./app -- "${BASE_CFG[@]}" -DCONFIG_IPC_MAJOR_4=y
-cp build/zephyr/zephyr.exe $OUT/sof-ipc4
+scripts/fuzz.sh -b -- -DEXTRA_CONF_FILE=stub_build_all_ipc4.conf
+cp build-fuzz/zephyr/zephyr.exe $OUT/sof-ipc4

--- a/projects/sound-open-firmware/fetch-sdk.sh
+++ b/projects/sound-open-firmware/fetch-sdk.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -eu
+# Copyright 2024 Google LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Zephyr doesn't provide a "latest" link, so clone the source tree
+# that produces the SDK (much smaller than the tarball itself, so
+# minimal overhead) and find the latest version tag as a proxy.  Will
+# likely break if the script is run in the moments between tagging a
+# release and the tarball appearing on github, but the risk is low and
+# it will recover with a retry.
+
+git clone --filter=tree:0 https://github.com/zephyrproject-rtos/sdk-ng
+
+VER=$(git -C sdk-ng tag -l 'v*' | sort -rV | head -1 | sed 's/v//')
+URL="https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v$VER/zephyr-sdk-${VER}_linux-x86_64_minimal.tar.xz"
+
+curl -L -o sdk.tar.xz "$URL"
+tar xf sdk.tar.xz
+rm sdk.tar.xz
+
+zephyr-sdk-$VER/setup.sh -h


### PR DESCRIPTION
This doesn't get as much attention as it should, fixups to recover oss-fuzz output:

1. The Zephyr SDK 0.16.1 probably still works from a year ago, but the fetch URL scheme changed so we'll never know.  Implement some horrible hackery to extract the "latest" version of the SDK at docker time so (absent more changes to the releases URLs) we stay current.

2. The build.sh was my original hack with manual kconfig settings, which have skewed vs. the app as it evolved and don't build anymore.  SOF has fuzzing implemented as a first class tool now (and even run it in their CI), so just use the official script which we can rely on being maintained.