### PR TITLE
make_build_replayable: stub out `git submodule`.

### DIFF
--- a/infra/base-images/base-builder/make_build_replayable.py
+++ b/infra/base-images/base-builder/make_build_replayable.py
@@ -142,7 +142,7 @@ def main():
   with open('/usr/bin/git', 'w') as f:
     f.write(
         create_wrapper("""
-  if any(arg in ('clean', 'clone', 'reset', 'apply') for arg in sys.argv[1:]):
+  if any(arg in ('clean', 'clone', 'reset', 'apply', 'submodule') for arg in sys.argv[1:]):
     sys.exit(0)
 """))
 


### PR DESCRIPTION
Re-running these should not necessary.