### PR TITLE
varnish: now needs recursive clone

### DIFF
--- a/projects/varnish/Dockerfile
+++ b/projects/varnish/Dockerfile
@@ -16,6 +16,6 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt install -y automake autoconf libtool pkg-config python3-docutils python3-sphinx libedit-dev libpcre2-dev libncurses-dev
-RUN git clone --depth 1 https://github.com/varnishcache/varnish-cache
+RUN git clone --depth 1 --recursive https://github.com/varnishcache/varnish-cache
 COPY build.sh $SRC
 WORKDIR $SRC/varnish-cache


### PR DESCRIPTION
varnish-cache is now using vtest as a submodule and hence needs a recursive clone. Ref: https://github.com/varnishcache/varnish-cache/pull/4333