### PR TITLE
cert-manager: fix broken build

### DIFF
--- a/projects/cert-manager/Dockerfile
+++ b/projects/cert-manager/Dockerfile
@@ -16,5 +16,11 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN git clone https://github.com/cert-manager/cert-manager --depth=1
+RUN git clone --depth=1 https://github.com/AdamKorcz/go-118-fuzz-build --branch=november-backup
+RUN wget https://go.dev/dl/go1.23.0.linux-amd64.tar.gz \
+    && mkdir temp-go \
+    && rm -rf /root/.go/* \
+    && tar -C temp-go/ -xzf go1.23.0.linux-amd64.tar.gz \
+    && mv temp-go/go/* /root/.go/
 COPY build.sh pki_fuzzer.go $SRC/
 WORKDIR $SRC/cert-manager

--- a/projects/cert-manager/build.sh
+++ b/projects/cert-manager/build.sh
@@ -17,16 +17,16 @@
 
 cp -r $SRC/pki_fuzzer.go $SRC/cert-manager/pkg/util/pki/
 
-cd $SRC
-git clone --depth=1 https://github.com/AdamKorcz/go-118-fuzz-build --branch=include-all-test-files
-cd go-118-fuzz-build
-ls $HOME/go/pkg/mod/github.com/
+cd $SRC/go-118-fuzz-build
 go build .
 mv go-118-fuzz-build /root/go/bin/
 
 cd $SRC/cert-manager
-go get github.com/AdamKorcz/go-118-fuzz-build/testing@include-all-test-files
-
+mkdir $SRC/cert-manager/pkg/fuzz
+printf "package fuzz \nimport _ \"github.com/AdamKorcz/go-118-fuzz-build/testing\"\n" > ./pkg/fuzz/fuzz-register.go
+go mod tidy
+go mod edit -replace github.com/AdamKorcz/go-118-fuzz-build=$SRC/go-118-fuzz-build
+go mod tidy
 compile_native_go_fuzzer github.com/cert-manager/cert-manager/pkg/controller/certificaterequests/vault FuzzVaultCRController FuzzVaultCRController
 compile_native_go_fuzzer github.com/cert-manager/cert-manager/pkg/controller/certificaterequests/venafi FuzzVenafiCRController FuzzVenafiCRController
 compile_go_fuzzer github.com/cert-manager/cert-manager/pkg/util/pki FuzzUnmarshalSubjectStringToRDNSequence FuzzUnmarshalSubjectStringToRDNSequence


### PR DESCRIPTION
Bump go and use different branch of go-118-fuzz-build.