### PR TITLE
[comrak] project proposal

### DIFF
--- a/projects/comrak/project.yaml
+++ b/projects/comrak/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://github.com/kivikakk/comrak"
+main_repo: "https://github.com/kivikakk/comrak.git"
+language: rust
+primary_contact: "ashe@kivikakk.ee"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer


### PR DESCRIPTION
Approved by https://github.com/kivikakk/comrak/issues/474#issue-2576801537.

[`comrak`](https://github.com/kivikakk/comrak/) is one of three go-to choices for markdown rendering for rust. It is similar to [`markdown-rs`](https://github.com/wooorm/markdown-rs) and [`pulldown-cmark`](https://github.com/pulldown-cmark/pulldown-cmark).

It can accept user input (most notably in CMS systems built on top of rust, i.e. https://github.com/ohsayan/jotsy) and can act as a vector for availability attacks. Ruby's [`commonmarker`](https://github.com/gjtorikian/commonmarker) also depends on it.

Despite its non-0.7 criticality score, it one of two good choices for markdown parsing in rust makes it a good candidate for fuzzing. 