### PR TITLE
[surrealdb] Install Rust 1.82 to fix build with Option::is_none_or

### DIFF
--- a/projects/surrealdb/Dockerfile
+++ b/projects/surrealdb/Dockerfile
@@ -15,6 +15,8 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder-rust
+# Aligned with the MSRV used by SurrealDB
+RUN rustup toolchain install 1.82.0 --profile minimal -c rust-src && rustup default 1.82.0
 RUN git clone --depth 1 https://github.com/surrealdb/surrealdb surrealdb
 RUN git clone --depth 1 https://github.com/surrealdb/docs.surrealdb.com.git surrealdb_website
 WORKDIR surrealdb


### PR DESCRIPTION
SurrealDB and its dependency tree require stable Rust ≥ 1.82 (`Option::is_none_or` was stabilised in 1.82). 

Builds on the current base-builder image fails with:

    error[E0658]: use of unstable library feature 'is_none_or'

This change installs the 1.82.0 toolchain (minimal profile + rust-src) and sets it as the default.

https://issues.oss-fuzz.com/issues/398679984