### PR TITLE
Migrate to `actions/upload-artifact@v4`.

### DIFF
--- a/docs/getting-started/continuous_integration.md
+++ b/docs/getting-started/continuous_integration.md
@@ -90,7 +90,7 @@ jobs:
        fuzz-seconds: 600
        output-sarif: true
    - name: Upload Crash
-     uses: actions/upload-artifact@v3
+     uses: actions/upload-artifact@v4
      if: failure() && steps.build.outcome == 'success'
      with:
        name: artifacts
@@ -170,7 +170,7 @@ jobs:
        sanitizer: ${{ matrix.sanitizer }}
        output-sarif: true
    - name: Upload Crash
-     uses: actions/upload-artifact@v3
+     uses: actions/upload-artifact@v4
      if: steps.build.outcome == 'success'
      with:
        name: ${{ matrix.sanitizer }}-artifacts
@@ -223,7 +223,7 @@ jobs:
        language: c++
        fuzz-seconds: 600
    - name: Upload Crash
-     uses: actions/upload-artifact@v3
+     uses: actions/upload-artifact@v4
      if: failure() && steps.build.outcome == 'success'
      with:
        name: artifacts

--- a/infra/cifuzz/example_cifuzz.yml
+++ b/infra/cifuzz/example_cifuzz.yml
@@ -19,11 +19,11 @@ jobs:
         fuzz-seconds: 600
         output-sarif: true
     - name: Upload Crash
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts
-        path: ./out/artifacts   
+        path: ./out/artifacts
     - name: Upload Sarif
       if: always() && steps.build.outcome == 'success'
       uses: github/codeql-action/upload-sarif@v2

--- a/tools/vscode-extension/src/cifuzz.ts
+++ b/tools/vscode-extension/src/cifuzz.ts
@@ -53,7 +53,7 @@ jobs:
         fuzz-seconds: ${secondToRun}
         output-sarif: true
     - name: Upload Crash
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure() && steps.build.outcome == 'success'
         with:
         name: artifacts


### PR DESCRIPTION
This fixes the deprecation of v3 of these actions.

Closes #13011.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/