### PR TITLE
httpdate: project intialisation

### DIFF
--- a/projects/httpdate/Dockerfile
+++ b/projects/httpdate/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+RUN apt-get update && apt-get install -y make autoconf automake libtool curl cmake python llvm-dev libclang-dev clang
+
+RUN git clone https://github.com/pyfisch/httpdate
+WORKDIR $SRC/httpdate
+
+COPY build.sh $SRC/

--- a/projects/httpdate/build.sh
+++ b/projects/httpdate/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cargo fuzz build -O
+
+cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_target_1 $OUT/
+cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_conversion $OUT/
+

--- a/projects/httpdate/project.yaml
+++ b/projects/httpdate/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/pyfisch/httpdate"
+main_repo: "https://github.com/pyfisch/httpdate.git"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+language: rust
+auto_ccs:
+  - "arthur.chan@adalogics.com"
+  - "david@adalogics.com"


### PR DESCRIPTION
This PR initialises OSS-Fuzz integration for the httpdate project in Rust. New fuzzers have been created, and a PR () has been submitted upstream to merge the fuzzers.

*REMARK: This PR only works when the upstream fuzzers PR has been merged.