### PR TITLE
libass: limit max input length

### DIFF
--- a/projects/libass/Dockerfile
+++ b/projects/libass/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config libfontconfig1-dev libfreetype-dev libfribidi-dev python3-pip && \
-    pip3 install meson==0.55.0 ninja
+    pip3 install meson==0.60.0 ninja
 
 RUN git clone --depth 1 https://github.com/libass/libass.git
 RUN git clone --depth 1 https://github.com/harfbuzz/harfbuzz.git

--- a/projects/libass/build.sh
+++ b/projects/libass/build.sh
@@ -38,7 +38,9 @@ cd $SRC/libass
 
 export PKG_CONFIG_PATH=/work/lib/pkgconfig
 ./autogen.sh
-./configure FUZZ_CPPFLAGS="-DASS_FUZZMODE=2" --disable-asm --disable-shared --enable-fuzz
+./configure \
+  FUZZ_CPPFLAGS="-DASS_FUZZMODE=2 -DASSFUZZ_MAX_LEN=8192" \
+  --disable-asm --disable-shared --enable-fuzz
 make -j "$(nproc)" fuzz/fuzz_ossfuzz
 cp fuzz/fuzz_ossfuzz $OUT/libass_fuzzer
 cp fuzz/ass.dict $OUT/ass.dict

--- a/projects/libass/libass_fuzzer.options
+++ b/projects/libass/libass_fuzzer.options
@@ -1,2 +1,3 @@
 [libfuzzer]
 dict = ass.dict
+max_len = 8192


### PR DESCRIPTION
The value was chosen based on research don in
https://github.com/libass/libass/pull/854 and
will hopefully avoid further timeout cases
and increase fuzzing efficacy.

While all currently used fuzzing engnes support flags to limit
the input length (-G for AFL and -max_file_size for honggfuzz),
there appears to be no way to set them via the options file.
It seems only the "libfuzzer" section is parsed and then incompletely
translated to other engines.
Thus the limit is also enforced by the fuzzer itself via
a build time toggle (as recommended in OSS Fuzz docs).

Note: the current corpus contains >200 samples larger than
the chosen limit and should be dropped. They don't
significantly contribute to coverage anyway.