### PR TITLE
gdk-pixbuf: disable the default glycin loader

### DIFF
--- a/projects/gdk-pixbuf/Dockerfile
+++ b/projects/gdk-pixbuf/Dockerfile
@@ -14,16 +14,23 @@
 #
 ################################################################################
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y ffmpeg python3-pip gtk-doc-tools libffi-dev
-RUN pip3 install meson==0.55.3 ninja
 
-RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/gdk-pixbuf.git
-ADD https://ftp.gnome.org/pub/gnome/sources/glib/2.64/glib-2.64.2.tar.xz $SRC
-RUN tar xvJf $SRC/glib-2.64.2.tar.xz
+RUN apt-get update && \
+    apt-get install -y ffmpeg python3-pip gtk-doc-tools libffi-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+RUN pip3 install --disable-pip-version-check --no-cache-dir \
+        pip==25.1.1
+RUN pip3 install --disable-pip-version-check --no-cache-dir \
+        corpus-replicator \
+        meson==1.8.2 \
+        ninja==1.11.1.4
 
-RUN python3 -m pip install --upgrade pip && python3 -m pip install corpus-replicator
+RUN git clone --depth=1 --no-tags https://gitlab.gnome.org/GNOME/gdk-pixbuf.git
+RUN git clone --depth=1 --branch=2.84.3 https://gitlab.gnome.org/GNOME/glib.git
+
 RUN corpus-replicator -o corpus image_gif_gif_ffmpeg.yml image_jpg_jpg_ffmpeg.yml image_png_png_ffmpeg.yml image
-RUN git clone --depth 1 https://github.com/glennrp/libpng.git && \
+RUN git clone --depth=1 --no-tags https://github.com/glennrp/libpng.git && \
     find $SRC/gdk-pixbuf/tests/ \( -name '*.jpeg' -o -name '*.jpg' -o -name '*.png' \) -exec cp -v '{}' corpus/ ';' && \
     find $SRC/libpng -name "*.png" | grep -v crashers | xargs cp -t corpus/ && \
     zip -q $SRC/gdk-pixbuf_seed_corpus.zip corpus/* && \

--- a/projects/gdk-pixbuf/build.sh
+++ b/projects/gdk-pixbuf/build.sh
@@ -28,31 +28,42 @@ rm -rf $BUILD
 mkdir -p $BUILD
 
 # Build glib
-pushd $SRC/glib-2.64.2
-meson \
+pushd $SRC/glib
+meson setup \
     --prefix=$PREFIX \
     --libdir=lib \
     --default-library=static \
     -Db_lundef=false \
     -Doss_fuzz=enabled \
     -Dlibmount=disabled \
-    -Dinternal_pcre=true \
+    -Dman-pages=disabled \
+    -Dsysprof=disabled \
+    -Dtests=false \
     _builddir
 ninja -C _builddir
 ninja -C _builddir install
 popd
 
 # Build gdk-pixbuf
+# TODO: Enable tiff support
 pushd $SRC/gdk-pixbuf
-meson \
+meson setup \
     --prefix=$PREFIX \
     --libdir=lib \
     --default-library=static \
     -Dintrospection=disabled \
-    -Dgtk_doc=false \
     -Dman=false \
-    -Ddocs=false \
+    -Ddocumentation=false \
+    -Dtests=false \
+    -Dinstalled_tests=false \
+    -Dthumbnailer=disabled \
+    -Dglycin=disabled \
     -Dbuiltin_loaders='all' \
+    -Djpeg=enabled \
+    -Dpng=enabled \
+    -Dgif=enabled \
+    -Dothers=enabled \
+    -Dtiff=disabled \
     _builddir
 ninja -C _builddir
 ninja -C _builddir install


### PR DESCRIPTION
The gdk-pixbuf development branch uses the glycin loader by default. This commit updates the build command to use the built-in loaders to match previous behavior and to focus fuzzing on gdk-pixbuf's own image handlers.

This commit also bumps GLib and meson to fix other build errors.