### PR TITLE
Apache poi various smaller changes

### DIFF
--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -262,7 +262,7 @@ def _check_one_apt_update(path):
     if 'RUN apt install' in dockerfile or 'RUN apt-get install' in dockerfile:
       print('Please add an "apt-get update" before "apt-get install". '
             'Otherwise, a cached and outdated RUN layer may lead to install '
-            'failures.')
+            'failures in file %s.' % str(path))
       return False
 
   return True

--- a/projects/apache-poi/Dockerfile
+++ b/projects/apache-poi/Dockerfile
@@ -44,7 +44,7 @@ WORKDIR ${SRC}
 RUN git clone --depth 1 https://github.com/apache/poi.git
 
 # install packages required for font-handling and other code in java.awt.*
-RUN apt-get install -y libxext6 libx11-6 libxrender1 libxtst6 libxi6 libxcb1 libxau6 libxdmcp6 \
+RUN apt-get update && apt-get install -y libxext6 libx11-6 libxrender1 libxtst6 libxi6 libxcb1 libxau6 libxdmcp6 \
 && apt-get clean autoclean \
 && apt-get autoremove --yes \
 && rm -rf /var/lib/{apt,dpkg,cache,log}/

--- a/projects/apache-poi/Dockerfile
+++ b/projects/apache-poi/Dockerfile
@@ -23,17 +23,19 @@ rm -rf maven.zip
 ENV MVN $SRC/maven-3.6.3/apache-maven-3.6.3/bin/mvn
 ENV TARGET_PACKAGE_PREFIX org.apache.poi.*:org.apache.xmlbeans.*
 
-RUN curl -L https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u382-b05/OpenJDK8U-jdk_x64_linux_hotspot_8u382b05.tar.gz -o OpenJDK8U-jdk_x64_linux_hotspot_8u382b05.tar.gz && \
-  tar xvf OpenJDK8U-jdk_x64_linux_hotspot_8u382b05.tar.gz && \
-  rm -rf OpenJDK8U-jdk_x64_linux_hotspot_8u382b05.tar.gz
+# Newer JDK releases are listed at https://github.com/adoptium/temurin8-binaries/releases/
+RUN curl -L https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u432-b06/OpenJDK8U-jdk_x64_linux_hotspot_8u432b06.tar.gz -o OpenJDK8U-jdk_x64_linux_hotspot_8u432b06.tar.gz && \
+  tar xvf OpenJDK8U-jdk_x64_linux_hotspot_8u432b06.tar.gz && \
+  rm -rf OpenJDK8U-jdk_x64_linux_hotspot_8u432b06.tar.gz
 
-ENV JAVA_HOME_8 $SRC/jdk8u382-b05
+ENV JAVA_HOME_8 $SRC/jdk8u432-b06
 
-RUN curl -L https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20%2B8/OpenJDK11U-jdk_x64_linux_hotspot_11.0.20_8.tar.gz -o OpenJDK11U-jdk_x64_linux_hotspot_11.0.20_8.tar.gz && \
-  tar xvf OpenJDK11U-jdk_x64_linux_hotspot_11.0.20_8.tar.gz && \
-  rm -rf OpenJDK11U-jdk_x64_linux_hotspot_11.0.20_8.tar.gz
+# Newer JDK releases are listed at https://github.com/adoptium/temurin11-binaries/releases/
+RUN curl -L https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.25%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.25_9.tar.gz -o OpenJDK11U-jdk_x64_linux_hotspot_11.0.25_9.tar.gz && \
+  tar xvf OpenJDK11U-jdk_x64_linux_hotspot_11.0.25_9.tar.gz && \
+  rm -rf OpenJDK11U-jdk_x64_linux_hotspot_11.0.25_9.tar.gz
 
-ENV JAVA_HOME_11 $SRC/jdk-11.0.20+8
+ENV JAVA_HOME_11 $SRC/jdk-11.0.25+9
 
 WORKDIR ${SRC}
 #

--- a/projects/apache-poi/pom.xml
+++ b/projects/apache-poi/pom.xml
@@ -16,6 +16,18 @@
 	</properties>
 
 	<!-- This repositories list is copy pasted from the projects' main BOM -->
+	<repositories>
+		<repository>
+			<id>central</id>
+			<name>Maven Central</name>
+			<url>https://repo.maven.apache.org/maven2/</url>
+		</repository>
+		<repository>
+			<id>apache-staging</id>
+			<name>Apache Staging</name>
+			<url>https://repository.apache.org/content/repositories/staging</url>
+		</repository>
+	</repositories>
 
 	<dependencies>
 		<!--
@@ -38,26 +50,59 @@
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
 			<version>${fuzzedLibaryVersion}</version>
+			<!-- these exclusions can be removed again when XmlBeans 5.3.0 is released with fixed bom-dependency
+				 See https://lists.apache.org/thread/tn9j8h94vtftr1r4xg28c43r8okp4hoj -->
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-bom</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-ooxml</artifactId>
 			<version>${fuzzedLibaryVersion}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-bom</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-scratchpad</artifactId>
 			<version>${fuzzedLibaryVersion}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-bom</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-examples</artifactId>
 			<version>${fuzzedLibaryVersion}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-bom</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.24.1</version>
+			<version>2.24.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-bom</artifactId>
+			<version>2.24.2</version>
+			<type>pom</type>
+			<scope>import</scope>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
* Update JDK 8 and 11 to latest patch-levels
* Add temporary work around for invalid dependency on log4j-bom introduced via recent XmlBeans
* Fix presubmit-checks for Apache POI
* Print out which file fails checks in presubmit.py to aid in finding the culprit
