### PR TITLE
giflib: ignore LPM coverage

### DIFF
--- a/projects/giflib/project.yaml
+++ b/projects/giflib/project.yaml
@@ -10,4 +10,4 @@ fuzzing_engines:
   - afl
   - honggfuzz
   - libfuzzer
-
+coverage_extra_args: -ignore-filename-regex=.*/LPM/.*


### PR DESCRIPTION
This is to direct OSS-Fuzz-gen away from non-interesting targets