### PR TITLE
infra: bazel_build_fuzz_tests: avoid change of OUT ownership

### DIFF
--- a/infra/base-images/base-builder/bazel_build_fuzz_tests
+++ b/infra/base-images/base-builder/bazel_build_fuzz_tests
@@ -67,7 +67,7 @@ ${BAZEL_TOOL} build "${BAZEL_BUILD_FLAGS[@]}" "${OSS_FUZZ_TESTS[@]}"
 
 echo "Extracting the fuzz test packages in the output directory."
 for oss_fuzz_archive in $(find bazel-bin/ -name "*${BAZEL_PACKAGE_SUFFIX}.tar"); do
-    tar -xvf "${oss_fuzz_archive}" -C "${OUT}"
+    tar --no-same-owner -xvf "${oss_fuzz_archive}" -C "${OUT}"
 done
 
 if [ "$SANITIZER" = "coverage" ]; then


### PR DESCRIPTION
The current bazel builds change the owner of the $OUT directory due to `tar`. This can cause some issues depending on how Docker is run, but, this is ultimately annoying since e.g. OSS-Fuzz-gen and end-to-end OSS-Fuzz runs relies on reading the files in the OUT directory, which is not possible when the owner changes. Furthermore, it's inconsistent with the existing `compile_*` scripts to change the owner of $OUT/

This fixes it by not changing the owner.