### PR TITLE
yoga: add run_tests.sh

### DIFF
--- a/projects/yoga/run_tests.sh
+++ b/projects/yoga/run_tests.sh
@@ -1,4 +1,5 @@
-# Copyright 2024 Google LLC
+#!/bin/bash -eu
+# Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,9 +14,4 @@
 # limitations under the License.
 #
 ################################################################################
-
-FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y cmake ninja-build
-RUN git clone --depth 1 https://github.com/facebook/yoga.git yoga
-WORKDIR yoga
-COPY build.sh run_tests.sh $SRC/
+ASAN_OPTIONS="detect_leaks=0" ./unit_tests


### PR DESCRIPTION
Adds run_tests.sh to the yoga project.

run_tests.sh is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

`infra/experimental/chronos/check_tests.sh yoga c`

```
[==========] Running 823 tests from 15 test suites.                                                                                                        
[----------] Global test environment set-up.                                                                                                               
[----------] 2 tests from YogaDeathTest                                                                                                                    
[ RUN      ] YogaDeathTest.cannot_add_child_to_node_with_measure_func                                                                                      
Cannot add child: Nodes with measure functions cannot have children.                                                                                       
[       OK ] YogaDeathTest.cannot_add_child_to_node_with_measure_func (0 ms)                                                                               
[ RUN      ] YogaDeathTest.cannot_add_nonnull_measure_func_to_non_leaf_node                                                                                
Cannot set measure function: Nodes with measure functions cannot have children.                                                                            
[       OK ] YogaDeathTest.cannot_add_nonnull_measure_func_to_non_leaf_node (0 ms)                                                                         
[----------] 2 tests from YogaDeathTest (0 ms total)                                                                                                       
                                                                                                                                                           
[----------] 12 tests from EventTest                                                                                                                       
[ RUN      ] EventTest.new_node_has_event                                                                                                                  
[       OK ] EventTest.new_node_has_event (0 ms)                                                                                                           
[ RUN      ] EventTest.new_node_with_config_event                                                                                                          
[       OK ] EventTest.new_node_with_config_event (0 ms)                                                                                                   
[ RUN      ] EventTest.clone_node_event                                                                                                                    
[       OK ] EventTest.clone_node_event (0 ms)                                                                                                             
[ RUN      ] EventTest.free_node_event                                                                                                                     
[       OK ] EventTest.free_node_event (0 ms)                                                                                                              
[ RUN      ] EventTest.layout_events                                                                                                                       
[       OK ] EventTest.layout_events (0 ms)                                                                                                                
[ RUN      ] EventTest.layout_events_single_node                                                                                                           
[       OK ] EventTest.layout_events_single_node (0 ms)
...
```

No tests fail.