### PR TITLE
explicitly pass crypto engine to configure script

### DIFF
--- a/projects/libsrtp/build.sh
+++ b/projects/libsrtp/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 cd $SRC/libsrtp
 autoreconf -ivf
-./configure
+./configure --with-crypto-library=internal
 LIBFUZZER="$LIB_FUZZING_ENGINE" make srtp-fuzzer
 make test
 zip -r srtp-fuzzer_seed_corpus.zip fuzzer/corpus


### PR DESCRIPTION
The default crytpo engine for libSRTP is changing so need to explicitly set the config to continue using the internal crypto engine.