### PR TITLE
arrow: Add Matt Topol to ccs

### DIFF
--- a/projects/arrow/project.yaml
+++ b/projects/arrow/project.yaml
@@ -15,4 +15,5 @@ auto_ccs:
   - "wesmckinn@gmail.com"
   - "xhochy@gmail.com"
   - "will.jones127@gmail.com"
+  - "zotthewizard@gmail.com"
 main_repo: 'https://github.com/apache/arrow.git'


### PR DESCRIPTION
Matt Topol (GitHub id "zeroshade") is a Apache Arrow PMC member and committer.