### PR TITLE
Update xbps homepage and main_repo in project.yaml

### DIFF
--- a/projects/xbps/project.yaml
+++ b/projects/xbps/project.yaml
@@ -1,9 +1,9 @@
-homepage: "https://github.com/voidlinux/xbps"
+homepage: "https://github.com/void-linux/xbps"
 primary_contact: "miwaxe@gmail.com"
 auto_ccs:
   - "gottox@voidlinux.eu"
   - "xtraeme@voidlinux.eu"
-main_repo: "https://github.com/voidlinux/xbps"
+main_repo: "https://github.com/void-linux/xbps"
 language: c
 
 fuzzing_engines:


### PR DESCRIPTION
The xbps project's homepage and main_repo entries were previously listed as https://github.com/voidlinux/xbps, which leads to a 404 page. This commit changes them to instead point to https://github.com/void-linux/xbps, which is correct.