### PR TITLE
flask: fix fuzz json

### DIFF
--- a/projects/flask/fuzz_json.py
+++ b/projects/flask/fuzz_json.py
@@ -14,7 +14,10 @@
 # limitations under the License.
 
 import atheris
+import os
 import sys
+
+
 
 with atheris.instrument_imports():
   import flask
@@ -38,7 +41,7 @@ def TestOneInput(data):
     return None
 
   parse_set_header(fdp.ConsumeUnicode(fdp.ConsumeIntInRange(0, 512)))
-  
+
   client = app.test_client()
 
   try:


### PR DESCRIPTION
Resolves the following message:

```
=== Uncaught Python exception: ===
NameError: name 'os' is not defined
Traceback (most recent call last):
  File "/opt/fuzz_json.py", line 33, in TestOneInput
    app = FuzzFlask("flask_test", root_path=os.path.dirname(__file__))
NameError: name 'os' is not defined

==3849== ERROR: libFuzzer: fuzz target exited
SUMMARY: libFuzzer: fuzz target exited
MS: 0 ; base unit: 0000000000000000000000000000000000000000
```