### PR TITLE
Init FIPS 203 Post-quantum crypto in Rust

### DIFF
--- a/projects/fips203/project.yaml
+++ b/projects/fips203/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://crates.io/crates/fips203"
+main_repo: "https://github.com/integritychain/fips203"
+language: rust
+primary_contact: "eschorn@integritychain.com"
+auto_ccs:
+  - "eschorn@gmail.com"


### PR DESCRIPTION
This Rust crate fully implements the recently finalized version of the FIPS 203 spec at https://csrc.nist.gov/pubs/fips/203/final
It is the post-quantum crypto Module-Lattice-Based Key-Encapsulation Mechanism Standard.
The code is a freely available open source library intended for general use.

