### PR TITLE
Configure Javy project

### DIFF
--- a/projects/javy/Dockerfile
+++ b/projects/javy/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/javy/Dockerfile
+++ b/projects/javy/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+RUN apt-get update \
+  && apt-get install -y curl pkg-config libssl-dev clang \
+  && rustup target add wasm32-wasip1 \
+  && git clone https://github.com/bytecodealliance/javy
+WORKDIR javy
+COPY build.sh $SRC/

--- a/projects/javy/build.sh
+++ b/projects/javy/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-# Copyright 2021 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/javy/build.sh
+++ b/projects/javy/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Using `--sanitizer none` because other sanitizers seem to cause out of memory errors
+# Setting `-fno-sanitize=all` since I see undefined references to `__sancov_gen_` if I don't
+CFLAGS="$CFLAGS -fno-sanitize=all" RUSTFLAGS="-C link-arg=-fno-sanitize=all" cargo fuzz build --sanitizer none
+cp target/x86_64-unknown-linux-gnu/release/json-differential $OUT/json-differential

--- a/projects/javy/project.yaml
+++ b/projects/javy/project.yaml
@@ -4,3 +4,7 @@ main_repo: "https://github.com/bytecodealliance/javy.git"
 primary_contact: "saule.cabrera@gmail.com"
 auto_ccs:
   - "jeff.charles@shopify.com"
+sanitizers:
+  - none
+fuzzing_engines:
+  - libfuzzer


### PR DESCRIPTION
Adds `Dockerfile`, `build.sh`, and updates `project.yaml` for Javy.

When running fuzzing locally, I keep seeing unbounded memory growth when using the address sanitizer and disabling the sanitizer results in steady state memory usage. Using the undefined sanitizer seems to result in linking errors when I try to build the project due to missing `__sancov_gen_` symbols. I'm not clear on how best to resolve those. In any case, for the `json-differential` target, we're trying to ensure correctness of our implementation first and foremost.