### PR TITLE
lima: move build script upstream

### DIFF
--- a/projects/lima/build.sh
+++ b/projects/lima/build.sh
@@ -15,13 +15,4 @@
 #
 ################################################################################
 
-printf "package store\nimport _ \"github.com/AdamKorcz/go-118-fuzz-build/testing\"\n" > $SRC/lima/pkg/store/register.go
-go mod tidy
-compile_native_go_fuzzer github.com/lima-vm/lima/pkg/store FuzzLoadYAMLByFilePath FuzzLoadYAMLByFilePath
-compile_native_go_fuzzer github.com/lima-vm/lima/pkg/store FuzzInspect FuzzInspect
-compile_native_go_fuzzer github.com/lima-vm/lima/pkg/nativeimgutil FuzzConvertToRaw FuzzConvertToRaw
-compile_native_go_fuzzer github.com/lima-vm/lima/pkg/cidata FuzzSetupEnv FuzzSetupEnv
-compile_native_go_fuzzer github.com/lima-vm/lima/pkg/iso9660util FuzzIsISO9660 FuzzIsISO9660
-compile_native_go_fuzzer github.com/lima-vm/lima/pkg/guestagent/procnettcp FuzzParse FuzzParse
-compile_native_go_fuzzer github.com/lima-vm/lima/pkg/yqutil FuzzEvaluateExpression FuzzEvaluateExpression
-compile_native_go_fuzzer github.com/lima-vm/lima/pkg/downloader FuzzDownload FuzzDownload
+./hack/oss-fuzz-build.sh


### PR DESCRIPTION
The build script was recently moved upstream, so updating accordingly here.