### PR TITLE
wasmtime: Remove usage of initialized corpus

### DIFF
--- a/projects/wasmtime/build.sh
+++ b/projects/wasmtime/build.sh
@@ -18,7 +18,6 @@
 # Commands migrated from Dockerfile to make CIFuzz work
 # REF: https://github.com/google/oss-fuzz/issues/6755
 git submodule update --init --recursive
-git clone --depth 1 https://github.com/bytecodealliance/wasmtime-libfuzzer-corpus wasmtime-libfuzzer-corpus
 
 # Note: This project creates Rust fuzz targets exclusively
 
@@ -52,12 +51,6 @@ build() {
       src_name=$(basename ${f%.*})
       dst_name=$fuzzer_prefix$src_name
       cp $FUZZ_TARGET_OUTPUT_DIR/$src_name $OUT/$dst_name
-
-      if [[ -d $SRC/wasmtime/wasmtime-libfuzzer-corpus/$dst_name/ ]]; then
-          zip -jr \
-              $OUT/${dst_name}_seed_corpus.zip \
-              $SRC/wasmtime/wasmtime-libfuzzer-corpus/$dst_name/
-      fi
 
       if [[ -f $SRC/$dst_name.options ]]; then
         cp $SRC/$dst_name.options $OUT/$dst_name.options


### PR DESCRIPTION
Wasmtime's initial corpus repository hasn't been updated in years. Many of its files are entirely unused at this time. Other preexisting corpus files no longer test what they originally did as Wasmtime's fuzzing relies on interpreting the input as a "DNA string" where the exact meaning of the DNA changes over time as we change fuzz targets. We concluded recently in Wasmtime to archive/delete the repository we were previously using to avoid confusion so this change follows-up on the OSS-Fuzz side of thing to remove usage of this outdated corpus.

cc @fitzgen 