### PR TITLE
Support a "full" base-clang build.

### DIFF
--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -45,7 +45,8 @@ RUN apt-get update && apt-get install -y git && \
 COPY checkout_build_install_llvm.sh /root/
 # Keep all steps in the same script to decrease the number of intermediate
 # layes in docker file.
-RUN /root/checkout_build_install_llvm.sh
+ARG FULL_LLVM_BUILD
+RUN FULL_LLVM_BUILD=$FULL_LLVM_BUILD /root/checkout_build_install_llvm.sh
 RUN rm /root/checkout_build_install_llvm.sh
 
 # Setup the environment.

--- a/infra/base-images/base-clang/README.md
+++ b/infra/base-images/base-clang/README.md
@@ -1,0 +1,14 @@
+# base-builder-clang
+
+## Regular build
+
+```
+docker build -t gcr.io/oss-fuzz-base/base-clang . 
+```
+
+## Full build 
+For a build including all binaries and libraries, including with everything built against libcxx, do
+
+```
+docker build -t gcr.io/oss-fuzz-base/base-clang-full --build-arg FULL_LLVM_BUILD=1 . 
+```


### PR DESCRIPTION
This build will contain all binaries/libraries.

Additionally, libcxx is bootstrapped and LLVM/clang is built with llvm in this mode. This is useful for building tools which link against LLVM/clang, because otherwise they'd have to link both libstdc++ and libc++. 