### PR TITLE
update boost regex test for new behavior

### DIFF
--- a/projects/boost/boost_regex_pattern_fuzzer.cc
+++ b/projects/boost/boost_regex_pattern_fuzzer.cc
@@ -23,7 +23,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     // Currently, we just consume all the fuzzed corpus into the regex pattern
     std::string regex_string = fdp.ConsumeRemainingBytesAsString();
     const uint8_t where_array[] = {0x48,0x48,0x48,0x48,0x48,0x48,0x48,0x48,0x48,0x48,0x48,0x48,0x48,0x48,0x48};
-    std::string random(where_array, where_array + sizeof(where_array)); 
+    std::string random(where_array, where_array + sizeof(where_array));
     std::string empty("");
     std::string spaces("                         ");
     try {
@@ -38,8 +38,17 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 #endif
 
         for (const auto& where : wheres) {
-            boost::match_results<std::string::const_iterator> what;
-            bool match = boost::regex_match(where, what, e, boost::match_default | boost::match_partial | boost::match_perl | boost::match_posix | boost::match_any);
+            try {
+                boost::match_results<std::string::const_iterator> what;
+                bool match = boost::regex_match(where, what, e, boost::match_default | boost::match_partial | boost::match_posix | boost::match_any);
+            } catch(...) {
+            }
+
+            try {
+                boost::match_results<std::string::const_iterator> what;
+                bool match = boost::regex_match(where, what, e, boost::match_default | boost::match_partial | boost::match_perl | boost::match_any);
+            } catch(...) {
+            }
         }
     } catch(...) {
     }


### PR DESCRIPTION
In future versions of Boost, this fuzzing test will throw unconditionally because it's erroneously mixing two different matching modes (`match_perl | match_posix`).

Right now, the test is fine but eventually, it will be broken and no longer function as it should.

You can see the new behavior being tested on the develop branch here:
https://github.com/boostorg/regex/blob/0cbaa4ef1740c88106337cf0ba5bf5c73b62863c/test/issue232.cpp#L58

By splitting the regex calls here into their own try-catch blocks, we also ensure a more robust test of the regex matching code by ensuring that both modes are always called always.

The other tests seemed unaffected by this change.

@jzmaddock might have some opinions on this too, as he's the primary Regex author.