### PR TITLE
Libconfig: Updated Dockerfile for Initial Integration

### DIFF
--- a/projects/libconfig/Dockerfile
+++ b/projects/libconfig/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/libconfig/Dockerfile
+++ b/projects/libconfig/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y cmake make
+
+RUN git clone --depth 1 https://github.com/capuanob/libconfig.git libconfig \
+        && cp libconfig/fuzz/build.sh $SRC/
+WORKDIR libconfig

--- a/projects/libconfig/Dockerfile
+++ b/projects/libconfig/Dockerfile
@@ -17,6 +17,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y cmake make
 
-RUN git clone --depth 1 https://github.com/capuanob/libconfig.git libconfig \
+RUN git clone --depth 1 https://github.com/hyperrealm/libconfig.git libconfig \
         && cp libconfig/fuzz/build.sh $SRC/
 WORKDIR libconfig

--- a/projects/libconfig/project.yaml
+++ b/projects/libconfig/project.yaml
@@ -4,3 +4,7 @@ primary_contact: "hyperrealm@gmail.com"
 auto_ccs:
   - "capuanobailey@gmail.com"
 main_repo: "https://github.com/hyperrealm/libconfig.git"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz


### PR DESCRIPTION
This pull requests integrates the Dockerfile needed to build the fuzzers for libconfig, as merged into upstream [here](https://github.com/hyperrealm/libconfig/pull/251).