### PR TITLE
[CHIP project] fix setuptools bug

### DIFF
--- a/projects/connectedhomeip/Dockerfile
+++ b/projects/connectedhomeip/Dockerfile
@@ -27,6 +27,10 @@ RUN apt-get update && \
 # the one already installed in /usr/local/bin
 ENV PATH="/usr/bin/:${PATH}"
 
+# This fixes setuptools bug related to version 71 
+# https://github.com/pypa/setuptools/issues/4483 
+RUN pip install -U packaging
+
 # PEP-517 needed for cryptography. Update pip
 RUN pip3 install --upgrade pip setuptools wheel
 


### PR DESCRIPTION
- this fixes docker build failure, due to bug introduced by update of [setuptools](https://pypi.org/project/setuptools/) python package to version 71

- the bug is described here: https://github.com/pypa/setuptools/issues/4483

- fix involves upgrading `packaging` to latest possible version, which fixes issue

