### PR TITLE
[GitPython] Update Project Contributor's Email in Auto-CC List

### DIFF
--- a/projects/gitpython/project.yaml
+++ b/projects/gitpython/project.yaml
@@ -3,7 +3,7 @@ language: python
 primary_contact: "byronimo@gmail.com"
 auto_ccs:
   - "david.js.lakin@gmail.com"
-  - "eliah.kagan@gmail.com"
+  - "eliahkagan@gmail.com"
 main_repo: "https://github.com/gitpython-developers/gitpython"
 fuzzing_engines:
   - libfuzzer


### PR DESCRIPTION
Removed a dot (`.`) from @EliahKagan's Gmail address that we suspect is preventing him from being able to properly authenticate on Monorail, thus blocking his access to undisclosed bugs he should be able to view for the GitPython project.

Ref: https://github.com/gitpython-developers/GitPython/discussions/1947