### PR TITLE
[sql-parser] Add seed corpus for fuzzing

### DIFF
--- a/projects/sql-parser/build.sh
+++ b/projects/sql-parser/build.sh
@@ -20,3 +20,5 @@ sed 's/static ?= no/LIB_CFLAGS += ${CXXFLAGS}\nstatic ?= no/g' -i Makefile
 make static=yes
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE \
     fuzz_sql_parse.cpp libsqlparser.a -I./src -o $OUT/fuzz_sql_parse
+
+zip -r $OUT/fuzz_sql_parse_seed_corpus.zip $SRC/sql-parser/test/queries/*


### PR DESCRIPTION
This patch adds a seed corpus for fuzz_sql_parse by including test queries from the sql-parser repository.