### PR TITLE
Add `--locked` to installation of `cargo fuzz`

### DIFF
--- a/infra/base-images/base-builder/install_rust.sh
+++ b/infra/base-images/base-builder/install_rust.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 curl https://sh.rustup.rs | sh -s -- -y --default-toolchain=$RUSTUP_TOOLCHAIN --profile=minimal
-cargo install cargo-fuzz && rm -rf /rust/registry
+cargo install cargo-fuzz --locked && rm -rf /rust/registry
 # Needed to recompile rust std library for MSAN
 rustup component add rust-src
 cp -r /usr/local/lib/x86_64-unknown-linux-gnu/* /usr/local/lib/


### PR DESCRIPTION
Helps pin dependencies at the time of when `cargo-fuzz` itself was published to avoid dependency updates breaking builds. This fixes a current issue where all Rust projects using `cargo fuzz` are broken due to the installation of `cargo-fuzz` failing due to failing to build a newer dependency with an older nightly.

Closes #12168