### PR TITLE
[clamav] Fix build when newer Rust version required

### DIFF
--- a/projects/clamav/Dockerfile
+++ b/projects/clamav/Dockerfile
@@ -20,7 +20,12 @@ RUN apt-get update && apt-get install -y \
     python3-dev \
     pkg-config
 
-RUN rustup update
+#
+# We need the latest toolchain to reliably build clamav.
+# oss-fuzz requires nightly for the -Z option, so we use that as well.
+#
+RUN rustup update nightly
+ENV RUSTUP_TOOLCHAIN=nightly-x86_64-unknown-linux-gnu
 
 #
 # Build static libs for dependencies


### PR DESCRIPTION
The oss-fuzz base-builder-rust image uses a specific version of Rust that is updated occasionally. During feature development, sometimes the ClamAV project requires a newer version of Rust.

This commit:
- Updates to the latest nightly toolchain.
- Changes the RUSTUP_TOOLCHAIN environment variable from the specific- version to the updated version.