### PR TITLE
fix build for moby OSS-Fuzz

### DIFF
--- a/projects/moby/build.sh
+++ b/projects/moby/build.sh
@@ -18,11 +18,11 @@
 # Temporarily disable coverage build in OSS-Fuzz's CI
 if [ -n "${OSS_FUZZ_CI-}" ]
 then
-	if [ "${SANITIZER}" = 'coverage' ]
-	then
-		exit 0
-	fi
-	
+        if [ "${SANITIZER}" = 'coverage' ]
+        then
+                exit 0
+        fi
+
 fi
 
 cd $SRC/go-118-fuzz-build
@@ -30,19 +30,19 @@ go build .
 mv go-118-fuzz-build /root/go/bin/
 
 cd $SRC/moby
-printf "package libnetwork\nimport _ \"github.com/AdamKorcz/go-118-fuzz-build/testing\"\n" > $SRC/moby/registerfuzzdependency.go
+
 
 mv $SRC/moby/vendor.mod $SRC/moby/go.mod
-go mod edit -replace github.com/AdamKorcz/go-118-fuzz-build=$SRC/go-118-fuzz-build
+find . -type f \( -name "*.go" -o -name "go.mod" \) -exec sed -i 's|github.com/docker/docker|github.com/moby/moby|g' {} +
 
-cp $SRC/jsonmessage_fuzzer.go $SRC/moby/pkg/jsonmessage/
+cp $SRC/jsonmessage_fuzzer.go $SRC/moby/client/pkg/jsonmessage
 cp $SRC/backend_build_fuzzer.go $SRC/moby/daemon/builder/backend/
 cp $SRC/remotecontext_fuzzer.go $SRC/moby/daemon/builder/remotecontext/
 cp $SRC/daemon_fuzzer.go $SRC/moby/daemon/
 
-rm $SRC/moby/daemon/logger/plugin_unsupported.go
-
-cd $SRC/moby
+printf "package libnetwork\nimport _ \"github.com/AdamKorcz/go-118-fuzz-build/testing\"\n" > $SRC/moby/registerfuzzdependency.go
+go mod edit -replace github.com/AdamKorcz/go-118-fuzz-build=$SRC/go-118-fuzz-build
+rm -f $SRC/moby/daemon/logger/plugin_unsupported.go
 go mod tidy && go mod vendor
 
 mv $SRC/moby/daemon/volume/mounts/parser_test.go $SRC/moby/daemon/volume/mounts/parser_test_fuzz.go
@@ -50,22 +50,26 @@ mv $SRC/moby/daemon/volume/mounts/validate_unix_test.go $SRC/moby/daemon/volume/
 
 
 if [ "$SANITIZER" != "coverage" ] ; then
-	go-fuzz -func FuzzDaemonSimple -o FuzzDaemonSimple.a github.com/docker/docker/daemon
+        go-fuzz -func FuzzDaemonSimple -o FuzzDaemonSimple.a github.com/moby/moby/daemon
 
-	$CXX $CXXFLAGS $LIB_FUZZING_ENGINE FuzzDaemonSimple.a \
+        $CXX $CXXFLAGS $LIB_FUZZING_ENGINE FuzzDaemonSimple.a \
         /src/LVM2.2.03.15/libdm/ioctl/libdevmapper.a \
         -o $OUT/FuzzDaemonSimple
 fi
 
