### PR TITLE
Revert "suricata: fuzz also on aarch64 (#12366)"

### DIFF
--- a/projects/suricata/project.yaml
+++ b/projects/suricata/project.yaml
@@ -12,7 +12,4 @@ fuzzing_engines:
   - afl
   - honggfuzz
   - libfuzzer
-architectures:
-  - x86_64
-  - aarch64
 main_repo: 'https://github.com/OISF/suricata.git'


### PR DESCRIPTION
This reverts commit 85f1bf4f9d9fdd2ab2c7af87b52150fa1165ac0b.

Would fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=71329