### PR TITLE
[elfutils] unpin the base-builder image

### DIFF
--- a/projects/elfutils/Dockerfile
+++ b/projects/elfutils/Dockerfile
@@ -14,10 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:56905c98ae0083d14da0e7371184e694560a74750533f321ac0e9145af0e8d2e
-# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
-# see https://github.com/google/oss-fuzz/pull/12365
-
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && \
     apt-get install -y pkg-config make autoconf autopoint zlib1g-dev zlib1g-dev:i386 flex gawk bison
 RUN git clone --depth 1 https://sourceware.org/git/elfutils.git

--- a/projects/elfutils/build.sh
+++ b/projects/elfutils/build.sh
@@ -62,6 +62,16 @@ sed -i 's/^\(NO_UNDEFINED=\).*/\1/' configure.ac
 # https://clang.llvm.org/docs/AddressSanitizer.html#usage
 sed -i 's/^\(ZDEFS_LDFLAGS=\).*/\1/' configure.ac
 
+# srcfiles.cxx started failing to compile with the OSS-Fuzz toolchain
+# when it was switched from clang-18.0.0 to clang-18.1.8 in
+# https://github.com/google/oss-fuzz/pull/12365.
+# https://github.com/google/oss-fuzz/pull/12365#discussion_r1784702452
+# It's probably an OSS-Fuzz toolchain bug but it doesn't matter much
+# because the srcfiles binary isn't relevant in terms of fuzzing and
+# can safely be excluded.
+sed -i 's/^\(srcfiles_\)/#/' src/Makefile.am
+sed -i 's/\bsrcfiles\b//' src/Makefile.am
+
 if [[ "$SANITIZER" == undefined ]]; then
     additional_ubsan_checks=alignment
     UBSAN_FLAGS="-fsanitize=$additional_ubsan_checks -fno-sanitize-recover=$additional_ubsan_checks"

--- a/projects/elfutils/build.sh
+++ b/projects/elfutils/build.sh
@@ -78,6 +78,7 @@ if [[ "$SANITIZER" == memory ]]; then
     CXXFLAGS+=" -U_FORTIFY_SOURCE"
 fi
 
+$CC --version
 autoreconf -i -f
 if ! ./configure --enable-maintainer-mode --disable-debuginfod --disable-libdebuginfod \
             --disable-demangler --without-bzlib --without-lzma --without-zstd \


### PR DESCRIPTION
* [elfutils] unpin the base-builder image

* [elfutils] show clang version
to make it a bit easier to figure out what's going on.

* [elfutils] no longer compile srcfiles.cxx
srcfiles.cxx started failing to compile with the OSS-Fuzz toolchain
when it was switched from clang-18.0.0 to clang-18.1.8 in
https://github.com/google/oss-fuzz/pull/12365.
https://github.com/google/oss-fuzz/pull/12365#discussion_r1784702452
It's probably an OSS-Fuzz toolchain bug but it doesn't matter much
because the srcfiles binary isn't relevant in terms of fuzzing and
can safely be excluded.