### PR TITLE
libpsl: add run_tests.sh

### DIFF
--- a/projects/libpsl/Dockerfile
+++ b/projects/libpsl/Dockerfile
@@ -42,4 +42,4 @@ RUN wget https://github.com/unicode-org/icu/releases/download/release-59-2/icu4c
 RUN git clone --depth=1 --recursive https://github.com/rockdaboot/libpsl.git
 
 WORKDIR libpsl
-COPY build.sh config.site md5sum $SRC/
+COPY build.sh config.site md5sum run_tests.sh $SRC/

--- a/projects/libpsl/run_tests.sh
+++ b/projects/libpsl/run_tests.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eux
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###############################################################################
+
+make check


### PR DESCRIPTION
run_tests.sh is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

```
./infra/experimental/chronos/check_tests.sh libpsl c++
...
...
make  check-TESTS
make[2]: Entering directory '/src/libpsl/fuzz'
make[3]: Entering directory '/src/libpsl/fuzz'
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 0
# PASS:  0
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
make[3]: Leaving directory '/src/libpsl/fuzz'
make[2]: Leaving directory '/src/libpsl/fuzz'
make[1]: Leaving directory '/src/libpsl/fuzz'
Making check in tests
make[1]: Entering directory '/src/libpsl/tests'
make  check-am
make[2]: Entering directory '/src/libpsl/tests'
make  test-is-public test-is-public-all test-is-cookie-domain-acceptable 
make[3]: Entering directory '/src/libpsl/tests'
make[3]: 'test-is-public' is up to date.
make[3]: 'test-is-public-all' is up to date.
make[3]: 'test-is-cookie-domain-acceptable' is up to date.
make[3]: Leaving directory '/src/libpsl/tests'
make  check-TESTS
make[3]: Entering directory '/src/libpsl/tests'
make[4]: Entering directory '/src/libpsl/tests'
PASS: test-is-public
PASS: test-is-public-all
PASS: test-is-cookie-domain-acceptable
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
make[4]: Leaving directory '/src/libpsl/tests'
make[3]: Leaving directory '/src/libpsl/tests'
make[2]: Leaving directory '/src/libpsl/tests'
make[1]: Leaving directory '/src/libpsl/tests'
Making check in msvc
make[1]: Entering directory '/src/libpsl/msvc'
make[1]: Nothing to be done for 'check'.
make[1]: Leaving directory '/src/libpsl/msvc'
make[1]: Entering directory '/src/libpsl'
make[1]: Nothing to be done for 'check-am'.
make[1]: Leaving directory '/src/libpsl'
+ echo 'Running tests for project: libpsl'
Running tests for project: libpsl
--------------------------------------------------------
Total time taken to replay tests: 1

```