### PR TITLE
Fix trust-dns clone

### DIFF
--- a/projects/trust-dns/Dockerfile
+++ b/projects/trust-dns/Dockerfile
@@ -16,6 +16,6 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-rust
 RUN apt-get update && apt-get install -y make autoconf automake libtool
-RUN git clone --depth 1 https://github.com/bluejekyll/trust-dns trust-dns
-WORKDIR trust-dns
+RUN git clone --depth 1 https://github.com/hickory-dns/hickory-dns hickory-dns
+WORKDIR hickory-dns
 COPY build.sh $SRC/

--- a/projects/trust-dns/project.yaml
+++ b/projects/trust-dns/project.yaml
@@ -1,6 +1,6 @@
-homepage: "https://github.com/bluejekyll/trust-dns"
+homepage: "https://github.com/hickory-dns/hickory-dns"
 language: rust
-main_repo: "https://github.com/bluejekyll/trust-dns"
+main_repo: "https://github.com/hickory-dns/hickory-dns"
 primary_contact: "bluejekyll@gmail.com"
 auto_ccs:
   - djc.ochtman@gmail.com


### PR DESCRIPTION
This corrects the repository used for the `trust-dns` project. It has since been rebranded to Hickory DNS, and the old URL now points to a stub repository, with just a README directing readers to the new one. This fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=71005.