### PR TITLE
librsvg: bump dependencies

### DIFF
--- a/projects/librsvg/Dockerfile
+++ b/projects/librsvg/Dockerfile
@@ -15,7 +15,9 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder-rust
-ENV RUSTUP_TOOLCHAIN nightly-2025-07-04
+
+ENV RUSTUP_TOOLCHAIN=nightly-2025-07-04
+
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install --no-install-recommends -y \
@@ -24,24 +26,24 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 RUN pip3 install --disable-pip-version-check --no-cache-dir \
-        pip==24.2
+        pip==25.1.1
 RUN pip3 install --disable-pip-version-check --no-cache-dir \
-        meson==1.5.1 \
-        ninja==1.11.1.1 \
-        packaging==24.1
+        meson==1.8.2 \
+        ninja==1.11.1.4 \
+        packaging==25.0
 
 # We have to compile various dependencies because the distro does not have recent enough
 # versions of packages like Pango. Manual compilation also makes it easier to use static linking:
 # https://google.github.io/oss-fuzz/further-reading/fuzzer-environment/
 
 RUN git clone --depth=1 --no-tags https://gitlab.gnome.org/GNOME/librsvg.git
-RUN git clone --depth=1 --branch=2.82.0 https://gitlab.gnome.org/GNOME/glib.git
+RUN git clone --depth=1 --branch=2.85.2 https://gitlab.gnome.org/GNOME/glib.git
 RUN git clone --depth=1 --branch=VER-2-13-3 https://gitlab.freedesktop.org/freetype/freetype.git
-RUN git clone --depth=1 --branch=v2.13.3 https://gitlab.gnome.org/GNOME/libxml2.git
-RUN git clone --depth=1 --branch=2.15.0 https://gitlab.freedesktop.org/fontconfig/fontconfig.git
-RUN git clone --depth=1 --branch=1.18.2 https://gitlab.freedesktop.org/cairo/cairo.git
-RUN git clone --depth=1 --branch=9.0.0 https://github.com/harfbuzz/harfbuzz.git
-RUN git clone --depth=1 --branch=1.54.0 https://gitlab.gnome.org/GNOME/pango.git
+RUN git clone --depth=1 --branch=v2.14.5 https://gitlab.gnome.org/GNOME/libxml2.git
+RUN git clone --depth=1 --branch=2.17.1 https://gitlab.freedesktop.org/fontconfig/fontconfig.git
+RUN git clone --depth=1 --branch=1.18.4 https://gitlab.freedesktop.org/cairo/cairo.git
+RUN git clone --depth=1 --branch=11.3.2 https://github.com/harfbuzz/harfbuzz.git
+RUN git clone --depth=1 --branch=1.56.4 https://gitlab.gnome.org/GNOME/pango.git
 
 RUN git clone --depth=1 --no-tags https://github.com/google/fuzzing.git
 

--- a/projects/librsvg/build.sh
+++ b/projects/librsvg/build.sh
@@ -34,7 +34,7 @@ export CXXFLAGS="$CFLAGS $CXXFLAGS_EXTRA"
 
 # Compile and install GLib
 cd "$SRC/glib"
-meson setup --prefix="$PREFIX" --buildtype=plain --default-library=static builddir -Dtests=false -Dsysprof=disabled
+meson setup --prefix="$PREFIX" --buildtype=plain --default-library=static builddir -Dman-pages=disabled -Dtests=false -Dsysprof=disabled
 ninja -C builddir
 ninja -C builddir install
 
@@ -64,13 +64,13 @@ ninja -C builddir install
 
 # Compile and install HarfBuzz
 cd "$SRC/harfbuzz"
-meson setup --prefix="$PREFIX" --buildtype=plain --default-library=static builddir -Dtests=disabled
+meson setup --prefix="$PREFIX" --buildtype=plain --default-library=static builddir -Ddocs=disabled -Dtests=disabled
 ninja -C builddir
 ninja -C builddir install
 
 # Compile and install Pango
 cd "$SRC/pango"
-meson setup --prefix="$PREFIX" --buildtype=plain --default-library=static builddir
+meson setup --prefix="$PREFIX" --buildtype=plain --default-library=static builddir -Dbuild-examples=false -Dbuild-testsuite=false
 ninja -C builddir
 ninja -C builddir install
 


### PR DESCRIPTION
This commit also disables unnecessary documentation and test-suite features when building some of the dependencies.