### PR TITLE
vulkan-loader: include "loader_json.h"instead of "cJSON.h"

### DIFF
--- a/projects/vulkan-loader/fuzzers/json_load_fuzzer.c
+++ b/projects/vulkan-loader/fuzzers/json_load_fuzzer.c
@@ -14,7 +14,7 @@ limitations under the License.
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "cJSON.h"
+#include "loader_json.h"
 #include "loader.h"
 
 /*


### PR DESCRIPTION
@DavidKorczynski Fix of the build - in the update to cJSON I moved the loader specific functions to `loader_json.h/.c` which breaks one of the original fuzzers. This updates that fuzzer to include what should be the correct file.