### PR TITLE
[Connectedhomeip] fix for Fuzz Introspector build

### DIFF
--- a/projects/connectedhomeip/build.sh
+++ b/projects/connectedhomeip/build.sh
@@ -15,6 +15,13 @@
 #
 ################################################################################
 
+
+# workaround to get Fuzz Introspector to build; making it link with lld instead of the environment's gold linker which gives an error
+if [ "$SANITIZER" == "introspector" ]; then
+  export CFLAGS=$(echo "$CFLAGS" | sed 's/gold/lld/g')
+  export CXXFLAGS=$(echo "$CXXFLAGS" | sed 's/gold/lld/g')
+fi
+
 cd $SRC/connectedhomeip
 
 # Activate Pigweed environment


### PR DESCRIPTION
Fuzz Introspector build is failing with error:
```
/usr/bin/ld.gold: internal error in read_header_prolog, at ../../gold/dwarf_reader.cc:1678
```

- I have tried solutions mentioned here #https://github.com/google/oss-fuzz/pull/10891 and saw this issue #https://github.com/google/oss-fuzz/issues/10237 but doesnt seem to be the same cause.

- so instead i will just build it with `lld` instead of the `gold` linker supplied by the environment