### PR TITLE
[elfutils] poke dwfl_core_file_attach and other tweaks

### DIFF
--- a/projects/elfutils/Dockerfile
+++ b/projects/elfutils/Dockerfile
@@ -17,6 +17,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && \
     apt-get install -y pkg-config make autoconf autopoint zlib1g-dev zlib1g-dev:i386 flex gawk bison
-RUN git clone --depth 1 git://sourceware.org/git/elfutils.git
+RUN git clone --depth 1 https://sourceware.org/git/elfutils.git
 WORKDIR elfutils
 COPY build.sh *.c *.zip $SRC/

--- a/projects/elfutils/build.sh
+++ b/projects/elfutils/build.sh
@@ -97,7 +97,7 @@ ASAN_OPTIONS=detect_leaks=0 make -j$(nproc) V=1
 # it's also built with ASan and UBSan.
 git clone https://github.com/madler/zlib
 pushd zlib
-git checkout v1.2.12
+git checkout v1.3.1
 if ! ./configure --static; then
     cat configure.log
     exit 1

--- a/projects/elfutils/build.sh
+++ b/projects/elfutils/build.sh
@@ -30,7 +30,7 @@
 #
 #  $ git clone https://github.com/google/oss-fuzz
 #  $ cd oss-fuzz/projects/elfutils
-#  $ git clone git://sourceware.org/git/elfutils.git
+#  $ git clone https://sourceware.org/git/elfutils.git
 #  $ ./build.sh
 #  $ wget -O fuzz-dwfl-core-corpus.zip "https://storage.googleapis.com/elfutils-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer/elfutils_fuzz-dwfl-core/public.zip"
 #  $ unzip -d CORPUS fuzz-dwfl-core-corpus.zip

--- a/projects/elfutils/fuzz-dwfl-core.c
+++ b/projects/elfutils/fuzz-dwfl-core.c
@@ -53,6 +53,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 		goto cleanup;
 	if (dwfl_report_end(dwfl, NULL, NULL) != 0)
 		goto cleanup;
+	if (dwfl_core_file_attach(dwfl, core) < 0)
+		goto cleanup;
 
 cleanup:
 	dwfl_end(dwfl);

--- a/projects/elfutils/project.yaml
+++ b/projects/elfutils/project.yaml
@@ -2,7 +2,7 @@ homepage: "https://sourceware.org/elfutils/"
 language: c++
 builds_per_day: 4
 primary_contact: "elfutils-devel@sourceware.org"
-main_repo: "git://sourceware.org/git/elfutils.git"
+main_repo: "https://sourceware.org/git/elfutils.git"
 fuzzing_engines:
   - libfuzzer
   - afl


### PR DESCRIPTION
* [elfutils] poke dwfl_core_file_attach
to slowly start covering https://storage.googleapis.com/oss-fuzz-coverage/elfutils/reports/20240820/linux/src/elfutils/backends/report.html and be prepared to go after threads and frames eventually.

* [elfutils] switch from git to https
by analogy with https://github.com/libbpf/libbpf/pull/718

* [elfutils] switch to the latest version of zlib
clang no longer produces a lot of "definition without a prototype" warnings among other things.