### PR TITLE
curl: Build deps in build.sh rather than image build.

### DIFF
--- a/projects/curl/Dockerfile
+++ b/projects/curl/Dockerfile
@@ -19,8 +19,5 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN git clone --depth 1 https://github.com/curl/curl.git /src/curl
 RUN git clone --depth 1 https://github.com/curl/curl-fuzzer.git /src/curl_fuzzer
 
-# Use curl-fuzzer's scripts to get latest dependencies.
-RUN $SRC/curl_fuzzer/scripts/ossfuzzdeps.sh
-
 WORKDIR $SRC/curl_fuzzer
 COPY build.sh $SRC/

--- a/projects/curl/build.sh
+++ b/projects/curl/build.sh
@@ -16,4 +16,6 @@
 ################################################################################
 
 # Run the OSS-Fuzz script in the curl-fuzzer project.
+
+./scripts/ossfuzzdeps.sh
 ./ossfuzz.sh


### PR DESCRIPTION
Otherwise we may not inject the correct instrumentation / compiler flags (which are determined at runtime / project build rather than image build).