### PR TITLE
Reclaim the python3-libraries fuzzer (repo change)

### DIFF
--- a/projects/python3-libraries/Dockerfile
+++ b/projects/python3-libraries/Dockerfile
@@ -18,5 +18,5 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && \
     apt-get install -y build-essential libncursesw5-dev libreadline-dev libssl-dev libgdbm-dev libc6-dev libsqlite3-dev tk-dev libbz2-dev zlib1g-dev libffi-dev
 RUN git clone https://github.com/python/cpython.git cpython
-RUN git clone --depth 1 https://github.com/guidovranken/python-library-fuzzers.git
+RUN git clone --depth 1 https://github.com/hugovk/python-library-fuzzers.git
 COPY build.sh $SRC/

--- a/projects/python3-libraries/project.yaml
+++ b/projects/python3-libraries/project.yaml
@@ -1,7 +1,7 @@
 homepage: "https://www.python.org/"
 main_repo: "https://github.com/python/cpython"
 language: c
-primary_contact: "guidovranken@gmail.com"
+primary_contact: "seth@python.org"
 auto_ccs:
  - "greg@krypto.org"
  - "alex.gaynor@gmail.com"


### PR DESCRIPTION
The fuzzer repo https://github.com/guidovranken/python-library-fuzzers was deleted for the owners own reasons so the project is now failing; #12746.  We've restored a fork of that repo and would like to keep this fuzzing running for the CPython project for ourselves.

_(we may choose to move the repo to under the /python/ GitHub org in the future, if so, that's just another followup PR)_