### PR TITLE
[rnp] Update to Botan 3.5.0

### DIFF
--- a/projects/rnp/build.sh
+++ b/projects/rnp/build.sh
@@ -17,12 +17,16 @@
 
 cd "$SRC"
 
-wget -qO- https://botan.randombit.net/releases/Botan-2.16.0.tar.xz | tar xJ
-cd Botan-2.16.0
+wget -qO- https://botan.randombit.net/releases/Botan-3.4.0.tar.xz | tar xJ
+cd Botan-3.4.0
+# Once updated to the 3.5.0, use  | sed 's/curve25519/x25519/g' below
+BOTAN_MODULES=$(<"$SRC/rnp/ci/botan3-modules" tr '\n' ',')
 ./configure.py --prefix=/usr --cc-bin="$CXX" --cc-abi-flags="$CXXFLAGS" \
+               --unsafe-fuzzer-mode \
+               --with-fuzzer-lib='FuzzingEngine' \
+               --minimized-build \
                --disable-modules=locking_allocator \
-               --unsafe-fuzzer-mode --build-fuzzers=libfuzzer \
-               --with-fuzzer-lib='FuzzingEngine'
+               --enable-modules="$BOTAN_MODULES"
 make "-j$(nproc)"
 make install
 
@@ -48,7 +52,6 @@ cmake \
     -DBUILD_SHARED_LIBS=on \
     -DBUILD_TESTING=off \
     -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
-    -DDOWNLOAD_SEXP:BOOL=ON \
     "$SRC/rnp"
 make "-j$(nproc)"
 
@@ -62,5 +65,5 @@ done
 
 mkdir -p "${OUT}/lib"
 cp src/lib/librnp.so.0 "${OUT}/lib/"
-cp /usr/lib/libbotan-2.so.16 "${OUT}/lib/"
+cp /usr/lib/libbotan-3.so.* "${OUT}/lib/"
 cp /lib/x86_64-linux-gnu/libjson-c.so.* "${OUT}/lib/"

--- a/projects/rnp/build.sh
+++ b/projects/rnp/build.sh
@@ -15,49 +15,49 @@
 #
 ################################################################################
 
-cd $SRC
+cd "$SRC"
 
 wget -qO- https://botan.randombit.net/releases/Botan-2.16.0.tar.xz | tar xJ
 cd Botan-2.16.0
-./configure.py --prefix=/usr --cc-bin=$CXX --cc-abi-flags="$CXXFLAGS" \
+./configure.py --prefix=/usr --cc-bin="$CXX" --cc-abi-flags="$CXXFLAGS" \
                --disable-modules=locking_allocator \
                --unsafe-fuzzer-mode --build-fuzzers=libfuzzer \
                --with-fuzzer-lib='FuzzingEngine'
-make -j$(nproc)
+make "-j$(nproc)"
 make install
 
-cd $SRC
+cd "$SRC"
 mkdir fuzzing_corpus
 
-cd $SRC/rnp/src/tests/data
-find . -type f -print0 | xargs -0 -I bob -- cp bob $SRC/fuzzing_corpus/
+cd "$SRC/rnp/src/tests/data"
+find . -type f -print0 | xargs -0 -I bob -- cp bob "$SRC/fuzzing_corpus/"
 
 # -DENABLE_SANITIZERS=0 because oss-fuzz will add the sanitizer flags in CFLAGS
 # See https://github.com/google/oss-fuzz/pull/4189 to explain CMAKE_C_LINK_EXECUTABLE
 
-cd $SRC
+cd "$SRC"
 mkdir rnp-build
 cd rnp-build
 cmake \
     -DENABLE_SANITIZERS=0 \
     -DENABLE_FUZZERS=1 \
-    -DCMAKE_C_COMPILER=$CC \
-    -DCMAKE_CXX_COMPILER=$CXX \
+    -DCMAKE_C_COMPILER="$CC" \
+    -DCMAKE_CXX_COMPILER="$CXX" \
     -DCMAKE_C_LINK_EXECUTABLE="$CXX <FLAGS> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS>  -o <TARGET> <LINK_LIBRARIES>" \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DBUILD_SHARED_LIBS=on \
     -DBUILD_TESTING=off \
     -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
     -DDOWNLOAD_SEXP:BOOL=ON \
-    $SRC/rnp
-make -j$(nproc)
+    "$SRC/rnp"
+make "-j$(nproc)"
 
-FUZZERS=`find src/fuzzing -maxdepth 1 -type f -name "fuzz_*" -exec basename {} \;`
-printf "Detected fuzzers: \n$FUZZERS\n"
+FUZZERS=$(find src/fuzzing -maxdepth 1 -type f -name "fuzz_*" -exec basename {} \;)
+printf "Detected fuzzers: \n%s\n" "$FUZZERS"
 for f in $FUZZERS; do
-    cp src/fuzzing/$f "${OUT}/"
-    patchelf --set-rpath '$ORIGIN/lib' "${OUT}/$f" || echo "patchelf failed with $?, ignoring."
-    zip -j -r "${OUT}/${f}_seed_corpus.zip" $SRC/fuzzing_corpus/
+    cp "src/fuzzing/$f" "${OUT}/"
+    patchelf --set-rpath "\$ORIGIN/lib" "${OUT}/$f" || echo "patchelf failed with $?, ignoring."
+    zip -j -r "${OUT}/${f}_seed_corpus.zip" "$SRC/fuzzing_corpus/"
 done
 
 mkdir -p "${OUT}/lib"

--- a/projects/rnp/project.yaml
+++ b/projects/rnp/project.yaml
@@ -11,4 +11,5 @@ fuzzing_engines:
   - libfuzzer
   - honggfuzz
   - afl
+  - centipede
 main_repo: 'https://github.com/rnpgp/rnp.git'


### PR DESCRIPTION
This PR updates used Botan version to 3.5.0 and limits number of built modules for performance reasons.