### PR TITLE
OpenSC: build with OpenPACE and config file

### DIFF
--- a/projects/opensc/Dockerfile
+++ b/projects/opensc/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y pcscd libccid libpcsclite-dev libssl-dev libreadline-dev autoconf automake build-essential docbook-xsl xsltproc libtool pkg-config zlib1g-dev
+RUN apt-get update && apt-get install -y pcscd libccid libpcsclite-dev libssl-dev libreadline-dev autoconf automake build-essential docbook-xsl xsltproc libtool pkg-config zlib1g-dev help2man gengetopt
 RUN git clone --depth 1 --single-branch --branch master https://github.com/OpenSC/OpenSC opensc
 WORKDIR opensc
 COPY build.sh $SRC/

--- a/projects/opensc/build.sh
+++ b/projects/opensc/build.sh
@@ -27,6 +27,9 @@ make
 make install
 popd
 
+# enable internal and old drivers
+sed -i '/^#ifdef OPENSC_CONFIG_STRING/i #define OPENSC_CONFIG_STRING "app default { card_drivers = old, internal; }"' src/libopensc/ctx.c
+
 ./bootstrap
 # FIXME FUZZING_LIBS="$LIB_FUZZING_ENGINE" fails with some missing C++ library, I don't know how to fix this
 ./configure --disable-optimization --enable-static --disable-shared --disable-pcsc --enable-ctapi --enable-openpace --enable-fuzzing FUZZING_LIBS="$LIB_FUZZING_ENGINE"

--- a/projects/opensc/build.sh
+++ b/projects/opensc/build.sh
@@ -15,9 +15,21 @@
 #
 ################################################################################
 
+# Build OpenPACE
+if [ -d "openpace" ]; then
+    rm -rf "openpace"
+fi
+git clone https://github.com/frankmorgner/openpace.git
+pushd openpace
+autoreconf --verbose --install
+./configure --enable-static --disable-shared --prefix=/usr
+make
+make install
+popd
+
 ./bootstrap
 # FIXME FUZZING_LIBS="$LIB_FUZZING_ENGINE" fails with some missing C++ library, I don't know how to fix this
-./configure --disable-optimization --disable-shared --disable-pcsc --enable-ctapi --enable-fuzzing FUZZING_LIBS="$LIB_FUZZING_ENGINE"
+./configure --disable-optimization --enable-static --disable-shared --disable-pcsc --enable-ctapi --enable-openpace --enable-fuzzing FUZZING_LIBS="$LIB_FUZZING_ENGINE"
 make -j4
 
 fuzzerFiles=$(find $SRC/opensc/src/tests/fuzzing/ -name "fuzz_*.c")


### PR DESCRIPTION
Add building with enable OpenPACE and supplied configuration for enabling both old and internal card drivers.