### PR TITLE
xerces-c: ignore LPM in coverage reports

### DIFF
--- a/projects/xerces-c/project.yaml
+++ b/projects/xerces-c/project.yaml
@@ -5,6 +5,7 @@ primary_contact: "vincent.ulitzsch@live.de"
 auto_ccs:
   - "vincent.ulitzsch@live.de"
   - "bshas3@gmail.com"
+coverage_extra_args: -ignore-filename-regex=.*/LPM/.*
 sanitizers:
  - address
  - memory


### PR DESCRIPTION
This is causing deflection for oss-fuzz-gen