### PR TITLE
Disable honggfuzz and AFL on lldb-eval

### DIFF
--- a/projects/lldb-eval/project.yaml
+++ b/projects/lldb-eval/project.yaml
@@ -8,3 +8,5 @@ sanitizers:
   - address
   - undefined
 file_github_issue: True
+fuzzing_engines:
+  - libfuzzer


### PR DESCRIPTION
It was enabled by accident and never worked.