### PR TITLE
wolfssl: fix build

### DIFF
--- a/projects/wolfssl/Dockerfile
+++ b/projects/wolfssl/Dockerfile
@@ -21,9 +21,8 @@ RUN git clone --depth 1 https://github.com/wolfssl/wolfssl $SRC/wolfssl
 RUN git clone --depth 1 https://github.com/wolfSSL/wolfsm
 RUN git clone --depth 1 https://github.com/wolfSSL/wolfssh.git
 RUN git clone --depth 1 https://github.com/guidovranken/fuzzing-headers.git
-RUN git clone --depth 1 https://github.com/guidovranken/wolf-ssl-ssh-fuzzers
+RUN git clone --depth 1 https://github.com/JacobBarthelmeh/wolf-ssl-ssh-fuzzers
 RUN git clone --depth 1 https://github.com/MozillaSecurity/cryptofuzz
-RUN git clone --depth 1 https://github.com/randombit/botan.git
 RUN git clone --depth 1 https://github.com/google/wycheproof.git
 RUN wget https://archives.boost.io/release/1.82.0/source/boost_1_82_0.tar.bz2
 RUN git clone https://github.com/wolfssl/oss-fuzz-targets --depth 1 $SRC/fuzz-targets
@@ -39,12 +38,6 @@ RUN gsutil cp gs://relic-backup.clusterfuzz-external.appspot.com/corpus/libFuzze
 RUN gsutil cp gs://cryptofuzz-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer/cryptofuzz_cryptofuzz-openssl/public.zip $SRC/corpus_cryptofuzz-openssl.zip
 RUN gsutil cp gs://cryptofuzz-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer/cryptofuzz_cryptofuzz-boringssl/public.zip $SRC/corpus_cryptofuzz-boringssl.zip
 RUN gsutil cp gs://cryptofuzz-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer/cryptofuzz_cryptofuzz-nss/public.zip $SRC/corpus_cryptofuzz-nss.zip
-
-# Botan corpora, which require a special import procedure
-RUN gsutil cp gs://botan-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer/botan_ecc_p256/public.zip $SRC/corpus_botan_ecc_p256.zip
-RUN gsutil cp gs://botan-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer/botan_ecc_p384/public.zip $SRC/corpus_botan_ecc_p384.zip
-RUN gsutil cp gs://botan-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer/botan_ecc_p521/public.zip $SRC/corpus_botan_ecc_p521.zip
-RUN gsutil cp gs://botan-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer/botan_ecc_bp256/public.zip $SRC/corpus_botan_ecc_bp256.zip
 
 # OpenSSL/LibreSSL corpora, which require a special import procedure
 RUN gsutil cp gs://openssl-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer/openssl_bignum/public.zip $SRC/corpus_openssl_expmod.zip

--- a/projects/wolfssl/build.sh
+++ b/projects/wolfssl/build.sh
@@ -35,24 +35,6 @@ then
     CFLAGS="" CXXFLAGS="" ./b2 headers
     cp -R boost/ /usr/include/
 
-    # Build Botan
-    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_BOTAN_IS_ORACLE"
-    cd $SRC/botan
-    if [[ $CFLAGS != *-m32* ]]
-    then
-        if [[ $CFLAGS != *sanitize=memory* ]]
-        then
-            ./configure.py --cc-bin=$CXX --cc-abi-flags="$CXXFLAGS" --disable-shared --disable-modules=locking_allocator --build-targets=static --without-documentation
-        else
-            ./configure.py --disable-asm --cc-bin=$CXX --cc-abi-flags="$CXXFLAGS" --disable-shared --disable-modules=locking_allocator --build-targets=static --without-documentation
-        fi
-    else
-        ./configure.py --cpu=x86_32 --cc-bin=$CXX --cc-abi-flags="$CXXFLAGS" --disable-shared --disable-modules=locking_allocator --build-targets=static --without-documentation
-    fi
-    make -j$(nproc)
-    export LIBBOTAN_A_PATH="$SRC/botan/libbotan-3.a"
-    export BOTAN_INCLUDE_PATH="$SRC/botan/build/include"
-
     OLD_CFLAGS="$CFLAGS"
     OLD_CXXFLAGS="$CXXFLAGS"
 
