### PR TITLE
boost: Use latest builder

### DIFF
--- a/projects/boost/Dockerfile
+++ b/projects/boost/Dockerfile
@@ -14,14 +14,10 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y g++ python
 
 RUN git clone --recursive https://github.com/boostorg/boost.git
 WORKDIR boost
 # Preferably, move boost_regex_fuzzer.cc to the boost repository.
 COPY build.sh *.zip *.cc $SRC/
-# This is to fix Fuzz Introspector build by using LLVM old pass manager
-# re https://github.com/ossf/fuzz-introspector/issues/305
-ENV OLD_LLVMPASS 1

--- a/projects/boost/build.sh
+++ b/projects/boost/build.sh
@@ -15,6 +15,9 @@
 #
 ################################################################################
 
+# Work around build issue
+cp "/usr/local/include/x86_64-unknown-linux-gnu/c++/v1/__config_site" "/usr/local/include/c++/v1/"
+
 # Build boost
 CXXFLAGS="$CXXFLAGS -stdlib=libc++ -pthread" LDFLAGS="-stdlib=libc++" \
     ./bootstrap.sh --with-toolset=clang --prefix=/usr;

--- a/projects/boost/build.sh
+++ b/projects/boost/build.sh
@@ -21,7 +21,8 @@ cp "/usr/local/include/x86_64-unknown-linux-gnu/c++/v1/__config_site" "/usr/loca
 # Build boost
 CXXFLAGS="$CXXFLAGS -stdlib=libc++ -pthread" LDFLAGS="-stdlib=libc++" \
     ./bootstrap.sh --with-toolset=clang --prefix=/usr;
-./b2 toolset=clang cxxflags="$CXXFLAGS -stdlib=libc++ -pthread" linkflags="-stdlib=libc++ -pthread" --with-graph --with-filesystem --with-program_options headers stage;
+echo "using clang : ossfuzz : $CXX : <compileflags>\"$CXXFLAGS\" <linkflags>\"$CXXFLAGS\" <linkflags>\"${LIB_FUZZING_ENGINE}\" ;" >user-config.jam
+./b2 --user-config=user-config.jam --toolset=clang-ossfuzz link=static --with-headers --with-graph --with-filesystem --with-program_options headers stage;
 
 # Very simple build rule, but sufficient here.
 #boost regexp


### PR DESCRIPTION
Required for the compiler bump in https://github.com/google/oss-fuzz/pull/12077

Full log: https://oss-fuzz-gcb-logs.storage.googleapis.com/log-49527212-a452-4fff-aaa5-293bf0924395.txt