### PR TITLE
libmicrohttpd2: Add new fuzzing targets

### DIFF
--- a/projects/libmicrohttpd2/fuzz_response.cpp
+++ b/projects/libmicrohttpd2/fuzz_response.cpp
@@ -23,9 +23,6 @@
 
 #include "mhd_helper.h"
 
-std::unique_ptr<FuzzedDataProvider> g_fdp;
-std::mutex g_fdp_mu;
-
 static void request_ended_cb(void *cls,
                              const struct MHD_RequestEndedData *data,
                              void *request_app_context) {

--- a/projects/libmicrohttpd2/mhd_helper.cpp
+++ b/projects/libmicrohttpd2/mhd_helper.cpp
@@ -26,8 +26,8 @@
 #include <errno.h>
 #include <poll.h>
 
-extern std::unique_ptr<FuzzedDataProvider> g_fdp;
-extern std::mutex g_fdp_mu;
+std::unique_ptr<FuzzedDataProvider> g_fdp;
+std::mutex g_fdp_mu;
 
 std::string b64encode(const std::string &in) {
   static const char* tbl =
@@ -78,6 +78,14 @@ std::string safe_ascii(const std::string& in, bool allow_space) {
   }
 
   return out;
+}
+
+// Dummy functions
+static enum MHD_Bool kv_cb(void*, enum MHD_ValueKind, const struct MHD_NameAndValue*) {
+  return MHD_YES;
+}
+static enum MHD_Bool post_cb(void*, const struct MHD_PostField* pf) {
+  return MHD_YES;
 }
 
 /* Start of internal helpers for sending http message to daemon through localhost socket */
@@ -735,4 +743,59 @@ req_cb(void* cls,
     return handle_basic_auth(request, opts);
   }
   return handle_digest_auth(request, opts);
+}
+
+MHD_FN_PAR_NONNULL_(2) MHD_FN_PAR_NONNULL_(3)
+const struct MHD_Action*
+req_cb_stream(void*,
+              struct MHD_Request* MHD_RESTRICT request,
+              const struct MHD_String* MHD_RESTRICT path,
+              enum MHD_HTTP_Method method,
+              uint_fast64_t upload_size) {
+  // Fuzz MHD_request_get_value for different parameters on random request
+  MHD_request_get_value(request, MHD_VK_HEADER, "host");
+  MHD_request_get_value(request, MHD_VK_HEADER, "content-type");
+  MHD_request_get_value(request, MHD_VK_COOKIE, "cookie");
+  MHD_request_get_value(request, MHD_VK_GET_ARGUMENT, "q");
+  MHD_request_get_values_cb(request, MHD_VK_HEADER, kv_cb, nullptr);
+  MHD_request_get_values_cb(request, MHD_VK_COOKIE, kv_cb, nullptr);
+  MHD_request_get_values_cb(request, MHD_VK_GET_ARGUMENT, kv_cb, nullptr);
+
+  // Fuzz MHD_request_get_post_data_cb on random request
+  MHD_request_get_post_data_cb(request, post_cb, nullptr);
+
+
+  // Fuzz MHD_request_get_info_fixed for different parameters on random request
+  union MHD_RequestInfoFixedData fix;
+  MHD_request_get_info_fixed(request, MHD_REQUEST_INFO_FIXED_HTTP_VER, &fix);
+  MHD_request_get_info_fixed(request, MHD_REQUEST_INFO_FIXED_HTTP_METHOD, &fix);
+  MHD_request_get_info_fixed(request, MHD_REQUEST_INFO_FIXED_DAEMON, &fix);
+  MHD_request_get_info_fixed(request, MHD_REQUEST_INFO_FIXED_CONNECTION, &fix);
+  MHD_request_get_info_fixed(request, MHD_REQUEST_INFO_FIXED_STREAM, &fix);
+  MHD_request_get_info_fixed(request, MHD_REQUEST_INFO_FIXED_APP_CONTEXT, &fix);
+
+  // Fuzz MHD_request_get_info_dynamic for different parameters on random request
+  union MHD_RequestInfoDynamicData dyn;
+  MHD_request_get_info_dynamic(request, MHD_REQUEST_INFO_DYNAMIC_HTTP_METHOD_STRING, &dyn);
+  MHD_request_get_info_dynamic(request, MHD_REQUEST_INFO_DYNAMIC_URI, &dyn);
+  MHD_request_get_info_dynamic(request, MHD_REQUEST_INFO_DYNAMIC_NUMBER_URI_PARAMS, &dyn);
+  MHD_request_get_info_dynamic(request, MHD_REQUEST_INFO_DYNAMIC_NUMBER_COOKIES, &dyn);
+  MHD_request_get_info_dynamic(request, MHD_REQUEST_INFO_DYNAMIC_HEADER_SIZE, &dyn);
+  MHD_request_get_info_dynamic(request, MHD_REQUEST_INFO_DYNAMIC_NUMBER_POST_PARAMS, &dyn);
+  MHD_request_get_info_dynamic(request, MHD_REQUEST_INFO_DYNAMIC_UPLOAD_PRESENT, &dyn);
+  MHD_request_get_info_dynamic(request, MHD_REQUEST_INFO_DYNAMIC_UPLOAD_CHUNKED, &dyn);
+  MHD_request_get_info_dynamic(request, MHD_REQUEST_INFO_DYNAMIC_UPLOAD_SIZE_TOTAL, &dyn);
+  MHD_request_get_info_dynamic(request, MHD_REQUEST_INFO_DYNAMIC_UPLOAD_SIZE_RECIEVED, &dyn);
+
+  // Fuzz response creation from random request processing
+  struct MHD_Response* resp = MHD_response_from_empty(MHD_HTTP_STATUS_NO_CONTENT);
+  if (!resp) {
+    return MHD_action_abort_request(request);
+  }
+
+  // Fuzz response and request abortion
+  MHD_response_add_header(resp, "x-fuzz", "values");
+  const struct MHD_Action* act = MHD_action_from_response(request, resp);
+  MHD_response_destroy(resp);
+  return act ? act : MHD_action_abort_request(request);
 }

--- a/projects/libmicrohttpd2/mhd_helper.h
+++ b/projects/libmicrohttpd2/mhd_helper.h
@@ -82,6 +82,12 @@ const struct MHD_Action* req_cb(void* cls,
                                 const struct MHD_String* MHD_RESTRICT path,
                                 enum MHD_HTTP_Method method,
                                 uint_fast64_t upload_size);
+MHD_FN_PAR_NONNULL_(2) MHD_FN_PAR_NONNULL_(3)
+const struct MHD_Action* req_cb_stream(void* cls,
+                                       struct MHD_Request* MHD_RESTRICT request,
+                                       const struct MHD_String* MHD_RESTRICT path,
+                                       enum MHD_HTTP_Method method,
+                                       uint_fast64_t upload_size);
 
 // Provide base64 encoding for the response/request
 std::string b64encode(const std::string &in);


### PR DESCRIPTION
This PR adds a new set of fuzzing targets for daemon request processing and allow the daemon randomly choose which request handler to use. 