### PR TITLE
[aiohttp] Fix Broken Fuzzer Build

### DIFF
--- a/projects/aiohttp/Dockerfile
+++ b/projects/aiohttp/Dockerfile
@@ -21,9 +21,13 @@ RUN apt-get update && apt-get install -y \
   zlib1g-dev \
   libjpeg-dev \
   libpng-dev \
-  npm \
-  libffi-dev
+  libffi-dev \
+  make \
+  autoconf \
+  libtool
 RUN python3 -m pip install --upgrade pip
+RUN curl -sL https://deb.nodesource.com/setup_22.x -o nodesource_setup.sh
+RUN bash nodesource_setup.sh && apt-get install -y nodejs
 RUN git clone --recurse-submodules https://github.com/aio-libs/aiohttp
 COPY build.sh $SRC/
 COPY fuzz_* $SRC/aiohttp/

--- a/projects/aiohttp/build.sh
+++ b/projects/aiohttp/build.sh
@@ -14,12 +14,15 @@
 # limitations under the License.
 #
 ################################################################################
-ln -sf /usr/local/bin/python3 /usr/local/bin/python
-ln -sf /usr/local/bin/pip3 /usr/local/bin/pip
+# Build the llhttp parser
+git submodule update --init --recursive
+pushd "$SRC/aiohttp/vendor/llhttp/"
+npm ci
+make
+popd # "$SRC/aiohttp/vendor/llhttp/"
 
-# install aiohttp
-pip3 install -r requirements/dev.txt
-pre-commit install
+# Build & install aiohttp
+make cythonize
 make install-dev
 
 # Duplicate fuzzers to use Pure python code (in addition

--- a/projects/aiohttp/fuzz_multipart.py
+++ b/projects/aiohttp/fuzz_multipart.py
@@ -44,15 +44,13 @@ class FuzzStream:
 
 @atheris.instrument_func
 async def fuzz_bodypart_reader(data):
-    newline=b'\n'
     fdp = atheris.FuzzedDataProvider(data)
     obj = aiohttp.BodyPartReader(
         b"--:",
         {
-            CONTENT_TYPE: fdp.ConsumeUnicode(30)
+            CONTENT_TYPE: fdp.ConsumeUnicode(30),
         },
         FuzzStream(fdp.ConsumeBytes(atheris.ALL_REMAINING)),
-        _newline=newline
     )
     if not obj.at_eof():
         await obj.form()
@@ -65,7 +63,7 @@ def TestOneInput(data):
         return
 
 def main():
-    atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
+    atheris.Setup(sys.argv, TestOneInput)
     loop = asyncio.get_event_loop()
     asyncio.set_event_loop(loop)
     atheris.Fuzz()


### PR DESCRIPTION
Fixes https://issues.oss-fuzz.com/issues/42532914

The project build and install steps which were failing sine 
2024-02-12 while trying to build the `llhttp` parser submodule using a very outdated Nodejs (v.10) provided by the default apt repositories. At the time of this commit, `aiohttp` v3.11 is using Nodejs 18 in CI for the same task.

The changes here upgrade Nodejs to the latest LTS release version available (v22.x) and update the build & install commands to bring them in line with the steps described by the aiohttp contributor documentation and properly build the LLHTTP parser from C & Cython sources.