@@ -136,12 +118,10 @@ then
         ./configure $WOLFCRYPT_CONFIGURE_PARAMS --disable-asm
     fi
     make -j$(nproc)
-    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL -DCRYPTOFUZZ_WOLFCRYPT -DCRYPTOFUZZ_BOTAN"
+    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL -DCRYPTOFUZZ_WOLFCRYPT"
     export WOLFCRYPT_LIBWOLFSSL_A_PATH="$SRC/wolfssl-normal-math/src/.libs/libwolfssl.a"
     export WOLFCRYPT_INCLUDE_PATH="$SRC/wolfssl-normal-math/"
     cd $SRC/cryptofuzz-normal-math/modules/wolfcrypt
-    make -j$(nproc)
-    cd $SRC/cryptofuzz-normal-math/modules/botan
     make -j$(nproc)
     cd $SRC/cryptofuzz-normal-math/
     LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" make -B -j$(nproc)
@@ -159,12 +139,10 @@ then
     CFLAGS="$CFLAGS -DHAVE_AES_ECB -DWOLFSSL_DES_ECB -DHAVE_ECC_SECPR2 -DHAVE_ECC_SECPR3 -DHAVE_ECC_BRAINPOOL -DHAVE_ECC_KOBLITZ -DWOLFSSL_ECDSA_SET_K -DWOLFSSL_ECDSA_SET_K_ONE_LOOP -DWOLFSSL_SP_INT_NEGATIVE"
     ./configure $WOLFCRYPT_CONFIGURE_PARAMS --enable-sp-math-all
     make -j$(nproc)
-    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL -DCRYPTOFUZZ_WOLFCRYPT -DCRYPTOFUZZ_BOTAN"
+    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL -DCRYPTOFUZZ_WOLFCRYPT"
     export WOLFCRYPT_LIBWOLFSSL_A_PATH="$SRC/wolfssl-sp-math-all/src/.libs/libwolfssl.a"
     export WOLFCRYPT_INCLUDE_PATH="$SRC/wolfssl-sp-math-all/"
     cd $SRC/cryptofuzz-sp-math-all/modules/wolfcrypt
-    make -j$(nproc)
-    cd $SRC/cryptofuzz-sp-math-all/modules/botan
     make -j$(nproc)
     cd $SRC/cryptofuzz-sp-math-all/
     LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" make -B -j$(nproc)
@@ -182,12 +160,10 @@ then
     CFLAGS="$CFLAGS -DHAVE_AES_ECB -DWOLFSSL_DES_ECB -DHAVE_ECC_SECPR2 -DHAVE_ECC_SECPR3 -DHAVE_ECC_BRAINPOOL -DHAVE_ECC_KOBLITZ -DWOLFSSL_ECDSA_SET_K -DWOLFSSL_ECDSA_SET_K_ONE_LOOP -DSP_WORD_SIZE=8 -DWOLFSSL_SP_INT_NEGATIVE"
     ./configure $WOLFCRYPT_CONFIGURE_PARAMS --enable-sp-math-all
     make -j$(nproc)
-    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL -DCRYPTOFUZZ_WOLFCRYPT -DCRYPTOFUZZ_BOTAN"
+    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL -DCRYPTOFUZZ_WOLFCRYPT"
     export WOLFCRYPT_LIBWOLFSSL_A_PATH="$SRC/wolfssl-sp-math-all-8bit/src/.libs/libwolfssl.a"
     export WOLFCRYPT_INCLUDE_PATH="$SRC/wolfssl-sp-math-all-8bit/"
     cd $SRC/cryptofuzz-sp-math-all-8bit/modules/wolfcrypt
-    make -j$(nproc)
-    cd $SRC/cryptofuzz-sp-math-all-8bit/modules/botan
     make -j$(nproc)
     cd $SRC/cryptofuzz-sp-math-all-8bit/
     LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" make -B -j$(nproc)
@@ -216,12 +192,10 @@ then
         ./configure $WOLFCRYPT_CONFIGURE_PARAMS_SP_MATH --enable-sp --enable-sp-math
     fi
     make -j$(nproc)
-    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL -DCRYPTOFUZZ_WOLFCRYPT -DCRYPTOFUZZ_BOTAN"
+    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL -DCRYPTOFUZZ_WOLFCRYPT"
     export WOLFCRYPT_LIBWOLFSSL_A_PATH="$SRC/wolfssl-sp-math/src/.libs/libwolfssl.a"
     export WOLFCRYPT_INCLUDE_PATH="$SRC/wolfssl-sp-math/"
     cd $SRC/cryptofuzz-sp-math/modules/wolfcrypt
