### PR TITLE
[Pillow] Use Python 3.9

### DIFF
--- a/projects/pillow/Dockerfile
+++ b/projects/pillow/Dockerfile
@@ -21,6 +21,9 @@ RUN apt-get update && \
     apt-get install -y \
       libxau-dev \
       pkg-config \
+      python3-pip \
+      python3.9-dev \
+      python3.9-distutils \
       rsync
 
 RUN git clone --depth 1 https://github.com/python-pillow/Pillow
@@ -29,7 +32,8 @@ RUN $SRC/Pillow/Tests/oss-fuzz/build_dictionaries.sh
 
 COPY build_depends.sh $SRC
 
-RUN ln -s /bin/true /usr/local/bin/yum_install \
+RUN ln -sf /usr/bin/python3.9 /usr/local/bin/python3 \
+    && ln -s /bin/true /usr/local/bin/yum_install \
     && ln -s /bin/true /usr/local/bin/yum \
     && cd $SRC/Pillow \
     && git submodule update --init wheels/multibuild \
@@ -38,7 +42,7 @@ RUN ln -s /bin/true /usr/local/bin/yum_install \
 # install extra test images for a better starting corpus
 RUN cd Pillow/depends && ./install_extra_test_images.sh
 
-RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install --upgrade atheris pyinstaller
 
 COPY build.sh $SRC/
 


### PR DESCRIPTION
Pillow's oss-fuzz is currently failing, because Pillow main has [dropped support for Python 3.8](https://github.com/python-pillow/Pillow/pull/8183).

Until a global solution is provided for #11419, this installs Python 3.9 to allow Pillow to work again.

cc @hugovk 