### PR TITLE
use `shutil.which` instead of `distutils.spawn.find_executable`

### DIFF
--- a/infra/build_specified_commit.py
+++ b/infra/build_specified_commit.py
@@ -20,7 +20,6 @@ like continuious integration fuzzing and bisection to find errors
 import argparse
 import bisect
 import datetime
-from distutils import spawn
 import os
 import collections
 import json
@@ -336,7 +335,7 @@ def detect_main_repo(project_name, repo_name=None, commit=None):
 
 def load_base_builder_repo():
   """Get base-image digests."""
-  gcloud_path = spawn.find_executable('gcloud')
+  gcloud_path = shutil.which('gcloud')
   if not gcloud_path:
     logging.warning('gcloud not found in PATH.')
     return None


### PR DESCRIPTION
`distutils` is deprecated and removed in Python 3.12 (this has broken osv.dev).
The [migration advice](https://peps.python.org/pep-0632/#migration-advice) says to replace `distutils.spawn.find_executable` with `shutil.which`.

`distutils.dir_util.copy_tree` is still used in [`infra/cifuzz/filestore/filesystem`](https://github.com/google/oss-fuzz/blob/72c3485bfd7eb0456646c51cf24879d3e7f5742a/infra/cifuzz/filestore/filesystem/__init__.py#L21), but I'm not sure what the correct replacement for that is.