### PR TITLE
libsrtp: add run_tests.sh

### DIFF
--- a/projects/libsrtp/Dockerfile
+++ b/projects/libsrtp/Dockerfile
@@ -18,4 +18,4 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y sudo autoconf build-essential libssl-dev pkg-config
 
 RUN git clone --depth 1 https://github.com/cisco/libsrtp
-COPY build.sh $SRC/
+COPY build.sh run_tests.sh $SRC/

--- a/projects/libsrtp/run_tests.sh
+++ b/projects/libsrtp/run_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2025 Google LLC
+# Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,11 +14,7 @@
 # limitations under the License.
 #
 ################################################################################
-cd $SRC/libsrtp
-autoreconf -ivf
-./configure
-LIBFUZZER="$LIB_FUZZING_ENGINE" make srtp-fuzzer
-make test
-zip -r srtp-fuzzer_seed_corpus.zip fuzzer/corpus
-cp $SRC/libsrtp/fuzzer/srtp-fuzzer $OUT
-cp srtp-fuzzer_seed_corpus.zip $OUT
+
+pushd $SRC/libsrtp
+  make runtest
+popd


### PR DESCRIPTION
`infra/experimental/chronos/check_tests.sh libsrtp c`

```
...
Build done. Please run 'make runtest' to run self tests.                                                                                                   
running libsrtp3 test applications...                                                                                                                      
crypto/test/cipher_driver -v >/dev/null                                                                                                                    
crypto/test/kernel_driver -v >/dev/null                                                                                                                    
test/test_srtp >/dev/null                                                                                                                                  
test/rdbx_driver -v >/dev/null                                                                                                                             
test/srtp_driver -v >/dev/null                                                                                                                             
test/roc_driver -v >/dev/null                                                                                                                              
test/replay_driver -v >/dev/null                                                                                                                           
cd test;  /src/libsrtp/test/rtpw_test.sh -w /src/libsrtp/test/words.txt >/dev/null                                                                         
libsrtp3 test applications passed.                                           
make -C crypto runtest                                                                                                                                     
make[1]: Entering directory '/src/libsrtp/crypto'                      
test/env # print out information on the build environment                    
CPU set to little-endian                (WORDS_BIGENDIAN == 0)               
CPU set to CISC                         (CPU_CISC == 1)                      
running crypto test applications...
test `test/aes_calc 000102030405060708090a0b0c0d0e0f 00112233445566778899aabbccddeeff` = 69c4e0d86a7b0430d8cdb78070b4c55a
test `test/aes_calc 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f 00112233445566778899aabbccddeeff` = 8ea2b7ca516745bfeafc49904b496089
test/sha1_driver -v >/dev/null
test/cipher_driver -v >/dev/null
test/datatypes_driver -v >/dev/null
test/kernel_driver -v >/dev/null
crypto test applications passed.
make[1]: Leaving directory '/src/libsrtp/crypto'
/src
```