### PR TITLE
bind9: Add libdns constructor and destructor symbols

### DIFF
--- a/projects/bind9/build.sh
+++ b/projects/bind9/build.sh
@@ -25,23 +25,23 @@ make -C tests/libtest -j"$(nproc)" all V=1
 LIBISC_CFLAGS="-Ilib/isc/include"
 LIBDNS_CFLAGS="-Ilib/dns/include"
 LIBISC_LIBS="lib/isc/.libs/libisc.a -Wl,-Bstatic -Wl,-u,isc__initialize,-u,isc__shutdown -lssl -lcrypto -lurcu-memb -lurcu-cds -lurcu-common -luv -lnghttp2 -Wl,-Bdynamic"
-LIBDNS_LIBS="lib/dns/.libs/libdns.a -Wl,-Bstatic -lcrypto -lurcu-memb -lurcu-cds -Wl,-Bdynamic"
+LIBDNS_LIBS="lib/dns/.libs/libdns.a -Wl,-Bstatic -Wl,-u,dst__lib_init -Wl,-u,dst__lib_destroy -Wl,-u,initialize_bits_for_byte -lcrypto -lurcu-memb -lurcu-cds -Wl,-Bdynamic"
 LIBTEST_LIBS="tests/libtest/.libs/libtest.a"
 
 # dns_name_fromwire needs old.c/old.h code to be linked in
 sed -i 's/#include "old.h"/#include "old.c"/' fuzz/dns_name_fromwire.c
 
 for fuzzer in fuzz/*.c; do
-    output=$(basename "${fuzzer%.c}")
-    [ "$output" = "main" ] && continue
-    [ "$output" = "old" ] && continue
-    # We need to try little bit harder to link everything statically
-    make -C fuzz -j"$(nproc)" "${output}.o" V=1
-    ${CXX} ${CXXFLAGS} \
-	   -o "${OUT}/${output}_fuzzer" \
-	   "fuzz/${output}.o" \
-	   -include config.h \
-	   $LIBISC_CFLAGS $LIBDNS_CFLAGS \
-	   $LIBDNS_LIBS $LIBISC_LIBS $LIBTEST_LIBS $LIB_FUZZING_ENGINE
-    zip -j "${OUT}/${output}_seed_corpus.zip" "fuzz/${output}.in/"*
+	output=$(basename "${fuzzer%.c}")
+	[ "$output" = "main" ] && continue
+	[ "$output" = "old" ] && continue
+	# We need to try little bit harder to link everything statically
+	make -C fuzz -j"$(nproc)" "${output}.o" V=1
+	${CXX} ${CXXFLAGS} \
+		-o "${OUT}/${output}_fuzzer" \
+		"fuzz/${output}.o" \
+		-include config.h \
+		$LIBISC_CFLAGS $LIBDNS_CFLAGS \
+		$LIBDNS_LIBS $LIBISC_LIBS $LIBTEST_LIBS $LIB_FUZZING_ENGINE
+	zip -j "${OUT}/${output}_seed_corpus.zip" "fuzz/${output}.in/"*
 done

--- a/projects/bind9/project.yaml
+++ b/projects/bind9/project.yaml
@@ -5,7 +5,6 @@ auto_ccs:
   - "artem@isc.org"
   - "aram@isc.org"
   - "each@isc.org"
-  - "fanf@isc.org"
   - "marka@isc.org"
   - "matthijs@isc.org"
   - "michal@isc.org"


### PR DESCRIPTION
The libdns now has constructors and destructors too, we need to add them to the linker list of undefined symbols to keep otherwise they will be removed when statically linked to the fuzz binaries.