### PR TITLE
PDFMiner.Six Initial Integration

### DIFF
--- a/projects/pdfminersix/Dockerfile
+++ b/projects/pdfminersix/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-python
+RUN pip3 install --upgrade pip
+RUN mkdir $SRC/corpus
+RUN git clone --depth 1 https://github.com/pdfminer/pdfminer.six.git pdfminer.six \
+        && cp pdfminer.six/fuzzing/build.sh $SRC/ \
+	&& cp pdfminer.six/samples/simple* $SRC/corpus
+WORKDIR $SRC/pdfminer.six
+


### PR DESCRIPTION
This pull requests integrates the Dockerfile needed to build the fuzzers for pdfminer.six, as merged into upstream in this [PR](https://github.com/pdfminer/pdfminer.six/pull/949).