### PR TITLE
Set INDEXER_BUILD for infra/helper.py index.

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -1717,6 +1717,7 @@ def index(args):
       f'ARCHITECTURE={args.architecture}',
       'HELPER=True',
       f'PROJECT_NAME={args.project.name}',
+      'INDEXER_BUILD=1',
   ]
   if args.e:
     env.extend(args.e)


### PR DESCRIPTION
This is required for e.g. openssl which keys on this env var for certain things (e.g. deleting source directory after building).