### PR TITLE
Add ability to pass through arguments from `compile` to `build.sh`

### DIFF
--- a/infra/base-images/base-builder/compile
+++ b/infra/base-images/base-builder/compile
@@ -304,9 +304,9 @@ fi
 if [[ ! -z "${REPLAY_ENABLED-}" ]]; then
   # If this is a replay, then use replay_build.sh. This is expected to be
   # running in a cached container where a build has already happened prior.
-  BUILD_CMD="bash -eux $SRC/replay_build.sh"
+  BUILD_CMD="bash -eux $SRC/replay_build.sh $@"
 else
-  BUILD_CMD="bash -eux $SRC/build.sh"
+  BUILD_CMD="bash -eux $SRC/build.sh $@"
 fi
 
 # Set +u temporarily to continue even if GOPATH and OSSFUZZ_RUSTPATH are undefined.


### PR DESCRIPTION
This is also to support https://github.com/google/oss-fuzz/pull/13427.

Where we would like the ability to build specific targets instead of all of them. This lets us pass this through `compile` to `replay_build.sh`.