### PR TITLE
opensc: add run_tests.sh

### DIFF
--- a/projects/opensc/build.sh
+++ b/projects/opensc/build.sh
@@ -17,7 +17,7 @@
 
 ./bootstrap
 # FIXME FUZZING_LIBS="$LIB_FUZZING_ENGINE" fails with some missing C++ library, I don't know how to fix this
-./configure --disable-optimization --disable-shared --disable-pcsc --enable-ctapi --enable-fuzzing FUZZING_LIBS="$LIB_FUZZING_ENGINE"
+./configure --enable-tests --disable-optimization --disable-shared --disable-pcsc --enable-ctapi --enable-fuzzing FUZZING_LIBS="$LIB_FUZZING_ENGINE"
 make -j4
 
 fuzzerFiles=$(find $SRC/opensc/src/tests/fuzzing/ -name "fuzz_*.c")

--- a/projects/opensc/run_tests.sh
+++ b/projects/opensc/run_tests.sh
@@ -1,4 +1,5 @@
-# Copyright 2019 Google Inc.
+#!/bin/bash -eu
+# Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,9 +14,4 @@
 # limitations under the License.
 #
 ################################################################################
-
-FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y pcscd libccid libpcsclite-dev libssl-dev libreadline-dev autoconf automake build-essential docbook-xsl xsltproc libtool pkg-config zlib1g-dev
-RUN git clone --depth 1 --single-branch --branch master https://github.com/OpenSC/OpenSC opensc
-WORKDIR opensc
-COPY build.sh run_tests.sh $SRC/
+make check


### PR DESCRIPTION
`infra/experimental/chronos/check_tests.sh opensc c`

```
PASS: test-manpage.sh                                                                                                                                      
PASS: test-duplicate-symbols.sh                                              
SKIP: test-pkcs11-tool-test-threads.sh                                       
SKIP: test-pkcs11-tool-allowed-mechanisms.sh                                 
SKIP: test-pkcs11-tool-sym-crypt-test.sh                                                                                                                   
SKIP: test-pkcs11-tool-test.sh                                               
SKIP: test-pkcs11-tool-sign-verify.sh                                        
SKIP: test-pkcs11-tool-unwrap-wrap-test.sh                                   
SKIP: test-pkcs11-tool-import.sh                                                                                                                           
============================================================================ 
Testsuite summary for OpenSC 0.26.1                                          
============================================================================ 
# TOTAL: 9                            
# PASS:  2                                                                   
# SKIP:  7                                                                   
# XFAIL: 0                                                                   
# FAIL:  0                                                                   
# XPASS: 0                                                                                                                                                 
# ERROR: 0                                                                                                                                                 
============================================================================
make[3]: Leaving directory '/src/opensc/tests'
make[2]: Leaving directory '/src/opensc/tests'
make[1]: Leaving directory '/src/opensc/tests'
make[1]: Entering directory '/src/opensc'
make[1]: Nothing to be done for 'check-am'.
make[1]: Leaving directory '/src/opensc
```