### PR TITLE
mpv: add support for Rust

### DIFF
--- a/projects/mpv/Dockerfile
+++ b/projects/mpv/Dockerfile
@@ -12,9 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y nasm pkg-config gperf zip rsync && pip3 install meson ninja
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+
+RUN <<EOT
+    set -ex
+
+    apt-get update
+    apt-get install --no-install-recommends -y nasm pkgconf gperf zip rsync
+    apt-get clean -y && rm -rf /var/lib/apt/lists/*
+EOT
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV VIRTUAL_ENV=$SRC/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN <<EOT
+    set -ex
+
+    python -m venv $VIRTUAL_ENV
+    python -m pip --no-cache-dir install meson ninja
+EOT
+
 RUN git clone --depth 1 https://github.com/mpv-player/mpv mpv
 RUN git clone --depth 1 https://github.com/FFmpeg/FFmpeg ffmpeg
-WORKDIR mpv
+
+WORKDIR $SRC/mpv
 COPY build.sh $SRC/


### PR DESCRIPTION
- Switch to base-builder-rust
- Create venv for pip installed packages
- Set rustc target explicity, needed for i386 build
- Don't fail if subprojects directory already exists
- Don't compress Matroska files to speed zip creation, they are not really compressible anyway.