### PR TITLE
sound-open-firmware: add corpus install to script

### DIFF
--- a/projects/sound-open-firmware/build.sh
+++ b/projects/sound-open-firmware/build.sh
@@ -34,6 +34,8 @@ cd $SRC/sof_workspace
 
 sof/scripts/fuzz.sh -b -s $SANITIZER -a $ARCHITECTURE -- -DEXTRA_CONF_FILE=stub_build_all_ipc3.conf -DEXTRA_CFLAGS="-fno-sanitize-recover=all"
 cp build-fuzz/zephyr/zephyr.exe $OUT/sof-ipc3
+zip $OUT/sof-ipc3.zip sof/tools/corpus/sof-ipc3/*
 
 sof/scripts/fuzz.sh -b -s $SANITIZER -a $ARCHITECTURE -- -DEXTRA_CONF_FILE=stub_build_all_ipc4.conf -DEXTRA_CFLAGS="-fno-sanitize-recover=all"
 cp build-fuzz/zephyr/zephyr.exe $OUT/sof-ipc4
+zip $OUT/sof-ipc4.zip sof/tools/corpus/sof-ipc4/*


### PR DESCRIPTION
Zip up corpus and add it to $OUT.

Blocked by https://github.com/thesofproject/sof/pull/9673