### PR TITLE
lua: fix undeclared lua_writestringerror

### DIFF
--- a/projects/lua/fuzz_lua.c
+++ b/projects/lua/fuzz_lua.c
@@ -69,15 +69,13 @@ static void laction (int i) {
   lua_sethook(globalL, lstop, flag, 1);
 }
 
-
-
 /*
 ** Prints an error message, adding the program name in front of it
 ** (if present)
 */
 static void l_message (const char *pname, const char *msg) {
-  if (pname) lua_writestringerror("%s: ", pname);
-  lua_writestringerror("%s\n", msg);
+  if (pname) fprintf(stderr, "%s: ", pname);
+  fprintf(stderr, "%s\n", msg);
 }
 
 


### PR DESCRIPTION
```
+ /src/aflplusplus/afl-clang-fast -O1 -fno-omit-frame-pointer -gline-tables-only -Wno-error=enum-constexpr-conversion -Wno-error=incompatible-function-pointer-types -Wno-error=int-conversion -Wno-error=deprecated-declarations -Wno-error=implicit-function-declaration -Wno-error=implicit-int -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=address -fsanitize-address-use-after-scope -I/src/testdir/build/lua-master/source/ -c /src/fuzz_lua.c -o fuzz_lua.o [1m/src/fuzz_lua.c:79:14: [0m[0;1;35mwarning: [0m[1mcall to undeclared function 'lua_writestringerror'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration][0m
   79 |   if (pname) lua_writestringerror("%s: ", pname);[0m
      | [0;1;32m             ^
[0m1 warning generated.
```