### PR TITLE
Do not call HTMLParser.unescape() in Python 3.9 in six

### DIFF
--- a/projects/six/fuzz_six.py
+++ b/projects/six/fuzz_six.py
@@ -55,7 +55,8 @@ def TestOneInput(data):
   except (TypeError, UnicodeDecodeError):
     pass
 
-  six.moves.html_parser.HTMLParser().unescape(
+  if sys.version_info < (3, 9):
+    six.moves.html_parser.HTMLParser().unescape(
       fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(1, 1024)))
 
 


### PR DESCRIPTION
Presumably, #11419 will be resolved at some point in the future by upgrading the base image to Python > 3.8. Maybe by #11420, maybe by #12027, maybe by a PR that has yet to be created.

When that happens, 'six' will have a problem.

https://github.com/google/oss-fuzz/blob/7fa4a40a8547a007bdf13c2bb391cec8c14d8dc0/projects/six/fuzz_six.py#L58-L59

In Python 3.9, 'unescape' was removed from HTMLParser - https://docs.python.org/3/whatsnew/3.9.html#porting-to-python-3-9
> The unescape() method in the [html.parser.HTMLParser](https://docs.python.org/3/library/html.parser.html#html.parser.HTMLParser) class has been removed (it was deprecated since Python 3.4).

Looking at the 'six' source code, `unescape` isn't actually called by anything internally. HTMLParser is sure, but that's it. So if the method is gone in Python >= 3.9, then there's no need to continue testing it when Python is upgraded.