### PR TITLE
Update Dockerfile for sigstore-go

### DIFF
--- a/projects/sigstore-go/Dockerfile
+++ b/projects/sigstore-go/Dockerfile
@@ -16,5 +16,5 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN git clone --depth 1 https://github.com/sigstore/sigstore-go
-COPY build.sh *.dict $SRC
+COPY build.sh *.dict $SRC/
 WORKDIR $SRC/sigstore-go


### PR DESCRIPTION
Fix build error https://oss-fuzz-build-logs.storage.googleapis.com/log-17235690-03af-4f88-a2c8-1f7203f4695c.txt

```Step #1: Step 3/4 : COPY build.sh *.dict $SRC
Step #1: When using COPY with more than one source file, the destination must be a directory and end with a /
Finished Step #1```

@AdamKorcz 