### PR TITLE
xz: enable assertions; more fuzzing engines; i386

### DIFF
--- a/projects/xz/build.sh
+++ b/projects/xz/build.sh
@@ -18,7 +18,7 @@
 ./autogen.sh --no-po4a --no-doxygen
 ./configure \
   --enable-static \
-  --disable-debug \
+  --enable-debug \
   --disable-shared \
   --disable-xz \
   --disable-xzdec \

--- a/projects/xz/project.yaml
+++ b/projects/xz/project.yaml
@@ -4,10 +4,6 @@ primary_contact: "lasse.collin@tukaani.org"
 auto_ccs:
   - "bshas3@gmail.com"
   - "samjd1024@gmail.com"
-fuzzing_engines:
-  - libfuzzer
-  - afl
-  - honggfuzz
 sanitizers:
   - address
   - memory

--- a/projects/xz/project.yaml
+++ b/projects/xz/project.yaml
@@ -4,6 +4,9 @@ primary_contact: "lasse.collin@tukaani.org"
 auto_ccs:
   - "bshas3@gmail.com"
   - "samjd1024@gmail.com"
+architectures:
+  - x86_64
+  - i386
 sanitizers:
   - address
   - memory


### PR DESCRIPTION
Lasse and I were discussing this in the context of CVE-2025-31115, and really, it seems like we want to fuzz with assertions enabled to better catch edge-cases (not that it would've found this, but we added a bunch more because of it).

The encoder has more coverage than the decoder at least right now.