### PR TITLE
phmap: add run_tests.sh

### DIFF
--- a/projects/phmap/Dockerfile
+++ b/projects/phmap/Dockerfile
@@ -18,5 +18,5 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN git clone https://github.com/greg7mdp/parallel-hashmap
 
 WORKDIR $SRC/parallel-hashmap
-COPY build.sh $SRC/
+COPY build.sh run_tests.sh $SRC/
 COPY phashmap_fuzz.cc $SRC/

--- a/projects/phmap/run_tests.sh
+++ b/projects/phmap/run_tests.sh
@@ -1,5 +1,4 @@
-#!/bin/bash -eu
-# Copyright 2021 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,8 +13,4 @@
 # limitations under the License.
 #
 ################################################################################
-
-cmake -DPHMAP_MASTER_PROJECT=ON -DPHMAP_BUILD_TESTS=ON -B build
-cmake --build build
-
-$CXX $CXXFLAGS $LIB_FUZZING_ENGINE $SRC/phashmap_fuzz.cc -I./ -o $OUT/phashmap_fuzz
+ctest --test-dir build


### PR DESCRIPTION
`run_tests.sh` is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

`infra/experimental/chronos/check_tests.sh phmap c`
```
Test project /src/parallel-hashmap/build
      Start  1: test_container_memory
 1/17 Test  #1: test_container_memory ...............   Passed    0.01 sec
      Start  2: test_hash_policy_testing
 2/17 Test  #2: test_hash_policy_testing ............   Passed    0.01 sec
      Start  3: test_node_hash_policy
 3/17 Test  #3: test_node_hash_policy ...............   Passed    0.01 sec
      Start  4: test_raw_hash_set
 4/17 Test  #4: test_raw_hash_set ...................   Passed    0.74 sec
      Start  5: test_raw_hash_set_allocator
 5/17 Test  #5: test_raw_hash_set_allocator .........   Passed    0.02 sec
      Start  6: test_flat_hash_set
 6/17 Test  #6: test_flat_hash_set ..................   Passed    0.04 sec
      Start  7: test_flat_hash_map
 7/17 Test  #7: test_flat_hash_map ..................   Passed    0.46 sec
      Start  8: test_node_hash_map
 8/17 Test  #8: test_node_hash_map ..................   Passed    0.05 sec
      Start  9: test_node_hash_set
 9/17 Test  #9: test_node_hash_set ..................   Passed    0.04 sec
      Start 10: test_parallel_flat_hash_map
10/17 Test #10: test_parallel_flat_hash_map .........   Passed    0.47 sec
      Start 11: test_parallel_flat_hash_set
11/17 Test #11: test_parallel_flat_hash_set .........   Passed    0.04 sec
      Start 12: test_parallel_node_hash_map
12/17 Test #12: test_parallel_node_hash_map .........   Passed    0.46 sec
      Start 13: test_parallel_node_hash_set
13/17 Test #13: test_parallel_node_hash_set .........   Passed    0.04 sec
      Start 14: test_parallel_flat_hash_map_mutex
14/17 Test #14: test_parallel_flat_hash_map_mutex ...   Passed    0.49 sec
      Start 15: test_dump_load
15/17 Test #15: test_dump_load ......................   Passed    0.01 sec
      Start 16: test_erase_if
16/17 Test #16: test_erase_if .......................   Passed    0.01 sec
      Start 17: test_btree
17/17 Test #17: test_btree ..........................   Passed   18.09 sec

100% tests passed, 0 tests failed out of 17

Total Test time (real) =  21.00 sec
```