### PR TITLE
Revert "libxml2: Disable TSCII charset in glibc (#13003)"

### DIFF
--- a/projects/libxml2/Dockerfile
+++ b/projects/libxml2/Dockerfile
@@ -26,17 +26,9 @@ RUN apt-get update && \
         make autoconf libtool pkg-config \
         zlib1g-dev liblzma-dev \
         $EXTRA_PACKAGES
-
 # Build requires automake 1.16.3
 RUN curl -LO http://mirrors.kernel.org/ubuntu/pool/main/a/automake-1.16/automake_1.16.5-1.3_all.deb && \
     apt install ./automake_1.16.5-1.3_all.deb
-
-# Disable buggy TSCII charset in glibc
-RUN sed -i.orig -e '/TSCII/ s/.*/#&/' /usr/lib/x86_64-linux-gnu/gconv/gconv-modules
-# For newer distros
-#RUN sed -i.orig -e '/TSCII/ s/.*/#&/' /usr/lib/x86_64-linux-gnu/gconv/gconv-modules.d/gconv-modules-extra.conf
-RUN iconvconfig
-
 RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/libxml2.git
 WORKDIR libxml2
 COPY build.sh $SRC/


### PR DESCRIPTION
This reverts commit e007cb7be3868cb4f55e030c6c2a4199ca750bb6.

This change didn't affect the base-runner image where it would be needed.