### PR TITLE
openbabel: add run_tests

### DIFF
--- a/projects/openbabel/run_tests.sh
+++ b/projects/openbabel/run_tests.sh
@@ -1,4 +1,5 @@
-# Copyright 2021 Google LLC
+#!/bin/bash -eux
+# Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,8 +15,10 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt install -y cmake
-RUN git clone --depth 1 https://github.com/openbabel/openbabel.git
-COPY *.sh $SRC
-WORKDIR $SRC/openbabel
+export ASAN_OPTIONS="detect_leaks=0"
+
+# Run almost all of the tests. Some of the tests are failing by default,
+# so we disable these for now.
+for test_idx in 0 1 3 4 6 8 9 10 12 13 14 15 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 36 37 38 41 43 44 45 46 47 48 49 50 51 52 53 54 56 57 58 59 60; do
+  echo "${test_idx}" | ./build/bin/test_runner
+done


### PR DESCRIPTION
run_tests.sh is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

```
$ ./infra/experimental/chronos/check_tests.sh openbabel c++
...
...
# Testing unit cell coordinate functions ...
13..24
ok 13 # wrapped cartesian x
ok 14 # wrapped cartesian y
ok 15 # wrapped cartesian z
ok 16 # wrapped fractional x
ok 17 # wrapped fractional y
ok 18 # wrapped fractional z
ok 19 # cart2frac x
ok 20 # cart2frac y
ok 21 # cart2frac z
ok 22 # frac2cart x
ok 23 # frac2cart y
ok 24 # frac2cart z
# cell volume 45.64
# lattice type 2
# cell volume 45.64
# lattice type 2
```