### PR TITLE
Ensure up-to-date dependencies for Capstone Python bindings.

### DIFF
--- a/projects/capstone/Dockerfile
+++ b/projects/capstone/Dockerfile
@@ -16,6 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-python
 RUN apt-get update && apt-get install -y make cmake
+RUN pip3 install --upgrade setuptools build wheel
 RUN git clone --depth 1 --branch v5 https://github.com/aquynh/capstone.git capstonev5
 RUN git clone --depth 1 --branch next https://github.com/aquynh/capstone.git capstonenext
 WORKDIR $SRC


### PR DESCRIPTION
The `base-builder-python` docker image installs `setuptools` `v42.0`. This is very likely the reason why Capstone's `setup.py` fails.

@DavidKorczynski Is there any reason why it is set to this (very old) version? The [docs](https://google.github.io/oss-fuzz/getting-started/new-project-guide/python-lang/#dockerfile) recommend this one.