### PR TITLE
jsonnet: add run_tests.sh

### DIFF
--- a/projects/jsonnet/build.sh
+++ b/projects/jsonnet/build.sh
@@ -18,8 +18,8 @@
 mkdir jsonnet/build
 pushd jsonnet/build
 cmake -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" \
-  -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DBUILD_TESTS=OFF ..
-make -j$(nproc) libjsonnet_static
+  -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DBUILD_TESTS=ON ..
+make -j$(nproc) all
 popd
 
 INSTALL_DIR="$SRC/jsonnet"

--- a/projects/jsonnet/run_tests.sh
+++ b/projects/jsonnet/run_tests.sh
@@ -1,4 +1,5 @@
-# Copyright 2018 Google Inc.
+#!/bin/bash -eu
+# Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,10 +15,5 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y build-essential cmake
-RUN git clone --depth 1 https://github.com/google/jsonnet.git jsonnet
-WORKDIR $SRC/
-
-COPY build.sh run_tests.sh $SRC/
-COPY *.cc $SRC/
+cd $SRC/jsonnet/build
+make test


### PR DESCRIPTION
```
$ docker run --rm -ti us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/jsonnet-ofg-cached-address /src/run_tests.sh
Running tests...
Test project /src/jsonnet/build
      Start  1: unicode_test
 1/10 Test  #1: unicode_test .....................   Passed    0.06 sec
      Start  2: lexer_test
 2/10 Test  #2: lexer_test .......................   Passed    0.01 sec
      Start  3: parser_test
 3/10 Test  #3: parser_test ......................   Passed    0.02 sec
      Start  4: libjsonnet_test
 4/10 Test  #4: libjsonnet_test ..................   Passed    0.25 sec
      Start  5: libjsonnet_test_file
 5/10 Test  #5: libjsonnet_test_file .............   Passed    0.31 sec
      Start  6: libjsonnet_test_snippet
 6/10 Test  #6: libjsonnet_test_snippet ..........   Passed    0.23 sec
      Start  7: jsonnet_test_snippet
 7/10 Test  #7: jsonnet_test_snippet .............   Passed    0.23 sec
      Start  8: libjsonnet++_test
 8/10 Test  #8: libjsonnet++_test ................   Passed    1.20 sec
      Start  9: libjsonnet_test_locale
 9/10 Test  #9: libjsonnet_test_locale ...........   Passed    0.23 sec
      Start 10: regression_test
10/10 Test #10: regression_test ..................   Passed  121.46 sec

100% tests passed, 0 tests failed out of 10

Total Test time (real) = 124.00 sec
```