### PR TITLE
python-multipart: fix fuzz blocker

### DIFF
--- a/projects/python-multipart/Dockerfile
+++ b/projects/python-multipart/Dockerfile
@@ -19,4 +19,5 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/Kludex/python-multipart python-multipart
 RUN python3 -m pip install --upgrade pip
 WORKDIR python-multipart
+COPY *.patch $SRC/python-multipart
 COPY build.sh $SRC/

--- a/projects/python-multipart/build.sh
+++ b/projects/python-multipart/build.sh
@@ -15,6 +15,7 @@
 #
 ################################################################################
 
+git apply $SRC/python-multipart/*.patch
 python3 -m pip install '.[dev]'
 for fuzzer in $(find $SRC -name "fuzz_*.py"); do
 	compile_python_fuzzer $fuzzer

--- a/projects/python-multipart/multipart.patch
+++ b/projects/python-multipart/multipart.patch
@@ -1,0 +1,13 @@
+diff --git a/multipart/multipart.py b/multipart/multipart.py
+index 0bf35c3..2a0e01c 100644
+--- a/multipart/multipart.py
++++ b/multipart/multipart.py
+@@ -1167,7 +1167,7 @@ class MultipartParser(BaseParser):
+                 # If we've reached a CR at the beginning of a header, it means
+                 # that we've reached the second of 2 newlines, and so there are
+                 # no more headers to parse.
+-                if c == CR:
++                if c == CR and index == 0:
+                     delete_mark("header_field")
+                     state = MultipartState.HEADERS_ALMOST_DONE
+                     i += 1


### PR DESCRIPTION
Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=67660 (Fuzz-Blocker)
This is a temp fix, till https://github.com/Kludex/python-multipart/pull/141 lands.