### PR TITLE
Build in stages to shed 9gb from the jvm base builder image

### DIFF
--- a/infra/base-images/base-builder-jvm/Dockerfile
+++ b/infra/base-images/base-builder-jvm/Dockerfile
@@ -27,7 +27,7 @@ RUN install_java.sh
 
 RUN chmod 777 /usr/local/bin && chmod 777 /usr/local/lib
 
-FROM base as builder
+FROM base AS builder
 RUN useradd -m jazzer_user
 
 USER jazzer_user
@@ -55,7 +55,7 @@ RUN cp $(bazel cquery --output=files //src/main/java/com/code_intelligence/jazze
     cp $(bazel cquery --output=files //deploy:jazzer-api) $JAZZER_API_PATH && \
     cp $(bazel cquery --output=files //deploy:jazzer-junit) $JAZZER_JUNIT_PATH
 
-from base as final
+FROM base AS final
 
 USER root
 COPY --from=builder /usr/local/bin/jazzer_agent_deploy.jar /usr/local/bin/jazzer_agent_deploy.jar

--- a/infra/base-images/base-builder-jvm/Dockerfile
+++ b/infra/base-images/base-builder-jvm/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder AS base
 
 ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64
 ENV JAVA_15_HOME /usr/lib/jvm/java-15-openjdk-amd64
@@ -27,6 +27,7 @@ RUN install_java.sh
 
 RUN chmod 777 /usr/local/bin && chmod 777 /usr/local/lib
 
+FROM base as builder
 RUN useradd -m jazzer_user
 
 USER jazzer_user
@@ -54,10 +55,13 @@ RUN cp $(bazel cquery --output=files //src/main/java/com/code_intelligence/jazze
     cp $(bazel cquery --output=files //deploy:jazzer-api) $JAZZER_API_PATH && \
     cp $(bazel cquery --output=files //deploy:jazzer-junit) $JAZZER_JUNIT_PATH
 
-USER root
+from base as final
 
-RUN rm -rf /home/jazzer_user/.cache/bazel /home/jazzer_user/.cache/bazelisk && \
-    rm -rf $SRC/jazzer
+USER root
+COPY --from=builder /usr/local/bin/jazzer_agent_deploy.jar /usr/local/bin/jazzer_agent_deploy.jar
+COPY --from=builder /usr/local/bin/jazzer_driver /usr/local/bin/jazzer_driver
+COPY --from=builder $JAZZER_API_PATH $JAZZER_API_PATH
+COPY --from=builder $JAZZER_JUNIT_PATH $JAZZER_JUNIT_PATH
 
 RUN chmod 755 /usr/local/bin && chmod 755 /usr/local/lib
 

--- a/infra/base-images/base-builder-jvm/Dockerfile
+++ b/infra/base-images/base-builder-jvm/Dockerfile
@@ -57,7 +57,6 @@ RUN cp $(bazel cquery --output=files //src/main/java/com/code_intelligence/jazze
 
 FROM base AS final
 
-USER root
 COPY --from=builder /usr/local/bin/jazzer_agent_deploy.jar /usr/local/bin/jazzer_agent_deploy.jar
 COPY --from=builder /usr/local/bin/jazzer_driver /usr/local/bin/jazzer_driver
 COPY --from=builder $JAZZER_API_PATH $JAZZER_API_PATH


### PR DESCRIPTION
This PR reduces the final `base-builder-jvm` image by 9GB.

Careful review and full integration testing across oss-fuzz projects are required before merging, obviously. 

This worked on two projects I was interested in. One that used `@FuzzTest` and one that used `fuzzerTestOneInput`
