### PR TITLE
chronos: fix PATH setting

### DIFF
--- a/infra/experimental/chronos/prepare-ccache
+++ b/infra/experimental/chronos/prepare-ccache
@@ -18,5 +18,5 @@
 PROJECT=$1
 {
     echo "COPY ccache-cache/ /ccache/cache";
-    echo "ENV PATH=/ccache/bin:$PATH"
+    echo "ENV PATH=\"/ccache/bin:\$PATH\""
 } >> "projects/$PROJECT/Dockerfile"


### PR DESCRIPTION
Currently the $PATH bit is expanded, i.e. the ENV string becomes the PATH of the host system, as opposed to the docker container's PATH. We should escape the `$` to ensure we don't overwrite the full PATH