### PR TITLE
pigweed: Fix sapphire fuzzers

### DIFF
--- a/projects/pigweed/build.sh
+++ b/projects/pigweed/build.sh
@@ -25,6 +25,10 @@ let lang_fuzz_tests = attr(generator_function, \"pw_cc_fuzz_test\", \$all_fuzz_t
 \$lang_fuzz_tests - attr(tags, \"no-oss-fuzz\", \$lang_fuzz_tests)
 "
 
-export BAZEL_EXTRA_BUILD_FLAGS="--config non_hermetic --cxxopt=-std=c++17"
+export BAZEL_EXTRA_BUILD_FLAGS="
+--config non_hermetic
+--cxxopt=-std=c++17
+--config=googletest
+"
 
 bazel_build_fuzz_tests


### PR DESCRIPTION
Sapphire's fuzzers use a set of test fakes that depend on gTest. This PR adds a Bazel flag to include gTest instead of the "light" pw_unit_test framework.

Bug: 382721836