### PR TITLE
moby: fix build failure caused by missing dependency library

### DIFF
--- a/projects/zeek/Dockerfile
+++ b/projects/zeek/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libmaxminddb-dev \
         libkrb5-dev \
         zlib1g-dev \
+        libzmq3-dev \
   && rm -rf /var/lib/apt/lists/*
 
 RUN git clone --depth 1 --recursive https://github.com/zeek/zeek zeek


### PR DESCRIPTION
The following is a screenshot of the error report.
![Snipaste_2025-08-05_15-43-17](https://github.com/user-attachments/assets/de254b03-4890-43b3-ad4a-9e93565b3e36)
The reason for the compilation error is the absence of the necessary external libraries.
The above modification has fixed this error.