### PR TITLE
thunderbird: add initial project.yaml

### DIFF
--- a/projects/thunderbird/project.yaml
+++ b/projects/thunderbird/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://www.thunderbird.net/"
+language: c++
+main_repo: "https://hg-edge.mozilla.org/comm-central/"
+primary_contact: "jtracey@thunderbird.net"
+auto_ccs:
+  - "kaie@thunderbird.net"


### PR DESCRIPTION
Add initial project information for [Thunderbird](https://www.thunderbird.net/). This will likely end up looking very similar to the configuration for [firefox](https://github.com/google/oss-fuzz/tree/master/projects/firefox), but I haven't set up the full configuration yet since Firefox's is [currently broken](https://bugzilla.mozilla.org/show_bug.cgi?id=1984160).