### PR TITLE
Add a `replay_build.sh` for ffmpeg.

### DIFF
--- a/projects/ffmpeg/Dockerfile
+++ b/projects/ffmpeg/Dockerfile
@@ -41,4 +41,4 @@ RUN git clone --depth 1 https://gitlab.xiph.org/xiph/theora.git
 RUN git clone --depth 1 https://gitlab.xiph.org/xiph/vorbis.git
 RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/libxml2.git
 
-COPY build.sh group_seed_corpus.py $SRC/
+COPY build.sh replay_build.sh group_seed_corpus.py $SRC/

--- a/projects/ffmpeg/build.sh
+++ b/projects/ffmpeg/build.sh
@@ -218,9 +218,14 @@ fi
         --disable-shared \
         --disable-doc \
         --disable-programs \
+        --enable-demuxers \
         $FFMPEG_BUILD_ARGS
 make clean
 make -j$(nproc) install
+
+if [[ -n ${CAPTURE_REPLAY_SCRIPT-} ]]; then
+  exit 0
+fi
 
 # Download test samples, will be used as seed corpus.
 # DISABLED.
@@ -314,40 +319,6 @@ zip -r $OUT/ffmpeg_AV_CODEC_ID_FFV1_fuzzer_seed_corpus.zip ffv1testset
 fuzzer_name=ffmpeg_IO_DEMUXER_fuzzer
 make tools/target_io_dem_fuzzer
 mv tools/target_io_dem_fuzzer $OUT/${fuzzer_name}
-
-#Build fuzzers for individual demuxers
-./configure \
-        --cc=$CC --cxx=$CXX --ld="$CXX $CXXFLAGS -std=c++11" \
-        --extra-cflags="-I$FFMPEG_DEPS_PATH/include" \
-        --extra-ldflags="-L$FFMPEG_DEPS_PATH/lib" \
-        --prefix="$FFMPEG_DEPS_PATH" \
-        --pkg-config-flags="--static" \
-        --enable-ossfuzz \
-        --libfuzzer=$LIB_FUZZING_ENGINE \
-        --optflags=-O1 \
-        --enable-gpl \
-        --enable-libxml2 \
-        --disable-libdrm \
-        --disable-muxers \
-        --disable-protocols \
-        --disable-devices \
-        --disable-shared \
-        --disable-encoders \
-        --disable-filters \
-        --disable-muxers \
-        --disable-parsers \
-        --disable-decoders \
-        --disable-hwaccels \
-        --disable-bsfs \
-        --disable-vaapi \
-        --disable-vdpau \
-        --disable-v4l2_m2m \
-        --disable-cuda_llvm \
-        --enable-demuxers \
-        --disable-demuxer=rtp,rtsp,sdp \
-        --disable-doc \
-        --disable-programs \
-        $FFMPEG_BUILD_ARGS
 
 CONDITIONALS=$(grep 'DEMUXER 1$' config_components.h | sed 's/#define CONFIG_\(.*\)_DEMUXER 1/\1/')
 if [ -n "${OSS_FUZZ_CI-}" ]; then

--- a/projects/ffmpeg/replay_build.sh
+++ b/projects/ffmpeg/replay_build.sh
@@ -54,7 +54,7 @@ if [ "$#" -lt 1 ]; then
   exit 0
 fi
 
-name=$(echo "$1" | sed -E 's/ffmpeg_(AV_CODEC_ID_?)(.*)_fuzzer/\L\2/' | sed 's/demuxer/dem/')
+name=$(echo "$1" | sed -E 's/ffmpeg_(AV_CODEC_ID_)?(.*)_fuzzer/\L\2/' | sed 's/demuxer/dem/')
 make tools/target_${name}_fuzzer || true
 if [ -f tools/target_${name}_fuzzer ]; then
   mv tools/target_${name}_fuzzer $OUT/$1

--- a/projects/ffmpeg/replay_build.sh
+++ b/projects/ffmpeg/replay_build.sh
@@ -54,7 +54,7 @@ if [ "$#" -lt 1 ]; then
   exit 0
 fi
 
