### PR TITLE
Remove former SurrealDB employee from auto-ccs

### DIFF
--- a/projects/surrealdb/project.yaml
+++ b/projects/surrealdb/project.yaml
@@ -4,15 +4,11 @@ primary_contact: "tobie@surrealdb.com"
 main_repo: "https://github.com/surrealdb/surrealdb"
 auto_ccs:
   - security@surrealdb.com
-  - finn.bear@surrealdb.com
-  - salvador.girones@surrealdb.com
-  - gerard.guillemas@surrealdb.com
   - mees.delzenne@surrealdb.com
   - emmanuel.keller@surrealdb.com
   - micha.de.vries@surrealdb.com
   - rushmore@surrealdb.com
   - rowan.baker@surrealdb.com
-  - nathaniel.brough@gmail.com
 
 sanitizers:
   - address


### PR DESCRIPTION
Tidy up of the surrealdb project.yaml to remove inactive email addresses of former SurrealDB employees or project contributors.

