### PR TITLE
Remove hacks in index image building.

### DIFF
--- a/infra/build/functions/build_project.py
+++ b/infra/build/functions/build_project.py
@@ -582,23 +582,6 @@ def get_indexer_build_steps(project_name,
               'commit',
               '-c',
               'ENV REPLAY_ENABLED 1',
-              # Add CFLAGS that enable debugging (this should match the
-              # index_build.py CFLAGS)
-              # TODO(ochang): Figure out how to just re-use the cflags from there instead of
-              # duplicating them here.
-              '-c',
-              ('ENV CFLAGS "$$CFLAGS '
-               '-fno-omit-frame-pointer '
-               '-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION '
-               '-O0 -glldb '
-               '-fsanitize=address '
-               '-Wno-invalid-offsetof '
-               '-fsanitize-coverage=bb,no-prune,trace-pc-guard '
-               '-gen-cdb-fragment-path $$OUT/cdb '
-               '-Qunused-arguments"'),
-              # Make sure the compiler wrapper is in $PATH.
-              '-c',
-              'ENV PATH "/opt/indexer:$$PATH"',
               _INDEXED_CONTAINER_NAME,
               _indexer_built_image_name(project.name) + f':{timestamp}'
           ],

--- a/infra/build/functions/build_project.py
+++ b/infra/build/functions/build_project.py
@@ -578,10 +578,7 @@ def get_indexer_build_steps(project_name,
           'name':
               build_lib.DOCKER_TOOL_IMAGE,
           'args': [
-              'container',
-              'commit',
-              '-c',
-              'ENV REPLAY_ENABLED 1',
+              'container', 'commit', '-c', 'ENV REPLAY_ENABLED 1',
               _INDEXED_CONTAINER_NAME,
               _indexer_built_image_name(project.name) + f':{timestamp}'
           ],


### PR DESCRIPTION
These are no longer necessary. We can just use

https://github.com/google/oss-fuzz/commit/0714250242802f265ff62bef1ed2f058abdf7436