### PR TITLE
xmldom: install @jazzer.js/core as part of build.sh

### DIFF
--- a/projects/xmldom/build.sh
+++ b/projects/xmldom/build.sh
@@ -17,10 +17,13 @@
 
 # build project
 npm ci
-unzip node_modules/xmltest/xmltest.zip
+# no longer part of xmldom dev dependencies since it can no longer be installed reliably
+npm i -D @jazzer.js/core
 
-# Copy corpus out
-cp -rf $SRC/xmldom/xmltest $OUT/xmltest
+# extract all *.xml files without a folder structure,
+# renaming duplicate filenames with ~, ~1, ~2, ...
+# into the target directory
+unzip -Bj node_modules/xmltest/xmltest.zip $OUT/xmltest '*.xml'
 
 # build fuzzers
 compile_javascript_fuzzer xmldom fuzz/dom-parser.xml.target.js --sync --timeout=10 xmltest

--- a/projects/xmldom/build.sh
+++ b/projects/xmldom/build.sh
@@ -20,10 +20,12 @@ npm ci
 # no longer part of xmldom dev dependencies since it can no longer be installed reliably
 npm i -D @jazzer.js/core
 
+
+mkdir "$OUT/xmltest"
 # extract all *.xml files without a folder structure,
 # renaming duplicate filenames with ~, ~1, ~2, ...
 # into the target directory
-unzip -Bj node_modules/xmltest/xmltest.zip $OUT/xmltest '*.xml'
+unzip -Bj node_modules/xmltest/xmltest.zip "$OUT/xmltest" '*.xml'
 
 # build fuzzers
 compile_javascript_fuzzer xmldom fuzz/dom-parser.xml.target.js --sync --timeout=10 xmltest

--- a/projects/xmldom/build.sh
+++ b/projects/xmldom/build.sh
@@ -15,18 +15,19 @@
 #
 ################################################################################
 
-# build project
+# install dependencies
 npm ci
-# no longer part of xmldom dev dependencies since it can no longer be installed reliably
+# no longer part of xmldom devDependencies since it can no longer be installed reliably
 npm i -D @jazzer.js/core
 
-
-mkdir "$OUT/xmltest"
+# prepare corpus
+XMLTEST_CORPUS=$OUT/xmldom/xmltest
+mkdir -p $XMLTEST_CORPUS
 # extract all *.xml files without a folder structure,
 # renaming duplicate filenames with ~, ~1, ~2, ...
 # into the target directory
-unzip -Bj node_modules/xmltest/xmltest.zip "$OUT/xmltest" '*.xml'
+unzip -Bj node_modules/xmltest/xmltest.zip $XMLTEST_CORPUS '*.xml'
 
 # build fuzzers
-compile_javascript_fuzzer xmldom fuzz/dom-parser.xml.target.js --sync --timeout=10 xmltest
-compile_javascript_fuzzer xmldom fuzz/dom-parser.html.target.js --sync --timeout=10 xmltest
+compile_javascript_fuzzer xmldom fuzz/dom-parser.xml.target.js --sync --timeout=10 $XMLTEST_CORPUS
+compile_javascript_fuzzer xmldom fuzz/dom-parser.html.target.js --sync --timeout=10 $XMLTEST_CORPUS

--- a/projects/xmldom/build.sh
+++ b/projects/xmldom/build.sh
@@ -26,7 +26,7 @@ mkdir -p $XMLTEST_CORPUS
 # extract all *.xml files without a folder structure,
 # renaming duplicate filenames with ~, ~1, ~2, ...
 # into the target directory
-unzip -Bj node_modules/xmltest/xmltest.zip $XMLTEST_CORPUS '*.xml'
+unzip -Bj node_modules/xmltest/xmltest.zip '*.xml' -d $XMLTEST_CORPUS
 
 # build fuzzers
 compile_javascript_fuzzer xmldom fuzz/dom-parser.xml.target.js --sync --timeout=10 $XMLTEST_CORPUS


### PR DESCRIPTION
it was [dropped from `devDependencies` in xmldom](https://github.com/xmldom/xmldom/pull/845), since it can no longer be installed reliably on all machines.