### PR TITLE
[envoy] fix build failure due to bazel issue

### DIFF
--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -15,6 +15,12 @@
 #
 ################################################################################
 
+# Overcome missing dependency declaration with path mapping issue. This is
+# similar to the current abseil build (see
+# https://github.com/google/oss-fuzz/pull/12858), to overcome the issue
+# mentioned in https://github.com/bazelbuild/bazel/issues/23681.
+export USE_BAZEL_VERSION=7.4.0
+
 declare -r FUZZ_TARGET_QUERY='
   let all_fuzz_tests = attr(tags, "fuzz_target", "test/...") in
   $all_fuzz_tests - attr(tags, "no_fuzz", $all_fuzz_tests)
@@ -57,7 +63,7 @@ fi
 export FUZZING_CFLAGS="$CFLAGS"
 export FUZZING_CXXFLAGS="$CXXFLAGS"
 
-# Disable instrumentation in various external libraries. These 
+# Disable instrumentation in various external libraries. These
 # are fuzzed elsewhere.
 # The following disables both coverage-instrumentation and other sanitizer instrumentation.
 # We disable instrumentation in:


### PR DESCRIPTION
Fixes a build issue:
```
[1A[K[31m[1mERROR: [0m/root/.cache/bazel/_bazel_root/4e9824db8e7d11820cfa25090ed4ed10/external/com_google_absl/absl/types/BUILD.bazel:178:11: Compiling absl/types/bad_variant_access.cc [for tool] failed: undeclared inclusion(s) in rule '@@com_google_absl//absl/types:bad_variant_access':
Step #3 - "compile-honggfuzz-address-x86_64": this rule is missing dependency declarations for the following files included by 'absl/types/bad_variant_access.cc':
Step #3 - "compile-honggfuzz-address-x86_64":   'bazel-out/k8-opt-exec-ST-13d3ddad9198/bin/external/com_google_absl/absl/base/core_headers.cppmap'
Step #3 - "compile-honggfuzz-address-x86_64":   'bazel-out/k8-opt-exec-ST-13d3ddad9198/bin/external/com_google_absl/absl/base/atomic_hook.cppmap'
```

This seems to be due to an issue in bazel: https://github.com/bazelbuild/bazel/issues/23681
The current fix follows the abseil-cpp fuzz fix: https://github.com/google/oss-fuzz/pull/12858
