### PR TITLE
wasmtime: Update Rust toolchain used to build

### DIFF
--- a/projects/wasmtime/Dockerfile
+++ b/projects/wasmtime/Dockerfile
@@ -38,6 +38,6 @@ WORKDIR wasmtime
 
 # The default toolchain used by OSS-Fuzz is too old to build Wasmtime at this
 # time.
-ENV RUSTUP_TOOLCHAIN nightly-2025-01-10
+ENV RUSTUP_TOOLCHAIN nightly-2025-07-16
 
 COPY build.sh *.options $SRC/


### PR DESCRIPTION
This updates Wasmtime's pinned nightly version to a more recent version to match what the codebase now requires.