### PR TITLE
libsodium: add run_tests.sh

### DIFF
--- a/projects/libsodium/run_tests.sh
+++ b/projects/libsodium/run_tests.sh
@@ -1,4 +1,5 @@
-# Copyright 2018 Google Inc.
+#!/bin/bash -eu
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,11 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make
-RUN git clone --depth 1 https://github.com/jedisct1/libsodium.git --branch stable libsodium
-WORKDIR libsodium
-COPY run_tests.sh build.sh *.cc *.h $SRC/
+cd $SRC/libsodium
+ASAN_OPTIONS=detect_leaks=0 make check


### PR DESCRIPTION
Adds `run_tests.sh` to the libsodium project.

`run_tests.sh` is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

Output of ./infra/experimental/chronos/check_tests.sh libsodium c++:
```
make  check-TESTS
make[3]: Entering directory '/src/libsodium/test/default'
make[4]: Entering directory '/src/libsodium/test/default'
PASS: aead_aegis128l
PASS: aead_aegis256
PASS: aead_aes256gcm
PASS: aead_aes256gcm2
PASS: aead_chacha20poly1305
PASS: aead_chacha20poly13052
PASS: aead_xchacha20poly1305
PASS: auth
PASS: auth2
PASS: auth3
PASS: auth5
PASS: auth6
PASS: auth7
PASS: box
PASS: box2
PASS: box7
PASS: box8
PASS: box_easy
PASS: box_easy2
PASS: box_seal
PASS: box_seed
PASS: chacha20
PASS: codecs
PASS: core1
PASS: core2
PASS: core3
PASS: core4
PASS: core5
PASS: core6
PASS: ed25519_convert
PASS: generichash
PASS: generichash2
PASS: generichash3
PASS: hash
PASS: hash3
PASS: kdf
PASS: keygen
PASS: kx
PASS: metamorphic
PASS: misuse
PASS: onetimeauth
PASS: onetimeauth2
PASS: onetimeauth7
PASS: pwhash_argon2i
PASS: pwhash_argon2id
PASS: randombytes
PASS: scalarmult
PASS: scalarmult2
PASS: scalarmult5
PASS: scalarmult6
PASS: scalarmult7
PASS: scalarmult8
PASS: secretbox
PASS: secretbox2
PASS: secretbox7
PASS: secretbox8
PASS: secretbox_easy
PASS: secretbox_easy2
PASS: secretstream_xchacha20poly1305
PASS: shorthash
PASS: sign
PASS: sodium_core
PASS: sodium_utils
PASS: sodium_version
PASS: stream
PASS: stream2
PASS: stream3
PASS: stream4
PASS: verify1
PASS: sodium_utils2
PASS: sodium_utils3
PASS: core_ed25519
PASS: core_ristretto255
PASS: kdf_hkdf
PASS: pwhash_scrypt
PASS: pwhash_scrypt_ll
PASS: scalarmult_ed25519
PASS: scalarmult_ristretto255
PASS: siphashx24
PASS: xchacha20
============================================================================
Testsuite summary for libsodium 1.0.20
============================================================================
# TOTAL: 80
# PASS:  80
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
make[4]: Leaving directory '/src/libsodium/test/default'
make[3]: Leaving directory '/src/libsodium/test/default'
make[2]: Leaving directory '/src/libsodium/test/default'
make[2]: Entering directory '/src/libsodium/test'
make[2]: Nothing to be done for 'check-am'.
make[2]: Leaving directory '/src/libsodium/test'
make[1]: Leaving directory '/src/libsodium/test'
make[1]: Entering directory '/src/libsodium'
make[1]: Nothing to be done for 'check-am'.
make[1]: Leaving directory '/src/libsodium'
```