### PR TITLE
tarantool: fix auto-ccs

### DIFF
--- a/projects/tarantool/project.yaml
+++ b/projects/tarantool/project.yaml
@@ -7,9 +7,7 @@ auto_ccs:
   - "totktonada.ru@gmail.com"
   - "sergeykaplun1998@gmail.com"
   - "imeevma@gmail.com"
-  - "leonid2012v@gmail.com"
   - "boris.stepanenko@gmail.com"
-  - "imun.dev@gmail.com"
 sanitizers:
   - address
   - undefined


### PR DESCRIPTION
Removed people are not involved in Tarantool development anymore.