### PR TITLE
Add Amine Alami to CCs for connectedhomeip fuzzing

### DIFF
--- a/projects/connectedhomeip/project.yaml
+++ b/projects/connectedhomeip/project.yaml
@@ -7,6 +7,7 @@ auto_ccs:
   - "mboyington@google.com"
   - "szewczyk@google.com"
   - "tennessee@google.com"
+  - "aalami@csa-iot.org"
 sanitizers:
   - address
   - undefined


### PR DESCRIPTION
Amine is part of the CSA staff that maintains the testing and automation and in particular fuzz tests and build health for them.