### PR TITLE
Update sanitizer strings for chronos builds.

### DIFF
--- a/infra/experimental/chronos/cloudbuild.yaml
+++ b/infra/experimental/chronos/cloudbuild.yaml
@@ -41,7 +41,7 @@ steps:
   args:
   - commit
   - ${_PROJECT}-origin-asan
-  - us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/${_PROJECT}-ofg-cached-asan
+  - us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/${_PROJECT}-ofg-cached-address
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - run
@@ -55,10 +55,10 @@ steps:
   args:
   - commit
   - ${_PROJECT}-origin-cov
-  - us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/${_PROJECT}-ofg-cached-cov
+  - us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/${_PROJECT}-ofg-cached-coverage
 images:
-- us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/${_PROJECT}-ofg-cached-asan
-- us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/${_PROJECT}-ofg-cached-cov
+- us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/${_PROJECT}-ofg-cached-address
+- us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/${_PROJECT}-ofg-cached-coverage
 timeout: 1800s
 logsBucket: oss-fuzz-gcb-logs
 tags:


### PR DESCRIPTION
Make these match the formatting conventions oss-fuzz already uses (i.e. "address" instead of "asan").