### PR TITLE
infra: Fix bazel 8.0 WORKSPACE disable problem

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -65,6 +65,7 @@ RUN unset CFLAGS CXXFLAGS && pip3 install -v --no-cache-dir \
 
 # Install Bazel through Bazelisk, which automatically fetches the latest Bazel version.
 ENV BAZELISK_VERSION 1.9.0
+ENV USE_BAZEL_VERSION 7.4.0
 RUN curl -L https://github.com/bazelbuild/bazelisk/releases/download/v$BAZELISK_VERSION/bazelisk-linux-amd64 -o /usr/local/bin/bazel && \
     chmod +x /usr/local/bin/bazel
 


### PR DESCRIPTION
The base-builder depends on the google/fuzztest project to precompile the centipede module. The google/fuzztest uses the WORKSPACE approach to provide repository location. But since bazel 8 (released yesterday), the WORKSPACE approach is no longer enabled by default (https://bazel.build/versions/8.0.0/external/migration). Also, in the Dockerfile of the base-builder, we automatically install the latest version of bazel (which is bazel 8 from yesterday), that make the building of fuzztest and eventually the base-builder failed. 

This PR fixes the problem temporary by forcing the installation of bazel version 7.4.0 to avoid the disabling of WORKSPACE defintion, this make the build of google/fuzztest success.