### PR TITLE
bind9: fix dns_message_checksig_fuzzer

### DIFF
--- a/projects/bind9/build.sh
+++ b/projects/bind9/build.sh
@@ -42,6 +42,7 @@ for fuzzer in fuzz/*.c; do
 		"fuzz/${output}.o" \
 		-include config.h \
 		$LIBISC_CFLAGS $LIBDNS_CFLAGS \
-		$LIBDNS_LIBS $LIBISC_LIBS $LIBTEST_LIBS $LIB_FUZZING_ENGINE
+		-Wl,--start-group $LIBISC_LIBS $LIBDNS_LIBS -Wl,--end-group \
+		$LIBTEST_LIBS $LIB_FUZZING_ENGINE
 	zip -j "${OUT}/${output}_seed_corpus.zip" "fuzz/${output}.in/"*
 done


### PR DESCRIPTION
The `dns_message_checksig_fuzzer` was failing because the `dns_tsigkey_create` function, called during `LLVMFuzzerInitialize`, returned a `DST_R_UNSUPPORTEDALG` error. This issue was caused by incorrect library initialization.

Two functions, `dst__lib_init` and `isc__initialize`, are marked with the `ISC_CONSTRUCTOR` attribute (`__attribute__((constructor))`), and `isc__initialize` must be called before `dst__lib_init`. However, due to an incorrect linker argument order, `isc__initialize` was not called before `dst__lib_init` as required, causing the issue.

This fix resolves the issue by using a linker group, which ensures that (a) `libisc.a` is passed before `libdns.a`, and (b) unresolved symbol errors are avoided, as `libdns.a` depends on `libisc.a`.