### PR TITLE
log4j2: Switch to the Log4j 2 development branch

### DIFF
--- a/projects/log4j2/build.sh
+++ b/projects/log4j2/build.sh
@@ -15,5 +15,5 @@
 #
 ################################################################################
 
-git clone --depth 1 --branch fuzzing --single-branch https://github.com/apache/logging-log4j2
+git clone --depth 1 --branch 2.x --single-branch https://github.com/apache/logging-log4j2
 ./logging-log4j2/oss-fuzz-build.sh "$OUT"


### PR DESCRIPTION
In #12304, we used `fuzzing` branch of the `apache/logging-log4j2` repository while developing the Log4j 2 integration. This work was successful and we eventually merged the `fuzzing` branch to `2.x`<sup>1</sup> in apache/logging-log4j2#2949. Now we can point OSS-Fuzz to the permanent location of the Log4j 2 fuzz tests.

<sup>1</sup> [`2.x` is the main branch where Log4j 2 development takes place.](https://logging.apache.org/log4j/2.x/development.html#branching)
