### PR TITLE
wavpack: add run_tests.sh

### DIFF
--- a/projects/wavpack/run_tests.sh
+++ b/projects/wavpack/run_tests.sh
@@ -1,4 +1,5 @@
-# Copyright 2019 Google Inc.
+#!/bin/bash -eux
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,9 +15,4 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool gettext
-RUN git clone --depth 1 https://github.com/dbry/WavPack.git wavpack
-RUN cp wavpack/fuzzing/build.sh $SRC
-COPY run_tests.sh $SRC/
-WORKDIR wavpack
+make check


### PR DESCRIPTION
run_tests.sh is used as part of Chronos with cached builds: https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests

```
$ ./infra/experimental/chronos/check_tests.sh wavpack c++
...
...
   *** 32-bit integer, 5.1 channels ***
test 0153...pass (   -fb4c, 87.25%, 4.08 bps, 2b7608040e81390e6926c39c94d3086d)
test 0154...pass (    -b4c, 87.16%, 4.11 bps, 74033ecd1a0cd518f851649e530a3164)
test 0155...pass (   -hb4c, 87.11%, 4.12 bps, 9ad5ef53970867690665ca3301ea3199)
test 0156...pass (  -hhb4c, 87.04%, 4.15 bps, 62ba102f67a46d57bb394c8b6f43640d)

   *** 32-bit float stored as integer (pathological), 5.1 channels ***
test 0157...pass (   -fb4c, 83.68%, 5.22 bps, d4b5d5c7245183123af355ed90f58c5f)
test 0158...pass (    -b4c, 83.41%, 5.31 bps, 74112a8bcbe2b448067aa8cee502176b)
test 0159...pass (   -hb4c, 83.57%, 5.26 bps, 84732c5974cdf0f4f8f1996ca7515721)
test 0160...pass (  -hhb4c, 83.56%, 5.26 bps, f7108e8070680f886cb6cad6e54f6daa)

   *** 32-bit float, 5.1 channels ***
test 0161...pass (   -fb4c, 87.27%, 4.07 bps, dcd3a9a818bb9add5e98fc4da07adb9a)
test 0162...pass (    -b4c, 87.19%, 4.10 bps, 08c3f941801b61d40ce83405d0edf934)
test 0163...pass (   -hb4c, 87.13%, 4.12 bps, f0af435d9ae54b359e49fcc54f566051)
test 0164...pass (  -hhb4c, 87.06%, 4.14 bps, a8272573fe178749ac0985c4d376381f)

all tests pass

PASS: cli/fast-tests
=============
1 test passed
=============
make[1]: Leaving directory '/src/wavpack'
--------------------------------------
```