### PR TITLE
infra: build: introspector: upload artifacts in all cases

### DIFF
--- a/infra/build/functions/build_and_run_coverage.py
+++ b/infra/build/functions/build_and_run_coverage.py
@@ -316,7 +316,11 @@ def get_fuzz_introspector_steps(  # pylint: disable=too-many-locals, too-many-ar
   env.append(f'PROJECT_NAME={project.name}')
 
   build_steps.append(
-      build_project.get_compile_step(project, build, env, config.parallel, allow_failure=True))
+      build_project.get_compile_step(project,
+                                     build,
+                                     env,
+                                     config.parallel,
+                                     allow_failure=True))
 
   # Upload the report.
   upload_report_url = bucket.get_upload_url('inspector-report')

--- a/infra/build/functions/build_and_run_coverage.py
+++ b/infra/build/functions/build_and_run_coverage.py
@@ -316,7 +316,7 @@ def get_fuzz_introspector_steps(  # pylint: disable=too-many-locals, too-many-ar
   env.append(f'PROJECT_NAME={project.name}')
 
   build_steps.append(
-      build_project.get_compile_step(project, build, env, config.parallel))
+      build_project.get_compile_step(project, build, env, config.parallel, allow_failure=True))
 
   # Upload the report.
   upload_report_url = bucket.get_upload_url('inspector-report')

--- a/infra/build/functions/build_project.py
+++ b/infra/build/functions/build_project.py
@@ -243,7 +243,7 @@ def get_env(fuzzing_language, build):
   return list(sorted([f'{key}={value}' for key, value in env_dict.items()]))
 
 
-def get_compile_step(project, build, env, parallel, upload_build_logs=None):
+def get_compile_step(project, build, env, parallel, upload_build_logs=None, allow_failure=False):
   """Returns the GCB step for compiling |projects| fuzzers using |env|. The type
   of build is specified by |build|."""
   failure_msg = (
@@ -277,7 +277,7 @@ def get_compile_step(project, build, env, parallel, upload_build_logs=None):
       'id': get_id('compile', build),
   }
 
-  if upload_build_logs:
+  if upload_build_logs or allow_failure:
     # The failure will be reported in a subsequent step.
     compile_step['allowFailure'] = True
 

--- a/infra/build/functions/build_project.py
+++ b/infra/build/functions/build_project.py
@@ -243,7 +243,12 @@ def get_env(fuzzing_language, build):
   return list(sorted([f'{key}={value}' for key, value in env_dict.items()]))
 
 
-def get_compile_step(project, build, env, parallel, upload_build_logs=None, allow_failure=False):
+def get_compile_step(project,
+                     build,
+                     env,
+                     parallel,
+                     upload_build_logs=None,
+                     allow_failure=False):
   """Returns the GCB step for compiling |projects| fuzzers using |env|. The type
   of build is specified by |build|."""
   failure_msg = (


### PR DESCRIPTION
Upload introspector report even when build fails. This is to ensure artifacts from FI light is uploaded for each build.