### PR TITLE
[lua] Disable building Aarch64

### DIFF
--- a/projects/lua/project.yaml
+++ b/projects/lua/project.yaml
@@ -7,6 +7,5 @@ auto_ccs:
   - "estetus@gmail.com"
 main_repo: 'https://github.com/lua/lua'
 architectures:
-  - aarch64
   - i386
   - x86_64


### PR DESCRIPTION
See also [1] and [2].

1. https://github.com/google/oss-fuzz/issues/12670
2. https://github.com/ligurio/lua-c-api-tests/issues/108