### PR TITLE
cilium: fix seed corpus placement

### DIFF
--- a/projects/cilium/Dockerfile
+++ b/projects/cilium/Dockerfile
@@ -19,7 +19,6 @@ RUN apt-get update && apt-get install -y wget
 RUN wget https://raw.githubusercontent.com/google/AFL/master/dictionaries/json.dict -O $OUT/fuzz.dict
 
 RUN git clone --depth 1 https://github.com/dvyukov/go-fuzz-corpus
-RUN zip $OUT/fuzz_seed_corpus.zip go-fuzz-corpus/json/corpus/*
 
 RUN git clone --depth 1 https://github.com/cilium/cilium
 RUN git clone --depth 1 https://github.com/cncf/cncf-fuzzing

--- a/projects/cilium/build.sh
+++ b/projects/cilium/build.sh
@@ -18,3 +18,5 @@
 
 $SRC/cilium/test/fuzzing/oss-fuzz-build.sh
 $SRC/cncf-fuzzing/projects/cilium/build.sh
+
+zip "$OUT/fuzz_seed_corpus.zip" "$SRC"/go-fuzz-corpus/json/corpus/*


### PR DESCRIPTION
Files copied to /out during image creation seem to get hidden by a volume mounted at /out when building the fuzzers.

Similar issues:
- https://github.com/google/oss-fuzz/pull/12254
- https://github.com/google/oss-fuzz/pull/12250
- https://github.com/google/oss-fuzz/pull/12259