### PR TITLE
pako: pass Uint8Array input instead of number[]

### DIFF
--- a/projects/pako/fuzz.js
+++ b/projects/pako/fuzz.js
@@ -28,7 +28,7 @@ module.exports.fuzz = function(data) {
       const memLevel = fdp.consumeIntegral(1);
       const strategy = fdp.consumeIntegral(1);
       const raw = fdp.consumeBoolean();
-      const input = fdp.consumeRemainingAsBytes();
+      const input = new Uint8Array(fdp.consumeRemainingAsBytes());
       const options = {
         level: comprLevel,
         windowBits: windowBits,
@@ -49,7 +49,7 @@ module.exports.fuzz = function(data) {
         memLevel: fdp.consumeIntegral(1),
         strategy: fdp.consumeIntegral(1)
       };
-      const input = fdp.consumeRemainingAsBytes();
+      const input = new Uint8Array(fdp.consumeRemainingAsBytes());
       const gzip = pako.gzip(input, gzipOptions);
       pako.ungzip(gzip, gzipOptions);
       pako.inflate(gzip);


### PR DESCRIPTION
pako's [expected input type](https://github.com/nodeca/pako/blob/62cb729e7813176ce2d2694b89c8724680fca383/lib/deflate.js#L304) is `Uint8Array | ArrayBuffer | string`. The driver currently passes a `number[]`. While this passes [input validation](https://github.com/nodeca/pako/blob/62cb729e7813176ce2d2694b89c8724680fca383/lib/deflate.js#L211), it hits shallow crashes [like these](https://github.com/nodeca/pako/blob/62cb729e7813176ce2d2694b89c8724680fca383/lib/zlib/deflate.js#L209) (since `subarray` is not a function on `number[]`) and doesn't actually fuzz the library.

This PR passes in a `Uint8Array` instead.
