### PR TITLE
tarantool: use libfuzzer options

### DIFF
--- a/projects/tarantool/build.sh
+++ b/projects/tarantool/build.sh
@@ -91,6 +91,7 @@ cmake --build build --target fuzzers --parallel --verbose
 # used in Lua C API tests [1].
 #
 # 1. https://github.com/ligurio/lua-c-api-tests/
+cp test/static/*.dict test/static/*.options $OUT/
 for f in $(find build/test/fuzz/ \( -name '*_fuzzer' -o -name '*_test' \) -type f);
 do
   name=$(basename $f);
@@ -98,10 +99,6 @@ do
   corpus_dir="test/static/corpus/$module"
   echo "Copying for $module";
   cp $f $OUT/
-  dict_path="test/static/$module.dict"
-  if [ -e "$dict_path" ]; then
-    cp $dict_path $OUT/
-  fi
   if [ -e "$corpus_dir" ]; then
     zip --quiet -j $OUT/"$name"_seed_corpus.zip $corpus_dir/*
   fi


### PR DESCRIPTION
If the dict filename is the same as your target binary name
(i.e. `%fuzz_target%.dict`), it will be automatically used.
If the name is different (e.g. because it is shared by several
targets), specify this in `.options` file.

1. https://google.github.io/oss-fuzz/getting-started/new-project-guide/#dictionaries

Needed for https://github.com/tarantool/tarantool/pull/10911