### PR TITLE
zeek/spicy: Add team member to user list

### DIFF
--- a/projects/spicy/project.yaml
+++ b/projects/spicy/project.yaml
@@ -10,6 +10,7 @@ auto_ccs:
   - "vern@corelight.com"
   - "benjamin.bannier@corelight.com"
   - "christian@corelight.com"
+  - "evan.typanski@corelight.com"
 fuzzing_engines:
   - libfuzzer
 sanitizers:

--- a/projects/zeek/project.yaml
+++ b/projects/zeek/project.yaml
@@ -12,6 +12,7 @@ auto_ccs:
   - "christian@corelight.com"
   - "arne.welzel@corelight.com"
   - "benjamin.bannier@corelight.com"
+  - "evan.typanski@corelight.com"
 fuzzing_engines:
   - libfuzzer
   - honggfuzz


### PR DESCRIPTION
This adds a new team member the user lists for the zeek and spicy projects.