### PR TITLE
chronos: add helper script for quickly testing run_test.sh

### DIFF
--- a/infra/experimental/chronos/check_tests.sh
+++ b/infra/experimental/chronos/check_tests.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Module for validating "run_tests.sh" of a given project. Before the run_tests.sh
+# script is run, a cached container image is first built. We assume here that the
+# replay is working for the target project.
+# (TODO): make sure this works for both replay_build.sh and ccached rebuilds.
+#         currently the focus is on replay_build.sh.
+_PROJECT=$1
+_FUZZING_LANGUAGE=$2
+_SANITIZER=${3:-address}
+
+BASE=$PWD
+
+# Final image is either ccache or replay script, depending on which worked.
+FINAL_IMAGE_NAME=us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/${_PROJECT}-ofg-cached-${_SANITIZER}
+
+# Step 1: build the base image
+cd projects/${_PROJECT}
+docker build -t gcr.io/oss-fuzz/${_PROJECT} .
+
+# Step 2: create a container where `compile` has run which enables ccaching
+#         and also generates a replay build script.
+cd ${BASE}
+mkdir -p ccaches/${_PROJECT}
+mkdir -p build/out/${_PROJECT}
+
+# Clean up existing images.
+docker container rm -f ${_PROJECT}-origin-${_SANITIZER}
+
+docker run \
+  --env=SANITIZER=${_SANITIZER} \
+  --env=CCACHE_DIR=/workspace/ccache \
+  --env=FUZZING_LANGUAGE=${_FUZZING_LANGUAGE} \
+  --env=CAPTURE_REPLAY_SCRIPT=1 \
+  --name=${_PROJECT}-origin-${_SANITIZER} \
+  -v=$PWD/ccaches/${_PROJECT}/ccache:/workspace/ccache \
+  -v=$PWD/build/out/${_PROJECT}/:/out/ \
+  gcr.io/oss-fuzz/${_PROJECT} \
+  /bin/bash -c \
+  "export PATH=/ccache/bin:\$PATH && compile && cp -n /usr/local/bin/replay_build.sh \$SRC/"
+
+
+# Step 3: save (commit, locally) the cached container as an image
+docker container commit -c "ENV REPLAY_ENABLED=1" -c "ENV CAPTURE_REPLAY_SCRIPT=" ${_PROJECT}-origin-${_SANITIZER} $FINAL_IMAGE_NAME
+
+# Step 4: run the actual run_tests.sh script in the container.
+docker run \
+  --rm \
+  -ti \
+  us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/${_PROJECT}-ofg-cached-address /bin/bash -c 'chmod +x /src/run_tests.sh && /src/run_tests.sh'


### PR DESCRIPTION
jsonnet:
```
./infra/experimental/chronos/check_tests.sh jsonnet c++
...
...
Running tests...
Test project /src/jsonnet/build
      Start  1: unicode_test
 1/10 Test  #1: unicode_test .....................   Passed    0.06 sec
      Start  2: lexer_test
 2/10 Test  #2: lexer_test .......................   Passed    0.01 sec
      Start  3: parser_test
 3/10 Test  #3: parser_test ......................   Passed    0.03 sec
      Start  4: libjsonnet_test
 4/10 Test  #4: libjsonnet_test ..................   Passed    0.26 sec
      Start  5: libjsonnet_test_file
 5/10 Test  #5: libjsonnet_test_file .............   Passed    0.32 sec
      Start  6: libjsonnet_test_snippet
 6/10 Test  #6: libjsonnet_test_snippet ..........   Passed    0.23 sec
      Start  7: jsonnet_test_snippet
 7/10 Test  #7: jsonnet_test_snippet .............   Passed    0.23 sec
      Start  8: libjsonnet++_test
 8/10 Test  #8: libjsonnet++_test ................   Passed    1.25 sec
      Start  9: libjsonnet_test_locale
 9/10 Test  #9: libjsonnet_test_locale ...........   Passed    0.23 sec
      Start 10: regression_test
10/10 Test #10: regression_test ..................   Passed  121.20 sec

100% tests passed, 0 tests failed out of 10

Total Test time (real) = 123.82 sec
```


assimp:
```
./infra/experimental/chronos/check_tests.sh assimp c++
...
...
[----------] 8 tests from ExtensionTests/ExtensionTest (0 ms total)

[----------] Global test environment tear-down
[==========] 591 tests from 117 test suites ran. (32219 ms total)
[  PASSED  ] 591 tests.
```