### PR TITLE
Add ccache to base-builder.

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -47,6 +47,16 @@ RUN export PYTHON_DEPS="\
     rm -rf /usr/local/lib/python3.8/test && \
     apt-get remove -y $PYTHON_DEPS # https://github.com/google/oss-fuzz/issues/3888
 
+
+ENV CCACHE_VERSION 4.10.2
+RUN cd /tmp && curl -OL https://github.com/ccache/ccache/releases/download/v$CCACHE_VERSION/ccache-$CCACHE_VERSION.tar.xz && \
+    tar -xvf ccache-$CCACHE_VERSION.tar.xz && cd ccache-$CCACHE_VERSION && \
+    mkdir build && cd build && \
+    export LDFLAGS='-lpthread' && \
+    cmake -D CMAKE_BUILD_TYPE=Release .. && \
+    make -j && make install && \
+    rm -rf /tmp/ccache-$CCACHE_VERSION /tmp/ccache-$CCACHE_VERSION.tar.xz
+
 # Install six for Bazel rules.
 RUN unset CFLAGS CXXFLAGS && pip3 install -v --no-cache-dir \
     six==1.15.0 && rm -rf /tmp/*
@@ -179,5 +189,14 @@ RUN chmod +x /usr/local/bin/clang-jcc /usr/local/bin/clang++-jcc /usr/local/bin/
 COPY llvmsymbol.diff $SRC
 COPY detect_repo.py /opt/cifuzz/
 COPY bazel.bazelrc /root/.bazelrc
+
+# Set up ccache binary and cache directory.
+# /ccache/bin will contain the compiler wrappers, and /ccache/cache will
+# contain the actual cache, which can be saved.
+# To use this, set PATH=/ccache/bin:$PATH.
+RUN mkdir -p /ccache/bin && mkdir -p /ccache/cache && \
+    ln -s /usr/local/bin/ccache /ccache/bin/clang && \
+    ln -s /usr/local/bin/ccache /ccache/bin/clang++
+ENV CCACHE_DIR /ccache/cache
 
 CMD ["compile"]


### PR DESCRIPTION
This installs clang wrappers at /ccache/bin, and sets up a build cache at /ccache/cache. To use this, inside the project container we just need to do:

```
export PATH=/ccache/bin:$PATH
```

In another PR, we can store the /ccache/cache somewhere we can pull down at runtime.

Some results:

Fresh compile:

real	0m49.249s
user	10m41.818s
sys	1m2.097s

With ccache cache:

real	0m9.877s
user	0m6.278s
sys	0m19.966s

Fresh compile:

real	1m17.214s
user	0m49.454s
sys	0m27.963s

With ccache:

real	0m34.962s
user	0m18.092s
sys	0m17.083s