### PR TITLE
Update gitoxide repo URL and auto_ccs list

### DIFF
--- a/projects/gitoxide/project.yaml
+++ b/projects/gitoxide/project.yaml
@@ -3,7 +3,7 @@ language: rust
 primary_contact: "byronimo@gmail.com"
 auto_ccs:
   - "nathaniel.brough@gmail.com"
-main_repo: "https://github.com/Byron/gitoxide"
+main_repo: "https://github.com/GitoxideLabs/gitoxide"
 file_github_issue: true
 sanitizers:
   - address

--- a/projects/gitoxide/project.yaml
+++ b/projects/gitoxide/project.yaml
@@ -3,6 +3,7 @@ language: rust
 primary_contact: "byronimo@gmail.com"
 auto_ccs:
   - "nathaniel.brough@gmail.com"
+  - "eliahkagan@gmail.com"
 main_repo: "https://github.com/GitoxideLabs/gitoxide"
 file_github_issue: true
 sanitizers:


### PR DESCRIPTION
Fixes #13282

This updates `project.yaml` for `gitoxide`:

- The project was moved into the `GitoxideLabs` organization a while ago. This updates the URL.
- As described in [#13282](https://github.com/google/oss-fuzz/issues/13282), it is intended that I be able to access reports, but I cannot yet do so. This adds me to `auto_ccs`.

See the commit messages for more information including how to confirm that each of the changes are accurate/authorized.

cc @Byron 