### PR TITLE
ghostscript: Remove kdlee

### DIFF
--- a/projects/ghostscript/project.yaml
+++ b/projects/ghostscript/project.yaml
@@ -9,7 +9,6 @@ auto_ccs:
   - "julians.artifex@gmail.com"
   - "chris.liddell@artifex.com"
   - "ken.sharp@artifex.com"
-  - "kdlee@chromium.org"
   - "david@adalogics.com"
 sanitizers:
   - address


### PR DESCRIPTION
kdlee (that's me) has since moved to a different project and no longer watches over the fuzzer bugs.

(For internal pings, I've got the same username, and my avatar provides a loose confirmation that this is in fact me)