### PR TITLE
infra: enable introspector light

### DIFF
--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -207,6 +207,14 @@ if [ "$SANITIZER" = "introspector" ]; then
   ln -sf /usr/local/bin/llvm-ar /usr/bin/ar
   ln -sf /usr/local/bin/llvm-nm /usr/bin/nm
   ln -sf /usr/local/bin/llvm-ranlib /usr/bin/ranlib
+
+  apt-get install -y libjpeg-dev zlib1g-dev libyaml-dev
+  python3 -m pip install --upgrade pip setuptools
+  python3 -m pip install cxxfilt pyyaml beautifulsoup4 lxml soupsieve
+  python3 -m pip install --prefer-binary matplotlib
+
+  python3 /fuzz-introspector/src/main.py light
+  rsync -avu --delete "$SRC/inspector/" "$OUT/inspector"
 fi
 
 echo "---------------------------------------------------------------"
@@ -260,10 +268,6 @@ if [ "$SANITIZER" = "introspector" ]; then
   unset CXXFLAGS
   unset CFLAGS
   export G_ANALYTICS_TAG="G-8WTFM1Y62J"
-  apt-get install -y libjpeg-dev zlib1g-dev libyaml-dev
-  python3 -m pip install --upgrade pip setuptools
-  python3 -m pip install cxxfilt pyyaml beautifulsoup4 lxml soupsieve
-  python3 -m pip install --prefer-binary matplotlib
 
   if [ "$FUZZING_LANGUAGE" = "jvm" ]; then
     echo "GOING jvm route"
@@ -328,6 +332,6 @@ if [ "$SANITIZER" = "introspector" ]; then
     REPORT_ARGS="$REPORT_ARGS --correlation_file=exe_to_fuzz_introspector_logs.yaml"
     python3 /fuzz-introspector/src/main.py report $REPORT_ARGS
 
-    cp -rf $SRC/inspector $OUT/inspector
+    rsync -avu --delete "$SRC/inspector/" "$OUT/inspector"
   fi
 fi

--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y wget sudo && \
 RUN apt-get update && apt-get install -y git && \
     git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
     cd fuzz-introspector && \
-    git checkout 3e66864b5fc85eca238f9fc3fd7492c0a9c39958 && \
+    git checkout 3ec7681506e00a936247103cb51ea4dc1538c930 && \
     git submodule init && \
     git submodule update && \
     apt-get autoremove --purge -y git && \


### PR DESCRIPTION
This enables a light version of introspector, which performs analysis prior to compilation, i.e. without use of LTO. At the current stage light FI has implemented features to support test-to-harness migration on OFG including harness source/executable pairing. Once this has been rolled out in full the light analysis will continue to support more interesting logic related to program analysis, all purely static.