### PR TITLE
karchive/kcodes/kimageformats: Temporarily switch to Qt 6.9 branch

### DIFF
--- a/projects/karchive/Dockerfile
+++ b/projects/karchive/Dockerfile
@@ -21,7 +21,7 @@ RUN git clone --depth 1 https://github.com/facebook/zstd.git
 RUN git clone --depth 1 https://github.com/nih-at/libzip.git
 RUN wget https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz
 RUN git clone https://github.com/tukaani-project/xz.git
-RUN git clone --depth 1 --branch=dev git://code.qt.io/qt/qtbase.git
+RUN git clone --depth 1 -b 6.9 git://code.qt.io/qt/qtbase.git
 RUN git clone --depth 1 -b master https://invent.kde.org/frameworks/extra-cmake-modules.git
 RUN git clone --depth 1 -b master https://invent.kde.org/frameworks/karchive.git
 COPY build.sh $SRC

--- a/projects/kcodecs/Dockerfile
+++ b/projects/kcodecs/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install --yes cmake ninja-build
 RUN curl -L http://ftp.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz -O
-RUN git clone --depth 1 --branch=dev git://code.qt.io/qt/qtbase.git
+RUN git clone --depth 1 -b 6.9 git://code.qt.io/qt/qtbase.git
 RUN git clone --depth 1 -b master https://invent.kde.org/frameworks/extra-cmake-modules.git
 RUN git clone --depth 1 -b master https://invent.kde.org/frameworks/kcodecs.git
 RUN git clone --depth 1 https://gitlab.freedesktop.org/uchardet/uchardet.git

--- a/projects/kimageformats/Dockerfile
+++ b/projects/kimageformats/Dockerfile
@@ -23,7 +23,7 @@ RUN wget https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz
 RUN git clone https://github.com/tukaani-project/xz.git
 RUN git clone --depth 1 --branch=RB-3.3 https://github.com/AcademySoftwareFoundation/openexr.git
 RUN git clone --depth 1 -b master https://invent.kde.org/frameworks/extra-cmake-modules.git
-RUN git clone --depth 1 --branch=dev git://code.qt.io/qt/qtbase.git
+RUN git clone --depth 1 -b 6.9 git://code.qt.io/qt/qtbase.git
 RUN git clone --depth 1 -b master https://invent.kde.org/frameworks/karchive.git
 RUN git clone --depth 1 -b master https://invent.kde.org/frameworks/kimageformats.git
 RUN git clone --depth 1 -b v3.11.0 https://aomedia.googlesource.com/aom


### PR DESCRIPTION
While they fix an issue in the dev branch