### PR TITLE
kubernetes: bump go version

### DIFF
--- a/projects/kubernetes/Dockerfile
+++ b/projects/kubernetes/Dockerfile
@@ -23,10 +23,10 @@ RUN git clone --depth 1 https://github.com/kubernetes/kops
 RUN git clone --depth 1 https://github.com/cncf/cncf-fuzzing
 RUN git clone --depth 1 https://github.com/AdamKorcz/instrumentation
 RUN git clone --depth 1 https://github.com/AdamKorcz/go-118-fuzz-build --branch=november-backup
-RUN wget https://go.dev/dl/go1.23.4.linux-amd64.tar.gz \
+RUN wget https://go.dev/dl/go1.24.5.linux-amd64.tar.gz \
     && mkdir temp-go \
     && rm -rf /root/.go/* \
-    && tar -C temp-go/ -xzf go1.23.4.linux-amd64.tar.gz \
+    && tar -C temp-go/ -xzf go1.24.5.linux-amd64.tar.gz \
     && mv temp-go/go/* /root/.go/
 WORKDIR $SRC/
 COPY build.sh $SRC/


### PR DESCRIPTION
Kubernetes uses 1.24. [Ref](https://github.com/kubernetes/kubernetes/blob/f9ed14bf9b1119a2e091f4b487a3b54930661034/go.mod#L9)