### PR TITLE
mpv: Don't use heredoc in Dockerfile

### DIFF
--- a/projects/mpv/Dockerfile
+++ b/projects/mpv/Dockerfile
@@ -14,23 +14,16 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-rust
 
-RUN <<EOT
-    set -ex
-
-    apt-get update
-    apt-get install --no-install-recommends -y nasm pkgconf gperf zip rsync
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y nasm pkgconf gperf zip rsync && \
     apt-get clean -y && rm -rf /var/lib/apt/lists/*
-EOT
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV VIRTUAL_ENV=$SRC/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-RUN <<EOT
-    set -ex
 
-    python -m venv $VIRTUAL_ENV
+RUN python -m venv $VIRTUAL_ENV && \
     python -m pip --no-cache-dir install meson ninja
-EOT
 
 RUN git clone --depth 1 https://github.com/mpv-player/mpv mpv
 RUN git clone --depth 1 https://github.com/FFmpeg/FFmpeg ffmpeg

--- a/projects/mpv/build.sh
+++ b/projects/mpv/build.sh
@@ -26,6 +26,8 @@ else
   rustup target add $RUST_TARGET
 fi
 
+export RUSTC="rustc --target=$RUST_TARGET"
+
 export FUZZ_INTROSPECTOR_CONFIG=$SRC/fuzz_introspector_exclusion.config
 cat > $FUZZ_INTROSPECTOR_CONFIG <<EOF
 FILES_TO_AVOID
@@ -95,7 +97,7 @@ meson setup build -Dbackend_max_links=4 -Ddefault_library=static -Dprefer_static
                   -Dlcms2:jpeg=disabled -Dlcms2:tiff=disabled \
                   -Dlibass:fontconfig=enabled -Dlibass:asm=disabled \
                   -Dc_link_args="$CXXFLAGS -lc++" -Dcpp_link_args="$CXXFLAGS" \
-                  --libdir $LIBDIR -Drust_args="--target=$RUST_TARGET"
+                  --libdir $LIBDIR
 meson compile -C build fuzzers
 
 find ./build/fuzzers -maxdepth 1 -type f -name 'fuzzer_*' -exec mv {} "$OUT" \; -exec echo "{} -> $OUT" \;


### PR DESCRIPTION
Apparently, the Docker version on build machines is older and doesn't support heredoc. It differs from the ones tested on CI before the merge.

Also, set RUSTC directly with the target because Meson doesn't append rust_args in all invocations. This is mostly a cosmetic change, as it was already appended where needed in our case.

Fixes: 44b432da8f057230a3efca529b6739cdbb373b70