### PR TITLE
KArchive: Set dummy password to force K7Zip decryption

### DIFF
--- a/projects/karchive/karchive_fuzzer.cc
+++ b/projects/karchive/karchive_fuzzer.cc
@@ -85,6 +85,12 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         if (b.isOpen()) {
             b.reset();
         }
+
+        if (auto k7zip = dynamic_cast<K7Zip *>(h)) {
+            // Set a dummy password to trigger decryption code
+            k7zip->setPassword("youshallnotpass");
+        }
+
         if (h->open(QIODevice::ReadOnly)) {
             const KArchiveDirectory *rootDir = h->directory();
             traverseArchive(rootDir); 


### PR DESCRIPTION
Set a dummy password on k7zip handler to trigger decryption code for encrypted archives.