### PR TITLE
[connectedhomeip] Reactivate UndfinedBehaviorSanitizer

### DIFF
--- a/projects/connectedhomeip/project.yaml
+++ b/projects/connectedhomeip/project.yaml
@@ -11,7 +11,9 @@ auto_ccs:
 sanitizers:
   - address
   - undefined
-  - memory
+# MemorySanitizer is deactivated due to false positives related to Glib
+# For MSan; Glib and all others libs should be compiled with MSan
+#  - memory
 fuzzing_engines:
   - libfuzzer
   - honggfuzz

--- a/projects/connectedhomeip/project.yaml
+++ b/projects/connectedhomeip/project.yaml
@@ -10,6 +10,8 @@ auto_ccs:
   - "aalami@csa-iot.org"
 sanitizers:
   - address
+  - undefined
+  - memory
 fuzzing_engines:
   - libfuzzer
   - honggfuzz


### PR DESCRIPTION
- Reactivating UndefinedBehaviorSanitizer after having fixed UBSan issue: https://github.com/project-chip/connectedhomeip/pull/35777

- MemorySanitizer can not be activated due to false positives showing for `glib`. Apparently all dependencies including glib will need to be re-compiled with MSan to avoid these false-positives.