### PR TITLE
Remove abartlett work email address

### DIFF
--- a/projects/samba/project.yaml
+++ b/projects/samba/project.yaml
@@ -3,7 +3,6 @@ main_repo: "https://git.samba.org/samba.git"
 language: c
 primary_contact: "douglas.bagnall@catalyst.net.nz"
 auto_ccs:
-  - "abartlet+google@catalyst.net.nz"
   - "abartlet@samba.org"
   - "cryptomilk@gmail.com"
   - "lockyergw@gmail.com"


### PR DESCRIPTION
As requested in https://github.com/google/oss-fuzz/pull/12605 Sorry for the spam. It happened by accident when migrating bug trackers. It should no longer be an issue. Let me know if you want more emails again :-)