### PR TITLE
numpy - Add missing coverage package

### DIFF
--- a/projects/numpy/Dockerfile
+++ b/projects/numpy/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
 # Install Python dependencies for python 3.11
 RUN curl -LO https://bootstrap.pypa.io/get-pip.py && \
     python3 get-pip.py && \
-    python3 -m pip install --root-user-action=ignore atheris pyinstaller
+    python3 -m pip install --root-user-action=ignore atheris pyinstaller coverage
 RUN git clone https://github.com/numpy/numpy && cd numpy && git submodule update --init
 WORKDIR $SRC
 COPY *.options *.py build.sh $SRC/


### PR DESCRIPTION
This is missing to gather proper coverage info. Without this package the introspector page for numpy is no longer updated.