### PR TITLE
vlc: use official repo + add seeds and dicts + add demuxers

### DIFF
--- a/projects/vlc/Dockerfile
+++ b/projects/vlc/Dockerfile
@@ -17,6 +17,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
   pkg-config cmake flex bison gettext libglu1-mesa-dev 
-RUN git clone --depth 1 https://github.com/videolan/vlc vlc
+RUN git clone --depth 1 https://code.videolan.org/videolan/vlc.git vlc
 WORKDIR vlc
 COPY build.sh $SRC/

--- a/projects/vlc/Dockerfile
+++ b/projects/vlc/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
-  pkg-config cmake flex bison gettext libglu1-mesa-dev 
+  pkg-config cmake flex bison gettext libglu1-mesa-dev ninja-build
 RUN git clone --depth 1 https://code.videolan.org/videolan/vlc.git vlc
 RUN git clone --depth 1 https://code.videolan.org/VideoLAN.org/vlc-fuzz-corpus.git vlc/fuzz-corpus
 WORKDIR vlc

--- a/projects/vlc/Dockerfile
+++ b/projects/vlc/Dockerfile
@@ -18,5 +18,6 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
   pkg-config cmake flex bison gettext libglu1-mesa-dev 
 RUN git clone --depth 1 https://code.videolan.org/videolan/vlc.git vlc
+RUN git clone --depth 1 https://code.videolan.org/VideoLAN.org/vlc-fuzz-corpus.git vlc/fuzz-corpus
 WORKDIR vlc
 COPY build.sh $SRC/

--- a/projects/vlc/build.sh
+++ b/projects/vlc/build.sh
@@ -15,18 +15,58 @@
 #
 ################################################################################
 
+# Build dependencies without instrumentation
+CFLAGS_SAVE="$CFLAGS"
+CXXFLAGS_SAVE="$CXXFLAGS"
+unset CFLAGS
+unset CXXFLAGS
+export AFL_NOOPT=1
+
+# But we need libc++
+export CXXFLAGS="-stdlib=libc++"
+
+mkdir contrib/contrib-build
+cd contrib/contrib-build
+../bootstrap
+
+make V=1 -j$(nproc) \
+    .matroska \
+    .ogg \
+    .libxml2
+
+cd ../../
+
+# Resume instrumentation
+export CFLAGS="${CFLAGS_SAVE}"
+export CXXFLAGS="${CXXFLAGS_SAVE}"
+unset AFL_NOOPT
+
 # Use OSS-Fuzz environment rather than hardcoded setup.
 sed -i 's/-fsanitize-coverage=trace-pc-guard//g' ./configure.ac
 sed -i 's/-fsanitize-coverage=trace-cmp//g' ./configure.ac
 sed -i 's/-fsanitize-coverage=trace-pc//g' ./configure.ac
 sed -i 's/-lFuzzer//g'  ./configure.ac
 
-# In order to build statically we avoid libxml and ogg plugins.
+# Use default -lc++
+sed -i 's/-lstdc++ //g' ./configure.ac
+sed -i 's/-lstdc++/$(NULL)/g' ./test/Makefile.am
+
 sed -i 's/..\/..\/lib\/libvlc_internal.h/lib\/libvlc_internal.h/g' ./test/src/input/decoder.c
-sed -i 's/..\/modules\/libxml_plugin.la//g' ./test/Makefile.am
-sed -i 's/..\/modules\/libogg_plugin.la//g' ./test/Makefile.am
-sed -i 's/f(misc_xml_xml)//g' ./test/src/input/demux-run.c
-sed -i 's/f(demux_ogg)//g' ./test/src/input/demux-run.c
+
+# clang is used to link the binary since there are no cpp sources (but we have
+# cpp modules), force clang++ usage
+touch ./test/dummy.cpp
+
+# Rework implicit RULEs so that the final sed add dummy.cpp
+RULE=vlc_demux_libfuzzer
+RULE_SOURCES="${RULE}_SOURCES = vlc-demux-libfuzzer.c"
+sed -i "s/${RULE}_LDADD/${RULE_SOURCES}\n${RULE}_LDADD/g" ./test/Makefile.am
+RULE=vlc_demux_run
+RULE_SOURCES="${RULE}_SOURCES = vlc-demux-run.c"
+sed -i "s/${RULE}_LDADD/${RULE_SOURCES}\n${RULE}_LDADD/g" ./test/Makefile.am
+
+# Add dummy.cpp to all rules
+sed -i 's/_SOURCES = /_SOURCES = dummy.cpp /g' ./test/Makefile.am
 
 # Ensure that we compile with the correct link flags.
 RULE="vlc_demux_libfuzzer_LDADD"
@@ -38,7 +78,8 @@ FUZZ_LDFLAGS="vlc_demux_dec_libfuzzer_LDFLAGS=\${LIB_FUZZING_ENGINE}"
 sed -i "s/${RULE}/${FUZZ_LDFLAGS}\n${RULE}/g" ./test/Makefile.am
 
 ./bootstrap
-./configure --disable-ogg --disable-oggspots --disable-libxml2 --disable-lua \
+
+./configure --disable-lua \
             --disable-shared \
             --enable-static \
             --enable-vlc=no \

--- a/projects/vlc/build.sh
+++ b/projects/vlc/build.sh
@@ -50,4 +50,3 @@ sed -i "s/${RULE}/${FUZZ_LDFLAGS}\n${RULE}/g" ./test/Makefile.am
             --with-libfuzzer
 make V=1 -j$(nproc)
 cp ./test/vlc-demux-dec-libfuzzer $OUT/
-cp ./test/vlc-demux-libfuzzer $OUT/

--- a/projects/vlc/build.sh
+++ b/projects/vlc/build.sh
@@ -80,6 +80,7 @@ sed -i "s/${RULE}/${FUZZ_LDFLAGS}\n${RULE}/g" ./test/Makefile.am
 ./bootstrap
 
 ./configure --disable-lua \
+            --disable-nls \
             --disable-shared \
             --enable-static \
             --enable-vlc=no \


### PR DESCRIPTION
- Remove useless vlc-demux-libfuzzer output target
- Use the official VideoLAN/vlc repository
- Add seeds and dicts: create one output target per format
- Add mkv, ogg, xml support