### PR TITLE
tmux: fix build issue

### DIFF
--- a/projects/tmux/build.sh
+++ b/projects/tmux/build.sh
@@ -31,19 +31,22 @@ find "${SRC}/tmux/fuzz/" -name '*-fuzzer.options' -exec cp -v '{}' "${OUT}"/ \;
 find "${SRC}/tmux/fuzz/" -name '*-fuzzer.dict' -exec cp -v '{}' "${OUT}"/ \;
 
 MAXLEN=$(grep -Po 'max_len\s+=\s+\K\d+' "${OUT}/input-fuzzer.options")
-mkdir "${WORK}/fuzzing_corpus"
-cd "${WORK}/fuzzing_corpus"
-bash "${SRC}/tmux/tools/24-bit-color.sh" | \
-    split -a4 -db$MAXLEN - 24-bit-color.out.
-perl "${SRC}/tmux/tools/256colors.pl" | \
-    split -a4 -db$MAXLEN - 256colors.out.
-cat "${SRC}/tmux/tools/UTF-8-demo.txt" | \
-    split -a4 -db$MAXLEN - UTF-8-demo.txt.
-cat "${SRC}/tmux-fuzzing-corpus/alacritty"/* | \
-    split -a4 -db$MAXLEN - alacritty.
-cat "${SRC}/tmux-fuzzing-corpus/esctest"/* | \
-    split -a4 -db$MAXLEN - esctest.
-cat "${SRC}/tmux-fuzzing-corpus/iterm2"/* | \
-    split -a5 -db$MAXLEN - iterm2.
-zip -q -j -r "${OUT}/input-fuzzer_seed_corpus.zip" \
-    "${WORK}/fuzzing_corpus/"
+
+if [ ! -d "${WORK}/fuzzing_corpus" ]; then
+    mkdir "${WORK}/fuzzing_corpus"
+    cd "${WORK}/fuzzing_corpus"
+    bash "${SRC}/tmux/tools/24-bit-color.sh" | \
+        split -a4 -db$MAXLEN - 24-bit-color.out.
+    perl "${SRC}/tmux/tools/256colors.pl" | \
+        split -a4 -db$MAXLEN - 256colors.out.
+    cat "${SRC}/tmux/tools/UTF-8-demo.txt" | \
+        split -a4 -db$MAXLEN - UTF-8-demo.txt.
+    cat "${SRC}/tmux-fuzzing-corpus/alacritty"/* | \
+        split -a4 -db$MAXLEN - alacritty.
+    cat "${SRC}/tmux-fuzzing-corpus/esctest"/* | \
+        split -a4 -db$MAXLEN - esctest.
+    cat "${SRC}/tmux-fuzzing-corpus/iterm2"/* | \
+        split -a5 -db$MAXLEN - iterm2.
+    zip -q -j -r "${OUT}/input-fuzzer_seed_corpus.zip" \
+        "${WORK}/fuzzing_corpus/"
+fi


### PR DESCRIPTION
Quick fix preventing the building process to break in case the corpus was already created (leading to a lack of coverage data in introspector).