### PR TITLE
libmicrohttpd2: Add third set of targets for daemon fuzzing

### DIFF
--- a/projects/libmicrohttpd2/mhd_helper.cpp
+++ b/projects/libmicrohttpd2/mhd_helper.cpp
@@ -799,3 +799,62 @@ req_cb_stream(void*,
   MHD_response_destroy(resp);
   return act ? act : MHD_action_abort_request(request);
 }
+
+MHD_FN_PAR_NONNULL_(2) MHD_FN_PAR_NONNULL_(3)
+const struct MHD_Action*
+req_cb_process(void*,
+               struct MHD_Request* MHD_RESTRICT request,
+               const struct MHD_String* MHD_RESTRICT path,
+               enum MHD_HTTP_Method method,
+               uint_fast64_t upload_size) {
+  // Create info unions
+  union MHD_RequestInfoFixedData f;
+  union MHD_RequestInfoDynamicData d;
+
+  // Fuzz MHD_request_get_info_fixed_sz for different parameters on random request
+  MHD_request_get_info_fixed_sz(request, MHD_REQUEST_INFO_FIXED_HTTP_VER, &f, sizeof(f));
+  MHD_request_get_info_fixed_sz(request, MHD_REQUEST_INFO_FIXED_HTTP_METHOD, &f, sizeof(f));
+  MHD_request_get_info_fixed_sz(request, MHD_REQUEST_INFO_FIXED_DAEMON, &f, sizeof(f));
+  MHD_request_get_info_fixed_sz(request, MHD_REQUEST_INFO_FIXED_CONNECTION, &f, sizeof(f));
+  MHD_request_get_info_fixed_sz(request, MHD_REQUEST_INFO_FIXED_STREAM, &f, sizeof(f));
+  MHD_request_get_info_fixed_sz(request, MHD_REQUEST_INFO_FIXED_APP_CONTEXT, &f, sizeof(f));
+
+  // Fuzz MHD_request_get_info_dynamic_sz for different parameters on random request
+  MHD_request_get_info_dynamic_sz(request, MHD_REQUEST_INFO_DYNAMIC_HTTP_METHOD_STRING, &d, sizeof(d));
+  MHD_request_get_info_dynamic_sz(request, MHD_REQUEST_INFO_DYNAMIC_URI, &d, sizeof(d));
+  MHD_request_get_info_dynamic_sz(request, MHD_REQUEST_INFO_DYNAMIC_NUMBER_URI_PARAMS, &d, sizeof(d));
+  MHD_request_get_info_dynamic_sz(request, MHD_REQUEST_INFO_DYNAMIC_NUMBER_COOKIES, &d, sizeof(d));
+  MHD_request_get_info_dynamic_sz(request, MHD_REQUEST_INFO_DYNAMIC_HEADER_SIZE, &d, sizeof(d));
+  MHD_request_get_info_dynamic_sz(request, MHD_REQUEST_INFO_DYNAMIC_AUTH_DIGEST_INFO, &d, sizeof(d));
+  MHD_request_get_info_dynamic_sz(request, MHD_REQUEST_INFO_DYNAMIC_AUTH_BASIC_CREDS, &d, sizeof(d));
+
+  {
+    static const char realm[] = "fuzz-realm";
+    static const char user[]  = "u";
+    static const char pass[]  = "p";
+
+    enum MHD_DigestAuthAlgo algos[] = {
+      MHD_DIGEST_AUTH_ALGO_MD5,
+      MHD_DIGEST_AUTH_ALGO_SHA256,
+      MHD_DIGEST_AUTH_ALGO_SHA512_256
+    };
+
+    for (unsigned i = 0; i < (unsigned)(sizeof(algos)/sizeof(algos[0])); ++i) {
+      size_t sz = MHD_digest_get_hash_size(algos[i]);
+      if (sz == 0 || sz > 64) {
+        continue;
+      }
+      unsigned char ha1[64];
+      if (MHD_SC_OK == MHD_digest_auth_calc_userdigest(algos[i], user, realm, pass, sz, ha1)) {
+        MHD_digest_auth_check_digest(
+            request, realm, user, sz, ha1,
+            0, MHD_DIGEST_AUTH_MULT_QOP_AUTH_ANY,
+            MHD_DIGEST_AUTH_MULT_ALGO_ANY_NON_SESSION);
+      }
+    }
+  }
+
+  // Force OK response
+  struct MHD_Response* r = MHD_response_from_empty(MHD_HTTP_STATUS_OK);
+  return MHD_action_from_response(request, r);
+}

--- a/projects/libmicrohttpd2/mhd_helper.h
+++ b/projects/libmicrohttpd2/mhd_helper.h
@@ -89,6 +89,13 @@ const struct MHD_Action* req_cb_stream(void* cls,
                                        enum MHD_HTTP_Method method,
                                        uint_fast64_t upload_size);
 
+MHD_FN_PAR_NONNULL_(2) MHD_FN_PAR_NONNULL_(3)
+const struct MHD_Action* req_cb_process(void* cls,
+                                        struct MHD_Request* MHD_RESTRICT request,
+                                        const struct MHD_String* MHD_RESTRICT path,
+                                        enum MHD_HTTP_Method method,
+                                        uint_fast64_t upload_size);
+
 // Provide base64 encoding for the response/request
 std::string b64encode(const std::string &in);
 


### PR DESCRIPTION
This PR adds the final batch of targets for request handling in daemon for project libmicrohttpd2.