### PR TITLE
Update Wasmtime's Rust toolchain

### DIFF
--- a/projects/wasmtime/Dockerfile
+++ b/projects/wasmtime/Dockerfile
@@ -36,4 +36,8 @@ WORKDIR wasmtime
 
 #RUN git clone --depth 1 https://github.com/bytecodealliance/wasmtime-libfuzzer-corpus wasmtime-libfuzzer-corpus
 
+# The default toolchain used by OSS-Fuzz is too old to build Wasmtime at this
+# time.
+ENV RUSTUP_TOOLCHAIN nightly-2025-01-10
+
 COPY build.sh *.options $SRC/


### PR DESCRIPTION
The default Rust toolchain use to build Rust projects on OSS-Fuzz, `nightly-2024-07-12`, is too old to build Wasmtime at this time. This toolchain is held back to match the LLVM version that Clang is using (18) and is one of the last Rust nightly builds that still uses LLVM 18 (`nightly-2024-07-30` is the last Rust nightly using 18, `nightly-2024-08-01` uses LLVM 19).

In lieu of updating the toolchain for all projects I've opted to only update Wasmtime at this time. I believe this means that Wasmtime will lose coverage information for fuzzing because LLVM tooling is at version 18 whereas Wasmtime will be producing coverage files from LLVM 19. For Wasmtime this is ok as we rely on the fuzzers themselves much more than the retrospective coverage information.