### PR TITLE
netty: Add fuzz test for HttpRequestDecoder

### DIFF
--- a/projects/netty/pom.xml
+++ b/projects/netty/pom.xml
@@ -11,7 +11,7 @@
 		<maven.compiler.source>15</maven.compiler.source>
 		<maven.compiler.target>15</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<fuzzedLibaryVersion>4.1.85.Final</fuzzedLibaryVersion>
+		<fuzzedLibaryVersion>4.1.115.Final</fuzzedLibaryVersion>
 		<exec.mainClass>io.netty.handler.codec.http.cookie.ServerCookieDecoderFuzzer</exec.mainClass>
 	</properties>
 
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>com.code-intelligence</groupId>
 			<artifactId>jazzer-api</artifactId>
-			<version>0.12.0</version>
+			<version>0.22.1</version>
 		</dependency>
 		<dependency>
 			<groupId>io.netty</groupId>

--- a/projects/netty/project.yaml
+++ b/projects/netty/project.yaml
@@ -5,6 +5,7 @@ primary_contact: "mr.chrisvest@gmail.com"
 auto_ccs:
   - "norman_maurer@apple.com"
   - "t@motd.kr"
+  - "me@yawk.at"
 fuzzing_engines:
   - libfuzzer
 sanitizers:

--- a/projects/netty/src/main/java/io/netty/handler/BaseHandlerFuzzer.java
+++ b/projects/netty/src/main/java/io/netty/handler/BaseHandlerFuzzer.java
@@ -1,3 +1,19 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
 package io.netty.handler;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;

--- a/projects/netty/src/main/java/io/netty/handler/BaseHandlerFuzzer.java
+++ b/projects/netty/src/main/java/io/netty/handler/BaseHandlerFuzzer.java
@@ -1,0 +1,19 @@
+package io.netty.handler;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+
+/**
+ * Base class for fuzzing the input of an inbound handler. Will report exceptions thrown by the handler.
+ */
+public abstract class BaseHandlerFuzzer {
+    protected final EmbeddedChannel channel = new EmbeddedChannel();
+
+    public void test(FuzzedDataProvider provider) {
+        byte[] bytes = provider.consumeRemainingAsBytes();
+        channel.writeInbound(Unpooled.wrappedBuffer(bytes));
+        channel.finishAndReleaseAll();
+        channel.checkException();
+    }
+}

--- a/projects/netty/src/main/java/io/netty/handler/HandlerFuzzerBase.java
+++ b/projects/netty/src/main/java/io/netty/handler/HandlerFuzzerBase.java
@@ -23,7 +23,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 /**
  * Base class for fuzzing the input of an inbound handler. Will report exceptions thrown by the handler.
  */
-public abstract class BaseHandlerFuzzer {
+public abstract class HandlerFuzzerBase {
     protected final EmbeddedChannel channel = new EmbeddedChannel();
 
     public void test(FuzzedDataProvider provider) {

--- a/projects/netty/src/main/java/io/netty/handler/codec/http/HttpRequestDecoderFuzzer.java
+++ b/projects/netty/src/main/java/io/netty/handler/codec/http/HttpRequestDecoderFuzzer.java
@@ -1,3 +1,19 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
 package io.netty.handler.codec.http;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;

--- a/projects/netty/src/main/java/io/netty/handler/codec/http/HttpRequestDecoderFuzzer.java
+++ b/projects/netty/src/main/java/io/netty/handler/codec/http/HttpRequestDecoderFuzzer.java
@@ -1,0 +1,14 @@
+package io.netty.handler.codec.http;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import io.netty.handler.BaseHandlerFuzzer;
+
+public class HttpRequestDecoderFuzzer extends BaseHandlerFuzzer {
+    {
+        channel.pipeline().addLast(new HttpRequestDecoder());
+    }
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider fuzzedDataProvider) {
+        new HttpRequestDecoderFuzzer().test(fuzzedDataProvider);
+    }
+}

--- a/projects/netty/src/main/java/io/netty/handler/codec/http/HttpRequestDecoderFuzzer.java
+++ b/projects/netty/src/main/java/io/netty/handler/codec/http/HttpRequestDecoderFuzzer.java
@@ -17,9 +17,9 @@
 package io.netty.handler.codec.http;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
-import io.netty.handler.BaseHandlerFuzzer;
+import io.netty.handler.HandlerFuzzerBase;
 
-public class HttpRequestDecoderFuzzer extends BaseHandlerFuzzer {
+public class HttpRequestDecoderFuzzer extends HandlerFuzzerBase {
     {
         channel.pipeline().addLast(new HttpRequestDecoder());
     }


### PR DESCRIPTION
This is my initial PR to get my feet wet, sort out the CLA, so it's just a small change.

The main change is a fuzzer for HttpRequestDecoder. This fuzzer reproduces the bug fixed by https://github.com/netty/netty/pull/13735 .

I also added myself to the contact list of the netty project. This was approved by @normanmaurer in January: https://github.com/netty/netty/issues/13033#issuecomment-1911318993 – unfortunately it took me until now to get corp approval for the CLA.