### PR TITLE
[pulldown-cmark] finalize

### DIFF
--- a/projects/pulldown-cmark/Dockerfile
+++ b/projects/pulldown-cmark/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+
+RUN git clone --depth 1 https://github.com/pulldown-cmark/pulldown-cmark pulldown-cmark
+WORKDIR $SRC
+
+COPY build.sh $SRC/

--- a/projects/pulldown-cmark/build.sh
+++ b/projects/pulldown-cmark/build.sh
@@ -1,0 +1,21 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Note: This project creates Rust fuzz targets exclusively
+cd $SRC/pulldown-cmark
+CARGO_PROFILE_RELEASE_LTO=thin cargo fuzz build -O
+cp fuzz/target/x86_64-unknown-linux-gnu/release/commonmark_js $OUT/
+cp fuzz/target/x86_64-unknown-linux-gnu/release/parse $OUT/

--- a/projects/pulldown-cmark/build.sh
+++ b/projects/pulldown-cmark/build.sh
@@ -17,5 +17,5 @@
 # Note: This project creates Rust fuzz targets exclusively
 cd $SRC/pulldown-cmark
 CARGO_PROFILE_RELEASE_LTO=thin cargo fuzz build -O
-cp fuzz/target/x86_64-unknown-linux-gnu/release/commonmark_js $OUT/
-cp fuzz/target/x86_64-unknown-linux-gnu/release/parse $OUT/
+cp target/x86_64-unknown-linux-gnu/release/commonmark_js $OUT/
+cp target/x86_64-unknown-linux-gnu/release/parse $OUT/


### PR DESCRIPTION
continues https://github.com/google/oss-fuzz/pull/12594. thin is used to counter [build errors](https://github.com/pulldown-cmark/pulldown-cmark/blob/db58c3153dff847e74c3ffd403bcf9b1a2e04839/fuzz/README.md#L17).