### PR TITLE
pcapplusplus: enable indexer

### DIFF
--- a/projects/pcapplusplus/pcapplusplus_enable_tests.diff
+++ b/projects/pcapplusplus/pcapplusplus_enable_tests.diff
@@ -1,27 +1,5 @@
-diff --git a/Packet++/header/LdapLayer.h b/Packet++/header/LdapLayer.h
-index 4485d17..b986f12 100644
---- a/Packet++/header/LdapLayer.h
-+++ b/Packet++/header/LdapLayer.h
-@@ -439,7 +439,7 @@ namespace pcpp
- 		static constexpr int diagnotsticsMessageIndex = 2;
- 		static constexpr int referralIndex = 3;
- 
--		static constexpr uint8_t referralTagType = 3;
-+		uint8_t referralTagType = 3;
- 
- 		LdapResponseLayer() = default;
- 		LdapResponseLayer(std::unique_ptr<Asn1Record> asn1Record, uint8_t* data, size_t dataLen, Layer* prevLayer,
-@@ -595,7 +595,7 @@ namespace pcpp
- 	protected:
- 		friend LdapLayer* LdapLayer::parseLdapMessage(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet);
- 
--		static constexpr int serverSaslCredentialsTagType = 7;
-+		int serverSaslCredentialsTagType = 7;
- 
- 		LdapBindResponseLayer(std::unique_ptr<Asn1Record> asn1Record, uint8_t* data, size_t dataLen, Layer* prevLayer,
- 		                      Packet* packet)
 diff --git a/Tests/Fuzzers/ossfuzz.sh b/Tests/Fuzzers/ossfuzz.sh
-index 6d461ff..c984c97 100755
+index 6d461ff6..ec272b5b 100755
 --- a/Tests/Fuzzers/ossfuzz.sh
 +++ b/Tests/Fuzzers/ossfuzz.sh
 @@ -12,7 +12,13 @@ make -j$(nproc)
@@ -35,7 +13,7 @@ index 6d461ff..c984c97 100755
 +    PCAPPP_BUILD_TESTS_VALUE="OFF"
 +fi
 +
-+cmake -DPCAPPP_BUILD_FUZZERS=ON -DPCAPPP_BUILD_TESTS=$PCAPPP_BUILD_TESTS_VALUE -DPCAPPP_BUILD_EXAMPLES=OFF -DPCAP_INCLUDE_DIR="${LIBPCAP_PATH}/" -DPCAP_LIBRARY="${LIBPCAP_PATH}/libpcap.a" -S . -B $TARGETS_DIR
++cmake -DCMAKE_CXX_STANDARD=20 -DPCAPPP_BUILD_FUZZERS=ON -DPCAPPP_BUILD_TESTS=$PCAPPP_BUILD_TESTS_VALUE -DPCAPPP_BUILD_EXAMPLES=OFF -DPCAP_INCLUDE_DIR="${LIBPCAP_PATH}/" -DPCAP_LIBRARY="${LIBPCAP_PATH}/libpcap.a" -S . -B $TARGETS_DIR
  cmake --build $TARGETS_DIR -j
  
  # Copy target and options


### PR DESCRIPTION
`static constexpr` for `referralTagType` and `serverSaslCredentialsTagType` is causing linking issues when `-O0` is forced across in pcapplusplus. These variables are never assigned, and only referenced a single place, so applying this change has no impact as such. I assume in higher optimization levels they are optimized to constants or similar, but without these changes the indexer fails due to forcing `-O0`.

This supersedes https://github.com/google/oss-fuzz/pull/13715 