### PR TITLE
bitcoin-core: Update dependency packages

### DIFF
--- a/projects/bitcoin-core/Dockerfile
+++ b/projects/bitcoin-core/Dockerfile
@@ -20,7 +20,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 # * https://github.com/bitcoin/bitcoin/blob/master/doc/build-unix.md#dependency-build-instructions
 # * https://github.com/bitcoin/bitcoin/blob/master/depends/README.md#for-linux-including-i386-arm-cross-compilation
 RUN apt-get update && apt-get install -y \
-  automake autotools-dev bsdmainutils build-essential cmake curl g++-multilib libtool make \
+  automake autotools-dev bsdmainutils build-essential curl g++-multilib libtool make \
   patch pkg-config python3 wget zip
 
 RUN git clone --depth=1 https://github.com/bitcoin/bitcoin.git bitcoin-core

--- a/projects/bitcoin-core/Dockerfile
+++ b/projects/bitcoin-core/Dockerfile
@@ -20,8 +20,8 @@ FROM gcr.io/oss-fuzz-base/base-builder
 # * https://github.com/bitcoin/bitcoin/blob/master/doc/build-unix.md#dependency-build-instructions
 # * https://github.com/bitcoin/bitcoin/blob/master/depends/README.md#for-linux-including-i386-arm-cross-compilation
 RUN apt-get update && apt-get install -y \
-  automake autotools-dev bsdmainutils build-essential curl g++-multilib libtool make \
-  patch pkg-config python3 wget zip
+  build-essential curl g++-multilib make \
+  patch pkgconf python3 wget zip
 
 RUN git clone --depth=1 https://github.com/bitcoin/bitcoin.git bitcoin-core
 RUN git clone --depth=1 https://github.com/bitcoin-core/qa-assets bitcoin-core/assets && \


### PR DESCRIPTION
Skip installing CMake from the base image repository for the following reasons:

1. The base image is based on Ubuntu Focal 20.04, whose repository provides CMake version 3.16.3, which is incompatible with Bitcoin Core's minimum requirements.

2. The base image [installs](https://github.com/google/oss-fuzz/blob/b4c1a273955cf84b991be6e39038c485c0b93560/infra/base-images/base-clang/Dockerfile#L25-L34) a newer CMake version specified by the `CMAKE_VERSION` variable, which is currently set to 3.29.2.

---

Additionally, other dependency packages have been updated after migration to CMake.