### PR TITLE
tidy-html5: add run_tests.sh and fix build

### DIFF
--- a/projects/tidy-html5/build.sh
+++ b/projects/tidy-html5/build.sh
@@ -16,8 +16,8 @@
 #
 ################################################################################
 
-mkdir -p ${WORK}/tidy-html5
-cd ${WORK}/tidy-html5
+mkdir -p build/cmake
+cd build/cmake
 
 cmake -GNinja ${SRC}/tidy-html5/
 ninja
@@ -28,6 +28,7 @@ for fuzzer in tidy_config_fuzzer tidy_fuzzer tidy_xml_fuzzer tidy_parse_string_f
     ${CXX} ${CXXFLAGS} -std=c++11 ${fuzzer}.o \
         -o $OUT/${fuzzer} \
         $LIB_FUZZING_ENGINE libtidy.a
+    cp $SRC/tidy_config_fuzzer.options $OUT/${fuzzer}.options
 done
 
 cp ${SRC}/*.options ${OUT}/

--- a/projects/tidy-html5/run_tests.sh
+++ b/projects/tidy-html5/run_tests.sh
@@ -1,4 +1,5 @@
-# Copyright 2018 Google Inc.
+#!/bin/bash -eu
+# Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,16 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-################################################################################
+###############################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        cmake ninja-build ruby-full && \
-    apt-get clean
-
-RUN git clone -b next --single-branch \
-    https://github.com/htacg/tidy-html5.git tidy-html5
-WORKDIR tidy-html5
-COPY *.sh *.c *.h *.options $SRC/
+cd regression_testing
+bundle2.7 install
+ASAN_OPTIONS=detect_leaks=0 ./test.rb test

--- a/projects/tidy-html5/tidy_config_fuzzer.options
+++ b/projects/tidy-html5/tidy_config_fuzzer.options
@@ -1,2 +1,3 @@
 [libfuzzer]
 close_fd_mask = 3
+detect_leaks = 0


### PR DESCRIPTION
Lots of the harnesses have leaks, and these leaks are also present when running tests. Disabling leak detection as well for now.

run_tests.sh is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

```
$ ./infra/experimental/chronos/check_tests.sh tidy-html5 c++
...
...
PASSED | status 1 expected 1 | /src/tidy-html5/regression_testing/cases/xml-cases/case-634889@1.html                             
PASSED | status 0 expected 0 | /src/tidy-html5/regression_testing/cases/xml-cases/case-640474@0.xml                              
PASSED | status 0 expected 0 | /src/tidy-html5/regression_testing/cases/xml-cases/case-646946@0.xml   
                                                                                                                                 
Ran 401 tests, of which 401 passed and 0 failed.                                                                                 
Test conducted with HTML Tidy 5.9.20 using test sets for version 5.9.20.   
```