### PR TITLE
infra: build: build_project: set entrypoint explicitly in compile step

### DIFF
--- a/infra/build/functions/build_project.py
+++ b/infra/build/functions/build_project.py
@@ -285,8 +285,9 @@ def get_compile_step(project,
   compile_step = {
       'name': project.image,
       'env': env,
+      'entrypoint':
+          '/bin/bash',
       'args': [
-          'bash',
           '-c',
           # Remove /out to make sure there are non instrumented binaries.
           # `cd /src && cd {workdir}` (where {workdir} is parsed from the

--- a/infra/build/functions/build_project.py
+++ b/infra/build/functions/build_project.py
@@ -285,8 +285,7 @@ def get_compile_step(project,
   compile_step = {
       'name': project.image,
       'env': env,
-      'entrypoint':
-          '/bin/bash',
+      'entrypoint': '/bin/bash',
       'args': [
           '-c',
           # Remove /out to make sure there are non instrumented binaries.


### PR DESCRIPTION
Follow same pattern as https://github.com/google/oss-fuzz/blob/2772bd6f5d11a44d068b86b8ce7732ab9aff6eb2/infra/build/functions/target_experiment.py#L151-L154

This should also solve a problem with Chronos where the entrypoint is set to `bin/bash` already: https://github.com/google/oss-fuzz/blob/2772bd6f5d11a44d068b86b8ce7732ab9aff6eb2/infra/experimental/chronos/build_cache_local.sh#L59

Chronos needs to set it in order for the images to work locally with `helper.py`.

Alternatively, we could set entrypoint in `helper.py`, I think