### PR TITLE
libressl: fix build

### DIFF
--- a/projects/libressl/Dockerfile
+++ b/projects/libressl/Dockerfile
@@ -20,8 +20,7 @@ FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30
 RUN apt-get update && apt-get install -y make cmake wget autoconf automake libtool bison flex texinfo lzip
 RUN git clone --depth 1 https://github.com/libressl/portable.git libressl
 RUN git clone --depth 1 https://github.com/libressl/fuzz.git libressl.fuzzers
-RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
-RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora
+RUN git clone --depth 1 https://github.com/MozillaSecurity/cryptofuzz
 RUN wget https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.bz2
 RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN wget https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz

--- a/projects/libressl/build.sh
+++ b/projects/libressl/build.sh
@@ -130,5 +130,3 @@ LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_LIBRESSL -
 cp $SRC/cryptofuzz/cryptofuzz $OUT/cryptofuzz
 # Copy dictionary
 cp $SRC/cryptofuzz/cryptofuzz-dict.txt $OUT/cryptofuzz.dict
-# Copy seed corpus
-cp $SRC/cryptofuzz-corpora/libressl_latest.zip $OUT/cryptofuzz_seed_corpus.zip


### PR DESCRIPTION
cryptofuzz has been removed, but a copy exists here: https://github.com/MozillaSecurity/cryptofuzz