### PR TITLE
arrow: Enable Snappy compression

### DIFF
--- a/projects/arrow/build.sh
+++ b/projects/arrow/build.sh
@@ -61,7 +61,7 @@ cmake ${ARROW} -GNinja \
     -DARROW_WITH_BROTLI=on \
     -DARROW_WITH_BZ2=off \
     -DARROW_WITH_LZ4=on \
-    -DARROW_WITH_SNAPPY=off \
+    -DARROW_WITH_SNAPPY=on \
     -DARROW_WITH_ZLIB=on \
     -DARROW_WITH_ZSTD=on \
     -DARROW_USE_GLOG=off \

--- a/projects/arrow/build.sh
+++ b/projects/arrow/build.sh
@@ -35,7 +35,6 @@ cd ${WORK}
 # would report leaks and error out.
 export ASAN_OPTIONS="detect_leaks=0"
 
-# Snappy disabled as it forces `-fno-rtti`, which is incompatible with UBSAN.
 cmake ${ARROW} -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
     -DARROW_DEPENDENCY_SOURCE=BUNDLED \


### PR DESCRIPTION
In PR #12320, we enabled more compression algorithms for Arrow C++, but had to disable Snappy because of build issues.

Since then, the Arrow project merged a PR (https://github.com/apache/arrow/pull/43706) which enables RTTI when building Snappy.

Therefore, we can now enable Snappy in the OSS-Fuzz builds of Arrow C++ as well.