### PR TITLE
infra: Add missing flags for coverage feedback

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -99,7 +99,7 @@ ENV COVERAGE_FLAGS="-fsanitize=fuzzer-no-link"
 
 # Use '-Wno-unused-command-line-argument' to suppress "warning: -ldl: 'linker' input unused"
 # messages which are treated as errors by some projects.
-ENV COVERAGE_FLAGS_coverage "-fprofile-instr-generate -fcoverage-mapping -pthread -Wl,--no-as-needed -Wl,-ldl -Wl,-lm -Wno-unused-command-line-argument"
+ENV COVERAGE_FLAGS_coverage "-fsanitize=fuzzer-no-link -fprofile-instr-generate -fcoverage-mapping -pthread -Wl,--no-as-needed -Wl,-ldl -Wl,-lm -Wno-unused-command-line-argument"
 
 # Default sanitizer, fuzzing engine and architecture to use.
 ENV SANITIZER="address"


### PR DESCRIPTION
There are some projects rely on the CFLAGS provided by OSS-Fuzz to do the coverage instrumentation.

For example:

https://github.com/h2o/picotls/blob/d13ff3b9fcbc084572a56a65a6d188643a0bf2fb/CMakeLists.txt#L251-L268

Although the `-fsanitize=fuzzer-no-link` is provided in 

https://github.com/google/oss-fuzz/blob/92d61f8231c6075e0f9f555e1d2c7eb5dfecfa34/infra/base-images/base-builder/Dockerfile#L97-L102

But due to the coverage flag overrides, `-fsanitize=fuzzer-no-link` is omitted.

https://github.com/google/oss-fuzz/blob/92d61f8231c6075e0f9f555e1d2c7eb5dfecfa34/infra/base-images/base-builder/compile#L97-L102

This results in no feedback when running fuzzer, it implies that these fuzzers are all running with a black box fuzzing setting?

```
vm.mmap_rnd_bits = 28
Using seed corpus: fuzz-client-hello_seed_corpus.zip
/out/fuzz-client-hello -rss_limit_mb=2560 -timeout=25 /tmp/fuzz-client-hello_corpus < /dev/null
WARNING: Failed to find function "__sanitizer_acquire_crash_state".
WARNING: Failed to find function "__sanitizer_print_stack_trace".
WARNING: Failed to find function "__sanitizer_set_death_callback".
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 1632178382
INFO:      665 files found in /tmp/fuzz-client-hello_corpus
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
INFO: seed corpus: files: 665 min: 1b max: 4096b total: 176295b rss: 26Mb
#666    INITED exec/s: 0 rss: 28Mb
WARNING: no interesting inputs were found so far. Is the code instrumented for coverage?
This may also happen if the target rejected all inputs we tried so far
^C==14== libFuzzer: run interrupted; exiting
```

The CFLAGS when compiling shown in the log

```
CFLAGS=-O1   -fno-omit-frame-pointer   -gline-tables-only   -Wno-error=enum-constexpr-conversion   -Wno-error=incompatible-function-pointer-types   -Wno-error=int-conversion   -Wno-error=deprecated-declarations   -Wno-error=implicit-function-declaration   -Wno-error=implicit-int   -Wno-error=vla-cxx-extension   -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION  -fprofile-instr-generate -fcoverage-mapping -pthread -Wl,--no-as-needed -Wl,-ldl -Wl,-lm -Wno-unused-command-line-argument
```

Steps:

```
python3 infra/helper.py pull_images
python3 infra/helper.py build_image picotls
python3 infra/helper.py build_fuzzers --sanitizer=coverage picotls
python3 infra/helper.py run_fuzzer picotls fuzz-client-hello
```
