### PR TITLE
apache-poi: Update dependencies for Apache POI to fix broken build

### DIFF
--- a/projects/apache-poi/pom.xml
+++ b/projects/apache-poi/pom.xml
@@ -11,7 +11,7 @@
 		<maven.compiler.source>15</maven.compiler.source>
 		<maven.compiler.target>15</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<fuzzedLibaryVersion>5.2.3</fuzzedLibaryVersion>
+		<fuzzedLibaryVersion>5.3.0</fuzzedLibaryVersion>
 		<exec.mainClass>org.apache.poi.XLSX2CSVFuzzer</exec.mainClass>
 	</properties>
 
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>com.code-intelligence</groupId>
 			<artifactId>jazzer-api</artifactId>
-			<version>0.12.0</version>
+			<version>0.22.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>
@@ -57,7 +57,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.20.0</version>
+			<version>2.24.1</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Apache POI seems to depend on a newer version of Log4j now.

Also update main version and jazzer-api to latest