### PR TITLE
tarantool: disable unsigned-integer-overflow

### DIFF
--- a/projects/tarantool/build.sh
+++ b/projects/tarantool/build.sh
@@ -62,11 +62,11 @@ cmake_args=(
 
     # C compiler
     -DCMAKE_C_COMPILER="${CC}"
-    -DCMAKE_C_FLAGS="${CFLAGS} -Wno-error=unused-command-line-argument"
+    -DCMAKE_C_FLAGS="${CFLAGS} -Wno-error=unused-command-line-argument -fno-sanitize=unsigned-integer-overflow"
 
     # C++ compiler
     -DCMAKE_CXX_COMPILER="${CXX}"
-    -DCMAKE_CXX_FLAGS="${CXXFLAGS} -Wno-error=unused-command-line-argument"
+    -DCMAKE_CXX_FLAGS="${CXXFLAGS} -Wno-error=unused-command-line-argument -fno-sanitize=unsigned-integer-overflow"
 
     # Linker
     -DCMAKE_LINKER="${LD}"


### PR DESCRIPTION
An input data for fuzzing tests can contain a LuaJIT cdata objects (1LL, 1ULL, etc) that triggers arithmetic operations in LuaJIT, UBSan handlers use FPR registers, and are called in the functions of purely GPR registers. This is fraught with inconsistence on LuaJIT traces and can lead to false positives crashes.

Important detail: these crashes cannot be reproduced without OSS Fuzz environment in Docker containers.

Examples of false positive reports:

- https://issues.oss-fuzz.com/issues/420248727
- https://issues.oss-fuzz.com/issues/393404275

Investigated by Sergey Kaplun (@Buristan).