### PR TITLE
Make indexer local dev easier.

### DIFF
--- a/infra/base-images/base-builder/indexer/README.md
+++ b/infra/base-images/base-builder/indexer/README.md
@@ -31,20 +31,15 @@ The resulting snapshots will be found in `<oss-fuzz checkout>/build/out/<project
 ## Development
 
 For faster local development on the scripts in this directory, we can mount in
-these scripts to overwrite the previous versions.
+everything inside this directory to overwrite the scripts in the base image by
+passing `--dev` to the index command.
+
+If the `indexer` binary does not exist, a prebuilt binary is
+[downloaded](https://clusterfuzz-builds.storage.googleapis.com/oss-fuzz-artifacts/indexer).
 
 ```
-export PROJECT_NAME=<project>
-export OSS_FUZZ_CHECKOUT=<path to your oss-fuzz checkout>
-cd $OSS_FUZZ_CHECKOUT/infra/base-images/base-builder/indexer
-
-# One time setup step to get a copy of the indexer binary.
-curl -o indexer https://clusterfuzz-builds.storage.googleapis.com/oss-fuzz-artifacts/indexer-59fad4ca5b1047c6afa2f60d754bd6ae1fa08c34
-chmod +x indexer
-
 cd $OSS_FUZZ_CHECKOUT
-python infra/helper.py index $PROJECT_NAME \
-    --docker_arg="--volume=$OSS_FUZZ_CHECKOUT/infra/base-images/base-builder/indexer:/opt/indexer"
+python infra/helper.py index --dev <PROJECT_NAME>
 ```
 
 The resulting snapshots will be found in `<oss-fuzz checkout>/build/out/<project>`.
@@ -52,6 +47,9 @@ The resulting snapshots will be found in `<oss-fuzz checkout>/build/out/<project
 ## Testing
 
 We have some basic tests to make sure the snapshots we're generating have the correct format.
+
+For this to work, you need to run `python infra/helper.py index --dev <PROJECT_NAME>` at least
+once, or make sure you have the `indexer` binary in this directory.
 
 ```
 sudo INDEX_BUILD_TESTS=1 python3 -m unittest index_build_test

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -30,6 +30,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import urllib.request
 
 import constants
 import templates
@@ -95,6 +96,9 @@ CLUSTERFUZZLITE_ENGINE = 'libfuzzer'
 CLUSTERFUZZLITE_ARCHITECTURE = 'x86_64'
 CLUSTERFUZZLITE_FILESTORE_DIR = 'filestore'
 CLUSTERFUZZLITE_DOCKER_IMAGE = 'gcr.io/oss-fuzz-base/cifuzz-run-fuzzers'
+
+INDEXER_PREBUILT_URL = ('https://clusterfuzz-builds.storage.googleapis.com/'
+                        'oss-fuzz-artifacts/indexer')
 
 logger = logging.getLogger(__name__)
 
@@ -369,6 +373,10 @@ def get_parser():  # pylint: disable=too-many-statements,too-many-locals
   index_parser = subparsers.add_parser('index', help='Index project.')
   index_parser.add_argument(
       '--targets', help='Allowlist of targets to index (comma-separated).')
+  index_parser.add_argument('--dev',
+                            action='store_true',
+                            help=('Use development versions of scripts and '
+                                  'indexer.'))
   index_parser.add_argument('--shell',
                             action='store_true',
                             help='Run /bin/bash instead of the indexer.')
@@ -1724,6 +1732,19 @@ def index(args):
 
   if args.docker_arg:
     run_args.extend(args.docker_arg)
+
+  if args.dev:
+    indexer_dir = os.path.join(OSS_FUZZ_DIR,
+                               'infra/base-images/base-builder/indexer')
+    indexer_binary_path = os.path.join(indexer_dir, 'indexer')
+    if not os.path.exists(indexer_binary_path):
+      print('Indexer binary does not exist, pulling prebuilt.')
+      with urllib.request.urlopen(INDEXER_PREBUILT_URL) as resp, \
+          open(indexer_binary_path, 'wb') as f:
+        shutil.copyfileobj(resp, f)
+        os.chmod(indexer_binary_path, 0o755)
+
+    run_args.extend(['-v', f'{indexer_dir}:/opt/indexer'])
 
   run_args.append(image_name)
   if args.shell:


### PR DESCRIPTION
Add a `--dev` flag which:
1. Mounts in the right directories.
2. Downloads the indexer binary if required.