### PR TITLE
Add command in the OSS-Fuzz on Demand compile build step to cp project.yaml to benchmark.yaml

### DIFF
--- a/infra/build/functions/fuzzbench.py
+++ b/infra/build/functions/fuzzbench.py
@@ -163,25 +163,28 @@ def get_build_fuzzers_steps(fuzzing_engine, project, env):
   }
   steps.append(engine_step)
 
+  project_yaml_path =  f'{GCB_WORKSPACE_DIR}/oss-fuzz/projects/{project.name}/project.yaml'
+  benchmark_yaml_path = '/benchmark.yaml'
   compile_project_step = {
-      'name':
-          get_engine_project_image_name(fuzzing_engine, project),
-      'env':
-          env,
-      'volumes': [{
-          'name': 'fuzzbench_path',
-          'path': FUZZBENCH_PATH,
-      }],
-      'args': [
-          'bash',
-          '-c',
-          # Remove /out to make sure there are non instrumented binaries.
-          # `cd /src && cd {workdir}` (where {workdir} is parsed from the
-          # Dockerfile). Container Builder overrides our workdir so we need
-          # to add this step to set it back.
-          (f'rm -r /out && cd /src && cd {project.workdir} && '
-           'mkdir -p $$OUT && compile'),
-      ],
+     'name':
+         get_engine_project_image_name(fuzzing_engine, project),
+     'env':
+         env,
+     'volumes': [{
+         'name': 'fuzzbench_path',
+         'path': FUZZBENCH_PATH,
+     }],
+     'args': [
+         'bash',
+         '-c',
+         # Remove /out to make sure there are non instrumented binaries.
+         # `cd /src && cd {workdir}` (where {workdir} is parsed from the
+         # Dockerfile). Container Builder overrides our workdir so we need
+         # to add this step to set it back.
+         (f'cp {project_yaml_path} {benchmark_yaml_path} && '
+          f'rm -r /out && cd /src && cd {project.workdir} && '
+          'mkdir -p $$OUT && compile'),
+     ],
   }
   steps.append(compile_project_step)
 


### PR DESCRIPTION
The `project.yaml` file in the OSS-Fuzz repository is analogous to `benchmark.yaml` in the FuzzBench repository. As OSS-Fuzz on Demand executes FuzzBench runs using OSS-Fuzz projects, I copied `project.yaml` to the file path where a FuzzBench run expects it to be. Some fuzzing engines might need this (e.g., the "patis" fuzzing engine).

- Add a command in the OSS-Fuzz on Demand compile build step to copy `project.yaml` to `benchmark.yaml`.

Related to b/401215144 .