### PR TITLE
make_build_replayable: avoid copying /bin/sh twice

### DIFF
--- a/infra/base-images/base-builder/make_build_replayable.py
+++ b/infra/base-images/base-builder/make_build_replayable.py
@@ -100,8 +100,6 @@ def main():
     sys.exit(0)
 """))
 
-  shutil.copyfile('/bin/sh', '/bin/bash')
-
   # Stub out cmake, but allow cmake --build.
   with open('/usr/bin/cmake', 'w') as f:
     f.write(


### PR DESCRIPTION
 /bin/sh is already copied earlier in the script after being overwritten. We don't need to do the copy twice.