### PR TITLE
tinyobjloader: add run_tests.sh

### DIFF
--- a/projects/tinyobjloader/Dockerfile
+++ b/projects/tinyobjloader/Dockerfile
@@ -16,5 +16,5 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN git clone --depth 1 https://github.com/tinyobjloader/tinyobjloader
-COPY build.sh $SRC
+COPY build.sh run_tests.sh $SRC
 WORKDIR $SRC/tinyobjloader

--- a/projects/tinyobjloader/run_tests.sh
+++ b/projects/tinyobjloader/run_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2021 Google LLC
+# Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,9 +14,4 @@
 # limitations under the License.
 #
 ################################################################################
-
-# build project
-mkdir build && cd build
-cmake .. -DBUILD_SHARED_LIBS=OFF
-make -j $(nproc)
-cp fuzz* $OUT/
+cd $SRC/tinyobjloader/tests && make check


### PR DESCRIPTION
Adds run_tests.sh to the tinyobjloader project.

run_tests.sh is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

`infra/experimental/chronos/check_tests.sh tinyobjloader c`

```
...
SUCCESS: All unit tests have passed.
```