### PR TITLE
chronos: Run build_cache_local.sh on cloud build

### DIFF
--- a/infra/base-images/base-builder/bash_parser.py
+++ b/infra/base-images/base-builder/bash_parser.py
@@ -196,7 +196,7 @@ def parse_script(bash_script, all_scripts) -> str:
     build_script = f.read()
   try:
     parts = bashlex.parse(build_script)
-  except bashlex.error.ParsingError:
+  except bashlex.errors.ParsingError:
     return ''
   for part in parts:
     new_script += handle_node(part, all_scripts, build_script)

--- a/infra/experimental/chronos/README.md
+++ b/infra/experimental/chronos/README.md
@@ -7,7 +7,7 @@
 From the OSS-Fuzz root
 
 ```sh
-$ RUN_ALL=1 ./infra/experimental/chronos/build_cache_local.sh htslib c
+$ RUN_ALL=1 ./infra/experimental/chronos/build_cache_local.sh htslib c address
 ...
 ...
 Vanilla compile time:

--- a/infra/experimental/chronos/cloudbuild.yaml
+++ b/infra/experimental/chronos/cloudbuild.yaml
@@ -26,89 +26,11 @@
 # TODO (David): add support for use of dedicated replay_build.sh
 steps:
 - name: 'gcr.io/cloud-builders/docker'
+  entrypoint: /bin/bash
   args:
-  - build
-  - -t
-  - gcr.io/oss-fuzz/${_PROJECT}
-  - .
-  dir: projects/${_PROJECT}
-- name: ubuntu
-  args:
-    - mkdir
-    - /workspace/ccache
-- name: 'gcr.io/cloud-builders/docker'
-  args:
-  - run
-  - --entrypoint=/bin/sh
-  - --env=SANITIZER=address
-  - --env=CCACHE_DIR=/workspace/ccache
-  - --env=FUZZING_LANGUAGE=${_FUZZING_LANGUAGE}
-  - --name=${_PROJECT}-origin-asan
-  - --volume=/workspace/ccache:/workspace/ccache
-  - gcr.io/oss-fuzz/${_PROJECT}
-  - -c
-  - "export PATH=/ccache/bin:$$PATH && compile && rm -rf /out/*"
-- name: ubuntu
-  args:
-    - cp
-    - -rf
-    - /workspace/ccache
-    - projects/${_PROJECT}/ccache-cache
-# Prepare for ccache environment
-- name: ubuntu
-  args:
-  - /workspace/infra/experimental/chronos/prepare-ccache
-  - ${_PROJECT}
-# Build the ccached instance
-- name: 'gcr.io/cloud-builders/docker'
-  args:
-  - build
-  - -t
-  - us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/${_PROJECT}-ofg-cached-address
-  - .
-  dir: projects/${_PROJECT}
-# Cleanup the ccache stored in the project folder
-- name: ubuntu
-  args:
-    - rm
-    - -rf
-    - projects/${_PROJECT}/ccache-cache
-    - /workspace/ccache
-# Build coverage image
-- name: 'gcr.io/cloud-builders/docker'
-  args:
-  - run
-  - --entrypoint=/bin/sh
-  - --env=SANITIZER=coverage
-  - --env=CCACHE_DIR=/workspace/ccache
-  - --env=FUZZING_LANGUAGE=${_FUZZING_LANGUAGE}
-  - --name=${_PROJECT}-origin-cov
-  - --volume=/workspace/ccache:/workspace/ccache
-  - gcr.io/oss-fuzz/${_PROJECT}
-  - -c
-  - "export PATH=/ccache/bin:$$PATH && compile && rm -rf /out/*"
-- name: ubuntu
-  args:
-    - cp
-    - -rf
-    - /workspace/ccache
-    - projects/${_PROJECT}/ccache-cache
-# Prepare for ccache environment
-- name: ubuntu
-  args:
-  - /workspace/infra/experimental/chronos/prepare-ccache
-  - ${_PROJECT}
-# Build the ccached instance
-- name: 'gcr.io/cloud-builders/docker'
-  args:
-  - build
-  - -t
-  - us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/${_PROJECT}-ofg-cached-coverage
-  - .
-  dir: projects/${_PROJECT}
+  - /workspace/infra/experimental/chronos/build_cache_local.sh ${_PROJECT} ${_FUZZING_LANGUAGE}
 images:
 - us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/${_PROJECT}-ofg-cached-address
-- us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/${_PROJECT}-ofg-cached-coverage
 timeout: 72000s  # 20 hours, same as build_lib.py
 logsBucket: oss-fuzz-gcb-logs
 tags:

--- a/infra/experimental/chronos/cloudbuild.yaml
+++ b/infra/experimental/chronos/cloudbuild.yaml
@@ -28,9 +28,26 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   entrypoint: /bin/bash
   args:
-  - /workspace/infra/experimental/chronos/build_cache_local.sh ${_PROJECT} ${_FUZZING_LANGUAGE}
+  - /workspace/infra/experimental/chronos/build_cache_local.sh
+  - ${_PROJECT}
+  - ${_FUZZING_LANGUAGE}
+  - address
+  env:
+  - RUN_ALL=1
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: /bin/bash
+  args:
+  - /workspace/infra/experimental/chronos/build_cache_local.sh
+  - ${_PROJECT}
+  - ${_FUZZING_LANGUAGE}
+  - coverage
+  env:
+  - RUN_ALL=1
 images:
 - us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/${_PROJECT}-ofg-cached-address
+- us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/${_PROJECT}-ofg-cached-coverage
+- us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/${_PROJECT}-ofg-ccache-address
+- us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/${_PROJECT}-ofg-ccache-coverage
 timeout: 72000s  # 20 hours, same as build_lib.py
 logsBucket: oss-fuzz-gcb-logs
 tags:


### PR DESCRIPTION
Also make some changes:

1. Support coverage builds by parameterising the sanitizer.

2. Build a total of 2 images: 
  - us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/${_PROJECT}-ofg-cached-${_SANITIZER}
  - us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/${_PROJECT}-ofg-ccache-${_SANITIZER}

    The "cached" image will be different depending on whether replay worked or not. The "ccache" image will always use ccache.

3. Fix an incorrect exception path in bash_parser.py