### PR TITLE
vlc: update primary contact and drop external CCs

### DIFF
--- a/projects/vlc/project.yaml
+++ b/projects/vlc/project.yaml
@@ -1,9 +1,6 @@
 homepage: "https://github.com/videolan/vlc"
 language: c
-primary_contact: "ossfuzz@videolan.org"
-auto_ccs:
-  - "adam@adalogics.com"
-  - "david@adalogics.com"
+primary_contact: "security@videolan.org"
 sanitizers:
   - address
   - undefined

--- a/projects/vlc/project.yaml
+++ b/projects/vlc/project.yaml
@@ -1,6 +1,12 @@
 homepage: "https://github.com/videolan/vlc"
 language: c
 primary_contact: "security@videolan.org"
+auto_ccs:
+  - "le.businessman@gmail.com"
+  - "thomas.guillem@gmail.com"
+  - "alexandre.janniaux@gmail.com"
+  - "kempfjb@gmail.com"
+  - "courmisch@gmail.com"
 sanitizers:
   - address
   - undefined


### PR DESCRIPTION
We handle all security issues through security@videolan.org exclusively now and want to limit the scope.