### PR TITLE
karchive, kcodecs, kimageformats: Add openssl and remove docker warnings

### DIFF
--- a/projects/karchive/Dockerfile
+++ b/projects/karchive/Dockerfile
@@ -18,12 +18,12 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install --yes cmake make autoconf automake autopoint libtool wget po4a ninja-build pkgconf
 RUN git clone --depth 1 https://github.com/madler/zlib.git
 RUN git clone --depth 1 https://github.com/facebook/zstd.git
+RUN git clone --depth 1 https://github.com/openssl/openssl.git
 RUN git clone --depth 1 https://github.com/nih-at/libzip.git
 RUN wget https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz
 RUN git clone https://github.com/tukaani-project/xz.git
 RUN git clone --depth 1 --branch=dev git://code.qt.io/qt/qtbase.git
 RUN git clone --depth 1 -b master https://invent.kde.org/frameworks/extra-cmake-modules.git
 RUN git clone --depth 1 -b master https://invent.kde.org/frameworks/karchive.git
-COPY build.sh $SRC
-COPY karchive_fuzzer.cc $SRC
-WORKDIR karchive
+COPY build.sh karchive_fuzzer.cc $SRC/
+WORKDIR $SRC/karchive

--- a/projects/karchive/build.sh
+++ b/projects/karchive/build.sh
@@ -16,20 +16,17 @@
 ################################################################################
 
 # build zstd
-cd $SRC
-cd zstd
+cd $SRC/zstd
 cmake -S build/cmake -DBUILD_SHARED_LIBS=OFF
 make install -j$(nproc)
 
 # Build zlib
-cd $SRC
-cd zlib
+cd $SRC/zlib
 ./configure --static
 make install -j$(nproc)
 
 # Build libzip
-cd $SRC
-cd libzip
+cd $SRC/libzip
 cmake . -DBUILD_SHARED_LIBS=OFF
 make install -j$(nproc)
 
@@ -54,23 +51,32 @@ export ORIG_CFLAGS="${CFLAGS}"
 export ORIG_CXXFLAGS="${CXXFLAGS}"
 unset CFLAGS
 unset CXXFLAGS
-cd $SRC
-cd xz
+cd $SRC/xz
 ./autogen.sh --no-po4a --no-doxygen
 ./configure --enable-static --disable-debug --disable-shared --disable-xz --disable-xzdec --disable-lzmainfo
 make install -j$(nproc)
 export CFLAGS="${ORIG_CFLAGS}"
 export CXXFLAGS="${ORIG_CXXFLAGS}"
 
+# Build openssl
+cd $SRC/openssl
+CONFIG_FLAGS="no-shared no-tests"
+if [[ $CFLAGS = *sanitize=memory* ]]
+then
+    # Disable assembly for proper instrumentation
+    CONFIG_FLAGS+=" no-asm"
+fi
+./config $CONFIG_FLAGS
+make -j$(nproc)
+make install_sw
+
 # Build extra-cmake-modules
-cd $SRC
-cd extra-cmake-modules
+cd $SRC/extra-cmake-modules
 cmake .
 make install -j$(nproc)
 
 # Build qtbase
-cd $SRC
-cd qtbase
+cd $SRC/qtbase
 ./configure -no-glib -qt-libpng -qt-pcre -opensource -confirm-license -static -no-opengl -no-icu -platform linux-clang-libc++ -debug -prefix /usr -no-feature-gui -no-feature-sql -no-feature-network  -no-feature-xml -no-feature-dbus -no-feature-printsupport
 cmake --build . --parallel $(nproc)
 cmake --install .
@@ -84,7 +90,7 @@ cmake . -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=OFF
 make install -j$(nproc)
 
 # Build karchive_fuzzer
