### PR TITLE
Fix git builds

### DIFF
--- a/projects/git/Makefile.diff
+++ b/projects/git/Makefile.diff
@@ -1,8 +1,16 @@
 diff --git a/Makefile b/Makefile
-index 4e255c81f2..05905e3a2e 100644
+index e298c8b55e..d813aac130 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -760,6 +760,19 @@ FUZZ_OBJS += oss-fuzz/fuzz-commit-graph.o
+@@ -1075,6 +1075,7 @@ LIB_OBJS += oid-array.o
+ LIB_OBJS += oidmap.o
+ LIB_OBJS += oidset.o
+ LIB_OBJS += oidtree.o
++LIB_OBJS += oss-fuzz/fuzz-cmd-base.o
+ LIB_OBJS += pack-bitmap-write.o
+ LIB_OBJS += pack-bitmap.o
+ LIB_OBJS += pack-check.o
+@@ -2381,6 +2382,19 @@ FUZZ_OBJS += oss-fuzz/fuzz-config.o
  FUZZ_OBJS += oss-fuzz/fuzz-date.o
  FUZZ_OBJS += oss-fuzz/fuzz-pack-headers.o
  FUZZ_OBJS += oss-fuzz/fuzz-pack-idx.o
@@ -22,28 +30,20 @@ index 4e255c81f2..05905e3a2e 100644
  .PHONY: fuzz-objs
  fuzz-objs: $(FUZZ_OBJS)
  
-@@ -1087,6 +1100,7 @@ LIB_OBJS += oid-array.o
- LIB_OBJS += oidmap.o
- LIB_OBJS += oidset.o
- LIB_OBJS += oidtree.o
-+LIB_OBJS += oss-fuzz/fuzz-cmd-base.o
- LIB_OBJS += pack-bitmap-write.o
- LIB_OBJS += pack-bitmap.o
- LIB_OBJS += pack-check.o
-@@ -3862,10 +3876,10 @@ FUZZ_CXXFLAGS ?= $(ALL_CFLAGS)
- 
+@@ -3847,10 +3861,10 @@ FUZZ_CXXFLAGS ?= $(ALL_CFLAGS)
  .PHONY: fuzz-all
+ fuzz-all: $(FUZZ_PROGRAMS)
  
 -$(FUZZ_PROGRAMS): %: %.o oss-fuzz/dummy-cmd-main.o $(GITLIBS) GIT-LDFLAGS
--	$(QUIET_LINK)$(CXX) $(FUZZ_CXXFLAGS) -o $@ $(ALL_LDFLAGS) \
+-	$(QUIET_LINK)$(FUZZ_CXX) $(FUZZ_CXXFLAGS) -o $@ $(ALL_LDFLAGS) \
 +$(FUZZ_PROGRAMS): all
-+	$(QUIET_LINK)$(CXX) $(FUZZ_CXXFLAGS) -o $@ $(ALL_LDFLAGS) $(BUILTIN_OBJS) \
++	$(QUIET_LINK)$(FUZZ_CXX) $(FUZZ_CXXFLAGS) -o $@ $(ALL_LDFLAGS) $(BUILTIN_OBJS) \
  		-Wl,--allow-multiple-definition \
 -		$(filter %.o,$^) $(filter %.a,$^) $(LIBS) $(LIB_FUZZING_ENGINE)
 +		$(filter %.o,$^) $(filter %.a,$^) git.o $@.o $(LIBS) $(LIB_FUZZING_ENGINE)
  
- fuzz-all: $(FUZZ_PROGRAMS)
- 
+ $(UNIT_TEST_PROGS): $(UNIT_TEST_BIN)/%$X: $(UNIT_TEST_DIR)/%.o \
+ 	$(UNIT_TEST_DIR)/test-lib.o \
 diff --git a/attr.c b/attr.c
 index 679e42258c..20e426726a 100644
 --- a/attr.c
@@ -71,10 +71,10 @@ index 3ad11dc5d0..2443906572 100644
  	int bundle_fd = -1;
  	int quiet = 0;
 diff --git a/builtin/tag.c b/builtin/tag.c
-index 37473ac21f..c719ea10e7 100644
+index a1fb218512..2b90e31ced 100644
 --- a/builtin/tag.c
 +++ b/builtin/tag.c
-@@ -589,8 +589,11 @@ int cmd_tag(int argc, const char **argv, const char *prefix)
+@@ -646,8 +646,11 @@ int cmd_tag(int argc, const char **argv, const char *prefix)
  	if (repo_get_oid(the_repository, object_ref, &object))
  		die(_("Failed to resolve '%s' as a valid ref."), object_ref);
  
