### PR TITLE
Don't check return result of LLVMFuzzerInitialize.

### DIFF
--- a/infra/base-images/base-builder/indexer/fuzzing_engine.cc
+++ b/infra/base-images/base-builder/indexer/fuzzing_engine.cc
@@ -80,12 +80,8 @@ int main(int argc, char* argv[]) {
   }
   close(fd);
 
-  int res = LLVMFuzzerInitialize(&argc, &argv);
-  if (res != 0) {
-    return res;
-  }
-
-  res = LLVMFuzzerTestOneInput(static_cast<uint8_t*>(mapping), size);
+  LLVMFuzzerInitialize(&argc, &argv);
+  int res = LLVMFuzzerTestOneInput(static_cast<uint8_t*>(mapping), size);
 
   munmap(mapping, size);
   return res;


### PR DESCRIPTION
This breaks projects like OpenSSL, which always return 1: https://github.com/openssl/openssl/blob/af5952d533b772ef8a3d7c666ed918acfc1dd911/fuzz/asn1.c#L302

libFuzzer doesn't do it either:
https://github.com/llvm/llvm-project/blob/f39696e7dee4f1dce8c10d2b17f987643c480895/compiler-rt/lib/fuzzer/FuzzerDriver.cpp#L651