### PR TITLE
valijson: add run_tests.sh

### DIFF
--- a/projects/valijson/run_tests.diff
+++ b/projects/valijson/run_tests.diff
@@ -1,0 +1,13 @@
+diff --git a/tests/fuzzing/oss-fuzz-build.sh b/tests/fuzzing/oss-fuzz-build.sh
+index be9757c..fdf5c90 100755
+--- a/tests/fuzzing/oss-fuzz-build.sh
++++ b/tests/fuzzing/oss-fuzz-build.sh
+@@ -5,7 +5,7 @@ git submodule update --init --depth 1 thirdparty
+ mkdir build
+ cd build
+ cmake \
+-  -Dvalijson_BUILD_TESTS=FALSE \
++  -Dvalijson_BUILD_TESTS=ON \
+   -Dvalijson_BUILD_EXAMPLES=FALSE \
+   -Dvalijson_EXCLUDE_BOOST=TRUE \
+   ..

--- a/projects/valijson/run_tests.sh
+++ b/projects/valijson/run_tests.sh
@@ -1,4 +1,5 @@
-# Copyright 2020 Google Inc.
+#!/bin/bash -eu
+# Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,13 +14,5 @@
 # limitations under the License.
 #
 ################################################################################
-
-
-FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool \
-  pkg-config cmake libcurlpp-dev libcurl4-openssl-dev
-RUN git clone --depth 1 https://github.com/tristanpenman/valijson
-COPY run_tests.diff run_tests.sh $SRC/
-RUN cd valijson && git apply $SRC/run_tests.diff
-WORKDIR valijson
-RUN cp $SRC/valijson/tests/fuzzing/oss-fuzz-build.sh $SRC/build.sh
+cd $SRC/valijson/build
+./test_suite


### PR DESCRIPTION
Adds run_tests.sh to the valijson project.

run_tests.sh is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

`infra/experimental/chronos/check_tests.sh valijson c`

```
Running main() from /src/valijson/thirdparty/googletest/googletest/src/gtest_main.cc                                                                       
[==========] Running 125 tests from 16 test suites.                                                                                                        
[----------] Global test environment set-up.                                                                                                               
[----------] 21 tests from TestAdapterComparison                                                                                                           
[ RUN      ] TestAdapterComparison.JsonCppVsJsonCpp                                                                                                        
[       OK ] TestAdapterComparison.JsonCppVsJsonCpp (9 ms)                                                                                                 
[ RUN      ] TestAdapterComparison.JsonCppVsPicoJson                                                                                                       
[       OK ] TestAdapterComparison.JsonCppVsPicoJson (3 ms)                                                                                                
[ RUN      ] TestAdapterComparison.JsonCppVsRapidJson                                                                                                      
[       OK ] TestAdapterComparison.JsonCppVsRapidJson (5 ms)                                                                                               
[ RUN      ] TestAdapterComparison.JsonCppVsRapidJsonCrtAlloc                                                                                              
[       OK ] TestAdapterComparison.JsonCppVsRapidJsonCrtAlloc (5 ms)
...
```