### PR TITLE
Update mongodb cmd path

### DIFF
--- a/projects/mongo-go-driver/build.sh
+++ b/projects/mongo-go-driver/build.sh
@@ -16,8 +16,7 @@
 ################################################################################
 
 go get github.com/AdamKorcz/go-118-fuzz-build/testing
-rm -rf $SRC/mongo-go-driver/vendor
-go run cmd/build-oss-fuzz-corpus/main.go $OUT/fuzz_decode_seed_corpus.zip
+go run internal/cmd/build-oss-fuzz-corpus/main.go $OUT/fuzz_decode_seed_corpus.zip
 
 mv bson/fuzz_test.go bson/fuzz.go
 mv bson/bson_corpus_spec_test.go bson/bson_corpus_spec.go


### PR DESCRIPTION
Resolves [71522](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=71522)

The MongoDB Go Driver has changed the location of the source file path in v2, which is now the default branch (master).