### PR TITLE
Update auto_ccs list for mdbook-i18n-helpers

### DIFF
--- a/projects/mdbook-i18n-helpers/project.yaml
+++ b/projects/mdbook-i18n-helpers/project.yaml
@@ -7,5 +7,5 @@ fuzzing_engines:
   - libfuzzer
 primary_contact: "mgeisler@google.com"
 auto_ccs:
-  - "kdark@google.com"
+  - "comprehensive-rust@google.com"
   - "darkhanu@gmail.com"


### PR DESCRIPTION
Adding the group which manages the project to `auto_ccs` so that they have access to the filed bugs.