### PR TITLE
Zstd-safe: project initialisation

### DIFF
--- a/projects/zstd-safe/Dockerfile
+++ b/projects/zstd-safe/Dockerfile
@@ -16,7 +16,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder-rust
 RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang
 
-RUN git clone https://github.com/gyscos/zstd-rs
-WORKDIR $SRC/zstd-rs
+RUN git clone --recursive https://github.com/gyscos/zstd-rs
+WORKDIR $SRC/zstd-rs/zstd-safe
 
 COPY build.sh $SRC/

--- a/projects/zstd-safe/Dockerfile
+++ b/projects/zstd-safe/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 #
 ################################################################################
 FROM gcr.io/oss-fuzz-base/base-builder-rust
-RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang
 
 RUN git clone --recursive https://github.com/gyscos/zstd-rs
 WORKDIR $SRC/zstd-rs/zstd-safe

--- a/projects/zstd-safe/Dockerfile
+++ b/projects/zstd-safe/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang
+
+RUN git clone https://github.com/gyscos/zstd-rs
+WORKDIR $SRC/zstd-rs
+
+COPY build.sh $SRC/

--- a/projects/zstd-safe/build.sh
+++ b/projects/zstd-safe/build.sh
@@ -15,13 +15,8 @@
 #
 ################################################################################
 
-# Retrieve zstd submodule
-git submodule init
-git submodule update
-
 # Build the fuzzers and project source code
-cd zstd-safe
-cargo fuzz build -O
+cargo fuzz build
 
 # Copy built fuzzer binaries to $OUT
 cp $SRC/zstd-rs/zstd-safe/fuzz/target/x86_64-unknown-linux-gnu/release/zstd_fuzzer $OUT

--- a/projects/zstd-safe/build.sh
+++ b/projects/zstd-safe/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -eu
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Retrieve zstd submodule
+git submodule init
+git submodule update
+
+# Build the fuzzers and project source code
+cd zstd-safe
+cargo fuzz build -O
+
+# Copy built fuzzer binaries to $OUT
+cp $SRC/zstd-rs/zstd-safe/fuzz/target/x86_64-unknown-linux-gnu/release/zstd_fuzzer $OUT

--- a/projects/zstd-safe/project.yaml
+++ b/projects/zstd-safe/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/gyscos/zstd-rs"
+main_repo: "https://github.com/gyscos/zstd-rs.git"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+language: rust
+auto_ccs:
+  - "arthur.chan@adalogics.com"
+  - "david@adalogics.com"

--- a/projects/zstd-safe/project.yaml
+++ b/projects/zstd-safe/project.yaml
@@ -1,5 +1,6 @@
 homepage: "https://github.com/gyscos/zstd-rs"
 main_repo: "https://github.com/gyscos/zstd-rs.git"
+primary_contact: "alexandre.bury@gmail.com"
 sanitizers:
   - address
 fuzzing_engines:


### PR DESCRIPTION
This PR initialises OSS-Fuzz integration for the zstd-safe project in Rust. New fuzzers have been created, and a PR (https://github.com/gyscos/zstd-rs/pull/308) has been submitted upstream to merge the fuzzers.