### PR TITLE
Fix introspector scheduling exception.

### DIFF
--- a/infra/build/functions/request_introspector_build.py
+++ b/infra/build/functions/request_introspector_build.py
@@ -32,8 +32,7 @@ def get_build_steps(project_name, image_project, base_images_project):
   project_yaml_contents, dockerfile_lines = request_build.get_project_data(
       project_name)
   return build_and_run_coverage.get_fuzz_introspector_steps(
-      project_name, project_yaml_contents, dockerfile_lines, image_project,
-      base_images_project, build_config)
+      project_name, project_yaml_contents, dockerfile_lines, build_config)
 
 
 def request_introspector_build(event, context):


### PR DESCRIPTION
This was caused by a very old refactor, but we never deployed the introspector scheduler since then so we didn't run into this until now.