### PR TITLE
KImageFormats: Added SCITEX plugin and updated libraries

### DIFF
--- a/projects/kimageformats/Dockerfile
+++ b/projects/kimageformats/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install --yes cmake make autoconf automake autopoint libtool wget po4a ninja-build pkgconf libclang-dev
+RUN apt-get update && apt-get install --yes cmake make autoconf automake autopoint libtool wget po4a ninja-build pkgconf
 RUN git clone --depth 1 https://github.com/madler/zlib.git
 RUN git clone --depth 1 https://github.com/facebook/zstd.git
 RUN git clone --depth 1 https://github.com/nih-at/libzip.git
@@ -24,7 +24,6 @@ RUN git clone https://github.com/tukaani-project/xz.git
 RUN git clone --depth 1 --branch=RB-3.3 https://github.com/AcademySoftwareFoundation/openexr.git
 RUN git clone --depth 1 -b master https://invent.kde.org/frameworks/extra-cmake-modules.git
 RUN git clone --depth 1 --branch=dev git://code.qt.io/qt/qtbase.git
-RUN git clone --depth 1 --branch=dev https://github.com/qt/qttools.git
 RUN git clone --depth 1 -b master https://invent.kde.org/frameworks/karchive.git
 RUN git clone --depth 1 -b master https://invent.kde.org/frameworks/kimageformats.git
 RUN git clone --depth 1 -b v3.9.1 https://aomedia.googlesource.com/aom

--- a/projects/kimageformats/Dockerfile
+++ b/projects/kimageformats/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install --yes cmake make autoconf automake autopoint libtool wget po4a ninja-build pkgconf
+RUN apt-get update && apt-get install --yes cmake make autoconf automake autopoint libtool wget po4a ninja-build pkgconf libclang-dev qt5-qmake qtbase5-private-dev
 RUN git clone --depth 1 https://github.com/madler/zlib.git
 RUN git clone --depth 1 https://github.com/facebook/zstd.git
 RUN git clone --depth 1 https://github.com/nih-at/libzip.git
@@ -24,6 +24,7 @@ RUN git clone https://github.com/tukaani-project/xz.git
 RUN git clone --depth 1 --branch=RB-3.3 https://github.com/AcademySoftwareFoundation/openexr.git
 RUN git clone --depth 1 -b master https://invent.kde.org/frameworks/extra-cmake-modules.git
 RUN git clone --depth 1 --branch=dev git://code.qt.io/qt/qtbase.git
+RUN git clone --depth 1 --branch=dev https://github.com/qt/qttools.git
 RUN git clone --depth 1 -b master https://invent.kde.org/frameworks/karchive.git
 RUN git clone --depth 1 -b master https://invent.kde.org/frameworks/kimageformats.git
 RUN git clone --depth 1 -b v3.9.1 https://aomedia.googlesource.com/aom

--- a/projects/kimageformats/Dockerfile
+++ b/projects/kimageformats/Dockerfile
@@ -21,13 +21,13 @@ RUN git clone --depth 1 https://github.com/facebook/zstd.git
 RUN git clone --depth 1 https://github.com/nih-at/libzip.git
 RUN wget https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz
 RUN git clone https://github.com/tukaani-project/xz.git
-RUN git clone --depth 1 --branch=RB-3.2 https://github.com/AcademySoftwareFoundation/openexr.git
+RUN git clone --depth 1 --branch=RB-3.3 https://github.com/AcademySoftwareFoundation/openexr.git
 RUN git clone --depth 1 -b master https://invent.kde.org/frameworks/extra-cmake-modules.git
 RUN git clone --depth 1 --branch=dev git://code.qt.io/qt/qtbase.git
 RUN git clone --depth 1 -b master https://invent.kde.org/frameworks/karchive.git
 RUN git clone --depth 1 -b master https://invent.kde.org/frameworks/kimageformats.git
 RUN git clone --depth 1 -b v3.9.1 https://aomedia.googlesource.com/aom
