### PR TITLE
llvm_libcxxabi: fix build

### DIFF
--- a/projects/llvm_libcxxabi/build.sh
+++ b/projects/llvm_libcxxabi/build.sh
@@ -15,5 +15,6 @@
 # limitations under the License.
 #
 ################################################################################
-$CXX $CXXFLAGS -std=c++11 -g src/cxa_demangle.cpp -Iinclude fuzz/cxa_demangle_fuzzer.cpp \
-  -o $OUT/cxa_demangle_fuzzer  $LIB_FUZZING_ENGINE
+$CXX $CXXFLAGS -std=c++11 -g src/cxa_demangle.cpp src/abort_message.cpp \
+  -Iinclude fuzz/cxa_demangle_fuzzer.cpp -o $OUT/cxa_demangle_fuzzer \
+  $LIB_FUZZING_ENGINE


### PR DESCRIPTION
This PR fixes a build error by adding `src/abort_message.cpp` to the linker. It requires because [DEMANGLE_ASSERT](https://github.com/llvm/llvm-project/blob/230946fad69c952dc434aa3e2f92853c1ee8d304/libcxxabi/src/cxa_demangle.cpp#L14) is used in the demangling module.

```
cxa_demangle.cpp:(.text._ZNK12_GLOBAL__N_116itanium_demangle4Node5visitINSt3__117reference_wrapperINS_11DumpVisitorEEEEEvT_[_ZNK12_GLOBAL__N_116itanium_demangle4Node5visitINSt3__117reference_wrapperINS_11DumpVisitorEEEEEvT_]+0xfcd): undefined reference to `__abort_message'
/usr/bin/ld: /tmp/cxa_demangle-39bd04.o: in function `__cxa_demangle':
cxa_demangle.cpp:(.text.__cxa_demangle[__cxa_demangle]+0x192c): undefined reference to `__abort_message'
/usr/bin/ld: /tmp/cxa_demangle-39bd04.o: in function `(anonymous namespace)::itanium_demangle::AbstractManglingParser<(anonymous namespace)::itanium_demangle::ManglingParser<(anonymous namespace)::DefaultAllocator>, (anonymous namespace)::DefaultAllocator>::parseEncoding(bool)':
cxa_demangle.cpp:(.text._ZN12_GLOBAL__N_116itanium_demangle22AbstractManglingParserINS0_14ManglingParserINS_16DefaultAllocatorEEES3_E13parseEncodingEb[_ZN12_GLOBAL__N_116itanium_demangle22AbstractManglingParserINS0_14ManglingParserINS_16DefaultAllocatorEEES3_E13parseEncodingEb]+0x297b): undefined reference to `__abort_message'
/usr/bin/ld: /tmp/cxa_demangle-39bd04.o: in function `(anonymous namespace)::itanium_demangle::AbstractManglingParser<(anonymous namespace)::itanium_demangle::ManglingParser<(anonymous namespace)::DefaultAllocator>, (anonymous namespace)::DefaultAllocator>::popTrailingNodeArray(unsigned long)':
cxa_demangle.cpp:(.text._ZN12_GLOBAL__N_116itanium_demangle22AbstractManglingParserINS0_14ManglingParserINS_16DefaultAllocatorEEES3_E20popTrailingNodeArrayEm[_ZN12_GLOBAL__N_116itanium_demangle22AbstractManglingParserINS0_14ManglingParserINS_16DefaultAllocatorEEES3_E20popTrailingNodeArrayEm]+0x407): undefined reference to `__abort_message'
/usr/bin/ld: cxa_demangle.cpp:(.text._ZN12_GLOBAL__N_116itanium_demangle22AbstractManglingParserINS0_14ManglingParserINS_16DefaultAllocatorEEES3_E20popTrailingNodeArrayEm[_ZN12_GLOBAL__N_116itanium_demangle22AbstractManglingParserINS0_14ManglingParserINS_16DefaultAllocatorEEES3_E20popTrailingNodeArrayEm]+0x441): undefined reference to `__abort_message'
/usr/bin/ld: /tmp/cxa_demangle-39bd04.o:cxa_demangle.cpp:(.text._ZN12_GLOBAL__N_116itanium_demangle22AbstractManglingParserINS0_14ManglingParserINS_16DefaultAllocatorEEES3_E18parseTemplateParamEv[_ZN12_GLOBAL__N_116itanium_demangle22AbstractManglingParserINS0_14ManglingParserINS_16DefaultAllocatorEEES3_E18parseTemplateParamEv]+0xffd): more undefined references to `__abort_message' follow
```

https://oss-fuzz-build-logs.storage.googleapis.com/log-85060829-7b6e-4940-bdbc-8fbf81f2055a.txt