### PR TITLE
arrow: Enable more compression libraries for Arrow

### DIFF
--- a/projects/arrow/build.sh
+++ b/projects/arrow/build.sh
@@ -59,10 +59,10 @@ cmake ${ARROW} -GNinja \
     -DPARQUET_REQUIRE_ENCRYPTION=off \
     -DARROW_WITH_BROTLI=on \
     -DARROW_WITH_BZ2=off \
-    -DARROW_WITH_LZ4=off \
-    -DARROW_WITH_SNAPPY=off \
-    -DARROW_WITH_ZLIB=off \
-    -DARROW_WITH_ZSTD=off \
+    -DARROW_WITH_LZ4=on \
+    -DARROW_WITH_SNAPPY=on \
+    -DARROW_WITH_ZLIB=on \
+    -DARROW_WITH_ZSTD=on \
     -DARROW_USE_GLOG=off \
     -DARROW_USE_ASAN=off \
     -DARROW_USE_UBSAN=off \

--- a/projects/arrow/build.sh
+++ b/projects/arrow/build.sh
@@ -35,6 +35,7 @@ cd ${WORK}
 # would report leaks and error out.
 export ASAN_OPTIONS="detect_leaks=0"
 
+# Snappy disabled as it forces `-fno-rtti`, which is incompatible with UBSAN.
 cmake ${ARROW} -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
     -DARROW_DEPENDENCY_SOURCE=BUNDLED \
@@ -60,7 +61,7 @@ cmake ${ARROW} -GNinja \
     -DARROW_WITH_BROTLI=on \
     -DARROW_WITH_BZ2=off \
     -DARROW_WITH_LZ4=on \
-    -DARROW_WITH_SNAPPY=on \
+    -DARROW_WITH_SNAPPY=off \
     -DARROW_WITH_ZLIB=on \
     -DARROW_WITH_ZSTD=on \
     -DARROW_USE_GLOG=off \


### PR DESCRIPTION
This may allow to find potentially more issues inside the Arrow C++ codebase.