### PR TITLE
tailscale: fix broken build

### DIFF
--- a/projects/tailscale/Dockerfile
+++ b/projects/tailscale/Dockerfile
@@ -17,6 +17,11 @@
 FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN apt-get update && apt-get install -y wget
 RUN git clone --depth 1 https://github.com/tailscale/tailscale
+RUN wget https://go.dev/dl/go1.23.1.linux-amd64.tar.gz \
+    && mkdir temp-go \
+    && rm -rf /root/.go/* \
+    && tar -C temp-go/ -xzf go1.23.1.linux-amd64.tar.gz \
+    && mv temp-go/go/* /root/.go/
 
 COPY build.sh $SRC/
 WORKDIR $SRC/tailscale


### PR DESCRIPTION
tailscale requires Go 1.23: https://github.com/tailscale/tailscale/blob/98f4dd9857b4128c2569a2f2157d0bb8325262fa/go.mod#L3 and OSS-Fuzz uses a lower one per default.