### PR TITLE
tidy-html5: fix so run_tests.sh work without network

### DIFF
--- a/projects/tidy-html5/Dockerfile
+++ b/projects/tidy-html5/Dockerfile
@@ -24,4 +24,5 @@ RUN apt-get update && \
 RUN git clone -b next --single-branch \
     https://github.com/htacg/tidy-html5.git tidy-html5
 WORKDIR tidy-html5
+RUN cd regression_testing && bundle2.7 install
 COPY *.sh *.c *.h *.options $SRC/

--- a/projects/tidy-html5/build.sh
+++ b/projects/tidy-html5/build.sh
@@ -31,9 +31,4 @@ for fuzzer in tidy_config_fuzzer tidy_fuzzer tidy_xml_fuzzer tidy_parse_string_f
     cp $SRC/tidy_config_fuzzer.options $OUT/${fuzzer}.options
 done
 
-# We need this for run_tests.sh
-cd ../../
-cd regression_testing
-bundle2.7 install
-
 cp ${SRC}/*.options ${OUT}/

--- a/projects/tidy-html5/build.sh
+++ b/projects/tidy-html5/build.sh
@@ -31,4 +31,9 @@ for fuzzer in tidy_config_fuzzer tidy_fuzzer tidy_xml_fuzzer tidy_parse_string_f
     cp $SRC/tidy_config_fuzzer.options $OUT/${fuzzer}.options
 done
 
+# We need this for run_tests.sh
+cd ../../
+cd regression_testing
+bundle2.7 install
+
 cp ${SRC}/*.options ${OUT}/

--- a/projects/tidy-html5/run_tests.sh
+++ b/projects/tidy-html5/run_tests.sh
@@ -16,5 +16,4 @@
 ###############################################################################
 
 cd regression_testing
-bundle2.7 install
 ASAN_OPTIONS=detect_leaks=0 ./test.rb test


### PR DESCRIPTION
```
./infra/experimental/chronos/check_tests.sh tidy-html5 c++
...
...
PASSED | status 0 expected 0 | /src/tidy-html5/regression_testing/cases/xml-cases/case-540045@0.xhtml 
PASSED | status 1 expected 1 | /src/tidy-html5/regression_testing/cases/xml-cases/case-542029@1.html
PASSED | status 1 expected 1 | /src/tidy-html5/regression_testing/cases/xml-cases/case-586555@1.html
PASSED | status 0 expected 0 | /src/tidy-html5/regression_testing/cases/xml-cases/case-616744@0.xml
PASSED | status 1 expected 1 | /src/tidy-html5/regression_testing/cases/xml-cases/case-634889@1.html
PASSED | status 0 expected 0 | /src/tidy-html5/regression_testing/cases/xml-cases/case-640474@0.xml
PASSED | status 0 expected 0 | /src/tidy-html5/regression_testing/cases/xml-cases/case-646946@0.xml
                                                  
Ran 401 tests, of which 401 passed and 0 failed.
Test conducted with HTML Tidy 5.9.20 using test sets for version 5.9.20.
--------------------------------------------------------
Total time taken to replay tests: 7  
```