### PR TITLE
[glaze] use upstream repository

### DIFF
--- a/projects/glaze/Dockerfile
+++ b/projects/glaze/Dockerfile
@@ -16,6 +16,6 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 # RUN apt-get update && apt-get install -y make autoconf automake libtool
-RUN git clone --depth 1 https://github.com/pauldreik/glaze --branch ossfuzz --single-branch glaze     # or use other version control
+RUN git clone --depth 1 https://github.com/stephenberry/glaze
 WORKDIR glaze
 COPY build.sh $SRC/


### PR DESCRIPTION
I missed to point the repository to upstream after the initial integration was done.