### PR TITLE
bitcoin-core: fix seccp256k1 configure option

### DIFF
--- a/projects/bitcoin-core/build_cryptofuzz.sh
+++ b/projects/bitcoin-core/build_cryptofuzz.sh
@@ -52,7 +52,8 @@ function build_libsecp256k1() {
         --enable-module-recovery
         --enable-experimental
         --enable-module-schnorrsig
-        --enable-module-ecdh"
+        --enable-module-ecdh
+        --enable-option-checking"
 
     if [[ $CFLAGS = *sanitize=memory* ]]
     then
@@ -151,24 +152,24 @@ cd ../../
 # Build with 3 configurations of libsecp256k1
 # Discussion: https://github.com/google/oss-fuzz/pull/5717#issuecomment-842765383
 
-build_libsecp256k1 "--with-ecmult-window=2" "--with-ecmult-gen-precision=2"
+build_libsecp256k1 "--with-ecmult-window=2" "--with-ecmult-gen-kb=2"
 cd $SRC/cryptofuzz/
 make -B -j$(nproc)
-cp cryptofuzz $OUT/cryptofuzz-bitcoin-cryptography-w2-p2
+cp cryptofuzz $OUT/cryptofuzz-bitcoin-cryptography-w2-kb2
 
-build_libsecp256k1 "--with-ecmult-window=15" "--with-ecmult-gen-precision=4"
+build_libsecp256k1 "--with-ecmult-window=15" "--with-ecmult-gen-kb=22"
 cd $SRC/cryptofuzz/
 rm cryptofuzz
 make
-cp cryptofuzz $OUT/cryptofuzz-bitcoin-cryptography-w15-p4
+cp cryptofuzz $OUT/cryptofuzz-bitcoin-cryptography-w15-kb22
 
 # If the window size is larger than 15, this file must be deleted before proceeding
 rm $SRC/secp256k1/src/precomputed_ecmult.c
-build_libsecp256k1 "--with-ecmult-window=20" "--with-ecmult-gen-precision=8"
+build_libsecp256k1 "--with-ecmult-window=20" "--with-ecmult-gen-kb=86"
 cd $SRC/cryptofuzz/
 rm cryptofuzz
 make
-cp cryptofuzz $OUT/cryptofuzz-bitcoin-cryptography-w20-p8
+cp cryptofuzz $OUT/cryptofuzz-bitcoin-cryptography-w20-kb86
 
 # Convert Wycheproof test vectors to Cryptofuzz corpus format
 mkdir $SRC/corpus-cryptofuzz-wycheproof/
@@ -176,6 +177,6 @@ find $SRC/wycheproof/testvectors/ -type f -name 'ecdsa_secp256k1_*' -exec $SRC/c
 # Pack the Wycheproof test vectors
 zip -j cryptofuzz-bitcoin-cryptography_seed_corpus.zip $SRC/corpus-cryptofuzz-wycheproof/*
 # Use them as the seed corpus for each of the fuzzers
-cp cryptofuzz-bitcoin-cryptography_seed_corpus.zip $OUT/cryptofuzz-bitcoin-cryptography-w2-p2_seed_corpus.zip
-cp cryptofuzz-bitcoin-cryptography_seed_corpus.zip $OUT/cryptofuzz-bitcoin-cryptography-w15-p4_seed_corpus.zip
-cp cryptofuzz-bitcoin-cryptography_seed_corpus.zip $OUT/cryptofuzz-bitcoin-cryptography-w20-p8_seed_corpus.zip
+cp cryptofuzz-bitcoin-cryptography_seed_corpus.zip $OUT/cryptofuzz-bitcoin-cryptography-w2-kb2_seed_corpus.zip
+cp cryptofuzz-bitcoin-cryptography_seed_corpus.zip $OUT/cryptofuzz-bitcoin-cryptography-w15-kb22_seed_corpus.zip
+cp cryptofuzz-bitcoin-cryptography_seed_corpus.zip $OUT/cryptofuzz-bitcoin-cryptography-w20-kb86_seed_corpus.zip


### PR DESCRIPTION
This option was renamed in https://github.com/bitcoin-core/secp256k1/pull/1058, resulting in `configure: WARNING: unrecognized options: --with-ecmult-gen-precision`.

Update the option and change the values.

Also add `--enable-option-checking`, so that it'll be harder for this to happen in future. See:
https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.72/html_node/Option-Checking.html.