### PR TITLE
[infra] Match workers and jobs per core

### DIFF
--- a/infra/cifuzz/actions/run_fuzzers/action.yml
+++ b/infra/cifuzz/actions/run_fuzzers/action.yml
@@ -45,7 +45,7 @@ inputs:
     required: false
     default: False
   parallel-fuzzing:
-    description: "Whether to use all available cores for fuzzing."
+    description: "How many cores to use cores for fuzzing. A specific number, True - all available cores or False to run single threaded on a single core."
     required: false
     default: false
   output-sarif:

--- a/infra/cifuzz/config_utils.py
+++ b/infra/cifuzz/config_utils.py
@@ -129,7 +129,7 @@ class BaseConfig:
     self.build_integration_path = (
         constants.DEFAULT_EXTERNAL_BUILD_INTEGRATION_PATH)
 
-    self.parallel_fuzzing = environment.get_bool('PARALLEL_FUZZING', False)
+    self.parallel_fuzzing = environment.get('PARALLEL_FUZZING', False)
     self.extra_environment_variables = _get_extra_environment_variables()
     self.output_sarif = environment.get_bool('OUTPUT_SARIF', False)
 

--- a/infra/cifuzz/external-actions/run_fuzzers/action.yml
+++ b/infra/cifuzz/external-actions/run_fuzzers/action.yml
@@ -57,7 +57,7 @@ inputs:
     required: false
     default: False
   parallel-fuzzing:
-    description: "Whether to use all available cores for fuzzing."
+    description: "How many cores to use cores for fuzzing. A specific number, True - all available cores or False to run single threaded on a single core."
     required: false
     default: false
   output-sarif:

--- a/infra/cifuzz/fuzz_target.py
+++ b/infra/cifuzz/fuzz_target.py
@@ -60,7 +60,8 @@ FuzzResult = collections.namedtuple('FuzzResult',
 def get_libfuzzer_parallel_options():
   """Returns a list containing options to pass to libFuzzer to fuzz using all
   available cores."""
-  return ['-jobs=' + str(multiprocessing.cpu_count())]
+  cpu_count = str(multiprocessing.cpu_count())
+  return [f'-jobs={cpu_count}', f'-workers={cpu_count}']
 
 
 class ReproduceError(Exception):


### PR DESCRIPTION
Although the `parallel-fuzzing` input parameter is documented `to use all available cores for fuzzing` it is not how it currently works because as it is written in libfuzzer documentation [`These jobs will be run across a set of worker processes, by default using half of the available CPU cores;`](https://llvm.org/docs/LibFuzzer.html#:~:text=These%20jobs%20will%20be%20run%20across%20a%20set%20of%20worker%20processes%2C%20by%20default%20using%20half%20of%20the%20available%20CPU%20cores%3B)
I.e. currently when `parallel-fuzzing` is set to `true` it uses for example 1 core on a 2 cores machine.

The PR makes jobs number always match the workers number. Additionally a user may specify the number of cores to use manually.