### PR TITLE
kubevirt: build all upstream fuzzers

### DIFF
--- a/projects/kubevirt/build.sh
+++ b/projects/kubevirt/build.sh
@@ -34,7 +34,6 @@ go mod tidy
 go mod vendor
 
 compile_native_go_fuzzer kubevirt.io/kubevirt/pkg/virt-controller/watch/node FuzzExecute FuzzNodeWatchExecute
-exit 0
 compile_native_go_fuzzer kubevirt.io/kubevirt/pkg/virt-controller/watch/vm FuzzExecute FuzzVMWatchExecute
 compile_native_go_fuzzer kubevirt.io/kubevirt/pkg/virt-controller/watch/vmi FuzzExecute FuzzVMIWatchExecute
 compile_native_go_fuzzer kubevirt.io/kubevirt/pkg/virt-controller/watch/clone FuzzVMCloneController FuzzVMCloneController


### PR DESCRIPTION
The rest of the fuzzers should be ready, so add them to the build.