### PR TITLE
typst: Bump Rust toolchain

### DIFF
--- a/projects/typst/Dockerfile
+++ b/projects/typst/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-rust
 
-RUN rustup toolchain install nightly-2023-09-13
+RUN rustup toolchain install nightly-2024-10-29
 RUN git clone --depth 1 https://github.com/typst/typst.git typst
 WORKDIR typst
 COPY build.sh $SRC/

--- a/projects/typst/build.sh
+++ b/projects/typst/build.sh
@@ -20,7 +20,7 @@ cd tests/fuzz
 # Typst has a large API and as a result, will often fail to build on nightly,
 # due to bugs in rustc. Because of this we are pinning the nightly version
 # to a specific version.
-cargo +nightly-2023-09-13 fuzz build -O --debug-assertions
+cargo +nightly-2024-10-29 fuzz build -O --debug-assertions
 
 FUZZ_TARGET_OUTPUT_DIR=$SRC/typst/target/x86_64-unknown-linux-gnu/release 
 for f in src/*.rs


### PR DESCRIPTION
The existing toolchain is unable to build the current Typst.