### PR TITLE
wasmtime: Install `pkg-config` in build container

### DIFF
--- a/projects/wasmtime/Dockerfile
+++ b/projects/wasmtime/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder-rust
 RUN apt-get update && apt-get install -y make autoconf automake libtool curl \
   cmake python llvm-dev libclang-dev clang \
-  libgmp-dev
+  libgmp-dev pkg-config
 
 # Install a newer version of OCaml than provided by Ubuntu 16.04 (base version for this image)
 RUN curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh -o install.sh && \


### PR DESCRIPTION
The build of Wasmtime failed last night due to changes in the upstream installation script of OCaml so attempt to resolve the issues with the installation of `pkg-config`. I've tested locally that the build fails before this was installed and passes after it's installed.