### PR TITLE
Update Clang toolchain from 18.0.0 to 18.1.8 

### DIFF
--- a/infra/base-images/base-builder-rust/Dockerfile
+++ b/infra/base-images/base-builder-rust/Dockerfile
@@ -26,7 +26,7 @@ ENV OSSFUZZ_RUSTPATH /rust
 # manually specifying what toolchain to use. Note that this environment variable
 # is additionally used by `install_rust.sh` as the toolchain to install.
 # cf https://rust-lang.github.io/rustup/overrides.html
-ENV RUSTUP_TOOLCHAIN nightly-2024-02-12
+ENV RUSTUP_TOOLCHAIN nightly-2024-07-12
 
 # Configure the linker used by default for x86_64 linux to be `clang` instead of
 # rustc's default of `cc` which is able to find custom-built libraries like

--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -60,8 +60,19 @@ ENV CCC "clang++"
 # warning, to allow compiling legacy code.
 # See https://releases.llvm.org/16.0.0/tools/clang/docs/ReleaseNotes.html#potentially-breaking-changes
 # Same for deprecated-declarations, int-conversion,
-# incompatible-function-pointer-types, enum-constexpr-conversion
+# incompatible-function-pointer-types, enum-constexpr-conversion,
+# vla-cxx-extension
 
-ENV CFLAGS "-O1 -fno-omit-frame-pointer -gline-tables-only -Wno-error=enum-constexpr-conversion -Wno-error=incompatible-function-pointer-types -Wno-error=int-conversion -Wno-error=deprecated-declarations -Wno-error=implicit-function-declaration -Wno-error=implicit-int -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"
+ENV CFLAGS -O1 \
+  -fno-omit-frame-pointer \
+  -gline-tables-only \
+  -Wno-error=enum-constexpr-conversion \
+  -Wno-error=incompatible-function-pointer-types \
+  -Wno-error=int-conversion \
+  -Wno-error=deprecated-declarations \
+  -Wno-error=implicit-function-declaration \
+  -Wno-error=implicit-int \
+  -Wno-error=vla-cxx-extension \
+  -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 ENV CXXFLAGS_EXTRA "-stdlib=libc++"
 ENV CXXFLAGS "$CFLAGS $CXXFLAGS_EXTRA"

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -54,7 +54,7 @@ apt-get update && apt-get install -y $LLVM_DEP_PACKAGES --no-install-recommends
 # languages, projects, ...) is needed.
 # Check CMAKE_VERSION infra/base-images/base-clang/Dockerfile was released
 # recently enough to fully support this clang version.
-OUR_LLVM_REVISION=llvmorg-18-init-4631-gd50b56d1
+OUR_LLVM_REVISION=llvmorg-18.1.8
 
 mkdir $SRC/chromium_tools
 cd $SRC/chromium_tools
@@ -116,6 +116,7 @@ cmake -G "Ninja" \
   -DLLVM_TARGETS_TO_BUILD="$TARGET_TO_BUILD" \
   -DLLVM_ENABLE_PROJECTS="clang;lld" \
   -DLLVM_BINUTILS_INCDIR="/usr/include/" \
+  -DLIBCXXABI_USE_LLVM_UNWINDER=OFF \
   $LLVM_SRC/llvm
 
 ninja -j $NPROC
