### PR TITLE
[simdutf] enable aarch64, centipede and memory sanitizer

### DIFF
--- a/projects/simdutf/project.yaml
+++ b/projects/simdutf/project.yaml
@@ -13,3 +13,4 @@ fuzzing_engines:
   - afl
   - honggfuzz
   - libfuzzer
+  - centipede

--- a/projects/simdutf/project.yaml
+++ b/projects/simdutf/project.yaml
@@ -14,3 +14,6 @@ fuzzing_engines:
   - honggfuzz
   - libfuzzer
   - centipede
+architectures:
+  - x86_64
+  - aarch64

--- a/projects/simdutf/project.yaml
+++ b/projects/simdutf/project.yaml
@@ -5,7 +5,10 @@ main_repo: "https://github.com/simdutf/simdutf"
 auto_ccs:
   - "nathaniel.brough@gmail.com"
   - "pauldreikossfuzz@gmail.com"
-
+sanitizers:
+  - address
+  - undefined
+  - memory
 fuzzing_engines:
   - afl
   - honggfuzz


### PR DESCRIPTION
simdutf has run clean for double digit days now. It is time to extend the fuzzing to also cover arm and msan. I enabled centipede as well, I see no reason to exclude it.