### PR TITLE
Fix FuzzIntrospector build failure: an older version of PyYaml is bei…

### DIFF
--- a/projects/connectedhomeip/Dockerfile
+++ b/projects/connectedhomeip/Dockerfile
@@ -19,7 +19,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 # Install prerequisite packages
 # See connectedhomeip/docs/guides/BUILDING.md#prerequisites
 RUN apt-get update && \
-    apt-get install -y pkg-config libssl-dev libdbus-1-dev libglib2.0-dev \
+    apt-get install -y --no-install-recommends pkg-config libssl-dev libdbus-1-dev libglib2.0-dev \
         libavahi-client-dev ninja-build \
         unzip libgirepository1.0-dev libcairo2-dev libreadline-dev
 


### PR DESCRIPTION
## Problem and Fix
- connectedhomeip Dockerfile installs an older version of PyYaml using APT (as a recommended dependenancy),
-  `FuzzIntrospector` later attempts to reinstall a newer version of PyYaml using `pip`, yet fails since `pip` cannot uninstall a package installed by APT.

- **Fix**: stop APT from installing recommended packages  `--no-install-recommends`
## Error Log
```
Step #6 - "compile-libfuzzer-introspector-x86_64":   Attempting uninstall: PyYAML
Step #6 - "compile-libfuzzer-introspector-x86_64":     Found existing installation: PyYAML 5.3.1
Step #6 - "compile-libfuzzer-introspector-x86_64": [1;31merror[0m: [1muninstall-distutils-installed-package[0m
Step #6 - "compile-libfuzzer-introspector-x86_64": 
Step #6 - "compile-libfuzzer-introspector-x86_64": [31m×[0m Cannot uninstall PyYAML 5.3.1
Step #6 - "compile-libfuzzer-introspector-x86_64": [31m╰─>[0m It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial 
```
- Log: https://oss-fuzz-build-logs.storage.googleapis.com/log-d984595c-7ee5-4f93-a1f7-3f5d7536ffca.txt