### PR TITLE
qemu: build glib manually

### DIFF
--- a/projects/qemu/Dockerfile
+++ b/projects/qemu/Dockerfile
@@ -15,9 +15,11 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool ninja-build libglib2.0-dev \
+ARG glib_tag=2.78.4
+RUN apt-get update && apt-get install -y make autoconf automake libtool ninja-build  \
     libfdt-dev libpixman-1-dev zlib1g-dev libslirp-dev patchelf wget \
     libattr1 libattr1-dev libcap-ng-dev pkg-config
+RUN git clone --depth 1 --branch $glib_tag https://gitlab.gnome.org/GNOME/glib
 RUN git clone --depth 1 https://git.qemu.org/git/qemu.git qemu
 WORKDIR qemu
 COPY build.sh $SRC/

--- a/projects/qemu/build.sh
+++ b/projects/qemu/build.sh
@@ -1,5 +1,4 @@
-#!/bin/sh -e
-# Copyright 2020 Google Inc.
+#!/bin/sh -e # Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +14,12 @@
 #
 ################################################################################
 
-pip3 install meson
+pip3 install meson tomli
 
-./scripts/oss-fuzz/build.sh
+cd $SRC/glib
+CC="" CFLAGS="" CXX="" CXXFLAGS="" meson setup --buildtype=plain --default-library=shared builddir -Dtests=false
+CC="" CFLAGS="" CXX="" CXXFLAGS="" ninja -C builddir
+ninja -C builddir install
+
+cd $SRC/qemu/
+$SRC/qemu/scripts/oss-fuzz/build.sh


### PR DESCRIPTION
qemu requires a newer version of glib than that which is packaged with oss-fuzz' version of Ubuntu