-$CXX $CXXFLAGS -fPIC -std=c++17 $SRC/karchive_fuzzer.cc -o $OUT/karchive_fuzzer -I /usr/include/QtCore/ -I /usr/local/include/KF6/KArchive -lQt6Core -lm -lQt6BundledPcre2 -ldl -lpthread $LIB_FUZZING_ENGINE /usr/local/lib/libzip.a /usr/local/lib/libz.a -lKF6Archive /usr/local/lib/libbz2.a -llzma /usr/local/lib/libzstd.a
+$CXX $CXXFLAGS -fPIC -std=c++17 $SRC/karchive_fuzzer.cc -o $OUT/karchive_fuzzer -I /usr/include/QtCore/ -I /usr/local/include/KF6/KArchive -lQt6Core -lm -lQt6BundledPcre2 -ldl -lpthread $LIB_FUZZING_ENGINE /usr/local/lib/libzip.a /usr/local/lib/libz.a -lKF6Archive /usr/local/lib/libbz2.a -llzma /usr/local/lib/libzstd.a /usr/local/lib64/libcrypto.a
 
 cd $SRC
-find . -name "*.gz" -o -name "*.zip" -o -name "*.xz" -o -name "*.tar" | zip -q $OUT/karchive_fuzzer_seed_corpus.zip -@
+find . -name "*.gz" -o -name "*.zip" -o -name "*.xz" -o -name "*.tar" -o -name "*.7z" | zip -q $OUT/karchive_fuzzer_seed_corpus.zip -@

--- a/projects/karchive/karchive_fuzzer.cc
+++ b/projects/karchive/karchive_fuzzer.cc
@@ -27,7 +27,6 @@
 #include <QBuffer>
 #include <QCoreApplication>
 #include <QVector>
-#include <iostream>
 
 #include <KF6/KArchive/k7zip.h>
 #include <KF6/KArchive/ktar.h>
@@ -83,7 +82,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     };
 
     for (KArchive *h : handlers) {
-        b.reset();
+        if (b.isOpen()) {
+            b.reset();
+        }
         if (h->open(QIODevice::ReadOnly)) {
             const KArchiveDirectory *rootDir = h->directory();
             traverseArchive(rootDir); 

--- a/projects/kcodecs/Dockerfile
+++ b/projects/kcodecs/Dockerfile
@@ -21,6 +21,5 @@ RUN git clone --depth 1 --branch=dev git://code.qt.io/qt/qtbase.git
 RUN git clone --depth 1 -b master https://invent.kde.org/frameworks/extra-cmake-modules.git
 RUN git clone --depth 1 -b master https://invent.kde.org/frameworks/kcodecs.git
 RUN git clone --depth 1 https://gitlab.freedesktop.org/uchardet/uchardet.git
-COPY build.sh $SRC
-COPY kcodecs_fuzzer.cc $SRC
-WORKDIR kcodecs
+COPY build.sh kcodecs_fuzzer.cc $SRC/
+WORKDIR $SRC/kcodecs

--- a/projects/kimageformats/Dockerfile
+++ b/projects/kimageformats/Dockerfile
@@ -35,6 +35,5 @@ RUN git clone --depth=1 --branch v0.11.x --recursive --shallow-submodules https:
 RUN git clone --depth 1 https://github.com/LibRaw/LibRaw
 RUN git clone --depth 1 https://github.com/mircomir/jxrlib.git
 RUN git clone --depth 1 -b v2.6.0 https://github.com/cisco/openh264.git
-COPY build.sh $SRC
-COPY kimgio_fuzzer.cc $SRC
-WORKDIR kimageformats
+COPY build.sh kimgio_fuzzer.cc $SRC/
+WORKDIR $SRC/kimageformats


### PR DESCRIPTION
### Fix KArchive Fuzzer Build & Improve Logging

- Added OpenSSL to fix failing KArchive fuzzer build.  
- Used absolute paths to remove Docker warnings.  
- Fixed `b.reset()` failing when the device is closed, preventing unnecessary error messages.  

@tsdgeos (Let me know if any changes are needed!)  