-RUN git clone --depth 1 -b v1.1.0 https://github.com/AOMediaCodec/libavif.git
+RUN git clone --depth 1 -b v1.1.1 https://github.com/AOMediaCodec/libavif.git
 RUN git clone --depth 1 https://github.com/strukturag/libde265.git
 RUN git clone --depth 1 -b v2.5.2 https://github.com/uclouvain/openjpeg.git
 RUN git clone --depth 1 https://github.com/strukturag/libheif.git

--- a/projects/kimageformats/Dockerfile
+++ b/projects/kimageformats/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install --yes cmake make autoconf automake autopoint libtool wget po4a ninja-build pkgconf libclang-dev qt5-qmake qtbase5-private-dev
+RUN apt-get update && apt-get install --yes cmake make autoconf automake autopoint libtool wget po4a ninja-build pkgconf libclang-dev
 RUN git clone --depth 1 https://github.com/madler/zlib.git
 RUN git clone --depth 1 https://github.com/facebook/zstd.git
 RUN git clone --depth 1 https://github.com/nih-at/libzip.git

--- a/projects/kimageformats/build.sh
+++ b/projects/kimageformats/build.sh
@@ -62,17 +62,24 @@ make install -j$(nproc)
 export CFLAGS="${ORIG_CFLAGS}"
 export CXXFLAGS="${ORIG_CXXFLAGS}"
 
-# Build extra-cmake-modules
-cd $SRC
-cd extra-cmake-modules
-cmake .
-make install -j$(nproc)
-
 cd $SRC
 cd qtbase
 ./configure -no-glib -qt-libpng -qt-pcre -opensource -confirm-license -static -no-opengl -no-icu -platform linux-clang-libc++ -debug -prefix /usr -no-feature-widgets -no-feature-sql -no-feature-network  -no-feature-xml -no-feature-dbus -no-feature-printsupport
 cmake --build . --parallel $(nproc)
 cmake --install .
+
+cd $SRC
+cd qttools
+git submodule update --init --recursive
+/usr/bin/qt-configure-module .
+cmake --build . --parallel $(nproc)
+cmake --install .
+
+# Build extra-cmake-modules
+cd $SRC
+cd extra-cmake-modules
+cmake .
+make install -j$(nproc)
 
 cd $SRC
 cd karchive
@@ -195,7 +202,7 @@ echo "$HANDLER_TYPES" | while read class format; do
   /usr/libexec/moc $SRC/kimageformats/src/imageformats/$format.cpp -o $format.moc
   header=`ls $SRC/kimageformats/src/imageformats/$format*.h`
   /usr/libexec/moc $header -o moc_`basename $header .h`.cpp
