### PR TITLE
leveldb: consistently use c++17

### DIFF
--- a/projects/leveldb/build.sh
+++ b/projects/leveldb/build.sh
@@ -20,6 +20,9 @@
 CFLAGS="$CFLAGS     -fno-sanitize=vptr"
 CXXFLAGS="$CXXFLAGS -fno-sanitize=vptr"
 
+# Pick C++17 due to use of std::filesystem
+CXXFLAGS="$CXXFLAGS -std=c++17"
+
 cd $SRC/leveldb
 mkdir -p build && cd build
 cmake -DCMAKE_BUILD_TYPE=Release -DLEVELDB_BUILD_TESTS=0 \
@@ -28,7 +31,7 @@ cmake -DCMAKE_BUILD_TYPE=Release -DLEVELDB_BUILD_TESTS=0 \
 for fuzzer in fuzz_db; do
     # Compile
     $CXX $CXXFLAGS -c ../${fuzzer}.cc -o ${fuzzer}.o \
-        -DLEVELDB_PLATFORM_POSIX=1 -std=c++11 -Wall \
+        -DLEVELDB_PLATFORM_POSIX=1 -Wall \
         -I$SRC/leveldb/build/include -I$SRC/leveldb/ -I$SRC/leveldb/include
 
     # Link

--- a/projects/leveldb/fuzz_db.cc
+++ b/projects/leveldb/fuzz_db.cc
@@ -40,7 +40,7 @@ class AutoDbDeleter {
   AutoDbDeleter& operator=(const AutoDbDeleter&) = delete;
 
   ~AutoDbDeleter() {
-    std::__fs::filesystem::remove_all(kDbPath);
+    std::filesystem::remove_all(kDbPath);
   }
 };
 


### PR DESCRIPTION
Required for the compiler bump in https://github.com/google/oss-fuzz/pull/12077

`std::filesystem` is only guaranteed to be in C++17, so select that consistently for this project.

Ref: https://oss-fuzz-gcb-logs.storage.googleapis.com/log-e7599eac-65b6-45fd-bc0d-1deec0235cea.txt

```
Step #21 - "compile-afl-address-x86_64": [100%] Built target leveldbutil
Step #21 - "compile-afl-address-x86_64": + for fuzzer in fuzz_db
Step #21 - "compile-afl-address-x86_64": + /src/aflplusplus/afl-clang-fast++ -O1 -fno-omit-frame-pointer -gline-tables-only -Wno-error=enum-constexpr-conversion -Wno-error=incompatible-function-pointer-types -Wno-error=int-conversion -Wno-error=deprecated-declarations -Wno-error=implicit-function-declaration -Wno-error=implicit-int -Wno-error=vla-cxx-extension -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=address -fsanitize-address-use-after-scope -stdlib=libc++ -fno-sanitize=vptr -c ../fuzz_db.cc -o fuzz_db.o -DLEVELDB_PLATFORM_POSIX=1 -std=c++11 -Wall -I/src/leveldb/build/include -I/src/leveldb/ -I/src/leveldb/include
Step #21 - "compile-afl-address-x86_64": [1m../fuzz_db.cc:43:28: [0m[0;1;31merror: [0m[1mno type named 'remove_all' in namespace 'std::filesystem'[0m
Step #21 - "compile-afl-address-x86_64":    43 |     std::__fs::filesystem::remove_all(kDbPath);[0m
Step #21 - "compile-afl-address-x86_64":       | [0;1;32m    ~~~~~~~~~~~~~~~~~~~~~~~^
Step #21 - "compile-afl-address-x86_64": [0m1 error generated.
Step #21 - "compile-afl-address-x86_64": ********************************************************************************
Step #21 - "compile-afl-address-x86_64": Failed to build.
Step #21 - "compile-afl-address-x86_64": To reproduce, run:
Step #21 - "compile-afl-address-x86_64": python infra/helper.py build_image leveldb
Step #21 - "compile-afl-address-x86_64": python infra/helper.py build_fuzzers --sanitizer address --engine afl --architecture x86_64 leveldb
Step #21 - "compile-afl-address-x86_64": ********************************************************************************
Finished Step #21 - "compile-afl-address-x86_64"
ERROR
ERROR: build step 21 "gcr.io/cloud-builders/docker" failed: step exited with non-zero status: 1
