### PR TITLE
Improve Wasmtime's coverage reports

### DIFF
--- a/projects/wasmtime/project.yaml
+++ b/projects/wasmtime/project.yaml
@@ -14,3 +14,10 @@ fuzzing_engines:
   - libfuzzer
 language: rust
 main_repo: 'https://github.com/bytecodealliance/wasmtime'
+
+# Ignore some ocaml files that show up, dependencies on crates.io, and the
+# standard library itself.
+coverage_extra_args: >
+  -ignore-filename-regex=.*/root/.opam/.*
+  -ignore-filename-regex=.*/registry/src/.*crates.io/.*
+  -ignore-filename-regex=.*/rustc/.*


### PR DESCRIPTION
Try adding a few ignores for dependencies that we're not interested in to help improve the quality of the coverage reports coming out of fuzzing for Wasmtime.