### PR TITLE
ffmpeg: Update main_repo to match Dockerfile clone

### DIFF
--- a/projects/ffmpeg/project.yaml
+++ b/projects/ffmpeg/project.yaml
@@ -22,4 +22,4 @@ sanitizers:
  - memory
  - undefined
 selective_unpack: true
-main_repo: 'https://git.ffmpeg.org/ffmpeg.git'
+main_repo: 'https://github.com/FFmpeg/FFmpeg'


### PR DESCRIPTION
https://github.com/google/oss-fuzz/commit/99577b7e69cbafaf0e13a8f17962fc7eaff95914
 broke use cases that need to find the main repo based
on project.yaml metadata.