### PR TITLE
infra: print log data when Python fuzz_target fails

### DIFF
--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -180,6 +180,7 @@ function run_python_fuzz_target {
   if (( $? != 0 )); then
     echo "Error happened getting coverage of $target"
     echo "This is likely because Atheris did not exit gracefully"
+    cat $LOGS_DIR/$target.log
     return 0
   fi
   mv .coverage $OUT/.coverage_$target


### PR DESCRIPTION
## Description

This will make it easier to debug coverage failures that are not reproducible locally.

The failure that I am trying to debug:
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62231
  - https://oss-fuzz-build-logs.storage.googleapis.com/log-c420cf0c-f073-4c42-b75c-422971ef272e.txt

```
Step #5: Already have image (with digest): gcr.io/oss-fuzz-base/base-runner
Step #5: Entering python fuzzing
Step #5: Error happened getting coverage of fuzz_parse
Step #5: This is likely because Atheris did not exit gracefully
```

Similar log data is displayed in other blocks:
https://github.com/google/oss-fuzz/blob/f7165902492d5cff5ee23c018875395061a3bd2b/infra/base-images/base-runner/coverage#L101-L105

https://github.com/google/oss-fuzz/blob/f7165902492d5cff5ee23c018875395061a3bd2b/infra/base-images/base-runner/coverage#L149-L153

https://github.com/google/oss-fuzz/blob/f7165902492d5cff5ee23c018875395061a3bd2b/infra/base-images/base-runner/coverage#L206-L210

https://github.com/google/oss-fuzz/blob/f7165902492d5cff5ee23c018875395061a3bd2b/infra/base-images/base-runner/coverage#L255-L260

---

This PR is a continuation of https://github.com/google/oss-fuzz/pull/12405 with a renamed branch to avoid trial-build errors:

```
ERROR: (gcloud.builds.submit) INVALID_ARGUMENT: invalid build: invalid build tag "testing-cm/display-coverage-log": must match format "^[\\w][\\w.-]{0,127}$"
```