### PR TITLE
moby: fix broken build 

### DIFF
--- a/projects/moby/daemon_fuzzer.go
+++ b/projects/moby/daemon_fuzzer.go
@@ -23,12 +23,12 @@ import (
 	"github.com/moby/sys/mount"
 	"github.com/sirupsen/logrus"
 
-	"github.com/moby/moby/api/types/backend"
-	"github.com/docker/docker/daemon/container"
-	"github.com/docker/docker/daemon/config"
-	"github.com/docker/docker/daemon/images"
-	"github.com/docker/docker/image"
-	dockerreference "github.com/docker/docker/reference"
+	"github.com/moby/moby/daemon/server/backend"
+	"github.com/moby/moby/daemon/container"
+	"github.com/moby/moby/daemon/config"
+	"github.com/moby/moby/daemon/images"
+	"github.com/moby/moby/daemon/internal/image"
+	reference "github.com/moby/moby/daemon/internal/refstore"
 	"github.com/opencontainers/go-digest"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
@@ -70,7 +70,7 @@ func FuzzDaemonSimple(data []byte) int {
 	if err != nil {
 		panic(err)
 	}
-	rStore, err := dockerreference.NewReferenceStore(jsonFile)
+	rStore, err := reference.NewReferenceStore(jsonFile)
 	if err != nil {
 		return 0
 	}


### PR DESCRIPTION
https://github.com/google/oss-fuzz/pull/13765
This is the updated version of the above-mentioned PR.
We adopt api and client of the latest v2 version  as dependencies, discarding the outdated fuzzing configuration based on docker/docker paths.On this basis, we made the smallest changes.