### PR TITLE
[airflow] Fix Broken Build & Harness

### DIFF
--- a/projects/airflow/Dockerfile
+++ b/projects/airflow/Dockerfile
@@ -17,7 +17,8 @@
 FROM gcr.io/oss-fuzz-base/base-builder-python
 
 RUN apt-get install sqlite3
-RUN pip3 install --upgrade pip
+RUN pip3 install --upgrade pip \
+    && pip3 install 'pyinstaller==6.10'
 
 RUN git clone https://github.com/apache/airflow
 ENV AIRFLOW_HOME=$SRC/airflow/

--- a/projects/airflow/Dockerfile
+++ b/projects/airflow/Dockerfile
@@ -16,12 +16,11 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-python
 
-RUN apt-get install sqlite3
+RUN apt-get update && apt-get install -y sqlite3
 RUN pip3 install --upgrade pip \
     && pip3 install 'pyinstaller==6.10'
-
-RUN git clone https://github.com/apache/airflow
+RUN git clone --depth 1 https://github.com/apache/airflow
 ENV AIRFLOW_HOME=$SRC/airflow/
-WORKDIR airflow
+WORKDIR $SRC/airflow
 
 COPY build.sh dag_fuzz.py $SRC/


### PR DESCRIPTION
Airflow's dependency requirements result in setuptools being upgraded to a version >= 71.0.0 which introduced a new approach to vendoring dependencies. Pyinstaller 6.10 was the first version to include support for the new approach.

Also updates the test harness to align with recent changes to Airflow's API.