### PR TITLE
[Pillow] Removed yum symlinks

### DIFF
--- a/projects/pillow/Dockerfile
+++ b/projects/pillow/Dockerfile
@@ -29,9 +29,7 @@ RUN $SRC/Pillow/Tests/oss-fuzz/build_dictionaries.sh
 
 COPY build_depends.sh $SRC
 
-RUN ln -s /bin/true /usr/local/bin/yum_install \
-    && ln -s /bin/true /usr/local/bin/yum \
-    && cd $SRC/Pillow \
+RUN cd $SRC/Pillow \
     && git submodule update --init wheels/multibuild \
     && bash $SRC/build_depends.sh
 


### PR DESCRIPTION
https://github.com/google/oss-fuzz/blob/2ef5c1fd8bb77f86866069ddf063e9b0efcc7256/projects/pillow/Dockerfile#L32-L33

These lines can be removed. Pillow no longer needs to suppress errors when calling yum.

They would have been there originally because
- multibuild called `yum_install` for installing [zlib](https://github.com/multi-build/multibuild/blob/42d761728d141d8462cd9943f4329f12fe62b155/library_builders.sh#L144) and [`cmake`](https://github.com/multi-build/multibuild/blob/42d761728d141d8462cd9943f4329f12fe62b155/library_builders.sh#L217), but https://github.com/python-pillow/pillow-wheels/pull/204 and https://github.com/python-pillow/Pillow/pull/8593 mean that those are used anymore.
- Pillow called `yum` to remove zlib-devel, but that is no longer the case after https://github.com/python-pillow/Pillow/pull/8658

cc @hugovk