### PR TITLE
fmt: add run_tests.sh

### DIFF
--- a/projects/fmt/Dockerfile
+++ b/projects/fmt/Dockerfile
@@ -23,4 +23,4 @@ RUN git clone --depth 1 --branch master \
   https://github.com/fmtlib/fmt.git
 
 WORKDIR fmt
-COPY build.sh $SRC/
+COPY run_tests.sh build.sh $SRC/

--- a/projects/fmt/run_tests.sh
+++ b/projects/fmt/run_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2019 Google Inc.
+# Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,28 +15,5 @@
 #
 ################################################################################
 
-#create zip files with initial corpus, taken from version control.
-#for f in $(ls fuzzers/initial_corpus/) ;do
-#  zip -j -r $OUT/fuzzer_${f}_seed_corpus.zip fuzzers/initial_corpus/$f
-#done
-
-mkdir build
 cd build
-
-# use C++ 14 instead of 17, because even if clang is
-# bleeding edge, cmake is old in the oss fuzz image.
-
-cmake .. \
--GNinja \
--DCMAKE_BUILD_TYPE=Debug \
--DCMAKE_CXX_STANDARD=14 \
--DFMT_DOC=Off \
--DFMT_TEST=On \
--DFMT_SAFE_DURATION_CAST=On \
--DFMT_FUZZ=On \
--DFMT_FUZZ_LINKMAIN=Off \
--DFMT_FUZZ_LDFLAGS=$LIB_FUZZING_ENGINE
-
-cmake --build .
-
-cp bin/*fuzzer $OUT
+ninja test


### PR DESCRIPTION
Adds `run_tests.sh` to the fmt project.

`run_tests.sh` is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

Output of ./infra/experimental/chronos/check_tests.sh fmt c++:
```
[0/1] Running tests...
Test project /src/fmt/build
      Start  1: args-test
 1/21 Test  #1: args-test ........................   Passed    0.07 sec
      Start  2: base-test
 2/21 Test  #2: base-test ........................   Passed    0.11 sec
      Start  3: assert-test
 3/21 Test  #3: assert-test ......................   Passed    0.40 sec
      Start  4: chrono-test
 4/21 Test  #4: chrono-test ......................   Passed    0.45 sec
      Start  5: color-test
 5/21 Test  #5: color-test .......................   Passed    0.07 sec
      Start  6: gtest-extra-test
 6/21 Test  #6: gtest-extra-test .................   Passed    0.13 sec
      Start  7: format-test
 7/21 Test  #7: format-test ......................   Passed    0.15 sec
      Start  8: format-impl-test
 8/21 Test  #8: format-impl-test .................   Passed    0.16 sec
      Start  9: ostream-test
 9/21 Test  #9: ostream-test .....................   Passed    0.04 sec
      Start 10: compile-test
10/21 Test #10: compile-test .....................   Passed    0.04 sec
      Start 11: compile-fp-test
11/21 Test #11: compile-fp-test ..................   Passed    0.04 sec
      Start 12: printf-test
12/21 Test #12: printf-test ......................   Passed    0.09 sec
      Start 13: ranges-test
13/21 Test #13: ranges-test ......................   Passed    0.06 sec
      Start 14: no-builtin-types-test
14/21 Test #14: no-builtin-types-test ............   Passed    0.05 sec
      Start 15: scan-test
15/21 Test #15: scan-test ........................   Passed    0.08 sec
      Start 16: std-test
16/21 Test #16: std-test .........................   Passed    0.05 sec
      Start 17: unicode-test
17/21 Test #17: unicode-test .....................   Passed    0.05 sec
      Start 18: xchar-test
18/21 Test #18: xchar-test .......................   Passed    0.06 sec
      Start 19: enforce-checks-test
19/21 Test #19: enforce-checks-test ..............   Passed    0.03 sec
      Start 20: posix-mock-test
20/21 Test #20: posix-mock-test ..................   Passed    0.06 sec
      Start 21: os-test
21/21 Test #21: os-test ..........................   Passed    0.07 sec

100% tests passed, 0 tests failed out of 21

Total Test time (real) =   2.32 sec
```