### PR TITLE
gnutls: Fix build

### DIFF
--- a/projects/gnutls/Dockerfile
+++ b/projects/gnutls/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get install -y \
  lzip
 
 ENV GNULIB_TOOL $SRC/gnulib/gnulib-tool
-RUN git clone --depth=1 git://git.savannah.gnu.org/gnulib.git
+RUN git clone --depth=500 git://git.savannah.gnu.org/gnulib.git
 RUN git clone --depth=1 https://git.savannah.gnu.org/git/libunistring.git
 RUN git clone --depth=1 https://gitlab.com/libidn/libidn2.git
 RUN hg clone https://gmplib.org/repo/gmp/ gmp || \

--- a/projects/gnutls/build.sh
+++ b/projects/gnutls/build.sh
@@ -21,18 +21,30 @@ export CPPFLAGS="-I$DEPS_PATH/include"
 export LDFLAGS="-L$DEPS_PATH/lib -L$DEPS_PATH/lib64"
 export GNULIB_SRCDIR=$SRC/gnulib
 
-cd $SRC/libunistring
+# gnutls requires autoconf 2.71 minimum which is not available in the Ubuntu 20 base image
+# Skip this step if a newer base image is used
+if grep -q -F "20.04" /etc/os-release ; then
+    cd /tmp
+    wget https://archive.ubuntu.com/ubuntu/pool/main/a/autoconf/autoconf_2.71-2_all.deb
+    # Ensure file is not modified or corrupted before install
+    if echo "96b528889794c4134015a63c75050f93d8aecdf5e3f2a20993c1433f4c61b80e autoconf_2.71-2_all.deb" | sha256sum --check --status ; then
+    	# Install but use G option to prevent downgrade in case this is
+    	dpkg -i -G /tmp/autoconf_2.71-2_all.deb
+    fi
+fi
+
+cd "$SRC"/libunistring
 ./autogen.sh
 ASAN_OPTIONS=detect_leaks=0 \
-  ./configure --enable-static --disable-shared --prefix=$DEPS_PATH
-make -j$(nproc)
+  ./configure --enable-static --disable-shared --prefix="$DEPS_PATH"
+make -j"$(nproc)"
 make install
 
-cd $SRC/libidn2
+cd "$SRC"/libidn2
 ./bootstrap
 ASAN_OPTIONS=detect_leaks=0 \
-  ./configure --enable-static --disable-shared --disable-doc --disable-gcc-warnings --prefix=$DEPS_PATH
-make -j$(nproc)
+  ./configure --enable-static --disable-shared --disable-doc --disable-gcc-warnings --prefix="$DEPS_PATH"
+make -j"$(nproc)"
 make install
 
 # always disable assembly in GMP to avoid issues due to SIGILL
@@ -40,31 +52,31 @@ make install
 #   https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=3159
 GMP_CONFIGURE_FLAGS="--disable-assembly --disable-fat"
 
-cd $SRC/gmp
+cd "$SRC"/gmp
 if [[ -e .bootstrap ]]; then
     bash .bootstrap
 fi
 ASAN_OPTIONS=detect_leaks=0 \
-  ./configure --disable-shared --prefix=$DEPS_PATH $GMP_CONFIGURE_FLAGS
-make -j$(nproc)
+  ./configure --disable-shared --prefix="$DEPS_PATH" $GMP_CONFIGURE_FLAGS
+make -j"$(nproc)"
 make install
 
 cd $SRC/libtasn1
 bash bootstrap
 ./configure --disable-gcc-warnings --disable-gtk-doc --disable-gtk-doc-pdf --disable-doc \
-  --disable-shared --enable-static --prefix=$DEPS_PATH
-make -j$(nproc)
+  --disable-shared --enable-static --prefix="$DEPS_PATH"
+make -j"$(nproc)"
 make install
 
 NETTLE_CONFIGURE_FLAGS="--disable-assembler"  # Temporarily disalbe asm to work around error "undefined reference to [...]"
 if [[ $CFLAGS = *sanitize=memory* ]]; then
   NETTLE_CONFIGURE_FLAGS="--disable-assembler --disable-fat"
 fi
-cd $SRC/nettle
+cd "$SRC"/nettle
 bash .bootstrap
 ASAN_OPTIONS=detect_leaks=0 \
-  ./configure --enable-static --disable-shared --disable-documentation --prefix=$DEPS_PATH $NETTLE_CONFIGURE_FLAGS
-( make -j$(nproc) || make -j$(nproc) ) && make install
+  ./configure --enable-static --disable-shared --disable-documentation --prefix="$DEPS_PATH" $NETTLE_CONFIGURE_FLAGS
+( make -j"$(nproc)" || make -j"$(nproc)" ) && make install
 if test $? != 0; then
   echo "Failed to compile nettle"
   exit 1
@@ -75,7 +87,7 @@ GNUTLS_CONFIGURE_FLAGS=""
 if [[ $CFLAGS = *sanitize=memory* ]]; then
   GNUTLS_CONFIGURE_FLAGS="--disable-hardware-acceleration"
 fi
-cd $SRC/gnutls
+cd "$SRC"/gnutls
 ./bootstrap
 ASAN_OPTIONS=detect_leaks=0 LIBS="-lunistring" CXXFLAGS="$CXXFLAGS -L$DEPS_PATH/lib" \
   ./configure --enable-fuzzer-target --disable-gcc-warnings --enable-static --disable-shared --disable-doc --disable-tests \
@@ -86,16 +98,16 @@ ASAN_OPTIONS=detect_leaks=0 LIBS="-lunistring" CXXFLAGS="$CXXFLAGS -L$DEPS_PATH/
 # to confuse memory sanitizer.
 sed -i 's|include <sys/syscall.h>|include <sys/syscall.h>\n#undef SYS_getrandom|' lib/nettle/sysrng-linux.c
 
-make -j$(nproc) -C gl
-make -j$(nproc) -C lib
+make -j"$(nproc)" -C gl
+make -j"$(nproc)" -C lib
 
 cd fuzz
 make oss-fuzz
-find . -name '*_fuzzer' -exec cp -v '{}' $OUT ';'
-find . -name '*_fuzzer.dict' -exec cp -v '{}' $OUT ';'
-find . -name '*_fuzzer.options' -exec cp -v '{}' $OUT ';'
+find . -name '*_fuzzer' -exec cp -v '{}' "$OUT" ';'
+find . -name '*_fuzzer.dict' -exec cp -v '{}' "$OUT" ';'
+find . -name '*_fuzzer.options' -exec cp -v '{}' "$OUT" ';'
 
 for dir in *_fuzzer.in; do
-    fuzzer=$(basename $dir .in)
+    fuzzer=$(basename "$dir" .in)
     zip -rj "$OUT/${fuzzer}_seed_corpus.zip" "${dir}/"
 done


### PR DESCRIPTION
1. gnutls: Fix build failure related to gnulib specific commit reference
Fix build failure caused by libtasn1 (a dependency of gnutls) bootstrap process that sets the gnulib git checkout to a specific commit ID. The commit ID must be present in the local checkout to succeed otherwise an error like "fatal: reference is not a tree: <commit hash ID>". A depth of 500 was chosen as a compromise to make it likely that the commit will be present as long as libtasn1 pulls in a fairly recent version and cloning the whole gnulib repo which is quite large.

2. gnutls: Fix build failure due to newer required autoconf and cleanup
Fix a build failure for GNUTLS caused by GNUTLS requiring a minimum version of autoconf 2.71 but the fuzzer base image is Ubuntu 20 based which has 2.6x. Also fix some shellcheck identified warnings related to unquoted path variables.
