### PR TITLE
yaml-cpp: add run_tests.sh

### DIFF
--- a/projects/yaml-cpp/Dockerfile
+++ b/projects/yaml-cpp/Dockerfile
@@ -24,6 +24,6 @@ RUN apt-get update && \
 RUN git clone --depth 1 https://github.com/jbeder/yaml-cpp.git $SRC/yaml-cpp/
 RUN git clone --depth 1 https://github.com/initializedd/yaml-cpp-fuzzer.git $SRC/yaml-cpp-fuzzer/
 
-COPY build.sh $SRC/
+COPY build.sh run_tests.sh $SRC/
 WORKDIR $SRC/yaml-cpp/
 

--- a/projects/yaml-cpp/run_tests.sh
+++ b/projects/yaml-cpp/run_tests.sh
@@ -1,5 +1,4 @@
 #!/bin/bash -eu
-
 # Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,26 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 ################################################################################
 
-mkdir build
 cd build
-
-cmake -DCMAKE_BUILD_TYPE=Release -DYAML_CPP_BUILD_TESTS=ON ..
-make -j4
-
-cp $SRC/yaml-cpp-fuzzer/*.dict $OUT/
-cp $SRC/yaml-cpp-fuzzer/*.options $OUT/
-
-for fuzzer in $(find $SRC/yaml-cpp-fuzzer/ -name "*_fuzzer.cpp"); do
-    fuzzer_basename=$(basename -s .cpp $fuzzer)
-    $CXX $CXXFLAGS $LIB_FUZZING_ENGINE \
-        -I$SRC/yaml-cpp/include \
-        $fuzzer \
-        -o $OUT/$fuzzer_basename \
-        libyaml-cpp.a
-
-    zip -q $OUT/${fuzzer_basename}_seed_corpus.zip $SRC/yaml-cpp-fuzzer/${fuzzer_basename}_seed_corpus/*
-done
-
+make test


### PR DESCRIPTION
Adds `run_tests.sh` to the expat project.

`run_tests.sh` is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

Output of ./infra/experimental/chronos/check_tests.sh yaml-cpp c++:
```
Running tests...
Test project /src/yaml-cpp/build
    Start 1: yaml-cpp::test
1/1 Test #1: yaml-cpp::test ...................   Passed    1.32 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   1.32 sec
```