### PR TITLE
glaze: add run_tests.sh

### DIFF
--- a/projects/glaze/Dockerfile
+++ b/projects/glaze/Dockerfile
@@ -18,4 +18,4 @@ FROM gcr.io/oss-fuzz-base/base-builder
 # RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/stephenberry/glaze
 WORKDIR glaze
-COPY build.sh $SRC/
+COPY build.sh run_tests.sh $SRC/

--- a/projects/glaze/run_tests.sh
+++ b/projects/glaze/run_tests.sh
@@ -1,5 +1,4 @@
-#!/bin/bash -eu
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,13 +13,5 @@
 # limitations under the License.
 #
 ################################################################################
-
-# Disable network tests
-sed -i '/add_subdirectory(networking_tests)/d' ./tests/CMakeLists.txt
-# remove some compiler flags for the tests which have conflict with OSS-Fuzz's flags
-sed -i '/target_compile_options(glz_test_common INTERFACE -fno-exceptions -fno-rtti)/d' ./tests/CMakeLists.txt
-mkdir build
-cmake -B build -DCMAKE_BUILD_TYPE=Release
-cmake --build build --config Release -j$(nproc)
-
-fuzzing/ossfuzz.sh
+cd build
+ASAN_OPTIONS=detect_leaks=0 ctest -C Release -j$(nproc) --output-on-failure


### PR DESCRIPTION
`run_tests.sh` is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

`infra/experimental/chronos/check_tests.sh glaze c`
```
Test project /src/glaze/build
      Start  1: api_test
      Start  2: beve_test
      Start  3: compare_test
      Start  4: csv_test
      Start  5: eigen_test
      Start  6: example_json
      Start  7: exceptions_test
      Start  8: inplace_vector_test
 1/28 Test  #1: api_test ...........................   Passed    0.01 sec
      Start  9: inplace_vector_test_noexceptions
 2/28 Test  #3: compare_test .......................   Passed    0.01 sec
      Start 10: int_parsing
 3/28 Test  #8: inplace_vector_test ................   Passed    0.01 sec
      Start 11: jmespath
 4/28 Test  #6: example_json .......................   Passed    0.02 sec
      Start 12: jsonrpc_test
 5/28 Test  #5: eigen_test .........................   Passed    0.02 sec
      Start 13: lib_test
 6/28 Test  #9: inplace_vector_test_noexceptions ...   Passed    0.02 sec
      Start 14: mock_json_test
 7/28 Test  #4: csv_test ...........................   Passed    0.04 sec
      Start 15: reflection
 8/28 Test #11: jmespath ...........................   Passed    0.03 sec
      Start 16: roundtrip_JSON
 9/28 Test #12: jsonrpc_test .......................   Passed    0.03 sec
      Start 17: roundtrip_BEVE
10/28 Test #13: lib_test ...........................   Passed    0.03 sec
      Start 18: stencil_test
11/28 Test #15: reflection .........................   Passed    0.02 sec
      Start 19: threading_test
12/28 Test #14: mock_json_test .....................   Passed    0.04 sec
13/28 Test #16: roundtrip_JSON .....................   Passed    0.02 sec
14/28 Test #17: roundtrip_BEVE .....................   Passed    0.01 sec
      Start 20: toml_test
      Start 21: utility_formats
      Start 22: json_conformance
15/28 Test  #7: exceptions_test ....................   Passed    0.07 sec
16/28 Test #18: stencil_test .......................   Passed    0.02 sec
      Start 23: json_performance
      Start 24: json_reflection_test
17/28 Test #21: utility_formats ....................   Passed    0.01 sec
      Start 25: json_test
18/28 Test #20: toml_test ..........................   Passed    0.02 sec
      Start 26: json_test_non_null
19/28 Test #22: json_conformance ...................   Passed    0.02 sec
      Start 27: json_t_test
20/28 Test #24: json_reflection_test ...............   Passed    0.02 sec
      Start 28: jsonschema_test
21/28 Test #27: json_t_test ........................   Passed    0.02 sec
22/28 Test #28: jsonschema_test ....................   Passed    0.05 sec
23/28 Test  #2: beve_test ..........................   Passed    1.17 sec
24/28 Test #19: threading_test .....................   Passed    1.30 sec
25/28 Test #25: json_test ..........................   Passed    2.24 sec
26/28 Test #26: json_test_non_null .................   Passed    2.30 sec
27/28 Test #10: int_parsing ........................   Passed   12.10 sec
28/28 Test #23: json_performance ...................   Passed   87.87 sec

100% tests passed, 0 tests failed out of 28

Label Time Summary:
format_BEVE    =   0.01 sec*proc (1 test)
format_JSON    =   0.02 sec*proc (1 test)

Total Test time (real) =  87.95 sec
--------------------------------------------------------
Total time taken to replay tests: 8
```