### PR TITLE
libssh: add run_tests.sh

### DIFF
--- a/projects/libssh/build.sh
+++ b/projects/libssh/build.sh
@@ -21,7 +21,7 @@ pushd $BUILD
 cmake -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" \
     -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
     -DBUILD_SHARED_LIBS=OFF -DWITH_INSECURE_NONE=ON -DWITH_EXEC=OFF \
-    $SRC/libssh
+    -DUNIT_TESTING=ON -DWITH_EXAMPLES=OFF $SRC/libssh
 make "-j$(nproc)"
 
 fuzzers=$(find $SRC/libssh/tests/fuzz/ -name "*_fuzzer.c")

--- a/projects/libssh/run_tests.sh
+++ b/projects/libssh/run_tests.sh
@@ -1,4 +1,5 @@
-# Copyright 2016 Google Inc.
+#!/bin/bash -eu
+# Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,10 +15,5 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y cmake zlib1g-dev libssl-dev libcmocka0 libcmocka-dev
-
-RUN git clone --depth=1 https://git.libssh.org/projects/libssh.git
-
-WORKDIR libssh
-COPY build.sh run_tests.sh $SRC/
+cd /work/build
+make test


### PR DESCRIPTION
Output from `infra/experimental/chronos/check_tests.sh libssh c`:

```
Running tests...
Test project /work/build
      Start  1: torture_bignum
 1/40 Test  #1: torture_bignum ......................   Passed    0.01 sec
      Start  2: torture_buffer
 2/40 Test  #2: torture_buffer ......................   Passed    0.79 sec
      Start  3: torture_bytearray
 3/40 Test  #3: torture_bytearray ...................   Passed    0.01 sec
      Start  4: torture_callbacks
 4/40 Test  #4: torture_callbacks ...................   Passed    0.01 sec
      Start  5: torture_crypto
 5/40 Test  #5: torture_crypto ......................   Passed    0.01 sec
      Start  6: torture_init
 6/40 Test  #6: torture_init ........................   Passed    0.01 sec
      Start  7: torture_list
 7/40 Test  #7: torture_list ........................   Passed    0.01 sec
      Start  8: torture_misc
 8/40 Test  #8: torture_misc ........................   Passed    0.29 sec
      Start  9: torture_config
 9/40 Test  #9: torture_config ......................   Passed    0.03 sec
      Start 10: torture_options
10/40 Test #10: torture_options .....................   Passed    0.18 sec
      Start 11: torture_isipaddr
11/40 Test #11: torture_isipaddr ....................   Passed    0.01 sec
      Start 12: torture_knownhosts_parsing
12/40 Test #12: torture_knownhosts_parsing ..........   Passed    0.03 sec
      Start 13: torture_hashes
13/40 Test #13: torture_hashes ......................   Passed    0.01 sec
      Start 14: torture_packet_filter
14/40 Test #14: torture_packet_filter ...............   Passed    0.03 sec
      Start 15: torture_temp_dir
15/40 Test #15: torture_temp_dir ....................   Passed    0.01 sec
      Start 16: torture_temp_file
16/40 Test #16: torture_temp_file ...................   Passed    0.01 sec
      Start 17: torture_push_pop_dir
17/40 Test #17: torture_push_pop_dir ................   Passed    0.01 sec
      Start 18: torture_session_keys
18/40 Test #18: torture_session_keys ................   Passed    0.01 sec
      Start 19: torture_string
19/40 Test #19: torture_string ......................   Passed    0.01 sec
      Start 20: torture_tokens
20/40 Test #20: torture_tokens ......................   Passed    0.01 sec
      Start 21: torture_packet
21/40 Test #21: torture_packet ......................   Passed    0.40 sec
      Start 22: torture_keyfiles
22/40 Test #22: torture_keyfiles ....................   Passed    0.02 sec
      Start 23: torture_pki
23/40 Test #23: torture_pki .........................   Passed    0.87 sec
      Start 24: torture_pki_rsa
24/40 Test #24: torture_pki_rsa .....................   Passed    1.67 sec
      Start 25: torture_pki_dsa
25/40 Test #25: torture_pki_dsa .....................   Passed    0.02 sec
      Start 26: torture_pki_ed25519
26/40 Test #26: torture_pki_ed25519 .................   Passed    1.39 sec
      Start 27: torture_channel
27/40 Test #27: torture_channel .....................   Passed    0.01 sec
      Start 28: torture_config_match_localnetwork
28/40 Test #28: torture_config_match_localnetwork ...   Passed    0.01 sec
      Start 29: torture_bind_config
29/40 Test #29: torture_bind_config .................   Passed    0.32 sec
      Start 30: torture_moduli
30/40 Test #30: torture_moduli ......................   Passed    0.01 sec
      Start 31: torture_pki_ecdsa
31/40 Test #31: torture_pki_ecdsa ...................   Passed    1.21 sec
      Start 32: torture_rand
32/40 Test #32: torture_rand ........................   Passed    2.18 sec
      Start 33: torture_threads_init
33/40 Test #33: torture_threads_init ................   Passed    0.02 sec
      Start 34: torture_threads_buffer
34/40 Test #34: torture_threads_buffer ..............   Passed   87.26 sec
      Start 35: torture_threads_crypto
35/40 Test #35: torture_threads_crypto ..............   Passed    0.05 sec
      Start 36: torture_threads_pki_rsa
36/40 Test #36: torture_threads_pki_rsa .............   Passed    3.34 sec
      Start 37: torture_unit_server
37/40 Test #37: torture_unit_server .................   Passed    0.01 sec
      Start 38: torture_server_x11
38/40 Test #38: torture_server_x11 ..................   Passed    0.10 sec
      Start 39: torture_forwarded_tcpip_callback
39/40 Test #39: torture_forwarded_tcpip_callback ....   Passed    0.28 sec
      Start 40: torture_server_direct_tcpip
40/40 Test #40: torture_server_direct_tcpip .........   Passed    0.20 sec
```