### PR TITLE
Change Expr email

### DIFF
--- a/projects/expr/project.yaml
+++ b/projects/expr/project.yaml
@@ -1,7 +1,7 @@
 homepage: "https://github.com/expr-lang/expr"
 primary_contact: "martin.swende@ethereum.org"
 auto_ccs:
-  - "anton@medv.io"
+  - "antonmedvio@gmail.com"
 language: go
 fuzzing_engines:
   - libfuzzer


### PR DESCRIPTION
Hello,

I've recently switched off my G-Suite on `anton@medv.io` and do not use Google account any more.

I create a new google account to access OSS-Fuzz: `antonmedvio@gmail.com`. 

Thanks!