### PR TITLE
Ensure up-to-date dependencies for Capstone Python bindings

### DIFF
--- a/projects/capstone/Dockerfile
+++ b/projects/capstone/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-python
 RUN apt-get update && apt-get install -y make cmake
-RUN pip3 install --upgrade setuptools build wheel
+RUN pip3 install --upgrade setuptools build wheel pip
 RUN git clone --depth 1 --branch v5 https://github.com/capstone-engine/capstone.git capstonev5
 RUN git clone --depth 1 --branch next https://github.com/capstone-engine/capstone.git capstonenext
 WORKDIR $SRC

--- a/projects/capstone/Dockerfile
+++ b/projects/capstone/Dockerfile
@@ -16,7 +16,8 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-python
 RUN apt-get update && apt-get install -y make cmake
-RUN git clone --depth 1 --branch v5 https://github.com/aquynh/capstone.git capstonev5
-RUN git clone --depth 1 --branch next https://github.com/aquynh/capstone.git capstonenext
+RUN pip3 install --upgrade setuptools build wheel
+RUN git clone --depth 1 --branch v5 https://github.com/capstone-engine/capstone.git capstonev5
+RUN git clone --depth 1 --branch next https://github.com/capstone-engine/capstone.git capstonenext
 WORKDIR $SRC
 COPY build.sh $SRC/

--- a/projects/capstone/build.sh
+++ b/projects/capstone/build.sh
@@ -18,7 +18,7 @@
 #add next branch
 for branch in v5 next
 do
-    cd capstone$branch
+    cd $SRC/capstone$branch
     # build project
     mkdir build
     # does not seem to work in source directory
@@ -33,7 +33,7 @@ do
     (
     export CFLAGS=""
     export AFL_NOOPT=1
-    python3 setup.py install
+    pip install .
     )
     cd $SRC/capstone$branch/suite
     mkdir fuzz/corpus
@@ -53,5 +53,5 @@ do
     fi
     $CXX $CXXFLAGS $FUZZO -o $OUT/fuzz_disasm$branch libcapstone.a $LIB_FUZZING_ENGINE
 
-    cd ../../
+    pip uninstall -y capstone
 done

--- a/projects/capstone/build.sh
+++ b/projects/capstone/build.sh
@@ -33,7 +33,7 @@ do
     (
     export CFLAGS=""
     export AFL_NOOPT=1
-    python3 -m pip install -y .
+    python3 -m pip install .
     )
     cd $SRC/capstone$branch/suite
     mkdir fuzz/corpus

--- a/projects/capstone/build.sh
+++ b/projects/capstone/build.sh
@@ -33,7 +33,7 @@ do
     (
     export CFLAGS=""
     export AFL_NOOPT=1
-    pip install .
+    python3 -m pip install -y .
     )
     cd $SRC/capstone$branch/suite
     mkdir fuzz/corpus
@@ -53,5 +53,5 @@ do
     fi
     $CXX $CXXFLAGS $FUZZO -o $OUT/fuzz_disasm$branch libcapstone.a $LIB_FUZZING_ENGINE
 
-    pip uninstall -y capstone
+    python3 -m pip uninstall -y capstone
 done


### PR DESCRIPTION
The `base-builder-python` docker image installs `setuptools v42.0`. This is very likely the reason why Capstone's `setup.py` fails.

@DavidKorczynski Is there any reason why it is set to this (very old) version? The [docs](https://google.github.io/oss-fuzz/getting-started/new-project-guide/python-lang/#dockerfile) recommend this one.