### PR TITLE
Update project contact information for Wasmtime

### DIFF
--- a/projects/wasmtime/project.yaml
+++ b/projects/wasmtime/project.yaml
@@ -1,15 +1,11 @@
 homepage: "https://wasmtime.dev/"
-primary_contact: "jonathan.foote@gmail.com"
+primary_contact: "tsc@bytecodealliance.org"
 auto_ccs:
   - "fitzgen@gmail.com"
   - "alex@alexcrichton.com"
   - "till@tillschneidereit.net"
-  - "ydelendik@mozilla.com"
   - "cfallin@gmail.com"
   - "andrew.s.brown2@gmail.com"
-  - "peterhuene@gmail.com"
-  - "jsharp@fastly.com"
-  - "telliott@fastly.com"
   - "saule.cabrera@gmail.com"
   - "jeff.charles@shopify.com"
 sanitizers:


### PR DESCRIPTION
Remove some contributors who are no longer working on the project, and additionally update the primary contact to the TSC of the Bytecode Alliance which is the umbrella organization owning the project.