### PR TITLE
[cups-filters] Init integration

### DIFF
--- a/projects/cups-filters/Dockerfile
+++ b/projects/cups-filters/Dockerfile
@@ -18,9 +18,10 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool build-essential 
 
 # for cups-filters-2.x
-RUN apt-get install -y gnutls-dev libppd-dev libavahi-common-dev libavahi-client-dev autopoint gettext libcups2-dev ghostscript mupdf-tools 
+RUN apt-get update && apt-get install -y gnutls-dev libppd-dev libavahi-common-dev libavahi-client-dev autopoint gettext libcups2-dev ghostscript mupdf-tools 
+
 # for cups-filters-1.x
-RUN apt-get install -y libexif-dev libglib2.0-dev libavahi-glib-dev liblcms2-dev libfreetype6-dev libfontconfig1-dev libqpdf-dev libpoppler-cpp-dev poppler-utils \
+RUN apt-get update && apt-get install -y libexif-dev libglib2.0-dev libavahi-glib-dev liblcms2-dev libfreetype6-dev libfontconfig1-dev libqpdf-dev libpoppler-cpp-dev poppler-utils \
 libunistring-dev libsystemd-dev libcap-dev
 
 # ubuntu 20.04 only supports cups-filters 1.x

--- a/projects/cups-filters/Dockerfile
+++ b/projects/cups-filters/Dockerfile
@@ -1,0 +1,31 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool build-essential 
+
+# for cups-filters-2.x
+RUN apt-get install -y gnutls-dev libppd-dev libavahi-common-dev libavahi-client-dev autopoint gettext libcups2-dev ghostscript mupdf-tools 
+# for cups-filters-1.x
+RUN apt-get install -y libexif-dev libglib2.0-dev libavahi-glib-dev liblcms2-dev libfreetype6-dev libfontconfig1-dev libqpdf-dev libpoppler-cpp-dev poppler-utils \
+libunistring-dev libsystemd-dev libcap-dev
+
+# ubuntu 20.04 only supports cups-filters 1.x
+RUN git clone --depth 1 -b "1.x" https://github.com/OpenPrinting/cups-filters.git
+RUN git clone --depth 1 https://github.com/OpenPrinting/fuzzing.git
+        
+RUN cp $SRC/fuzzing/projects/cups-filters/oss_fuzz_build.sh $SRC/build.sh   
+WORKDIR $SRC/cups-filters                   

--- a/projects/cups-filters/project.yaml
+++ b/projects/cups-filters/project.yaml
@@ -1,0 +1,31 @@
+homepage: "https://github.com/OpenPrinting/cups-filters"
+main_repo: "https://github.com/OpenPrinting/cups-filters.git"
+# help_url:
+language: c++
+
+primary_contact: "jiongchiyu@gmail.com"
+auto_ccs:
+  - "till.kamppeter@gmail.com"
+  - "ossfuzz@iosifache.me"
+  # - "msweet@msweet.org"
+  # - "jsmeix@suse.de"
+  # - "debian@alteholz.de"
+  # - "zdohnal@redhat.com"
+  # - "basu.aveek@gmail.com"
+# vendor_ccs:
+
+architectures:
+  - x86_64
+  # - i386
+
+sanitizers:
+  - address
+  - memory
+  # - undefined   
+
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  # - honggfuzz
+
+# builds_per_day: 2


### PR DESCRIPTION
This PR includes the integration for project cups-filters from OpenPrinting into OSS-Fuzz workflow. The harness repo is maintained seperately here [OpenPrinting fuzzing](https://github.com/OpenPrinting/fuzzing).

All harness building related changes has been locally tested and verified.