### PR TITLE
[simdutf] disable aarch64

### DIFF
--- a/projects/simdutf/project.yaml
+++ b/projects/simdutf/project.yaml
@@ -16,4 +16,3 @@ fuzzing_engines:
   - centipede
 architectures:
   - x86_64
-  - aarch64


### PR DESCRIPTION
there are build problems, see https://github.com/google/oss-fuzz/issues/12670