### PR TITLE
unblob: fix dependency install

### DIFF
--- a/projects/unblob/Dockerfile
+++ b/projects/unblob/Dockerfile
@@ -12,10 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 FROM gcr.io/oss-fuzz-base/base-builder-python
-RUN pip3 install --upgrade pip
+
 RUN git clone https://github.com/onekey-sec/unblob
-RUN unblob/unblob/install-deps.sh
-RUN pip install ./unblob
+
+RUN apt-get update && apt-get install build-essential libssl-dev libffi-dev pkg-config python3-dev cargo -y
+RUN python3 -m pip install --upgrade pip
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup install nightly
+RUN rustup default nightly
+
+RUN unblob/install-deps.sh
+RUN python3 -m pip install ./unblob
 
 COPY build.sh $SRC/
 WORKDIR $SRC/unblob

--- a/projects/unblob/build.sh
+++ b/projects/unblob/build.sh
@@ -14,7 +14,13 @@
 # limitations under the License.
 #
 ################################################################################
-pip3 install .
+
+python3 -m pip cache purge
+
+unset RUSTFLAGS
+unset CXXFLAGS
+unset CFLAGS
+python3 -m pip install .
 
 # Build fuzzers in $OUT.
 for fuzzer in $(find $SRC -name '*_fuzzer.py'); do


### PR DESCRIPTION
We recently merged⁰ the Rust part of unblob (so called 'unblob-native') into unblob and re-organized the repository structure in the process.

This broke OSS-fuzz integration for unblob since the bash script that installs dependencies no longer lives at this address.

[0] https://github.com/onekey-sec/unblob/pull/1096/