### PR TITLE
Fix typo on cubefs project.yaml

### DIFF
--- a/projects/cubefs/project.yaml
+++ b/projects/cubefs/project.yaml
@@ -3,7 +3,7 @@ main_repo: "https://github.com/cubefs/cubefs"
 primary_contact: "626148589@qq.com"
 auto_ccs:
   - "changliang@oppo.com"
-  - "baijiaruo@126.com "
+  - "baijiaruo@126.com"
   - "tangjingyu@oppo.com"
   - "david@adalogics.com"
   - "adam@adalogics.com"


### PR DESCRIPTION
This typo is breaking oss_fuzz_apply_ccs.