### PR TITLE
jsoncpp: Fix build

### DIFF
--- a/projects/jsoncpp/build.sh
+++ b/projects/jsoncpp/build.sh
@@ -15,6 +15,8 @@
 #
 ################################################################################
 
+sed -i 's/set(CMAKE_CXX_STANDARD 11)/set(CMAKE_CXX_STANDARD 17)/' CMakeLists.txt
+
 mkdir -p build
 cd build
 cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_CXX_FLAGS="$CXXFLAGS" \


### PR DESCRIPTION
This patch ensures that jsoncpp is consistently built with C++17 by modifying CMakeLists.txt to replace CMAKE_CXX_STANDARD 11 with CMAKE_CXX_STANDARD 17.