### PR TITLE
glslang: add run_tests.sh

### DIFF
--- a/projects/glslang/build.sh
+++ b/projects/glslang/build.sh
@@ -18,7 +18,10 @@
 
 mkdir -p build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_CTEST=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DENABLE_OPT=0 ../
+cmake -DCMAKE_BUILD_TYPE=Release \
+      -DGLSLANG_TESTS=ON \
+      -DCMAKE_VERBOSE_MAKEFILE=ON \
+      -DENABLE_OPT=0 ../
 make V=1 -j4 install
 
 

--- a/projects/glslang/run_tests.sh
+++ b/projects/glslang/run_tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eux
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###############################################################################
+
+cd build
+make test


### PR DESCRIPTION
run_tests.sh is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

```
$ ./infra/experimental/chronos/check_tests.sh glslang c++
...
...
+ cd build                                                                                                                                                                                                                                                         
+ make test                                                                                                                                                                                                                                                        
Running tests...                                                                                                                                                                                                                                                   
/usr/local/bin/ctest --force-new-ctest-process                                                                                                                                                                                                                     
Test project /src/glslang/build                                                                                                                                                                                                                                    
    Start 1: glslang-testsuite                                                                                                                                                                                                                                     
1/1 Test #1: glslang-testsuite ................   Passed   35.85 sec                                                             
                                                                                                                                 
100% tests passed, 0 tests failed out of 1                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                   
Total Test time (real) =  35.85 sec
```