### PR TITLE
pcre2: add run_tests.sh

### DIFF
--- a/projects/pcre2/build.sh
+++ b/projects/pcre2/build.sh
@@ -18,7 +18,7 @@
 # build project
 ./autogen.sh
 ./configure --enable-fuzz-support \
-    --enable-never-backslash-C --with-match-limit=1000 --with-match-limit-depth=1000 \
+    --enable-never-backslash-C --with-match-limit=1000000 --with-match-limit-depth=1000000 \
     --enable-jit \
     --enable-pcre2-16 --enable-pcre2-32
 make -j$(nproc) clean
@@ -35,7 +35,7 @@ $CXX $CXXFLAGS -o $OUT/pcre2_fuzzer_32 \
 # test different link sizes
 for i in $(seq 3 4); do
     ./configure --enable-fuzz-support \
-        --enable-never-backslash-C --with-match-limit=1000 --with-match-limit-depth=1000 \
+        --enable-never-backslash-C --with-match-limit=1000000 --with-match-limit-depth=1000000 \
         --enable-jit \
         --enable-pcre2-16 --enable-pcre2-32 --with-link-size=${i}
     make -j$(nproc) clean

--- a/projects/pcre2/run_tests.sh
+++ b/projects/pcre2/run_tests.sh
@@ -1,4 +1,5 @@
-# Copyright 2016 Google Inc.
+#!/bin/bash -eu
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,10 +14,4 @@
 # limitations under the License.
 #
 ################################################################################
-
-FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool subversion
-
-RUN git clone --recursive https://github.com/PCRE2Project/pcre2 pcre2
-WORKDIR pcre2
-COPY build.sh run_tests.sh $SRC/
+make check


### PR DESCRIPTION
Adds run_tests.sh to the pcre2 project. 

The PR changes the max match limit. Otherwise the tests fail.

`run_tests.sh` is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

`infra/experimental/chronos/check_tests.sh pcre2 c`

```
...
PASS: pcre2posix_test                                                        
PASS: pcre2_jit_test                                                                                                                                       
PASS: RunTest                                                                
PASS: RunGrepTest                                                            
============================================================================ 
Testsuite summary for PCRE2 10.46-DEV                                        
============================================================================ 
# TOTAL: 4                                                                                                                                                 
# PASS:  4                                                                                                                                                 
# SKIP:  0                                                                   
# XFAIL: 0                                                                   
# FAIL:  0                                                                                                                                                 
# XPASS: 0                                                                   
# ERROR: 0                                                                   
============================================================================
make[3]: Leaving directory '/src/pcre2'                                                                                                                    
make[2]: Leaving directory '/src/pcre2'                                      
make[1]: Leaving directory '/src/pcre2'
```