### PR TITLE
[cups-filters] update due to failed building with afl

### DIFF
--- a/projects/cups-filters/project.yaml
+++ b/projects/cups-filters/project.yaml
@@ -25,7 +25,7 @@ sanitizers:
 
 fuzzing_engines:
   - libfuzzer
-  - afl
+  # - afl
   # - honggfuzz
 
 # builds_per_day: 2


### PR DESCRIPTION
The building with AFL engine works properly during local testing but continuously fails in ClusterFuzz. Temporarily remove it to ensure at least one successful build of cups-filters.