### PR TITLE
h3: add run_tests.sh

### DIFF
--- a/projects/h3/build.sh
+++ b/projects/h3/build.sh
@@ -17,8 +17,8 @@
 
 mkdir build
 cd build
-cmake ..
-make -j$(nproc) h3
+cmake -DBUILD_TESTING=ON ..
+make -j$(nproc) all
 
 H3_BASE=/src/h3/
 

--- a/projects/h3/run_tests.sh
+++ b/projects/h3/run_tests.sh
@@ -1,4 +1,5 @@
-# Copyright 2021 Google LLC
+#!/bin/bash -eux
+# Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,9 +15,5 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool \
-  pkg-config
-RUN git clone --depth 1 https://github.com/uber/h3
-WORKDIR h3
-COPY *.sh $SRC/
+cd build
+make test


### PR DESCRIPTION
run_tests.sh is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

```
$ infra/experimental/chronos/check_tests.sh h3 c++

277/283 Test #277: testCliUncompactCellsStdin3_test139 ..............   Passed    0.01 sec                                                                     
        Start 278: testCliUncompactCellsArg1_test139                                                                                                           
278/283 Test #278: testCliUncompactCellsArg1_test139 ................   Passed    0.01 sec                                                                     
        Start 279: testCliUncompactCellsArg2_test139    
279/283 Test #279: testCliUncompactCellsArg2_test139 ................   Passed    0.01 sec
        Start 280: testCliUncompactCellsArg3_test139      
280/283 Test #280: testCliUncompactCellsArg3_test139 ................   Passed    0.01 sec                                                                     
        Start 281: testCliVertexToLatLng_test139                 
281/283 Test #281: testCliVertexToLatLng_test139 ....................   Passed    0.01 sec                                                                     
        Start 282: testCliNotVertexToLatLng_test139                                                                                                            
282/283 Test #282: testCliNotVertexToLatLng_test139 .................   Passed    0.01 sec
        Start 283: testH3Memory_test140                                                                                                                        
283/283 Test #283: testH3Memory_test140 .............................   Passed    0.01 sec                                                                     
                                                                                                                                                               
100% tests passed, 0 tests failed out of 283
```