### PR TITLE
helper: fix coverage extra args reading

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -162,6 +162,8 @@ class Project:
 
     coverage_flags = ''
     read_coverage_extra_args = False
+    # Pass the yaml file and extract the value of the coverage_extra_args key.
+    # This is naive yaml parsing and we do not handle comments at this point.
     for line in content.splitlines():
       if read_coverage_extra_args:
         # Break reading coverage args if a new yaml key is defined.

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -170,6 +170,7 @@ class Project:
         coverage_flags += line
       if 'coverage_extra_args' in line:
         read_coverage_extra_args = True
+        # Include the first line only if it's not a multi-line value.
         if 'coverage_extra_args: >' not in line:
           coverage_flags += line.replace('coverage_extra_args: ', '')
     return coverage_flags


### PR DESCRIPTION
There's a bit more to reading the coverage extra args in https://github.com/google/oss-fuzz/pull/12229. We need to essentially pass the whole yaml value. This fixes it.

Fixes: https://github.com/google/oss-fuzz/issues/12251
Fixes: https://github.com/google/oss-fuzz/issues/12252