### PR TITLE
Jsonway: project intialisation

### DIFF
--- a/projects/jsonway/Dockerfile
+++ b/projects/jsonway/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+
+RUN git clone https://github.com/rustless/jsonway
+WORKDIR $SRC/jsonway
+
+COPY build.sh patch.diff $SRC/

--- a/projects/jsonway/build.sh
+++ b/projects/jsonway/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -eu
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Patch the code as the rustc failed to compile the code because anonymous parameters
+# are used which are deprecated
+git apply $SRC/patch.diff
+
+# Build the fuzzers and project source code
+cargo fuzz build
+
+# Copy built fuzzer binaries to $OUT
+cp fuzz/target/x86_64-unknown-linux-gnu/release/json_fuzzer $OUT/

--- a/projects/jsonway/patch.diff
+++ b/projects/jsonway/patch.diff
@@ -1,0 +1,40 @@
+--- a/src/array_serializer.rs
++++ b/src/array_serializer.rs
+@@ -4,7 +4,7 @@ use object_builder;
+ use array_builder;
+ 
+ pub trait ArraySerializer {
+-    fn build(&self, &mut array_builder::ArrayBuilder);
++    fn build(&self, _: &mut array_builder::ArrayBuilder);
+ 
+     #[inline]
+     fn root(&self) -> Option<&str> {
+--- a/src/serializer.rs
++++ b/src/serializer.rs
+@@ -33,7 +33,7 @@ use object_builder;
+ /// ```
+ pub trait Serializer {
+ 
+-    fn build(&self, &mut object_builder::ObjectBuilder);
++    fn build(&self, _: &mut object_builder::ObjectBuilder);
+ 
+     #[inline]
+     fn root(&self) -> Option<&str> {
+@@ -82,7 +82,7 @@ pub trait Serializer {
+ /// ```
+ pub trait ObjectSerializer<T> {
+ 
+-    fn build(&self, &T, &mut object_builder::ObjectBuilder);
++    fn build(&self, _: &T, _: &mut object_builder::ObjectBuilder);
+ 
+     #[inline]
+     fn root(&self) -> Option<&str> {
+@@ -151,7 +151,7 @@ pub trait ObjectSerializer<T> {
+ /// ```
+ pub trait ObjectScopeSerializer<T, S> {
+ 
+-    fn build(&self, &T, &S, &mut object_builder::ObjectBuilder);
++    fn build(&self, _: &T, _: &S, _: &mut object_builder::ObjectBuilder);
+ 
+     #[inline]
+     fn root(&self) -> Option<&str> {

--- a/projects/jsonway/project.yaml
+++ b/projects/jsonway/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/rustless/jsonway"
+main_repo: "https://github.com/rustless/jsonway.git"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+language: rust
+auto_ccs:
+  - "arthur.chan@adalogics.com"
+  - "david@adalogics.com"


### PR DESCRIPTION
This PR initialises OSS-Fuzz integration for the jsonway project in Rust. New fuzzers have been created, and a PR () has been submitted upstream to merge the fuzzers.

**REMARK: This PR only works when the upstream fuzzers PR has been merged.**