### PR TITLE
[connectedhomeip][Fix ] Adapt OSS-Fuzz Dockerfile to changes in requirements.build.txt

### DIFF
--- a/projects/connectedhomeip/Dockerfile
+++ b/projects/connectedhomeip/Dockerfile
@@ -48,6 +48,8 @@ RUN rustup default nightly
 
 RUN git clone --depth=1 https://github.com/project-chip/connectedhomeip.git connectedhomeip
 
+# PW_PROJECT_ROOT is used in requirements.build.txt
+ENV PW_PROJECT_ROOT=$SRC/connectedhomeip
 
 # Ensure global python has access to build requirements
 RUN pip3 install -r connectedhomeip/scripts/setup/requirements.build.txt


### PR DESCRIPTION
- After PR https://github.com/project-chip/connectedhomeip/pull/38410
- we need to have environment variable `PW_PROJECT_ROOT`  pointing to CHIP_ROOT