### PR TITLE
model-transparency: initial integration

### DIFF
--- a/projects/model-transparency/Dockerfile
+++ b/projects/model-transparency/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-python
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+RUN git clone --depth 1 https://github.com/sigstore/model-transparency
+WORKDIR model-transparency
+COPY build.sh $SRC/

--- a/projects/model-transparency/build.sh
+++ b/projects/model-transparency/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -eu
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+python3 -m pip install .
+for fuzzer in $(find $SRC/model-transparency/tests/fuzzing -name 'fuzz_*.py'); do
+  compile_python_fuzzer $fuzzer
+done

--- a/projects/model-transparency/project.yaml
+++ b/projects/model-transparency/project.yaml
@@ -1,0 +1,12 @@
+fuzzing_engines:
+- libfuzzer
+homepage: https://github.com/sigstore/model-transparency
+language: python
+main_repo: https://github.com/sigstore/model-transparency
+sanitizers:
+- address
+primary_contact: mihaimaruseac@google.com 
+vendor_ccs:
+- david@adalogics.com
+- adam@adalogics.com
+- arthur.chan@adalogics.com


### PR DESCRIPTION
Initial integration of [model-transparency](https://github.com/sigstore/model-transparency), Sigstores library for signing and verifying ML models.