### PR TITLE
nss: enable replayable build

### DIFF
--- a/projects/nss/Dockerfile
+++ b/projects/nss/Dockerfile
@@ -20,6 +20,5 @@ RUN apt-get update && apt-get install -y make mercurial zlib1g-dev gyp ninja-bui
 RUN hg clone https://hg.mozilla.org/projects/nspr nspr
 RUN hg clone https://hg.mozilla.org/projects/nss nss
 RUN git clone --depth 1 https://github.com/MozillaSecurity/nss-fuzzing-corpus.git nss-corpus
-
-WORKDIR nss
-COPY build.sh $SRC/
+COPY build.sh replay_build.sh $SRC/
+WORKDIR $SRC/nss

--- a/projects/nss/build.sh
+++ b/projects/nss/build.sh
@@ -15,6 +15,10 @@
 #
 ################################################################################
 
+if [[ -n ${CAPTURE_REPLAY_SCRIPT-} ]]; then
+  # Make sure we don't remove cached directory
+  sed -i 's/rm -rf/#rm -rf/g' automation/ossfuzz/build.sh
+fi
 
 # Build NSS with fuzzers.
 ./automation/ossfuzz/build.sh

--- a/projects/nss/replay_build.sh
+++ b/projects/nss/replay_build.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -eu
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# This script is useful for OSS-Fuzz infrastructure which is used to rebuild
+# code from cached images. This is to support various ongoing efforts in
+# OSS-Fuzz.
+
+# List of targets disabled for oss-fuzz.                                        
+declare -A disabled=()
+# List of targets we want to fuzz in TLS and non-TLS mode.
+declare -A tls_targets=([tls-client]=1 [tls-server]=1 [dtls-client]=1 [dtls-server]=1)
+# Helper function that copies a fuzzer binary and its seed corpus.
+copy_fuzzer()
+{
+    local fuzzer=$1
+    local name=$2
+    # Copy the binary.
+    cp ../dist/Debug/bin/$fuzzer $OUT/$name
+}
+
+# Modify the harness to make sure we recompile
+ninja -C /src/nss/out/Debug -v                                                
+                                                                               
+# Build the library only in TLS fuzzing mode.                                  
+cd $SRC/nss
+
+# Copy dual mode targets in TLS mode.                                          
+for name in "${!tls_targets[@]}"; do
+    if [ -z "${disabled[$name]:-}" ]; then
+        copy_fuzzer nssfuzz-$name $name
+    fi
+done


### PR DESCRIPTION
Adds replayable script for nss.

Nss performs two builds:
- https://hg-edge.mozilla.org/projects/nss/file/tip/automation/ossfuzz/build.sh#l33
- https://hg-edge.mozilla.org/projects/nss/file/tip/automation/ossfuzz/build.sh#l46
Because the second build overwrites the first builds cache (the actual build cache, not OSS-Fuzz's internal caching stuff) we can only capture the replay of the second build, which includes the fuzzing harnesses: `dtls-client`, `dtls-server`, `tls-client` and `tls-server`.

Performance:
```
nss: Compile times: Vanilla=61; Replay=1;
```