### PR TITLE
[Pillow] Removed python symlink

### DIFF
--- a/projects/pillow/Dockerfile
+++ b/projects/pillow/Dockerfile
@@ -43,7 +43,8 @@ RUN python3 -m pip install --upgrade pip
 COPY build.sh $SRC/
 
 # pillow optional runtime dependencies
-RUN apt-get install -y \
+RUN apt-get update && \
+    apt-get install -y \
      python3-tk \
      tcl8.6-dev \
      tk8.6-dev

--- a/projects/pillow/Dockerfile
+++ b/projects/pillow/Dockerfile
@@ -29,8 +29,7 @@ RUN $SRC/Pillow/Tests/oss-fuzz/build_dictionaries.sh
 
 COPY build_depends.sh $SRC
 
-RUN ln -s /usr/local/bin/python3 /usr/local/bin/python \
-    && ln -s /bin/true /usr/local/bin/yum_install \
+RUN ln -s /bin/true /usr/local/bin/yum_install \
     && ln -s /bin/true /usr/local/bin/yum \
     && cd $SRC/Pillow \
     && git submodule update --init wheels/multibuild \


### PR DESCRIPTION
Pillow's oss-fuzz is currently failing, because Pillow main has [dropped support for Python 3.8](https://github.com/python-pillow/Pillow/pull/8183).

#12027 attempts to resolve this by upgrading the base builder to Python 3.10, but the [latest status update](https://github.com/google/oss-fuzz/pull/12027#issuecomment-2278901499) over there says that Pillow [fails in that branch with](https://oss-fuzz-gcb-logs.storage.googleapis.com/log-e19625fb-a984-47b1-be32-f92b4c76fc7f.txt)
> Step 17: Step 6/11 : RUN ln -s /usr/local/bin/python3 /usr/local/bin/python     && ln -s /bin/true /usr/local/bin/yum_install     && ln -s /bin/true /usr/local/bin/yum     && cd $SRC/Pillow     && git submodule update --init wheels/multibuild     && bash $SRC/build_depends.sh
Step 17:  ---> Running in 932abd1dc89a
Step 17: [91mln: failed to create symbolic link '/usr/local/bin/python': File exists

So this pull request removes the python symlink in order to try and help.

cc @hugovk