### PR TITLE
aiohttp: fix build and checks

### DIFF
--- a/projects/aiohttp/Dockerfile
+++ b/projects/aiohttp/Dockerfile
@@ -21,8 +21,8 @@ RUN apt-get update && apt-get install -y \
   zlib1g-dev \
   libjpeg-dev \
   libpng-dev \
-  npm \
   libffi-dev
+RUN install_javascript.sh
 RUN python3 -m pip install --upgrade pip
 RUN git clone --recurse-submodules https://github.com/aio-libs/aiohttp
 COPY build.sh $SRC/

--- a/projects/aiohttp/fuzz_multipart.py
+++ b/projects/aiohttp/fuzz_multipart.py
@@ -44,7 +44,7 @@ class FuzzStream:
 
 @atheris.instrument_func
 async def fuzz_bodypart_reader(data):
-    newline=b'\n'
+    data = data.replace(b'\n', b'\r\n')
     fdp = atheris.FuzzedDataProvider(data)
     obj = aiohttp.BodyPartReader(
         b"--:",
@@ -52,7 +52,6 @@ async def fuzz_bodypart_reader(data):
             CONTENT_TYPE: fdp.ConsumeUnicode(30)
         },
         FuzzStream(fdp.ConsumeBytes(atheris.ALL_REMAINING)),
-        _newline=newline
     )
     if not obj.at_eof():
         await obj.form()


### PR DESCRIPTION
[Building](https://oss-fuzz-build-logs.storage.googleapis.com/index.html#aiohttp) has been failing since Feb 9, 2024 because system Node.js v10.19.0 is too old for building llhttp (dependency of aiohttp).
I used a common script `install_javascript.sh` for installing newer Node.js v20.18.1 which fixes the issue.