### PR TITLE
suricata: do not fuzz version 6 anymore

### DIFF
--- a/projects/suricata/Dockerfile
+++ b/projects/suricata/Dockerfile
@@ -30,8 +30,7 @@ RUN git clone --depth=1 https://github.com/catenacyber/fuzzpcap
 ADD https://rules.emergingthreats.net/open/suricata/emerging.rules.zip emerging.rules.zip
 
 ENV RUSTUP_TOOLCHAIN nightly
-# TODO remove version pinning once https://redmine.openinfosecfoundation.org/issues/7206 is fixed
-RUN cargo install --version 0.26.0 --force cbindgen
+RUN cargo install --force cbindgen
 # TODO remove once we have clang with coverage version 9 as rustc
 ENV RUSTUP_TOOLCHAIN nightly-2024-02-12
 

--- a/projects/suricata/build.sh
+++ b/projects/suricata/build.sh
@@ -85,7 +85,6 @@ fi
 fuzz_branches=("")
 if [[ "$SANITIZER" != "memory" ]] && [[ ! -v CIFUZZ ]]
 then
-    fuzz_branches+=("6")
     fuzz_branches+=("7")
 fi
 


### PR DESCRIPTION
as it reached its end of life

Also, remove a temporary workaround for cbindgen (which will not be fixed in version 6)