### PR TITLE
astroid: fix build and update maintainers

### DIFF
--- a/projects/astroid/Dockerfile
+++ b/projects/astroid/Dockerfile
@@ -13,8 +13,15 @@
 # limitations under the License.
 #
 ##########################################################################
+
 FROM gcr.io/oss-fuzz-base/base-builder-python
-RUN pip3 install --upgrade pip
-RUN git clone https://github.com/PyCQA/astroid astroid
-COPY *.sh *py $SRC/
-WORKDIR $SRC/astroid
+
+RUN pip3 install --disable-pip-version-check --no-cache-dir pip==24.2
+
+# Pin the astroid version to 3.2.4 until Python 3.9+ is supported on OSS-Fuzz:
+# https://github.com/google/oss-fuzz/pull/12027
+RUN git clone --depth=1 --branch=v3.2.4 https://github.com/pylint-dev/astroid
+
+COPY *.py *.sh "$SRC/"
+
+WORKDIR "$SRC/astroid"

--- a/projects/astroid/project.yaml
+++ b/projects/astroid/project.yaml
@@ -1,9 +1,12 @@
-homepage: https://github.com/PyCQA/astroid
-main_repo: https://github.com/PyCQA/astroid
+homepage: https://github.com/pylint-dev/astroid
+main_repo: https://github.com/pylint-dev/astroid
 language: python
+primary_contact: "jacobtylerwalls@gmail.com"
+auto_ccs:
+  - "correctmost@gmail.com"
 fuzzing_engines:
-- libfuzzer
+  - libfuzzer
 sanitizers:
-- address
+  - address
 vendor_ccs:
-- david@adalogics.com
+  - "david@adalogics.com"


### PR DESCRIPTION
I have received permission to update the maintainers list here: https://github.com/pylint-dev/astroid/issues/2511#issuecomment-2297611878

This commit also fixes the build by pinning astroid to the latest version with Python 3.8 support.  This will allow the corpus to grow until Python 3.9+ is supported on OSS-Fuzz.