### PR TITLE
spicy: Do not install pre-commit

### DIFF
--- a/projects/spicy/Dockerfile
+++ b/projects/spicy/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update \
     python3-sphinx-rtd-theme \
     python3-setuptools \
     python3-wheel doxygen \
- && pip3 install --no-cache-dir "btest>=0.66" pre-commit \
+ && pip3 install --no-cache-dir "btest>=0.66" \
  # Install a recent CMake.
  && mkdir -p /opt/cmake \
  && curl -L https://github.com/Kitware/CMake/releases/download/v3.29.2/cmake-3.29.2-linux-x86_64.tar.gz | tar xzvf - -C /opt/cmake --strip-components 1 \


### PR DESCRIPTION
We do not need pre-commit for fuzzing. Installing it via pip raises pip._vendor.pep517.wrappers.BackendUnavailable due to some dependency. Drop it, as it's not needed.

I don't think we need btest either unless for installing the packages via zkg, so keeping that one for now.