### PR TITLE
relic: fix build

### DIFF
--- a/projects/relic/Dockerfile
+++ b/projects/relic/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool wget python
 RUN git clone --depth 1 https://github.com/relic-toolkit/relic.git
 RUN git clone --depth 1 https://github.com/randombit/botan.git
-RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
+RUN git clone --depth 1 https://github.com/MozillaSecurity/cryptofuzz
 RUN wget https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.bz2
 COPY build.sh $SRC/
 # This is to fix Fuzz Introspector build by using LLVM old pass manager

--- a/projects/relic/project.yaml
+++ b/projects/relic/project.yaml
@@ -7,7 +7,6 @@ auto_ccs:
 sanitizers:
  - address
  - undefined
- - memory
 architectures:
  - x86_64
  - i386


### PR DESCRIPTION
Cryptofuzz has been removed, but is revived here:
https://github.com/MozillaSecurity/cryptofuzz