### PR TITLE
Update build script for data-encoding to fix broken build

### DIFF
--- a/projects/data-encoding/build.sh
+++ b/projects/data-encoding/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 cd lib
-cargo fuzz build --features=data-encoding/v3-preview
+cargo fuzz build
 
 find $SRC/data-encoding/target/x86_64-unknown-linux-gnu/release -maxdepth 1 \
     -type f -perm -u=x -exec cp {} $OUT \;


### PR DESCRIPTION
The unpublished v3-preview feature has been removed by https://github.com/ia0/data-encoding/pull/120. The v3 development version will be added in a separate folder. I'll update the build script to add the fuzzing for v3 once that's done.