### PR TITLE
minizip: fix build

### DIFF
--- a/projects/minizip/Dockerfile
+++ b/projects/minizip/Dockerfile
@@ -15,7 +15,8 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make cmake pkg-config libssl-dev:i386
+RUN apt-get update && apt-get install -y make cmake pkg-config libssl-dev:i386 \
+    zlib1g-dev:i386 libbz2-dev:i386 liblzma-dev:i386 libzstd-dev:i386
 
 RUN git clone -b develop https://github.com/zlib-ng/minizip-ng
 WORKDIR minizip-ng

--- a/projects/minizip/build.sh
+++ b/projects/minizip/build.sh
@@ -19,6 +19,9 @@
 if [ "$ARCHITECTURE" = 'i386' ]; then
   rm /usr/lib/i386-linux-gnu/libssl.so*
   rm /usr/lib/i386-linux-gnu/libcrypto.so*
+  rm /usr/lib/i386-linux-gnu/libz.so*
+  rm /usr/lib/i386-linux-gnu/libbz2.so*
+  rm /usr/lib/i386-linux-gnu/liblzma.so*
 fi
 
 # Build project


### PR DESCRIPTION
```
[ 71%] Building C object CMakeFiles/minizip.dir/compat/unzip.c.o
/src/minizip-ng/compat/unzip.c:687:16: error: use of undeclared identifier 'Z_ERRNO'
  687 |         return UNZ_ERRNO;
      |                ^
/src/minizip-ng/compat/unzip.h:51:34: note: expanded from macro 'UNZ_ERRNO'
   51 | #define UNZ_ERRNO               (Z_ERRNO)
      |                                  ^
1 error generated.
```

https://oss-fuzz-build-logs.storage.googleapis.com/log-9d4da045-29d1-4b5f-b65b-1c3ac84b00a9.txt