### PR TITLE
bitcoin-core: Switch to "Debug" build configuration

### DIFF
--- a/projects/bitcoin-core/build.sh
+++ b/projects/bitcoin-core/build.sh
@@ -72,9 +72,10 @@ fi
 
 cmake -B build_fuzz \
   --toolchain depends/${BUILD_TRIPLET}/toolchain.cmake \
+  -DCMAKE_BUILD_TYPE=Debug \
   `# Setting these flags to an empty string ensures that the flags set by an OSS-Fuzz environment remain unaltered` \
-  -DCMAKE_C_FLAGS_RELWITHDEBINFO="" \
-  -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="" \
+  -DCMAKE_C_FLAGS_DEBUG="" \
+  -DCMAKE_CXX_FLAGS_DEBUG="" \
   -DBUILD_FOR_FUZZING=ON \
   -DSANITIZER_LDFLAGS="$LIB_FUZZING_ENGINE" \
   $EXTRA_BUILD_OPTIONS


### PR DESCRIPTION
This PR ensures consistent usage of the "Debug" build configuration when depends are built with `DEBUG=1`.

For more details, please refer to [this](https://github.com/bitcoin/bitcoin/pull/30778#issuecomment-2326460252) discussion.