### PR TITLE
mpv: fix introspector build

### DIFF
--- a/projects/mpv/Dockerfile
+++ b/projects/mpv/Dockerfile
@@ -16,7 +16,7 @@ FROM gcr.io/oss-fuzz-base/base-builder-rust
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y nasm pkgconf gperf zip rsync && \
-    apt-get clean -y && rm -rf /var/lib/apt/lists/*
+    apt-get clean -y
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV VIRTUAL_ENV=$SRC/venv


### PR DESCRIPTION
Apparently it installs some packages later on in build process. Removing cached apt lists doesn't work well in this case.

Fixes:
E: Unable to locate package libjpeg-dev
E: Unable to locate package zlib1g-dev
E: Unable to locate package libyaml-dev