### PR TITLE
qemu: add run_tests.sh

### DIFF
--- a/projects/qemu/Dockerfile
+++ b/projects/qemu/Dockerfile
@@ -28,4 +28,4 @@ RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/glib.git --branch=$glib_t
 
 RUN git clone --depth 1 https://git.qemu.org/git/qemu.git qemu
 WORKDIR qemu
-COPY build.sh $SRC/
+COPY run_tests.sh build.sh $SRC/

--- a/projects/qemu/run_tests.sh
+++ b/projects/qemu/run_tests.sh
@@ -1,5 +1,5 @@
-#!/bin/sh -e
-# Copyright 2020 Google Inc.
+#!/bin/bash -eu
+# Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,8 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 ################################################################################
 
-cd $SRC/qemu/
-$SRC/qemu/scripts/oss-fuzz/build.sh
+cd $SRC/qemu/build-oss-fuzz
+make -j"$(nproc)" check-unit


### PR DESCRIPTION
Adds `run_tests.sh` to the qemu project.

`run_tests.sh` is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

Output of ./infra/experimental/chronos/check_tests.sh qemu c++:
```
[1/3] Generating qemu-version.h with a custom command (wrapped by meson to capture output)
/src/qemu/build-oss-fuzz/pyvenv/bin/meson test  --no-rebuild -t 1  --num-processes 8 --print-errorlogs  --suite unit
  1/100 qemu:unit / check-block-qdict                    OK               0.10s   10 subtests passed
  2/100 qemu:unit / check-qdict                          OK               0.08s   15 subtests passed
  3/100 qemu:unit / test-crypto-block                    SKIP             0.23s
  4/100 qemu:unit / check-qnum                           OK               0.13s   8 subtests passed
  5/100 qemu:unit / check-qstring                        OK               0.13s   4 subtests passed
  6/100 qemu:unit / check-qlist                          OK               0.12s   4 subtests passed
  7/100 qemu:unit / check-qnull                          OK               0.10s   2 subtests passed
  8/100 qemu:unit / check-qobject                        OK               0.11s   7 subtests passed
  9/100 qemu:unit / check-qlit                           OK               0.12s   2 subtests passed
 10/100 qemu:unit / test-qobject-output-visitor          OK               0.11s   16 subtests passed
 11/100 qemu:unit / test-clone-visitor                   OK               0.12s   7 subtests passed
 12/100 qemu:unit / test-forward-visitor                 OK               0.11s   7 subtests passed
 13/100 qemu:unit / test-qobject-input-visitor           OK               0.20s   42 subtests passed
 14/100 qemu:unit / test-string-input-visitor            OK               0.16s   8 subtests passed
 15/100 qemu:unit / test-string-output-visitor           OK               0.12s   14 subtests passed
 16/100 qemu:unit / test-error-report                    OK               0.43s   6 subtests passed
 17/100 qemu:unit / test-visitor-serialization           OK               0.17s   156 subtests passed
 18/100 qemu:unit / test-bitmap                          OK               0.13s   2 subtests passed
 19/100 qemu:unit / test-resv-mem                        OK               0.15s   3 subtests passed
 20/100 qemu:unit / test-x86-topo                        OK               0.10s   1 subtests passed
 21/100 qemu:unit / check-qjson                          OK               0.66s   31 subtests passed
 22/100 qemu:unit / test-div128                          OK               0.10s   2 subtests passed
 23/100 qemu:unit / test-shift128                        OK               0.12s   2 subtests passed
 24/100 qemu:unit / test-cutils                          OK               0.19s   179 subtests passed
 25/100 qemu:unit / test-mul64                           OK               0.12s   2 subtests passed
 26/100 qemu:unit / test-int128                          OK               0.15s   11 subtests passed
 27/100 qemu:unit / rcutorture                           OK               2.09s   2 subtests passed
 28/100 qemu:unit / test-qdist                           OK               0.05s   8 subtests passed
 29/100 qemu:unit / test-qht                             OK               1.18s   2 subtests passed
 30/100 qemu:unit / test-bufferiszero                    OK               4.23s   1 subtests passed
 31/100 qemu:unit / test-qtree                           OK               0.06s   4 subtests passed
 32/100 qemu:unit / test-bitops                          OK               0.05s   6 subtests passed
 33/100 qemu:unit / test-bitcnt                          OK               0.05s   4 subtests passed
 34/100 qemu:unit / test-qgraph                          OK               0.05s   23 subtests passed
 35/100 qemu:unit / check-qom-interface                  OK               0.05s   2 subtests passed
 36/100 qemu:unit / check-qom-proplist                   OK               0.05s   9 subtests passed
 37/100 qemu:unit / test-qemu-opts                       OK               0.06s   19 subtests passed
 38/100 qemu:unit / test-keyval                          OK               0.06s   13 subtests passed
 39/100 qemu:unit / test-qapi-util                       OK               0.04s   2 subtests passed
 40/100 qemu:unit / test-logging                         OK               0.11s   4 subtests passed
 41/100 qemu:unit / test-interval-tree                   OK               0.06s   6 subtests passed
 42/100 qemu:unit / test-fifo                            OK               0.05s   10 subtests passed
 43/100 qemu:unit / test-qmp-event                       OK               0.05s   6 subtests passed
 44/100 qemu:unit / test-coroutine                       OK               0.10s   12 subtests passed
 45/100 qemu:unit / test-replication                     OK               4.75s   13 subtests passed
 46/100 qemu:unit / test-throttle                        OK               0.06s   17 subtests passed
 47/100 qemu:unit / test-rcu-list                        OK               4.08s   3 subtests passed
 48/100 qemu:unit / test-rcu-simpleq                     OK               4.10s   3 subtests passed
 49/100 qemu:unit / test-bdrv-graph-mod                  OK               0.07s   5 subtests passed
 50/100 qemu:unit / test-rcu-tailq                       OK               4.17s   3 subtests passed
 51/100 qemu:unit / test-blockjob                        OK               0.09s   8 subtests passed
 52/100 qemu:unit / test-rcu-slist                       OK               4.20s   3 subtests passed
 53/100 qemu:unit / test-blockjob-txn                    OK               0.12s   7 subtests passed
 54/100 qemu:unit / test-hbitmap                         OK               0.51s   40 subtests passed
 55/100 qemu:unit / test-block-backend                   OK               0.11s   2 subtests passed
 56/100 qemu:unit / test-bdrv-drain                      OK               0.35s   30 subtests passed
 57/100 qemu:unit / test-write-threshold                 OK               0.11s   2 subtests passed
 58/100 qemu:unit / test-crypto-hash                     OK               0.10s   6 subtests passed
 59/100 qemu:unit / test-crypto-hmac                     OK               0.09s   4 subtests passed
 60/100 qemu:unit / test-block-iothread                  OK               0.20s   22 subtests passed
 61/100 qemu:unit / test-crypto-cipher                   SKIP             0.12s
 62/100 qemu:unit / test-crypto-akcipher                 OK               0.12s   16 subtests passed
 63/100 qemu:unit / test-crypto-secret                   OK               0.12s   10 subtests passed
 64/100 qemu:unit / test-crypto-der                      OK               0.13s   4 subtests passed
 65/100 qemu:unit / test-authz-simple                    OK               0.13s   1 subtests passed
 66/100 qemu:unit / test-authz-list                      OK               0.13s   6 subtests passed
 67/100 qemu:unit / test-authz-listfile                  OK               0.13s   5 subtests passed
 68/100 qemu:unit / test-io-task                         OK               0.14s   5 subtests passed
 69/100 qemu:unit / test-io-channel-command              SKIP             0.08s   0 subtests passed
 70/100 qemu:unit / test-io-channel-file                 OK               0.11s   5 subtests passed
 71/100 qemu:unit / test-io-channel-socket               OK               0.18s   7 subtests passed
 72/100 qemu:unit / test-io-channel-buffer               OK               0.13s   1 subtests passed
 73/100 qemu:unit / test-io-channel-null                 OK               0.11s   1 subtests passed
 74/100 qemu:unit / test-crypto-ivgen                    OK               0.12s   9 subtests passed
 75/100 qemu:unit / test-timed-average                   OK               0.10s   1 subtests passed
 76/100 qemu:unit / test-uuid                            OK               0.08s   6 subtests passed
 77/100 qemu:unit / test-crypto-afsplit                  OK               0.16s   4 subtests passed
 78/100 qemu:unit / test-image-locking                   OK               0.10s   2 subtests passed
 79/100 qemu:unit / test-nested-aio-poll                 OK               0.07s   1 subtests passed
 80/100 qemu:unit / test-crypto-pbkdf                    SKIP             0.13s
 81/100 qemu:unit / ptimer-test                          OK               0.13s   576 subtests passed
 82/100 qemu:unit / test-xs-node                         OK               0.10s   7 subtests passed
 83/100 qemu:unit / test-virtio-dmabuf                   OK               0.09s   5 subtests passed
 84/100 qemu:unit / test-qmp-cmds                        OK               0.09s   10 subtests passed
 85/100 qemu:unit / test-util-sockets                    OK               0.08s   21 subtests passed
 86/100 qemu:unit / test-base64                          OK               0.07s   4 subtests passed
 87/100 qemu:unit / test-opts-visitor                    OK               0.30s   33 subtests passed
 88/100 qemu:unit / test-smp-parse                       OK               0.11s   10 subtests passed
 89/100 qemu:unit / test-vmstate                         OK               0.10s   23 subtests passed
 90/100 qemu:unit / test-yank                            OK               0.09s   6 subtests passed
 91/100 qemu:unit / test-xbzrle                          OK               0.32s   6 subtests passed
 92/100 qemu:unit / test-util-filemonitor                OK               0.13s   1 subtests passed
 93/100 qemu:unit / test-qdev-global-props               OK               0.17s   4 subtests passed
 94/100 qemu:unit / test-iov                             OK               0.65s   6 subtests passed
 95/100 qemu:unit / xml-preprocess                       OK               0.31s
 96/100 qemu:unit / test-aio-multithread                 OK               7.57s   6 subtests passed
 97/100 qemu:unit / test-aio                             OK               3.88s   27 subtests passed
 98/100 qemu:unit / test-char                            OK               2.32s   40 subtests passed
 99/100 qemu:unit / test-thread-pool                     OK               4.13s   6 subtests passed
100/100 qemu:unit / test-qga                             OK               4.40s   29 subtests passed

Ok:                96  
Fail:              0   
Skipped:           4   

Full log written to /src/qemu/build-oss-fuzz/meson-logs/testlog.txt
```