### PR TITLE
micronaut: Build with existing fuzz tests

### DIFF
--- a/projects/micronaut/Dockerfile
+++ b/projects/micronaut/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 
-WORKDIR $SRC
 RUN apt-get update && apt-get install -y locales
 RUN locale-gen en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8

--- a/projects/micronaut/Dockerfile
+++ b/projects/micronaut/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-jvm
+
+WORKDIR $SRC
+RUN apt-get install -y locales
+RUN locale-gen en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+RUN git clone --depth=1 https://github.com/micronaut-projects/micronaut-fuzzing.git
+RUN micronaut-fuzzing/oss-fuzz/checkout.sh
+RUN ln -s micronaut-fuzzing/oss-fuzz/build.sh .

--- a/projects/micronaut/Dockerfile
+++ b/projects/micronaut/Dockerfile
@@ -17,6 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 
 WORKDIR $SRC
+RUN apt-get update
 RUN apt-get install -y locales
 RUN locale-gen en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8

--- a/projects/micronaut/Dockerfile
+++ b/projects/micronaut/Dockerfile
@@ -17,8 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 
 WORKDIR $SRC
-RUN apt-get update
-RUN apt-get install -y locales
+RUN apt-get update && apt-get install -y locales
 RUN locale-gen en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 RUN git clone --depth=1 https://github.com/micronaut-projects/micronaut-fuzzing.git

--- a/projects/micronaut/project.yaml
+++ b/projects/micronaut/project.yaml
@@ -1,9 +1,13 @@
 homepage: "https://micronaut.io/"
 main_repo: "https://github.com/micronaut-projects/micronaut-core"
-language: java
+language: jvm
 primary_contact: "jonas.konrad@oracle.com"
 auto_ccs:
   - "me@yawk.at"
   - "sergiodelamocaballero@gmail.com"
   - "graeme.rocher@oracle.com"
   - "denis.s.stepanov@oracle.com"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
Initial fuzz build with the existing targets we have at https://github.com/micronaut-projects/micronaut-fuzzing . I tried to keep as much of the build infra in our repos as possible, including the build.sh.

I've tested locally (build_image, build_fuzzers, check_build, run_fuzzer) and it works.