### PR TITLE
astroid: fuzz against the main branch instead of the v3.2.4 tag

### DIFF
--- a/projects/astroid/Dockerfile
+++ b/projects/astroid/Dockerfile
@@ -18,19 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder-python
 
 RUN pip3 install --disable-pip-version-check --no-cache-dir pip==24.2
 
-# Pin the astroid version to 3.2.4 until Python 3.9+ is supported on OSS-Fuzz:
-# https://github.com/google/oss-fuzz/pull/12027
-RUN git clone --branch=v3.2.4 https://github.com/pylint-dev/astroid
-
-# Apply crash fixes to fix coverage builds:
-# https://github.com/pylint-dev/astroid/pull/2596
-# https://github.com/pylint-dev/astroid/pull/2597
-RUN cd astroid && \
-    git show dfe1ccce8576fd5854e7eb578985d10f464c1b67 > crash.diff && \
-    git apply --exclude=ChangeLog crash.diff && \
-    git show d174ca24bde0bba7df63f024124381efe908330d > crash.diff && \
-    git apply crash.diff && \
-    rm crash.diff
+RUN git clone --depth=1 --no-tags https://github.com/pylint-dev/astroid
 
 COPY *.py *.sh "$SRC/"
 


### PR DESCRIPTION
Now that Python 3.10 is supported, pinning is no longer necessary.