### PR TITLE
tarantool: fix seed corpus

### DIFF
--- a/projects/tarantool/Dockerfile
+++ b/projects/tarantool/Dockerfile
@@ -25,4 +25,8 @@ RUN apt-get update && apt-get install -y \
 RUN git clone --jobs $(nproc) --recursive https://github.com/tarantool/tarantool
 WORKDIR $SRC/tarantool
 
+# Download a seed corpus.
+RUN rm -rf test/static
+RUN git clone https://github.com/ligurio/tarantool-corpus test/static
+
 COPY build.sh $SRC/


### PR DESCRIPTION
Seed corpus has been moved to a separate Git repository, see [1].

1. https://github.com/tarantool/tarantool/pull/11042