### PR TITLE
fix pcapplusplus build

### DIFF
--- a/projects/pcapplusplus/Dockerfile
+++ b/projects/pcapplusplus/Dockerfile
@@ -25,4 +25,4 @@ RUN git clone --depth=1 https://github.com/the-tcpdump-group/libpcap.git libpcap
 
 WORKDIR PcapPlusPlus
 
-COPY *.sh pcapplusplus_enable_tests.diff $SRC
+COPY *.sh pcapplusplus_enable_tests.diff $SRC/


### PR DESCRIPTION
```
Step #1 - "build-bb7d6cb6-a60e-4204-802d-41c0dbaa661c": Step 7/7 : COPY *.sh pcapplusplus_enable_tests.diff $SRC
Step #1 - "build-bb7d6cb6-a60e-4204-802d-41c0dbaa661c": When using COPY with more than one source file, the destination must be a directory and end with a /
```