-    make -j$(nproc)
-    cd $SRC/cryptofuzz-sp-math/modules/botan
     make -j$(nproc)
     cd $SRC/cryptofuzz-sp-math/
     LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" make -B -j$(nproc)
@@ -239,12 +213,10 @@ then
     CFLAGS="$CFLAGS -DHAVE_AES_ECB -DWOLFSSL_DES_ECB -DHAVE_ECC_SECPR2 -DHAVE_ECC_SECPR3 -DHAVE_ECC_BRAINPOOL -DHAVE_ECC_KOBLITZ -DWOLFSSL_ECDSA_SET_K -DWOLFSSL_ECDSA_SET_K_ONE_LOOP"
     ./configure $WOLFCRYPT_CONFIGURE_PARAMS --enable-fastmath
     make -j$(nproc)
-    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL -DCRYPTOFUZZ_WOLFCRYPT -DCRYPTOFUZZ_BOTAN"
+    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL -DCRYPTOFUZZ_WOLFCRYPT"
     export WOLFCRYPT_LIBWOLFSSL_A_PATH="$SRC/wolfssl-fastmath/src/.libs/libwolfssl.a"
     export WOLFCRYPT_INCLUDE_PATH="$SRC/wolfssl-fastmath/"
     cd $SRC/cryptofuzz-fastmath/modules/wolfcrypt
-    make -j$(nproc)
-    cd $SRC/cryptofuzz-fastmath/modules/botan
     make -j$(nproc)
     cd $SRC/cryptofuzz-fastmath/
     LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" make -B -j$(nproc)
@@ -262,12 +234,10 @@ then
     CFLAGS="$CFLAGS -DHAVE_AES_ECB -DWOLFSSL_DES_ECB -DHAVE_ECC_SECPR2 -DHAVE_ECC_SECPR3 -DHAVE_ECC_BRAINPOOL -DHAVE_ECC_KOBLITZ -DWOLFSSL_ECDSA_SET_K -DWOLFSSL_ECDSA_SET_K_ONE_LOOP"
     ./configure $WOLFCRYPT_CONFIGURE_PARAMS --enable-heapmath
     make -j$(nproc)
-    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL -DCRYPTOFUZZ_WOLFCRYPT -DCRYPTOFUZZ_BOTAN"
+    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL -DCRYPTOFUZZ_WOLFCRYPT"
     export WOLFCRYPT_LIBWOLFSSL_A_PATH="$SRC/wolfssl-heapmath/src/.libs/libwolfssl.a"
     export WOLFCRYPT_INCLUDE_PATH="$SRC/wolfssl-heapmath/"
     cd $SRC/cryptofuzz-heapmath/modules/wolfcrypt
-    make -j$(nproc)
-    cd $SRC/cryptofuzz-heapmath/modules/botan
     make -j$(nproc)
     cd $SRC/cryptofuzz-heapmath/
     LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" make -B -j$(nproc)
@@ -291,23 +261,6 @@ then
     unzip -n $SRC/corpus_cryptofuzz-openssl.zip -d $SRC/cryptofuzz_seed_corpus/ >/dev/null
     unzip -n $SRC/corpus_cryptofuzz-boringssl.zip -d $SRC/cryptofuzz_seed_corpus/ >/dev/null
     unzip -n $SRC/corpus_cryptofuzz-nss.zip -d $SRC/cryptofuzz_seed_corpus/ >/dev/null
