### PR TITLE
helper: Add additional index arguments.

### DIFF
--- a/infra/base-images/base-builder/indexer/README.md
+++ b/infra/base-images/base-builder/indexer/README.md
@@ -12,8 +12,18 @@ Snapshots are also built by our infrastructure and available at
 ```bash
 python infra/helper.py build_image <project>
 python infra/helper.py index <project>
+
 # Only build snapshots for `target1` and `target2`.
 python infra/helper.py index --targets 'target1,target2' <project>
+
+# Drop into /bin/bash instead of automatically running /opt/indexer/index_build.py.
+python infra/helper.py index --shell <project>
+
+# Add additional docker args.
+python infra/helper.py index --docker_args="-e FOO=123 -e BAR=456" <project>
+
+# Pass through flags to the entrypoint.
+python infra/helper.py index <project> -- --target-args '123'
 ```
 
 The resulting snapshots will be found in `<oss-fuzz checkout>/build/out/<project>`.

--- a/infra/base-images/base-builder/indexer/README.md
+++ b/infra/base-images/base-builder/indexer/README.md
@@ -20,7 +20,7 @@ python infra/helper.py index --targets 'target1,target2' <project>
 python infra/helper.py index --shell <project>
 
 # Add additional docker args.
-python infra/helper.py index --docker_args="-e FOO=123 -e BAR=456" <project>
+python infra/helper.py index --docker_arg="-eFOO=123" --docker_arg="-eBAR=456" <project>
 
 # Pass through flags to the entrypoint.
 python infra/helper.py index <project> -- --target-args '123'

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -372,8 +372,11 @@ def get_parser():  # pylint: disable=too-many-statements,too-many-locals
   index_parser.add_argument('--shell',
                             action='store_true',
                             help='Run /bin/bash instead of the indexer.')
-  index_parser.add_argument('--docker_args',
-                            help='Additional docker arguments.')
+  index_parser.add_argument('--docker_arg',
+                            help='Additional docker argument to pass through '
+                            '(can be specified multiple times).',
+                            nargs='*',
+                            action='extend')
   index_parser.add_argument('project', help='Project')
   index_parser.add_argument(
       'extra_args',
@@ -1719,8 +1722,8 @@ def index(args):
       '-t',
   ])
 
-  if args.docker_args:
-    run_args.extend(shlex.split(args.docker_args))
+  if args.docker_arg:
+    run_args.extend(args.docker_arg)
 
   run_args.append(image_name)
   if args.shell:
@@ -1731,8 +1734,7 @@ def index(args):
   if args.targets:
     run_args.extend(['--targets', args.targets])
 
-  if args.extra_args:
-    run_args.extend(args.extra_args)
+  run_args.extend(args.extra_args)
 
   logger.info(f'Running indexer for project: {args.project.name}')
   result = docker_run(run_args, architecture=args.architecture)

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -369,7 +369,16 @@ def get_parser():  # pylint: disable=too-many-statements,too-many-locals
   index_parser = subparsers.add_parser('index', help='Index project.')
   index_parser.add_argument(
       '--targets', help='Allowlist of targets to index (comma-separated).')
+  index_parser.add_argument('--shell',
+                            action='store_true',
+                            help='Run /bin/bash instead of the indexer.')
+  index_parser.add_argument('--docker_args',
+                            help='Additional docker arguments.')
   index_parser.add_argument('project', help='Project')
+  index_parser.add_argument(
+      'extra_args',
+      nargs='*',
+      help='Additional args to pass through to the Docker entrypoint.')
   _add_architecture_args(index_parser)
   _add_environment_args(index_parser)
 
@@ -1703,12 +1712,27 @@ def index(args):
 
   run_args = _env_to_docker_args(env)
   run_args.extend([
-      '-v', f'{args.project.out}:/out', '-v', f'{args.project.work}:/work',
-      '-t', image_name, '/opt/indexer/index_build.py'
+      '-v',
+      f'{args.project.out}:/out',
+      '-v',
+      f'{args.project.work}:/work',
+      '-t',
   ])
+
+  if args.docker_args:
+    run_args.extend(shlex.split(args.docker_args))
+
+  run_args.append(image_name)
+  if args.shell:
+    run_args.append('/bin/bash')
+  else:
+    run_args.append('/opt/indexer/index_build.py')
 
   if args.targets:
     run_args.extend(['--targets', args.targets])
+
+  if args.extra_args:
+    run_args.extend(args.extra_args)
 
   logger.info(f'Running indexer for project: {args.project.name}')
   result = docker_run(run_args, architecture=args.architecture)


### PR DESCRIPTION
- Add a passthrough for arguments to `index_build.py`.
- Add a `--docker_args` argument to add pass through args to docker.
- Add `--shell` to drop into a shell instead of running the indexer automatically.