### PR TITLE
utf8proc: add run_tests.sh

### DIFF
--- a/projects/utf8proc/run_tests.sh
+++ b/projects/utf8proc/run_tests.sh
@@ -1,4 +1,5 @@
-# Copyright 2021 Google Inc.
+#!/bin/bash -eux
+# Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,15 +15,5 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
-
-RUN apt-get update && \
-    apt-get install -y wget tar
-
-RUN git clone --depth 1 https://github.com/JuliaStrings/utf8proc.git
-
-RUN wget -O $SRC/utf8proc/test/NormalizationTest.txt https://www.unicode.org/Public/13.0.0/ucd/NormalizationTest.txt
-RUN wget -O $SRC/utf8proc/test/GraphemeBreakTest.txt https://www.unicode.org/Public/13.0.0/ucd/auxiliary/GraphemeBreakTest.txt
-
-WORKDIR $SRC/utf8proc/
-COPY *.sh $SRC/
+cd build
+make test


### PR DESCRIPTION
run_tests.sh is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

```
$ infra/experimental/chronos/check_tests.sh utf8proc c++
...
...
Running tests...
Test project /src/utf8proc/build
      Start  1: utf8proc.testcase
 1/10 Test  #1: utf8proc.testcase ................   Passed    0.07 sec
      Start  2: utf8proc.testcustom
 2/10 Test  #2: utf8proc.testcustom ..............   Passed    0.01 sec
      Start  3: utf8proc.testiterate
 3/10 Test  #3: utf8proc.testiterate .............   Passed    0.01 sec
      Start  4: utf8proc.testmisc
 4/10 Test  #4: utf8proc.testmisc ................   Passed    0.01 sec
      Start  5: utf8proc.testprintproperty
 5/10 Test  #5: utf8proc.testprintproperty .......   Passed    0.00 sec
      Start  6: utf8proc.testvalid
 6/10 Test  #6: utf8proc.testvalid ...............   Passed    0.01 sec
      Start  7: utf8proc.testmaxdecomposition
 7/10 Test  #7: utf8proc.testmaxdecomposition ....   Passed    0.03 sec
      Start  8: utf8proc.testcharwidth
 8/10 Test  #8: utf8proc.testcharwidth ...........   Passed    0.09 sec
      Start  9: utf8proc.testgraphemetest
 9/10 Test  #9: utf8proc.testgraphemetest ........   Passed    0.01 sec
      Start 10: utf8proc.testnormtest
10/10 Test #10: utf8proc.testnormtest ............   Passed    0.35 sec

100% tests passed, 0 tests failed out of 10

Total Test time (real) =   0.58 sec
```