### PR TITLE
Vulkan-Loader: Fix json_loader_fuzzer.c memory leak

### DIFF
--- a/projects/vulkan-loader/fuzzers/json_load_fuzzer.c
+++ b/projects/vulkan-loader/fuzzers/json_load_fuzzer.c
@@ -45,7 +45,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   }
 
   if (json != NULL) {
-    free(json);
+    loader_cJSON_Delete(json);
   }
 
 out:


### PR DESCRIPTION
loader_cJSON_Delete needs to be called to delete all subobjects correctly.

@DavidKorczynski 
