### PR TITLE
Fix build for opentelemetry-go-contrib

### DIFF
--- a/projects/opentelemetry-go-contrib/build.sh
+++ b/projects/opentelemetry-go-contrib/build.sh
@@ -17,7 +17,7 @@
 
 cd $SRC/opentelemetry-go-contrib
 
-pushd config/v0.3.0
+pushd otelconf/v0.3.0
 go get github.com/AdamKorcz/go-118-fuzz-build/testing
 compile_native_go_fuzzer $(go list) FuzzJSON FuzzJSON
 compile_native_go_fuzzer $(go list) FuzzYAML FuzzYAML


### PR DESCRIPTION
Fix build errors https://oss-fuzz-build-logs.storage.googleapis.com/index.html#opentelemetry-go-contrib

Per https://github.com/open-telemetry/opentelemetry-go-contrib/pull/6796 which moved config directory to otelconf