### PR TITLE
fuzz_dlltool issue 387378117

### DIFF
--- a/projects/binutils/build.sh
+++ b/projects/binutils/build.sh
@@ -27,6 +27,12 @@ cd binutils-gdb
 cd binutils
 sed -i 's/vfprintf (stderr/\/\//' elfcomm.c
 sed -i 's/fprintf (stderr/\/\//' elfcomm.c
+
+# Fix a dlltool leak, which won't be fixed upstream because it uses a
+# non-posix yacc feature.  It also isn't seen as a direct leak when
+# running dlltool stand-alone.
+sed -i '/^%%$/i%destructor { free (\$\$); } ID' defparse.y
+
 cd ../
 
 ./configure --disable-gdb --disable-gdbserver --disable-gdbsupport \
@@ -80,7 +86,6 @@ sed 's/main (int argc/old_main (int argc, char **argv);\nint old_main (int argc/
 
 # Special handling of dlltool
 sed 's/main (int ac/old_main32 (int ac, char **av);\nint old_main32 (int ac/' dlltool.c > fuzz_dlltool.h
-sed -i 's/copy_mian/copy_main/g' fuzz_dlltool.h
 
 # Patch the rest
 for i in objdump nm objcopy windres strings addr2line; do

--- a/projects/binutils/fuzz_dlltool.c
+++ b/projects/binutils/fuzz_dlltool.c
@@ -27,14 +27,15 @@ init_dlltool_global_state() {
   imp_name = NULL;
   delayimp_name = NULL;
   identify_imp_name = NULL;
-  identify_strict = NULL;
+  identify_strict = false;
   head_label = NULL;
   imp_name_lab = NULL;
   dll_name = NULL;
+  dll_name_set_by_exp_name = 0;
   add_indirect = 0;
   add_underscore = 0;
   add_stdcall_underscore = 0;
-  leading_underscore = -1;
+  leading_underscore = "_";
   dontdeltemps = 0;
   do_default_excludes = true;
   use_nul_prefixed_import_tables = false;


### PR DESCRIPTION
This fixes a dlltool leak that is only seen under oss-fuzz, ie. it is not seen as a direct leak when running dlltool stand-alone.  The fix to defparse.y which I'd commit upstream if we didn't fuss about posix compliance, is instead edited by build.sh.  This patch also updates fuzz_dlltool.c for upstream changes, and removes an unnecessary sed command in build.sh.