### PR TITLE
infra: apply coverage ignores when running locally

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -73,7 +73,7 @@ HTTPS_CORPUS_BACKUP_URL_FORMAT = (
 LANGUAGE_REGEX = re.compile(r'[^\s]+')
 PROJECT_LANGUAGE_REGEX = re.compile(r'\s*language\s*:\s*([^\s]+)')
 
-PROJECT_COVERAGE_EXTRA_ARGS = re.compile(
+PROJECT_COVERAGE_EXTRA_ARGS_REGEX = re.compile(
     r'\s*coverage_extra_args\s*:\s*([^\s]+)')
 
 WORKDIR_REGEX = re.compile(r'\s*WORKDIR\s*([^\s]+)')
@@ -163,7 +163,7 @@ class Project:
     with open(project_yaml_path) as file_handle:
       content = file_handle.read()
       for line in content.splitlines():
-        match = PROJECT_COVERAGE_EXTRA_ARGS.match(line)
+        match = PROJECT_COVERAGE_EXTRA_ARGS_REGEX.match(line)
         if match:
           return match.group(1)
     # Return empty string when no extra args are specified. No need to log a

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -157,7 +157,7 @@ class Project:
     project_yaml_path = os.path.join(self.build_integration_path,
                                      'project.yaml')
     if not os.path.exists(project_yaml_path):
-      logger.warning('No project.yaml.')
+      logger.warning('project.yaml not found: %s.', project_yaml_path)
       return ''
 
     with open(project_yaml_path) as file_handle:

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -1239,7 +1239,7 @@ def coverage(args):  # pylint: disable=too-many-branches
       return False
 
   extra_cov_args = (
-    f'{args.project.coverage_extra_args.strip()} {" ".join(args.extra_args)}')
+      f'{args.project.coverage_extra_args.strip()} {" ".join(args.extra_args)}')
   env = [
       'FUZZING_ENGINE=libfuzzer',
       'HELPER=True',


### PR DESCRIPTION
`coverage_extra_args` are currently only used in cloud builds e.g. https://github.com/google/oss-fuzz/blob/7db2eae0b12d30e14112a1b41aada627dd6de0a0/infra/build/functions/build_and_run_coverage.py#L128 and not locally. Besides being confusing, this can cause some issues with e.g. OSS-Fuzz-gen which relies on the `coverage` command to extract coverage reports, as it may end up comparing apples to oranges.

This commit fixes it by applying the coverage extra args when coverage is run by way of `infra/helper.py coverage`.