### PR TITLE
Fix issue 59779

### DIFF
--- a/projects/binutils/fuzz_disassemble.c
+++ b/projects/binutils/fuzz_disassemble.c
@@ -82,6 +82,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     disasm_info.stream = &s;
     disasm_info.bytes_per_line = 0;
 
+    disasm_info.flags |= USER_SPECIFIED_MACHINE_TYPE;
     disasm_info.arch = Data[Size-1];
     disasm_info.mach = bfd_getl64(&Data[Size-9]);
     disasm_info.flavour = Data[Size-10];


### PR DESCRIPTION
private_data is supposed to be private to the disassembler.  It isn't valid to supply random private_data as an input, as was done in commit c7f7c24040.  One other reason for that change was presumably so that the arm disassembler took notice of the "mach" value supplied.  The correct way to do that is by setting USER_SPECIFIED_MACHINE_TYPE in disassemble_info.flags, which is what this patch does both for fuzz_disas_ext.c and fuzz_disassemble.c.  I've also removed random bytes_per_chunk input, also not a valid input, and corected the offset in Data for the start of insns.