### PR TITLE
Update index_build.py

### DIFF
--- a/infra/base-images/base-builder/Dockerfile
+++ b/infra/base-images/base-builder/Dockerfile
@@ -219,9 +219,7 @@ RUN cd /tmp && git clone https://github.com/NixOS/patchelf && \
     rm -rf /tmp/patchelf && apt-get remove -y autoconf
 
 COPY indexer /opt/indexer
-ADD https://clusterfuzz-builds.storage.googleapis.com/oss-fuzz-artifacts/indexer /opt/indexer/indexer
+ADD https://clusterfuzz-builds.storage.googleapis.com/oss-fuzz-artifacts/indexer-59fad4ca5b1047c6afa2f60d754bd6ae1fa08c34 /opt/indexer/indexer
 RUN chmod a+x /opt/indexer/indexer /opt/indexer/index_build.py
-RUN cp /opt/indexer/clang_wrapper.py /opt/indexer/clang
-RUN cp /opt/indexer/clang_wrapper.py /opt/indexer/clang++
 
 CMD ["compile"]

--- a/infra/base-images/base-builder/indexer/README.md
+++ b/infra/base-images/base-builder/indexer/README.md
@@ -29,9 +29,7 @@ export OSS_FUZZ_CHECKOUT=<path to your oss-fuzz checkout>
 cd $OSS_FUZZ_CHECKOUT/infra/base-images/base-builder/indexer
 
 # One time setup steps
-ln -s clang_wrapper.py clang
-ln -s clang_wrapper.py clang++
-curl -O https://clusterfuzz-builds.storage.googleapis.com/oss-fuzz-artifacts/indexer
+curl -o indexer https://clusterfuzz-builds.storage.googleapis.com/oss-fuzz-artifacts/indexer-59fad4ca5b1047c6afa2f60d754bd6ae1fa08c34
 chmod +x indexer
 
 cd $OSS_FUZZ_CHECKOUT

--- a/infra/base-images/base-builder/indexer/clang
+++ b/infra/base-images/base-builder/indexer/clang
@@ -1,0 +1,1 @@
+clang_wrapper.py

--- a/infra/base-images/base-builder/indexer/clang++
+++ b/infra/base-images/base-builder/indexer/clang++
@@ -1,0 +1,1 @@
+clang_wrapper.py


### PR DESCRIPTION
- Update indexer binary.
- Remove index src copying and rely on indexer binary to do this instead.
- Remove gline-tables-only in clang wrapper since it messes up debugging symbols.
- Ignore CDB fragments that don't output a file.

Also create clang/clang++ symlinks in the indexer dir to make it easier to do development.