### PR TITLE
Apache poi add missing limits and revert log4j workaround

### DIFF
--- a/projects/apache-poi/pom.xml
+++ b/projects/apache-poi/pom.xml
@@ -50,59 +50,26 @@
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
 			<version>${fuzzedLibaryVersion}</version>
-			<!-- these exclusions can be removed again when XmlBeans 5.3.0 is released with fixed bom-dependency
-				 See https://lists.apache.org/thread/tn9j8h94vtftr1r4xg28c43r8okp4hoj -->
-			<exclusions>
-				<exclusion>
-					<groupId>org.apache.logging.log4j</groupId>
-					<artifactId>log4j-bom</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-ooxml</artifactId>
 			<version>${fuzzedLibaryVersion}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.apache.logging.log4j</groupId>
-					<artifactId>log4j-bom</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-scratchpad</artifactId>
 			<version>${fuzzedLibaryVersion}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.apache.logging.log4j</groupId>
-					<artifactId>log4j-bom</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-examples</artifactId>
 			<version>${fuzzedLibaryVersion}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.apache.logging.log4j</groupId>
-					<artifactId>log4j-bom</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
 			<version>2.24.2</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-bom</artifactId>
-			<version>2.24.2</version>
-			<type>pom</type>
-			<scope>import</scope>
 		</dependency>
 	</dependencies>
 

--- a/projects/apache-poi/src/main/java/org/apache/poi/EncryptDecryptFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/EncryptDecryptFuzzer.java
@@ -38,6 +38,10 @@ import org.apache.poi.util.IOUtils;
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 
 public class EncryptDecryptFuzzer {
+	public static void fuzzerInitialize() {
+		POIFuzzer.adjustLimits();
+	}
+
 	public static void fuzzerTestOneInput(FuzzedDataProvider data) throws IOException, GeneralSecurityException {
 		try {
 			EncryptionMode encryptionMode = EncryptionMode.values()[(data.consumeInt(0, EncryptionMode.values().length - 1))];

--- a/projects/apache-poi/src/main/java/org/apache/poi/POIFuzzer.java
+++ b/projects/apache-poi/src/main/java/org/apache/poi/POIFuzzer.java
@@ -49,8 +49,14 @@ import org.apache.poi.util.RecordFormatException;
  * It catches all exceptions that are currently expected.
  */
 public class POIFuzzer {
+	public static void fuzzerInitialize() {
+		adjustLimits();
+	}
+
 	public static void fuzzerTestOneInput(byte[] input) {
 		// try to invoke various methods which parse documents/workbooks/slide-shows/...
+		// all of these catch expected exceptions and thus any failure indicates something
+		// that we should take a look at
 
 		fuzzAny(input);
 


### PR DESCRIPTION
Issue https://issues.oss-fuzz.com/issues/42537716 is caused by a missing lower limit which we adjust for other fuzz-targets already to adjust for the available memory which oss-fuzz uses.

This PR applies the limit in two more places and removes a workaround for a version-incompatibility in log4j 2.24.1 and an issue with pom-dependencies in XMLBeans.