### PR TITLE
php: fix build

### DIFF
--- a/projects/php/build.sh
+++ b/projects/php/build.sh
@@ -36,7 +36,6 @@ fi
     --enable-option-checking=fatal \
     --enable-fuzzer \
     --enable-exif \
-    --enable-opcache \
     --without-pcre-jit \
     --disable-phpdbg \
     --disable-cgi \
@@ -67,10 +66,6 @@ done
 if [ "$SANITIZER" != "memory" ] && [ "$SANITIZER" != "undefined" ]; then
     cp sapi/fuzzer/php-fuzz-function-jit $OUT/
     cp sapi/fuzzer/php-fuzz-tracing-jit $OUT/
-
-    # Copy opcache.so extension, which does not support static linking.
-    mkdir -p $OUT/modules
-    cp modules/opcache.so $OUT/modules
 fi
 
 # copy corpora from source


### PR DESCRIPTION
opcache is now mandatory and no longer optional:
https://github.com/php/php-src/commit/7b4c14dc10167b65ce51371507d7b37b74252077