### PR TITLE
Add initial integration of Volcano

### DIFF
--- a/projects/volcano/Dockerfile
+++ b/projects/volcano/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/volcano-sh/volcano
+WORKDIR volcano
+COPY build.sh $SRC/

--- a/projects/volcano/build.sh
+++ b/projects/volcano/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+./hack/oss-fuzz-build.sh

--- a/projects/volcano/project.yaml
+++ b/projects/volcano/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://volcano.sh/"
+language: go
+primary_contact: "cxz2536818783@gmail.com"
+main_repo: "https://github.com/volcano-sh/volcano"
+auto_ccs:
+  - "adam@adalogics.com"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
This PR adds initial integration of Volcano.

Volcano is a cloud-native batch scheduling system for Kubernetes hosted by the CNCF. It is used by companies such as Huawei, Baidu, JD.com.
