### PR TITLE
KImageFormats: JXR library modified with a patched one

### DIFF
--- a/projects/kimageformats/Dockerfile
+++ b/projects/kimageformats/Dockerfile
@@ -33,7 +33,7 @@ RUN git clone --depth 1 -b v2.5.2 https://github.com/uclouvain/openjpeg.git
 RUN git clone --depth 1 https://github.com/strukturag/libheif.git
 RUN git clone --depth=1 --branch v0.10.x --recursive --shallow-submodules https://github.com/libjxl/libjxl.git
 RUN git clone --depth 1 https://github.com/LibRaw/LibRaw
-RUN git clone --depth 1 https://github.com/4creators/jxrlib.git
+RUN git clone --depth 1 https://github.com/mircomir/jxrlib.git
 COPY build.sh $SRC
 COPY kimgio_fuzzer.cc $SRC
 WORKDIR kimageformats


### PR DESCRIPTION
The previous version does not accept changes and is compiled by default without the NDEBUG option.