### PR TITLE
containerd: disable custom fuzzers

### DIFF
--- a/projects/containerd/Dockerfile
+++ b/projects/containerd/Dockerfile
@@ -17,6 +17,5 @@
 FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN apt-get update && apt-get install -y btrfs-progs libc-dev pkg-config libseccomp-dev gcc wget libbtrfs-dev
 RUN git clone --depth 1 https://github.com/containerd/containerd
-RUN git clone --depth=1 https://github.com/AdamKorcz/instrumentation
 COPY build.sh $SRC/
 WORKDIR $SRC/containerd


### PR DESCRIPTION
Related to containerd/containerd/issues/12007

This change disables the custom fuzzers from github.com/AdamKorcz/instrumentation

This is to unblock changes in the containerd release/1.7 branch where the Go toolchain is older than the minimum requirement for the fuzzers in AdamKorcz/instrumentation.