### PR TITLE
graphicsmagick: Pull stable branch of x265 project

### DIFF
--- a/projects/graphicsmagick/Dockerfile
+++ b/projects/graphicsmagick/Dockerfile
@@ -44,8 +44,10 @@ RUN git clone --depth 1 https://github.com/strukturag/libde265 || \
     printf "https://github.com/strukturag/libde265 is not available!\n"
 
 # x265 HEVC Encoder needed by libheif
-RUN git clone --depth 1 https://bitbucket.org/multicoreware/x265_git.git x265 || \
-    printf "https://bitbucket.org/multicoreware/x265_git.git is not available!\n"
+# https://bitbucket.org/multicoreware/x265_git/src/stable/
+# https://bitbucket.org/multicoreware/x265_git/src/master/
+RUN git clone --depth 1 https://bitbucket.org/multicoreware/x265_git/src/stable/ x265 || \
+    printf "https://bitbucket.org/multicoreware/x265_git/src/stable/ is not available!\n"
 
 # AV1 Codec Library needed by libheif
 RUN git clone --depth 1 --branch master https://aomedia.googlesource.com/aom aom || \


### PR DESCRIPTION
Pull from stable branch of x265 project for builds.  Default repository content does not seem to be fully populated for use.