### PR TITLE
vlc: add a cc and fix targets

### DIFF
--- a/projects/vlc/build.sh
+++ b/projects/vlc/build.sh
@@ -96,26 +96,17 @@ cp ./test/vlc-demux-dec-libfuzzer $OUT/
 for i in fuzz-corpus/seeds/* fuzz-corpus/dictionaries/*.dict
 do
     target=`basename "$i" .dict`
-    outfile="$OUT/vlc-demux-dec-$target-libfuzzer"
+    outfile="$OUT/vlc-demux-dec-libfuzzer"
+    # the target will be selected from the command name
+    outfile_target="$outfile-$target"
 
     # Copy dict or seeds
     if [ -f "$i" ]; then
-        cp "$i" "${outfile}.dict"
+        cp "$i" "${outfile_target}.dict"
     else
-        zip -jr "${outfile}_seed_corpus.zip" "$i"/*
+        zip -jr "${outfile_target}_seed_corpus.zip" "$i"/*
     fi
 
-    # may be already created by seeds
-    if [ -f "$outfile" ];then
-        continue;
-    fi
-
-    # Create a binary wrapper with correct env variables
-    cat <<EOF > "$outfile"
-#!/bin/sh
-export VLC_TARGET=$target
-exec ./vlc-demux-dec-libfuzzer "\$@"
-EOF
-
-    chmod +x "$outfile"
+    # Create one binary per target
+    cp "$outfile" "$outfile_target"
 done

--- a/projects/vlc/project.yaml
+++ b/projects/vlc/project.yaml
@@ -7,6 +7,7 @@ auto_ccs:
   - "alexandre.janniaux@gmail.com"
   - "kempfjb@gmail.com"
   - "courmisch@gmail.com"
+  - "robux4@gmail.com"
 sanitizers:
   - address
   - undefined


### PR DESCRIPTION
Setting env from a script does not work from oss-fuzz, so append the target to the binary name, cf. https://code.videolan.org/videolan/vlc/-/merge_requests/6879