### PR TITLE
wasmtime: Disable ASAN in fuzzing

### DIFF
--- a/projects/wasmtime/build.sh
+++ b/projects/wasmtime/build.sh
@@ -40,7 +40,7 @@ build() {
     export RUSTFLAGS="$RUSTFLAGS --remap-path-prefix $i=$crate_src_abspath/$i"
   done <<< "$(find . -name "*.rs" | cut -d/ -f2 | uniq)"
 
-  cd $PROJECT_DIR/fuzz && cargo fuzz build --strip-dead-code -O --debug-assertions "$@"
+  cd $PROJECT_DIR/fuzz && cargo fuzz build --sanitizer none --strip-dead-code -O --debug-assertions "$@"
 
   FUZZ_TARGET_OUTPUT_DIR=$PROJECT_DIR/$fuzz_target_path/x86_64-unknown-linux-gnu/release
 


### PR DESCRIPTION
This commit is an attempt to disable the use of ASAN for the Wasmtime project. Historically ASAN has not provided the project much benefit and ends up having the net effect of making fuzzing ~2x slower than it would be otherwise. Wasmtime is a WebAssembly runtime written in Rust, and while it has a nontrivial amount of `unsafe` code it's all primarily interacting with un-instrumented JIT code. This means that ASAN, even when enabled, is of little benefit as it's already not checking some of the most critical parts of Wasmtime.

In addition to causing a slowdown we also have a history in Wasmtime of fighting ASAN about signal handlers. Just recently we found that attempting to destroy a `sigaltstack` in a TLS destructor was (presumably) corrupting internal ASAN state. This took a number of months to figure out and in the meantime we had 2-3 crashes per day due to this (very rarely could reliably reproduce, intermittent, difficult to debug).

Currently AFAIK OSS-Fuzz doesn't have "official" support for disabling ASAN so the way this is implemented is to pretend that ASAN is enabled but instruct the build tooling to actually disable sanitizers entirely. My hope is that this will continue to fuzz and execute just fine and the various `ASAN_OPTIONS` permutations that OSS-Fuzz sets will largely just be ignored. If this ends up causing other infrastructure issues though my plan would be to re-enable ASAN.