### PR TITLE
suricata: use latest jansson release from github

### DIFF
--- a/projects/suricata/Dockerfile
+++ b/projects/suricata/Dockerfile
@@ -29,7 +29,10 @@ RUN git clone --depth=1 https://github.com/catenacyber/fuzzpcap
 
 ADD https://rules.emergingthreats.net/open/suricata/emerging.rules.zip emerging.rules.zip
 
+ENV RUSTUP_TOOLCHAIN nightly
 RUN cargo install --force cbindgen
+# TODO remove once https://redmine.openinfosecfoundation.org/issues/7130 is solved
+ENV RUSTUP_TOOLCHAIN nightly-2024-02-12
 
 RUN git clone --depth 1 https://github.com/OISF/suricata.git suricata
 RUN git clone --depth 1 --branch master-6.0.x https://github.com/OISF/suricata.git suricata6

--- a/projects/suricata/Dockerfile
+++ b/projects/suricata/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y build-essential autoconf automake libto
 # TODO libmagic, liblzma and other optional libraries
 ADD https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.39/pcre2-10.39.tar.gz pcre2-10.39.tar.gz
 ADD https://www.tcpdump.org/release/libpcap-1.9.1.tar.gz libpcap-1.9.1.tar.gz
-ADD http://www.digip.org/jansson/releases/jansson-2.12.tar.gz jansson-2.12.tar.gz
+ADD https://github.com/akheron/jansson/releases/download/v2.14/jansson-2.14.tar.gz jansson-2.14.tar.gz
 RUN git clone --depth=1 https://github.com/yaml/libyaml
 ADD https://github.com/lz4/lz4/archive/v1.9.2.tar.gz lz4-1.9.2.tar.gz
 RUN git clone --depth 1 https://github.com/catenacyber/quadfuzz.git

--- a/projects/suricata/build.sh
+++ b/projects/suricata/build.sh
@@ -43,8 +43,8 @@ cp lib/liblz4.a /usr/local/lib/
 cp lib/lz4*.h /usr/local/include/
 cd ..
 
-tar -xvzf jansson-2.12.tar.gz
-cd jansson-2.12
+tar -xvzf jansson-2.14.tar.gz
+cd jansson-2.14
 ./configure --disable-shared
 make -j$(nproc)
 make install


### PR DESCRIPTION
cf https://oss-fuzz-build-logs.storage.googleapis.com/log-15fe5b44-39aa-4f14-86e8-11086ea4c4f1.txt