### PR TITLE
[connectedhomeip] Upgrade python version to 3.10

### DIFF
--- a/projects/connectedhomeip/Dockerfile
+++ b/projects/connectedhomeip/Dockerfile
@@ -20,19 +20,25 @@ FROM gcr.io/oss-fuzz-base/base-builder
 # See connectedhomeip/docs/guides/BUILDING.md#prerequisites
 RUN apt-get update && \
     apt-get install -y pkg-config libssl-dev libdbus-1-dev libglib2.0-dev \
-		libavahi-client-dev ninja-build python3-venv python3-dev python3-pip \
-		unzip libgirepository1.0-dev libcairo2-dev libreadline-dev
+        libavahi-client-dev ninja-build \
+        unzip libgirepository1.0-dev libcairo2-dev libreadline-dev
+
+# Installing Python3.10 and using it instead of the default Python taken from the base-builder image
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get update && \
+    apt-get install -y pkg-config python3.10 python3.10-dev python3.10-venv && \
+    ln --force -s /usr/bin/python3.10 /usr/bin/python3
 
 # Ensure python that was just installed gets precedence over
 # the one already installed in /usr/local/bin
 ENV PATH="/usr/bin/:${PATH}"
 
-# This fixes setuptools bug related to version 71 
-# https://github.com/pypa/setuptools/issues/4483 
-RUN pip install -U packaging
+RUN python3 -m ensurepip --upgrade
 
 # PEP-517 needed for cryptography. Update pip
-RUN pip3 install --upgrade pip setuptools wheel
+RUN python3 -m pip install --upgrade pip setuptools wheel
 
 # Install Rust for building `cryptography` python package when bootstraping pigweed
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y


### PR DESCRIPTION
- OSS-Fuzz builds are failing after pigweed was rebased in https://github.com/project-chip/connectedhomeip/pull/35644
- One of the failures is related to pigweed becoming incompatible with python <3.9. Such as using subscript notation in the type hints.

- Fix: Base images in OSS-Fuzz use python 3.8, This PR aims to force the usage of python3.10 instead
### Example Error
```
Step #1: Traceback (most recent call last):
Step #1:   File "../../third_party/pigweed/repo/pw_build/py/pw_build/python_runner.py", line 38, in <module>
Step #1:     import gn_resolver  # type: ignore
Step #1:   File "/src/connectedhomeip/third_party/pigweed/repo/pw_build/py/pw_build/gn_resolver.py", line 319, in <module>
Step #1:     _Actions = Iterator[tuple[_ArgAction, str]]
Step #1: TypeError: 'type' object is not subscriptable
Step #1: [137/1234] ln -f ../../third_party/pigweed/repo/pw_thread/pw_thread_protos/thread_snapshot_service.proto
```
