### PR TITLE
golang: add options to Dockerfile

### DIFF
--- a/projects/golang/Dockerfile
+++ b/projects/golang/Dockerfile
@@ -40,6 +40,7 @@ COPY build.sh text_fuzzer.go \
      fuzz_tiff_decode.options \
      openpgp_fuzzer.go \
      webp_fuzzer.go \
+     fuzz_webp_decode.options \
      filepath_fuzzer.go \
      strings_fuzzer.go \
      multipart_fuzzer.go \


### PR DESCRIPTION
Follow-up to #13426, in which I didn't realize I needed to add the options file to the Dockerfile.