### PR TITLE
graphicsmagick: Clone hg repository in stream mode for better performance

### DIFF
--- a/projects/graphicsmagick/Dockerfile
+++ b/projects/graphicsmagick/Dockerfile
@@ -32,9 +32,9 @@ RUN apt-get update && \
     yasm
 
 # GraphicsMagick
-RUN hg clone --time -b default https://foss.heptapod.net/graphicsmagick/graphicsmagick graphicsmagick || \
-    hg clone --time -b default https://foss.heptapod.net/graphicsmagick/graphicsmagick graphicsmagick || \
-    hg clone --time -b default https://foss.heptapod.net/graphicsmagick/graphicsmagick graphicsmagick
+RUN hg clone --time --stream https://foss.heptapod.net/graphicsmagick/graphicsmagick graphicsmagick || \
+    hg clone --time --stream https://foss.heptapod.net/graphicsmagick/graphicsmagick graphicsmagick || \
+    hg clone --time --stream https://foss.heptapod.net/graphicsmagick/graphicsmagick graphicsmagick
 
 # Libtiff
 RUN git clone --depth 1 https://gitlab.com/libtiff/libtiff


### PR DESCRIPTION
A normal clone of the GraphicsMagick repository takes a lot of server-side resources due to the repository complexity and long history. Using stream (image) mode results in a much faster clone time.