### PR TITLE
[systemd],[util-linux] remove evverx's non-gmail address

### DIFF
--- a/projects/systemd/project.yaml
+++ b/projects/systemd/project.yaml
@@ -15,7 +15,6 @@ auto_ccs:
   - zbyszek@in.waw.pl
   - poettering@gmail.com
   - watanabe.yu@gmail.com
-  - evvers@ya.ru
   - evverx@gmail.com
   - Tixxdz@gmail.com
   - fsumsal@redhat.com

--- a/projects/util-linux/project.yaml
+++ b/projects/util-linux/project.yaml
@@ -4,7 +4,6 @@ language: c
 builds_per_day: 4
 auto_ccs:
   - "kzak@redhat.com"
-  - "evvers@ya.ru"
   - "evverx@gmail.com"
   - "kerolasa@gmail.com"
   - "gmazyland@gmail.com"


### PR DESCRIPTION
It seems notifications are no longer sent there.

It would be great to make it work for other email addresses like the elfutils mailing list because it's the only way to notify the upstream project.