### PR TITLE
proton-bridge: disable FuzzReadHeaderBody build and update auto_ccs

### DIFF
--- a/projects/proton-bridge/Dockerfile
+++ b/projects/proton-bridge/Dockerfile
@@ -16,6 +16,5 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN git clone --depth 1 https://github.com/ProtonMail/proton-bridge.git
-RUN go install github.com/AdamKorcz/go-118-fuzz-build@latest
 COPY build.sh $SRC/
 WORKDIR $SRC/proton-bridge

--- a/projects/proton-bridge/build.sh
+++ b/projects/proton-bridge/build.sh
@@ -19,6 +19,6 @@ go get github.com/AdamKorcz/go-118-fuzz-build/testing
 
 compile_native_go_fuzzer   $PWD/internal/legacy/credentials     FuzzUnmarshal               fuzz_unmarshal   
 compile_native_go_fuzzer   $PWD/pkg/message/parser              FuzzNewParser               fuzz_new_parser
-compile_native_go_fuzzer   $PWD/pkg/message                     FuzzReadHeaderBody          fuzz_read_header_body
+#compile_native_go_fuzzer   $PWD/pkg/message                     FuzzReadHeaderBody          fuzz_read_header_body
 compile_native_go_fuzzer   $PWD/pkg/mime                        FuzzDecodeHeader            fuzz_decode_header
 compile_native_go_fuzzer   $PWD/pkg/mime                        FuzzDecodeCharset           fuzz_decode_charset

--- a/projects/proton-bridge/project.yaml
+++ b/projects/proton-bridge/project.yaml
@@ -2,9 +2,9 @@ homepage: "https://proton.me"
 language: go
 primary_contact: "security@proton.me"
 auto_ccs:
-  - "ajsinghyadav00@gmail.com"
+  - "pkillarjun@protonmail.com"
 fuzzing_engines:
   - libfuzzer
 sanitizers:
   - address
-main_repo: "https://github.com/ProtonMail/proton-bridge"
+main_repo: "https://github.com/ProtonMail/proton-bridge.git"


### PR DESCRIPTION
There is a build [failure](https://oss-fuzz-build-logs.storage.googleapis.com/log-81f25874-a254-40ed-b129-ec0ac7c4a0b8.txt), Due to this bug https://github.com/AdamKorcz/go-118-fuzz-build/issues/25, Or you can say it's `a minor missing requirement`.