### PR TITLE
zip: Updated Dockerfile for initial integration

### DIFF
--- a/projects/zip/Dockerfile
+++ b/projects/zip/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y cmake make
+
+RUN git clone --depth 1 https://github.com/kuba--/zip.git zip \
+        && cp zip/fuzz/build.sh $SRC/
+WORKDIR zip

--- a/projects/zip/project.yaml
+++ b/projects/zip/project.yaml
@@ -2,3 +2,7 @@ homepage: "https://github.com/kuba--/zip"
 language: c
 primary_contact: "capuanobailey@gmail.com"
 main_repo: "https://github.com/kuba--/zip.git"
+fuzzing_engines:
+    - libfuzzer
+    - afl
+    - honggfuzz


### PR DESCRIPTION
This pull requests integrates the Dockerfile needed to build the fuzzers for zip, as merged into upstream [here](https://github.com/kuba--/zip/pull/365).