### PR TITLE
gitoxide: Use updated nightly to fix serde error

### DIFF
--- a/projects/gitoxide/Dockerfile
+++ b/projects/gitoxide/Dockerfile
@@ -16,6 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-rust
 RUN git clone --depth 1 https://github.com/Byron/gitoxide.git gitoxide
+RUN rustup update nightly
 WORKDIR gitoxide
 RUN rustup component add rust-src
 COPY build.sh $SRC/

--- a/projects/gitoxide/build.sh
+++ b/projects/gitoxide/build.sh
@@ -25,7 +25,7 @@ for CRATE_DIR in ${FUZZ_CRATE_DIRS[@]};
 do
   echo "Building crate: $CRATE_DIR"
   cd $CRATE_DIR
-  cargo fuzz build -O --debug-assertions
+  cargo +nightly fuzz build -O --debug-assertions
   FUZZ_TARGET_OUTPUT_DIR=$CARGO_BUILD_TARGET_DIR/x86_64-unknown-linux-gnu/release
   for f in fuzz/fuzz_targets/*.rs
   do


### PR DESCRIPTION
Since around https://github.com/Byron/gitoxide/pull/1536, fuzzing is broken for `gitoxide` due to an error related to `serde`. As shown there and in https://github.com/Byron/gitoxide/pull/1596, the error is:

    error[E0658]: `#[diagnostic]` attribute name space is experimental
       --> /rust/registry/src/index.crates.io-6f17d22bba15001f/serde-1.0.210/src/de/mod.rs:536:5
        |
    536 |     diagnostic::on_unimplemented(
        |     ^^^^^^^^^^
        |
        = note: see issue #111996 <https://github.com/rust-lang/rust/issues/111996> for more information
        = help: add `#![feature(diagnostic_namespace)]` to the crate attributes to enable
        = note: this compiler was built on 2024-02-11; consider upgrading it if it is out of date

Since https://github.com/rust-lang/rust/issues/111996 is closed as completed, and similar errors appear to have been fixed in oss-fuzz for other projects by using the latest nightly toolchain, this makes the same change for `gitoxide` as was made in:

- https://github.com/google/oss-fuzz/pull/12404 for `starlark-rust`
- https://github.com/google/oss-fuzz/pull/12409 for `rhai`

See also:

- https://github.com/google/oss-fuzz/issues/12410
- https://github.com/serde-rs/serde/issues/2770

cc @Byron