### PR TITLE
nghttp2: add run_tests.sh

### DIFF
--- a/projects/nghttp2/run_tests.sh
+++ b/projects/nghttp2/run_tests.sh
@@ -1,4 +1,5 @@
-# Copyright 2016 Google Inc.
+#!/bin/bash -eu
+# Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,17 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y \
-  make \
-  autoconf \
-  automake \
-  libtool \
-  pkg-config
-
-RUN git clone --recursive --shallow-submodules --depth 1 https://github.com/nghttp2/nghttp2.git
-WORKDIR nghttp2
-COPY run_tests.sh build.sh *.options $SRC/
+cd $SRC/nghttp2/build
+make check


### PR DESCRIPTION
Adds `run_tests.sh` to the expat project.

`run_tests.sh` is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

Output of ./infra/experimental/chronos/check_tests.sh nghttp2 c++:
```
[ 51%] Built target nghttp2_static
[ 66%] Built target failmalloc
[100%] Built target main
Test project /src/nghttp2/build
    Start 1: main
1/2 Test #1: main .............................   Passed    2.61 sec
    Start 2: failmalloc
2/2 Test #2: failmalloc .......................   Passed    0.09 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) =   2.71 sec
[100%] Built target check
```