### PR TITLE
arrow: Use latest builder

### DIFF
--- a/projects/arrow/Dockerfile
+++ b/projects/arrow/Dockerfile
@@ -14,20 +14,20 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
+FROM gcr.io/oss-fuzz-base/base-builder
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update -y -q && \
-    apt-get update -y -q && \
     apt-get install -y -q --no-install-recommends \
         bison \
         build-essential \
         cmake \
         flex \
-        libboost-all-dev \
+        libboost-dev \
         ninja-build \
         python3
+# Temporarily use newer boost until the base image it bumped
+RUN sed --in-place 's/focal/noble/g' /etc/apt/sources.list && apt update && apt install libboost-dev --reinstall --yes
 
 RUN git clone --depth=1 --recurse-submodules \
     https://github.com/apache/arrow.git $SRC/arrow

--- a/projects/arrow/Dockerfile
+++ b/projects/arrow/Dockerfile
@@ -23,7 +23,6 @@ RUN apt-get update -y -q && \
         build-essential \
         cmake \
         flex \
-        libboost-dev \
         ninja-build \
         python3
 RUN wget https://archives.boost.io/release/1.85.0/source/boost_1_85_0.tar.bz2  # Temporarily use manual installation over the outdated libboost-dev package

--- a/projects/arrow/Dockerfile
+++ b/projects/arrow/Dockerfile
@@ -26,8 +26,7 @@ RUN apt-get update -y -q && \
         libboost-dev \
         ninja-build \
         python3
-# Temporarily use newer boost until the base image it bumped
-RUN sed --in-place 's/focal/noble/g' /etc/apt/sources.list && apt update && apt install libboost-dev --reinstall --yes
+RUN wget https://archives.boost.io/release/1.85.0/source/boost_1_85_0.tar.bz2  # Temporarily use manual installation over the outdated libboost-dev package
 
 RUN git clone --depth=1 --recurse-submodules \
     https://github.com/apache/arrow.git $SRC/arrow

--- a/projects/arrow/build.sh
+++ b/projects/arrow/build.sh
@@ -17,6 +17,16 @@
 
 set -ex
 
+# Install Boost headers
+(
+ cd $SRC/
+ tar jxf boost_1_85_0.tar.bz2
+ cd boost_1_85_0/
+ CFLAGS="" CXXFLAGS="" ./bootstrap.sh
+ CFLAGS="" CXXFLAGS="" ./b2 headers
+ cp -R boost/ /usr/include/
+)
+
 ARROW=${SRC}/arrow/cpp
 
 cd ${WORK}


### PR DESCRIPTION
Required for the compiler bump in https://github.com/google/oss-fuzz/pull/12077