### PR TITLE
librsvg: use a recent nightly compiler to fix the build

### DIFF
--- a/projects/librsvg/Dockerfile
+++ b/projects/librsvg/Dockerfile
@@ -40,6 +40,11 @@ RUN git clone --depth=1 --branch=1.18.0 https://gitlab.freedesktop.org/cairo/cai
 RUN git clone --depth=1 --branch=8.4.0 https://github.com/harfbuzz/harfbuzz.git
 RUN git clone --depth=1 --branch=1.52.2 https://gitlab.gnome.org/GNOME/pango.git
 
+# A recent nightly must be used to compile serde: https://github.com/serde-rs/serde/issues/2770
+# This has the unfortunate side effect of breaking coverage reports until LLVM is upgraded:
+# https://github.com/google/oss-fuzz/pull/12077
+ENV RUSTUP_TOOLCHAIN="nightly-2024-07-10"
+
 COPY build.sh "$SRC/"
 COPY *.options "$OUT/"
 


### PR DESCRIPTION
The nightly in the base image is too old to compile serde.

This change will break coverage reports until LLVM is updated on the base image.