### PR TITLE
[clamav] Update rust when building image

### DIFF
--- a/projects/clamav/Dockerfile
+++ b/projects/clamav/Dockerfile
@@ -20,6 +20,8 @@ RUN apt-get update && apt-get install -y \
     python3-dev \
     pkg-config
 
+RUN rustup update
+
 #
 # Build static libs for dependencies
 #


### PR DESCRIPTION
The Rust base image does not provide a new enough version of Rust to build with recently updated dependencies.