### PR TITLE
kubeflow spark-operator: initial integration

### DIFF
--- a/projects/kubeflow-spark-operator/Dockerfile
+++ b/projects/kubeflow-spark-operator/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/kubeflow/spark-operator
+WORKDIR spark-operator
+COPY build.sh *.go $SRC/

--- a/projects/kubeflow-spark-operator/build.sh
+++ b/projects/kubeflow-spark-operator/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+rm $SRC/spark-operator/pkg/certificate/certificate_test.go
+rm $SRC/spark-operator/pkg/certificate/suite_test.go
+rm $SRC/spark-operator/pkg/certificate/util_test.go
+mv $SRC/parseSecret_fuzzer.go $SRC/spark-operator/pkg/certificate/
+compile_native_go_fuzzer_v2 github.com/kubeflow/spark-operator/v2/pkg/certificate FuzzParseCertManagerSecret FuzzParseCertManagerSecret
+compile_native_go_fuzzer_v2 github.com/kubeflow/spark-operator/v2/pkg/certificate FuzzParseInternalCertSecret FuzzParseInternalCertSecret

--- a/projects/kubeflow-spark-operator/parseSecret_fuzzer.go
+++ b/projects/kubeflow-spark-operator/parseSecret_fuzzer.go
@@ -1,0 +1,50 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package certificate
+
+import (
+	"testing"
+
+	"github.com/kubeflow/spark-operator/v2/pkg/common"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func FuzzParseCertManagerSecret(f *testing.F) {
+	f.Fuzz(func(t *testing.T, input1, input2, input3 []byte) {
+		cp := &Provider{}
+		cp.parseCertManagerSecret(&corev1.Secret{
+			Data: map[string][]byte{
+				common.CACert:  input1,
+				common.TLSCert: input2,
+				common.TLSKey:  input3,
+			},
+		})
+	})
+}
+
+func FuzzParseInternalCertSecret(f *testing.F) {
+	f.Fuzz(func(t *testing.T, input1, input2, input3, input4 []byte) {
+		cp := &Provider{}
+		cp.parseInternalCertSecret(&corev1.Secret{
+			Data: map[string][]byte{
+				common.CACertPem:     input1,
+				common.CAKeyPem:      input2,
+				common.ServerCertPem: input3,
+				common.ServerKeyPem:  input4,
+			},
+		})
+	})
+}

--- a/projects/kubeflow-spark-operator/project.yaml
+++ b/projects/kubeflow-spark-operator/project.yaml
@@ -1,0 +1,11 @@
+homepage: "https://github.com/kubeflow/spark-operator"
+language: go
+primary_contact: "github@chenyicn.net"
+main_repo: "https://github.com/kubeflow/spark-operator"
+auto_ccs:
+  - "adam@adalogics.com"
+  - "vara.bonthu@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
Adds initial integration of Kubeflow Spark Operator which is [adopted](https://github.com/kubeflow/spark-operator/blob/master/ADOPTERS.md) by companies such as Alibaba, Carrefour, CERN, Lyft and Salesforce.