### PR TITLE
[haproxy] Fix HAProxy build issue

### DIFF
--- a/projects/haproxy/build.sh
+++ b/projects/haproxy/build.sh
@@ -17,8 +17,8 @@ export ORIG_CFLAGS=${CFLAGS}
 cd haproxy
 
 # Fix some things in the Makefile where there are no options available
-sed 's/CFLAGS = $(ARCH_FLAGS) $(CPU_CFLAGS) $(DEBUG_CFLAGS) $(SPEC_CFLAGS)/CFLAGS = $(ARCH_FLAGS) $(CPU_CFLAGS) $(DEBUG_CFLAGS) $(SPEC_CFLAGS) ${ORIG_CFLAGS}/g' -i Makefile
-sed 's/LDFLAGS = $(ARCH_FLAGS) -g/LDFLAGS = $(ARCH_FLAGS) -g ${CXXFLAGS}/g' -i Makefile
+sed 's/COPTS += $(DEBUG) $(OPTIONS_CFLAGS) $(CFLAGS) $(ADDINC)/COPTS += $(DEBUG) $(OPTIONS_CFLAGS) $(CFLAGS) $(ADDINC) ${ORIG_CFLAGS}/g' -i Makefile
+sed 's/LDOPTS = $(TARGET_LDFLAGS) $(OPTIONS_LDFLAGS) $(ADDLIB)/LDOPTS = $(TARGET_LDFLAGS) $(OPTIONS_LDFLAGS) $(ADDLIB) ${CXXFLAGS}/g' -i Makefile
 make TARGET=generic CC=${CC} LD=${CXX} 
 
 # Make a copy of the main file since it has many global functions we need to declare


### PR DESCRIPTION
HAProxy's Makefile changed years ago, causing the sed pattern to no longer apply. As a result, the build flags were not forwarded, and the fuzzer ran without instrumentation or feedback. This patch updates the patterns to ensure proper flag forwarding.