### PR TITLE
tinysparql: Provide Dockerfile and build script

### DIFF
--- a/projects/tinysparql/Dockerfile
+++ b/projects/tinysparql/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y python3-pip libdbus-1-dev libnghttp2-dev libpsl-dev asciidoc-base libunistring-dev libffi-dev libpcre2-dev
+RUN unset CFLAGS CXXFLAGS && pip3 install -U meson ninja packaging
+RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/tinysparql.git
+WORKDIR tinysparql
+COPY build.sh $SRC/

--- a/projects/tinysparql/build.sh
+++ b/projects/tinysparql/build.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -eu
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+BUILD=$WORK/meson
+
+rm -rf $BUILD
+mkdir $BUILD
+
+meson setup $BUILD \
+  -Doss_fuzz=enabled \
+  -Db_lundef=false \
+  -Ddefault_library=static \
+  -Dunicode_support=unistring \
+  -Dsystemd_user_services=false \
+  -Dintrospection=disabled \
+  -Dbuiltin_modules=true \
+  -Dvapi=disabled \
+  -Ddocs=false \
+  -Dtests=false \
+  -Dlibsoup3:tests=false \
+  -Dlibsoup3:docs=disabled \
+  -Dglib:tests=false \
+  -Dglib:libmount=disabled \
+  -Dglib:oss_fuzz=disabled
+
+ninja -C $BUILD
+
+find $BUILD/fuzzing -maxdepth 1 -executable -type f -exec cp "{}" $OUT \;
+
+find fuzzing -type f -name "*.dict" -exec cp "{}" $OUT \;
+
+for CORPUS in $(find fuzzing -type f -name "*.corpus"); do
+  BASENAME=${CORPUS##*/}
+  zip $OUT/${BASENAME%%.*}_seed_corpus.zip . -ws -r -i@$CORPUS
+done

--- a/projects/tinysparql/project.yaml
+++ b/projects/tinysparql/project.yaml
@@ -3,4 +3,8 @@ language: c
 primary_contact: "mrgarnacho@gmail.com"
 auto_ccs:
 - ssssam@gmail.com
+sanitizers:
+- address
+- undefined
+help_url: https://gitlab.gnome.org/GNOME/tinysparql/tree/main/fuzzing#how-to-reproduce-oss-fuzz-bugs-locally
 main_repo: 'https://gitlab.gnome.org/GNOME/tinysparql'


### PR DESCRIPTION
Finish integration of the TinySPARQL project, and provide the plumbing to run the recently added fuzzing targets.