### PR TITLE
KArchive: traverse the contents of the archive

### DIFF
--- a/projects/karchive/karchive_fuzzer.cc
+++ b/projects/karchive/karchive_fuzzer.cc
@@ -46,6 +46,7 @@ void traverseArchive(const KArchiveDirectory *dir, const QString &path = QString
             auto file = static_cast<const KArchiveFile*>(entry);
             std::cout << "fullpath: " << fullPath.toStdString()
                       << ", size: " << file->size()
+                      << ", datasize: " << file->data().size()
                       << ", date: " << file->date().toString().toStdString()
                       << ", name: " << file->name().toStdString()
                       << ", user: " << file->user().toStdString()

--- a/projects/karchive/karchive_fuzzer.cc
+++ b/projects/karchive/karchive_fuzzer.cc
@@ -27,12 +27,36 @@
 #include <QBuffer>
 #include <QCoreApplication>
 #include <QVector>
+#include <iostream>
 
 #include <KF6/KArchive/k7zip.h>
 #include <KF6/KArchive/ktar.h>
 #include <KF6/KArchive/kzip.h>
 #include <KF6/KArchive/kar.h>
 #include <KF6/KArchive/kcompressiondevice.h>
+
+void traverseArchive(const KArchiveDirectory *dir, const QString &path = QString()) {
+    const auto allEntries = dir->entries();
+
+    for (const auto& entryName : allEntries) {
+        auto entry = dir->entry(entryName);
+        const QString fullPath = path + QString::fromUtf8("/") + entryName;
+
+        if (entry->isFile()) {
+            auto file = static_cast<const KArchiveFile*>(entry);
+            std::cout << "fullpath: " << fullPath.toStdString()
+                      << ", size: " << file->size()
+                      << ", date: " << file->date().toString().toStdString()
+                      << ", name: " << file->name().toStdString()
+                      << ", user: " << file->user().toStdString()
+                      << ", group: " << file->group().toStdString()
+                      << std::endl;
+        } else if (entry->isDirectory()) {
+            auto subDir = static_cast<const KArchiveDirectory*>(entry);
+            traverseArchive(subDir, fullPath);
+        }
+    }
+}
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
@@ -41,6 +65,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     QBuffer b;
     b.setData(QByteArray((const char *)data, size));
+    std::cout << "size: " << size << std::endl;
 
     std::unique_ptr<KCompressionDevice> gzipKD(new KCompressionDevice(&b, false, KCompressionDevice::GZip));
     std::unique_ptr<KCompressionDevice> bzipKD(new KCompressionDevice(&b, false, KCompressionDevice::BZip2));
@@ -60,8 +85,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     for (KArchive *h : handlers) {
         b.reset();
-        h->open(QIODevice::ReadOnly);
-        h->close();
+        if (h->open(QIODevice::ReadOnly)) {
+            const KArchiveDirectory *rootDir = h->directory();
+            traverseArchive(rootDir); 
+            h->close();
+        }
     }
 
     qDeleteAll(handlers);

--- a/projects/karchive/karchive_fuzzer.cc
+++ b/projects/karchive/karchive_fuzzer.cc
@@ -65,7 +65,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     QBuffer b;
     b.setData(QByteArray((const char *)data, size));
-    std::cout << "size: " << size << std::endl;
 
     std::unique_ptr<KCompressionDevice> gzipKD(new KCompressionDevice(&b, false, KCompressionDevice::GZip));
     std::unique_ptr<KCompressionDevice> bzipKD(new KCompressionDevice(&b, false, KCompressionDevice::BZip2));

--- a/projects/karchive/karchive_fuzzer.cc
+++ b/projects/karchive/karchive_fuzzer.cc
@@ -44,14 +44,13 @@ void traverseArchive(const KArchiveDirectory *dir, const QString &path = QString
 
         if (entry->isFile()) {
             auto file = static_cast<const KArchiveFile*>(entry);
-            std::cout << "fullpath: " << fullPath.toStdString()
-                      << ", size: " << file->size()
-                      << ", datasize: " << file->data().size()
-                      << ", date: " << file->date().toString().toStdString()
-                      << ", name: " << file->name().toStdString()
-                      << ", user: " << file->user().toStdString()
-                      << ", group: " << file->group().toStdString()
-                      << std::endl;
+            auto fullpath = fullPath.toStdString();
+            auto filesize =  file->size();
+            auto datasize = file->data().size();
+            auto date =  file->date().toString().toStdString();
+            auto filename = file->name().toStdString();
+            auto user = file->user().toStdString();
+            auto group = file->group().toStdString();
         } else if (entry->isDirectory()) {
             auto subDir = static_cast<const KArchiveDirectory*>(entry);
             traverseArchive(subDir, fullPath);


### PR DESCRIPTION
Implemented functionality in the PR to not only handle archive opening and closing operations but also traverse its contents to retrieve file metadata including names, dates, sizes, etc. for all files within the specified archive. Assigned by @tsdgeos. 🎉 
