### PR TITLE
libass: add seed corpus

### DIFF
--- a/projects/libass/Dockerfile
+++ b/projects/libass/Dockerfile
@@ -20,5 +20,6 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-conf
 
 RUN git clone --depth 1 https://github.com/libass/libass.git
 RUN git clone --depth 1 https://github.com/harfbuzz/harfbuzz.git
+RUN git clone --depth 1 https://github.com/libass/libass-tests.git
 
 COPY build.sh *.options $SRC/

--- a/projects/libass/build.sh
+++ b/projects/libass/build.sh
@@ -44,3 +44,4 @@ cp fuzz/fuzz_ossfuzz $OUT/libass_fuzzer
 cp fuzz/ass.dict $OUT/ass.dict
 
 cp $SRC/*.options $OUT/
+find $SRC -name "*.ass" | xargs zip -r -j -q $OUT/libass_fuzzer_seed_corpus.zip


### PR DESCRIPTION
I noticed that [ass_parse_tags](https://storage.googleapis.com/oss-fuzz-coverage/libass/reports/20241101/linux/src/libass/libass/ass_parse.c.html#L282) is not covered good enough. This PR adds a seed corpus from the libass-tests repository which improves coverage