### PR TITLE
KDE-Thumbnailers: Cleanup $WORK data after build

### DIFF
--- a/projects/kde-thumbnailers/build.sh
+++ b/projects/kde-thumbnailers/build.sh
@@ -20,3 +20,6 @@ $SRC/kio-extras/thumbnail/autotests/ossfuzz/build_fuzzers.sh
 $SRC/kdegraphics-thumbnailers/autotests/ossfuzz/build_fuzzers.sh
 $SRC/kdesdk-thumbnailers/autotests/ossfuzz/build_fuzzers.sh
 $SRC/ffmpegthumbs/autotests/ossfuzz/build_fuzzers.sh
+
+# Cleanup
+rm -rf $WORK/*


### PR DESCRIPTION
The build fails at the `check_build` step due to running out of storage. 
This change cleans up $WORK after the build to free up space.  

https://oss-fuzz-build-logs.storage.googleapis.com/log-150d58fe-14f9-41cc-ac9c-1ae491fe4556.txt
