### PR TITLE
pistache: fix build error

### DIFF
--- a/projects/pistache/build.sh
+++ b/projects/pistache/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 mkdir build && cd build
-cmake -DBUILD_SHARED_LIBS=OFF ..
+cmake -DBUILD_SHARED_LIBS=OFF -DPISTACHE_BUILD_TESTS=OFF ..
 make pistache_static
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE -o $OUT/fuzz_parsers \
     -std=c++17 -I../include/ ../tests/fuzzers/fuzz_parser.cpp ./src/libpistache.a


### PR DESCRIPTION
Error:

```
GoogleTest not found. Consider installing it on your system. Downloading it from source...
CMake Error at /usr/local/share/cmake-3.29/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find CURL (missing: CURL_LIBRARY CURL_INCLUDE_DIR)
Call Stack (most recent call first):
  /usr/local/share/cmake-3.29/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
  /usr/local/share/cmake-3.29/Modules/FindCURL.cmake:196 (find_package_handle_standard_args)
  tests/CMakeLists.txt:5 (find_package)


-- Configuring incomplete, errors occurred!
```

https://oss-fuzz-build-logs.storage.googleapis.com/log-82eaa7c0-9aaa-42c3-bea0-26dde478d2e2.txt