### PR TITLE
containerd: add additional security advisor

### DIFF
--- a/projects/containerd/project.yaml
+++ b/projects/containerd/project.yaml
@@ -9,6 +9,7 @@ auto_ccs :
   - "mikebrow@gmail.com"
   - "cjingram@google.com"
   - "kato.kazuyoshi@gmail.com"
+  - "vinaygo@google.com"
 language: go
 fuzzing_engines:
   - libfuzzer


### PR DESCRIPTION
Vinayak is a containerd [security advisor](https://github.com/containerd/project/blob/6d5d6d4908802608d7ba29c9a3e5e3aaccc14390/SECURITY_ADVISORS#L17C2-L17C18); access will allow him to help triage reports.

cc @vinayakankugoyal