### PR TITLE
Add cloudbuild for building chronos images for all C++.

### DIFF
--- a/infra/experimental/chronos/Dockerfile
+++ b/infra/experimental/chronos/Dockerfile
@@ -1,3 +1,18 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
 FROM gcr.io/cloud-builders/gcloud
 
 RUN apt-get update && apt-get install -y jq

--- a/infra/experimental/chronos/Dockerfile
+++ b/infra/experimental/chronos/Dockerfile
@@ -1,0 +1,3 @@
+FROM gcr.io/cloud-builders/gcloud
+
+RUN apt-get update && apt-get install -y jq

--- a/infra/experimental/chronos/build_all.sh
+++ b/infra/experimental/chronos/build_all.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2024 Google Inc.
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/experimental/chronos/build_all.sh
+++ b/infra/experimental/chronos/build_all.sh
@@ -19,9 +19,12 @@
 c_project_yaml=$(find projects/ -name project.yaml -exec grep -l 'language: c' {} \;)
 projs=$(echo $c_project_yaml | xargs dirname | xargs basename -a | sort)
 
+cd infra/experimental/chronos
+
 for proj in $projs; do
     fuzz_target=$(curl -s "https://introspector.oss-fuzz.com/api/harness-source-and-executable?project=$proj" | jq --raw-output '.pairs[0].executable')
     if [ "$fuzz_target" != null ]; then
         echo ./build_on_cloudbuild.sh $proj $fuzz_target c
+        ./build_on_cloudbuild.sh $proj $fuzz_target c
     fi
 done

--- a/infra/experimental/chronos/build_all.sh
+++ b/infra/experimental/chronos/build_all.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright 2024 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Build all C/C++ projects.
+c_project_yaml=$(find projects/ -name project.yaml -exec grep -l 'language: c' {} \;)
+projs=$(echo $c_project_yaml | xargs dirname | xargs basename -a | sort)
+
+for proj in $projs; do
+    fuzz_target=$(curl -s "https://introspector.oss-fuzz.com/api/harness-source-and-executable?project=$proj" | jq --raw-output '.pairs[0].executable')
+    if [ "$fuzz_target" != null ]; then
+        echo ./build_on_cloudbuild.sh $proj $fuzz_target c
+    fi
+done

--- a/infra/experimental/chronos/build_on_cloudbuild.sh
+++ b/infra/experimental/chronos/build_on_cloudbuild.sh
@@ -19,6 +19,7 @@ FUZZ_TARGET=$2
 FUZZING_LANGUAGE=$3
 
 gcloud builds submit "https://github.com/google/oss-fuzz" \
+  --async \
   --git-source-revision=master \
   --config=cloudbuild.yaml \
   --substitutions=_PROJECT=$PROJECT,_FUZZ_TARGET=$FUZZ_TARGET,_FUZZING_LANGUAGE=$FUZZING_LANGUAGE \

--- a/infra/experimental/chronos/cloudbuild.yaml
+++ b/infra/experimental/chronos/cloudbuild.yaml
@@ -61,8 +61,9 @@ images:
 - us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/${_PROJECT}-ofg-cached-cov
 timeout: 1800s
 serviceAccount: 'projects/oss-fuzz/serviceAccounts/builder@oss-fuzz.iam.gserviceaccount.com'
+logsBucket: oss-fuzz-gcb-logs
 options:
-  logging: CLOUD_LOGGING_ONLY
+  logging: GCS_ONLY
 tags:
 - ${_PROJECT}
 - chronos

--- a/infra/experimental/chronos/cloudbuild.yaml
+++ b/infra/experimental/chronos/cloudbuild.yaml
@@ -63,3 +63,6 @@ timeout: 1800s
 serviceAccount: 'projects/oss-fuzz/serviceAccounts/builder@oss-fuzz.iam.gserviceaccount.com'
 options:
   logging: CLOUD_LOGGING_ONLY
+tags:
+- ${_PROJECT}
+- chronos

--- a/infra/experimental/chronos/cloudbuild_all.yaml
+++ b/infra/experimental/chronos/cloudbuild_all.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/experimental/chronos/cloudbuild_all.yaml
+++ b/infra/experimental/chronos/cloudbuild_all.yaml
@@ -1,0 +1,34 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+# CloudBuild for generating Chronos-cached images.
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - build
+  - -t
+  - gcloud
+  - .
+  dir: infra/experimental/chronos
+- name: 'gcloud'
+  args:
+  - infra/experimental/chronos/build_all.sh
+  entrypoint: /bin/bash
+timeout: 1800s
+serviceAccount: 'projects/oss-fuzz/serviceAccounts/builder@oss-fuzz.iam.gserviceaccount.com'
+options:
+  logging: CLOUD_LOGGING_ONLY
+tags:
+- chronos-all

--- a/infra/experimental/chronos/cloudbuild_all.yaml
+++ b/infra/experimental/chronos/cloudbuild_all.yaml
@@ -27,7 +27,7 @@ steps:
   - infra/experimental/chronos/build_all.sh
   entrypoint: /bin/bash
 timeout: 1800s
-serviceAccount: 'projects/oss-fuzz/serviceAccounts/builder@oss-fuzz.iam.gserviceaccount.com'
+serviceAccount: 'projects/oss-fuzz/serviceAccounts/llm-eval@oss-fuzz.iam.gserviceaccount.com'
 options:
   logging: CLOUD_LOGGING_ONLY
 tags:


### PR DESCRIPTION
Once this is merged, we just need to set up an automated trigger to run this daily. 