### PR TITLE
bitcoin-core: Fix build for `i386`

### DIFF
--- a/projects/bitcoin-core/build.sh
+++ b/projects/bitcoin-core/build.sh
@@ -23,12 +23,7 @@ cd $SRC/bitcoin-core/
 # Build dependencies
 # This will also force static builds
 if [ "$ARCHITECTURE" = "i386" ]; then
-  export BUILD_TRIPLET="i686-pc-linux-gnu"
-
-  # Temp workaround
-  mkdir /usr/local/lib/clang/18/lib/linux
-  ln -s /usr/local/lib/clang/18/lib/i386-unknown-linux-gnu/libclang_rt.asan_static.a /usr/local/lib/clang/18/lib/linux/libclang_rt.asan_static-i386.a
-  ln -s /usr/local/lib/clang/18/lib/i386-unknown-linux-gnu/libclang_rt.asan.a /usr/local/lib/clang/18/lib/linux/libclang_rt.asan-i386.a
+  export BUILD_TRIPLET="i386-linux-gnu"
 else
   export BUILD_TRIPLET="x86_64-pc-linux-gnu"
 fi


### PR DESCRIPTION
This PR is required following the merge of https://github.com/bitcoin/bitcoin/pull/31849.

Additionally, the path workaround has been removed.

Fixes https://github.com/bitcoin/bitcoin/issues/32167.