### PR TITLE
circl: Removing fetch from empty bucket.

### DIFF
--- a/projects/circl/Dockerfile
+++ b/projects/circl/Dockerfile
@@ -21,9 +21,5 @@ RUN git clone --depth 1 https://github.com/MozillaSecurity/cryptofuzz
 RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone --depth 1 https://github.com/supranational/blst.git
 RUN wget https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.bz2
-RUN wget https://storage.googleapis.com/pub/gsutil.tar.gz -O $SRC/gsutil.tar.gz
-RUN tar zxf $SRC/gsutil.tar.gz
-ENV PATH="${PATH}:$SRC/gsutil"
-RUN gsutil cp gs://bls-signatures-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer/bls-signatures_cryptofuzz-bls-signatures/public.zip $SRC/cryptofuzz_seed_corpus.zip
 
 COPY build.sh $SRC/

--- a/projects/circl/build.sh
+++ b/projects/circl/build.sh
@@ -92,5 +92,3 @@ cd $SRC/cryptofuzz/
 make -j $(nproc)
 
 cp cryptofuzz $OUT/
-
-cp $SRC/cryptofuzz_seed_corpus.zip $OUT/


### PR DESCRIPTION
Build is failing since it cannot fetch the corpus from an empty bucket.

https://issues.oss-fuzz.com/issues/399183983