### PR TITLE
fix build for zeek OSS-Fuzz

### DIFF
--- a/projects/zeek/Dockerfile
+++ b/projects/zeek/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libmaxminddb-dev \
         libkrb5-dev \
         zlib1g-dev \
+        libzmq3-dev \
   && rm -rf /var/lib/apt/lists/*
 
 RUN git clone --depth 1 --recursive https://github.com/zeek/zeek zeek


### PR DESCRIPTION
The root cause of the compilation failure problem lies in the lack of the ZeroMQ (libzmq) development library in the build environment
I add libzmq3-dev to the installation list in the Dockerfile file