### PR TITLE
Update `main_url` of `apache-commons-collections`

### DIFF
--- a/projects/apache-commons-collections/project.yaml
+++ b/projects/apache-commons-collections/project.yaml
@@ -2,7 +2,7 @@ fuzzing_engines:
 - libfuzzer
 homepage: https://commons.apache.org/proper/commons-collections/
 language: jvm
-main_repo: https://gitbox.apache.org/repos/asf/commons-codellections.git
+main_repo: https://github.com/apache/commons-collections.git
 primary_contact: "fuzz-testing@commons.apache.org"
 sanitizers:
 - address


### PR DESCRIPTION
An anonymous attentive audience of our fuzzing workshop at Ubuntu Summit 2024 noticed this outdated URL and kindly informed me.

The old URL is not available anymore.
The new URL can be confirmed on the [project's homepage](https://commons.apache.org/proper/commons-collections/).