### PR TITLE
[connectedhomeip] Adding zap-cli to PATH and statically linking some libs

### DIFF
--- a/projects/connectedhomeip/Dockerfile
+++ b/projects/connectedhomeip/Dockerfile
@@ -40,7 +40,8 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN rustup install nightly
 RUN rustup default nightly
 
-RUN git clone --depth=1 https://github.com/project-chip/connectedhomeip.git connectedhomeip
+RUN git clone --depth=1 --branch AA/UBSANandpkgconfig https://github.com/Alami-Amine/connectedhomeip.git connectedhomeip
+
 
 # Ensure global python has access to build requirements
 RUN pip3 install -r connectedhomeip/scripts/setup/requirements.build.txt

--- a/projects/connectedhomeip/Dockerfile
+++ b/projects/connectedhomeip/Dockerfile
@@ -40,7 +40,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN rustup install nightly
 RUN rustup default nightly
 
-RUN git clone --depth=1 --branch AA/UBSANandpkgconfig https://github.com/Alami-Amine/connectedhomeip.git connectedhomeip
+RUN git clone --depth=1 --branch AA/pkgconfig https://github.com/Alami-Amine/connectedhomeip.git connectedhomeip
 
 
 # Ensure global python has access to build requirements

--- a/projects/connectedhomeip/build.sh
+++ b/projects/connectedhomeip/build.sh
@@ -29,6 +29,9 @@ set +u
 PW_ENVSETUP_QUIET=1 source scripts/activate.sh
 set -u
 
+#This adds zap-cli to PATH, needed for fuzzing all-clusters-app
+export PATH="/src/connectedhomeip/.environment/cipd/packages/zap/:$PATH"
+
 # Create a build directory with the following options:
 # - `oss_fuzz` enables OSS-Fuzz build
 # - `is_clang` selects clang toolchains (does not support AFL fuzzing engine)
@@ -39,7 +42,7 @@ set -u
 #   error on GenericConnectivityManagerImpl_Thread.ipp and current fuzzing
 #   does not differentiate between thread/Wifi/TCP/UDP/BLE connectivity
 #   implementations.
-# - `target_ldflags` forces compiler to use LLVM's linker
+# - `target_ldflags` forces compiler to use LLVM's linker + explicitly linking some libraries (statically)
 gn gen out/fuzz_targets \
   --args="
     oss_fuzz=true \
@@ -47,7 +50,7 @@ gn gen out/fuzz_targets \
     enable_rtti=true \
     chip_enable_thread_safety_checks=false \
     chip_enable_openthread=false \
-    target_ldflags=[\"-fuse-ld=lld\"]"
+    target_ldflags=[\"-fuse-ld=lld\", \"-Bstatic\", \"-lselinux\", \"-lmount\", \"-lblkid\", \"-lz\", \"-lpcre\", \"-lffi\", \"-lgmodule-2.0\", \"-Wl,-Bdynamic\"]"
 
 # Deactivate Pigweed environment to use OSS-Fuzz toolchains
 deactivate

--- a/projects/connectedhomeip/build.sh
+++ b/projects/connectedhomeip/build.sh
@@ -50,7 +50,7 @@ gn gen out/fuzz_targets \
     enable_rtti=true \
     chip_enable_thread_safety_checks=false \
     chip_enable_openthread=false \
-    target_ldflags=[\"-fuse-ld=lld\", \"-Bstatic\", \"-lselinux\", \"-lmount\", \"-lblkid\", \"-lz\", \"-lpcre\", \"-lffi\", \"-lgmodule-2.0\", \"-Wl,-Bdynamic\"]"
+    target_ldflags=[\"-fuse-ld=lld\"]"
 
 # Deactivate Pigweed environment to use OSS-Fuzz toolchains
 deactivate

--- a/projects/connectedhomeip/project.yaml
+++ b/projects/connectedhomeip/project.yaml
@@ -10,8 +10,6 @@ auto_ccs:
   - "aalami@csa-iot.org"
 sanitizers:
   - address
-  - undefined
-  - memory
 fuzzing_engines:
   - libfuzzer
   - honggfuzz


### PR DESCRIPTION
This fixes two build failures:
1. Zap generation failure due to not finding zap-cli
2. Fixing linking errors such as:
```
ld.lld: error: undefined symbol: is_selinux_enabled
>>> referenced by glocalfileinfo.c.o:(set_selinux_context) in archive /lib/x86_64-linux-gnu/libgio-2.0.a
>>> referenced by glocalfileinfo.c.o:(_g_local_file_info_get) in archive /lib/x86_64-linux-gnu/libgio-2.0.a
>>> referenced by glocalfileinfo.c.o:(_g_local_file_info_get_from_fd) in archive /lib/x86_64-linux-gnu/libgio-2.0.a
>>> referenced 1 more times
```

- This got fixed by explicitly linking some libs, which are transitive dependencies of libgio-2.0