### PR TITLE
[connectedhomeip] Fix Failure related to packaging python module

### DIFF
--- a/projects/connectedhomeip/Dockerfile
+++ b/projects/connectedhomeip/Dockerfile
@@ -38,7 +38,7 @@ ENV PATH="/usr/bin/:${PATH}"
 RUN python3 -m ensurepip --upgrade
 
 # PEP-517 needed for cryptography. Update pip
-RUN python3 -m pip install --upgrade pip setuptools wheel
+RUN python3 -m pip install --upgrade pip setuptools wheel packaging
 
 # Install Rust for building `cryptography` python package when bootstraping pigweed
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y


### PR DESCRIPTION
- OSS-fuzz stopped building after `python-path` was introduced to Matter Repo in https://github.com/project-chip/connectedhomeip/pull/39826


<details>
<summary><h3>Error Log</h3></summary> 

```bash
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c": Collecting python-path (from -r connectedhomeip/scripts/setup/requirements.build.txt (line 13))
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":   Downloading python_path-0.1.3.tar.gz (2.3 kB)
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":   Preparing metadata (setup.py): started
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":   Preparing metadata (setup.py): finished with status 'error'
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c": [91m  error: subprocess-exited-with-error
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":   
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":   × python setup.py egg_info did not run successfully.
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":   │ exit code: 1
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":   ╰─> [40 lines of output]
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":       running egg_info
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":       creating /tmp/pip-pip-egg-info-1o2_zbsb/python_path.egg-info
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":       writing /tmp/pip-pip-egg-info-1o2_zbsb/python_path.egg-info/PKG-INFO
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":       writing dependency_links to /tmp/pip-pip-egg-info-1o2_zbsb/python_path.egg-info/dependency_links.txt
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":       writing top-level names to /tmp/pip-pip-egg-info-1o2_zbsb/python_path.egg-info/top_level.txt
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":       writing manifest file '/tmp/pip-pip-egg-info-1o2_zbsb/python_path.egg-info/SOURCES.txt'
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":       reading manifest file '/tmp/pip-pip-egg-info-1o2_zbsb/python_path.egg-info/SOURCES.txt'
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":       reading manifest template 'MANIFEST.in'
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":       Traceback (most recent call last):
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":         File "<string>", line 2, in <module>
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":         File "<pip-setuptools-caller>", line 35, in <module>
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":         File "/tmp/pip-install-4w5zzqql/python-path_06421286c8f84d7aad3e9b33d11e4f38/setup.py", line 5, in <module>
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":           setup(
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":         File "/usr/local/lib/python3.10/dist-packages/setuptools/__init__.py", line 115, in setup
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":           return distutils.core.setup(**attrs)
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":         File "/usr/local/lib/python3.10/dist-packages/setuptools/_distutils/core.py", line 186, in setup
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":           return run_commands(dist)
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":         File "/usr/local/lib/python3.10/dist-packages/setuptools/_distutils/core.py", line 202, in run_commands
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":           dist.run_commands()
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":         File "/usr/local/lib/python3.10/dist-packages/setuptools/_distutils/dist.py", line 1002, in run_commands
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":           self.run_command(cmd)
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":         File "/usr/local/lib/python3.10/dist-packages/setuptools/dist.py", line 1102, in run_command
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":           super().run_command(command)
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":         File "/usr/local/lib/python3.10/dist-packages/setuptools/_distutils/dist.py", line 1021, in run_command
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":           cmd_obj.run()
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":         File "/usr/local/lib/python3.10/dist-packages/setuptools/command/egg_info.py", line 312, in run
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":           self.find_sources()
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":         File "/usr/local/lib/python3.10/dist-packages/setuptools/command/egg_info.py", line 320, in find_sources
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":           mm.run()
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":         File "/usr/local/lib/python3.10/dist-packages/setuptools/command/egg_info.py", line 548, in run
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":           self.prune_file_list()
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":         File "/usr/local/lib/python3.10/dist-packages/setuptools/command/sdist.py", line 162, in prune_file_list
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":           super().prune_file_list()
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":         File "/usr/local/lib/python3.10/dist-packages/setuptools/_distutils/command/sdist.py", line 386, in prune_file_list
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":           base_dir = self.distribution.get_fullname()
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":         File "/usr/local/lib/python3.10/dist-packages/setuptools/_core_metadata.py", line 275, in get_fullname
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":           return _distribution_fullname(self.get_name(), self.get_version())
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":         File "/usr/local/lib/python3.10/dist-packages/setuptools/_core_metadata.py", line 293, in _distribution_fullname
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":           canonicalize_version(version, strip_trailing_zero=False),
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":       TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":       [end of output]
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":   
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c":   note: This error originates from a subprocess, and is likely not a problem with pip.
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c": [0m[91merror: metadata-generation-failed
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c": 
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c": × Encountered error while generating package metadata.
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c": ╰─> See above for output.
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c": 
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c": note: This is an issue with the package mentioned above, not pip.
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c": hint: See above for details.
Step #1 - "build-aa040769-b630-4a4e-a3ad-488764c3158c": The command '/bin/sh -c pip3 install -r connectedhomeip/scripts/setup/requirements.build.txt' returned a non-zero code: 1
```
</details>

### Fix
- Fix: Update "Packaging" Module in Docker before install requirements