-compile_native_go_fuzzer github.com/docker/docker/daemon/volume/mounts FuzzParseLinux FuzzParseLinux
-compile_go_fuzzer github.com/docker/docker/pkg/jsonmessage FuzzDisplayJSONMessagesStream FuzzDisplayJSONMessagesStream
-compile_go_fuzzer github.com/docker/docker/daemon/builder/backend FuzzsanitizeRepoAndTags FuzzsanitizeRepoAndTags
-compile_go_fuzzer github.com/docker/docker/daemon/builder/remotecontext FuzzreadAndParseDockerfile FuzzreadAndParseDockerfile
-compile_native_go_fuzzer github.com/docker/docker/pkg/tailfile FuzzTailfile FuzzTailfile
-compile_native_go_fuzzer github.com/docker/docker/daemon/logger/jsonfilelog FuzzLoggerDecode FuzzLoggerDecode
-compile_native_go_fuzzer github.com/docker/docker/daemon/libnetwork/etchosts FuzzAdd FuzzAdd
-compile_native_go_fuzzer github.com/docker/docker/oci FuzzAppendDevicePermissionsFromCgroupRules FuzzAppendDevicePermissionsFromCgroupRules
-compile_native_go_fuzzer github.com/docker/docker/daemon/logger/jsonfilelog/jsonlog FuzzJSONLogsMarshalJSONBuf FuzzJSONLogsMarshalJSONBuf
+go-fuzz -func FuzzDisplayJSONMessagesStream -o FuzzDisplayJSONMessagesStream.a github.com/moby/moby/client/pkg/jsonmessage
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE FuzzDisplayJSONMessagesStream.a -o $OUT/FuzzDisplayJSONMessagesStream
+go-fuzz -func FuzzsanitizeRepoAndTags -o FuzzsanitizeRepoAndTags.a github.com/moby/moby/daemon/builder/backend
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE FuzzsanitizeRepoAndTags.a -o $OUT/FuzzsanitizeRepoAndTags
+go-fuzz -func FuzzreadAndParseDockerfile -o FuzzreadAndParseDockerfile.a github.com/moby/moby/daemon/builder/remotecontext
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE FuzzreadAndParseDockerfile.a -o $OUT/FuzzreadAndParseDockerfile
+
+compile_native_go_fuzzer github.com/moby/moby/daemon/volume/mounts FuzzParseLinux FuzzParseLinux
+compile_native_go_fuzzer github.com/moby/moby/pkg/tailfile FuzzTailfile FuzzTailfile
+compile_native_go_fuzzer github.com/moby/moby/daemon/logger/jsonfilelog FuzzLoggerDecode FuzzLoggerDecode
+compile_native_go_fuzzer github.com/moby/moby/daemon/libnetwork/etchosts FuzzAdd FuzzAdd
+compile_native_go_fuzzer github.com/moby/moby/daemon/pkg/oci FuzzAppendDevicePermissionsFromCgroupRules FuzzAppendDevicePermissionsFromCgroupRules
+compile_native_go_fuzzer github.com/moby/moby/daemon/logger/jsonfilelog/jsonlog FuzzJSONLogsMarshalJSONBuf FuzzJSONLogsMarshalJSONBuf
 
 cp $SRC/*.options $OUT/
 
@@ -76,3 +80,4 @@ go mod tidy
 compile_native_go_fuzzer github.com/moby/go-archive/compression FuzzDecompressStream FuzzDecompressStream
 compile_native_go_fuzzer github.com/moby/go-archive FuzzApplyLayer FuzzApplyLayer
 compile_native_go_fuzzer github.com/moby/go-archive FuzzUntar FuzzUntar
+

--- a/projects/moby/daemon_fuzzer.go
+++ b/projects/moby/daemon_fuzzer.go
@@ -23,12 +23,12 @@ import (
 	"github.com/moby/sys/mount"
 	"github.com/sirupsen/logrus"
 
-	"github.com/moby/moby/api/types/backend"
-	"github.com/docker/docker/daemon/container"
-	"github.com/docker/docker/daemon/config"
-	"github.com/docker/docker/daemon/images"
-	"github.com/docker/docker/image"
-	dockerreference "github.com/docker/docker/reference"
+	"github.com/moby/moby/daemon/server/backend"
+	"github.com/moby/moby/daemon/container"
+	"github.com/moby/moby/daemon/config"
+	"github.com/moby/moby/daemon/images"
+	"github.com/moby/moby/daemon/internal/image"
+	reference "github.com/moby/moby/daemon/internal/refstore"
 	"github.com/opencontainers/go-digest"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
@@ -70,7 +70,7 @@ func FuzzDaemonSimple(data []byte) int {
 	if err != nil {
 		panic(err)
 	}
-	rStore, err := dockerreference.NewReferenceStore(jsonFile)
+	rStore, err := reference.NewReferenceStore(jsonFile)
 	if err != nil {
 		return 0
 	}


### PR DESCRIPTION
First, the `compile_native_go_fuzzer` helper script could not handle go-fuzz–style fuzzers.
Next, we patched the sequence of `go.mod` editing operations.
Finally, we fixed the issues caused by changes to file paths in the Moby project.
