### PR TITLE
bluez: fix run_tests.sh modifications and parallelise build

### DIFF
--- a/projects/bluez/build.sh
+++ b/projects/bluez/build.sh
@@ -18,7 +18,7 @@
 ./bootstrap
 autoreconf -f
 ./configure --disable-systemd
-make
+make -j$(nproc)
 
 INCLUDES="-I. -I./src -I./lib -I./gobex -I/usr/local/include/glib-2.0/ -I/src/glib/_build/glib/"
 STATIC_LIBS="./src/.libs/libshared-glib.a ./lib/.libs/libbluetooth-internal.a  -l:libical.a -l:libicalss.a -l:libicalvcal.a -l:libdbus-1.a /src/glib/_build/glib/libglib-2.0.a"

--- a/projects/bluez/run_tests.sh
+++ b/projects/bluez/run_tests.sh
@@ -16,8 +16,8 @@
 ###############################################################################
 
 # Remove tests that are not building with the fuzzing set up
-rm unit/test-mesh-crypto.c
-rm unit/test-midi.c
+mv unit/test-mesh-crypto.c /tmp/
+mv unit/test-midi.c /tmp/
 for unit_test in $(ls unit/test-*.c); do
   unit_name=$(basename ${unit_test})
   unit_name="${unit_name%.*}"
@@ -26,3 +26,6 @@ for unit_test in $(ls unit/test-*.c); do
   make unit/${unit_name}
   ./unit/${unit_name}
 done
+
+mv /tmp/test-mesh-crypto.c unit/test-mesh-crypto.c
+mv /tmp/test-midi.c unit/test-midi.c


### PR DESCRIPTION
Improves build performance and restores removed files when running `run_tests.sh`

```
$ ./infra/experimental/chronos/check_tests.sh bluez c
...
...
AICS/SR/CP/BV-01-C                                   Passed       0.011 seconds
AICS/SR/SPE/BI-01-C                                  Passed       0.001 seconds
Total: 20, Passed: 20 (100.0%), Failed: 0, Not Run: 0
Overall execution time: 0.0363 seconds
+ mv /tmp/test-mesh-crypto.c unit/test-mesh-crypto.c
+ mv /tmp/test-midi.c unit/test-midi.c
--------------------------------------------------------
Total time taken to replay tests: 71
```