### PR TITLE
mbedtls: add run_tests.sh

### DIFF
--- a/projects/mbedtls/Dockerfile
+++ b/projects/mbedtls/Dockerfile
@@ -32,4 +32,4 @@ RUN git clone --depth 1 https://github.com/openssl/openssl.git openssl && \
     cd openssl && \
     git submodule update --init fuzz/corpora
 WORKDIR mbedtls
-COPY build.sh $SRC/
+COPY build.sh run_tests.sh $SRC/

--- a/projects/mbedtls/build.sh
+++ b/projects/mbedtls/build.sh
@@ -24,7 +24,7 @@ scripts/config.py set MBEDTLS_PLATFORM_TIME_ALT
 scripts/config.py unset MBEDTLS_USE_PSA_CRYPTO
 mkdir build
 cd build
-cmake -DENABLE_TESTING=OFF ..
+cmake -DENABLE_TESTING=ON ..
 # build including fuzzers
 make -j$(nproc) all
 cp programs/fuzz/fuzz_* $OUT/

--- a/projects/mbedtls/run_tests.sh
+++ b/projects/mbedtls/run_tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+pushd $SRC/mbedtls
+  make check
+popd


### PR DESCRIPTION
Adds run_tests.sh to the mbedtls project.

run_tests.sh is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

`infra/experimental/chronos/check_tests.sh mbedtls c`

```
...
test_suite_ssl_decrypt.misc ....................................... PASS     
test_suite_test_helpers ........................................... PASS
test_suite_timing ................................................. PASS                                                                                   
test_suite_version ................................................ PASS                                                                                   
test_suite_x509parse .............................................. PASS                                                                                   
test_suite_x509write .............................................. PASS                                                                                   
------------------------------------------------------------------------
PASSED (135 suites, 31747 tests run)
```