-  $CXX $CXXFLAGS -fPIC -DHANDLER=$class -std=c++17 $SRC/kimgio_fuzzer.cc $SRC/kimageformats/src/imageformats/$format.cpp $SRC/kimageformats/src/imageformats/scanlineconverter.cpp -o $OUT/$fuzz_target_name -DJXL_STATIC_DEFINE -DJXL_THREADS_STATIC_DEFINE -DJXL_CMS_STATIC_DEFINE -DINITGUID -I $SRC/kimageformats/src/imageformats/ -I $SRC/libavif/include/ -I $SRC/libjxl/build/lib/include/ -I $SRC/libjxl/lib/include/ -I /usr/local/include/OpenEXR/ -I /usr/local/include/KF6/KArchive/ -I /usr/local/include/Imath -I $SRC/jxrlib/common/include -I $SRC/jxrlib/jxrgluelib -I $SRC/jxrlib/image/sys -I /usr/include/QtCore/ -I /usr/include/QtGui/ -I . $SRC/libavif/build/libavif.a /usr/local/lib/libheif.a /usr/local/lib/libde265.a $SRC/aom/build.libavif/libaom.a $SRC/libjxl/build/lib/libjxl_threads.a $SRC/libjxl/build/lib/libjxl.a $SRC/libjxl/build/lib/libjxl_cms.a $SRC/libjxl/build/third_party/highway/libhwy.a $SRC/libjxl/build/third_party/brotli/libbrotlidec.a $SRC/libjxl/build/third_party/brotli/libbrotlienc.a $SRC/libjxl/build/third_party/brotli/libbrotlicommon.a -lQt6Gui -lQt6Core -lQt6BundledLibpng -lQt6BundledHarfbuzz -lm -lQt6BundledPcre2 -ldl -lpthread $LIB_FUZZING_ENGINE /usr/local/lib/libzip.a /usr/local/lib/libz.a -lKF6Archive /usr/local/lib/libz.a /usr/local/lib/libraw.a /usr/local/lib/libOpenEXR-3_2.a /usr/local/lib/libIex-3_2.a /usr/local/lib/libImath-3_1.a /usr/local/lib/libIlmThread-3_2.a /usr/local/lib/libOpenEXRCore-3_2.a /usr/local/lib/libOpenEXRUtil-3_2.a /usr/local/lib/libopenjp2.a /usr/local/lib/libzstd.a $SRC/jxrlib/build/libjxrglue.a $SRC/jxrlib/build/libjpegxr.a -llzma /usr/local/lib/libbz2.a -lclang_rt.builtins
+  $CXX $CXXFLAGS -fPIC -DHANDLER=$class -std=c++17 $SRC/kimgio_fuzzer.cc $SRC/kimageformats/src/imageformats/$format.cpp $SRC/kimageformats/src/imageformats/scanlineconverter.cpp -o $OUT/$fuzz_target_name -DJXL_STATIC_DEFINE -DJXL_THREADS_STATIC_DEFINE -DJXL_CMS_STATIC_DEFINE -DINITGUID -I $SRC/kimageformats/src/imageformats/ -I $SRC/libavif/include/ -I $SRC/libjxl/build/lib/include/ -I $SRC/libjxl/lib/include/ -I /usr/local/include/OpenEXR/ -I /usr/local/include/KF6/KArchive/ -I /usr/local/include/Imath -I $SRC/jxrlib/common/include -I $SRC/jxrlib/jxrgluelib -I $SRC/jxrlib/image/sys -I /usr/include/QtCore/ -I /usr/include/QtGui/ -I . $SRC/libavif/build/libavif.a /usr/local/lib/libheif.a /usr/local/lib/libde265.a $SRC/aom/build.libavif/libaom.a $SRC/libjxl/build/lib/libjxl_threads.a $SRC/libjxl/build/lib/libjxl.a $SRC/libjxl/build/lib/libjxl_cms.a $SRC/libjxl/build/third_party/highway/libhwy.a $SRC/libjxl/build/third_party/brotli/libbrotlidec.a $SRC/libjxl/build/third_party/brotli/libbrotlienc.a $SRC/libjxl/build/third_party/brotli/libbrotlicommon.a -lQt6Gui -lQt6Core -lQt6BundledLibpng -lQt6BundledHarfbuzz -lm -lQt6BundledPcre2 -ldl -lpthread $LIB_FUZZING_ENGINE /usr/local/lib/libzip.a /usr/local/lib/libz.a -lKF6Archive /usr/local/lib/libz.a /usr/local/lib/libraw.a /usr/local/lib/libOpenEXR-3_3.a /usr/local/lib/libIex-3_3.a /usr/local/lib/libImath-3_1.a /usr/local/lib/libIlmThread-3_3.a /usr/local/lib/libOpenEXRCore-3_3.a /usr/local/lib/libOpenEXRUtil-3_3.a /usr/local/lib/libopenjp2.a /usr/local/lib/libzstd.a $SRC/jxrlib/build/libjxrglue.a $SRC/jxrlib/build/libjpegxr.a -llzma /usr/local/lib/libbz2.a -lclang_rt.builtins
 
   # -lclang_rt.builtins in the previous line is a temporary workaround to avoid a linker error "undefined reference to __truncsfhf2". Investigate why this is needed here, but not anywhere else, and possibly remove it.
 

--- a/projects/kimageformats/build.sh
+++ b/projects/kimageformats/build.sh
@@ -84,7 +84,7 @@ make install -j$(nproc)
 cd $SRC
 cd karchive
 rm -rf poqm
-cmake . -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=OFF
+cmake . -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=/usr/local
 make install -j$(nproc)
 
 # Build JXRlib

--- a/projects/kimageformats/build.sh
+++ b/projects/kimageformats/build.sh
@@ -191,7 +191,7 @@ HANDLER_TYPES="ANIHandler ani
         RASHandler ras
         RAWHandler raw
         RGBHandler rgb
