### PR TITLE
XMLSec requires push functionality in LibXML2

### DIFF
--- a/projects/xmlsec/build.sh
+++ b/projects/xmlsec/build.sh
@@ -23,7 +23,6 @@ mkdir -p $XMLSEC_DEPS_PATH
 cd $SRC/libxml2
 ./autogen.sh \
     --without-legacy \
-    --without-push \
     --without-python \
     --without-zlib \
     --without-lzma \


### PR DESCRIPTION
See build failure: https://oss-fuzz-build-logs.storage.googleapis.com/log-49081235-d5d8-4447-bc70-a32b48c39f0d.txt