### PR TITLE
Use a seperate pool for Chronos

### DIFF
--- a/infra/experimental/chronos/cloudbuild.yaml
+++ b/infra/experimental/chronos/cloudbuild.yaml
@@ -66,4 +66,4 @@ tags:
 - chronos
 options:
   pool:
-    name: projects/oss-fuzz/locations/us-central1/workerPools/buildpool
+    name: projects/oss-fuzz/locations/us-central1/workerPools/buildpool-chronos


### PR DESCRIPTION
It seems to be causing congestion that is breaking oss-fuzz builds.
Fixes: https://github.com/google/oss-fuzz/issues/12573