### PR TITLE
graphicsmagick: Libxml2 (fall back to github mirror if gitlab.gnome.o…

### DIFF
--- a/projects/graphicsmagick/Dockerfile
+++ b/projects/graphicsmagick/Dockerfile
@@ -84,8 +84,10 @@ RUN git clone --depth 1 https://gitlab.com/federicomenaquintero/bzip2.git
 # Jasper
 RUN git clone --depth 1 https://github.com/jasper-software/jasper
 
-# Libxml2
-RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/libxml2.git
+# Libxml2 (fall back to github mirror if gitlab.gnome.org is overloaded)
+RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/libxml2.git || \
+    git clone --depth 1 https://gitlab.gnome.org/GNOME/libxml2.git || \
+    git clone --depth 1 https://github.com/GNOME/libxml2
 
 # Libjxl
 RUN git clone --depth 1 https://github.com/libjxl/libjxl.git


### PR DESCRIPTION
Clones from https://gitlab.gnome.org/GNOME/libxml2.git are recently sometimes failing due to server load.  Try a second time, and then fall-back to the mirror at https://github.com/GNOME/libxml2.