### PR TITLE
(Fixed) Prost information out of date

### DIFF
--- a/projects/prost/project.yaml
+++ b/projects/prost/project.yaml
@@ -1,6 +1,6 @@
 homepage: "https://crates.io/crates/prost"
-main_repo: "https://github.com/danburkert/prost"
-primary_contact: "dan@danburkert.com"
+main_repo: "https://github.com/tokio-rs/prost"
+primary_contact: "luciofranco14@gmail.com"
 sanitizers:
   - address
 fuzzing_engines:
@@ -8,3 +8,4 @@ fuzzing_engines:
 language: rust
 auto_ccs:
   - "david@adalogics.com"
+  - "casper@meijn.net"


### PR DESCRIPTION
Fixes #12209

Updated the information in  https://github.com/google/oss-fuzz/blob/master/projects/prost/project.yaml