### PR TITLE
lcms: add run_tests.sh

### DIFF
--- a/projects/lcms/Dockerfile
+++ b/projects/lcms/Dockerfile
@@ -34,4 +34,4 @@ RUN mkdir $SRC/seeds && \
     zip -rj $SRC/seed_corpus.zip $SRC/seeds/*
 
 WORKDIR lcms
-COPY build.sh *.c *.options *.dict $SRC/
+COPY build.sh run_tests.sh *.c *.options *.dict $SRC/

--- a/projects/lcms/run_tests.sh
+++ b/projects/lcms/run_tests.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -eu
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+make check


### PR DESCRIPTION
Adds run_tests.sh to the lcms project.

run_tests.sh is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

`infra/experimental/chronos/check_tests.sh lcms c`

```
8 bits on SAME Matrix-Shaper profiles        : 45.6 MPixel/sec.              
16 bits on SAME Matrix-Shaper profiles       : 45.0 MPixel/sec.                                                                                            
32 bits on SAME Matrix-Shaper profiles       : 1.49 MPixel/sec.              
                                                                             
8 bits on Matrix-Shaper profiles (AbsCol)    : 28.7 MPixel/sec.              
16 bits on Matrix-Shaper profiles (AbsCol)   : 19.1 MPixel/sec.              
32 bits on Matrix-Shaper profiles (AbsCol)   : 1.68 MPixel/sec.              
                                                                                                                                                           
8 bits on curves                             : 36.8 MPixel/sec.              
16 bits on curves                            : 40.3 MPixel/sec.                                                                                            
32 bits on curves                            : 1.46 MPixel/sec.         
                                                                             
8 bits on CMYK profiles                      : 6.21 MPixel/sec.              
16 bits on CMYK profiles                     : 6.72 MPixel/sec.              
32 bits on CMYK profiles                     : 0.991 MPixel/sec.             
                                                                             
8 bits on gray-to gray                       : 56.3 MPixel/sec.              
16 bits on gray-to gray                      : 56.0 MPixel/sec.              
32 bits on gray-to gray                      : 2.94 MPixel/sec.              
                                                                             
8 bits on gray-to-lab gray                   : 56.4 MPixel/sec.
16 bits on gray-to-lab gray                  : 55.7 MPixel/sec.              
32 bits on gray-to-lab gray                  : 2.15 MPixel/sec.                                                                                            
                                                                             
8 bits on SAME gray-to-gray                  : 55.8 MPixel/sec.                                                                                            
16 bits on SAME gray-to-gray                 : 56.2 MPixel/sec.
32 bits on SAME gray-to-gray                 : 2.91 MPixel/sec.

[Memory statistics]
Allocated = 0 MaxAlloc = 3055792 Single block hit = 1204224
if [ .. != .. ]; then \
        rm -f ../testbed/*.ic?; \
fi
make[1]: Leaving directory '/src/lcms/testbed'
make[1]: Entering directory '/src/lcms'
make[1]: Nothing to be done for 'check-am'.
make[1]: Leaving directory '/src/lcms'
```