### PR TITLE
Add lukasza@chromium.org to `auto_ccs` for `image-png` project.

### DIFF
--- a/projects/image-png/project.yaml
+++ b/projects/image-png/project.yaml
@@ -9,4 +9,5 @@ language: rust
 auto_ccs:
   - "fintelia@gmail.com"
   - "david@adalogics.com"
+  - "lukasza@chromium.org"
 file_github_issue: True


### PR DESCRIPTION
OSS-Fuzz maintainers - can you PTAL?

Trustworthiness of this request:

* This is a memory-safe, Rust-based project (no `unsafe` in `png` and `fdeflate` crates, although there is some `unsafe` in other dependencies).  This argues that most issues discovered by fuzzing should *not* be security issues, merely correctness/functional issues (or at most Denial-of-Service issues when a timeout happens for some inputs).
* I am contributing to the `png` project as a Chromium Security engineer, so I can hopefully claim some of the trust/karma that may be attributed to the Chromium Security team. 

Motivation for this request:

* I have recently added a new failure mode to one of `image-png` fuzzers (see fuzzer changes underneath https://github.com/image-rs/image-png/pull/496) and fixed a few resulting failures found by OSS-Fuzz (e.g. https://github.com/image-rs/image-png/pull/498, https://github.com/image-rs/image-png/pull/499, or https://github.com/image-rs/image-png/pull/500).  I would like to monitor OSS-Fuzz for additional failures (if any) and help with investigating and/or fixing them.
* There is one OSS-Fuzz-reported failure in another `image-png` fuzzer that I have trouble repro-ing: https://oss-fuzz.com/testcase-detail/5146320858316800.  I hope that getting access to the full fuzzing corpus will help me repro this in a different way locally.

Disclaimer: in the long-term the ownership of `png` / Skia / Chromium integration my shift, but I think it still makes sense to add me for now

/cc @fintelia 