@@ -86,8 +86,8 @@ index 37473ac21f..c719ea10e7 100644
 +		goto cleanup;
 +	}
  
- 	if (read_ref(ref.buf, &prev))
- 		oidclr(&prev);
+ 	if (refs_read_ref(get_main_ref_store(the_repository), ref.buf, &prev))
+ 		oidclr(&prev, the_repository->hash_algo);
 diff --git a/diff.c b/diff.c
 index ccfa1fca0d..97f895a122 100644
 --- a/diff.c

--- a/projects/git/fuzz-cmd-apply-check.c
+++ b/projects/git/fuzz-cmd-apply-check.c
@@ -9,6 +9,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+#define USE_THE_REPOSITORY_VARIABLE
+
 #include <stddef.h>
 #include <stdint.h>
 #include <unistd.h>
@@ -34,7 +36,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 		create_templ_dir();
 	}
 
-	initialize_the_repository();
+	initialize_repository(the_repository);
 
 	if (!initialized)
 	{

--- a/projects/git/fuzz-cmd-bundle-verify.c
+++ b/projects/git/fuzz-cmd-bundle-verify.c
@@ -9,6 +9,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+#define USE_THE_REPOSITORY_VARIABLE
+
 #include <stddef.h>
 #include <stdint.h>
 #include "fuzz-cmd-base.h"
@@ -32,7 +34,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 		initialized = 1;
 	}
 
-	initialize_the_repository();
+	initialize_repository(the_repository);
 
 	argv[0] = "init";
 	argv[1] = "--quiet";

--- a/projects/git/fuzz-cmd-diff.c
+++ b/projects/git/fuzz-cmd-diff.c
@@ -9,6 +9,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+#define USE_THE_REPOSITORY_VARIABLE
+
 #include "git-compat-util.h"
 #include <ftw.h>
 #include <unistd.h>
@@ -71,7 +73,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	system("echo \"TEMP1TEMP1TEMP1TEMP1\" > ./TEMP_1");
 	system("echo \"TEMP1TEMP1TEMP1TEMP1\" > ./TEMP_2");
 
-	initialize_the_repository();
+	initialize_repository(the_repository);
 
 	/*
 	 *  Initialize the repository

--- a/projects/git/fuzz-cmd-status.c
+++ b/projects/git/fuzz-cmd-status.c
@@ -43,7 +43,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	system("echo \"TEMP1TEMP1TEMP1TEMP1\" > ./TEMP_1");
 	system("echo \"TEMP1TEMP1TEMP1TEMP1\" > ./TEMP_2");
 
-	initialize_the_repository();
+	initialize_repository(the_repository);
 
 	if (reset_git_folder())
 	{

--- a/projects/git/fuzz-cmd-tag-create.c
+++ b/projects/git/fuzz-cmd-tag-create.c
@@ -9,6 +9,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+#define USE_THE_REPOSITORY_VARIABLE
+
 #include <stddef.h>
 #include <stdint.h>
 #include "fuzz-cmd-base.h"
@@ -59,7 +61,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
 	if (!initialized)
 	{
-		initialize_the_repository();
+		initialize_repository(the_repository);
 		system("rm -rf ./.git");
 		system("echo \"TEMP1TEMP1TEMP1TEMP1\" > ./TEMP_1");
 		system("echo \"TEMP1TEMP1TEMP1TEMP1\" > ./TEMP_2");

--- a/projects/git/fuzz-cmd-unpack-objects.c
+++ b/projects/git/fuzz-cmd-unpack-objects.c
@@ -9,6 +9,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+#define USE_THE_REPOSITORY_VARIABLE
+
 #include <stddef.h>
 #include <stdint.h>
 #include <unistd.h>
@@ -34,7 +36,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 		create_templ_dir();
 	}
 
-	initialize_the_repository();
+	initialize_repository(the_repository);
 
 	if (!initialized)
 	{

--- a/projects/git/fuzz-command.c
+++ b/projects/git/fuzz-command.c
@@ -67,7 +67,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	/*
 	 *  Initialize the repository
 	 */
-	initialize_the_repository();
+	initialize_repository(the_repository);
 	if (repo_init(the_repository, basedir, "."))
 	{
 		return 0;

--- a/projects/git/fuzz-parse-attr-line.c
+++ b/projects/git/fuzz-parse-attr-line.c
@@ -13,8 +13,8 @@ limitations under the License.
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-#include "attr.h"
 #include "git-compat-util.h"
+#include "attr.h"
 
 struct attr_state {
 	const struct git_attr *attr;


### PR DESCRIPTION
Due to various changes in the upstream Git repo, both build_images and build_fuzzers have been failing for Git in oss-fuzz. These commits collect a few fixes to successfully build against Git's 'next' branch.