### PR TITLE
apache-commons-lang: fix broken build

### DIFF
--- a/projects/apache-commons-lang/build.sh
+++ b/projects/apache-commons-lang/build.sh
@@ -17,7 +17,7 @@
 
 mv $SRC/{*.zip,*.dict} $OUT
 
-MAVEN_ARGS="-Djavac.src.version=15 -Djavac.target.version=15 -DskipTests -Drat.ignoreErrors=true"
+MAVEN_ARGS="-Djavac.src.version=15 -Djavac.target.version=15 -Dmaven.javadoc.skip=true -DskipTests -Drat.ignoreErrors=true"
 $MVN package $MAVEN_ARGS
 CURRENT_VERSION=$($MVN org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate \
  -Dexpression=project.version -q -DforceStdout)


### PR DESCRIPTION
by disabling javadoc