### PR TITLE
Initial project skeleton xhtml2pdf

### DIFF
--- a/projects/xhtml2pdf/project.yaml
+++ b/projects/xhtml2pdf/project.yaml
@@ -1,0 +1,11 @@
+homepage: "https://xhtml2pdf.readthedocs.io/en/latest/"
+language: python
+primary_contact: "github@timo.brembeck.email"
+auto_ccs: 
+  - "ennamarie19@gmail.com"
+fuzzing_engines: 
+  - libfuzzer
+sanitizers: 
+  - address
+  - undefined
+main_repo: "https://github.com/xhtml2pdf/xhtml2pdf.git"


### PR DESCRIPTION
xhtml2pdf is a HTML to PDF converter using Python, the ReportLab Toolkit, html5lib and pypdf. The main benefit of this tool is that a user with web skills like HTML and CSS is able to generate PDF templates very quickly without learning new technologies. 15,713 repositories depend on xhtml2pdf, most notably maigret (9.9k+ stars), rst2pdf, aequitas, tendenci and django-easy-pdf. This is a security critical repository because people use this repository to convert html to pdf. For example, a bad actor could insert malicious code into the codebase that inserts macros into every generated pdf file. Further, this repo should be continuously fuzzed for bugs and vulnerabilities so that these dependent 15k repositories are put at less of a risk.