### PR TITLE
More indexer fixes:

### DIFF
--- a/infra/base-images/base-builder/indexer/clang_wrapper.py
+++ b/infra/base-images/base-builder/indexer/clang_wrapper.py
@@ -232,7 +232,12 @@ def read_cdb_fragments(cdb_path: str) -> Any:
       print(f"Invalid compile commands file {file}: {data}\nDONEMARKER")
       time.sleep(10)
     else:
-      assert False, f"Invalid compile commands file {file}: {data}\nDONEMARKER"
+      # Some build systems seem to have a weird issue where the autotools
+      # generated `test.c` for testing compilers doesn't result in valid cdb
+      # fragments.
+      if 'test.c' not in file:
+        raise RuntimeError(
+            f"Invalid compile commands file {file}: {data}\nDONEMARKER")
 
   contents = ",\n".join(contents)
   contents = "[" + contents + "]"

--- a/infra/base-images/base-builder/indexer/index_build.py
+++ b/infra/base-images/base-builder/indexer/index_build.py
@@ -528,20 +528,23 @@ def archive_target(
   set_rpath_to_ossfuzzlib(target_path)
   archive_path = SNAPSHOT_DIR / f"{uuid}.tar"
 
-  save_build(
-      Manifest(
-          name=name,
-          uuid=uuid,
-          binary_name=target.name,
-          binary_args=target.binary_args,
-          version=ARCHIVE_VERSION,
-          is_oss_fuzz=False,
-      ),
-      source_dir=str(SRC),
-      build_dir=str(OUT),
-      index_dir=str(index_dir),
-      archive_path=archive_path,
-  )
+  # TODO: re-enable SRC copying (with some filtering to only include source
+  # files.)
+  with tempfile.TemporaryDirectory() as empty_src_dir:
+    save_build(
+        Manifest(
+            name=name,
+            uuid=uuid,
+            binary_name=target.name,
+            binary_args=target.binary_args,
+            version=ARCHIVE_VERSION,
+            is_oss_fuzz=False,
+        ),
+        source_dir=Path(empty_src_dir),
+        build_dir=OUT,
+        index_dir=index_dir,
+        archive_path=archive_path,
+    )
 
   logging.info("Wrote archive to: %s", archive_path)
   # TODO: this will break projects that re-use libs and have multiple targets.


### PR DESCRIPTION
- Don't copy $SRC -- it's not actually necessary today.
- Handle a weird case of autotools doing a compile that results in a bad cdb.