### PR TITLE
spirv-cross: add run_tests.sh

### DIFF
--- a/projects/spirv-cross/build.sh
+++ b/projects/spirv-cross/build.sh
@@ -15,6 +15,9 @@
 #
 ################################################################################
 
+# Apply the following patch for tests to succeed.
+git apply --ignore-space-change --ignore-whitespace  ../patch.diff
+
 # Update submodule
 ./checkout_glslang_spirv_tools.sh
 NPROC="--parallel $(nproc)" ./build_glslang_spirv_tools.sh

--- a/projects/spirv-cross/patch.diff
+++ b/projects/spirv-cross/patch.diff
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index b44eb5e8..def197c9 100644
+--- a/Makefile
++++ b/Makefile
+@@ -30,7 +30,7 @@ all: $(TARGET)
+ -include $(DEPS)
+ 
+ $(TARGET): $(CLI_OBJECTS) $(STATIC_LIB)
+-	$(CXX) -o $@ $(CLI_OBJECTS) $(STATIC_LIB) $(LDFLAGS)
++	$(CXX) ${CXXFLAGS} -o $@ $(CLI_OBJECTS) $(STATIC_LIB) $(LDFLAGS)
+ 
+ $(STATIC_LIB): $(OBJECTS)
+ 	$(AR) rcs $@ $(OBJECTS)

--- a/projects/spirv-cross/run_tests.sh
+++ b/projects/spirv-cross/run_tests.sh
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 ###############################################################################
-
+export CXXFLAGS="$CXXFLAGS -pthread -stdlib=libc++"
 ./test_shaders.sh

--- a/projects/spirv-cross/run_tests.sh
+++ b/projects/spirv-cross/run_tests.sh
@@ -1,4 +1,5 @@
-# Copyright 2024 Google LLC
+#!/bin/bash -eu
+# Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,16 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-################################################################################
+###############################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update &&  \
-  apt-get install -y build-essential autoconf automake libtool pkg-config make \
-                     cmake
-
-
-RUN git clone https://github.com/KhronosGroup/SPIRV-Cross spirv-cross
-WORKDIR $SRC/spirv-cross
-
-COPY *_fuzzer.cpp *.diff *.sh $SRC/
-
+./test_shaders.sh


### PR DESCRIPTION
`run_tests.sh` is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

```
$ ./infra/experimental/chronos/check_tests.sh spirv-cross c++
...
...
Testing MSL shader: shaders-ue4-no-opt/asm/tese/ds-texcoord-array.asm.tese
Reference shader path: reference/shaders-ue4-no-opt/asm/tese/ds-texcoord-array.asm.tese
metal toolkit does not exist, ignoring further attempts to use it.

Testing MSL shader: shaders-ue4-no-opt/asm/frag/array-copy-error.asm.invalid.frag
Reference shader path: reference/shaders-ue4-no-opt/asm/frag/array-copy-error.asm.invalid.frag

Testing MSL shader: shaders-ue4-no-opt/asm/frag/accesschain-invalid-expression.asm.invalid.frag
Reference shader path: reference/shaders-ue4-no-opt/asm/frag/accesschain-invalid-expression.asm.invalid.frag

Testing MSL shader: shaders-ue4-no-opt/asm/frag/phi-variable-declaration.asm.invalid.frag
Reference shader path: reference/shaders-ue4-no-opt/asm/frag/phi-variable-declaration.asm.invalid.frag

Testing MSL shader: shaders-ue4-no-opt/asm/vert/loop-accesschain-writethrough.asm.invalid.vert
Reference shader path: reference/shaders-ue4-no-opt/asm/vert/loop-accesschain-writethrough.asm.invalid.vert
Tests completed!
```