### PR TITLE
fix: explicitly pass platform to avoid docker InvalidBaseImagePlatfor…

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -667,6 +667,8 @@ def build_image_impl(project, cache=True, pull=False, architecture='x86_64'):
         'plain',
         '--load',
     ]
+  else:
+    build_args += ['--platform','linux/amd64',]
   if not cache:
     build_args.append('--no-cache')
 


### PR DESCRIPTION
If I do not explicitly pass the platform on arm64 mac, I get the following error when running `python3 infra/helper.py build_image tendermint`:
```
- InvalidBaseImagePlatform: Base image gcr.io/oss-fuzz-base/base-builder-go was pulled with platform "linux/amd64", expected "linux/arm64" for current build (line 17)