### PR TITLE
solidity: Bump boost

### DIFF
--- a/projects/solidity/Dockerfile
+++ b/projects/solidity/Dockerfile
@@ -28,19 +28,19 @@ RUN git clone --branch="v0.11.0" --recurse-submodules \
 
 # Install statically built dependencies in "/usr" directory
 # Install boost
-RUN cd $SRC; \
-    wget -q 'https://archives.boost.io/release/1.73.0/source/boost_1_73_0.tar.bz2' -O boost.tar.bz2; \
-    test "$(sha256sum boost.tar.bz2)" = "4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402  boost.tar.bz2"; \
-    tar -xf boost.tar.bz2; \
-    rm boost.tar.bz2; \
-    cd boost_1_73_0; \
-    CXXFLAGS="-stdlib=libc++ -pthread" LDFLAGS="-stdlib=libc++" ./bootstrap.sh --with-toolset=clang --prefix=/usr; \
-    ./b2 toolset=clang cxxflags="-stdlib=libc++ -pthread" linkflags="-stdlib=libc++ -pthread" headers; \
+RUN cd $SRC && \
+    wget -q 'https://archives.boost.io/release/1.83.0/source/boost_1_83_0.tar.bz2' -O boost.tar.bz2 && \
+    test "$(sha256sum boost.tar.bz2)" = "6478edfe2f3305127cffe8caf73ea0176c53769f4bf1585be237eb30798c3b8e  boost.tar.bz2" && \
+    tar -xf boost.tar.bz2 && \
+    rm boost.tar.bz2 && \
+    cd boost_1_83_0 && \
+    CXXFLAGS="-stdlib=libc++ -pthread" LDFLAGS="-stdlib=libc++" ./bootstrap.sh --with-toolset=clang --prefix=/usr && \
+    ./b2 toolset=clang cxxflags="-stdlib=libc++ -pthread" linkflags="-stdlib=libc++ -pthread" headers && \
     ./b2 toolset=clang cxxflags="-stdlib=libc++ -pthread" linkflags="-stdlib=libc++ -pthread" \
         link=static variant=release runtime-link=static \
         system filesystem unit_test_framework program_options \
-        install -j $(($(nproc)/2)); \
-    rm -rf $SRC/boost_1_73_0
+        install -j $(($(nproc)/2)) && \
+    rm -rf $SRC/boost_1_83_0
 
 # Install libprotobuf-mutator
 # Use commit prior to libprotobuf upgrade that broke solidity build


### PR DESCRIPTION
Required for the compiler bump in https://github.com/google/oss-fuzz/pull/12077

See https://oss-fuzz-gcb-logs.storage.googleapis.com/log-97a29aa7-6149-4c95-8428-5de204bd2214.txt

```
Step #21 - "compile-afl-address-x86_64": + cd /src/solidity/build
Step #21 - "compile-afl-address-x86_64": + CXXFLAGS='-O1   -fno-omit-frame-pointer   -gline-tables-only   -Wno-error=enum-constexpr-conversion   -Wno-error=incompatible-function-pointer-types   -Wno-error=int-conversion   -Wno-error=deprecated-declarations   -Wno-error=implicit-function-declaration   -Wno-error=implicit-int   -Wno-error=vla-cxx-extension   -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=address -fsanitize-address-use-after-scope  -stdlib=libc++ -I/usr/local/include/c++/v1'
Step #21 - "compile-afl-address-x86_64": + cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/ossfuzz.cmake -DCMAKE_BUILD_TYPE=Release /src/solidity
Step #21 - "compile-afl-address-x86_64": -- The C compiler identification is Clang 18.1.8
Step #21 - "compile-afl-address-x86_64": -- The CXX compiler identification is Clang 18.1.8
Step #21 - "compile-afl-address-x86_64": -- Detecting C compiler ABI info
Step #21 - "compile-afl-address-x86_64": -- Detecting C compiler ABI info - done
Step #21 - "compile-afl-address-x86_64": -- Check for working C compiler: /src/aflplusplus/afl-clang-fast - skipped
Step #21 - "compile-afl-address-x86_64": -- Detecting C compile features
Step #21 - "compile-afl-address-x86_64": -- Detecting C compile features - done
Step #21 - "compile-afl-address-x86_64": -- Detecting CXX compiler ABI info
Step #21 - "compile-afl-address-x86_64": -- Detecting CXX compiler ABI info - done
Step #21 - "compile-afl-address-x86_64": -- Check for working CXX compiler: /src/aflplusplus/afl-clang-fast++ - skipped
Step #21 - "compile-afl-address-x86_64": -- Detecting CXX compile features
Step #21 - "compile-afl-address-x86_64": -- Detecting CXX compile features - done
Step #21 - "compile-afl-address-x86_64": [31mCMake Error at /usr/lib/cmake/Boost-1.73.0/BoostConfig.cmake:141 (find_package):
Step #21 - "compile-afl-address-x86_64":   Found package configuration file:
Step #21 - "compile-afl-address-x86_64": 
Step #21 - "compile-afl-address-x86_64":     /usr/lib/cmake/boost_unit_test_framework-1.73.0/boost_unit_test_framework-config.cmake
Step #21 - "compile-afl-address-x86_64": 
Step #21 - "compile-afl-address-x86_64":   but it set boost_unit_test_framework_FOUND to FALSE so package
Step #21 - "compile-afl-address-x86_64":   "boost_unit_test_framework" is considered to be NOT FOUND.  Reason given by
Step #21 - "compile-afl-address-x86_64":   package:
Step #21 - "compile-afl-address-x86_64": 
Step #21 - "compile-afl-address-x86_64":   No suitable build variant has been found.
Step #21 - "compile-afl-address-x86_64": 
Step #21 - "compile-afl-address-x86_64": Call Stack (most recent call first):
Step #21 - "compile-afl-address-x86_64":   /usr/lib/cmake/Boost-1.73.0/BoostConfig.cmake:258 (boost_find_component)
Step #21 - "compile-afl-address-x86_64":   /usr/local/share/cmake-3.29/Modules/FindBoost.cmake:594 (find_package)
Step #21 - "compile-afl-address-x86_64":   cmake/EthDependencies.cmake:40 (find_package)
Step #21 - "compile-afl-address-x86_64":   CMakeLists.txt:51 (include)
Step #21 - "compile-afl-address-x86_64": 
Step #21 - "compile-afl-address-x86_64": [0m
Step #21 - "compile-afl-address-x86_64": -- Configuring incomplete, errors occurred!
Step #21 - "compile-afl-address-x86_64": ********************************************************************************
Step #21 - "compile-afl-address-x86_64": Failed to build.
Step #21 - "compile-afl-address-x86_64": To reproduce, run:
Step #21 - "compile-afl-address-x86_64": python infra/helper.py build_image solidity
Step #21 - "compile-afl-address-x86_64": python infra/helper.py build_fuzzers --sanitizer address --engine afl --architecture x86_64 solidity
Step #21 - "compile-afl-address-x86_64": ********************************************************************************
Finished Step #21 - "compile-afl-address-x86_64"
ERROR
ERROR: build step 21 "gcr.io/cloud-builders/docker" failed: step exited with non-zero status: 1
