### PR TITLE
Update rust to 1.88.0-nightly

### DIFF
--- a/infra/base-images/base-builder-rust/Dockerfile
+++ b/infra/base-images/base-builder-rust/Dockerfile
@@ -26,7 +26,7 @@ ENV OSSFUZZ_RUSTPATH /rust
 # manually specifying what toolchain to use. Note that this environment variable
 # is additionally used by `install_rust.sh` as the toolchain to install.
 # cf https://rust-lang.github.io/rustup/overrides.html
-ENV RUSTUP_TOOLCHAIN nightly-2024-07-12
+ENV RUSTUP_TOOLCHAIN nightly-2025-04-05
 
 # Configure the linker used by default for x86_64 linux to be `clang` instead of
 # rustc's default of `cc` which is able to find custom-built libraries like


### PR DESCRIPTION
This base breaks for projects using creates with `edition = 2024`. Those require rust 1.85+

For my project, I had to re-built a simples version of this image from the base builder. https://github.com/auyer/Protonup-rs/pull/47