### PR TITLE
Bump introspector webapp memory

### DIFF
--- a/infra/build/fuzz-introspector-webapp/cloudbuild.yaml
+++ b/infra/build/fuzz-introspector-webapp/cloudbuild.yaml
@@ -28,9 +28,9 @@ steps:
     - '--max-instances'
     - '100'
     - '--cpu'
-    - '4'
+    - '6'
     - '--memory'
-    - '16Gi'
+    - '24Gi'
 options:
   machineType: 'E2_HIGHCPU_32'
 timeout: 21600s  # 6 hours


### PR DESCRIPTION
Running into OOMs again.

24Gi also requires 6 CPUs instead of 4.