### PR TITLE
gzip: constrain input_buffer size

### DIFF
--- a/projects/zlib/gzio_fuzzer.c
+++ b/projects/zlib/gzio_fuzzer.c
@@ -30,7 +30,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataLen) {
     gzFile file;
     char fname[] = "gzio.XXXXXX";
     close(mkstemp(fname));
-    unsigned mode_sz = dataLen ? (--dataLen, *data++)|2 : 8;
+    unsigned mode_sz = (dataLen ? (--dataLen, *data++) | 2 : 8) & 0xF;
     char mode[mode_sz];
     memcpy(mode, data, dataLen >= mode_sz ? mode_sz - 1: dataLen);
     mode[mode_sz - 1] = 0;


### PR DESCRIPTION
Otherwise gzio_fuzzer is blocked, while it does increase the number of functions statically reachable, see
https://storage.googleapis.com/oss-fuzz-introspector/zlib/inspector-report/20250211/fuzz_report.html