### PR TITLE
libcoap: add run_tests.sh

### DIFF
--- a/projects/libcoap/Dockerfile
+++ b/projects/libcoap/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
-    pkg-config
+    pkg-config libcunit1 libcunit1-doc libcunit1-dev
 RUN git clone --depth 1 https://github.com/obgm/libcoap.git libcoap
 WORKDIR libcoap
-COPY build.sh $SRC/
+COPY *.sh $SRC/

--- a/projects/libcoap/run_tests.sh
+++ b/projects/libcoap/run_tests.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-# Copyright 2018 Google Inc.
+#!/bin/bash -eux
+# Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,15 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-################################################################################
+##############################################################################
 
-if [ "$SANITIZER" == "introspector" ]; then
-  export WARNING_CFLAGS="${CFLAGS}"
-fi
-
-./autogen.sh && ./configure --disable-doxygen --disable-manpages \
-                            --disable-dtls --enable-tests        \
-    && make -j$(nproc)
-
-# build all fuzzer targets
-make -C tests/oss-fuzz -f Makefile.oss-fuzz
+./tests/testdriver


### PR DESCRIPTION
run_tests.sh is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

```
./infra/experimental/chronos/check_tests.sh libcoap c++
...
...

  Test: t_session5 ...passed
  Test: t_session6 ...passed
Suite: sendqueue
  Test: t_sendqueue1 ...passed
  Test: t_sendqueue2 ...passed
  Test: t_sendqueue3 ...passed
  Test: t_sendqueue4 ...passed
  Test: t_sendqueue5 ...passed
  Test: t_sendqueue6 ...passed
  Test: t_sendqueue7 ...passed
  Test: t_sendqueue8 ...passed
  Test: t_sendqueue9 ...passed
  Test: t_sendqueue10 ...passed
Suite: .well-known/core
  Test: t_wellknown1 ...passed
  Test: t_wellknown2 ...passed
  Test: t_wellknown3 ...passed
  Test: t_wellknown4 ...passed
Suite: TLS
  Test: t_tls1 ...passed
  Test: t_tls2 ...passed

Run Summary:    Type  Total    Ran Passed Failed Inactive
              suites     16     16    n/a      0        0
               tests    163    163    163      0        0
             asserts   1249   1249   1249      0      n/a

Elapsed time =    0.005 seconds
--------------------------------------------------------
Total time taken to replay tests: 1
```