### PR TITLE
spicy: fix build

### DIFF
--- a/projects/spicy/build.sh
+++ b/projects/spicy/build.sh
@@ -40,7 +40,7 @@ rm -rf "${TO}/spicy/runtime/include/spicy/rt"/*
 cp -rP "${FROM}/spicy/runtime/include/"* "${TO}/spicy/runtime/include/spicy/rt"
 
 # Replace softlinks to 3rdparty dependencies with actual contents.
-for DEP in any ArticleEnumClass-v2 ghc SafeInt tinyformat nlohmann; do
+for DEP in ArticleEnumClass-v2 SafeInt tinyformat nlohmann; do
 	D=${TO}/hilti/runtime/include/hilti/rt/3rdparty
 	rm -r "${D}/${DEP}"
 	mkdir -p "${D}/${DEP}"


### PR DESCRIPTION
gch and any are no longer needed following

- https://github.com/zeek/spicy/commit/063bfa8e1970770d1993f6e68a900e02c5d70b3b
- https://github.com/zeek/spicy/commit/26ee745b3384ba3aa4da8a74dd0271ec2438baee