### PR TITLE
mpv: disable Centipede

### DIFF
--- a/projects/mpv/project.yaml
+++ b/projects/mpv/project.yaml
@@ -13,7 +13,6 @@ sanitizers:
   - undefined
 fuzzing_engines:
   - afl
-  - centipede
   - honggfuzz
   - libfuzzer
 selective_unpack: true


### PR DESCRIPTION
It is unstable. Likely due to storage limitations. Works locally correctly. Disable it and let other fuzzing engines work.

See: #12429