### PR TITLE
haproxy: add run_tests.sh

### DIFF
--- a/projects/haproxy/build.sh
+++ b/projects/haproxy/build.sh
@@ -39,3 +39,8 @@ for fuzzer in hpack_decode cfg_parser; do
   $CC $CFLAGS $SETTINGS -c fuzz_${fuzzer}.c  -o fuzz_${fuzzer}.o
   $CXX -g $CXXFLAGS $LIB_FUZZING_ENGINE  fuzz_${fuzzer}.o libhaproxy.a -o $OUT/fuzz_${fuzzer}
 done
+
+# build vtest for run_tests.sh
+cd $SRC/VTest2
+make vtest
+# vtest binary is in $SRC/VTest2/vtest

--- a/projects/haproxy/run_tests.sh
+++ b/projects/haproxy/run_tests.sh
@@ -1,4 +1,5 @@
-# Copyright 2020 Google Inc.
+#!/bin/bash -eu
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,12 +14,11 @@
 # limitations under the License.
 #
 ################################################################################
-FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make libpcre2-dev zlib1g-dev
-RUN git clone https://github.com/haproxy/haproxy
-RUN git clone https://github.com/vtest/VTest2 --depth=1
 
-WORKDIR $SRC
+cd $SRC/haproxy
 
-COPY build.sh run_tests.sh $SRC
-COPY fuzz* $SRC/
+# This tests fails so remove it
+rm reg-tests/http-rules/converters_ipmask_concat_strcmp_field_word.vtc
+
+make unit-tests
+HAPROXY_PROGRAM=$SRC/haproxy/haproxy VTEST_PROGRAM=$SRC/VTest2/vtest make reg-tests


### PR DESCRIPTION
Adds run_tests.sh the haproxy project.

`run_tests.sh` is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

