### PR TITLE
Add OSS-Fuzz on Demand build steps to upload testcases

### DIFF
--- a/infra/build/functions/fuzzbench.py
+++ b/infra/build/functions/fuzzbench.py
@@ -129,16 +129,14 @@ def get_build_fuzzers_steps(fuzzing_engine, project, env):
                                     project), '--file', engine_dockerfile_path,
       os.path.join(FUZZBENCH_PATH, 'fuzzers')
   ]
-  engine_step = [
-      {
-          'name': 'gcr.io/cloud-builders/docker',
-          'args': build_args,
-          'volumes': [{
-              'name': 'fuzzbench_path',
-              'path': FUZZBENCH_PATH,
-          }],
-      },
-  ]
+  engine_step = {
+      'name': 'gcr.io/cloud-builders/docker',
+      'args': build_args,
+      'volumes': [{
+          'name': 'fuzzbench_path',
+          'path': FUZZBENCH_PATH,
+      }],
+  }
   steps.append(engine_step)
 
   compile_project_step = {
@@ -240,7 +238,7 @@ def get_build_ood_image_steps(fuzzing_engine, project, env_dict):
           'build', '--tag', ood_image, '--file', fuzzer_runtime_dockerfile_path,
           os.path.join(GCB_WORKSPACE_DIR + FUZZBENCH_PATH, 'fuzzers')
       ]
-  },
+  }
   steps.append(build_runtime_step)
 
   oss_fuzz_on_demand_dockerfile_path = f'{GCB_WORKSPACE_DIR}/oss-fuzz/infra/build/functions/ood.Dockerfile'

--- a/infra/build/functions/fuzzbench.py
+++ b/infra/build/functions/fuzzbench.py
@@ -331,7 +331,7 @@ def get_upload_testcase_steps(project, env_dict):
   steps = []
 
   access_token_file_path = f'{GCB_WORKSPACE_DIR}/at.txt'
-  upload_testcase_step = {
+  get_access_token_step = {
       'name':
           'google/cloud-sdk',
       'args': [
@@ -339,7 +339,7 @@ def get_upload_testcase_steps(project, env_dict):
           f'gcloud auth print-access-token > {access_token_file_path}'
       ]
   }
-  steps.append(upload_testcase_step)
+  steps.append(get_access_token_step)
 
   upload_testcase_script_path = f'{GCB_WORKSPACE_DIR}/oss-fuzz/infra/build/functions/ood_upload_testcase.py'
   job_name = f'libfuzzer_asan_{project.name}'

--- a/infra/build/functions/ood_upload_testcase.py
+++ b/infra/build/functions/ood_upload_testcase.py
@@ -51,7 +51,7 @@ def get_headers(access_token_path):
 def upload_testcase(upload_url, testcase_path, job, target, access_token_path):
   """Make an upload testcase request."""
   files = {
-      'file': open(testcase_path),
+      'file': open(testcase_path, 'rb'),
   }
   data = {
       'job': job,

--- a/infra/build/functions/ood_upload_testcase.py
+++ b/infra/build/functions/ood_upload_testcase.py
@@ -30,12 +30,7 @@ except ImportError:
   subprocess.check_call([sys.executable, "-m", "pip", "install", "requests"])
   import requests
 
-# Note: your @google.com account needs to be added to
-# https://team.git.corp.google.com/gosst/clusterfuzz-config/+/refs/heads/master/configs/internal/gae/auth.yaml#25
-# under "whitelisted_oauth_emails".
-
 POST_URL = 'https://oss-fuzz.com/upload-testcase/upload-oauth'
-# ACCESS_TOKEN: gcloud auth print-access-token
 
 
 def get_access_token(access_token_path):

--- a/infra/build/functions/ood_upload_testcase.py
+++ b/infra/build/functions/ood_upload_testcase.py
@@ -57,14 +57,15 @@ def upload_testcase(upload_url, testcase_path, job, target, access_token_path):
       'job': job,
       'target': target,
   }
-  resp = requests.post(upload_url,
+  try:
+    resp = requests.post(upload_url,
                        files=files,
                        data=data,
                        headers=get_headers(access_token_path))
-  if resp.status_code == 200:
+    resp.raise_for_status()
     result = json.loads(resp.text)
     print('Upload succeeded. Testcase ID is', result['id'])
-  else:
+  except:
     print('Failed to upload with status', resp.status_code)
     print(resp.text)
 

--- a/infra/build/functions/ood_upload_testcase.py
+++ b/infra/build/functions/ood_upload_testcase.py
@@ -24,11 +24,11 @@ import sys
 import subprocess
 
 try:
-    import requests
+  import requests
 except ImportError:
-    logging.info("requests library not found. Installing...")
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "requests"])
-    import requests
+  print("requests library not found. Installing...")
+  subprocess.check_call([sys.executable, "-m", "pip", "install", "requests"])
+  import requests
 
 # Note: your @google.com account needs to be added to
 # https://team.git.corp.google.com/gosst/clusterfuzz-config/+/refs/heads/master/configs/internal/gae/auth.yaml#25
