### PR TITLE
Add new project Obs-studio project

### DIFF
--- a/projects/obs-studio/Dockerfile
+++ b/projects/obs-studio/Dockerfile
@@ -1,0 +1,44 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+
+# Install OBS dependencies and ffmpeg build dependencies
+RUN apt-get update && apt-get install -y \
+    # OBS dependencies
+    libx264-dev libcurl4-openssl-dev libmbedtls-dev libgl1-mesa-dev libjansson-dev \
+    libluajit-5.1-dev python3-dev libx11-dev libxcb-randr0-dev libxcb-shm0-dev libxcb-xinerama0-dev \
+    libxcb-composite0-dev libxcomposite-dev libxinerama-dev libxcb1-dev libx11-xcb-dev libxcb-xfixes0-dev \
+    swig libcmocka-dev libxss-dev libglvnd-dev libgles2-mesa libgles2-mesa-dev ninja-build \
+    libpci-dev libqrcodegencpp-dev uthash-dev software-properties-common \
+    extra-cmake-modules uuid-dev libpulse-dev  libdrm-dev \
+    # FFmpeg build dependencies
+    build-essential yasm nasm libvpx-dev libmp3lame-dev libopus-dev wget bzip2
+
+RUN apt-get install -y pkg-config
+# Download, build, and install FFmpeg 6.1.1
+RUN cd /tmp && \
+    wget https://ffmpeg.org/releases/ffmpeg-6.1.1.tar.bz2 && \
+    tar xjvf ffmpeg-6.1.1.tar.bz2 && \
+    cd ffmpeg-6.1.1 && \
+    env CFLAGS="" CXXFLAGS="" LDFLAGS="" ./configure \
+      --prefix=/usr/local \
+      --enable-shared \
+      --enable-gpl \
+      --enable-libx264 \
+      --enable-libvpx \
+      --enable-libmp3lame \
+      --enable-libopus && \
+    make -j$(nproc) && \
+    make install && \
+    ldconfig && \
+    # Clean up source files to reduce final image size
+    cd / && rm -rf /tmp/ffmpeg-6.1.1*
+
+RUN add-apt-repository ppa:okirby/qt6-backports
+RUN apt update
+RUN apt-get install -y qt6-tools-dev libqt6svg6-dev libqt6xml6 qt6-base-dev libqt6widgets6 nlohmann-json3-dev libqt6svg6 libxkbcommon-dev qt6-base-private-dev
+
+# Clone OBS Studio and set up for the build
+RUN git clone --recursive https://github.com/obsproject/obs-studio.git obs-studio
+WORKDIR obs-studio
+
+COPY build.sh $SRC
+COPY fuzz_*.cpp $SRC

