### PR TITLE
Unsafe-libyaml: project integration

### DIFF
--- a/projects/unsafe-libyaml/Dockerfile
+++ b/projects/unsafe-libyaml/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang
+
+RUN git clone https://github.com/dtolnay/unsafe-libyaml
+WORKDIR $SRC/unsafe-libyaml
+
+COPY build.sh $SRC/

--- a/projects/unsafe-libyaml/build.sh
+++ b/projects/unsafe-libyaml/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cargo fuzz build -O
+
+cp fuzz/target/x86_64-unknown-linux-gnu/release/load $OUT/
+cp fuzz/target/x86_64-unknown-linux-gnu/release/parse $OUT/
+cp fuzz/target/x86_64-unknown-linux-gnu/release/scan $OUT/
+

--- a/projects/unsafe-libyaml/project.yaml
+++ b/projects/unsafe-libyaml/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/dtolnay/unsafe-libyaml"
+main_repo: "https://github.com/dtolnay/unsafe-libyaml.git"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+language: rust
+auto_ccs:
+  - "arthur.chan@adalogics.com"
+  - "david@adalogics.com"


### PR DESCRIPTION
This PR initialises OSS-Fuzz integration for project unsafe-libyaml in Rust, adopting the existing fuzzers from upstream repository.