### PR TITLE
infra: build: functions: add default empty list for tags

### DIFF
--- a/infra/build/functions/target_experiment.py
+++ b/infra/build/functions/target_experiment.py
@@ -326,7 +326,7 @@ def main():
   parser.add_argument('--experiment_name',
                       required=True,
                       help='Experiment name.')
-  parser.add_argument('--tags', nargs='*', help='Tags for cloud build.')
+  parser.add_argument('--tags', nargs='*', help='Tags for cloud build.', default=[])
   args = parser.parse_args()
 
   run_experiment(args.project, args.target, args.args, args.upload_output_log,

--- a/infra/build/functions/target_experiment.py
+++ b/infra/build/functions/target_experiment.py
@@ -326,7 +326,10 @@ def main():
   parser.add_argument('--experiment_name',
                       required=True,
                       help='Experiment name.')
-  parser.add_argument('--tags', nargs='*', help='Tags for cloud build.', default=[])
+  parser.add_argument('--tags',
+                      nargs='*',
+                      help='Tags for cloud build.',
+                      default=[])
   args = parser.parse_args()
 
   run_experiment(args.project, args.target, args.args, args.upload_output_log,


### PR DESCRIPTION
This caused a regression for experiments in OFG.

```sh
2024-09-20 22:39:56.906 INFO models - do_generate: vertex_ai_gemini-1-5 generating response with config: {'temperature': 0.6, 'max_output_tokens': 8192}
2024-09-20 22:39:57.088 ERROR builder_runner - _run_with_retry_control: Failed to evaluate /experiment/results/output-htslib-hfile_list_plugins/fixed_targets/02.c on cloud, attempt 1:

Traceback (most recent call last):	  File "/tmp/tmp5dlnpp7z/infra/build/functions/target_experiment.py", line 339, in <module>	    main()	  File "/tmp/tmp5dlnpp7z/infra/build/functions/target_experiment.py", line 332, in main	    run_experiment(args.project, args.target, args.args, args.upload_output_log,	  File "/tmp/tmp5dlnpp7z/infra/build/functions/target_experiment.py", line 288, in run_experiment	    extra_tags=[experiment_name, project_name] + tags)	               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~	TypeError: can only concatenate list (not "NoneType") to list	
2024-09-20 22:39:57.088 INFO evaluator - log: Fixing /experiment/results/output-htslib-hfile_list_plugins/fixed_targets/02.c with vertex_ai_gemini-1-5, attempt 1.
2024-09-20 22:39:57.088 WARNING prompt_builder - _format_fixer_problem: Unexpected empty error message in fix prompt for error_desc: None
2024-09-20 22:39:57.089 INFO models - do_generate: vertex_ai_gemini-1-5 generating response with config: {'temperature': 0.46, 'max_output_tokens': 8192}
```

From https://github.com/google/oss-fuzz-gen/pull/636

Ref: https://github.com/google/oss-fuzz/pull/12520