### PR TITLE
gss-ntlmssp: add run_tests.sh

### DIFF
--- a/projects/gss-ntlmssp/run_tests.sh
+++ b/projects/gss-ntlmssp/run_tests.sh
@@ -1,4 +1,5 @@
-# Copyright 2023 Google LLC
+#!/bin/bash -eux
+# Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,21 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-################################################################################
+###############################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y \
-    autoconf \
-    docbook-xsl \
-    gettext \
-    libkrb5-dev \
-    libtool \
-    libunistring-dev \
-    libxml2-utils \
-    make \
-    xsltproc \
-    zlib1g-dev
-RUN git clone --depth 1 https://github.com/gssapi/gss-ntlmssp
-COPY *.sh $SRC/
-COPY fuzzing/ $SRC/gss-ntlmssp/fuzzing/
-WORKDIR $SRC/gss-ntlmssp/
+make check


### PR DESCRIPTION
run_tests.sh is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

```
./infra/experimental/chronos/check_tests.sh gss-ntlmssp c++
...
...
make[2]: Leaving directory '/src/gss-ntlmssp'                                                                                                                                                               
make  check-TESTS                                                                                                                                                                                           
make[2]: Entering directory '/src/gss-ntlmssp'                                                                                                                                                              
make[3]: Entering directory '/src/gss-ntlmssp'                                                                                                                                                              
PASS: ntlmssptest                                                                                                                                                                                           
PASS: tests/env1.sh                                                                                                                                                                                         
PASS: tests/env2.sh                                                                                                                                                                                         
============================================================================                                                                                                                                
Testsuite summary for gssntlmssp 1.3.1                                                                                                                                                                      
============================================================================                                                                                                                                
# TOTAL: 3                                                                                                                                                                                                  
# PASS:  3                                                                                                                                                                                                  
# SKIP:  0                                                                                                                                                                                                  
# XFAIL: 0                                                                                                                                                                                                  
# FAIL:  0                                                                                            
# XPASS: 0                                                                                            
# ERROR: 0                                                                                            
============================================================================
make[3]: Leaving directory '/src/gss-ntlmssp'                                                         
make[2]: Leaving directory '/src/gss-ntlmssp'                                                         
make[1]: Leaving directory '/src/gss-ntlmssp'                                                         
--------------------------------------------------------
Total time taken to replay tests: 19
```