### PR TITLE
apache-logging-log4cxx: Switch to the main branch

### DIFF
--- a/projects/apache-logging-log4cxx/build.sh
+++ b/projects/apache-logging-log4cxx/build.sh
@@ -15,5 +15,5 @@
 #
 ################################################################################
 
-git clone --quiet --depth 1 --branch fuzzing --single-branch https://github.com/apache/logging-log4cxx
+git clone --quiet --depth 1 --branch master --single-branch https://github.com/apache/logging-log4cxx
 ./logging-log4cxx/src/fuzzers/bash/oss-fuzz-build.sh "$OUT"


### PR DESCRIPTION
In #12352, we used the `fuzzing` branch of the `apache/logging-log4cxx` repository while developing the Log4cxx integration. This work was successful and we eventually merged the `fuzzing` branch to `master` in apache/logging-log4cxx#411. Now we can point OSS-Fuzz to the permanent location of the Log4cxx fuzz tests.