### PR TITLE
bind9: fix build

### DIFF
--- a/projects/bind9/Dockerfile
+++ b/projects/bind9/Dockerfile
@@ -31,7 +31,9 @@ RUN apt-get -y install		\
 	liburcu-dev		\
 	libuv1-dev		\
 	pkg-config		\
-	zip
+	zip && \
+    python3 -m pip install  -U meson ninja
+
 RUN git clone --depth 1 https://gitlab.isc.org/isc-projects/bind9.git
 WORKDIR bind9
-COPY build.sh $SRC/
+COPY build.sh *.diff $SRC/

--- a/projects/bind9/build.sh
+++ b/projects/bind9/build.sh
@@ -15,34 +15,20 @@
 #
 ################################################################################
 
-# build the project
-autoreconf -fi
-./configure --disable-shared --enable-static --enable-developer --without-cmocka --without-zlib --prefix="$WORK" --enable-fuzzing=ossfuzz
-make -C lib/isc -j"$(nproc)" all V=1
-make -C lib/dns -j"$(nproc)" all V=1
-make -C tests/libtest -j"$(nproc)" all V=1
+export CFLAGS="${CFLAGS} -fPIC"
+export CXXFLAGS="${CXXFLAGS} -fPIC"
 
-LIBISC_CFLAGS="-Ilib/isc/include"
-LIBDNS_CFLAGS="-Ilib/dns/include"
-LIBISC_LIBS="lib/isc/.libs/libisc.a -Wl,-Bstatic -Wl,-u,isc__initialize,-u,isc__shutdown -lssl -lcrypto -lurcu-memb -lurcu-cds -lurcu-common -luv -lnghttp2 -Wl,-Bdynamic"
-LIBDNS_LIBS="lib/dns/.libs/libdns.a -Wl,-Bstatic -Wl,-u,dst__lib_init -Wl,-u,dst__lib_destroy -Wl,-u,initialize_bits_for_byte -lcrypto -lurcu-memb -lurcu-cds -Wl,-Bdynamic"
-LIBTEST_LIBS="tests/libtest/.libs/libtest.a"
+git apply  --ignore-space-change --ignore-whitespace $SRC/patch.diff
 
-# dns_name_fromwire needs old.c/old.h code to be linked in
-sed -i 's/#include "old.h"/#include "old.c"/' fuzz/dns_name_fromwire.c
+meson setup build -Dfuzzing=oss-fuzz \
+    -Dc_link_args="$CFLAGS" -Dcpp_link_args="$CXXFLAGS" \
+    -Dc_args="$CFLAGS" -Dcpp_args="$CXXFLAGS" \
+    -Ddefault_library=static -Dprefer_static=true
+meson compile -C build fuzz_dns_master_load fuzz_dns_message_checksig fuzz_dns_message_parse fuzz_dns_name_fromtext_target fuzz_dns_name_fromwire fuzz_dns_qp fuzz_dns_qpkey_name fuzz_dns_rdata_fromtext fuzz_dns_rdata_fromwire_text fuzz_isc_lex_getmastertoken fuzz_isc_lex_gettoken --verbose
 
-for fuzzer in fuzz/*.c; do
-	output=$(basename "${fuzzer%.c}")
-	[ "$output" = "main" ] && continue
-	[ "$output" = "old" ] && continue
-	# We need to try little bit harder to link everything statically
-	make -C fuzz -j"$(nproc)" "${output}.o" V=1
-	${CXX} ${CXXFLAGS} \
-		-o "${OUT}/${output}_fuzzer" \
-		"fuzz/${output}.o" \
-		-include config.h \
-		$LIBISC_CFLAGS $LIBDNS_CFLAGS \
-		-Wl,--start-group $LIBISC_LIBS $LIBDNS_LIBS -Wl,--end-group \
-		$LIBTEST_LIBS $LIB_FUZZING_ENGINE
-	zip -j "${OUT}/${output}_seed_corpus.zip" "fuzz/${output}.in/"*
+for fuzzname in fuzz_dns_master_load fuzz_dns_message_checksig fuzz_dns_message_parse fuzz_dns_name_fromtext_target fuzz_dns_name_fromwire fuzz_dns_qp fuzz_dns_qpkey_name fuzz_dns_rdata_fromtext fuzz_dns_rdata_fromwire_text fuzz_isc_lex_getmastertoken fuzz_isc_lex_gettoken; do
+  fuzzer_basename="${fuzzname:5}"
+  fuzzer_name="${fuzzname:5}_fuzzer"
+  cp build/${fuzzname} $OUT/${fuzzer_name}
+  zip -j "${OUT}/${fuzzer_name}_seed_corpus.zip" ./fuzz/${fuzzer_basename}.in/* || true
 done

--- a/projects/bind9/patch.diff
+++ b/projects/bind9/patch.diff
@@ -1,0 +1,26 @@
+diff --git a/meson.build b/meson.build
+index d4a675b..f5cb72a 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1584,7 +1584,7 @@ foreach name, sources : fuzz_binaries
+         implicit_include_directories: true,
+         install: false,
+         c_args: ['-Wno-vla'],
+-        link_args: fuzz_link_args,
++        link_args: fuzz_link_args + ['-fsanitize=fuzzer'],
+         dependencies: [
+             libdns_dep,
+             libisc_dep,
+diff --git a/tests/meson.build b/tests/meson.build
+index 416ba51..6feb638 100644
+--- a/tests/meson.build
++++ b/tests/meson.build
+@@ -15,7 +15,7 @@ test_inc = include_directories(
+     '..' / 'lib' / 'dns',
+ )
+ 
+-libtest = shared_library(
++libtest = static_library(
+     'bindtest',
+     files(
+         'libtest/dns.c',

--- a/projects/bind9/project.yaml
+++ b/projects/bind9/project.yaml
@@ -16,6 +16,5 @@ sanitizers:
 main_repo: 'https://gitlab.isc.org/isc-projects/bind9.git'
 
 fuzzing_engines:
-  - honggfuzz
   - libfuzzer
 

--- a/projects/bind9/project.yaml
+++ b/projects/bind9/project.yaml
@@ -16,7 +16,6 @@ sanitizers:
 main_repo: 'https://gitlab.isc.org/isc-projects/bind9.git'
 
 fuzzing_engines:
-  - afl
   - honggfuzz
   - libfuzzer
 


### PR DESCRIPTION
bind9 now relies on meson.
The names of the fuzzers have been set to match before build broke.