### PR TITLE
scrypt: initial integration

### DIFF
--- a/projects/scrypt/Dockerfile
+++ b/projects/scrypt/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+
+RUN git clone https://github.com/RustCrypto/password-hashes
+WORKDIR $SRC/password-hashes/scrypt
+
+COPY build.sh $SRC/

--- a/projects/scrypt/Dockerfile
+++ b/projects/scrypt/Dockerfile
@@ -16,6 +16,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder-rust
 
 RUN git clone https://github.com/RustCrypto/password-hashes
-WORKDIR $SRC/password-hashes/scrypt
+WORKDIR $SRC/password-hashes
 
 COPY build.sh $SRC/

--- a/projects/scrypt/build.sh
+++ b/projects/scrypt/build.sh
@@ -19,5 +19,5 @@
 cargo fuzz build
 
 # Copy built fuzzer binaries to $OUT
-find $SRC/password-hashes/fuzz/target/x86_64-unknown-linux-gnu/release -maxdepth 1 \
+find $SRC/password-hashes/fuzz/target/x86_64-unknown-linux-gnu/release -maxdepth 1 -name scrypt* \
     -type f -perm -u=x -exec cp {} $OUT \;

--- a/projects/scrypt/build.sh
+++ b/projects/scrypt/build.sh
@@ -19,4 +19,5 @@
 cargo fuzz build
 
 # Copy built fuzzer binaries to $OUT
-cp $SRC/password-hashes/target/x86_64-unknown-linux-gnu/release/scrypt_fuzzer $OUT/
+find $SRC/password-hashes/target/x86_64-unknown-linux-gnu/release -maxdepth 1 \
+    -type f -perm -u=x -exec cp {} $OUT \;

--- a/projects/scrypt/build.sh
+++ b/projects/scrypt/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Build the fuzzers and project source code
+cargo fuzz build
+
+# Copy built fuzzer binaries to $OUT
+cp $SRC/password-hashes/target/x86_64-unknown-linux-gnu/release/scrypt_fuzzer $OUT/

--- a/projects/scrypt/build.sh
+++ b/projects/scrypt/build.sh
@@ -19,5 +19,5 @@
 cargo fuzz build
 
 # Copy built fuzzer binaries to $OUT
-find $SRC/password-hashes/target/x86_64-unknown-linux-gnu/release -maxdepth 1 \
+find $SRC/password-hashes/fuzz/target/x86_64-unknown-linux-gnu/release -maxdepth 1 \
     -type f -perm -u=x -exec cp {} $OUT \;

--- a/projects/scrypt/project.yaml
+++ b/projects/scrypt/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://docs.rs/scrypt"
+main_repo: "https://github.com/RustCrypto/password-hashes"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+language: rust
+auto_ccs:
+  - "arthur.chan@adalogics.com"
+  - "david@adalogics.com"

--- a/projects/scrypt/project.yaml
+++ b/projects/scrypt/project.yaml
@@ -1,5 +1,6 @@
 homepage: "https://docs.rs/scrypt"
 main_repo: "https://github.com/RustCrypto/password-hashes"
+primary_contact: "newpavlov@gmail.com"
 sanitizers:
   - address
 fuzzing_engines:
@@ -8,3 +9,4 @@ language: rust
 auto_ccs:
   - "arthur.chan@adalogics.com"
   - "david@adalogics.com"
+  - "bascule@gmail.com"


### PR DESCRIPTION
This PR initialises OSS-Fuzz integration for the scrypt project in Rust. New fuzzers have been created, and a PR (https://github.com/RustCrypto/password-hashes/pull/534) has been submitted upstream to merge the fuzzers.