@@ -202,6 +203,7 @@ function cmake_libcxx {
       -DLIBCXX_ENABLE_SHARED=OFF \
       -DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON \
       -DLIBCXXABI_ENABLE_SHARED=OFF \
+      -DLIBCXXABI_USE_LLVM_UNWINDER=OFF \
       -DCMAKE_BUILD_TYPE=Release \
       -DLLVM_ENABLE_PIC=ON \
       -DLLVM_TARGETS_TO_BUILD="$TARGET_TO_BUILD" \

--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -115,7 +115,7 @@ function run_fuzz_target {
     # Extract fuzztest binary name from fuzztest wrapper script.
     target=(${target//@/ }[0])
   fi
-  profraw_update.py $OUT/$target $profraw_file_mask $profraw_file_mask
+  profraw_update.py $OUT/$target -i $profraw_file_mask
   llvm-profdata merge -j=1 -sparse $profraw_file_mask -o $profdata_file
 
   # Delete unnecessary and (potentially) large .profraw files.

--- a/projects/elfutils/Dockerfile
+++ b/projects/elfutils/Dockerfile
@@ -14,7 +14,10 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:56905c98ae0083d14da0e7371184e694560a74750533f321ac0e9145af0e8d2e
+# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
+# see https://github.com/google/oss-fuzz/pull/12365
+
 RUN apt-get update && \
     apt-get install -y pkg-config make autoconf autopoint zlib1g-dev zlib1g-dev:i386 flex gawk bison
 RUN git clone --depth 1 https://sourceware.org/git/elfutils.git

--- a/projects/envoy/Dockerfile
+++ b/projects/envoy/Dockerfile
@@ -15,7 +15,10 @@
 ################################################################################
 
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:56905c98ae0083d14da0e7371184e694560a74750533f321ac0e9145af0e8d2e
+# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
+# see https://github.com/google/oss-fuzz/pull/12365
+
 
 RUN apt-get update && apt-get -y install  \
 	build-essential \

--- a/projects/icu/project.yaml
+++ b/projects/icu/project.yaml
@@ -17,5 +17,10 @@ sanitizers:
  - undefined 
 # Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
+fuzzing_engines:
+  - libfuzzer
+  - honggfuzz
+  - afl
+  # - centipede disabled due to https://github.com/google/oss-fuzz/pull/12365 clang 18 update
 
 main_repo: 'https://github.com/unicode-org/icu.git'

--- a/projects/librawspeed/build.sh
+++ b/projects/librawspeed/build.sh
@@ -15,4 +15,6 @@
 #
 ################################################################################
 
+export CFLAGS="$CFLAGS -Wno-error=nan-infinity-disabled"
+export CXXFLAGS="$CXXFLAGS -Wno-error=nan-infinity-disabled"
 $SRC/librawspeed/.ci/oss-fuzz.sh

--- a/projects/rust-lexical/Dockerfile
+++ b/projects/rust-lexical/Dockerfile
@@ -13,7 +13,10 @@
 # limitations under the License.
 #
 ################################################################################
-FROM gcr.io/oss-fuzz-base/base-builder-rust
+FROM gcr.io/oss-fuzz-base/base-builder-rust@sha256:b9a45fecf0d9be6559fca019e90577632242be120ee2d97cec5c2045c1440710
+# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
+# /usr/bin/ld: /src/rust-lexical/fuzz/target/x86_64-unknown-linux-gnu/release/deps/parse_integer_u16-53e4bc89ab30e724.parse_integer_u16.9056e4c0a19617b4-cgu.0.rcgu.o: in function `asan.module_dtor.204':
+#          parse_integer_u16.9056e4c0a19617b4-cgu.0:(.text.asan.module_dtor.204[asan.module_dtor]+0x6): undefined reference to `__sancov_gen_.998'
 
 RUN git clone --depth 1 https://github.com/Alexhuszagh/rust-lexical
 COPY build.sh $SRC/

--- a/projects/samba/build.sh
+++ b/projects/samba/build.sh
@@ -15,6 +15,6 @@
 #
 ################################################################################
 
-export CFLAGS="$CFLAGS -Wno-error=strict-prototypes"
+export CFLAGS="$CFLAGS -Wno-error=strict-prototypes -Wno-error=format-truncation"
 # The real script is maintained in the Samba repo
 exec lib/fuzzing/oss-fuzz/build_samba.sh

--- a/projects/suricata/Dockerfile
+++ b/projects/suricata/Dockerfile
@@ -29,10 +29,7 @@ RUN git clone --depth=1 https://github.com/catenacyber/fuzzpcap
 
 ADD https://rules.emergingthreats.net/open/suricata/emerging.rules.zip emerging.rules.zip
 
-ENV RUSTUP_TOOLCHAIN nightly
 RUN cargo install --force cbindgen
-# TODO remove once we have clang with coverage version 9 as rustc
-ENV RUSTUP_TOOLCHAIN nightly-2024-02-12
 
 RUN git clone --depth 1 https://github.com/OISF/suricata.git suricata
 RUN git clone --depth 1 --branch master-6.0.x https://github.com/OISF/suricata.git suricata6

--- a/projects/suricata/Dockerfile
+++ b/projects/suricata/Dockerfile
@@ -32,7 +32,6 @@ ADD https://rules.emergingthreats.net/open/suricata/emerging.rules.zip emerging.
 RUN cargo install --force cbindgen
 
 RUN git clone --depth 1 https://github.com/OISF/suricata.git suricata
-RUN git clone --depth 1 --branch master-6.0.x https://github.com/OISF/suricata.git suricata6
 RUN git clone --depth 1 --branch main-7.0.x https://github.com/OISF/suricata.git suricata7
 RUN git clone --depth 1 https://github.com/OISF/libhtp.git libhtp
 RUN git clone --depth 1 https://github.com/OISF/suricata-verify suricata-verify

--- a/projects/suricata/build.sh
+++ b/projects/suricata/build.sh
@@ -160,7 +160,6 @@ cat $t/*.rules > corpus/$i || true; echo -ne '\0' >> corpus/$i; cat $t/*.pcap >>
 done
 set -x
 zip -q -r $OUT/fuzz_sigpcap_seed_corpus.zip corpus
-cp $OUT/fuzz_sigpcap_seed_corpus.zip $OUT/fuzz_sigpcap6_seed_corpus.zip
 rm -Rf corpus
 mkdir corpus
 set +x
@@ -170,7 +169,6 @@ echo -ne '\0' >> corpus/$i; python3 $SRC/fuzzpcap/tcptofpc.py $t/*.pcap >> corpu
 done
 set -x
 zip -q -r $OUT/fuzz_sigpcap_aware_seed_corpus.zip corpus
-cp $OUT/fuzz_sigpcap_aware_seed_corpus.zip $OUT/fuzz_sigpcap_aware6_seed_corpus.zip
 rm -Rf corpus
 mkdir corpus
 set +x
@@ -180,4 +178,3 @@ python3 $SRC/fuzzpcap/tcptofpc.py $t/*.pcap >> corpus/$i || rm corpus/$i; i=$((i
 done
 set -x
 zip -q -r $OUT/fuzz_predefpcap_aware_seed_corpus.zip corpus
-cp $OUT/fuzz_predefpcap_aware_seed_corpus.zip $OUT/fuzz_predefpcap_aware6_seed_corpus.zip

--- a/projects/wasmer/Dockerfile
+++ b/projects/wasmer/Dockerfile
@@ -27,4 +27,7 @@ RUN mkdir -p $SRC/.llvm && curl --proto '=https' --tlsv1.2 -sSf \
 
 WORKDIR wasmer
 
+# dead code warnings with nightly-2024-07-12
+ENV RUSTUP_TOOLCHAIN nightly-2024-02-12
+
 COPY build.sh default.options $SRC/


### PR DESCRIPTION
Follow-up on #12077 by @alexcrichton cc @maflcko 

Main difference is to update infra/base-images/base-runner/profraw_update.py so that oss-fuzz converts profraw version 8 to 9 (and llvm-cov seems more tolerant in older version reading cf llvm/lib/ProfileData/Coverage/CoverageMappingReader.cpp

This way, it should be more transparent for projects, that can be updated individually or not