### PR TITLE
[lcms] fix lcms dockerfile

### DIFF
--- a/projects/lcms/Dockerfile
+++ b/projects/lcms/Dockerfile
@@ -31,7 +31,6 @@ RUN mkdir $SRC/seeds && \
     cp $SRC/lcms/testbed/test3.icc . && \
     cp $SRC/lcms/testbed/test4.icc . && \
     cp $SRC/lcms/testbed/test5.icc . && \
-    cp $SRC/lcms/testbed/TestCLT.icc . && \
     zip -rj $SRC/seed_corpus.zip $SRC/seeds/*
 
 WORKDIR lcms


### PR DESCRIPTION
The image for lcms fails to build: https://oss-fuzz-build-logs.storage.googleapis.com/log-288a8d76-2e99-4e63-90aa-e3d769a57d21.txt

The error is because the file `TestCLT.icc` is removed in this commit: https://github.com/mm2/Little-CMS/commit/08f4abb92df247ffa03fd740a31c2c496fa52de3

This PR removes the copy for this removed file.