### PR TITLE
cloud-hypervisor: Use the latest nightly toolchain

### DIFF
--- a/projects/cloud-hypervisor/Dockerfile
+++ b/projects/cloud-hypervisor/Dockerfile
@@ -18,7 +18,9 @@ FROM gcr.io/oss-fuzz-base/base-builder-rust as builder
 ## Install build dependencies.
 RUN apt-get update
 RUN git clone --depth 1 https://github.com/cloud-hypervisor/cloud-hypervisor.git
+
+# Always use the latest nightly toolchain since that's the version being
+# validated with Cloud Hypervisor CI
+ENV RUSTUP_TOOLCHAIN nightly
+
 COPY build.sh $SRC/
-
-
-


### PR DESCRIPTION
This should address the recent building errors [1].

[1] https://issues.oss-fuzz.com/issues/422421343