### PR TITLE
muparser: add run_tests.sh

### DIFF
--- a/projects/muparser/Dockerfile
+++ b/projects/muparser/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool
-RUN apt-get install -y build-essential cmake pkg-config
+RUN apt-get update && apt-get install -y build-essential cmake pkg-config
 RUN git clone --depth 1 https://github.com/beltoforion/muparser.git muparser
 WORKDIR muparser
 COPY run_tests.sh build.sh set_eval_fuzzer.cc $SRC/

--- a/projects/muparser/run_tests.sh
+++ b/projects/muparser/run_tests.sh
@@ -1,4 +1,5 @@
-# Copyright 2020 Google Inc.
+#!/bin/bash -eu
+# Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,9 +15,4 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool
-RUN apt-get install -y build-essential cmake pkg-config
-RUN git clone --depth 1 https://github.com/beltoforion/muparser.git muparser
-WORKDIR muparser
-COPY run_tests.sh build.sh set_eval_fuzzer.cc $SRC/
+make test


### PR DESCRIPTION
Adds `run_tests.sh` to the muparser project.

`run_tests.sh` is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

Output of ./infra/experimental/chronos/check_tests.sh muparser c++:
```
Running tests...
Test project /src/muparser
    Start 1: ParserTest
1/1 Test #1: ParserTest .......................   Passed    0.68 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.69 sec
```