### PR TITLE
js-yaml: fix driver

### DIFF
--- a/projects/js-yaml/fuzz.js
+++ b/projects/js-yaml/fuzz.js
@@ -27,7 +27,10 @@ module.exports.fuzz = function(data) {
   try {
     const parsedYaml = yaml.load(yamlString, loadOptions);
     const _serializedYaml = yaml.dump(parsedYaml, dumpOptions);
-  } catch (YAMLException) {
+  } catch (e) {
+    if (!(e instanceof YAMLException)) {
+      throw e
+    }
   }
 };
 

--- a/projects/js-yaml/fuzz.js
+++ b/projects/js-yaml/fuzz.js
@@ -56,19 +56,10 @@ function generateRandomDumpOptions(provider) {
 
 
 function getSchema(number) {
-
   switch (number) {
-    case 0:
-      options.schema = "DEFAULT_SCHEMA";
-      break
-    case 1:
-      options.schema = "FAILSAFE_SCHEMA";
-      break
-    case 2:
-      options.schema = "JSON_SCHEMA";
-      break
-    case 3:
-      options.schema = "CORE_SCHEMA";
-      break
+    case 0: return yaml.DEFAULT_SCHEMA
+    case 1: return yaml.FAILSAFE_SCHEMA
+    case 2: return yaml.JSON_SCHEMA
+    case 3: return yaml.CORE_SCHEMA
   }
 }

--- a/projects/js-yaml/fuzz.js
+++ b/projects/js-yaml/fuzz.js
@@ -28,7 +28,7 @@ module.exports.fuzz = function(data) {
     const parsedYaml = yaml.load(yamlString, loadOptions);
     const _serializedYaml = yaml.dump(parsedYaml, dumpOptions);
   } catch (e) {
-    if (!(e instanceof YAMLException)) {
+    if (!(e instanceof yaml.YAMLException)) {
       throw e
     }
   }


### PR DESCRIPTION
There were three issues with the fuzz driver for js-yaml:
1. With `catch (YAMLException)` I believe the intent was to ignore instances of `YAMLException` only. However, catch statements like these would ignore _all_ exceptions in JavaScript. Added an explicit `instanceof` check.
2. `getSchema` does not have the intended `options` object in scope. Instead, it sets `schema` on the _global_ options object that Jazzer.js [defines](https://github.com/CodeIntelligenceTesting/jazzer.js/blob/592be5c6d7f453e96822be41fe3f2a1351b8fd96/packages/core/core.ts#L129). Return a schema from `getSchema` instead.
3. Schemas are supposed to be instances of the `Schema` class, not strings. Replace string values with the constants this library [exports](https://github.com/nodeca/js-yaml/blob/0d3ca7a27b03a6c974790a30a89e456007d62976/index.js#L21).