### PR TITLE
vulkan-loader: Fix leak in settings fuzzer

### DIFF
--- a/projects/vulkan-loader/fuzzers/settings_fuzzer.c
+++ b/projects/vulkan-loader/fuzzers/settings_fuzzer.c
@@ -71,6 +71,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   bool should_search_for_other_layers = true;
   get_settings_layers(NULL, &settings_layers, &should_search_for_other_layers);
+  // Free allocated memory
+  loader_delete_layer_list_and_properties(NULL, (struct loader_layer_list *)settings_layers.list);
   should_skip_logging_global_messages(0);
   update_global_loader_settings();
   teardown_global_loader_settings();


### PR DESCRIPTION
The fuzzer would leak the settings layer list if it successfully found the layers. This creates memory leaks that aren't directly the fault of the Vulkan-Loader project.