### PR TITLE
libprotobuf-mutator: Start using `-DLIB_PROTO_MUTATOR_EXAMPLES_USE_LATEST=ON`

### DIFF
--- a/projects/libprotobuf-mutator/build.sh
+++ b/projects/libprotobuf-mutator/build.sh
@@ -23,6 +23,7 @@ pushd build
 rm -rf *
 cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release \
     -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON \
+    -DLIB_PROTO_MUTATOR_EXAMPLES_USE_LATEST=ON \
     -DLIB_PROTO_MUTATOR_FUZZER_LIBRARIES=FuzzingEngine
 ninja libxml2_example expat_example
 cp -f examples/libxml2/libxml2_example $OUT/


### PR DESCRIPTION
.. to keep examples `expat_example` and `libxml2_example` that are fuzzed in OSS-Fuzz using latest libexpat and libxml2

Related: https://github.com/google/libprotobuf-mutator/pull/273

CC @vitalybuka

