### PR TITLE
Make ccache work with jcc.

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -196,7 +196,14 @@ COPY bazel.bazelrc /root/.bazelrc
 # To use this, set PATH=/ccache/bin:$PATH.
 RUN mkdir -p /ccache/bin && mkdir -p /ccache/cache && \
     ln -s /usr/local/bin/ccache /ccache/bin/clang && \
-    ln -s /usr/local/bin/ccache /ccache/bin/clang++
+    ln -s /usr/local/bin/ccache /ccache/bin/clang++ && \
+    ln -s /usr/local/bin/ccache /ccache/bin/clang-jcc && \
+    ln -s /usr/local/bin/ccache /ccache/bin/clang++-jcc
 ENV CCACHE_DIR /ccache/cache
+
+# Don't check that the compiler is the same, so we can switch between jcc and
+# clang under the hood and re-use the same build cache.
+ENV CCACHE_COMPILERCHECK none
+ENV CCACHE_COMPILERTYPE clang
 
 CMD ["compile"]

--- a/infra/build/functions/target_experiment.py
+++ b/infra/build/functions/target_experiment.py
@@ -25,8 +25,6 @@ import google.auth
 import build_lib
 import build_project
 
-JCC_DIR = '/usr/local/bin'
-
 
 def run_experiment(project_name, target_name, args, output_path, errlog_path,
                    build_output_path, upload_corpus_path, upload_coverage_path,
@@ -62,8 +60,8 @@ def run_experiment(project_name, target_name, args, output_path, errlog_path,
   project_yaml['run_tests'] = False
 
   jcc_env = [
-      f'CC={JCC_DIR}/clang-jcc',
-      f'CXX={JCC_DIR}/clang++-jcc',
+      f'CC=clang-jcc',
+      f'CXX=clang++-jcc',
   ]
   steps = build_project.get_build_steps(project_name,
                                         project_yaml,


### PR DESCRIPTION
Create ccache wrappers for clang[++]-jcc, and remove the explicit path from the CC/CXX variables in target_experiment.py.

Note: this is not fully tested end to end yet.

Part of https://github.com/google/oss-fuzz-gen/issues/682.