### PR TITLE
lima: initial integration

### DIFF
--- a/projects/lima/Dockerfile
+++ b/projects/lima/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/lima-vm/lima
+WORKDIR lima
+COPY build.sh FuzzLoadYAMLByFilePath.go $SRC/

--- a/projects/lima/FuzzLoadYAMLByFilePath.go
+++ b/projects/lima/FuzzLoadYAMLByFilePath.go
@@ -1,0 +1,36 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"os"
+	"testing"
+)
+
+func FuzzLoadYAMLByFilePath(f *testing.F) {
+	f.Fuzz(func(t *testing.T, fileContents []byte) {
+		fp, err := os.Create("yaml_file.yml")
+		if err != nil {
+			panic(err)
+		}
+		_, err = fp.Write(fileContents)
+		if err != nil {
+			fp.Close()
+			panic(err)
+		}
+		fp.Close()
+		_, _ = LoadYAMLByFilePath("yaml_file.yml")
+	})
+}

--- a/projects/lima/FuzzLoadYAMLByFilePath.go
+++ b/projects/lima/FuzzLoadYAMLByFilePath.go
@@ -21,16 +21,11 @@ import (
 
 func FuzzLoadYAMLByFilePath(f *testing.F) {
 	f.Fuzz(func(t *testing.T, fileContents []byte) {
-		fp, err := os.Create("yaml_file.yml")
+		err := os.WriteFile("yaml_file.yml", fileContents, 0600)
 		if err != nil {
-			panic(err)
+			t.Fatal(err)
 		}
-		_, err = fp.Write(fileContents)
-		if err != nil {
-			fp.Close()
-			panic(err)
-		}
-		fp.Close()
+
 		_, _ = LoadYAMLByFilePath("yaml_file.yml")
 	})
 }

--- a/projects/lima/build.sh
+++ b/projects/lima/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -eu
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+mv $SRC/FuzzLoadYAMLByFilePath.go $SRC/lima/pkg/store/fuzz_test.go
+printf "package store\nimport _ \"github.com/AdamKorcz/go-118-fuzz-build/testing\"\n" > $SRC/lima/pkg/store/register.go
+go mod tidy
+compile_native_go_fuzzer github.com/lima-vm/lima/pkg/store FuzzLoadYAMLByFilePath FuzzLoadYAMLByFilePath

--- a/projects/lima/project.yaml
+++ b/projects/lima/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://lima-vm.io/"
+language: go
+primary_contact: "adam@adalogics.com"
+main_repo: "https://github.com/lima-vm/lima"
+auto_ccs:
+  - "adam@adalogics.com"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address

--- a/projects/lima/project.yaml
+++ b/projects/lima/project.yaml
@@ -1,6 +1,6 @@
 homepage: "https://lima-vm.io/"
 language: go
-primary_contact: "adam@adalogics.com"
+primary_contact: "jan.dubois@suse.com"
 main_repo: "https://github.com/lima-vm/lima"
 auto_ccs:
   - "adam@adalogics.com"


### PR DESCRIPTION
Lima is a CNCF-hosted project with nearly 15k stars. Lima is a core component in several open-source alternatives to Docker Desktop including:

- Rancher Desktop. Rancher is widely used by many enterprises including T Mobile, Home Depot, Intel, Samsung and Siemens. Rancher has an open source product called Rancher Desktop that allows users to manage containers and Kubernetes on their desktop.
- Finch: An open source client for container development [released by AWS](https://aws.amazon.com/blogs/opensource/introducing-finch-an-open-source-client-for-container-development/). 
- Podman: Podman is a popular alternative to Docker, and Lima is a core component of their desktop product Podman Desktop.
____________________________

This PR adds initial fuzzing integration for the Lima project: Build files for OSS-Fuzz and the first fuzzer. Once this is merged, OSS-Fuzz will run the fuzzer in this PR and future Lima fuzzers continuously and report findings to the email addresses listed in the `project.yaml` file of this PR. OSS-Fuzz will regularly build Limas fuzzers and run them with vast compute power. If any issues come up and the Lima community fixes them, OSS-Fuzz will automatically detect the fixes and close the issue in its bug tracker.

I would like to add more fuzzers to Limas integration once Lima has been integrated into OSS-Fuzz. To complete this initial integration, we need at least one maintainer on the mailing list in the `project.yaml` of this PR.

@AkihiroSuda @jandubois @afbjorklund @balajiv113 @alexandear Can we add any of your emails? We can change this at any time after merging by modifying the `project.yaml` file of this PR.