### PR TITLE
fix(xs): correct email for collaborators

### DIFF
--- a/projects/xs/project.yaml
+++ b/projects/xs/project.yaml
@@ -6,7 +6,7 @@ auto_ccs:
   - ps@moddable.com
   - raphael@agoric.com
   - kris@agoric.com
-  - richard@agoric.com
+  - gibson@agoric.com
 sanitizers:
   - address
   - memory


### PR DESCRIPTION
Accidentally used an alias rather than the email. Fixing mistake made in #12360 