### PR TITLE
Remove some `@sha256:...` pins in Dockerfiles

### DIFF
--- a/projects/opencv/Dockerfile
+++ b/projects/opencv/Dockerfile
@@ -14,8 +14,8 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors. A compiler bug is the suspected cause, and it may be fixed on the next oss-fuzz clang roll
+FROM gcr.io/oss-fuzz-base/base-builder
+
 RUN apt-get update && apt-get install -y build-essential cmake pkg-config
 RUN git clone --depth 1 https://github.com/opencv/opencv.git opencv
 WORKDIR opencv/

--- a/projects/zeek/Dockerfile
+++ b/projects/zeek/Dockerfile
@@ -14,8 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
-# ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
+FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         patchelf \


### PR DESCRIPTION
Following https://github.com/google/oss-fuzz/pull/12365 : only zeek and opencv seem fixed