### PR TITLE
Add protobuf-go fuzzers: AnyUnmarshal, MergeMessage, JSONBinaryDiff

### DIFF
--- a/projects/protobuf-go-fuzz/Dockerfile
+++ b/projects/protobuf-go-fuzz/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN git clone --depth 1 https://github.com/protocolbuffers/protobuf-go.git /src/protobuf-go
+WORKDIR protobuf-go-fuzz
+COPY build.sh $SRC/

--- a/projects/protobuf-go-fuzz/Dockerfile
+++ b/projects/protobuf-go-fuzz/Dockerfile
@@ -16,6 +16,6 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN apt-get update && apt-get install -y make autoconf automake libtool
-RUN git clone --depth 1 https://github.com/protocolbuffers/protobuf-go.git /src/protobuf-go
+RUN git clone --depth 1 -b oss-fuzz-harness https://github.com/kripto-geek/protobuf-go.git /src/protobuf-go
 WORKDIR protobuf-go-fuzz
 COPY build.sh $SRC/

--- a/projects/protobuf-go-fuzz/build.sh
+++ b/projects/protobuf-go-fuzz/build.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -eu
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# build project
+# e.g.
+# ./autogen.sh
+# ./configure
+# make -j$(nproc) all
+
+# build fuzzers
+# e.g.
+# $CXX $CXXFLAGS -std=c++11 -Iinclude \
+#     /path/to/name_of_fuzzer.cc -o $OUT/name_of_fuzzer \
+#     $LIB_FUZZING_ENGINE /path/to/library.a
+
+#!/bin/bash -eu
+
+# Build the Unmarshal harness
+compile_native_go_fuzzer \
+  github.com/protocolbuffers/protobuf-go/reflect/protoreflect/fuzz \
+  FuzzAnyUnmarshal \
+  fuzz_anyunmarshal \
+  fuzz
+
+# Build the Merge harness
+compile_native_go_fuzzer \
+  github.com/protocolbuffers/protobuf-go/reflect/protoreflect/fuzz \
+  FuzzMergeMessage \
+  fuzz_merge_message \
+  fuzz
+
+# Build the JSON/Bin diff harness
+compile_native_go_fuzzer \
+  github.com/protocolbuffers/protobuf-go/reflect/protoreflect/fuzz \
+  FuzzJSONBinaryDiff \
+  fuzz_json_binary_diff \
+  fuzz

--- a/projects/protobuf-go-fuzz/project.yaml
+++ b/projects/protobuf-go-fuzz/project.yaml
@@ -1,0 +1,9 @@
+name: protobuf-go-fuzz
+display_name: "Protocol Buffers Go (protobuf-go)"
+repo: https://github.com/protocolbuffers/protobuf-go
+branch: main
+language: go
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer


### PR DESCRIPTION
This PR adds native Go fuzzers for the `protobuf-go` project:

- `FuzzAnyUnmarshal`: fuzzes unmarshaling of `google.protobuf.Any`
- `FuzzMergeMessage`: fuzzes the message merge logic
- `FuzzJSONBinaryDiff`: fuzzes binary/JSON equivalence for messages

All fuzzers include basic seed corpora and follow Go native fuzzing conventions.
Fuzzers were tested locally before submission.

Fuzz target repo: https://github.com/kripto-geek/protobuf-go (custom harness branch)
