### PR TITLE
Add netatalk to projects

### DIFF
--- a/projects/netatalk/project.yaml
+++ b/projects/netatalk/project.yaml
@@ -1,0 +1,4 @@
+homepage: "https://netatalk.io/"
+language: c
+primary_contact: "markstedt@gmail.com"
+main_repo: "https://github.com/Netatalk/netatalk"


### PR DESCRIPTION
Netatalk is a Free and Open Source file server for Macs. The Netatalk software runs on a UNIX-like operating system (such as Linux, BSD or macOS) and allows Macintosh computers to easily connect with each other and share files on a local network or over the Internet.

Written in pure C, it is light-weight, performant, and portable. Conforming to the Apple Filing Protocol specification up to and including AFP 3.4, any macOS, Mac OS X, or Mac OS system can talk to a Netatalk file server out of the box.

Netatalk was started as a research project at the University of Michigan in 1990.