### PR TITLE
xs: project updates and fixes

### DIFF
--- a/projects/xs/Dockerfile
+++ b/projects/xs/Dockerfile
@@ -39,6 +39,8 @@ RUN git clone --depth 1 https://github.com/tc39/test262 && \
     find test262/test/built-ins -iname '*.js' -exec stripcomments --write --confirm-overwrite '{}' \+ && \
     # strip empty lines
     find test262/test/built-ins -iname '*.js' -exec sed -i '/^[[:space:]]*$/d' '{}' \+ && \
+    # strip functions that sleep
+    find test262/test/built-ins -iname '*.js' -exec grep -l 'Atomics\.wait' {} \; -exec rm -f {} \; && \
     find test262/test/built-ins -iname '*.js' | zip -@ -q $SRC/xst_seed_corpus.zip
 
 RUN git clone --depth=1 https://github.com/Moddable-OpenSource/moddable moddable && \

--- a/projects/xs/build.sh
+++ b/projects/xs/build.sh
@@ -28,7 +28,7 @@ REALBIN_PATH=$OUT
 
 # build main target
 cd "$MODDABLE/xs/makefiles/lin"
-FUZZING=1 OSSFUZZ=1 FUZZ_METER=10240000 make debug
+FUZZING=1 OSSFUZZ=1 FUZZ_METER=2560000 make debug
 
 cd "$MODDABLE"
 cp ./build/bin/lin/debug/xst $REALBIN_PATH/xst
@@ -37,7 +37,7 @@ cp $SRC/xst.options $OUT/
 # build jsonparse target
 cd "$MODDABLE/xs/makefiles/lin"
 make -f xst.mk clean
-FUZZING=1 OSSFUZZ=1 OSSFUZZ_JSONPARSE=1 FUZZ_METER=10240000 make debug
+FUZZING=1 OSSFUZZ=1 OSSFUZZ_JSONPARSE=1 FUZZ_METER=2560000 make debug
 
 cd "$MODDABLE"
 cp ./build/bin/lin/debug/xst $REALBIN_PATH/xst_jsonparse

--- a/projects/xs/project.yaml
+++ b/projects/xs/project.yaml
@@ -4,12 +4,10 @@ primary_contact: "peter.hoddie@gmail.com"
 auto_ccs:
   - peter@moddable.com
   - ps@moddable.com
-  - ari@agoric.com
   - raphael@agoric.com
 sanitizers:
   - address
-  - memory:
-      experimental: True
+  - memory
   - undefined:
       experimental: True 
 main_repo: 'https://github.com/Moddable-OpenSource/moddable.git'

--- a/projects/xs/xst.options
+++ b/projects/xs/xst.options
@@ -1,3 +1,2 @@
 [asan]
 detect_stack_use_after_return=0
-leak_check_at_exit=0


### PR DESCRIPTION
Updating XS project:

* Removing experimental from MSAN.
* Updating auto ccs

Additionally, we update the build to :

- Reduce the number of metering units. This should fix timeouts -- the majority are test cases that run for too long and do not hit the meter limit.
- Re-enable `leak_check_at_exit`. We have a custom allocator for fuzzing, so we force purging memory in abort paths (to avoid "leaks" that are transient allocations expected to clean up at exit, which is imminent). As a result, we only report leaks that would have been long-lived, survived VM destruction, and therefore true memory leaks.
- Remove sleep functions from the seed corpus. This should fix timeouts caused by the fuzzer calling functions that sleep indefinitely.