### PR TITLE
libssh: Build without exec() support

### DIFF
--- a/projects/libssh/build.sh
+++ b/projects/libssh/build.sh
@@ -20,7 +20,8 @@ mkdir -p $BUILD
 pushd $BUILD
 cmake -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" \
     -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
-    -DBUILD_SHARED_LIBS=OFF -DWITH_INSECURE_NONE=ON $SRC/libssh
+    -DBUILD_SHARED_LIBS=OFF -DWITH_INSECURE_NONE=ON -DWITH_EXEC=OFF \
+    $SRC/libssh
 make "-j$(nproc)"
 
 fuzzers=$(find $SRC/libssh/tests/fuzz/ -name "*_fuzzer.c")
@@ -39,5 +40,3 @@ for f in $fuzzers; do
     fi
 done
 popd
-
-echo "SRCMAAAAAAP" && cat /workspace/srcmap.json || true


### PR DESCRIPTION
It looks like the current corpus contains some "malicious" inputs that mess up with the filesystem as libssh executes them if they are parsed as part of configuration file.

This sounds generally dangerous so the new CMake option to prevent this was introduced in libssh:
 
https://gitlab.com/libssh/libssh-mirror/-/merge_requests/509

This change is disabling the libssh to call exec() on the input from fuzzers, which should avoid build and coverage build failures

Should fix #10136.