### PR TITLE
Parallelize pull_images command

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -1723,10 +1723,10 @@ def pull_images(language=None):
   """Pulls base images used to build projects in language lang (or all if lang
   is None)."""
   images = [
-    base_image for base_image_lang, base_images in BASE_IMAGES.items()
-    for base_image in base_images
-    if (language is None or base_image_lang == 'generic' or
-        base_image_lang == language)
+      base_image for base_image_lang, base_images in BASE_IMAGES.items()
+      for base_image in base_images
+      if (language is None or base_image_lang == 'generic' or
+          base_image_lang == language)
   ]
   thread_pool = ThreadPool()
   return all(thread_pool.map(docker_pull, images))

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -1722,14 +1722,18 @@ def shell(args):
 def pull_images(language=None):
   """Pulls base images used to build projects in language lang (or all if lang
   is None)."""
-  for base_image_lang, base_images in BASE_IMAGES.items():
-    if (language is None or base_image_lang == 'generic' or
-        base_image_lang == language):
-      for base_image in base_images:
-        if not docker_pull(base_image):
-          return False
-
-  return True
+  images = [
+    base_image
+    for base_image_lang, base_images in BASE_IMAGES.items()
+    for base_image in base_images
+    if (
+        language is None
+        or base_image_lang == 'generic'
+        or base_image_lang == language
+    )
+  ]
+  thread_pool = ThreadPool()
+  return all(thread_pool.map(docker_pull, images))
 
 
 if __name__ == '__main__':

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -1723,14 +1723,10 @@ def pull_images(language=None):
   """Pulls base images used to build projects in language lang (or all if lang
   is None)."""
   images = [
-    base_image
-    for base_image_lang, base_images in BASE_IMAGES.items()
+    base_image for base_image_lang, base_images in BASE_IMAGES.items()
     for base_image in base_images
-    if (
-        language is None
-        or base_image_lang == 'generic'
-        or base_image_lang == language
-    )
+    if (language is None or base_image_lang == 'generic' or
+        base_image_lang == language)
   ]
   thread_pool = ThreadPool()
   return all(thread_pool.map(docker_pull, images))


### PR DESCRIPTION
I noticed that running `pull_images` takes quite a while [on first run](https://google.github.io/oss-fuzz/advanced-topics/code-coverage/#pull-the-latest-docker-images). This PR parallelizes the `pull_images` command in the same way as `download_corpora`.