### PR TITLE
golang: increase timeout for webp decoding target

### DIFF
--- a/projects/golang/fuzz_webp_decode.options
+++ b/projects/golang/fuzz_webp_decode.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+timeout = 120


### PR DESCRIPTION
We see a not insignificant number of timeout issues when running the fuzz_webp_decode target, which appear to magically resolve themselves despite the underlying code not changing.

I expect that running the target under ASAN, with limited resources, is just a little slow.

Bump the timeout from the default (60s) to 120s. I expect this will just silence the timeouts.