### PR TITLE
[dbus-broker] disable it for now

### DIFF
--- a/projects/dbus-broker/project.yaml
+++ b/projects/dbus-broker/project.yaml
@@ -1,3 +1,4 @@
+disabled: true
 homepage: "https://github.com/bus1/dbus-broker"
 language: c
 primary_contact: "david.rheinsberg@gmail.com"


### PR DESCRIPTION
Currently it fails to build so it can be disabled until https://github.com/bus1/dbus-broker/issues/408 is addressed one way or another.