### PR TITLE
Add c-kzg-4844 to projects

### DIFF
--- a/projects/c-kzg-4844/Dockerfile
+++ b/projects/c-kzg-4844/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+ENV RUSTUP_TOOLCHAIN=nightly
+ENV RUSTFLAGS="-C link-args=-lc++ -C link-args=-lc++abi"
+RUN curl https://nim-lang.org/choosenim/init.sh -sSf | sh -s -- -y
+ENV PATH=/root/.nimble/bin:$PATH
+RUN git clone --recursive --depth=1 https://github.com/ethereum/c-kzg-4844.git
+ENTRYPOINT "c-kzg-4844/build.sh"

--- a/projects/c-kzg-4844/project.yaml
+++ b/projects/c-kzg-4844/project.yaml
@@ -1,0 +1,8 @@
+homepage: https://github.com/ethereum/c-kzg-4844
+main_repo: https://github.com/ethereum/c-kzg-4844
+primary_contact: security@ethereum.org
+language: rust
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
[`c-kzg-4844`](https://github.com/ethereum/c-kzg-4844) is an important cryptographic library which several Ethereum clients use for computing/verifying KZG commitments to blobs. The project here is a differential fuzzer which provides the same inputs to multiple libraries ([`crate-crypto/rust-eth-kzg`](https://github.com/crate-crypto/rust-eth-kzg) and [`mratsim/constantine`](https://github.com/mratsim/constantine)) which implement the same API, then checks that their outputs are the same or errors if there is a difference. For more information, please see [this](https://github.com/ethereum/c-kzg-4844/tree/main/fuzz).