### PR TITLE
snappy: add run_tests.sh

### DIFF
--- a/projects/snappy/Dockerfile
+++ b/projects/snappy/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool gettext 
 RUN git clone --recurse-submodules https://github.com/google/snappy
 
 WORKDIR $SRC/
-COPY build.sh $SRC/
+COPY run_tests.sh build.sh $SRC/

--- a/projects/snappy/run_tests.sh
+++ b/projects/snappy/run_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2020 Google Inc.
+# Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,9 +15,5 @@
 #
 ################################################################################
 
-cd $SRC/snappy
-mkdir -p build && cd build
-cmake -DSNAPPY_FUZZING_BUILD=ON -DSNAPPY_BUILD_TESTS=1 \
-    -DSNAPPY_BUILD_BENCHMARKS=0 ../ && cmake --build .
-
-cp *_fuzzer $OUT/
+cd $SRC/snappy/build
+ctest --output-on-failure


### PR DESCRIPTION
Adds `run_tests.sh` to the snappy project.

`run_tests.sh` is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

Output of ./infra/experimental/chronos/check_tests.sh snappy c++:
```
Test project /src/snappy/build
    Start 1: snappy_unittest
1/1 Test #1: snappy_unittest ..................   Passed   27.88 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =  27.88 sec
```