-name=$(echo "$1" | sed -E 's/ffmpeg_(AV_CODEC_ID_?)(.*)_fuzzer/\L\2/')
+name=$(echo "$1" | sed -E 's/ffmpeg_(AV_CODEC_ID_?)(.*)_fuzzer/\L\2/' | sed 's/demuxer/dem/')
 make tools/target_${name}_fuzzer || true
 if [ -f tools/target_${name}_fuzzer ]; then
   mv tools/target_${name}_fuzzer $OUT/$1

--- a/projects/ffmpeg/replay_build.sh
+++ b/projects/ffmpeg/replay_build.sh
@@ -1,0 +1,71 @@
+#!/bin/bash -eux
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Disable UBSan vptr since several targets built with -fno-rtti.
+export CFLAGS="$CFLAGS -fno-sanitize=vptr"
+export CXXFLAGS="$CXXFLAGS -fno-sanitize=vptr"
+
+if [[ "$CXXFLAGS" == *"-fsanitize=address"* ]]; then
+    export CXXFLAGS="$CXXFLAGS -fno-sanitize-address-use-odr-indicator"
+fi
+
+if [[ "$CFLAGS" == *"-fsanitize=address"* ]]; then
+    export CFLAGS="$CFLAGS -fno-sanitize-address-use-odr-indicator"
+fi
+
+if [[ "$ARCHITECTURE" == i386 ]]; then
+  export CFLAGS="$CFLAGS -m32"
+  export CXXFLAGS="$CXXFLAGS -m32"
+fi
+
+# The option `-fuse-ld=gold` can't be passed via `CFLAGS` or `CXXFLAGS` because
+# Meson injects `-Werror=ignored-optimization-argument` during compile tests.
+# Remove the `-fuse-ld=` and let Meson handle it.
+# https://github.com/mesonbuild/meson/issues/6377#issuecomment-575977919
+export MESON_CFLAGS="$CFLAGS"
+if [[ "$CFLAGS" == *"-fuse-ld=gold"* ]]; then
+    export MESON_CFLAGS="${CFLAGS//-fuse-ld=gold/}"
+    export CC_LD=gold
+fi
+export MESON_CXXFLAGS="$CXXFLAGS"
+if [[ "$CXXFLAGS" == *"-fuse-ld=gold"* ]]; then
+    export MESON_CXXFLAGS="${CXXFLAGS//-fuse-ld=gold/}"
+    export CXX_LD=gold
+fi
+
+cd $SRC/ffmpeg
+make -j$(nproc) install
+
+if [ "$#" -lt 1 ]; then
+  exit 0
+fi
+
+name=$(echo "$1" | sed -E 's/ffmpeg_(AV_CODEC_ID_?)(.*)_fuzzer/\L\2/')
+make tools/target_${name}_fuzzer || true
+if [ -f tools/target_${name}_fuzzer ]; then
+  mv tools/target_${name}_fuzzer $OUT/$1
+fi
+
+make tools/target_dec_${name}_fuzzer || true
+if [ -f tools/target_dec_${name}_fuzzer ]; then
+  mv tools/target_dec_${name}_fuzzer $OUT/$1
+fi
+
+make tools/target_enc_${name}_fuzzer || true
+if [ -f tools/target_enc_${name}_fuzzer ]; then
+  mv tools/target_enc_${name}_fuzzer $OUT/$1
+fi

--- a/projects/ffmpeg/replay_build.sh
+++ b/projects/ffmpeg/replay_build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eux
-# Copyright 2016 Google Inc.
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is meant to be a manual override over what chronos (https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos) generates.

The idea is we'll snapshot the ffmpeg build container after running compile into a new Docker image. This image will have build artifacts saved so that subsequent `make` calls only trigger on changed files.

This makes rebuilding a specific target **a lot** faster (From 2600 seconds down to instantaneous).

This does change the `build.sh` -- merging the two ./configure calls down to one in order to faciliate this.