### PR TITLE
infra: fix flag recognition in bad build checks

### DIFF
--- a/infra/base-images/base-runner/bad_build_check
+++ b/infra/base-images/base-runner/bad_build_check
@@ -72,7 +72,7 @@ function check_engine {
 
   if [[ "$FUZZING_ENGINE" == libfuzzer ]]; then
     # Store fuzz target's output into a temp file to be used for further checks.
-    $FUZZER -seed=1337 -runs=$MIN_NUMBER_OF_RUNS &>$FUZZER_OUTPUT
+    $FUZZER -- -seed=1337 -runs=$MIN_NUMBER_OF_RUNS &>$FUZZER_OUTPUT
     CHECK_FAILED=$(egrep "ERROR: no interesting inputs were found. Is the code instrumented" -c $FUZZER_OUTPUT)
     if (( $CHECK_FAILED > 0 )); then
       echo "BAD BUILD: $FUZZER does not seem to have coverage instrumentation."

--- a/infra/base-images/base-runner/run_fuzzer
+++ b/infra/base-images/base-runner/run_fuzzer
@@ -195,7 +195,7 @@ elif [[ "$FUZZING_ENGINE" = centipede ]]; then
   CMD_LINE="$OUT/centipede --workdir=$CENTIPEDE_WORKDIR --corpus_dir=\"$CORPUS_DIR\" --fork_server=1 --exit_on_crash=1 --timeout=1200 --rss_limit_mb=4096 --address_space_limit_mb=5120 $(get_dictionary) --binary=\"$OUT/${FUZZER}\" $(get_extra_binaries) $*"
 else
 
-  CMD_LINE="$OUT/$FUZZER $FUZZER_ARGS $*"
+  CMD_LINE="$OUT/$FUZZER -- $FUZZER_ARGS $*"
 
   if [ -z ${SKIP_SEED_CORPUS:-} ]; then
     CMD_LINE="$CMD_LINE $CORPUS_DIR"


### PR DESCRIPTION
Some harnesses won't recognise the flags if `--` is not supplied, causing the bad build check to run the fuzzers forever or until they crash. This happens for Envoy.

Tested this works on other projects as well, but will do a bit more testing before it's ready.