### PR TITLE
jsonc: add run_tests.sh

### DIFF
--- a/projects/json-c/Dockerfile
+++ b/projects/json-c/Dockerfile
@@ -18,4 +18,4 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make cmake
 RUN git clone --depth 1 https://github.com/json-c/json-c.git json-c
 WORKDIR json-c
-COPY build.sh *.cc *.dict $SRC/
+COPY run_tests.sh build.sh *.cc *.dict $SRC/

--- a/projects/json-c/run_tests.sh
+++ b/projects/json-c/run_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2018 Google Inc.
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,19 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 ################################################################################
-mkdir json-c-build
+
 cd json-c-build
-cmake -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=ON ..
-make -j$(nproc)
-cd ..
-
-cp $SRC/json-c/fuzz/*.dict $OUT/
-
-for f in $SRC/json-c/fuzz/*_fuzzer.cc; do
-    fuzzer=$(basename "$f" _fuzzer.cc)
-    $CXX $CXXFLAGS -std=c++11 -I$SRC/json-c -I$SRC/json-c/json-c-build\
-         $SRC/json-c/fuzz/${fuzzer}_fuzzer.cc -o $OUT/${fuzzer}_fuzzer \
-         $LIB_FUZZING_ENGINE $SRC/json-c/json-c-build/libjson-c.a
-done
+make test


### PR DESCRIPTION
Adds `run_tests.sh` to the jsonc project.

`run_tests.sh` is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

Output of `./infra/experimental/chronos/check_tests.sh jsoncpp c++`:
```
Running tests...
Test project /src/json-c/json-c-build
      Start  1: test1
 1/25 Test  #1: test1 ............................   Passed    0.22 sec
      Start  2: test2
 2/25 Test  #2: test2 ............................   Passed    0.15 sec
      Start  3: test4
 3/25 Test  #3: test4 ............................   Passed    0.05 sec
      Start  4: testReplaceExisting
 4/25 Test  #4: testReplaceExisting ..............   Passed    0.04 sec
      Start  5: test_cast
 5/25 Test  #5: test_cast ........................   Passed    0.05 sec
      Start  6: test_charcase
 6/25 Test  #6: test_charcase ....................   Passed    0.06 sec
      Start  7: test_compare
 7/25 Test  #7: test_compare .....................   Passed    0.05 sec
      Start  8: test_deep_copy
 8/25 Test  #8: test_deep_copy ...................   Passed    0.05 sec
      Start  9: test_double_serializer
 9/25 Test  #9: test_double_serializer ...........   Passed    0.04 sec
      Start 10: test_float
10/25 Test #10: test_float .......................   Passed    0.04 sec
      Start 11: test_int_add
11/25 Test #11: test_int_add .....................   Passed    0.04 sec
      Start 12: test_int_get
12/25 Test #12: test_int_get .....................   Passed    0.04 sec
      Start 13: test_locale
13/25 Test #13: test_locale ......................   Passed    0.05 sec
      Start 14: test_null
14/25 Test #14: test_null ........................   Passed    0.04 sec
      Start 15: test_parse
15/25 Test #15: test_parse .......................   Passed    0.05 sec
      Start 16: test_parse_int64
16/25 Test #16: test_parse_int64 .................   Passed    0.05 sec
      Start 17: test_printbuf
17/25 Test #17: test_printbuf ....................   Passed    0.05 sec
      Start 18: test_set_serializer
18/25 Test #18: test_set_serializer ..............   Passed    0.04 sec
      Start 19: test_set_value
19/25 Test #19: test_set_value ...................   Passed    0.05 sec
      Start 20: test_strerror
20/25 Test #20: test_strerror ....................   Passed    0.04 sec
      Start 21: test_util_file
21/25 Test #21: test_util_file ...................   Passed    0.05 sec
      Start 22: test_visit
22/25 Test #22: test_visit .......................   Passed    0.05 sec
      Start 23: test_object_iterator
23/25 Test #23: test_object_iterator .............   Passed    0.05 sec
      Start 24: test_json_pointer
24/25 Test #24: test_json_pointer ................   Passed    0.05 sec
      Start 25: test_json_patch
25/25 Test #25: test_json_patch ..................   Passed    0.07 sec

100% tests passed, 0 tests failed out of 25

Total Test time (real) =   1.48 sec
```