### PR TITLE
Fix openssh fuzzers after recent PKCS#11 changes

### DIFF
--- a/projects/openssh/build.sh
+++ b/projects/openssh/build.sh
@@ -38,11 +38,12 @@ fi
 make -j$(nproc) all
 
 # Build fuzzers
-EXTRA_CFLAGS="-DCIPHER_NONE_AVAIL=1"
+EXTRA_CFLAGS="-DCIPHER_NONE_AVAIL=1 -D_GNU_SOURCE"
 STATIC_CRYPTO="-Wl,-Bstatic -lcrypto -Wl,-Bdynamic"
 
 SK_NULL=ssh-sk-null.o
 SK_DUMMY=sk-dummy.o
+COMMON_DEPS="ssh-pkcs11-client.o -lssh -lopenbsd-compat"
 
 $CC $CFLAGS $EXTRA_CFLAGS -I. -g -c \
 	regress/misc/fuzz-harness/ssh-sk-null.cc -o ssh-sk-null.o
@@ -51,28 +52,28 @@ $CC $CFLAGS $EXTRA_CFLAGS -I. -g -c \
 
 $CXX $CXXFLAGS -std=c++11 $EXTRA_CFLAGS -I. -L. -Lopenbsd-compat -g \
 	regress/misc/fuzz-harness/pubkey_fuzz.cc -o $OUT/pubkey_fuzz \
-	-lssh -lopenbsd-compat $SK_NULL $STATIC_CRYPTO $LIB_FUZZING_ENGINE
+	$COMMON_DEPS $SK_NULL $STATIC_CRYPTO $LIB_FUZZING_ENGINE
 $CXX $CXXFLAGS -std=c++11 $EXTRA_CFLAGS -I. -L. -Lopenbsd-compat -g \
 	regress/misc/fuzz-harness/privkey_fuzz.cc -o $OUT/privkey_fuzz \
-	-lssh -lopenbsd-compat $SK_NULL $STATIC_CRYPTO $LIB_FUZZING_ENGINE
+	$COMMON_DEPS $SK_NULL $STATIC_CRYPTO $LIB_FUZZING_ENGINE
 $CXX $CXXFLAGS -std=c++11 $EXTRA_CFLAGS -I. -L. -Lopenbsd-compat -g \
 	regress/misc/fuzz-harness/sig_fuzz.cc -o $OUT/sig_fuzz \
-	-lssh -lopenbsd-compat $SK_NULL $STATIC_CRYPTO $LIB_FUZZING_ENGINE
+	$COMMON_DEPS $SK_NULL $STATIC_CRYPTO $LIB_FUZZING_ENGINE
 $CXX $CXXFLAGS -std=c++11 $EXTRA_CFLAGS -I. -L. -Lopenbsd-compat -g \
 	regress/misc/fuzz-harness/authopt_fuzz.cc -o $OUT/authopt_fuzz \
-	auth-options.o -lssh -lopenbsd-compat $SK_NULL $STATIC_CRYPTO \
+	auth-options.o $COMMON_DEPS $SK_NULL $STATIC_CRYPTO \
 	$LIB_FUZZING_ENGINE
 $CXX $CXXFLAGS -std=c++11 $EXTRA_CFLAGS -I. -L. -Lopenbsd-compat -g \
 	regress/misc/fuzz-harness/sshsig_fuzz.cc -o $OUT/sshsig_fuzz \
-	sshsig.o -lssh -lopenbsd-compat $SK_NULL $STATIC_CRYPTO \
+	sshsig.o $COMMON_DEPS $SK_NULL $STATIC_CRYPTO \
 	$LIB_FUZZING_ENGINE
 $CXX $CXXFLAGS -std=c++11 $EXTRA_CFLAGS -I. -L. -Lopenbsd-compat -g \
 	regress/misc/fuzz-harness/sshsigopt_fuzz.cc -o $OUT/sshsigopt_fuzz \
-	sshsig.o -lssh -lopenbsd-compat $SK_NULL $STATIC_CRYPTO \
+	sshsig.o $COMMON_DEPS $SK_NULL $STATIC_CRYPTO \
 	$LIB_FUZZING_ENGINE
 $CXX $CXXFLAGS -std=c++11 $EXTRA_CFLAGS -I. -L. -Lopenbsd-compat -g \
 	regress/misc/fuzz-harness/kex_fuzz.cc -o $OUT/kex_fuzz \
-	-lssh -lopenbsd-compat -lz $SK_NULL $STATIC_CRYPTO \
+	$COMMON_DEPS -lz $SK_NULL $STATIC_CRYPTO \
 	$LIB_FUZZING_ENGINE
 
 $CC $CFLAGS $EXTRA_CFLAGS -I. -g -c \
@@ -80,7 +81,7 @@ $CC $CFLAGS $EXTRA_CFLAGS -I. -g -c \
 $CC $CFLAGS $EXTRA_CFLAGS -I. -g -c -DENABLE_SK_INTERNAL=1 ssh-sk.c -o ssh-sk.o
 $CXX $CXXFLAGS -std=c++11 $EXTRA_CFLAGS -I. -L. -Lopenbsd-compat -g \
 	regress/misc/fuzz-harness/agent_fuzz.cc -o $OUT/agent_fuzz \
-	$SK_DUMMY agent_fuzz_helper.o ssh-sk.o -lssh -lopenbsd-compat -lz \
+	$SK_DUMMY agent_fuzz_helper.o ssh-sk.o $COMMON_DEPS -lz \
 	$STATIC_CRYPTO $LIB_FUZZING_ENGINE
 
 # Prepare seed corpora


### PR DESCRIPTION
OpenSSH a8c0e5c87 refactored some things in the PKCS#11 code which necessitates a new build-time dependency