### PR TITLE
librsvg: fix leak suppression

### DIFF
--- a/projects/librsvg/Dockerfile
+++ b/projects/librsvg/Dockerfile
@@ -40,7 +40,6 @@ RUN git clone --depth=1 --branch=1.18.0 https://gitlab.freedesktop.org/cairo/cai
 RUN git clone --depth=1 --branch=8.4.0 https://github.com/harfbuzz/harfbuzz.git
 RUN git clone --depth=1 --branch=1.52.2 https://gitlab.gnome.org/GNOME/pango.git
 
-COPY build.sh "$SRC/"
-COPY *.options "$OUT/"
+COPY build.sh *.options "$SRC/"
 
 WORKDIR "$SRC/librsvg"

--- a/projects/librsvg/build.sh
+++ b/projects/librsvg/build.sh
@@ -90,6 +90,9 @@ cargo update --package serde --precise 1.0.203
 cargo fuzz build -O
 cp target/x86_64-unknown-linux-gnu/release/render_document "$OUT/"
 
+# Copy options files for fuzz targets
+cp "$SRC"/*.options "$OUT/"
+
 # Build a seed corpus consisting of all the SVGs from the librsvg repo
 CORPUS_DIR="$WORK/corpus"
 mkdir -p "$CORPUS_DIR"


### PR DESCRIPTION
.options files copied to /out during image creation seem to get hidden by a later volume mount to /out.