### PR TITLE
args: add run_tests.sh

### DIFF
--- a/projects/args/Dockerfile
+++ b/projects/args/Dockerfile
@@ -23,6 +23,6 @@ RUN apt-get update && \
 
 RUN git clone --depth 1 https://github.com/Taywee/args.git $SRC/args/
 
-COPY build.sh $SRC/
+COPY build.sh run_tests.sh $SRC/
 WORKDIR $SRC/args/
 

--- a/projects/args/run_tests.sh
+++ b/projects/args/run_tests.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -eu
-
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,20 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 ################################################################################
 
-mkdir build
 cd build
-
-cmake -DCMAKE_BUILD_TYPE=Release -DARGS_BUILD_TESTS=ON ..
-make -j4
-
-for fuzzer in $(find $SRC/args/fuzz/ -name "*_fuzzer.cpp"); do
-    fuzzer_basename=$(basename -s .cpp $fuzzer)
-    $CXX $CXXFLAGS $LIB_FUZZING_ENGINE \
-        -I$SRC/args \
-        $fuzzer \
-        -o $OUT/$fuzzer_basename
-done
-
+ctest --output-on-failure


### PR DESCRIPTION
Adds `run_tests.sh` to the args project.

`run_tests.sh` is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

Output of ./infra/experimental/chronos/check_tests.sh args c++:
```
Test project /src/args/build
    Start 1: test
1/2 Test #1: test .............................   Passed    0.27 sec
    Start 2: test-multiple-inclusion
2/2 Test #2: test-multiple-inclusion ..........   Passed    0.06 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) =   0.34 sec
```