### PR TITLE
Fix typo on email from auto_ccs in libhtp

### DIFF
--- a/projects/libhtp/project.yaml
+++ b/projects/libhtp/project.yaml
@@ -3,7 +3,7 @@ language: rust
 primary_contact: "vjulien@openinfosecfoundation.org"
 auto_ccs :
 - "p.antoine@catenacyber.fr"
-- "jish@openinfosecfoundation.org "
+- "jish@openinfosecfoundation.org"
 - "todd.mortimer@gmail.com"
 
 sanitizers:


### PR DESCRIPTION
This extra space is causing build status to fail