### PR TITLE
Fixes 2 problems in target_experiment.py

### DIFF
--- a/infra/build/functions/target_experiment.py
+++ b/infra/build/functions/target_experiment.py
@@ -25,6 +25,8 @@ import google.auth
 import build_lib
 import build_project
 
+# 12 hours, allowing more than enough waiting time before cloud build starts.
+build_lib.BUILD_TIMEOUT = 12 * 60 * 60
 
 def run_experiment(project_name,
                    target_name,
@@ -298,8 +300,6 @@ def run_experiment(project_name,
   })
 
   credentials, _ = google.auth.default()
-  # Empirically, 3 hours is more than enough for 30-minute fuzzing cloud builds.
-  build_lib.BUILD_TIMEOUT = 3 * 60 * 60
   build_id = build_project.run_build(
       project_name,
       steps,

--- a/infra/build/functions/target_experiment.py
+++ b/infra/build/functions/target_experiment.py
@@ -28,6 +28,7 @@ import build_project
 # 12 hours, allowing more than enough waiting time before cloud build starts.
 build_lib.BUILD_TIMEOUT = 12 * 60 * 60
 
+
 def run_experiment(project_name,
                    target_name,
                    args,


### PR DESCRIPTION
1. Insufficient timeout. Cloud Build Timeout = waiting time + execution time. Some executions timed out because they waited for too long. Since Cloud Build does not have an execution-only timeout config, the new 12 hour overall time out should be sufficient.
2. Cleanup JCC. We have to do this because some projects are not even compatible with the current minimum scaffold. This mostly happens when they identifying which CC is being used, and is likely because of the way they read/expect stdout/stderr from commands.

BTW, we can further simplify this script. E.g., no need to save build log as compilation is done within agents.
But it's not a high priority at this point. We can do it in GSoC.