### PR TITLE
Revert "infra: bump indexer to llvm-21"

### DIFF
--- a/infra/base-images/all.sh
+++ b/infra/base-images/all.sh
@@ -17,7 +17,6 @@
 
 docker build --pull -t gcr.io/oss-fuzz-base/base-image "$@" infra/base-images/base-image
 docker build -t gcr.io/oss-fuzz-base/base-clang "$@" infra/base-images/base-clang
-docker build -t gcr.io/oss-fuzz-base/base-clang-full --build-arg FULL_LLVM_BUILD=1 "$@" infra/base-images/base-clang
 docker build -t gcr.io/oss-fuzz-base/base-builder "$@" infra/base-images/base-builder
 docker build -t gcr.io/oss-fuzz-base/base-builder-go "$@" infra/base-images/base-builder-go
 docker build -t gcr.io/oss-fuzz-base/base-builder-jvm "$@" infra/base-images/base-builder-jvm
@@ -25,6 +24,5 @@ docker build -t gcr.io/oss-fuzz-base/base-builder-python "$@" infra/base-images/
 docker build -t gcr.io/oss-fuzz-base/base-builder-rust "$@" infra/base-images/base-builder-rust
 docker build -t gcr.io/oss-fuzz-base/base-builder-ruby "$@" infra/base-images/base-builder-ruby
 docker build -t gcr.io/oss-fuzz-base/base-builder-swift "$@" infra/base-images/base-builder-swift
-docker build -t gcr.io/oss-fuzz-base/indexer "$@" infra/indexer
 docker build -t gcr.io/oss-fuzz-base/base-runner "$@" infra/base-images/base-runner
 docker build -t gcr.io/oss-fuzz-base/base-runner-debug "$@" infra/base-images/base-runner-debug

--- a/infra/base-images/base-builder/precompile_honggfuzz
+++ b/infra/base-images/base-builder/precompile_honggfuzz
@@ -33,8 +33,7 @@ make clean
 # These CFLAGs match honggfuzz's default, with the exception of -mtune to
 # improve portability and `-D_HF_LINUX_NO_BFD` to remove assembly instructions
 # from the filenames.
-sed -i 's/-Werror//g' Makefile
-CC=clang CFLAGS="-O3 -funroll-loops -D_HF_LINUX_NO_BFD -Wno-unterminated-string-initialization -Wno-error" make
+CC=clang CFLAGS="-O3 -funroll-loops -D_HF_LINUX_NO_BFD" make
 
 # libhfuzz.a will be added by CC/CXX linker directly during linking,
 # but it's defined here to satisfy the build infrastructure

--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -33,6 +33,15 @@ RUN apt-get update && apt-get install -y wget sudo && \
     SUDO_FORCE_REMOVE=yes apt-get autoremove --purge -y wget sudo && \
     rm -rf /usr/local/doc/cmake /usr/local/bin/cmake-gui
 
+RUN apt-get update && apt-get install -y git && \
+    git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
+    cd fuzz-introspector && \
+    git checkout 332d674f00b8abc4c9ebf10e9c42e5b72b331c63 && \
+    git submodule init && \
+    git submodule update && \
+    apt-get autoremove --purge -y git && \
+    rm -rf .git
+
 COPY checkout_build_install_llvm.sh /root/
 # Keep all steps in the same script to decrease the number of intermediate
 # layes in docker file.
@@ -65,7 +74,6 @@ ENV CFLAGS -O1 \
   -Wno-error=implicit-function-declaration \
   -Wno-error=implicit-int \
   -Wno-error=vla-cxx-extension \
-  -Wno-error=unknown-warning-option \
   -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 ENV CXXFLAGS_EXTRA "-stdlib=libc++"
 ENV CXXFLAGS "$CFLAGS $CXXFLAGS_EXTRA"

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -60,24 +60,15 @@ apt-get update && apt-get install -y $LLVM_DEP_PACKAGES --no-install-recommends
 # languages, projects, ...) is needed.
 # Check CMAKE_VERSION infra/base-images/base-clang/Dockerfile was released
 # recently enough to fully support this clang version.
