### PR TITLE
Update protobuf-python bazel build to set --noenable_bzlmod

### DIFF
--- a/projects/protobuf-python/Dockerfile
+++ b/projects/protobuf-python/Dockerfile
@@ -17,5 +17,5 @@
 FROM gcr.io/oss-fuzz-base/base-builder-python
 RUN curl -L -O https://raw.githubusercontent.com/protobuf-c/protobuf-c/39cd58f5ff06048574ed5ce17ee602dc84006162/t/test-full.proto
 RUN git clone https://github.com/protocolbuffers/protobuf.git
-RUN cd protobuf && bazel build --nobuild //:protoc //python/dist:binary_wheel
+RUN cd protobuf && bazel build --nobuild //:protoc //python/dist:binary_wheel --noenable_bzlmod
 COPY build.sh fuzz_* $SRC/

--- a/projects/protobuf-python/build.sh
+++ b/projects/protobuf-python/build.sh
@@ -30,7 +30,7 @@ cd $SRC/protobuf
   type -a python3
   /usr/bin/python3 --version
 )
-bazel build $BAZEL_FLAGS //:protoc //python/dist:binary_wheel
+bazel build $BAZEL_FLAGS //:protoc //python/dist:binary_wheel --noenable_bzlmod
 PROTOC=$(realpath bazel-bin/protoc)
 
 # Install the protobuf python runtime.


### PR DESCRIPTION
//python/dist currently does not build with bzlmod, since we don't support system_python in bzlmod yet.

```
Skipping '//python/dist:binary_wheel': error loading package 'python/dist': Unable to find package for @@[unknown repo 'system_python' requested from @@]//:version.bzl: The repository '@@[unknown repo 'system_python' requested from @@]' could not be resolved: No repository visible as '@system_python' from main repository.
Step #1: [0m[91mERROR: error loading package 'python/dist': Unable to find package for @@[unknown repo 'system_python' requested from @@]//:version.bzl: The repository '@@[unknown repo 'system_python' requested from @@]' could not be resolved: No repository visible as '@system_python' from main repository.
```