@@ -37,11 +37,12 @@ except ImportError:
 POST_URL = 'https://oss-fuzz.com/upload-testcase/upload-oauth'
 # ACCESS_TOKEN: gcloud auth print-access-token
 
+
 def get_access_token(access_token_path):
   """Returns the ACCESS_TOKEN for upload testcase requests"""
   with open(access_token_path, 'r') as f:
-      line = f.readline()
-      return line.strip()
+    line = f.readline()
+    return line.strip()
 
 
 def get_headers(access_token_path):
@@ -61,7 +62,9 @@ def upload_testcase(upload_url, testcase_path, job, target, access_token_path):
       'job': job,
       'target': target,
   }
-  resp = requests.post(upload_url, files=files, data=data,
+  resp = requests.post(upload_url,
+                       files=files,
+                       data=data,
                        headers=get_headers(access_token_path))
   if resp.status_code == 200:
     result = json.loads(resp.text)

--- a/infra/build/functions/ood_upload_testcase.py
+++ b/infra/build/functions/ood_upload_testcase.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+#
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+"""Upload OSS-Fuzz on Demand testcases."""
+
+import json
+import logging
+import os
+import sys
+import subprocess
+
+try:
+    import requests
+except ImportError:
+    logging.info("requests library not found. Installing...")
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "requests"])
+    import requests
+
+# Note: your @google.com account needs to be added to
+# https://team.git.corp.google.com/gosst/clusterfuzz-config/+/refs/heads/master/configs/internal/gae/auth.yaml#25
+# under "whitelisted_oauth_emails".
+
+POST_URL = 'https://oss-fuzz.com/upload-testcase/upload-oauth'
+# ACCESS_TOKEN: gcloud auth print-access-token
+
+def get_access_token(access_token_path):
+  """Returns the ACCESS_TOKEN for upload testcase requests"""
+  with open(access_token_path, 'r') as f:
+      line = f.readline()
+      return line.strip()
+
+
+def get_headers(access_token_path):
+  """Returns the headers required to upload testcase requests"""
+  access_token = get_access_token(access_token_path)
+  return {
+      'Authorization': 'Bearer ' + access_token,
+  }
+
+
+def upload_testcase(upload_url, testcase_path, job, target, access_token_path):
+  """Make an upload testcase request."""
+  files = {
+      'file': open(testcase_path),
+  }
+  data = {
+      'job': job,
+      'target': target,
+  }
+  resp = requests.post(upload_url, files=files, data=data,
+                       headers=get_headers(access_token_path))
+  if resp.status_code == 200:
+    result = json.loads(resp.text)
+    print('Upload succeeded. Testcase ID is', result['id'])
+  else:
+    print('Failed to upload with status', resp.status_code)
+    print(resp.text)
+
+
+def get_file_path(dir_path):
+  """Returns the path of a file inside 'dir_path'. Returns None if there are no
+  files inside the the given directory."""
+  files = []
+  for entry in os.scandir(dir_path):
+    if entry.is_file():
+      return f'{dir_path}/{entry.name}'
+  return None
+
+
+def main():
+  """Upload an OSS-Fuzz on Demand testcase."""
+  testcase_dir_path = sys.argv[1]
+  job = sys.argv[2]
+  target = sys.argv[3]
+  access_token_path = sys.argv[4]
+  testcase_path = get_file_path(testcase_dir_path)
+
+  if not testcase_path:
+    print('OSS-Fuzz on Demand did not find any crashes.')
+  else:
+    upload_testcase(POST_URL, testcase_path, job, target, access_token_path)
+
+  return 0
+
+
+if __name__ == '__main__':
+  main()

--- a/infra/build/functions/ood_upload_testcase.py
+++ b/infra/build/functions/ood_upload_testcase.py
@@ -59,9 +59,9 @@ def upload_testcase(upload_url, testcase_path, job, target, access_token_path):
   }
   try:
     resp = requests.post(upload_url,
-                       files=files,
-                       data=data,
-                       headers=get_headers(access_token_path))
+                         files=files,
+                         data=data,
+                         headers=get_headers(access_token_path))
     resp.raise_for_status()
     result = json.loads(resp.text)
     print('Upload succeeded. Testcase ID is', result['id'])

--- a/infra/build/functions/ood_upload_testcase_test.py
+++ b/infra/build/functions/ood_upload_testcase_test.py
@@ -31,16 +31,13 @@ class GetFilePath(unittest.TestCase):
     """Set tem_dir attribute"""
     self.temp_dir = tempfile.mkdtemp()
 
-
   def tearDown(self):
     """Remove temp_dir after tests"""
     shutil.rmtree(self.temp_dir)
 
-
   def test_no_files(self):
     """Test for empty directory"""
     self.assertIsNone(ood_upload_testcase.get_file_path(self.temp_dir))
-
 
   def test_single_file(self):
     """Test for single file"""
@@ -48,8 +45,7 @@ class GetFilePath(unittest.TestCase):
     file_path = os.path.join(self.temp_dir, file_name)
     open(file_path, 'w').close()
     self.assertEqual(ood_upload_testcase.get_file_path(self.temp_dir),
-                    file_path)
-
+                     file_path)
 
   def test_multiple_files(self):
     """Test for multiple files"""
