### PR TITLE
mpv: disable scale filter in ffmpeg build

### DIFF
--- a/projects/mpv/build.sh
+++ b/projects/mpv/build.sh
@@ -34,7 +34,7 @@ pushd $SRC/ffmpeg
 ./configure --cc=$CC --cxx=$CXX --ld="$CXX $CXXFLAGS" \
             --enable-{gpl,nonfree} \
             --disable-{asm,bsfs,doc,encoders,filters,muxers,network,postproc,programs,shared} \
-            --enable-filter={scale,sine,yuvtestsrc} \
+            --enable-filter={sine,yuvtestsrc} \
             --pkg-config-flags="--static" \
             $FFMPEG_BUILD_ARGS
 make -j`nproc`

--- a/projects/mpv/project.yaml
+++ b/projects/mpv/project.yaml
@@ -19,4 +19,5 @@ fuzzing_engines:
 selective_unpack: true
 coverage_extra_args: >
   -ignore-filename-regex=mpv/subprojects/.*
+  -ignore-filename-regex=mpv/build/subprojects/.*
   -ignore-filename-regex=ffmpeg/.*


### PR DESCRIPTION
Fixes timeouts and OOMs on huge scaling sizes. It is not mpv filter anyway, so we can skip testing it.