### PR TITLE
askama: update used rust toolchain

### DIFF
--- a/projects/askama/Dockerfile
+++ b/projects/askama/Dockerfile
@@ -18,4 +18,9 @@ FROM gcr.io/oss-fuzz-base/base-builder-rust
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/askama-rs/askama.git askama
 WORKDIR askama/fuzzing
+
+# The current default toolchain used by OSS-Fuzz (1.81) is too old for askama v0.14,
+# which needs at least 1.83.
+ENV RUSTUP_TOOLCHAIN nightly-2025-01-10
+
 COPY build.sh $SRC/


### PR DESCRIPTION
The next version of askama (v0.14) will need at least rust 1.83 to compile. The current toolchain shipped in docker is rust 1.81, so the project could not get fuzzed anymore.

This PR sets the used toolchain to 1.83.

Cc @GuillaumeGomez

Related issue: <https://github.com/askama-rs/askama/pull/405>