### PR TITLE
quickjs: add run_test.sh

### DIFF
--- a/projects/quickjs/run_tests.sh
+++ b/projects/quickjs/run_tests.sh
@@ -1,4 +1,5 @@
-# Copyright 2020 Google Inc.
+#!/bin/bash -eu
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,9 +15,10 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make
-RUN git clone --depth 1 https://github.com/bellard/quickjs quickjs
-RUN git clone --depth 1 https://github.com/renatahodovan/quickjs-corpus
-WORKDIR $SRC/quickjs
-COPY build.sh run_tests.sh run_tests_patch.diff $SRC/
+# At the time of writing, `tests/test_worker.js`
+# fails from latest master, so we remove it.
+# This is being tracked in https://github.com/bellard/quickjs/issues/390.
+# A TODO is to track when it has been patched
+# upstream and enable all tests.
+git apply $SRC/run_tests_patch.diff
+CONFIG_CLANG=y make test

--- a/projects/quickjs/run_tests_patch.diff
+++ b/projects/quickjs/run_tests_patch.diff
@@ -1,0 +1,12 @@
+diff --git a/Makefile b/Makefile
+index 3b1c745..e0a1b97 100644
+--- a/Makefile
++++ b/Makefile
+@@ -449,7 +449,6 @@ test: qjs$(EXE)
+ 	$(WINE) ./qjs$(EXE) tests/test_loop.js
+ 	$(WINE) ./qjs$(EXE) tests/test_bigint.js
+ 	$(WINE) ./qjs$(EXE) tests/test_cyclic_import.js
+-	$(WINE) ./qjs$(EXE) tests/test_worker.js
+ ifndef CONFIG_WIN32
+ 	$(WINE) ./qjs$(EXE) tests/test_std.js
+ endif


### PR DESCRIPTION
Adds `run_tests.sh` for the quickjs project.

`run_tests.sh` is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

output from `infra/experimental/chronos/check_tests.sh quickjs c`
```
./qjs tests/test_closure.js
./qjs tests/test_language.js
./qjs --std tests/test_builtin.js
./qjs tests/test_loop.js
./qjs tests/test_bigint.js
./qjs tests/test_cyclic_import.js
./qjs tests/test_std.js
./qjs tests/test_bjson.js
./qjs examples/test_point.js
```