### PR TITLE
botan: add run_tests.sh

### DIFF
--- a/projects/botan/run_tests.sh
+++ b/projects/botan/run_tests.sh
@@ -1,4 +1,5 @@
-# Copyright 2016 Google Inc.
+#!/bin/bash -eux
+# Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,11 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-################################################################################
+##############################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make python
-RUN git clone --depth 1 https://github.com/randombit/botan.git botan
-RUN git clone --depth 1 https://github.com/randombit/crypto-corpus.git fuzzer_corpus
-WORKDIR botan
-COPY *.sh $SRC/
+make check


### PR DESCRIPTION
run_tests.sh is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

```
python3 infra/experimental/chronos/manager.py check-test botan
...
INFO:__main__:Test completion succeessful: True. Duration of run_tests.sh: 615.37 seconds
```