### PR TITLE
pygments: fix dictionary placement

### DIFF
--- a/projects/pygments/Dockerfile
+++ b/projects/pygments/Dockerfile
@@ -26,38 +26,5 @@ RUN python3 -m pip install --upgrade pip
 WORKDIR pygments
 
 RUN git clone --depth 1 https://github.com/google/fuzzing
-RUN cat fuzzing/dictionaries/aff.dict \
-        fuzzing/dictionaries/bash.dict \
-        fuzzing/dictionaries/creole.dict \
-        fuzzing/dictionaries/css.dict \
-        fuzzing/dictionaries/graphviz.dict \
-        fuzzing/dictionaries/fbs.dict \
-        fuzzing/dictionaries/html.dict \
-        fuzzing/dictionaries/jinja2.dict \
-        fuzzing/dictionaries/js.dict \
-        fuzzing/dictionaries/json.dict \
-        fuzzing/dictionaries/lua.dict \
-        fuzzing/dictionaries/markdown.dict \
-        fuzzing/dictionaries/mathml.dict \
-        fuzzing/dictionaries/pdf.dict \
-        fuzzing/dictionaries/protobuf.dict \
-        fuzzing/dictionaries/ps.dict \
-        fuzzing/dictionaries/regexp.dict \
-        fuzzing/dictionaries/rst.dict \
-        fuzzing/dictionaries/rtf.dict \
-        fuzzing/dictionaries/sql.dict \
-        fuzzing/dictionaries/svg.dict \
-        fuzzing/dictionaries/tex.dict \
-        fuzzing/dictionaries/toml.dict \
-        fuzzing/dictionaries/utf8.dict \
-        fuzzing/dictionaries/vcf.dict \
-        fuzzing/dictionaries/wkt.dict \
-        fuzzing/dictionaries/x86.dict \
-        fuzzing/dictionaries/xml.dict \
-        fuzzing/dictionaries/xpath.dict \
-        fuzzing/dictionaries/xslt.dict \
-        fuzzing/dictionaries/yaml.dict \
-        fuzzing/dictionaries/yara.dict \
-      > $OUT/pygments_fuzzer.dict
 
 COPY build.sh fuzz_guesser.py fuzz_lexers.py $SRC/

--- a/projects/pygments/build.sh
+++ b/projects/pygments/build.sh
@@ -23,5 +23,42 @@ for fuzzer in $(find $SRC -name 'fuzz_*.py'); do
   compile_python_fuzzer $fuzzer
 done
 
+# Create shared seed corpus
 find tests/examplefiles/ -type f | zip -@ -q $OUT/fuzz_lexers_seed_corpus.zip
 cp $OUT/fuzz_lexers_seed_corpus.zip $OUT/fuzz_guesser_seed_corpus.zip
+
+# Create shared dictionary
+cat fuzzing/dictionaries/aff.dict \
+    fuzzing/dictionaries/bash.dict \
+    fuzzing/dictionaries/creole.dict \
+    fuzzing/dictionaries/css.dict \
+    fuzzing/dictionaries/graphviz.dict \
+    fuzzing/dictionaries/fbs.dict \
+    fuzzing/dictionaries/html.dict \
+    fuzzing/dictionaries/jinja2.dict \
+    fuzzing/dictionaries/js.dict \
+    fuzzing/dictionaries/json.dict \
+    fuzzing/dictionaries/lua.dict \
+    fuzzing/dictionaries/markdown.dict \
+    fuzzing/dictionaries/mathml.dict \
+    fuzzing/dictionaries/pdf.dict \
+    fuzzing/dictionaries/protobuf.dict \
+    fuzzing/dictionaries/ps.dict \
+    fuzzing/dictionaries/regexp.dict \
+    fuzzing/dictionaries/rst.dict \
+    fuzzing/dictionaries/sql.dict \
+    fuzzing/dictionaries/svg.dict \
+    fuzzing/dictionaries/tex.dict \
+    fuzzing/dictionaries/toml.dict \
+    fuzzing/dictionaries/utf8.dict \
+    fuzzing/dictionaries/vcf.dict \
+    fuzzing/dictionaries/wkt.dict \
+    fuzzing/dictionaries/x86.dict \
+    fuzzing/dictionaries/xml.dict \
+    fuzzing/dictionaries/xpath.dict \
+    fuzzing/dictionaries/xslt.dict \
+    fuzzing/dictionaries/yaml.dict \
+    fuzzing/dictionaries/yara.dict \
+> "$OUT/fuzz_lexers.dict"
+
+cp "$OUT/fuzz_lexers.dict" "$OUT/fuzz_guesser.dict"


### PR DESCRIPTION
Files copied to /out during image creation seem to get hidden by a volume mounted at /out when building the fuzzers.

Similar issues:
- https://github.com/google/oss-fuzz/pull/12254
- https://github.com/google/oss-fuzz/pull/12250