### PR TITLE
[simdutf] make cifuzz work better for pull requests

### DIFF
--- a/projects/simdutf/build.sh
+++ b/projects/simdutf/build.sh
@@ -1,4 +1,5 @@
-# Copyright 2023 Google LLC
+#!/bin/bash -eu
+# Copyright 2024 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,8 +15,4 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make cmake
-RUN git clone --depth 1 https://github.com/simdutf/simdutf simdutf
-WORKDIR simdutf
-COPY build.sh $SRC/
+fuzz/build.sh


### PR DESCRIPTION
I recently made changes to the fuzzer build script in the simdutf repo. The CIfuzz job failed.

The reason is that CIfuzz checks out the default branch when building the docker image.
The current dockerfile copied the build script into the docker image.

This means the build script is used from the default branch, while doing CIfuzz on the PR branch. This broke when I made changes to the build script.

With the changes in this PR, the build script from the checked out code (the PR to run CIfuzz on) is executed instead. That should make it more robust, and make it possible to work with improvements in the build script without having to merge first.

Ping @lemire 