-        ScitexHandler scitex
+        ScitexHandler sct
         TGAHandler tga
         XCFHandler xcf"
 

--- a/projects/kimageformats/build.sh
+++ b/projects/kimageformats/build.sh
@@ -68,13 +68,6 @@ cd qtbase
 cmake --build . --parallel $(nproc)
 cmake --install .
 
-cd $SRC
-cd qttools
-git submodule update --init --recursive
-/usr/bin/qt-configure-module .
-cmake --build . --parallel $(nproc)
-cmake --install .
-
 # Build extra-cmake-modules
 cd $SRC
 cd extra-cmake-modules

--- a/projects/kimageformats/build.sh
+++ b/projects/kimageformats/build.sh
@@ -78,7 +78,7 @@ cmake --install .
 # Build extra-cmake-modules
 cd $SRC
 cd extra-cmake-modules
-cmake .
+cmake . -DBUILD_TESTING=OFF
 make install -j$(nproc)
 
 cd $SRC

--- a/projects/kimageformats/build.sh
+++ b/projects/kimageformats/build.sh
@@ -140,7 +140,7 @@ cd $SRC
 cd openexr
 mkdir _build
 cd _build
-cmake  -DBUILD_SHARED_LIBS=OFF .. 
+cmake  -DBUILD_SHARED_LIBS=OFF ..
 make -j$(nproc)
 make install -j$(nproc)
 
@@ -184,6 +184,7 @@ HANDLER_TYPES="ANIHandler ani
         RASHandler ras
         RAWHandler raw
         RGBHandler rgb
+        ScitexHandler scitex
         TGAHandler tga
         XCFHandler xcf"
 

--- a/projects/kimageformats/kimgio_fuzzer.cc
+++ b/projects/kimageformats/kimgio_fuzzer.cc
@@ -20,7 +20,7 @@
   Usage:
     python infra/helper.py build_image kimageformats
     python infra/helper.py build_fuzzers --sanitizer undefined|address|memory kimageformats
-    python infra/helper.py run_fuzzer kimageformats kimgio_[ani|avif|exr|hdr|heif|jxl|jxr|kra|ora|pcx|pfm|pic|psd|pxr|qoi|ras|raw|rgb|tga|xcf]_fuzzer
+    python infra/helper.py run_fuzzer kimageformats kimgio_[ani|avif|exr|hdr|heif|jxl|jxr|kra|ora|pcx|pfm|pic|psd|pxr|qoi|ras|raw|rgb|scitex|tga|xcf]_fuzzer
 */
 
 
@@ -46,6 +46,7 @@
 #include "ras_p.h"
 #include "raw_p.h"
 #include "rgb_p.h"
+#include "scitex_p.h"
 #include "tga_p.h"
 #include "xcf_p.h"
 

--- a/projects/kimageformats/kimgio_fuzzer.cc
+++ b/projects/kimageformats/kimgio_fuzzer.cc
@@ -20,7 +20,7 @@
   Usage:
     python infra/helper.py build_image kimageformats
     python infra/helper.py build_fuzzers --sanitizer undefined|address|memory kimageformats
-    python infra/helper.py run_fuzzer kimageformats kimgio_[ani|avif|exr|hdr|heif|jxl|jxr|kra|ora|pcx|pfm|pic|psd|pxr|qoi|ras|raw|rgb|scitex|tga|xcf]_fuzzer
+    python infra/helper.py run_fuzzer kimageformats kimgio_[ani|avif|exr|hdr|heif|jxl|jxr|kra|ora|pcx|pfm|pic|psd|pxr|qoi|ras|raw|rgb|sct|tga|xcf]_fuzzer
 */
 
 
@@ -46,7 +46,7 @@
 #include "ras_p.h"
 #include "raw_p.h"
 #include "rgb_p.h"
-#include "scitex_p.h"
+#include "sct_p.h"
 #include "tga_p.h"
 #include "xcf_p.h"
 


### PR DESCRIPTION
Apply the following changes to the KImageFormats project:
- Moved EXR lib to branch 3.3
- Update AVIF lib to latest patch release
- Added SCITEX plugin to fuzzer test
- Fixed KDE/extra-cmake-modules build error
