### PR TITLE
vulkan-loader: Use correct variable in destroy function

### DIFF
--- a/projects/vulkan-loader/fuzzers/settings_fuzzer.c
+++ b/projects/vulkan-loader/fuzzers/settings_fuzzer.c
@@ -72,7 +72,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   bool should_search_for_other_layers = true;
   get_settings_layers(NULL, &settings_layers, &should_search_for_other_layers);
   // Free allocated memory
-  loader_delete_layer_list_and_properties(NULL, (struct loader_layer_list *)settings_layers.list);
+  loader_delete_layer_list_and_properties(NULL, &settings_layers);
   should_skip_logging_global_messages(0);
   update_global_loader_settings();
   teardown_global_loader_settings();


### PR DESCRIPTION
Commit e17999e "fixed" the settings_fuzzer.c test by cleaning up memory, but did not pass in the correct variable. It would reinterpret a pointer to memory as a `loader_layer_list` struct, which is all sorts of wrong. It doesn't help that I forcibly cast the memory pointer to the loader_layer_list struct type, causing any warnings to be surpressed.

@DavidKorczynski 

2nd tries the charm hopefully.