### PR TITLE
caffeine: Initial integration

### DIFF
--- a/projects/caffeine/CaffeineSpecFuzzer.java
+++ b/projects/caffeine/CaffeineSpecFuzzer.java
@@ -1,0 +1,35 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.api.FuzzerSecurityIssueLow;
+import com.github.benmanes.caffeine.cache.CaffeineSpec;
+import java.lang.IllegalArgumentException;
+
+public class CaffeineSpecFuzzer {
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+    try {
+      CaffeineSpec spec = CaffeineSpec.parse(data.consumeRemainingAsString());
+      if (spec == null) {
+        throw new FuzzerSecurityIssueLow("null specification");
+      }
+    } catch (IllegalArgumentException e) {
+      /* documented to be thrown, ignore */
+    } catch (Exception e) {
+      e.printStackTrace(System.out);
+      throw new FuzzerSecurityIssueLow("Undocumented Exception");
+    }
+  }
+}

--- a/projects/caffeine/Dockerfile
+++ b/projects/caffeine/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-jvm
+
+RUN git clone --depth 1 https://github.com/ben-manes/caffeine
+
+RUN apt update && apt install -y openjdk-11-jdk-headless openjdk-21-jdk-headless
+ENV JAVA_HOME /usr/lib/jvm/java-21-openjdk-amd64
+
+COPY build.sh $SRC/
+COPY *Fuzzer.java $SRC/
+WORKDIR $SRC/caffeine

--- a/projects/caffeine/build.sh
+++ b/projects/caffeine/build.sh
@@ -1,0 +1,56 @@
+#!/bin/bash -eu
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+ALL_JARS=""
+
+pushd "${SRC}/caffeine"
+  ./gradlew --no-daemon caffeine:jar
+  install -v ./caffeine/build/libs/caffeine-*-SNAPSHOT.jar "$OUT/caffeine.jar"
+  ALL_JARS="${ALL_JARS} caffeine.jar"
+popd
+
+# The classpath at build-time includes the project jars in $OUT as well as the
+# Jazzer API.
+BUILD_CLASSPATH=$(echo $ALL_JARS | xargs printf -- "$OUT/%s:"):$JAZZER_API_PATH
+
+# All .jar and .class files lie in the same directory as the fuzzer at runtime.
+RUNTIME_CLASSPATH=$(echo $ALL_JARS | xargs printf -- "\$this_dir/%s:"):\$this_dir
+
+# compile all java files and copy them to $OUT
+javac --release 11 -cp $SRC:$BUILD_CLASSPATH -g $SRC/*.java
+cp $SRC/*.class $OUT/
+
+for fuzzer in $(find $SRC -name '*Fuzzer.java'); do
+  fuzzer_basename=$(basename -s .java $fuzzer)
+
+  # Create an execution wrapper that executes Jazzer with the correct arguments.
+  echo "#!/bin/bash
+# LLVMFuzzerTestOneInput for fuzzer detection.
+this_dir=\$(dirname \"\$0\")
+if [[ \"\$@\" =~ (^| )-runs=[0-9]+($| ) ]]; then
+  mem_settings='-Xmx1900m:-Xss900k'
+else
+  mem_settings='-Xmx2048m:-Xss1024k'
+fi
+LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\":\$this_dir \
+\$this_dir/jazzer_driver --agent_path=\$this_dir/jazzer_agent_deploy.jar \
+--cp=$RUNTIME_CLASSPATH \
+--target_class=$fuzzer_basename \
+--jvm_args=\"\$mem_settings\" \
+\$@" > $OUT/$fuzzer_basename
+  chmod u+x $OUT/$fuzzer_basename
+done

--- a/projects/caffeine/project.yaml
+++ b/projects/caffeine/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/ben-manes/caffeine"
+language: jvm
+main_repo: "https://github.com/ben-manes/caffeine.git"
+primary_contact: "ben.manes@gmail.com"
+auto_ccs:
+  - "cpovirk@google.com"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
[Caffeine Cache](https://github.com/ben-manes/caffeine) is the [successor](https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/cache/CacheBuilder.html#prefer-caffeine-over-guava-s-caching-api-heading) to Google Guava's Cache. It had 250M downloads from Maven Central in 2024.

I have tested this locally based on your documented steps.

/cc @cpovirk