### PR TITLE
Restore request_build.get_empty_config

### DIFF
--- a/infra/build/functions/request_build.py
+++ b/infra/build/functions/request_build.py
@@ -61,6 +61,11 @@ def get_project_data(project_name):
   return project_yaml, project.dockerfile_contents
 
 
+def get_empty_config():
+  """Returns an empty build config."""
+  return build_project.Config()
+
+
 def get_build_steps(project_name):
   """Retrieve build steps."""
   project_yaml, dockerfile_lines = get_project_data(project_name)


### PR DESCRIPTION
This was removed in https://github.com/google/oss-fuzz/pull/13207, but we still need it in:

https://github.com/google/oss-fuzz/blob/84ff40bf62048901b6935eaa1f9664d76d5833eb/infra/build/functions/request_coverage_build.py#L30

and

https://github.com/google/oss-fuzz/blob/84ff40bf62048901b6935eaa1f9664d76d5833eb/infra/build/functions/request_introspector_build.py#L31