### PR TITLE
grpc-httpjson-transcoding: Install Python3 explicitly

### DIFF
--- a/projects/grpc-httpjson-transcoding/Dockerfile
+++ b/projects/grpc-httpjson-transcoding/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER nareddyt@google.com
 
-RUN apt-get update && apt-get install python -y
+RUN apt-get update && apt-get install python3 -y
 RUN git clone https://github.com/grpc-ecosystem/grpc-httpjson-transcoding.git
 WORKDIR $SRC/grpc-httpjson-transcoding/
 COPY build.sh $SRC/


### PR DESCRIPTION
Similar to #9507, to get past failures of the form:

```
/usr/bin/env: 'python3': No such file or directory
```