### PR TITLE
fix: juju build failure

### DIFF
--- a/projects/juju/Dockerfile
+++ b/projects/juju/Dockerfile
@@ -16,5 +16,5 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN git clone --depth 1 https://github.com/juju/juju
-COPY build.sh storage_fuzzer.go $SRC/
+COPY build.sh devices_fuzzer.go $SRC/
 WORKDIR $SRC/juju

--- a/projects/juju/build.sh
+++ b/projects/juju/build.sh
@@ -20,5 +20,5 @@ go mod download
 find /root/go/pkg/mod/github.com/aws/aws-sdk-go-v2 -name "*fuzz.go" -exec rm -rf {} \;
 
 # Compile fuzzer:
-mv $SRC/storage_fuzzer.go $SRC/juju/storage/
-compile_go_fuzzer github.com/juju/juju/storage Fuzz storage_fuzzer
+mv $SRC/devices_fuzzer.go $SRC/juju/core/devices/
+compile_go_fuzzer github.com/juju/juju/core/devices Fuzz devices_fuzzer

--- a/projects/juju/devices_fuzzer.go
+++ b/projects/juju/devices_fuzzer.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-package storage
+package devices
 
 func Fuzz(data []byte) int {
 	_, err := ParseConstraints(string(data))


### PR DESCRIPTION
The parse constraint function was moved to a better location, but the fuzzer wasn't updated.

This fixes: https://issues.oss-fuzz.com/issues/42538415