### PR TITLE
golang: limit size of decoded tiffs

### DIFF
--- a/projects/golang/tiff_fuzzer.go
+++ b/projects/golang/tiff_fuzzer.go
@@ -26,6 +26,10 @@ func FuzzTiffDecode(data []byte) int {
 		}
 		runtime.GC()
 	}()
+	config, err := DecodeConfig(bytes.NewReader(data))
+	if err != nil || config.Width > 16384 || config.Height > 16384 {
+		return 1
+	}
 	_, _ = Decode(bytes.NewReader(data))
 	return 1
 }


### PR DESCRIPTION
A small tiff can decode into a large image.

Users who want to limit memory consumption need to validate images prior to decompression.

Skip decompressing tiffs larger than 16k in either dimension.