### PR TITLE
Revert "matio: Test possible downstream zlib fix in inflate / inflateCopy (#12421)"

### DIFF
--- a/projects/matio/Dockerfile
+++ b/projects/matio/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool-bin
-RUN git clone --depth 1 --branch test-70617 https://github.com/tbeu/zlib
+RUN git clone --depth 1 https://github.com/madler/zlib
 RUN git clone --depth 1 https://github.com/tbeu/matio.git matio
 RUN git clone --depth 1 --branch hdf5_1_14 https://github.com/HDFGroup/hdf5.git hdf5
 WORKDIR matio


### PR DESCRIPTION
This reverts the temporary commit 095ccad36f66aa39eeb61808881fcca52a36283e after downstream fix https://github.com/madler/zlib/commit/f7d01aae6ec6115184de821b93fa47810abd88f9.