### PR TITLE
bitcoin-core: temporarily disable IPC build

### DIFF
--- a/projects/bitcoin-core/build.sh
+++ b/projects/bitcoin-core/build.sh
@@ -42,7 +42,9 @@ export CPPFLAGS="-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -DBOOST_M
 (
   cd depends
   sed -i --regexp-extended '/.*rm -rf .*extract_dir.*/d' ./funcs.mk  # Keep extracted source
+  # Disable IPC pending https://github.com/google/oss-fuzz/pull/13018
   make HOST=$BUILD_TRIPLET DEBUG=1 NO_QT=1 NO_ZMQ=1 NO_USDT=1 \
+       NO_IPC=1 \
        AR=llvm-ar NM=llvm-nm RANLIB=llvm-ranlib STRIP=llvm-strip \
        -j$(nproc)
 )


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/pull/31802 builds libmultiprocess and enables IPC by default, but my understanding is that this breaks oss-fuzz. One proposed solution is https://github.com/google/oss-fuzz/pull/13018.

This PR builds depends with `NO_IPC=1`, which disables the feature, for now while we work on an actual fix.