-if [[ -n "$FULL_LLVM_BUILD" ]]; then
-  OUR_LLVM_REVISION=llvmorg-21.1.0-rc3
-else
-  OUR_LLVM_REVISION=llvmorg-18.1.8
-fi
+OUR_LLVM_REVISION=llvmorg-18.1.8
 
 mkdir $SRC/chromium_tools
 cd $SRC/chromium_tools
 git clone https://chromium.googlesource.com/chromium/src/tools/clang
-
 cd clang
-if [[ -n "$FULL_LLVM_BUILD" ]]; then
-  OUR_CLANG_REVISION=329189001bce28e8f90dfa1c96075731a7a8f7de
-else
-  # Pin clang script due to https://github.com/google/oss-fuzz/issues/7617
-  OUR_CLANG_REVISION=9eb79319239629c1b23cf7a59e5ebb2bab319a34
-fi
-git checkout $OUR_CLANG_REVISION
+# Pin clang script due to https://github.com/google/oss-fuzz/issues/7617
+git checkout 9eb79319239629c1b23cf7a59e5ebb2bab319a34
+
 LLVM_SRC=$SRC/llvm-project
 # Checkout
 CHECKOUT_RETRIES=10
@@ -106,20 +97,7 @@ clone_with_retries https://github.com/llvm/llvm-project.git $LLVM_SRC
 git -C $LLVM_SRC checkout $OUR_LLVM_REVISION
 echo "Using LLVM revision: $OUR_LLVM_REVISION"
 
-# Prepare fuzz introspector.
-echo "Installing fuzz introspector"
-if [[ -n "$FULL_LLVM_BUILD" ]]; then
-  FUZZ_INTROSPECTOR_CHECKOUT=341ebbd72bc9116733bcfcfab5adfd7f9b633e07
-else
-  FUZZ_INTROSPECTOR_CHECKOUT=332d674f00b8abc4c9ebf10e9c42e5b72b331c63
-fi
-
-git clone https://github.com/ossf/fuzz-introspector.git /fuzz-introspector
-cd /fuzz-introspector
-git checkout $FUZZ_INTROSPECTOR_CHECKOUT
-git submodule init
-git submodule update
-
+# For fuzz introspector.
 echo "Applying introspector changes"
 OLD_WORKING_DIR=$PWD
 cd $LLVM_SRC


### PR DESCRIPTION
Reverts google/oss-fuzz#13848

Unfortunately, this breaks the indexer for many projects that are still building on clang 18 with errors like:

```
Step #23: fatal error: too many errors emitted, stopping now [-ferror-limit=]
Step #23:       |                                         ^~~~~~~~~~~~
Step #23:   422 |     return (__m64)__builtin_ia32_paddsb((__v8qi)__m1, (__v8qi)__m2);
Step #23: /usr/local/lib/clang/18/include/mmintrin.h:422:41: error: cannot initialize a parameter of type 'unsigned int' with an rvalue of type '__v8qi' (vector of 8 'char' values)
Step #23:       |                   ^~~~~~~~~~~~~~~~~~~~~
Step #23:   422 |     return (__m64)__builtin_ia32_paddsb((__v8qi)__m1, (__v8qi)__m2);
Step #23: /usr/local/lib/clang/18/include/mmintrin.h:422:19: error: use of undeclared identifier '__builtin_ia32_paddsb'; did you mean '__builtin_ia32_kaddsi'?
Step #23:       |                   ^~~~~~~~~~~~~~~~~~~~
Step #23:   400 |     return (__m64)__builtin_ia32_paddd((__v2si)__m1, (__v2si)__m2);
Step #23: /usr/local/lib/clang/18/include/mmintrin.h:400:19: error: use of undeclared identifier '__builtin_ia32_paddd'
Step #23:       |                   ^~~~~~~~~~~~~~~~~~~~
Step #23:   379 |     return (__m64)__builtin_ia32_paddw((__v4hi)__m1, (__v4hi)__m2);
Step #23: /usr/local/lib/clang/18/include/mmintrin.h:379:19: error: use of undeclared identifier '__builtin_ia32_paddw'
Step #23:       |                   ^~~~~~~~~~~~~~~~~~~~
Step #23:   358 |     return (__m64)__builtin_ia32_paddb((__v8qi)__m1, (__v8qi)__m2);
Step #23: /usr/local/lib/clang/18/include/mmintrin.h:358:19: error: use of undeclared identifier '__builtin_ia32_paddb'
```