### PR TITLE
libtheora: patch configure to allow older autoconf

### DIFF
--- a/projects/libtheora/build.sh
+++ b/projects/libtheora/build.sh
@@ -36,6 +36,8 @@ cd $SRC/fuzzing-headers/
 ./install.sh
 
 cd $SRC/libtheora/
+# patch configure since the baseimage is using an older autoconf
+sed -i 's/AC_PREREQ(\[[^]]*\])/AC_PREREQ([2.60])/' configure.ac
 ./autogen.sh
 
 if [[ $CFLAGS = *sanitize=memory* || $CFLAGS = *-m32* ]]


### PR DESCRIPTION
gcr.io/oss-fuzz-base/base-builder is using an older autoconf version, so we can relax this requirement which is just to avoid warnings.