### PR TITLE
librsvg: set detect_leaks=0 in ASAN_OPTIONS

### DIFF
--- a/projects/librsvg/render_document.options
+++ b/projects/librsvg/render_document.options
@@ -1,4 +1,8 @@
-[libfuzzer]
 # Suppress spurious leak reports:
 # https://gnome.pages.gitlab.gnome.org/librsvg/devel-docs/memory_leaks.html
+
+[asan]
+detect_leaks = 0
+
+[libfuzzer]
 detect_leaks = 0


### PR DESCRIPTION
libFuzzer is still reporting leaks when run with -detect_leaks=0, so we now set ASAN_OPTIONS="detect_leaks=0" as well.