### PR TITLE
ffmpeg: disable Centipede again

### DIFF
--- a/projects/ffmpeg/project.yaml
+++ b/projects/ffmpeg/project.yaml
@@ -14,7 +14,6 @@ auto_ccs:
  - "jordyzomer@google.com"
 fuzzing_engines:
  - afl
- - centipede
  - honggfuzz
  - libfuzzer
 sanitizers:


### PR DESCRIPTION
It is not stable, there are multiple bus errors:

Step #22 - "build-check-centipede-none-x86_64":
/usr/local/bin/run_fuzzer: line 227: 172132 Bus error (core dumped) bash -c "$CMD_LINE"

Disable it for now, to let other recent changes take effect, we can revisit it later.

Fixes: 0318a945e1399771083778242866db369ad06900