@@ -59,9 +55,7 @@ class GetFilePath(unittest.TestCase):
       file_path = os.path.join(self.temp_dir, name)
       file_paths.append(file_path)
       open(file_path, 'w').close()
-    self.assertIn(ood_upload_testcase.get_file_path(self.temp_dir),
-                file_paths)
-
+    self.assertIn(ood_upload_testcase.get_file_path(self.temp_dir), file_paths)
 
   def test_with_subdirectory(self):
     """Test for directory with subdirectory"""
@@ -72,4 +66,4 @@ class GetFilePath(unittest.TestCase):
     file_path = os.path.join(self.temp_dir, file_name)
     open(file_path, 'w').close()
     self.assertEqual(ood_upload_testcase.get_file_path(self.temp_dir),
-                    file_path)
+                     file_path)

--- a/infra/build/functions/ood_upload_testcase_test.py
+++ b/infra/build/functions/ood_upload_testcase_test.py
@@ -1,0 +1,75 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+"""Tests for ood_upload_testcase_test.py."""
+
+import os
+import shutil
+import tempfile
+import unittest
+from unittest import mock
+
+import ood_upload_testcase
+
+
+class GetFilePath(unittest.TestCase):
+  """Tests for get_file_path."""
+
+  def setUp(self):
+    """Set tem_dir attribute"""
+    self.temp_dir = tempfile.mkdtemp()
+
+
+  def tearDown(self):
+    """Remove temp_dir after tests"""
+    shutil.rmtree(self.temp_dir)
+
+
+  def test_no_files(self):
+    """Test for empty directory"""
+    self.assertIsNone(ood_upload_testcase.get_file_path(self.temp_dir))
+
+
+  def test_single_file(self):
+    """Test for single file"""
+    file_name = "test_file.txt"
+    file_path = os.path.join(self.temp_dir, file_name)
+    open(file_path, 'w').close()
+    self.assertEqual(ood_upload_testcase.get_file_path(self.temp_dir),
+                    file_path)
+
+
+  def test_multiple_files(self):
+    """Test for multiple files"""
+    file_names = ["file1.txt", "file2.csv", "data.json"]
+    file_paths = []
+    for name in file_names:
+      file_path = os.path.join(self.temp_dir, name)
+      file_paths.append(file_path)
+      open(file_path, 'w').close()
+    self.assertIn(ood_upload_testcase.get_file_path(self.temp_dir),
+                file_paths)
+
+
+  def test_with_subdirectory(self):
+    """Test for directory with subdirectory"""
+    os.makedirs(os.path.join(self.temp_dir, "subdir"))
+    self.assertIsNone(ood_upload_testcase.get_file_path(self.temp_dir))
+
+    file_name = "test_file.txt"
+    file_path = os.path.join(self.temp_dir, file_name)
+    open(file_path, 'w').close()
+    self.assertEqual(ood_upload_testcase.get_file_path(self.temp_dir),
+                    file_path)

--- a/infra/build/functions/ood_upload_testcase_test.py
+++ b/infra/build/functions/ood_upload_testcase_test.py
@@ -41,7 +41,7 @@ class GetFilePath(unittest.TestCase):
 
   def test_single_file(self):
     """Test for single file"""
-    file_name = "test_file.txt"
+    file_name = 'test_file.txt'
     file_path = os.path.join(self.temp_dir, file_name)
     open(file_path, 'w').close()
     self.assertEqual(ood_upload_testcase.get_file_path(self.temp_dir),
@@ -49,7 +49,7 @@ class GetFilePath(unittest.TestCase):
 
   def test_multiple_files(self):
     """Test for multiple files"""
-    file_names = ["file1.txt", "file2.csv", "data.json"]
+    file_names = ['file1.txt', 'file2.csv', 'data.json']
     file_paths = []
     for name in file_names:
       file_path = os.path.join(self.temp_dir, name)
@@ -59,10 +59,10 @@ class GetFilePath(unittest.TestCase):
 
   def test_with_subdirectory(self):
     """Test for directory with subdirectory"""
-    os.makedirs(os.path.join(self.temp_dir, "subdir"))
+    os.makedirs(os.path.join(self.temp_dir, 'subdir'))
     self.assertIsNone(ood_upload_testcase.get_file_path(self.temp_dir))
 
-    file_name = "test_file.txt"
+    file_name = 'test_file.txt'
     file_path = os.path.join(self.temp_dir, file_name)
     open(file_path, 'w').close()
     self.assertEqual(ood_upload_testcase.get_file_path(self.temp_dir),


### PR DESCRIPTION
Add build steps to generate an access token and use it to upload a testcase if OSS-Fuzz on Demand found crashes.

- Add `ood_upload_testcase.py` script to which upload a testcase on ClusterFuzz External upload testcase endpoint.
- Add a build step to generate the access token using `gcloud auth print-access-token`.
- Add a build step to run  `ood_upload_testcase.py`  in Google Cloud Build.

Related to b/401215144 .