### PR TITLE
jsoncpp: add run_tests.sh

### DIFF
--- a/projects/jsoncpp/Dockerfile
+++ b/projects/jsoncpp/Dockerfile
@@ -21,4 +21,4 @@ RUN git clone --depth 1 https://github.com/open-source-parsers/jsoncpp
 WORKDIR jsoncpp
 RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
 RUN (mkdir LPM && cd LPM && cmake ../libprotobuf-mutator -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release && ninja)
-COPY build.sh *.proto *.h *.cc $SRC/
+COPY run_tests.sh build.sh *.proto *.h *.cc $SRC/

--- a/projects/jsoncpp/build.sh
+++ b/projects/jsoncpp/build.sh
@@ -20,7 +20,10 @@ sed -i 's/set(CMAKE_CXX_STANDARD 11)/set(CMAKE_CXX_STANDARD 17)/' CMakeLists.txt
 mkdir -p build
 cd build
 cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
-      -DBUILD_SHARED_LIBS=OFF -G "Unix Makefiles" ..
+      -DBUILD_SHARED_LIBS=OFF \
+      -DJSONCPP_WITH_TESTS=ON \
+      -DJSONCPP_WITH_POST_BUILD_UNITTEST=OFF \
+      -G "Unix Makefiles" ..
 make
 
 # Compile fuzzer.

--- a/projects/jsoncpp/run_tests.sh
+++ b/projects/jsoncpp/run_tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###############################################################################
+
+cd build
+make test


### PR DESCRIPTION
Adds `run_tests.sh` to the jsoncpp project.

`run_tests.sh` is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

Output of ./infra/experimental/chronos/check_tests.sh jsoncpp c++:
```
Running tests...
Test project /src/jsoncpp/build
    Start 1: jsoncpp_readerwriter
1/3 Test #1: jsoncpp_readerwriter ................   Passed    4.95 sec
    Start 2: jsoncpp_readerwriter_json_checker
2/3 Test #2: jsoncpp_readerwriter_json_checker ...   Passed    6.45 sec
    Start 3: jsoncpp_test
3/3 Test #3: jsoncpp_test ........................   Passed    0.05 sec

100% tests passed, 0 tests failed out of 3

Total Test time (real) =  11.46 sec
```