### PR TITLE
[pem] Fix Broken Build & Improve Fuzz Harness

### DIFF
--- a/projects/pem/Dockerfile
+++ b/projects/pem/Dockerfile
@@ -16,7 +16,13 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-python
 RUN apt-get update && apt-get install -y make autoconf automake libtool
-RUN pip3 install --upgrade pip && pip install twisted
+RUN python3 -m pip install --upgrade pip \
+    && python3 -m pip install 'pyinstaller==6.10.0' 'setuptools==72.1.0' twisted
 RUN git clone --depth 1 https://github.com/hynek/pem
+RUN urls="\
+https://raw.githubusercontent.com/google/fuzzing/master/dictionaries/pem.dict \
+https://raw.githubusercontent.com/google/fuzzing/master/dictionaries/utf8.dict" \
+  && target_file="$SRC/__base.dict" \
+  && echo $urls | xargs -n 1 wget -qO- >> $target_file
 WORKDIR pem
 COPY build.sh *.py *.pem $SRC/

--- a/projects/pem/build.sh
+++ b/projects/pem/build.sh
@@ -15,10 +15,23 @@
 #
 ################################################################################
 
-pip3 install .
+python3 -m pip install .
+
+make_dictionary_for_fuzz_harness() {
+  local fuzz_harness="$1"
+  local base_dictionary="$SRC/__base.dict"
+  local output_dict="$OUT/${fuzz_harness##*/}"
+  output_dict="${output_dict%.py}.dict"
+
+  [[ -r "$base_dictionary" ]] && {
+    [[ -s "$output_dict" ]] && echo >>"$output_dict"
+    cat "$base_dictionary" >>"$output_dict"
+  }
+}
 
 for fuzzer in $(find $SRC -name 'fuzz_*.py'); do
   compile_python_fuzzer $fuzzer
+  make_dictionary_for_fuzz_harness "$fuzzer"
 done
 
 zip -rj $OUT/fuzz_pem_seed_corpus.zip $SRC/data.pem

--- a/projects/pem/fuzz_pem.py
+++ b/projects/pem/fuzz_pem.py
@@ -17,7 +17,8 @@ import os
 import sys
 import atheris
 
-import pem
+with atheris.instrument_imports():
+    import pem
 
 def TestOneInput(data):
     certs = pem.parse(data)
@@ -27,7 +28,6 @@ def TestOneInput(data):
     s1 = certs[0].sha1_hexdigest
 
 def main():
-    atheris.instrument_all()
     atheris.Setup(sys.argv, TestOneInput)
     atheris.Fuzz()
 


### PR DESCRIPTION
### Fix [Issue 70805: pem: Fuzzing build failure](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=70805)

Fixes broken fuzzer builds that have been failing since Jul 30, 2024.

### Key Changes:

- **Pyinstaller Upgrade**: Updated Pyinstaller to version 3.10.0, which is the minimum version supporting setuptools >= 71.0.0. This upgrade addresses the build failures caused by the new dependency vendoring approach in setuptools.
- **Dictionary Addition**: Added a dictionary for setuptools fuzz harnesses.
- **Fuzzer Optimization**: Improved fuzzer cold-start time by using `atheris.instrument_imports` instead of `atheris.instrument_all`. This significantly speeds up the time it takes for the fuzzer to start running.