### PR TITLE
openweave: Avoid OOM in make -j

### DIFF
--- a/projects/openweave/build.sh
+++ b/projects/openweave/build.sh
@@ -45,7 +45,7 @@ sed -i 's/sys\/stat.h>/sys\/stat.h>\n#include <linux\/sockios.h>/g' ./third_part
 # OpenSSL now declares RAND_bytes so we must patch
 find ./src/test-apps/fuzz/ -name "FuzzP*.cpp" -exec sed -i 's/RAND_bytes/RAND_bytes2/g' {} \;
 
-make -j$(nproc)
+make -j$(nproc) || make -j2 || make
 
 find src/test-apps/fuzz/ -type f -executable -name "Fuzz*" | while read i; do
     patchelf --set-rpath '$ORIGIN/lib' ${i}

--- a/projects/openweave/build.sh
+++ b/projects/openweave/build.sh
@@ -45,7 +45,9 @@ sed -i 's/sys\/stat.h>/sys\/stat.h>\n#include <linux\/sockios.h>/g' ./third_part
 # OpenSSL now declares RAND_bytes so we must patch
 find ./src/test-apps/fuzz/ -name "FuzzP*.cpp" -exec sed -i 's/RAND_bytes/RAND_bytes2/g' {} \;
 
-make -j$(nproc) || make -j2 || make
+# Don't use all cores to avoid OOM.
+# See https://github.com/google/oss-fuzz/pull/12174
+make -j$(expr $(nproc) / 2)
 
 find src/test-apps/fuzz/ -type f -executable -name "Fuzz*" | while read i; do
     patchelf --set-rpath '$ORIGIN/lib' ${i}


### PR DESCRIPTION
Required for the compiler bump in https://github.com/google/oss-fuzz/pull/12077

See https://oss-fuzz-gcb-logs.storage.googleapis.com/log-7213ec9e-cac7-4eec-bd21-472547b52220.txt

```
Step #21 - "compile-libfuzzer-coverage-x86_64":   CXXLD    TestBinding
Step #21 - "compile-libfuzzer-coverage-x86_64":   CXXLD    TestEventLogging
Step #21 - "compile-libfuzzer-coverage-x86_64":   CXXLD    TestInetLayer
Step #21 - "compile-libfuzzer-coverage-x86_64": clang++: [0;1;31merror: [0m[1munable to execute command: Killed[0m
Step #21 - "compile-libfuzzer-coverage-x86_64": clang++: [0;1;31merror: [0m[1mlinker command failed due to signal (use -v to see invocation)[0m
Step #21 - "compile-libfuzzer-coverage-x86_64": make[4]: *** [Makefile:4371: TestWeaveCert] Error 1
Step #21 - "compile-libfuzzer-coverage-x86_64": make[4]: *** Waiting for unfinished jobs....
Step #21 - "compile-libfuzzer-coverage-x86_64": clang++: [0;1;31merror: [0m[1munable to execute command: Killed[0m
Step #21 - "compile-libfuzzer-coverage-x86_64": clang++: [0;1;31merror: [0m[1mlinker command failed due to signal (use -v to see invocation)[0m
Step #21 - "compile-libfuzzer-coverage-x86_64": make[4]: *** [Makefile:4188: TestTAKE] Error 1
Step #21 - "compile-libfuzzer-coverage-x86_64": clang++: [0;1;31merror: [0m[1munable to execute command: Killed[0m
Step #21 - "compile-libfuzzer-coverage-x86_64": clang++: [0;1;31merror: [0m[1mlinker command failed due to signal (use -v to see invocation)[0m
Step #21 - "compile-libfuzzer-coverage-x86_64": make[4]: *** [Makefile:4078: TestInetEndPoint] Error 1
Step #21 - "compile-libfuzzer-coverage-x86_64": clang++: [0;1;31merror: [0m[1munable to execute command: Killed[0m
Step #21 - "compile-libfuzzer-coverage-x86_64": clang++: [0;1;31merror: [0m[1mlinker command failed due to signal (use -v to see invocation)[0m
Step #21 - "compile-libfuzzer-coverage-x86_64": make[4]: *** [Makefile:4098: TestKeyExport] Error 1
Step #21 - "compile-libfuzzer-coverage-x86_64": clang++: [0;1;31merror: [0m[1munable to execute command: Killed[0m
Step #21 - "compile-libfuzzer-coverage-x86_64": clang++: [0;1;31merror: [0m[1mlinker command failed due to signal (use -v to see invocation)[0m
Step #21 - "compile-libfuzzer-coverage-x86_64": make[4]: *** [Makefile:4106: TestMsgEnc] Error 1
Step #21 - "compile-libfuzzer-coverage-x86_64": clang++: [0;1;31merror: [0m[1munable to execute command: Killed[0m
Step #21 - "compile-libfuzzer-coverage-x86_64": clang++: [0;1;31merror: [0m[1mlinker command failed due to signal (use -v to see invocation)[0m
Step #21 - "compile-libfuzzer-coverage-x86_64": make[4]: *** [Makefile:4048: TestECMath] Error 1
Step #21 - "compile-libfuzzer-coverage-x86_64": clang++: [0;1;31merror: [0m[1munable to execute command: Killed[0m
Step #21 - "compile-libfuzzer-coverage-x86_64": clang++: [0;1;31merror: [0m[1mlinker command failed due to signal (use -v to see invocation)[0m
Step #21 - "compile-libfuzzer-coverage-x86_64": make[4]: *** [Makefile:4044: TestECDSA] Error 1
Step #21 - "compile-libfuzzer-coverage-x86_64": make[3]: *** [Makefile:6509: all-recursive] Error 1
Step #21 - "compile-libfuzzer-coverage-x86_64": make[2]: *** [Makefile:642: all-recursive] Error 1
Step #21 - "compile-libfuzzer-coverage-x86_64": make[1]: *** [Makefile:739: all-recursive] Error 1
Step #21 - "compile-libfuzzer-coverage-x86_64": make: *** [Makefile:665: all] Error 2
Step #21 - "compile-libfuzzer-coverage-x86_64": ********************************************************************************
Step #21 - "compile-libfuzzer-coverage-x86_64": Failed to build.
Step #21 - "compile-libfuzzer-coverage-x86_64": To reproduce, run:
Step #21 - "compile-libfuzzer-coverage-x86_64": python infra/helper.py build_image openweave
Step #21 - "compile-libfuzzer-coverage-x86_64": python infra/helper.py build_fuzzers --sanitizer coverage --engine libfuzzer --architecture x86_64 openweave
Step #21 - "compile-libfuzzer-coverage-x86_64": ********************************************************************************
Finished Step #21 - "compile-libfuzzer-coverage-x86_64"
ERROR
ERROR: build step 21 "gcr.io/cloud-builders/docker" failed: step exited with non-zero status: 1
