### PR TITLE
[initial integration] Add Xen Hypervisor Project

### DIFF
--- a/projects/xen/Dockerfile
+++ b/projects/xen/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN apt-get update && apt-get -y install iasl uuid-dev \
+    libncurses-dev pkg-config libglib2.0-dev libpixman-1-dev \
+    libyajl-dev
+RUN git clone --depth=1 https://xenbits.xen.org/git-http/xen.git
+
+COPY build.sh $SRC/

--- a/projects/xen/build.sh
+++ b/projects/xen/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+chmod +x xen/tools/fuzz/oss-fuzz/build.sh
+xen/tools/fuzz/oss-fuzz/build.sh

--- a/projects/xen/project.yaml
+++ b/projects/xen/project.yaml
@@ -5,7 +5,7 @@ auto_ccs:
   - "tamas.k.lengyel@gmail.com"
   - "jbeulich@suse.com"
   - "andrew.cooper3@citrix.com"
-  - "roger.pau@citrix.com"
+  - "roger.pau@cloud.com"
   - "sstabellini@kernel.org"
 sanitizers:
   - address

--- a/projects/xen/project.yaml
+++ b/projects/xen/project.yaml
@@ -1,0 +1,14 @@
+homepage: https://xenproject.org
+language: c
+main_repo: https://xenbits.xen.org/git-http/xen.git
+auto_ccs:
+  - "tamas.k.lengyel@gmail.com"
+  - "jbeulich@suse.com"
+  - "andrew.cooper3@citrix.com"
+  - "roger.pau@citrix.com"
+  - "sstabellini@kernel.org"
+sanitizers:
+  - address
+  - undefined
+fuzzing_engines:
+  - libfuzzer


### PR DESCRIPTION
The [Xen Hypervisor Project ](https://xenproject.org) is a type-1 VMM that's fairly popular and is widely deployed. It currently implements a libfuzzer harness for its core x86 instruction emulator code which is build-compatible with oss-fuzz. In this PR we pull in the Xen build to start continuous fuzzing for this critical piece of code, and potentially additional harnesses in the future.