### PR TITLE
serenity: Transfer ownership to current project admin

### DIFF
--- a/projects/serenity/project.yaml
+++ b/projects/serenity/project.yaml
@@ -1,6 +1,6 @@
 homepage: "https://github.com/SerenityOS/serenity"
 language: c++
-primary_contact: "kling@serenityos.org"
+primary_contact: "jelle@gmta.nl"
 auto_ccs:
   - "david@adalogics.com"
   - "mail@linusgroh.de"
@@ -12,7 +12,6 @@ auto_ccs:
   - "timledbetter@gmail.com"
   - "atkinssj@serenityos.org"
   - "thakis@chromium.org"
-  - "~awesomekling/serenityos-dev@lists.sr.ht"
 
 # Bug reports are public by default:
 view_restrictions: none


### PR DESCRIPTION
I am no longer involved with this project, so let's make @gmta the primary contact since he's the chief admin of SerenityOS now. :)