### PR TITLE
cppcheck: build with all available processes

### DIFF
--- a/projects/cppcheck/build.sh
+++ b/projects/cppcheck/build.sh
@@ -18,7 +18,7 @@
 # build fuzzer
 
 cd $SRC/cppcheck/oss-fuzz
-make oss-fuzz-client
+make -j$(nproc) oss-fuzz-client
 cp oss-fuzz-client $OUT/
 
 


### PR DESCRIPTION
this did not have any effect back when it was integrated but the Makefile has been refactored since to leverage this.