### PR TITLE
lighttpd: add run_tests.sh

### DIFF
--- a/projects/lighttpd/run_tests.sh
+++ b/projects/lighttpd/run_tests.sh
@@ -1,4 +1,5 @@
-# Copyright 2021 Google LLC
+#!/bin/bash -eux
+# Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,12 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-################################################################################
+###############################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y libz-dev libpcre2-dev libtool pkg-config autoconf
-RUN git clone https://github.com/lighttpd/lighttpd1.4
-
-WORKDIR $SRC/lighttpd1.4
-COPY *.sh $SRC/
-COPY fuzz_* $SRC/
+make check


### PR DESCRIPTION
run_tests.sh is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

```
./infra/experimental/chronos/check_tests.sh lighttpd c++
....
....
make  check-TESTS
Testing in build directory: '..' and cwd: '/src/lighttpd1.4/tests'
preparing infrastructure                PASS: prepare.sh
./core-condition.t .. ok     
./mod-fastcgi.t ..... ok     
./mod-scgi.t ........ ok     
./request.t ......... ok       
All tests successful.
Files=4, Tests=231,  1 wallclock secs ( 0.04 usr  0.01 sys +  0.39 cusr  0.23 csys =  0.67 CPU)
Result: PASS
PASS: run-tests.pl
cleaning up                             PASS: cleanup.sh
==================
All 3 tests passed
==================
make[1]: Nothing to be done for 'check-am'.
--------------------------------------------------------
Total time taken to replay tests: 2

```