### PR TITLE
infra: bump to llvm 22

### DIFF
--- a/infra/base-images/base-builder-rust/Dockerfile
+++ b/infra/base-images/base-builder-rust/Dockerfile
@@ -26,7 +26,7 @@ ENV OSSFUZZ_RUSTPATH /rust
 # manually specifying what toolchain to use. Note that this environment variable
 # is additionally used by `install_rust.sh` as the toolchain to install.
 # cf https://rust-lang.github.io/rustup/overrides.html
-ENV RUSTUP_TOOLCHAIN nightly-2024-07-12
+ENV RUSTUP_TOOLCHAIN nightly-2025-09-05
 
 # Configure the linker used by default for x86_64 linux to be `clang` instead of
 # rustc's default of `cc` which is able to find custom-built libraries like

--- a/infra/base-images/base-builder/precompile_honggfuzz
+++ b/infra/base-images/base-builder/precompile_honggfuzz
@@ -33,7 +33,8 @@ make clean
 # These CFLAGs match honggfuzz's default, with the exception of -mtune to
 # improve portability and `-D_HF_LINUX_NO_BFD` to remove assembly instructions
 # from the filenames.
-CC=clang CFLAGS="-O3 -funroll-loops -D_HF_LINUX_NO_BFD" make
+sed -i 's/-Werror//g' Makefile
+CC=clang CFLAGS="-O3 -funroll-loops -D_HF_LINUX_NO_BFD -Wno-unterminated-string-initialization -Wno-error" make
 
 # libhfuzz.a will be added by CC/CXX linker directly during linking,
 # but it's defined here to satisfy the build infrastructure

--- a/infra/base-images/base-clang/Dockerfile
+++ b/infra/base-images/base-clang/Dockerfile
@@ -33,16 +33,8 @@ RUN apt-get update && apt-get install -y wget sudo && \
     SUDO_FORCE_REMOVE=yes apt-get autoremove --purge -y wget sudo && \
     rm -rf /usr/local/doc/cmake /usr/local/bin/cmake-gui
 
-RUN apt-get update && apt-get install -y git && \
-    git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
-    cd fuzz-introspector && \
-    git checkout 332d674f00b8abc4c9ebf10e9c42e5b72b331c63 && \
-    git submodule init && \
-    git submodule update && \
-    apt-get autoremove --purge -y git && \
-    rm -rf .git
-
 COPY checkout_build_install_llvm.sh /root/
+
 # Keep all steps in the same script to decrease the number of intermediate
 # layes in docker file.
 ARG FULL_LLVM_BUILD
@@ -67,12 +59,12 @@ ENV CCC "clang++"
 ENV CFLAGS -O1 \
   -fno-omit-frame-pointer \
   -gline-tables-only \
-  -Wno-error=enum-constexpr-conversion \
   -Wno-error=incompatible-function-pointer-types \
   -Wno-error=int-conversion \
   -Wno-error=deprecated-declarations \
   -Wno-error=implicit-function-declaration \
   -Wno-error=implicit-int \
+  -Wno-error=unknown-warning-option \
   -Wno-error=vla-cxx-extension \
   -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 ENV CXXFLAGS_EXTRA "-stdlib=libc++"

--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -60,14 +60,15 @@ apt-get update && apt-get install -y $LLVM_DEP_PACKAGES --no-install-recommends
 # languages, projects, ...) is needed.
 # Check CMAKE_VERSION infra/base-images/base-clang/Dockerfile was released
 # recently enough to fully support this clang version.
-OUR_LLVM_REVISION=llvmorg-18.1.8
+OUR_LLVM_REVISION=cb2f0d0a5f14
 
 mkdir $SRC/chromium_tools
 cd $SRC/chromium_tools
 git clone https://chromium.googlesource.com/chromium/src/tools/clang
 cd clang
 # Pin clang script due to https://github.com/google/oss-fuzz/issues/7617
-git checkout 9eb79319239629c1b23cf7a59e5ebb2bab319a34
+OUR_CLANG_REVISION=063d3766486a820c708e888d737b004d11543410
+git checkout $OUR_CLANG_REVISION
 
 LLVM_SRC=$SRC/llvm-project
 # Checkout
@@ -97,7 +98,16 @@ clone_with_retries https://github.com/llvm/llvm-project.git $LLVM_SRC
 git -C $LLVM_SRC checkout $OUR_LLVM_REVISION
 echo "Using LLVM revision: $OUR_LLVM_REVISION"
 
-# For fuzz introspector.
+# Prepare fuzz introspector.
+echo "Installing fuzz introspector"
+FUZZ_INTROSPECTOR_CHECKOUT=341ebbd72bc9116733bcfcfab5adfd7f9b633e07
+
+git clone https://github.com/ossf/fuzz-introspector.git /fuzz-introspector
+cd /fuzz-introspector
+git checkout $FUZZ_INTROSPECTOR_CHECKOUT
+git submodule init
+git submodule update
+
 echo "Applying introspector changes"
 OLD_WORKING_DIR=$PWD
 cd $LLVM_SRC
@@ -107,6 +117,7 @@ cp -rf /fuzz-introspector/frontends/llvm/lib/Transforms/FuzzIntrospector ./llvm/
 # LLVM currently does not support dynamically loading LTO passes. Thus, we
 # hardcode it into Clang instead. Ref: https://reviews.llvm.org/D77704
 /fuzz-introspector/frontends/llvm/patch-llvm.sh
+
 cd $OLD_WORKING_DIR
 
 mkdir -p $WORK/llvm-stage2 $WORK/llvm-stage1


### PR DESCRIPTION
Follow up to https://github.com/google/oss-fuzz/pull/13901 and https://github.com/google/oss-fuzz/pull/13848

This proposes a clean llvm upgrade, so without having different llvm versions in base-clang and base-clang-full.

Continuing from issues in https://github.com/google/oss-fuzz/pull/13848#issuecomment-3239148653