### PR TITLE
llvm: Re-enable dictionary builder

### DIFF
--- a/projects/llvm/build.sh
+++ b/projects/llvm/build.sh
@@ -179,14 +179,10 @@ cp $OUT/llvm-opt-fuzzer $OUT/llvm-opt-fuzzer--x86_64-sroa
 mv $OUT/llvm-opt-fuzzer $OUT/llvm-opt-fuzzer--x86_64-instcombine
 
 
-
-# 10th August 2022: The lines for building the dictionaries
-# broke the whole build. They are left as a reminder to re-enable
-# them once they have been fixed upstream.
-#ninja clang-fuzzer-dictionary
-#for fuzzer in "${CLANG_DICT_FUZZERS[@]}"; do
-#  bin/clang-fuzzer-dictionary > $OUT/$fuzzer.dict
-#done
+ninja clang-fuzzer-dictionary
+for fuzzer in "${CLANG_DICT_FUZZERS[@]}"; do
+  bin/clang-fuzzer-dictionary > $OUT/$fuzzer.dict
+done
 
 zip -j "${OUT}/clang-objc-fuzzer_seed_corpus.zip"  $SRC/$LLVM/../clang/tools/clang-fuzzer/corpus_examples/objc/*
 zip -j "${OUT}/clangd-fuzzer_seed_corpus.zip"  $SRC/$LLVM/../clang-tools-extra/clangd/test/*


### PR DESCRIPTION
This was disabled in d154d875ada04e4edeb1f9a9f1f13f1f826c11ff to fix a build issue in LLVM. That build issue was just
[fixed](https://github.com/llvm/llvm-project/pull/99871) and this patch reenables the dict generation.