### PR TITLE
kubeflow model-registry: initial integration

### DIFF
--- a/projects/kubeflow-model-registry/Dockerfile
+++ b/projects/kubeflow-model-registry/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/kubeflow/model-registry
+WORKDIR model-registry
+COPY build.sh *.go $SRC/

--- a/projects/kubeflow-model-registry/build.sh
+++ b/projects/kubeflow-model-registry/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+mv $SRC/filter_fuzzer.go $SRC/model-registry/internal/db/filter/
+compile_native_go_fuzzer_v2 github.com/kubeflow/model-registry/internal/db/filter FuzzFilterParse FuzzFilterParse

--- a/projects/kubeflow-model-registry/filter_fuzzer.go
+++ b/projects/kubeflow-model-registry/filter_fuzzer.go
@@ -1,0 +1,26 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package filter
+
+import (
+	"testing"
+)
+
+func FuzzFilterParse(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data string) {
+		Parse(data)
+	})
+}

--- a/projects/kubeflow-model-registry/project.yaml
+++ b/projects/kubeflow-model-registry/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/kubeflow/model-registry"
+language: go
+primary_contact: "mmortari+kubeflow@redhat.com"
+main_repo: "https://github.com/kubeflow/model-registry"
+auto_ccs:
+  - "adam@adalogics.com"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
Adds initial integration of Kubeflow Model Registry which is [adopted](https://github.com/kubeflow/model-registry/blob/main/ADOPTERS.md) by companies such as Pepsico, Red Hat and VMware.