### PR TITLE
kubeflow katib: initial integration

### DIFF
--- a/projects/kubeflow-katib/Dockerfile
+++ b/projects/kubeflow-katib/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/kubeflow/katib
+RUN wget https://go.dev/dl/go1.25.1.linux-amd64.tar.gz \
+    && mkdir temp-go \
+    && rm -rf /root/.go/* \
+    && tar -C temp-go/ -xzf go1.25.1.linux-amd64.tar.gz \
+    && mv temp-go/go/* /root/.go/
+WORKDIR katib
+COPY build.sh *.go $SRC/

--- a/projects/kubeflow-katib/build.sh
+++ b/projects/kubeflow-katib/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+mv $SRC/generateNNImage_fuzzer.go $SRC/katib/pkg/ui/v1beta1/
+compile_native_go_fuzzer_v2 github.com/kubeflow/katib/pkg/ui/v1beta1 FuzzGenerateNNImage FuzzGenerateNNImage

--- a/projects/kubeflow-katib/generateNNImage_fuzzer.go
+++ b/projects/kubeflow-katib/generateNNImage_fuzzer.go
@@ -1,0 +1,32 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package v1beta1
+
+import (
+	"testing"
+)
+
+func FuzzGenerateNNImage(f *testing.F) {
+	f.Fuzz(func(t *testing.T, input1, input2 string) {
+		// the target function is full of panics,
+		// so we fuzz only for unrecoverable bugs.
+		defer func() {
+			if r := recover(); r != nil {
+			}
+		}()
+		generateNNImage(input1, input2)
+	})
+}

--- a/projects/kubeflow-katib/project.yaml
+++ b/projects/kubeflow-katib/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://github.com/kubeflow/katib"
+language: go
+primary_contact: "andrey.velichkevich@gmail.com"
+main_repo: "https://github.com/kubeflow/katib"
+auto_ccs:
+  - "adam@adalogics.com"
+  - "johnugeorge109@gmail.com"
+  - "antonin@stefanutti.fr"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
Adds initial integration of Kubeflow Katib which is [adopted](https://github.com/kubeflow/katib/blob/master/ADOPTERS.md) by companies such as Canonical, CERN and Cisco.