### PR TITLE
surrealdb: update auto_ccs

### DIFF
--- a/projects/surrealdb/project.yaml
+++ b/projects/surrealdb/project.yaml
@@ -11,6 +11,7 @@ auto_ccs:
   - emmanuel.keller@surrealdb.com
   - micha.de.vries@surrealdb.com
   - rushmore@surrealdb.com
+  - rowan.baker@surrealdb.com
   - nathaniel.brough@gmail.com
 
 sanitizers:


### PR DESCRIPTION
Add current SurrealDB employee to contacts in order to allow them to access the issue tracker and test cases.