Output from `infra/experimental/chronos/check_tests.sh haproxy c`:
```
########################## Preparing to run unit tests ##########################
Testing with haproxy version: 3.3-dev2-378c18-74
Target : generic
Options : -51DEGREES -ACCEPT4 -BACKTRACE -CLOSEFROM -CPU_AFFINITY -CRYPT_H -DEVICEATLAS -DL -ENGINE -EPOLL -EVPORTS -GETADDRINFO -KQUEUE -LIBATOMIC -LI
BCRYPT -LINUX_CAP -LINUX_SPLICE -LINUX_TPROXY -LUA -MATH -MEMORY_PROFILING -NETFILTER -NS -OBSOLETE_LINKER -OPENSSL -OPENSSL_AWSLC -OPENSSL_WOLFSSL -OT
 -PCRE -PCRE2 -PCRE2_JIT -PCRE_JIT +POLL -PRCTL -PROCCTL -PROMEX -PTHREAD_EMULATION -QUIC -QUIC_OPENSSL_COMPAT -RT +SLZ -SSL -STATIC_PCRE -STATIC_PCRE2
 -TFO -THREAD -THREAD_DUMP +TPROXY -WURFL -ZLIB
Services : none
Unit tests: none
########################## Gathering tests to run ##########################
  Skip ./tests/unit/jwk/test.sh
  Skip ./tests/unit/jwk/jws.sh
  Skip ./tests/unit/smoke/test.sh
  Add test: ./tests/unit/ist.sh
  Skip ./tests/unit/quic/quic.sh
########################## Starting unit tests ##########################
0 tests failed, 4 tests skipped, 1 tests passed

########################## Preparing to run tests ##########################
Testing with haproxy version: 3.3-dev2-378c18-74
Target : generic
Options : -51DEGREES -ACCEPT4 -BACKTRACE -CLOSEFROM -CPU_AFFINITY -CRYPT_H -DEVICEATLAS -DL -ENGINE -EPOLL -EVPORTS -GETADDRINFO -KQUEUE -LIBATOMIC -LI
BCRYPT -LINUX_CAP -LINUX_SPLICE -LINUX_TPROXY -LUA -MATH -MEMORY_PROFILING -NETFILTER -NS -OBSOLETE_LINKER -OPENSSL -OPENSSL_AWSLC -OPENSSL_WOLFSSL -OT
 -PCRE -PCRE2 -PCRE2_JIT -PCRE_JIT +POLL -PRCTL -PROCCTL -PROMEX -PTHREAD_EMULATION -QUIC -QUIC_OPENSSL_COMPAT -RT +SLZ -SSL -STATIC_PCRE -STATIC_PCRE2
 -TFO -THREAD -THREAD_DUMP +TPROXY -WURFL -ZLIB
Services : none
########################## Gathering tests to run ##########################
  Add test: reg-tests/stream/unique-id.vtc
  Add test: reg-tests/stream/unique-id-from-proxy.vtc
  Add test: reg-tests/connection/tcp_to_http_upgrade.vtc
  Add test: reg-tests/connection/reverse_server.vtc
  Add test: reg-tests/connection/http_reuse_safe.vtc
  Add test: reg-tests/connection/http_reuse_always.vtc
  Skip reg-tests/connection/proxy_protocol_send_unique_id_alpn.vtc because haproxy is not compiled with the required option OPENSSL
  Add test: reg-tests/connection/http_reuse_never.vtc
  Add test: reg-tests/connection/reverse_connect_full.vtc
  Add test: reg-tests/connection/http_reuse_dispatch.vtc
  Skip reg-tests/connection/http_reuse_conn_hash.vtc because haproxy is not compiled with the required option OPENSSL
  Add test: reg-tests/connection/tcp_md5_signature.vtc
  Add test: reg-tests/connection/proxy_protocol_send_unique_id.vtc
  Add test: reg-tests/connection/reverse_server_name.vtc
  Add test: reg-tests/connection/proxy_protocol_tlv_validation.vtc
  Add test: reg-tests/connection/http_reuse_be_transparent.vtc
  Skip reg-tests/connection/proxy_protocol_random_fail.vtc because its type 'broken' is excluded
  Skip reg-tests/connection/proxy_protocol_random_fail.vtc because haproxy is not compiled with the required option OPENSSL
  Add test: reg-tests/connection/cli_src_dst.vtc
  Add test: reg-tests/connection/http_reuse_aggressive.vtc
  Add test: reg-tests/connection/h2_glitches.vtc
  Add test: reg-tests/connection/dispatch.vtc
  Add test: reg-tests/connection/proxy_protocol_send_generic.vtc
  Add test: reg-tests/spoe/wrong_init.vtc
  Add test: reg-tests/jwt/jws_verify.vtc
  Skip reg-tests/contrib/prometheus.vtc because haproxy is not compiled with the required service prometheus-exporter
  Add test: reg-tests/sample_fetches/acl.vtc
  Add test: reg-tests/sample_fetches/srv_name.vtc
  Add test: reg-tests/sample_fetches/tcpinfo_rtt.vtc  
  Add test: reg-tests/sample_fetches/ubase64.vtc
  Add test: reg-tests/sample_fetches/so_name.vtc
  Add test: reg-tests/sample_fetches/cook.vtc
  Add test: reg-tests/sample_fetches/hashes.vtc
  Add test: reg-tests/sample_fetches/tlvs.vtc
  Add test: reg-tests/sample_fetches/cond_set_var.vtc
  Add test: reg-tests/sample_fetches/vars.vtc
  Add test: reg-tests/filters/random-forwarding.vtc
  Add test: reg-tests/http-errorfiles/http_errors.vtc
  Add test: reg-tests/http-errorfiles/errorfiles.vtc
  Add test: reg-tests/http-errorfiles/http_return.vtc
  Add test: reg-tests/http-errorfiles/http_deny_errors.vtc
  Add test: reg-tests/http-errorfiles/http-error.vtc
  Add test: reg-tests/stats/stats-file.vtc
  Add test: reg-tests/http-set-timeout/set_timeout.vtc
  Add test: reg-tests/converter/url_enc.vtc
  Add test: reg-tests/converter/word.vtc
  Add test: reg-tests/converter/json.vtc
  Add test: reg-tests/converter/url_dec.vtc
  Add test: reg-tests/converter/mqtt.vtc
  Add test: reg-tests/converter/be2dec.vtc
  Add test: reg-tests/converter/add_item.vtc
  Add test: reg-tests/converter/field.vtc
  Add test: reg-tests/converter/be2hex.vtc
  Skip reg-tests/converter/secure_memcmp.vtc because haproxy is not compiled with the required option OPENSSL
  Add test: reg-tests/converter/json_query.vtc
  Skip reg-tests/converter/sha2.vtc because haproxy is not compiled with the required option OPENSSL
  Skip reg-tests/converter/digest.vtc because haproxy is not compiled with the required option OPENSSL
  Add test: reg-tests/converter/bytes.vtc
  Add test: reg-tests/converter/fix.vtc
  Add test: reg-tests/converter/iif.vtc
  Add test: reg-tests/converter/param.vtc
  Skip reg-tests/converter/hmac.vtc because haproxy is not compiled with the required option OPENSSL
  Add test: reg-tests/http-cookies/h2_cookie_concat.vtc
  Add test: reg-tests/http-cookies/cookie_insert_indirect.vtc
  Add test: reg-tests/balance/balance-hash-maxconn.vtc
  Add test: reg-tests/balance/balance-uri.vtc
  Skip reg-tests/balance/balance-hash-maxqueue.vtc because its type 'broken' is excluded
  Add test: reg-tests/balance/balance-uri-path-only.vtc
  Add test: reg-tests/balance/balance-rr.vtc
  Add test: reg-tests/ssl/ssl_crt-list_filters.vtc 
  Skip reg-tests/ssl/set_ssl_cert.vtc because haproxy is not compiled with the required option OPENSSL
  Skip reg-tests/ssl/del_ssl_crt-list.vtc because haproxy is not compiled with the required option OPENSSL
  Add test: reg-tests/ssl/log_forward_ssl.vtc
  Skip reg-tests/ssl/ssl_server_samples.vtc because haproxy is not compiled with the required option OPENSSL
  Add test: reg-tests/ssl/ssl_generate_certificate.vtc
  Add test: reg-tests/ssl/crt_store.vtc
  Skip reg-tests/ssl/wrong_ctx_storage.vtc because haproxy is not compiled with the required option OPENSSL
  Add test: reg-tests/ssl/ssl_default_server.vtc  
  Skip reg-tests/ssl/ssl_client_auth.vtc because haproxy is not compiled with the required option OPENSSL
  Add test: reg-tests/ssl/ocsp_compat_check.vtc
  Add test: reg-tests/ssl/ssl_curves.vtc
  Add test: reg-tests/ssl/set_ssl_crlfile.vtc
  Add test: reg-tests/ssl/set_ssl_cafile.vtc
  Skip reg-tests/ssl/ssl_simple_crt-list.vtc because haproxy is not compiled with the required option OPENSSL
  Add test: reg-tests/ssl/new_del_ssl_cafile.vtc
  Add test: reg-tests/ssl/set_ssl_cert_bundle.vtc
  Add test: reg-tests/ssl/new_del_ssl_crlfile.vtc
  Skip reg-tests/ssl/set_ssl_bug_2265.vtc because haproxy is not compiled with the required option OPENSSL
  Add test: reg-tests/ssl/ssl_alpn.vtc
  Add test: reg-tests/ssl/issuers_chain_path.vtc
  Add test: reg-tests/ssl/ssl_curve_name.vtc
  Add test: reg-tests/ssl/show_ssl_ocspresponse.vtc
  Add test: reg-tests/ssl/ssl_reuse.vtc
  Skip reg-tests/ssl/ssl_frontend_samples.vtc because haproxy is not compiled with the required option OPENSSL
  Add test: reg-tests/ssl/ssl_errors.vtc
  Skip reg-tests/ssl/set_ssl_cert_noext.vtc because haproxy is not compiled with the required option OPENSSL   
  Add test: reg-tests/ssl/ssl_dh.vtc
  Skip reg-tests/ssl/add_ssl_crt-list.vtc because haproxy is not compiled with the required option OPENSSL
  Skip reg-tests/ssl/dynamic_server_ssl.vtc because haproxy is not compiled with the required option OPENSSL
  Add test: reg-tests/ssl/ssl_client_samples.vtc
  Add test: reg-tests/ssl/set_ssl_server_cert.vtc
  Add test: reg-tests/ssl/ocsp_auto_update.vtc
  Add test: reg-tests/cache/basic.vtc
  Add test: reg-tests/cache/sample_fetches.vtc
  Add test: reg-tests/cache/vary_accept_encoding.vtc
  Add test: reg-tests/cache/if-none-match.vtc
  Add test: reg-tests/cache/vary.vtc
  Add test: reg-tests/cache/post_on_entry.vtc
  Add test: reg-tests/cache/expires.vtc
  Add test: reg-tests/cache/if-modified-since.vtc 
  Add test: reg-tests/cache/caching_rules.vtc
  Add test: reg-tests/compression/basic.vtc
  Add test: reg-tests/compression/vary.vtc
  Add test: reg-tests/compression/min_size.vtc
  Add test: reg-tests/compression/etags_conversion.vtc
  Skip reg-tests/compression/lua_validation.vtc because haproxy is not compiled with the required option LUA
  Skip reg-tests/compression/lua_validation.vtc because haproxy is not compiled with the required option OPENSSL
  Add test: reg-tests/stickiness/srvkey-addr.vtc
  Add test: reg-tests/stickiness/lb-services.vtc
  Add test: reg-tests/http-rules/http-err-fail.vtc 
  Add test: reg-tests/http-rules/map_ordering.vtc
  Add test: reg-tests/http-rules/strict_rw_mode.vtc  
  Add test: reg-tests/http-rules/restrict_req_hdr_names.vtc
  Add test: reg-tests/http-rules/del_header.vtc
  Add test: reg-tests/http-rules/default_rules.vtc
  Add test: reg-tests/http-rules/except-forwardfor-originalto.vtc
  Add test: reg-tests/http-rules/http_return.vtc  
  Add test: reg-tests/http-rules/acl_cli_spaces.vtc
  Add test: reg-tests/http-rules/map_redirect.vtc
  Add test: reg-tests/http-rules/http_after_response.vtc
  Add test: reg-tests/http-rules/path_and_pathq.vtc
  Add test: reg-tests/http-rules/forwarded-header-7239.vtc
  Add test: reg-tests/http-rules/ifnone-forwardfor.vtc
  Add test: reg-tests/http-rules/h1or2_to_h1c.vtc
  Add test: reg-tests/http-rules/map_regm_with_backref.vtc
  Add test: reg-tests/http-rules/normalize_uri.vtc
  Add test: reg-tests/webstats/missing-stats-fields.vtc  
  Add test: reg-tests/webstats/webstats-scope-and-post-change.vtc
  Skip reg-tests/peers/tls_basic_sync_wo_stkt_backend.vtc because haproxy is not compiled with the required option OPENSSL
  Skip reg-tests/peers/tls_basic_sync.vtc because haproxy is not compiled with the required option OPENSSL
  Add test: reg-tests/peers/basic_sync_wo_stkt_backend.vtc
  Add test: reg-tests/peers/basic_sync.vtc
  Skip reg-tests/seamless-reload/abns_socket.vtc because haproxy is compiled for the excluded target generic
  Add test: reg-tests/http-capture/multiple_headers.vtc
  Skip reg-tests/lua/bad_http_clt_req_duration.vtc because haproxy is not compiled with the required option LUA
  Skip reg-tests/lua/lua_httpclient.vtc because haproxy is not compiled with the required option LUA
  Skip reg-tests/lua/wrong_types_usage.vtc because haproxy is not compiled with the required option LUA
  Skip reg-tests/lua/close_wait_lf.vtc because haproxy is not compiled with the required option LUA
  Skip reg-tests/lua/set_var.vtc because haproxy is not compiled with the required option LUA
  Skip reg-tests/lua/txn_get_priv-thread.vtc because haproxy is not compiled with the required option LUA
  Skip reg-tests/lua/txn_get_priv-thread.vtc because haproxy is not compiled with the required option OPENSSL
  Skip reg-tests/lua/httpclient_action.vtc because haproxy is not compiled with the required option LUA   
  Skip reg-tests/lua/txn_get_priv.vtc because haproxy is not compiled with the required option LUA
  Skip reg-tests/lua/txn_get_priv.vtc because haproxy is not compiled with the required option OPENSSL
  Skip reg-tests/lua/h_txn_get_priv.vtc because haproxy is not compiled with the required option LUA
  Skip reg-tests/lua/lua_socket.vtc because haproxy is not compiled with the required option LUA
  Add test: reg-tests/mcli/mcli_debug_dev.vtc
  Add test: reg-tests/mcli/mcli_show_info.vtc
  Add test: reg-tests/startup/check_condition.vtc 
  Add test: reg-tests/startup/default_rules.vtc  
  Skip reg-tests/startup/automatic_maxconn.vtc because its type 'broken' is excluded
  Skip reg-tests/mailers/healthcheckmail.vtc because haproxy is not compiled with the required option LUA
  Add test: reg-tests/quic/retry.vtc  Add test: reg-tests/server/cli_delete_server.vtc 
  Add test: reg-tests/server/cli_delete_dynamic_server.vtc
  Skip reg-tests/server/abnsz.vtc because haproxy is compiled for the excluded target generic
  Skip reg-tests/server/cli_set_ssl.vtc because haproxy is not compiled with the required option OPENSSL
  Add test: reg-tests/server/cli_add_ssl_server.vtc
  Add test: reg-tests/server/cli_set_fqdn.vtc
  Add test: reg-tests/server/cli_add_server.vtc
  Add test: reg-tests/server/cli_add_check_server.vtc
  Add test: reg-tests/server/cli_add_track_server.vtc
  Add test: reg-tests/http-messaging/scheme_based_normalize.vtc
  Add test: reg-tests/http-messaging/truncated.vtc
  Add test: reg-tests/http-messaging/h1_host_normalization.vtc
  Add test: reg-tests/http-messaging/http_bodyless_response.vtc  
  Add test: reg-tests/http-messaging/srv_ws.vtc
  Add test: reg-tests/http-messaging/http_splicing_chunk.vtc
  Add test: reg-tests/http-messaging/http_transfer_encoding.vtc
  Add test: reg-tests/http-messaging/h1_request_target_validation.vtc
  Add test: reg-tests/http-messaging/h2_to_h1.vtc
  Add test: reg-tests/http-messaging/http_wait_for_body.vtc
  Add test: reg-tests/http-messaging/http_splicing.vtc
  Add test: reg-tests/http-messaging/h1_to_h1.vtc
  Add test: reg-tests/http-messaging/h2_desync_attacks.vtc
  Add test: reg-tests/http-messaging/protocol_upgrade.vtc
  Add test: reg-tests/http-messaging/http_bodyless_spliced_response.vtc
  Add test: reg-tests/http-messaging/http_abortonclose.vtc
  Add test: reg-tests/http-messaging/http_request_buffer.vtc
  Add test: reg-tests/http-messaging/websocket.vtc
  Skip reg-tests/checks/tcp-check_multiple_ports.vtc because haproxy is compiled for the excluded target generic
  Add test: reg-tests/checks/1be_40srv_odd_health_checks.vtc
  Skip reg-tests/checks/tcp-check-client-hello.vtc because haproxy is compiled for the excluded target generic
  Add test: reg-tests/checks/spop-check.vtc
  Add test: reg-tests/checks/mysql-check.vtc
  Add test: reg-tests/checks/http-check.vtc
  Add test: reg-tests/checks/4be_1srv_health_checks.vtc
  Add test: reg-tests/checks/redis-check.vtc
  Add test: reg-tests/checks/agent-check.vtc
  Skip reg-tests/checks/40be_2srv_odd_health_checks.vtc because haproxy is compiled for the excluded target generic
  Skip reg-tests/checks/tcp-check_min-recv.vtc because haproxy is compiled for the excluded target generic
  Add test: reg-tests/checks/http-check-send.vtc
  Skip reg-tests/checks/tls_health_checks.vtc because haproxy is not compiled with the required option OPENSSL
  Skip reg-tests/checks/ssl-hello-check.vtc because haproxy is not compiled with the required option OPENSSL
  Skip reg-tests/checks/4be_1srv_smtpchk_httpchk_layer47errors.vtc because haproxy is compiled for the excluded target generic
  Add test: reg-tests/checks/tcp-checks-socks4.vtc
  Add test: reg-tests/checks/smtp-check.vtc
  Add test: reg-tests/checks/http-check-expect.vtc
  Add test: reg-tests/checks/http-monitor-uri.vtc
  Add test: reg-tests/checks/pgsql-check.vtc
  Add test: reg-tests/checks/ldap-check.vtc
  Skip reg-tests/checks/tcp-check-ssl.vtc because haproxy is not compiled with the required option OPENSSL
  Add test: reg-tests/stick-table/src_conn_rate.vtc
  Add test: reg-tests/stick-table/unknown_key.vtc
  Add test: reg-tests/stick-table/converteers_ref_cnt_never_dec.vtc
  Add test: reg-tests/log/log_forward.vtc
  Add test: reg-tests/log/log_uri.vtc
  Add test: reg-tests/log/wrong_ip_port_logging.vtc
  Add test: reg-tests/log/log_profiles.vtc
  Add test: reg-tests/log/load_balancing.vtc
  Add test: reg-tests/log/log_backend.vtc
  Add test: reg-tests/log/last_rule.vtc
  Add test: reg-tests/tcp-rules/default_rules.vtc
########################## Starting vtest ##########################
Testing with haproxy version: 3.3-dev2-378c18-74
0 tests failed, 35 tests skipped, 138 tests passed
```