### PR TITLE
wpantund: add run_tests.sh

### DIFF
--- a/projects/wpantund/run_tests.sh
+++ b/projects/wpantund/run_tests.sh
@@ -1,4 +1,5 @@
-# Copyright 2017 Google Inc.
+#!/bin/bash -eux
+# Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,24 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-################################################################################
+###############################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
-
-RUN apt-get -y update \
-	&& DEBIAN_FRONTEND=noninteractive \
-			apt-get install -y -q --no-install-recommends \
-				gdb \
-				libdbus-1-dev \
-				libboost-dev \
-				pkg-config \
-				libtool \
-				autoconf \
-				autoconf-archive \
-				automake
-
-COPY build.sh *.options run_tests.sh $SRC/
-
-RUN git clone --depth 1 https://github.com/openthread/wpantund
-
-WORKDIR wpantund
+make check


### PR DESCRIPTION
```
./infra/experimental/chronos/check_tests.sh wpantund c++
...
ake[5]: Leaving directory '/src/wpantund/src/missing/strlcpy'
make  check-TESTS                                             
make[5]: Entering directory '/src/wpantund/src/missing/strlcpy'
make[6]: Entering directory '/src/wpantund/src/missing/strlcpy'
PASS: strlcpy_test        
============================================================================                                                       
Testsuite summary for wpantund 0.08.00d 
============================================================================                                                       
# TOTAL: 1                                     
# PASS:  1                                               
# SKIP:  0                                    
# XFAIL: 0                                              
# FAIL:  0                                    
# XPASS: 0                                              
# ERROR: 0                                     
============================================================================                                                       
make[6]: Leaving directory '/src/wpantund/src/missing/strlcpy'
make[5]: Leaving directory '/src/wpantund/src/missing/strlcpy'
make[4]: Leaving directory '/src/wpantund/src/missing/strlcpy'
Making check in strlcat               
make[4]: Entering directory '/src/wpantund/src/missing/strlcat'
make  strlcat_test                         
make[5]: Entering directory '/src/wpantund/src/missing/strlcat'
  CC       strlcat_test-strlcat_test.o         
  CCLD     strlcat_test                                     
make[5]: Leaving directory '/src/wpantund/src/missing/strlcat'
make  check-TESTS                                                                                                                  
make[5]: Entering directory '/src/wpantund/src/missing/strlcat'                                                                    
make[6]: Entering directory '/src/wpantund/src/missing/strlcat'                                                                    
PASS: strlcat_test                  
============================================================================                                                       
Testsuite summary for wpantund 0.08.00d 
============================================================================                                                       
# TOTAL: 1                                                                                                                                                                                                                                                            
# PASS:  1                                                                                                                                                                                                                                                            
# SKIP:  0                                      
# XFAIL: 0                                            
# FAIL:  0                                      
# XPASS: 0                                      
# ERROR: 0                                      
============================================================================                           
...
```