### PR TITLE
libxslt: add run_tests.sh

### DIFF
--- a/projects/libxslt/Dockerfile
+++ b/projects/libxslt/Dockerfile
@@ -24,7 +24,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Build requires automake 1.16.3
 RUN curl -LO http://mirrors.kernel.org/ubuntu/pool/main/a/automake-1.16/automake_1.16.5-1.3_all.deb && \
     apt install ./automake_1.16.5-1.3_all.deb
-RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/libxml2.git
+# TODO: Update this when new releases are issued
+# to keep run_tests.sh working. The reason for this
+# is https://gitlab.gnome.org/GNOME/libxslt/-/issues/126#note_2273444
+ENV LATEST_LIBXML2_RELEASE_TAG=v2.14.4
+RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/libxml2.git --branch=$LATEST_LIBXML2_RELEASE_TAG
 RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/libxslt.git
 WORKDIR libxslt
-COPY build.sh $SRC/
+COPY build.sh run_tests.sh $SRC/

--- a/projects/libxslt/run_tests.sh
+++ b/projects/libxslt/run_tests.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+cd $SRC/libxslt
+make check


### PR DESCRIPTION
Adds run_tests.sh to the libxslt project.

`run_tests.sh` is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

Output of `infra/experimental/chronos/check_tests.sh libxslt c`

```
## Running REC2 tests
## Running REC tests
## Running REC tests (standalone)
## Running REC tests without dictionaries
## Running REC tests without dictionaries (standalone)
## Running general tests
## Running general tests without dictionaries
## Running encoding tests
## Running documents tests
## Running numbers tests
## Running keys tests
## Running namespaces tests
## Running extensions tests
## Running reports tests
## Running exslt common tests
## Running exslt crypto tests
## Running exslt date tests
## Running exslt dynamic tests
## Running exslt functions tests
## Running exslt math tests
## Running exslt saxon tests
## Running exslt sets tests
## Running exslt strings tests
Total 748 tests, no errors
make[3]: Leaving directory '/src/libxslt/tests'
make[2]: Leaving directory '/src/libxslt/tests'
make[1]: Leaving directory '/src/libxslt/tests'
make[1]: Entering directory '/src/libxslt'
make[1]: Leaving directory '/src/libxslt'
```