### PR TITLE
Update unrar OSS-fuzz integration

### DIFF
--- a/projects/unrar/Dockerfile
+++ b/projects/unrar/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make build-essential
 
-RUN git clone -b oss_fuzz --depth 1 https://github.com/aawc/unrar.git
+RUN git clone -b main --depth 1 https://github.com/aawc/unrar.git
 WORKDIR unrar
 
 COPY build.sh $SRC/


### PR DESCRIPTION
Unrar is fuzzed through a mirror of the official source code on GitHub (https://github.com/aawc/unrar). We have not been updating the oss_fuzz branch, which leads to obsolete bugs like
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=69968.

Since the main purpose of this repo is to enable fuzzing, we're going to remove the oss_fuzz branch and update the integration here.