### PR TITLE
QuickJS: disable workers

### DIFF
--- a/projects/quickjs/build.sh
+++ b/projects/quickjs/build.sh
@@ -18,6 +18,7 @@
 # build quickjs
 # Makefile should not override CFLAGS
 sed -i -e 's/CFLAGS=/CFLAGS+=/' Makefile
+sed -i -e 's/#define USE_WORKER/\/\/#define USE_WORKER/' quickjs-libc.c
 CONFIG_CLANG=y make libquickjs.fuzz.a .obj/fuzz_common.o .obj/libregexp.fuzz.o .obj/cutils.fuzz.o .obj/libunicode.fuzz.o
 zip -r $OUT/fuzz_eval_seed_corpus.zip $SRC/quickjs-corpus/js/*.js
 zip -r $OUT/fuzz_compile_seed_corpus.zip $SRC/quickjs-corpus/js/*.js


### PR DESCRIPTION
Workers are not suitable for testing with libFuzzer due to their multi-file nature: each libFuzzer corpus item is independent and processed in isolation. As a result, it's not feasible to ensure that any referenced worker file is available or remains accessible during a fuzzing session.

Additionally, if the fuzz target references a nonexistent worker file and any handler is attached to it, it can cause the process to hang indefinitely.

This patch disables worker support during fuzzing to avoid such issues.