### PR TITLE
surrealdb: update build script

### DIFF
--- a/projects/surrealdb/build.sh
+++ b/projects/surrealdb/build.sh
@@ -22,9 +22,7 @@ cp fuzz/fuzz_targets/*.dict $OUT/ || true
 # Add additional compiler flags required for a successful build.
 export RUSTFLAGS="$RUSTFLAGS --cfg surrealdb_unstable"
 
-cd sdk
-cargo fuzz build -O --debug-assertions --fuzz-dir ../fuzz
-cd ..
+cargo fuzz build -O --debug-assertions --target-dir sdk --fuzz-dir fuzz
 
 FUZZ_TARGET_OUTPUT_DIR=fuzz/target/x86_64-unknown-linux-gnu/release
 for f in fuzz/fuzz_targets/*.rs

--- a/projects/surrealdb/build.sh
+++ b/projects/surrealdb/build.sh
@@ -22,7 +22,9 @@ cp fuzz/fuzz_targets/*.dict $OUT/ || true
 # Add additional compiler flags required for a successful build.
 export RUSTFLAGS="$RUSTFLAGS --cfg surrealdb_unstable"
 
-cargo fuzz build -O --debug-assertions
+cd sdk
+cargo fuzz build -O --debug-assertions --fuzz-dir ../fuzz
+cd ..
 
 FUZZ_TARGET_OUTPUT_DIR=fuzz/target/x86_64-unknown-linux-gnu/release
 for f in fuzz/fuzz_targets/*.rs

--- a/projects/surrealdb/build.sh
+++ b/projects/surrealdb/build.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 ################################################################################
-cd sdk 
+cd crates
 
 # Copy dictionaries, but don't fail if there aren't any.
 cp fuzz/fuzz_targets/*.dict $OUT/ || true

--- a/projects/surrealdb/build.sh
+++ b/projects/surrealdb/build.sh
@@ -22,9 +22,17 @@ cp fuzz/fuzz_targets/*.dict $OUT/ || true
 # Add additional compiler flags required for a successful build.
 export RUSTFLAGS="$RUSTFLAGS --cfg surrealdb_unstable"
 
-cargo fuzz build -O --debug-assertions --target-dir sdk --fuzz-dir fuzz
+cargo fuzz build -O --debug-assertions --target-dir fuzz --fuzz-dir fuzz
 
-FUZZ_TARGET_OUTPUT_DIR=sdk/x86_64-unknown-linux-gnu/release
+if [ -d "fuzz/target/x86_64-unknown-linux-gnu/release" ]; then
+    FUZZ_TARGET_OUTPUT_DIR="fuzz/target/x86_64-unknown-linux-gnu/release"
+elif [ -d "fuzz/x86_64-unknown-linux-gnu/release" ]; then
+    FUZZ_TARGET_OUTPUT_DIR="fuzz/x86_64-unknown-linux-gnu/release"
+else
+    echo "Fuzz targets could not be found."
+    exit 1
+fi
+
 for f in fuzz/fuzz_targets/*.rs
 do
     FUZZ_TARGET_NAME=$(basename ${f%.*})

--- a/projects/surrealdb/build.sh
+++ b/projects/surrealdb/build.sh
@@ -24,7 +24,7 @@ export RUSTFLAGS="$RUSTFLAGS --cfg surrealdb_unstable"
 
 cargo fuzz build -O --debug-assertions --target-dir sdk --fuzz-dir fuzz
 
-FUZZ_TARGET_OUTPUT_DIR=fuzz/target/x86_64-unknown-linux-gnu/release
+FUZZ_TARGET_OUTPUT_DIR=sdk/x86_64-unknown-linux-gnu/release
 for f in fuzz/fuzz_targets/*.rs
 do
     FUZZ_TARGET_NAME=$(basename ${f%.*})


### PR DESCRIPTION
After https://github.com/surrealdb/surrealdb/pull/4933 the fuzzing crate is under `crates` rather than `sdk`.