### PR TITLE
Various projects: run `git apply` in Dockerfile instead.

### DIFF
--- a/projects/geos/Dockerfile
+++ b/projects/geos/Dockerfile
@@ -21,3 +21,4 @@ RUN git clone --depth 1 https://git.osgeo.org/gitea/geos/geos.git || git clone -
 COPY build.sh $SRC
 COPY patch.diff $SRC
 WORKDIR $SRC/geos
+RUN git apply ../patch.diff

--- a/projects/geos/build.sh
+++ b/projects/geos/build.sh
@@ -16,7 +16,6 @@
 ################################################################################
 
 # build project
-git apply ../patch.diff
 mkdir build
 cd build
 cmake -DBUILD_SHARED_LIBS=OFF ..

--- a/projects/mysql-server/Dockerfile
+++ b/projects/mysql-server/Dockerfile
@@ -22,3 +22,4 @@ WORKDIR $SRC
 COPY build.sh $SRC/
 COPY fix.diff $SRC/
 COPY targets $SRC/mysql-server/fuzz
+RUN cd mysql-server && git apply ../fix.diff

--- a/projects/mysql-server/build.sh
+++ b/projects/mysql-server/build.sh
@@ -17,7 +17,6 @@
 ################################################################################
 
 cd mysql-server
-git apply ../fix.diff
 mkdir build
 cd build
 if [[ $SANITIZER = *undefined* ]]; then

--- a/projects/ntp/Dockerfile
+++ b/projects/ntp/Dockerfile
@@ -24,3 +24,4 @@ RUN bk clone http://bk.ntp.org/ntp-dev
 WORKDIR $SRC
 COPY build.sh $SRC/
 COPY patch.diff $SRC/
+RUN cd ntp-dev && git apply ../patch.diff

--- a/projects/ntp/build.sh
+++ b/projects/ntp/build.sh
@@ -16,7 +16,6 @@
 ################################################################################
 
 cd ntp-dev
-git apply ../patch.diff
 #avoids https://bugs.llvm.org/show_bug.cgi?id=34636
 cp /usr/bin/ld.gold /usr/bin/ld
 ./bootstrap


### PR DESCRIPTION
There are some projects that add fuzz targets via a diff file applied in the `build.sh`.

This is incompatible with OSS-Fuzz-Gen, because OSS-Fuzz-Gen injects targets via a Dockerfile `COPY`. When the patch is later applied in the build process, this causes a conflict.

Instead, we do the patching as a `RUN` step in the Dockerfile to avoid this.

Note: mysql-server and ntp are currently broken because the patch no longer applies. This needs to be fixed in a followup.