### PR TITLE
[goipp] Initial integration

### DIFF
--- a/projects/goipp/Dockerfile
+++ b/projects/goipp/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+
+RUN git clone --depth 1 https://github.com/OpenPrinting/goipp.git $SRC/goipp
+RUN git clone --depth 1 https://github.com/OpenPrinting/fuzzing.git $SRC/fuzzing
+
+COPY build.sh $SRC/
+WORKDIR $SRC/goipp

--- a/projects/goipp/build.sh
+++ b/projects/goipp/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+chmod +x $SRC/fuzzing/projects/goipp/oss_fuzz_build.sh
+$SRC/fuzzing/projects/goipp/oss_fuzz_build.sh

--- a/projects/goipp/project.yaml
+++ b/projects/goipp/project.yaml
@@ -1,0 +1,13 @@
+homepage: "https://github.com/OpenPrinting/goipp"
+main_repo: "https://github.com/OpenPrinting/goipp"
+primary_contact: "mdimad005@gmail.com"
+auto_ccs:
+  - "till.kamppeter@gmail.com"
+  - "ossfuzz@iosifache.me"
+  - "jiongchiyu@gmail.com"
+  - "pzz@apevzner.com"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
This PR adds initial integration for the [goipp](https://github.com/OpenPrinting/goipp) project - a Go implementation of the Internet Printing Protocol (IPP) core.

All fuzz harnesses are maintained externally in the [OpenPrinting/fuzzing](https://github.com/OpenPrinting/fuzzing) repository.

CC: @tillkamppeter @iosifache @fish98 