### PR TITLE
[msgpack-python] Fix Broken Build

### DIFF
--- a/projects/msgpack-python/Dockerfile
+++ b/projects/msgpack-python/Dockerfile
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 FROM gcr.io/oss-fuzz-base/base-builder-python
-RUN git clone https://github.com/msgpack/msgpack-python msgpack-python
+RUN git clone --depth 1 https://github.com/msgpack/msgpack-python msgpack-python
+RUN python3 -m pip install --upgrade pip \
+    && python3 -m pip install -r $SRC/msgpack-python/requirements.txt
 COPY *.sh *py $SRC/
 WORKDIR $SRC/msgpack-python

--- a/projects/msgpack-python/build.sh
+++ b/projects/msgpack-python/build.sh
@@ -14,7 +14,8 @@
 # limitations under the License.
 #
 ################################################################################
-pip3 install .
+make cython
+python3 -m pip install .
 
 if [ "$SANITIZER" = "address" ]
 then


### PR DESCRIPTION
Fixes [Monorail Issue 68724: msgpack-python: Fuzzing build failure](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=68724)

Resolves two issues that were causing the fuzzer build to fail:

1. An outdated `pip` was failing to parse the `pyproject.toml` file, and failing with a `TomlError`.

Upgrading `pip` resolved this.

2. Cython was not installed & the prerequisite Cython build step was not run before the install step resulting in failure with the message: 

> clang: error: no such file or directory: 'msgpack/_cmsgpack.c'

Installing Cython via the version specified in the upstream requirements file, and running the build step in the upstream makefile resolved this.

Also adds `--depth 1` to the Dockerfile's `git clone` to make the checkout slightly more efficient.