### PR TITLE
disable ox-ruby temporarily

### DIFF
--- a/projects/ox-ruby/project.yaml
+++ b/projects/ox-ruby/project.yaml
@@ -7,6 +7,6 @@ sanitizers:
   - address
   - undefined
 main_repo: 'https://github.com/ohler55/ox'
-
+disabled: true
 fuzzing_engines:
   - libfuzzer


### PR DESCRIPTION
It's broken and causing noise on oss-fuzz when we are debugging some big changes.