### PR TITLE
bleach: fix dictionary copying

### DIFF
--- a/projects/bleach/Dockerfile
+++ b/projects/bleach/Dockerfile
@@ -24,7 +24,5 @@ RUN git clone \
 WORKDIR bleach
 
 RUN git clone --depth 1 https://github.com/google/fuzzing
-RUN cat fuzzing/dictionaries/html.dict > $OUT/linkify_fuzzer.dict
-RUN cat fuzzing/dictionaries/html.dict > $OUT/sanitize_fuzzer.dict
 
 COPY build.sh sanitize_fuzzer.py linkify_fuzzer.py $SRC/

--- a/projects/bleach/build.sh
+++ b/projects/bleach/build.sh
@@ -22,3 +22,7 @@ pip3 install .
 for fuzzer in $(find $SRC -name '*_fuzzer.py'); do
   compile_python_fuzzer $fuzzer
 done
+
+# Copy fuzzer dictionaries to $OUT
+cp fuzzing/dictionaries/html.dict "$OUT/linkify_fuzzer.dict"
+cp fuzzing/dictionaries/html.dict "$OUT/sanitize_fuzzer.dict"


### PR DESCRIPTION
Files copied to /out during image creation seem to get hidden by a volume mounted at /out when building the fuzzers.

I noticed this general issue while testing https://github.com/google/oss-fuzz/pull/12250.