### PR TITLE
Improve output path resolution during build

### DIFF
--- a/projects/msquic/Dockerfile
+++ b/projects/msquic/Dockerfile
@@ -27,9 +27,6 @@ RUN apt-get update && \
 
 RUN git clone https://github.com/microsoft/msquic && \
     cd msquic && \
-    git submodule init submodules/clog && \
-    git submodule init submodules/openssl && \
-    git submodule init submodules/googletest && \
-    git submodule update
+    git submodule update --init && \
 COPY build.sh $SRC/
 WORKDIR $SRC/msquic

--- a/projects/msquic/Dockerfile
+++ b/projects/msquic/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && \
 
 RUN git clone https://github.com/microsoft/msquic && \
     cd msquic && \
-    git submodule update --init && \
+    git submodule update --init
+
 COPY build.sh $SRC/
 WORKDIR $SRC/msquic

--- a/projects/msquic/build.sh
+++ b/projects/msquic/build.sh
@@ -21,6 +21,11 @@ export CXXFLAGS="$CXXFLAGS -Wno-error=invalid-unevaluated-string"
 
 pwsh ./scripts/build.ps1 -Static -DisableTest -DisablePerf -DisableLogs -Parallel 1
 
+BUILDFILENAME=$(find . -name 'msquic-config.cmake')
+BUILDDIR=$(dirname $BUILDFILENAME)
+LIBMSQUICDIR=$(cmake -LAH $BUILDDIR/CMakeCache.txt | grep QUIC_OUTPUT_DIR | cut -d'=' -f 2)
+QUICTLSLIB=$(cmake -LAH $BUILDDIR/CMakeCache.txt | grep  QUIC_TLS_LIB | cut -d'=' -f 2)
+
 cd $SRC/msquic/src/fuzzing
 
 $CXX $CXXFLAGS -DCX_PLATFORM_LINUX -DQUIC_TEST_APIS \
@@ -28,13 +33,11 @@ $CXX $CXXFLAGS -DCX_PLATFORM_LINUX -DQUIC_TEST_APIS \
     -I/src/msquic/src/inc \
     -I/src/msquic/src/generated/common \
     -I/src/msquic/src/generated/linux \
-    -I/src/msquic/build/linux/x64_openssl/_deps/opensslquic-build/openssl/include \
+    -I/src/msquic/build/linux/x64_$QUICTLSLIB/_deps/opensslquic-build/$QUICTLSBUILD/include \
     -isystem /src/msquic/submodules/googletest/googletest/include \
     -isystem /src/msquic/submodules/googletest/googletest \
     -c fuzz.cc -o fuzz.o
 
-CMAKECACHE=$(find ./build -name 'CmakeCache.txt'
-LIBMSQUICDIR=$(cmake -LAH $CMAKECACHE | grep QUIC_OUTPUT_DIR | cut -d'=' -f 2)
 
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz.o -o $OUT/fuzz \
     $LIBMSQUICDIR/libmsquic.a
@@ -46,10 +49,10 @@ $CXX $CXXFLAGS -DCX_PLATFORM_LINUX -DQUIC_TEST_APIS -DFUZZING -DQUIC_BUILD_STATI
     -I/src/msquic/src/inc \
     -I/src/msquic/src/generated/common \
     -I/src/msquic/src/generated/linux \
-    -I/src/msquic/build/linux/x64_openssl/_deps/opensslquic-build/openssl/include \
+    -I/src/msquic/build/linux/x64_$QUICTLSLIB/_deps/opensslquic-build/$QUICTLSLIB/include \
     -isystem /src/msquic/submodules/googletest/googletest/include \
     -isystem /src/msquic/submodules/googletest/googletest \
     -c ./msquic/src/tools/spin/spinquic.cpp -o spinquic.o
 
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE spinquic.o -o $OUT/spinquic \
-    /src/msquic/artifacts/bin/linux/x64_Debug_openssl/libmsquic.a
+    /src/msquic/artifacts/bin/linux/x64_Debug_$QUICTLSLIB/libmsquic.a

--- a/projects/msquic/build.sh
+++ b/projects/msquic/build.sh
@@ -33,8 +33,11 @@ $CXX $CXXFLAGS -DCX_PLATFORM_LINUX -DQUIC_TEST_APIS \
     -isystem /src/msquic/submodules/googletest/googletest \
     -c fuzz.cc -o fuzz.o
 
+CMAKECACHE=$(find ./build -name 'CmakeCache.txt'
+LIBMSQUICDIR=$(cmake -LAH $CMAKECACHE | grep QUIC_OUTPUT_DIR | cut -d'=' -f 2)
+
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz.o -o $OUT/fuzz \
-    /src/msquic/artifacts/bin/linux/x64_Debug_openssl/libmsquic.a
+    $LIBMSQUICDIR/libmsquic.a
 
 cd $SRC
 

--- a/projects/msquic/build.sh
+++ b/projects/msquic/build.sh
@@ -33,7 +33,7 @@ $CXX $CXXFLAGS -DCX_PLATFORM_LINUX -DQUIC_TEST_APIS \
     -I/src/msquic/src/inc \
     -I/src/msquic/src/generated/common \
     -I/src/msquic/src/generated/linux \
-    -I/src/msquic/build/linux/x64_$QUICTLSLIB/_deps/opensslquic-build/$QUICTLSBUILD/include \
+    -I/src/msquic/build/linux/x64_$QUICTLSLIB/_deps/opensslquic-build/$QUICTLSLIB/include \
     -isystem /src/msquic/submodules/googletest/googletest/include \
     -isystem /src/msquic/submodules/googletest/googletest \
     -c fuzz.cc -o fuzz.o
@@ -55,4 +55,4 @@ $CXX $CXXFLAGS -DCX_PLATFORM_LINUX -DQUIC_TEST_APIS -DFUZZING -DQUIC_BUILD_STATI
     -c ./msquic/src/tools/spin/spinquic.cpp -o spinquic.o
 
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE spinquic.o -o $OUT/spinquic \
-    /src/msquic/artifacts/bin/linux/x64_Debug_$QUICTLSLIB/libmsquic.a
+    $LIBMSQUICDIR/libmsquic.a


### PR DESCRIPTION
The build.sh script for msquic assumes an output path with a configurable name, set during the build.  If that name changes, then the build breaks when the fuzzer attempts linkage, as the libmsquic.a library path is hard coded.

instead, pull the name from the cmake configuration and just use that, so we don't have to hard code it here