### PR TITLE
[envoy] disable layering_check from bazel build

### DIFF
--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -30,6 +30,9 @@ else
 fi
 
 declare -r EXTRA_BAZEL_FLAGS="$(
+# Disabling layering_check because it breaks the abseil build. See
+# https://github.com/google/oss-fuzz/blob/f0fa8b5cd3f99b5905e91b336d07a870ca1bc2e3/projects/abseil-cpp/build.sh#L17-L21.
+echo "--features=-layering_check"
 if [ -n "$CC" ]; then
   echo "--action_env=CC=${CC}"
 fi


### PR DESCRIPTION
A recent upgrade of Envoy' abseil library (https://github.com/envoyproxy/envoy/pull/36317) enabled `layering_check` ([imported commit](https://github.com/abseil/abseil-cpp/commit/143e983739333ce4b30320d26bce8594bd24b5f3#diff-8498e61ae6ae818e1ee9bcefffd37b44a3a596e63d1de03c58087299ccbe7a22)) when building abseil (as part of Envoy).

Here's an example of the failure during the build:
```
[1A[K[31m[1mERROR: [0m/root/.cache/bazel/_bazel_root/4e9824db8e7d11820cfa25090ed4ed10/external/com_google_absl/absl/types/BUILD.bazel:178:11: Compiling absl/types/bad_variant_access.cc failed: undeclared inclusion(s) in rule '@com_google_absl//absl/types:bad_variant_access':
Step #3 - "compile-honggfuzz-address-x86_64": this rule is missing dependency declarations for the following files included by 'absl/types/bad_variant_access.cc':
Step #3 - "compile-honggfuzz-address-x86_64":   'bazel-out/k8-fastbuild-ST-74a21d80f561/bin/external/com_google_absl/absl/base/core_headers.cppmap'
Step #3 - "compile-honggfuzz-address-x86_64":   'bazel-out/k8-fastbuild-ST-74a21d80f561/bin/external/com_google_absl/absl/base/atomic_hook.cppmap'
Step #3 - "compile-honggfuzz-address-x86_64":   'bazel-out/k8-fastbuild-ST-74a21d80f561/bin/external/com_google_absl/absl/base/errno_saver.cppmap'
Step #3 - "compile-honggfuzz-address-x86_64":   'bazel-out/k8-fastbuild-ST-74a21d80f561/bin/external/com_google_absl/absl/base/log_severity.cppmap'
```

Seems that this was encountered in the OSS-Fuzz abseil build and it was patched to disable layering check #11325:
 https://github.com/google/oss-fuzz/blob/f0fa8b5cd3f99b5905e91b336d07a870ca1bc2e3/projects/abseil-cpp/build.sh#L17-L21

This PR introduces the same change in Envoy's abseil build.