--- a/projects/obs-studio/build.sh
+++ b/projects/obs-studio/build.sh
@@ -1,0 +1,62 @@
+: ${LD:="${CXX}"}
+: ${LDFLAGS:="${CXXFLAGS}"}  # to make sure we link with sanitizer runtime
+
+cmake_args=(
+    -DCMAKE_BUILD_TYPE=Debug
+	-DENABLE_SCRIPTING=OFF
+	-DENABLE_PLUGINS=OFF
+    #-DENABLE_NEW_MPEGTS_OUTPUT=OFF #Used in obs-ffmpeg plugin which is not built
+    #-DENABLE_PIPEWIRE=OFF # Plugins are not buit, so this is not needed
+	-DENABLE_TESTS=ON
+	-DENABLE_UI=OFF
+    -DENABLE_FRONTEND=OFF
+	-DENABLE_WAYLAND=OFF
+    #-DENABLE_RELOCATABLE=ON
+	#-DENABLE_PORTABLE_CONFIG=ON
+    -DENABLE_STATIC=ON
+    -DBUILD_SHARED_LIBS=OFF
+
+    # C compiler
+    -DCMAKE_C_COMPILER="${CC}"
+    -DCMAKE_C_FLAGS="${CFLAGS}"
+    # C++ compiler
+    -DCMAKE_CXX_COMPILER="${CXX}"
+    -DCMAKE_CXX_FLAGS="${CXXFLAGS}"
+    # Linker
+    -DCMAKE_LINKER="${LD}"
+    -DCMAKE_EXE_LINKER_FLAGS="${LDFLAGS}"
+    -DCMAKE_MODULE_LINKER_FLAGS="${LDFLAGS}"
+    -DCMAKE_SHARED_LINKER_FLAGS="${LDFLAGS}"
+)
+
+# Temporary fixes as libobs is not built as a static library by default
+# 1) turn libobs into a STATIC lib
+sed -i 's#^add_library(libobs SHARED)#add_library(libobs STATIC)#' libobs/CMakeLists.txt
+# 2) only export when NOT static (so the install/export step won’t fail)
+sed -i '/^target_export(libobs)$/c\
+if(NOT ENABLE_STATIC)\
+  target_export(libobs)\
+endif()' libobs/CMakeLists.txt
+# 3) enable -fPIC on the static lib so it can be linked into .so’s
+sed -i '/add_library(libobs STATIC)/a \
+set_target_properties(libobs PROPERTIES POSITION_INDEPENDENT_CODE ON)' libobs/CMakeLists.txt
+# 4) build libobs-opengl as a static lib as well
+sed -i -e 's#^add_library(libobs-opengl SHARED)#add_library(libobs-opengl STATIC)#' \
+       -e '/add_library(libobs-opengl STATIC)/a\
+set_target_properties(libobs-opengl PROPERTIES POSITION_INDEPENDENT_CODE ON)' \
+       libobs-opengl/CMakeLists.txt
+
+
+mkdir -p obs-build
+cmake -S . -B obs-build "${cmake_args[@]}"
+cmake --build obs-build -- -k -j$(nproc)
+
+# Build the fuzz target
+$CXX $CXXFLAGS -std=c++17 \
+    -I$SRC/obs-studio/libobs \
+    -I$SRC/obs-studio/obs-build/libobs \
+    $SRC/fuzz_util_bitstream_reader.cpp \
+    /src/obs-studio/obs-build/libobs/libobs.a \
+    -lpthread -ldl -lm \
+    -o $OUT/fuzz_util_bitstream_reader \
+    $LIB_FUZZING_ENGINE

--- a/projects/obs-studio/build.sh
+++ b/projects/obs-studio/build.sh
@@ -37,7 +37,7 @@ sed -i '/^target_export(libobs)$/c\
 if(NOT ENABLE_STATIC)\
   target_export(libobs)\
 endif()' libobs/CMakeLists.txt
-# 3) enable -fPIC on the static lib so it can be linked into .so’s
+# 3) enable -fPIC on the static lib so it can be linked
 sed -i '/add_library(libobs STATIC)/a \
 set_target_properties(libobs PROPERTIES POSITION_INDEPENDENT_CODE ON)' libobs/CMakeLists.txt
 # 4) build libobs-opengl as a static lib as well

--- a/projects/obs-studio/fuzz_util_bitstream_reader.cpp
+++ b/projects/obs-studio/fuzz_util_bitstream_reader.cpp
@@ -1,0 +1,16 @@
+#include <fuzzer/FuzzedDataProvider.h>
+
+#include <util/bitstream.h>
+
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+	struct bitstream_reader reader;
+	// Get data from the fuzzer
+    FuzzedDataProvider stream(data, size);
+
+	bitstream_reader_init(&reader, const_cast<uint8_t*>(data), size);
+
+    bitstream_reader_read_bits(&reader, size * 8);
+
+    return 0;   
+}

--- a/projects/obs-studio/project.yaml
+++ b/projects/obs-studio/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://obsproject.com/"
+language: c
+primary_contact: "todo@mail.com"
+sanitizers:
+- address
+- undefined
+- memory
+main_repo: 'https://github.com/obsproject/obs-studio/'


### PR DESCRIPTION
Initialise the OBS Studio project, including an initial build and an initial fuzz driver.

Note that, due to the base image being built in Ubuntu 20.04, I had to resolve some broken dependencies, such as those relating to ffmpeg and Qt6.
Once #13018 has been closed, I will fix this build accordingly.

Please note that this pull request has been opened as a draft due to missing OBS maintainer emails.
I am contacting them to obtain their approval and email addresses, so that I can continue with the integration by adding new fuzz drivers.