### PR TITLE
skcms: fix build

### DIFF
--- a/projects/skcms/Dockerfile
+++ b/projects/skcms/Dockerfile
@@ -19,7 +19,9 @@ FROM gcr.io/oss-fuzz-base/base-builder
 # checkout all sources needed to build your project
 RUN git clone --depth 1 https://skia.googlesource.com/skcms.git
 
-RUN wget -O $SRC/skcms/iccprofile_seed_corpus.zip https://storage.googleapis.com/skia-fuzzer/oss-fuzz/iccprofile_seed_corpus.zip
+# Disable the below to fix build. The URL is not accessible. Leaving it
+# commented out if the URL becomes available again.
+# RUN wget -O $SRC/skcms/iccprofile_seed_corpus.zip https://storage.googleapis.com/skia-fuzzer/oss-fuzz/iccprofile_seed_corpus.zip
 
 # current directory for build script
 WORKDIR skcms

--- a/projects/skcms/build.sh
+++ b/projects/skcms/build.sh
@@ -26,8 +26,8 @@ cp iccprofile.options $OUT/iccprofile_info.options
 cp iccprofile.options $OUT/iccprofile_atf.options
 cp iccprofile.options $OUT/fuzz_iccprofile_transform.options
 # They all share the same seed corpus of icc profiles
-cp iccprofile_seed_corpus.zip $OUT/iccprofile_info_seed_corpus.zip
-cp iccprofile_seed_corpus.zip $OUT/iccprofile_atf_seed_corpus.zip
-cp iccprofile_seed_corpus.zip $OUT/iccprofile_transform_seed_corpus.zip
+#cp iccprofile_seed_corpus.zip $OUT/iccprofile_info_seed_corpus.zip
+#cp iccprofile_seed_corpus.zip $OUT/iccprofile_atf_seed_corpus.zip
+#cp iccprofile_seed_corpus.zip $OUT/iccprofile_transform_seed_corpus.zip
 # They all use the same dictionary file.
 cp iccprofile.dict $OUT/iccprofile.dict


### PR DESCRIPTION
corpus url is no longer accessible. Blocking e.g. https://github.com/google/oss-fuzz/pull/13642