### PR TITLE
Update to suit upstream binutils

### DIFF
--- a/projects/binutils/fuzz_objdump.c
+++ b/projects/binutils/fuzz_objdump.c
@@ -66,7 +66,7 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 #endif
 
   // Main fuzz entrypoint in objdump.c
-  display_file(filename, NULL, true);
+  display_file(filename, NULL);
 
   unlink(filename);
   return 0;


### PR DESCRIPTION
The display_file() signature has changed, update fuzz_objdump to suit.