### PR TITLE
tpm2-tss: add run_tests.sh

### DIFF
--- a/projects/tpm2-tss/Dockerfile
+++ b/projects/tpm2-tss/Dockerfile
@@ -84,4 +84,4 @@ RUN rm -rf uthash-${uthash}/ v${uthash}.tar.gz
 RUN git clone --depth 1 \
   https://github.com/tpm2-software/tpm2-tss $SRC/tpm2-tss/
 WORKDIR $SRC/tpm2-tss/
-COPY build.sh $SRC/
+COPY *.sh $SRC/

--- a/projects/tpm2-tss/run_tests.sh
+++ b/projects/tpm2-tss/run_tests.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eux
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###############################################################################
+
+make check


### PR DESCRIPTION
run_tests.sh is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

```
./infra/experimental/chronos/check_tests.sh tpm2-tss c++
...
PASS: test/fuzz/Tss2_Sys_CreateLoaded_Complete.fuzz
PASS: test/fuzz/Tss2_Sys_PolicyAuthorizeNV_Prepare.fuzz
PASS: test/fuzz/Tss2_Sys_PolicyAuthorizeNV_Complete.fuzz
============================================================================
Testsuite summary for tpm2-tss 15abbfc
============================================================================
# TOTAL: 238
# PASS:  238
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
make[2]: Leaving directory '/src/tpm2-tss'
make[1]: Leaving directory '/src/tpm2-tss'
--------------------------------------------------------
Total time taken to replay tests: 10

```