### PR TITLE
[memcached] Update CC's list to include bxa alt email

### DIFF
--- a/projects/memcached/project.yaml
+++ b/projects/memcached/project.yaml
@@ -4,6 +4,7 @@ main_repo: "https://github.com/memcached/memcached"
 primary_contact: "alan@cacheforge.com"
 auto_ccs:
   - "bxa@stripe.com"
+  - "shodivine@gmail.com"
 fuzzing_engines:
   - libfuzzer
 sanitizers:


### PR DESCRIPTION
As it reads on the tin. Add my alt email to auto CC's. 