### PR TITLE
libxml2: Disable aarch64

### DIFF
--- a/projects/libxml2/project.yaml
+++ b/projects/libxml2/project.yaml
@@ -21,7 +21,6 @@ sanitizers:
 architectures:
   - x86_64
   - i386
-  - aarch64
 fuzzing_engines:
   - libfuzzer
   - honggfuzz


### PR DESCRIPTION
In the last days, this seems to cause build failures like:

    "compile-libfuzzer-address-aarch64": exec /usr/bin/bash: exec
    format error