### PR TITLE
flask: drop checks of deleted functions

### DIFF
--- a/projects/flask/fuzz_werkzeug_url.py
+++ b/projects/flask/fuzz_werkzeug_url.py
@@ -22,50 +22,13 @@ with atheris.instrument_imports():
 
 def TestOneInput(data):
     fdp = atheris.FuzzedDataProvider(data)
-    original = fdp.ConsumeUnicode(100)
     try:
-        werkzeug.urls.url_fix(original)
+        werkzeug.urls.iri_to_uri(fdp.ConsumeUnicode(30))  #
     except UnicodeEncodeError as e2:
         return
     except ValueError as e:
         if not "IPv6" in str(e):
             raise e
-
-    try:
-        werkzeug.urls.url_join(
-            fdp.ConsumeUnicode(30),
-            fdp.ConsumeUnicode(30)
-        )
-    except UnicodeEncodeError as e2:
-        return
-    except ValueError as e:
-        if not "IPv6" in str(e):
-            raise e
-
-    try:
-        werkzeug.urls.url_parse(fdp.ConsumeUnicode(30))
-    except UnicodeEncodeError as e2:
-        return
-    except ValueError as e:
-        if not "IPv6" in str(e):
-            raise e
-
-    try:
-        werkzeug.urls.iri_to_uri(fdp.ConsumeUnicode(30))
-    except UnicodeEncodeError as e2:
-        return
-    except ValueError as e:
-        if not "IPv6" in str(e):
-            raise e
-
-    try:
-        werkzeug.urls.url_decode(fdp.ConsumeUnicode(30))
-    except UnicodeEncodeError as e2:
-        return
-    except ValueError as e:
-        if not "IPv6" in str(e):
-            raise e
-    return
 
 
 def main():


### PR DESCRIPTION
Werkzeug used by Flask experienced a major cleanup in 2023 https://github.com/pallets/werkzeug/pull/2768.
Multiple functions tested by OSS-Fuzz were deleted since they were available in the Python standard library. Because of this, Flask OSS-Fuzz builds have been failing since August 14, 2023.