### PR TITLE
[llhttp] Fix Build Issues & Coverage Failure

### DIFF
--- a/projects/llhttp/Dockerfile
+++ b/projects/llhttp/Dockerfile
@@ -15,10 +15,9 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN curl -sL https://deb.nodesource.com/setup_22.x -o nodesource_setup.sh \
-    && bash nodesource_setup.sh
 RUN apt-get update \
-    && apt-get install -y nodejs make autoconf automake libtool
+    && apt-get install -y make autoconf automake libtool
+RUN install_javascript.sh
 RUN git clone --depth 1 https://github.com/nodejs/llhttp $SRC/llhttp
 COPY build.sh $SRC/
 WORKDIR $SRC/llhttp

--- a/projects/llhttp/Dockerfile
+++ b/projects/llhttp/Dockerfile
@@ -15,10 +15,10 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool
-RUN curl -sL https://deb.nodesource.com/setup_14.x -o nodesource_setup.sh
-RUN bash nodesource_setup.sh
-RUN apt install -y nodejs
-RUN git clone --depth 1 https://github.com/nodejs/llhttp llhttp
-WORKDIR llhttp
+RUN curl -sL https://deb.nodesource.com/setup_22.x -o nodesource_setup.sh \
+    && bash nodesource_setup.sh
+RUN apt-get update \
+    && apt-get install -y nodejs make autoconf automake libtool
+RUN git clone --depth 1 https://github.com/nodejs/llhttp $SRC/llhttp
 COPY build.sh $SRC/
+WORKDIR $SRC/llhttp

--- a/projects/llhttp/build.sh
+++ b/projects/llhttp/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/bash -euo
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,10 +15,11 @@
 #
 ################################################################################
 
-npm install -g typescript
-npm link typescript
-npm install .
+rm -rf "${WORK:?}/"*
+make clean
+
+npm ci
 make build/libllhttp.a
 
-$CC $CFLAGS -c ./test/fuzzers/fuzz_parser.c -I./build/ ./build/libllhttp.a -o $OUT/fuzz_parser.o
-$CXX $CXXFLAGS $LIB_FUZZING_ENGINE -fuse-ld=lld -I./build/ ./build/libllhttp.a $OUT/fuzz_parser.o -o $OUT/fuzz_parser
+$CC $CFLAGS -c ./test/fuzzers/fuzz_parser.c -I./build/ ./build/libllhttp.a -o $WORK/fuzz_parser.o
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE -fuse-ld=lld -I./build/ ./build/libllhttp.a $WORK/fuzz_parser.o -o $OUT/fuzz_parser


### PR DESCRIPTION
Fixes several issues in the build which have been breaking the runtime code coverage collection since at least 2024-11-24.

### Key Changes:
- Upgraded Node.js to the latest LTS release via the base image `install_javascriot.sh` script for compatibility with the upstream project's requirements.
- Refined the build commands to prefer the upstream project's documentation.
- Adjusted compiler flags to ensure only the executable fuzzing harness is placed in the `$OUT` directory so unnecessary build artifacts can't break anything in unexpected ways.

### Impact:
- Resolves the broken coverage collection.
- Marginally improves overall build times (see note below.)

---

#### Note Nodejs Install Script Slowdowns

The Dockerfile, both before and after this PR, uses a script hosted by https://deb.nodesource\.com to install a more recent version of Nodejs than the (extremely) old version available in the container by default.

That has been working just fine, however while I was reviewing the build logs I noticed the install script prints a warning about the deprecation of this node 14 version, but more importantly:

It deliberately sleeps for 80 seconds after printing the warnings, halting the build before continuing.

Unfortunately this is not easy to spot when reviewing the raw log directly: https://oss-fuzz-build-logs.storage.googleapis.com/log-fdce3d72-fe01-4a10-9f84-98617dc5110b.txt

It is a bit easier in the build status dashboard though: https://oss-fuzz-build-logs.storage.googleapis.com/index.html#llhttp

See below:

<details><summary>Log excerpt</summary>

```sh
Step #1:  ---> 92c0ffa5f35b
Step #1: Step 3/8 : RUN curl -sL https://deb.nodesource.com/setup_14.x -o nodesource_setup.sh
Step #1:  ---> Running in 2337f2ad0189
Step #1: Removing intermediate container 2337f2ad0189
Step #1:  ---> 4612ae8ce782
Step #1: Step 4/8 : RUN bash nodesource_setup.sh
Step #1:  ---> Running in e7a6477832e8
Step #1: 
Step #1: ================================================================================
Step #1: ================================================================================
Step #1: 
Step #1:                               DEPRECATION WARNING                            
Step #1: 
Step #1:   Node.js 14.x is no longer actively supported!
Step #1: 
Step #1:   You will not receive security or critical stability updates for this version.
Step #1: 
Step #1:   You should migrate to a supported version of Node.js as soon as possible.
Step #1:   Use the installation script that corresponds to the version of Node.js you
Step #1:   wish to install. e.g.
Step #1: 
Step #1:    * https://deb.nodesource.com/setup_16.x — Node.js 16 "Gallium"
Step #1:    * https://deb.nodesource.com/setup_18.x — Node.js 18 LTS "Hydrogen" (recommended)
Step #1:    * https://deb.nodesource.com/setup_19.x — Node.js 19 "Nineteen"
Step #1:    * https://deb.nodesource.com/setup_20.x — Node.js 20 "Iron" (current)
Step #1: 
Step #1:   Please see https://github.com/nodejs/Release for details about which
Step #1:   version may be appropriate for you.
Step #1: 
Step #1:   The NodeSource Node.js distributions repository contains
Step #1:   information both about supported versions of Node.js and supported Linux
Step #1:   distributions. To learn more about usage, see the repository:
Step #1:     https://github.com/nodesource/distributions
Step #1: 
Step #1: ================================================================================
Step #1: ================================================================================
Step #1: 
Step #1: Continuing in 20 seconds ...
Step #1: 
Step #1: 
Step #1: ================================================================================
Step #1: ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
Step #1: ================================================================================
Step #1: 
Step #1:                            SCRIPT DEPRECATION WARNING                    
Step #1: 
Step #1:   
Step #1:   This script, located at https://deb.nodesource.com/setup_X, used to
Step #1:   install Node.js is deprecated now and will eventually be made inactive.
Step #1: 
Step #1:   Please visit the NodeSource distributions Github and follow the
Step #1:   instructions to migrate your repo.
Step #1:   https://github.com/nodesource/distributions
Step #1: 
Step #1:   The NodeSource Node.js Linux distributions GitHub repository contains
Step #1:   information about which versions of Node.js and which Linux distributions
Step #1:   are supported and how to install it.
Step #1:   https://github.com/nodesource/distributions
Step #1: 
Step #1: 
Step #1:                           SCRIPT DEPRECATION WARNING
Step #1: 
Step #1: ================================================================================
Step #1: ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
Step #1: ================================================================================
Step #1: 
Step #1: TO AVOID THIS WAIT MIGRATE THE SCRIPT
Step #1: Continuing in 60 seconds (press Ctrl-C to abort) ...
Step #1: 
Step #1: 
Step #1: ## Installing the NodeSource Node.js 14.x repo...
Step #1: 
Step #1: 
Step #1: ## Populating apt-get cache...
Step #1: 
Step #1: + apt-get update
Step #1: Hit:1 http://securi
```



</details> 