### PR TITLE
tink: rename and fix broken build

### DIFF
--- a/projects/tink-cc/Dockerfile
+++ b/projects/tink-cc/Dockerfile
@@ -17,11 +17,11 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN apt-get update && apt-get install -y make pkg-config
-RUN git clone --depth 1 https://github.com/google/tink
+RUN git clone --depth 1 https://github.com/tink-crypto/tink-cc
 
-RUN mkdir $SRC/tink/cc/fuzzing
-COPY fuzzing_CMake $SRC/tink/cc/fuzzing/CMakeLists.txt
-COPY tink_encrypt_decrypt_fuzzer.cc $SRC/tink/cc/fuzzing/tink_encrypt_decrypt_fuzzer.cc
+RUN mkdir $SRC/tink-cc/fuzzing
+COPY fuzzing_CMake $SRC/tink-cc/fuzzing/CMakeLists.txt
+COPY tink_encrypt_decrypt_fuzzer.cc $SRC/tink-cc/fuzzing/tink_encrypt_decrypt_fuzzer.cc
 COPY build.sh $SRC/
 
-WORKDIR tink
+WORKDIR tink-cc

--- a/projects/tink-cc/build.sh
+++ b/projects/tink-cc/build.sh
@@ -15,13 +15,13 @@
 #
 ################################################################################
 
-cd cc/fuzzing && cmake .
+cd $SRC/tink-cc/fuzzing && cmake .
 make -j$(nproc)
 mv tink_encrypt_fuzzer $OUT/
 
 # Hack to get coverage to work. We need this due to /src/tink/cc/fuzzing/tink/__include_alias/tink
 # being an symbolic link. Instead, we exchange it with the actual contents.
-rm /src/tink/cc/fuzzing/tink/__include_alias/tink
+rm /src/tink-cc/fuzzing/tink-cc/__include_alias/tink
 mkdir /src/tinktmp
-cp -rf /src/tink/cc/ /src/tinktmp/tink
-cp -rf /src/tinktmp/tink/ /src/tink/cc/fuzzing/tink/__include_alias/tink
+cp -rf /src/tink-cc/ /src/tinktmp/tink
+cp -rf /src/tinktmp/tink/ /src/tink-cc/fuzzing/tink-cc/__include_alias/tink

--- a/projects/tink-cc/fuzzing_CMake
+++ b/projects/tink-cc/fuzzing_CMake
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 project(tink_fuzz CXX)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 
-add_subdirectory(../.. tink)
+add_subdirectory(.. tink-cc)
 
 add_executable(tink_encrypt_fuzzer tink_encrypt_decrypt_fuzzer.cc)
 target_link_libraries(tink_encrypt_fuzzer tink::static $ENV{LIB_FUZZING_ENGINE})

--- a/projects/tink-cc/project.yaml
+++ b/projects/tink-cc/project.yaml
@@ -7,8 +7,8 @@ auto_ccs:
   - "tholenst@google.com"
 sanitizers:
   - address
-  - undefined
   - memory
+#  - undefined # TODO: Needs investigation
 main_repo: "https://github.com/google/tink"
 file_github_issue: True
 

--- a/projects/tink-cc/tink_encrypt_decrypt_fuzzer.cc
+++ b/projects/tink-cc/tink_encrypt_decrypt_fuzzer.cc
@@ -21,11 +21,11 @@ extern "C"
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     crypto::tink::util::SecretData key = crypto::tink::util::SecretDataFromStringView("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f");
     auto res = crypto::tink::subtle::AesSivBoringSsl::New(key);
-    auto cipher = std::move(res.ValueOrDie());
+    auto cipher = std::move(res.value());
     std::string aad = "Additional data";
     std::string message(reinterpret_cast<const char*>(data), size);
     auto ct = cipher->EncryptDeterministically(message, aad);
-    auto pt = cipher->DecryptDeterministically(ct.ValueOrDie(), aad);
+    auto pt = cipher->DecryptDeterministically(ct.value(), aad);
 
     return 0;
 }


### PR DESCRIPTION
Tink has been split into projects for the respective implementation languages. This was part of the reason that the build was broken.

This PR renames the project and fixes a few other nits to fix the build.