### PR TITLE
rust-coreutils: make bug reports public

### DIFF
--- a/projects/rust-coreutils/project.yaml
+++ b/projects/rust-coreutils/project.yaml
@@ -10,3 +10,6 @@ file_github_issue: True
 vendor_ccs:
   - "sylvestre.ledru@gmail.com"
   - "dhofstet@gmail.com"
+# Bug reports are public by default:
+view_restrictions: none
+main_repo: 'https://github.com/uutils/coreutils'


### PR DESCRIPTION
Heavily inspired by projects/serenity/project.yaml

@sylvestre, I believe you are on-board with this, did I understand that correctly?