### PR TITLE
micronaut: New project submission

### DIFF
--- a/projects/micronaut/project.yaml
+++ b/projects/micronaut/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://micronaut.io/"
+main_repo: "https://github.com/micronaut-projects/micronaut-core"
+language: java
+primary_contact: "jonas.konrad@oracle.com"
+auto_ccs:
+  - "me@yawk.at"
+  - "sergiodelamocaballero@gmail.com"
+  - "graeme.rocher@oracle.com"
+  - "denis.s.stepanov@oracle.com"


### PR DESCRIPTION
The micronaut framework is a Java application framework focused on HTTP applications. The [core repository](https://github.com/micronaut-projects/micronaut-core):

- Has 6k stars on GitHub
- A criticality score of 0.69541 in the latest public data run, 0.70123 in the October run
- \>1M monthly downloads on maven central

I believe that should qualify for oss-fuzz.

All contacts listed are project contributors and oracle employees. I also used some personal emails associated with google accounts for clusterfuzz access.