### PR TITLE
fio: add run_tests.sh

### DIFF
--- a/projects/fio/build.sh
+++ b/projects/fio/build.sh
@@ -19,6 +19,7 @@
 export LDFLAGS="$CXXFLAGS"
 ./configure
 make -j$(nproc)
+make unittests/unittest
 cp t/fuzz/fuzz_parseini $OUT/
 
 # builds corpus

--- a/projects/fio/run_tests.sh
+++ b/projects/fio/run_tests.sh
@@ -1,4 +1,5 @@
-# Copyright 2021 Google LLC
+#!/bin/bash -eu
+# Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,9 +14,5 @@
 # limitations under the License.
 #
 ################################################################################
-
-FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make libcunit1 libcunit1-dev
-RUN git clone --depth 1 https://github.com/axboe/fio.git fio
-WORKDIR $SRC/fio
-COPY build.sh run_tests.sh $SRC/
+export ASAN_OPTIONS="detect_leaks=0"
+./unittests/unittest


### PR DESCRIPTION
Adds run_tests.sh to the fio project.

run_tests.sh is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

`infra/experimental/chronos/check_tests.sh fio c`

```
...
Run Summary:    Type  Total    Ran Passed Failed Inactive                                                                                                 
              suites      7      7    n/a      0        0                    
               tests     16     16     16      0        0                    
             asserts     63     63     63      0      n/a                    
                                                                             
Elapsed time =    0.000 seconds
```