### PR TITLE
base-builder: introspector: disable dead code optimizations

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -82,7 +82,7 @@ ENV SANITIZER_FLAGS_memory "-fsanitize=memory -fsanitize-memory-track-origins"
 
 ENV SANITIZER_FLAGS_thread "-fsanitize=thread"
 
-ENV SANITIZER_FLAGS_introspector "-O0 -flto -fno-inline-functions -fuse-ld=gold -Wno-unused-command-line-argument"
+ENV SANITIZER_FLAGS_introspector "-O0 -flto -fno-inline-functions -fuse-ld=gold -Wno-unused-command-line-argument -Wl,--mllvm,-compute-dead=false -disable-globaldce"
 
 # Do not use any sanitizers in the coverage build.
 ENV SANITIZER_FLAGS_coverage ""


### PR DESCRIPTION
Despite -O0 these optimizations still happen. This is particularly important for OFG runs where we run on new projects as they will be based on an empty fuzzing harness, meaning a lot of the code is potentially affected. Less so on existing projects where the optimizations are less impactful.