### PR TITLE
Customize cloud build region

### DIFF
--- a/infra/build/build_status/update_build_status.py
+++ b/infra/build/build_status/update_build_status.py
@@ -139,7 +139,7 @@ class BuildGetter:  # pylint: disable=too-few-public-methods
         'v1',
         credentials=self._credentials,
         cache_discovery=False,
-        client_options=build_lib.US_CENTRAL_CLIENT_OPTIONS)
+        client_options=build_lib.REGIONAL_CLIENT_OPTIONS)
     self._cloudbuilds = [self._global_cloudbuild, self._central_cloudbuild]
     self._swapped = False
 

--- a/infra/build/functions/build_lib.py
+++ b/infra/build/functions/build_lib.py
@@ -96,7 +96,7 @@ OSS_FUZZ_EXPERIMENTS_BUILDPOOL_NAME = os.getenv(
     'GCB_BUILDPOOL_NAME', 'projects/oss-fuzz/locations/us-central1/'
     'workerPools/buildpool-experiments')
 
-CLOUD_BUILD_LOCATION = os.getenv('CLOUD_BUILD_LOCATIONS', 'us-central1')
+CLOUD_BUILD_LOCATION = os.getenv('CLOUD_BUILD_LOCATION', 'us-central1')
 REGIONAL_CLIENT_OPTIONS = google.api_core.client_options.ClientOptions(
     api_endpoint=f'https://{CLOUD_BUILD_LOCATION}-cloudbuild.googleapis.com/')
 

--- a/infra/build/functions/build_lib.py
+++ b/infra/build/functions/build_lib.py
@@ -96,8 +96,9 @@ OSS_FUZZ_EXPERIMENTS_BUILDPOOL_NAME = os.getenv(
     'GCB_BUILDPOOL_NAME', 'projects/oss-fuzz/locations/us-central1/'
     'workerPools/buildpool-experiments')
 
-US_CENTRAL_CLIENT_OPTIONS = google.api_core.client_options.ClientOptions(
-    api_endpoint='https://us-central1-cloudbuild.googleapis.com/')
+CLOUD_BUILD_LOCATION = os.getenv('CLOUD_BUILD_LOCATIONS', 'us-central1')
+REGIONAL_CLIENT_OPTIONS = google.api_core.client_options.ClientOptions(
+    api_endpoint=f'https://{CLOUD_BUILD_LOCATION}-cloudbuild.googleapis.com/')
 
 DOCKER_TOOL_IMAGE = 'gcr.io/cloud-builders/docker'
 
@@ -603,7 +604,7 @@ def run_build(  # pylint: disable=too-many-arguments, too-many-locals
                            'v1',
                            credentials=credentials,
                            cache_discovery=False,
-                           client_options=US_CENTRAL_CLIENT_OPTIONS)
+                           client_options=REGIONAL_CLIENT_OPTIONS)
 
   build_info = cloudbuild.projects().builds().create(projectId=cloud_project,
                                                      body=build_body).execute()
@@ -621,7 +622,7 @@ def wait_for_build(build_id, credentials, cloud_project):
                            'v1',
                            credentials=credentials,
                            cache_discovery=False,
-                           client_options=US_CENTRAL_CLIENT_OPTIONS)
+                           client_options=REGIONAL_CLIENT_OPTIONS)
 
   while True:
     try:
@@ -643,6 +644,6 @@ def cancel_build(build_id, credentials, cloud_project):
                            'v1',
                            credentials=credentials,
                            cache_discovery=False,
-                           client_options=US_CENTRAL_CLIENT_OPTIONS)
+                           client_options=REGIONAL_CLIENT_OPTIONS)
   cloudbuild.projects().builds().cancel(projectId=cloud_project,
                                         id=build_id).execute()

--- a/infra/build/functions/trial_build.py
+++ b/infra/build/functions/trial_build.py
@@ -267,7 +267,7 @@ def wait_on_builds(build_ids, credentials, cloud_project, end_time):  # pylint: 
                            'v1',
                            credentials=credentials,
                            cache_discovery=False,
-                           client_options=build_lib.US_CENTRAL_CLIENT_OPTIONS)
+                           client_options=build_lib.REGIONAL_CLIENT_OPTIONS)
   cloudbuild_api = cloudbuild.projects().builds()  # pylint: disable=no-member
 
   wait_builds = build_ids.copy()


### PR DESCRIPTION
Avoids hardcoding cloud build region to `us-central1`, so that users (e.g., `target_experiment.py`) can define their own region.