### PR TITLE
Remove centipede from tinyxml2

### DIFF
--- a/projects/tinyxml2/project.yaml
+++ b/projects/tinyxml2/project.yaml
@@ -14,5 +14,3 @@ fuzzing_engines:
   - afl
   - honggfuzz
   - libfuzzer
-  - centipede
-


### PR DESCRIPTION
Builds don't contain binaries and cause exceptions