### PR TITLE
zeek: fix build failure caused by missing dependency library and  the missing shared libraries

### DIFF
--- a/projects/zeek/Dockerfile
+++ b/projects/zeek/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libmaxminddb-dev \
         libkrb5-dev \
         zlib1g-dev \
+        libzmq3-dev \
   && rm -rf /var/lib/apt/lists/*
 
 RUN git clone --depth 1 --recursive https://github.com/zeek/zeek zeek

--- a/projects/zeek/build.sh
+++ b/projects/zeek/build.sh
@@ -60,6 +60,8 @@ for f in ${fuzzers}; do
         copy_lib ${f} libcrypto
         copy_lib ${f} libz
         copy_lib ${f} libmaxminddb
+        copy_lib ${f} libzmq
+        copy_lib ${f} libsodium
     fi
 
     patchelf --set-rpath '$ORIGIN/lib' ${OUT}/${fuzzer_exe}


### PR DESCRIPTION
The following is a screenshot of the error report.
![Snipaste_2025-08-05_15-43-17](https://github.com/user-attachments/assets/36693f32-3ef3-4189-8572-4ceb0a74e95f)
The reason for the compilation error is the absence of the necessary external libraries.
Not only that, the missing shared libraries leads to the collapse of the soundness check.
The above modification has fixed this error.