### PR TITLE
Add Log4cxx integration

### DIFF
--- a/projects/apache-logging-log4cxx/Dockerfile
+++ b/projects/apache-logging-log4cxx/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+# Log4cxx build dependencies: https://logging.apache.org/log4cxx/latest_stable/build-cmake.html
+RUN apt-get update && apt-get install -y build-essential libapr1-dev libaprutil1-dev gzip zip
+
+COPY build.sh $SRC/
+
+WORKDIR $SRC

--- a/projects/apache-logging-log4cxx/README.adoc
+++ b/projects/apache-logging-log4cxx/README.adoc
@@ -1,0 +1,19 @@
+////
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+////
+
+Log4cxx fuzz tests are distributed as a part of https://github.com/apache/logging-log4cxx[the official project sources].
+Here we only store the `Dockerfile` to build the container image to build and run fuzz tests.
+Likewise, `build.sh` simply delegates to a build script distributed with the Log4j source code.

--- a/projects/apache-logging-log4cxx/build.sh
+++ b/projects/apache-logging-log4cxx/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+git clone --quiet --depth 1 --branch fuzzing --single-branch https://github.com/apache/logging-log4cxx
+./logging-log4cxx/src/fuzzers/bash/oss-fuzz-build.sh "$OUT"

--- a/projects/apache-logging-log4cxx/project.yaml
+++ b/projects/apache-logging-log4cxx/project.yaml
@@ -1,0 +1,22 @@
+homepage: "https://logging.apache.org/log4cxx"
+main_repo: "https://github.com/apache/logging-log4cxx"
+language: c++
+
+fuzzing_engines:
+  - afl
+  - honggfuzz
+  - libfuzzer
+
+sanitizers:
+  - address
+  - memory
+  - undefined
+
+# Apache Logging Services PMC members[1] that contribute the fuzz tests.
+# We cannot share `security@logging.apache.org` here, since it must be associated with a Google account[2].
+#
+# [1] https://logging.apache.org/team-list.html
+# [2] https://google.github.io/oss-fuzz/getting-started/new-project-guide/#primary
+primary_contact: volkan@yazi.ci
+auto_ccs:
+  - piotr.karwasz@gmail.com

--- a/projects/apache-logging-log4cxx/project.yaml
+++ b/projects/apache-logging-log4cxx/project.yaml
@@ -4,13 +4,12 @@ language: c++
 
 fuzzing_engines:
   - afl
+  - centipede
   - honggfuzz
   - libfuzzer
 
 sanitizers:
   - address
-  - memory
-  - undefined
 
 # Apache Logging Services PMC members[1] that contribute the fuzz tests.
 # We cannot share `security@logging.apache.org` here, since it must be associated with a Google account[2].

--- a/projects/apache-logging-log4cxx/project.yaml
+++ b/projects/apache-logging-log4cxx/project.yaml
@@ -3,9 +3,6 @@ main_repo: "https://github.com/apache/logging-log4cxx"
 language: c++
 
 fuzzing_engines:
-  - afl
-  - centipede
-  - honggfuzz
   - libfuzzer
 
 sanitizers:


### PR DESCRIPTION
[Log4cxx](https://logging.apache.org/log4cxx) is a widely<sup>1</sup> used logging framework for C++. It is developed and maintained by [Apache Logging Services](https://logging.apache.org) next to [Log4j](https://logging.apache.org/log4j) and [Log4Net](https://logging.apache.org/log4net). This PR integrates Log4cxx to OSS-Fuzz.

<sup>1</sup> While it is difficult to assess the usage of C++ libraries, according to [the ASF statistics](https://infra-reports.apache.org/#downloads&project=logging) (requires an ASF account), it had 1299 downloads in the last two months [until today, i.e., 2024-08-15].