-
-    # Import Botan corpora
-    mkdir $SRC/botan-p256-corpus/
-    unzip $SRC/corpus_botan_ecc_p256.zip -d $SRC/botan-p256-corpus/ >/dev/null
-    find $SRC/botan-p256-corpus/ -type f -exec $SRC/cryptofuzz-fastmath/cryptofuzz --from-botan={},$SRC/cryptofuzz-seed-corpus/,secp256r1 \;
-
-    mkdir $SRC/botan-p384-corpus/
-    unzip $SRC/corpus_botan_ecc_p384.zip -d $SRC/botan-p384-corpus/ >/dev/null
-    find $SRC/botan-p384-corpus/ -type f -exec $SRC/cryptofuzz-fastmath/cryptofuzz --from-botan={},$SRC/cryptofuzz-seed-corpus/,secp384r1 \;
-
-    mkdir $SRC/botan-p521-corpus/
-    unzip $SRC/corpus_botan_ecc_p521.zip -d $SRC/botan-p521-corpus/ >/dev/null
-    find $SRC/botan-p521-corpus/ -type f -exec $SRC/cryptofuzz-fastmath/cryptofuzz --from-botan={},$SRC/cryptofuzz-seed-corpus/,secp521r1 \;
-
-    mkdir $SRC/botan-bp256-corpus/
-    unzip $SRC/corpus_botan_ecc_bp256.zip -d $SRC/botan-bp256-corpus/ >/dev/null
-    find $SRC/botan-bp256-corpus/ -type f -exec $SRC/cryptofuzz-fastmath/cryptofuzz --from-botan={},$SRC/cryptofuzz-seed-corpus/,brainpool256r1 \;
 
     # Import OpenSSL/LibreSSL corpora
     mkdir $SRC/openssl-expmod-corpus/
@@ -334,10 +287,6 @@ then
     cp $SRC/cryptofuzz_seed_corpus.zip $OUT/cryptofuzz-heapmath_seed_corpus.zip
 
     # Remove files that are no longer needed to prevent running out of disk space
-    rm -rf $SRC/botan-p256-corpus/
-    rm -rf $SRC/botan-p384-corpus/
-    rm -rf $SRC/botan-p521-corpus/
-    rm -rf $SRC/botan-bp256-corpus/
     rm -rf $SRC/openssl-expmod-corpus/
     rm -rf $SRC/libressl-expmod-corpus/
     rm -rf $SRC/cryptofuzz_seed_corpus/


### PR DESCRIPTION
guidovranken/wolf-ssl-ssh-fuzzers has an issue with using an older OCSP function declaration. This updates the Docker image to look at JacobBarthelmeh/wolf-ssl-ssh-fuzzers which contains a fix for the following error.

```
E_FOR_PRODUCTION -fsanitize=memory -fsanitize-memory-track-origins -fsanitize=fuzzer-no-link -DWOLFSSL_STATIC_PSK -I .. -I /src/wolf-ssl-ssh-fuzzers/oss-fuzz/projects/wolf-ssl-ssh/fuzzers/include ocsp.c -c -o ocsp.o
ocsp.c:14:47: warning: passing 'const uint8_t *' (aka 'const unsigned char *') to parameter of type 'byte *' (aka 'unsigned char *') discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
   14 |     InitOcspResponse(&resp, &single, &status, data, size, NULL);
      |                                               ^~~~
../wolfssl/wolfcrypt/asn.h:2582:48: note: passing argument to parameter 'source' here
 2582 |                      CertStatus* status, byte* source, word32 inSz, void* heap);
      |                                                ^
ocsp.c:15:44: error: too few arguments to function call, expected 5, have 4
   15 |     OcspResponseDecode(&resp, NULL, NULL, 1);
      |     ~~~~~~~~~~~~~~~~~~                     ^
../wolfssl/wolfcrypt/asn.h:2584:19: note: 'OcspResponseDecode' declared here
 2584 | WOLFSSL_LOCAL int OcspResponseDecode(OcspResponse* resp, void* cm, void* heap,
      |                   ^                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 2585 |                                      int noVerifyCert, int noVerifySignature);
      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning and 1 error generated.
```

Botan was having issues being built when trying locally. This PR removes building Botan.

Botan error:

```
      |       ^
/src/botan/build/include/public/botan/api.h:73:36: note: expanded from macro 'BOTAN_DEPRECATED'
   73 |    #define BOTAN_DEPRECATED(msg) [[deprecated(msg)]]
      |                                    ^
bn_ops.cpp:416:59: error: no viable conversion from 'Botan::Modular_Reducer' to incomplete type 'const Barrett_Reduction'
  416 |     if ( Botan::is_bailie_psw_probable_prime(bn[0].Ref(), mod_n) ) {
      |                                                           ^~~~~
/src/botan/build/include/internal/botan/internal/primality.h:17:7: note: forward declaration of 'Botan::Barrett_Reduction'
   17 | class Barrett_Reduction;
```