### PR TITLE
icu: add run_tests.sh

### DIFF
--- a/projects/icu/run_tests.sh
+++ b/projects/icu/run_tests.sh
@@ -1,4 +1,5 @@
-# Copyright 2016 Google Inc.
+#!/bin/bash -eu
+# Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,9 +14,5 @@
 # limitations under the License.
 #
 ################################################################################
-
-FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make
-
-RUN git clone --depth 1 https://github.com/unicode-org/icu.git icu
-COPY build.sh run_tests.sh $SRC/
+cd $WORK/icu
+make check


### PR DESCRIPTION
Adds run_tests.sh to the ICU project.

`run_tests.sh` is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

`infra/experimental/chronos/check_tests.sh icu c`
```
...
[All tests passed successfully...]                                                                                                                         
Elapsed Time: 00:00:50.444                                                   
make[2]: Leaving directory '/work/icu/test/cintltst'                                                                                                       
---------------                                                                                                                                            
ALL TESTS SUMMARY:                                                                                                                                         
All tests OK:  testdata intltest iotest cintltst                                                                                                           
make[1]: Leaving directory '/work/icu/test'                                                                                                                
make[1]: Entering directory '/work/icu'                                      
verifying that icu-config --selfcheck can operate                                                                                                          
verifying that make -f Makefile.inc selfcheck can operate                                                                                                  
PASS: config selfcheck OK                                                    
rm -rf test-local.xml                                                                                                                                      
make[1]: Leaving directory '/work/icu'
```