### PR TITLE
Fix problems indexing

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -211,6 +211,7 @@ ENV CCACHE_COMPILERTYPE clang
 
 COPY indexer /opt/indexer
 ADD https://clusterfuzz-builds.storage.googleapis.com/oss-fuzz-artifacts/indexer /opt/indexer/indexer
+RUN chmod a+x /opt/indexer/indexer
 RUN cp /opt/indexer/clang_wrapper.py /opt/indexer/clang
 RUN cp /opt/indexer/clang_wrapper.py /opt/indexer/clang++
 

--- a/infra/base-images/base-builder/indexer/fuzzing_engine.cc
+++ b/infra/base-images/base-builder/indexer/fuzzing_engine.cc
@@ -27,6 +27,16 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t data[], size_t n);
 
+
+extern "C" size_t LLVMFuzzerMutate(char *data, size_t size, size_t maxSize);
+
+__attribute__((weak)) extern "C" size_t LLVMFuzzerMutate(char *data, size_t size, size_t maxSize) {
+  (void) data;
+  (void) size;
+  (void) maxSize;
+  abort();
+}
+
 __attribute__((weak)) int LLVMFuzzerInitialize(
     __attribute__((unused)) int* argc, __attribute__((unused)) char*** argv) {
   return 0;

--- a/infra/base-images/base-builder/indexer/index_build.py
+++ b/infra/base-images/base-builder/indexer/index_build.py
@@ -190,6 +190,7 @@ def sha256(files: Union[Path, Sequence[Path]]) -> str:
 
 
 def copy_fuzzing_engine():
+  # Not every project saves source to $SRC/$PROJECT_NAME
   fuzzing_engine_dir = SRC / PROJECT
   if not fuzzing_engine_dir.exists():
     fuzzing_engine_dir = SRC / 'fuzzing_engine'

--- a/infra/base-images/base-builder/indexer/index_build.py
+++ b/infra/base-images/base-builder/indexer/index_build.py
@@ -34,7 +34,9 @@ ARCHIVE_VERSION = 1
 
 INDEX_DB_NAME = "db.sqlite"
 
-PROJECT = os.environ['PROJECT_NAME']
+PROJECT = Path(os.environ['PROJECT_NAME'])
+SNAPSHOT_DIR = Path('/snapshot')
+SRC = Path(os.getenv('SRC'))
 
 
 def set_env_vars():
@@ -106,7 +108,7 @@ def save_build(
       _save_dir(index_dir, "idx/")
     # Warning, we overwrite here when default behavior used to be false.
     shutil.copyfile(tmp.name, archive_path)
-  
+
 
 def _add_string_to_tar(tar: tarfile.TarFile, name: str, data: str) -> None:
   data = io.BytesIO(data.encode("utf-8"))
@@ -140,7 +142,7 @@ def enumerate_build_targets(
 
       if binary_path.is_relative_to('/out/'):
         binary_path = Path('./build', binary_path.relative_to('/out/'))
-        
+
       targets.append(
         BinaryMetadata(
           name=name,
@@ -187,6 +189,16 @@ def sha256(files: Union[Path, Sequence[Path]]) -> str:
   return hash_value.hexdigest()
 
 
+def copy_fuzzing_engine():
+  fuzzing_engine_dir = SRC / PROJECT
+  if not fuzzing_engine_dir.exists():
+    fuzzing_engine_dir = SRC / 'fuzzing_engine'
+    fuzzing_engine_dir.mkdir()
+
+  shutil.copy('/opt/indexer/fuzzing_engine.cc', fuzzing_engine_dir)
+  return fuzzing_engine_dir
+
+
 def build_project():
   set_env_vars()
   existing_cflags = os.environ.get('CFLAGS', '')
@@ -204,7 +216,9 @@ def build_project():
     '-resource-dir /usr/local/lib/clang/18 '
   )
   os.environ['CFLAGS'] = f'{existing_cflags} {extra_flags}'.strip()
-  shutil.copy('/opt/indexer/fuzzing_engine.cc', os.path.join(os.getenv('SRC'), PROJECT, 'fuzzing_engine.cc'))
+
+  fuzzing_engine_path = copy_fuzzing_engine()
+
   build_fuzzing_engine_command = [
     '/opt/indexer/clang++',
     '-c',
@@ -214,7 +228,7 @@ def build_project():
     '-std=c++20',
     '-glldb',
     '-O0',
-    f'/src/{PROJECT}/fuzzing_engine.cc',
+    fuzzing_engine_path / 'fuzzing_engine.cc',
     '-o',
     '/out/fuzzing_engine.o',
     '-gen-cdb-fragment-path',
@@ -239,11 +253,12 @@ def build_project():
   ]
   subprocess.run(ar_cmd, check=True)
   lib_fuzzing_engine = '/usr/lib/libFuzzingEngine.a'
-  os.remove(lib_fuzzing_engine)
+  if os.path.exists(lib_fuzzing_engine):
+    os.remove(lib_fuzzing_engine)
   os.symlink('/opt/indexer/fuzzing_engine.a', lib_fuzzing_engine)
   subprocess.run(['/usr/local/bin/compile'], check=True)
 
-  
+
 def test_target(
     target: BinaryMetadata,
     root_dir: Path,
@@ -287,7 +302,8 @@ def archive_target(
     build_dir = root_dir / "out"
 
     index_db_path = os.path.join(index_tmp_dir, INDEX_DB_NAME)
-    cmd = ['/opt/indexer/indexer', '--build_dir', build_dir, '--index_path', index_db_path, '--source_dir', os.environ['SRC']]
+    cmd = ['/opt/indexer/indexer', '--build_dir', build_dir, '--index_path',
+           index_db_path, '--source_dir', os.environ['SRC']]
     result = subprocess.run(cmd, check=True)
     if result.returncode != 0:
       raise Exception(
@@ -327,7 +343,7 @@ def archive_target(
         index_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(file_path, index_path)
 
-    archive_path = Path(f"/out/{uuid}.tar")
+    archive_path = SNAPSHOT_DIR / f"{uuid}.tar"
 
     save_build(
       Manifest(
@@ -353,7 +369,13 @@ def index():
   root = Path('/')
   targets = enumerate_build_targets(root)
   for target in targets:
-    if not test_target(target, root):
+    try:
+      # TODO(metzman): Figure out if this is a good idea, it makes some things
+      # pass that should but causes some things to pass that shouldn't.
+      if not test_target(target, root):
+        continue
+    except Exception as e:
+      print(f'Error: {e}')
       continue
     archive_target(target, root)
 
@@ -372,14 +394,20 @@ def get_index_files(index_db_path) -> Iterator[str]:
         yield os.path.join(dirname, basename)
 
     conn.close()
-  
+
 
 def main():
   for directory in ['aflplusplus', 'fuzztest', 'honggfuzz', 'libfuzzer']:
     path = os.path.join(os.environ['SRC'], directory)
     shutil.rmtree(path, ignore_errors=True)
+  # Initially, we put snapshots directly in /out. This caused a bug where each
+  # snapshot was added to the next because they contain the contents of /out.
+  SNAPSHOT_DIR.mkdir(exist_ok=True)
   build_project()
   index()
+  for snapshot in SNAPSHOT_DIR.iterdir():
+    shutil.move(str(snapshot), '/out')
+
 
 if __name__ == '__main__':
   main()

--- a/infra/base-images/base-builder/indexer/index_build.py
+++ b/infra/base-images/base-builder/indexer/index_build.py
@@ -34,6 +34,8 @@ ARCHIVE_VERSION = 1
 
 INDEX_DB_NAME = "db.sqlite"
 
+PROJECT = os.environ['PROJECT_NAME']
+
 
 def set_env_vars():
   os.environ['SANITIZER'] = os.environ['FUZZING_ENGINE'] = 'none'
@@ -202,7 +204,7 @@ def build_project():
     '-resource-dir /usr/local/lib/clang/18 '
   )
   os.environ['CFLAGS'] = f'{existing_cflags} {extra_flags}'.strip()
-  shutil.copy('/opt/indexer/fuzzing_engine.cc', os.path.join(os.getenv('SRC'), os.getenv('PROJECT', 'skcms'), 'fuzzing_engine.cc'))
+  shutil.copy('/opt/indexer/fuzzing_engine.cc', os.path.join(os.getenv('SRC'), PROJECT, 'fuzzing_engine.cc'))
   build_fuzzing_engine_command = [
     '/opt/indexer/clang++',
     '-c',
@@ -212,7 +214,7 @@ def build_project():
     '-std=c++20',
     '-glldb',
     '-O0',
-    '/src/skcms/fuzzing_engine.cc',
+    f'/src/{PROJECT}/fuzzing_engine.cc',
     '-o',
     '/out/fuzzing_engine.o',
     '-gen-cdb-fragment-path',
@@ -276,12 +278,8 @@ def archive_target(
   # for the project, or something like that, but this will do for now.
   target_hash = short_file_hash((build_dir / target.name))
 
-  # name = f"{self._project_name}.{target.name}"
-  # uuid = f"{self._project_name}.{target.name}.{target_hash}"
-
-  # !!!
-  name = f"skcms.{target.name}"
-  uuid = f"skcms.{target.name}.{target_hash}"
+  name = f"{PROJECT}.{target.name}"
+  uuid = f"{PROJECT}.{target.name}.{target_hash}"
 
 
   with tempfile.TemporaryDirectory(prefix="index_") as index_tmp_dir:


### PR DESCRIPTION
1. Mark indexer executable after download
2. Support linking against LLVMFuzzerMutate (upstreamed)
3. Use real project name when making snapshot.
4. Handle projects that don't save their source to a directory with the same name as their project.
5. Handle partial failures.
6. Don't accidentally include other snapshots in snapshots.
7. Support indexing in helper.py
8. Provide PROJECT_NAME in helper.py shell command.
9. Remove trailing whitespace.