### PR TITLE
indexer: Fix .so copying

### DIFF
--- a/infra/base-images/base-builder/indexer/index_build.py
+++ b/infra/base-images/base-builder/indexer/index_build.py
@@ -126,7 +126,9 @@ def save_build(
             if only_include_target and _is_elf(file):
               # Skip ELF files that aren't the relevant target (unless it's a
               # shared library).
-              if file.name != only_include_target and file.suffix != '.so':
+              if (file.name != only_include_target and
+                  '.so' not in file.name and
+                  not file.absolute().is_relative_to(Path(OUT) / 'lib')):
                 continue
 
             tar.add(


### PR DESCRIPTION
We didn't properly account for variations of .so extensions (e.g. .so.1, .so.2).

Split from https://github.com/google/oss-fuzz/pull/13342.