### PR TITLE
Fix poppler build.

### DIFF
--- a/projects/poppler/Dockerfile
+++ b/projects/poppler/Dockerfile
@@ -22,7 +22,11 @@ RUN git clone --depth 1 https://github.com/madler/zlib.git
 RUN git clone --depth 1 https://gitlab.freedesktop.org/freetype/freetype.git
 RUN git clone --depth 1 https://github.com/mm2/Little-CMS.git
 RUN git clone --depth 1 https://github.com/uclouvain/openjpeg
-RUN git clone --depth 1 https://github.com/glennrp/libpng.git
+# Pin libpng to avoid a build failure:
+# configure: pkgconfig directory is ${libdir}/pkgconfig
+# ./configure: line 10024: syntax error near unexpected token `)'
+# ./configure: line 10024: `            riscv*)'
+RUN git clone https://github.com/glennrp/libpng.git && cd libpng && git checkout b4800bae3379f1abf82359703c28e727b5df4135
 RUN git clone --depth 1 https://gitlab.freedesktop.org/fontconfig/fontconfig.git
 RUN git clone --depth 1 https://gitlab.freedesktop.org/cairo/cairo.git
 RUN git clone --depth 1 --branch=5.15 git://code.qt.io/qt/qtbase.git

--- a/projects/poppler/build.sh
+++ b/projects/poppler/build.sh
@@ -27,6 +27,13 @@ rm -rf $WORK/*
 rm -rf $BUILD
 mkdir -p $BUILD
 
+# Temporarily Add -D_GNU_SOURCE to CFLAGS to fix freetype's dependence on GNU
+# extensions for dlsym to dynamically load harfbuzz. This feature
+# should potentially be disabled instead of fixing the compilation. But that is
+# not possible to do from the OSS-Fuzz repo :-)
+# See https://github.com/google/oss-fuzz/pull/13325 for more details.
+export CFLAGS="$CFLAGS -D_GNU_SOURCE"
+
 # Install Boost headers
 cd $SRC/
 tar jxf boost_1_87_0.tar.bz2


### PR DESCRIPTION
- Fix same issue as https://github.com/google/oss-fuzz/pull/13325.
- Pin libpng to avoid a build failure.