### PR TITLE
bump go version

### DIFF
--- a/infra/base-images/base-builder/install_go.sh
+++ b/infra/base-images/base-builder/install_go.sh
@@ -17,9 +17,10 @@
 
 cd /tmp
 
-wget https://go.dev/dl/go1.23.4.linux-amd64.tar.gz
+export GOROOT=/root/.go
+wget https://go.dev/dl/go1.25.0.linux-amd64.tar.gz
 mkdir temp-go
-tar -C temp-go/ -xzf go1.23.4.linux-amd64.tar.gz
+tar -C temp-go/ -xzf go1.25.0.linux-amd64.tar.gz
 
 mkdir /root/.go/
 mv temp-go/go/* /root/.go/

--- a/infra/base-images/base-runner/install_go.sh
+++ b/infra/base-images/base-runner/install_go.sh
@@ -22,7 +22,7 @@ case $(uname -m) in
       # Download and install Go.
       wget -q https://storage.googleapis.com/golang/getgo/installer_linux -O $SRC/installer_linux
       chmod +x $SRC/installer_linux
-      SHELL="bash" $SRC/installer_linux -version 1.24.6
+      SHELL="bash" $SRC/installer_linux -version 1.25.0
       rm $SRC/installer_linux
       # Set up Golang coverage modules.
       printf $(find . -name gocoverage)


### PR DESCRIPTION
In base-builder and base-runner. Also set `GOROOT` to where we download the go files to.