### PR TITLE
re-integrate cosign

### DIFF
--- a/projects/cosign/Dockerfile
+++ b/projects/cosign/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/AdamKorcz/cosign --branch=fuzz-aug-24
+
+COPY build.sh $SRC
+WORKDIR $SRC/cosign

--- a/projects/cosign/build.sh
+++ b/projects/cosign/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -eu
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+go get github.com/AdamKorcz/go-118-fuzz-build/testing
+
+mv ./pkg/cosign/keys_test.go ./pkg/cosign/keys_test_keep_in_fuzz_scope.go
+compile_native_go_fuzzer github.com/sigstore/cosign/v2/pkg/cosign/attestation FuzzGenerateStatement FuzzGenerateStatement
+compile_native_go_fuzzer github.com/sigstore/cosign/v2/pkg/cosign/cue FuzzValidateJSON FuzzValidateJSON_cue
+compile_native_go_fuzzer github.com/sigstore/cosign/v2/pkg/cosign/rego FuzzValidateJSON FuzzValidateJSON_rego
+compile_native_go_fuzzer github.com/sigstore/cosign/v2/pkg/cosign FuzzImportKeyPairLoadPrivateKey FuzzImportKeyPairLoadPrivateKey
+compile_native_go_fuzzer github.com/sigstore/cosign/v2/pkg/cosign FuzzSigVerify FuzzSigVerify
+compile_native_go_fuzzer github.com/sigstore/cosign/v2/pkg/policy FuzzEvaluatePolicyAgainstJSON FuzzEvaluatePolicyAgainstJSON

--- a/projects/cosign/project.yaml
+++ b/projects/cosign/project.yaml
@@ -1,0 +1,15 @@
+homepage: "https://sigstore.dev"
+main_repo: "https://github.com/sigstore/cosign"
+primary_contact: "security@sigstore.dev"
+auto_ccs:
+  - lhinds@sigstore.dev
+  - hblauzvern@sigstore.dev
+  - codysoyland@sigstore.dev
+  - bcallaway@sigstore.dev
+vendor_ccs:
+  - adam@adalogics.com
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
Cosign was removed in https://github.com/google/oss-fuzz/pull/6838 because its harness got removed upstream. With new fuzzers ready in https://github.com/sigstore/cosign/pull/3834, Cosign can re-integrate into OSS-Fuzz.

@codysoyland @haydentherapper @bobcallaway @davidkorczynski for info