### PR TITLE
Extend indexer build steps to also build and upload tracer image

### DIFF
--- a/infra/build/functions/build_project.py
+++ b/infra/build/functions/build_project.py
@@ -514,10 +514,14 @@ def _indexer_built_image_name(name: str):
 def _tracer_built_image_name(name: str):
   # TODO(ochang): Write this to a tar (via docker image save) and upload this to
   # GCS.
-  return f'us-docker.pkg.dev/oss-fuzz/tracing/{name}'
+  return f'us-docker.pkg.dev/oss-fuzz/tracer/{name}'
 
 
-def _create_build_steps(project, build, timestamp, env, build_type='indexer'):
+def _create_indexed_build_steps(project,
+                                build,
+                                timestamp,
+                                env,
+                                build_type='indexer'):
   """Creates the build steps for a specific indexer type."""
   if build_type == 'indexer':
     container_name = _INDEXED_CONTAINER_NAME
@@ -646,17 +650,17 @@ def get_indexer_build_steps(project_name,
   env.append('INDEXER_BUILD=1')
   env.append('CAPTURE_REPLAY_SCRIPT=1')
 
-  indexer_steps = _create_build_steps(project,
-                                      build,
-                                      timestamp,
-                                      env,
-                                      build_type='indexer')
+  indexer_steps = _create_indexed_build_steps(project,
+                                              build,
+                                              timestamp,
+                                              env,
+                                              build_type='indexer')
 
-  tracer_steps = _create_build_steps(project,
-                                     build,
-                                     timestamp,
-                                     env,
-                                     build_type='tracer')
+  tracer_steps = _create_indexed_build_steps(project,
+                                             build,
+                                             timestamp,
+                                             env,
+                                             build_type='tracer')
   return build_steps + indexer_steps + tracer_steps
 
 

--- a/infra/build/functions/build_project.py
+++ b/infra/build/functions/build_project.py
@@ -66,6 +66,7 @@ _CACHED_IMAGE = ('us-central1-docker.pkg.dev/oss-fuzz/oss-fuzz-gen/'
                  '{name}-ofg-cached-{sanitizer}')
 _CACHED_SANITIZERS = ('address', 'coverage')
 _INDEXED_CONTAINER_NAME = 'indexed-container'
+_TRACING_CONTAINER_NAME = 'tracing-container'
 
 
 @dataclass
@@ -510,6 +511,109 @@ def _indexer_built_image_name(name: str):
   return f'us-docker.pkg.dev/oss-fuzz/indexer/{name}'
 
 
+def _tracer_built_image_name(name: str):
+  # TODO(ochang): Write this to a tar (via docker image save) and upload this to
+  # GCS.
+  return f'us-docker.pkg.dev/oss-fuzz/tracing/{name}'
+
+
+def _create_build_steps(project, build, timestamp, env, build_type='indexer'):
+  """Creates the build steps for a specific indexer type."""
+  if build_type == 'indexer':
+    container_name = _INDEXED_CONTAINER_NAME
+    image_name = _indexer_built_image_name(project.name)
+    build_script_command = '/opt/indexer/index_build.py'
+    # Save the CDB fragments so we can re-use them for rebuilding indexes.
+    artifact_commands = ['cp -r $$OUT/cdb /cdb']
+  elif build_type == 'tracer':
+    container_name = _TRACING_CONTAINER_NAME
+    image_name = _tracer_built_image_name(project.name)
+    build_script_command = (
+        '/opt/indexer/index_build.py '
+        '--fuzzing-engine=tracing_engine.cc '
+        '--coverage-flags=-fsanitize-coverage=trace-pc-guard,func '
+        '--binaries-only')
+    artifact_commands = []
+  else:
+    raise ValueError(f'Unknown build_type: {build_type}')
+
+  command_sequence = [
+      'cd /src',
+      f'cd {project.workdir}',
+      f'mkdir -p {build.out}',
+      build_script_command,
+      # Enable re-building both the project and the indexes.
+      'cp -n /usr/local/bin/replay_build.sh $$SRC/',
+  ]
+  command_sequence.extend(artifact_commands)
+  command_sequence.extend([
+      # Link /out to the actual $OUT and actually create it in the container's
+      # filesystem since it's a mount.
+      'rm -rf /out && ln -s $$OUT /out',
+      'umount /workspace && mkdir -p $$OUT',
+      # Unshallow the main repository so we have easy access to the git history.
+      f'/usr/local/bin/unshallow_repos.py {project.main_repo}',
+  ])
+
+  build_step = {
+      'name': project.image,
+      'args': ['bash', '-c', ' && '.join(command_sequence)],
+      'env': env,
+  }
+  build_lib.dockerify_run_step(build_step,
+                               build,
+                               use_architecture_image_name=build.is_arm,
+                               container_name=container_name)
+
+  upload_steps = []
+  # TODO: Don't upload anything if we're in trial build.
+  if build_type == 'indexer':
+    prefix = f'indexer_indexes/{project.name}/{timestamp}/'
+    signed_policy_document = build_lib.get_signed_policy_document_upload_prefix(
+        'clusterfuzz-builds', prefix)
+    curl_signed_args = shlex.join(
+        build_lib.signed_policy_document_curl_args(signed_policy_document))
+    upload_steps = [
+        {
+            # TODO(metzman): Make sure not to include other tars, and support
+            # .tar.gz
+            'name': get_uploader_image(),
+            'args': [
+                '-c', f'for tar in {build.out}/*.tar; '
+                f'do curl {curl_signed_args} -F key="{prefix}$(basename $tar)" '
+                f'-F file="@$tar" https://{signed_policy_document.bucket}'
+                '.storage.googleapis.com; '
+                'done'
+            ],
+            'entrypoint': 'bash',
+            'allowFailure': True,
+        },
+        build_lib.upload_using_signed_policy_document('/workspace/srcmap.json',
+                                                      f'{prefix}srcmap.json',
+                                                      signed_policy_document)
+    ]
+
+  push_image_steps = [
+      {
+          'name':
+              build_lib.DOCKER_TOOL_IMAGE,
+          'args': [
+              'container', 'commit', '-c', 'ENV REPLAY_ENABLED 1',
+              container_name, image_name + f':{timestamp}'
+          ],
+      },
+      {
+          'name': build_lib.DOCKER_TOOL_IMAGE,
+          'args': ['tag', image_name + f':{timestamp}', image_name],
+      },
+      {
+          'name': build_lib.DOCKER_TOOL_IMAGE,
+          'args': ['push', '--all-tags', image_name],
+      },
+  ]
+  return [build_step] + upload_steps + push_image_steps
+
+
 def get_indexer_build_steps(project_name,
                             project_yaml,
                             dockerfile,
@@ -542,87 +646,18 @@ def get_indexer_build_steps(project_name,
   env.append('INDEXER_BUILD=1')
   env.append('CAPTURE_REPLAY_SCRIPT=1')
 
-  prefix = f'indexer_indexes/{project.name}/{timestamp}/'
-  signed_policy_document = build_lib.get_signed_policy_document_upload_prefix(
-      'clusterfuzz-builds', prefix)
-  curl_signed_args = shlex.join(
-      build_lib.signed_policy_document_curl_args(signed_policy_document))
+  indexer_steps = _create_build_steps(project,
+                                      build,
+                                      timestamp,
+                                      env,
+                                      build_type='indexer')
 
-  index_step = {
-      'name': project.image,
-      'args': [
-          'bash',
-          '-c',
-          f'cd /src && cd {project.workdir} && mkdir -p {build.out} && '
-          '/opt/indexer/index_build.py && '
-          # Enable re-building both the project and the indexes.
-          'cp -n /usr/local/bin/replay_build.sh $$SRC/ && '
-          # Save the CDB fragments so we can re-use them for rebuilding indexes.
-          'cp -r $$OUT/cdb /cdb && '
-          # Link /out to the actual $OUT and actually create it in the
-          # container's filesystem since it's a mount.
-          'rm -rf /out && ln -s $$OUT /out && '
-          'umount /workspace && mkdir -p $$OUT && '
-          # Unshallow the main repository so we have easy access to the git
-          # history.
-          f'/usr/local/bin/unshallow_repos.py {project.main_repo}'
-      ],
-      'env': env,
-  }
-  build_lib.dockerify_run_step(index_step,
-                               build,
-                               use_architecture_image_name=build.is_arm,
-                               container_name=_INDEXED_CONTAINER_NAME)
-  push_image_steps = [
-      {
-          'name':
-              build_lib.DOCKER_TOOL_IMAGE,
-          'args': [
-              'container', 'commit', '-c', 'ENV REPLAY_ENABLED 1',
-              _INDEXED_CONTAINER_NAME,
-              _indexer_built_image_name(project.name) + f':{timestamp}'
-          ],
-      },
-      {
-          'name':
-              build_lib.DOCKER_TOOL_IMAGE,
-          'args': [
-              'tag',
-              _indexer_built_image_name(project.name) + f':{timestamp}',
-              _indexer_built_image_name(project.name)
-          ],
-      },
-      {
-          'name':
-              build_lib.DOCKER_TOOL_IMAGE,
-          'args': [
-              'push', '--all-tags',
-              _indexer_built_image_name(project.name)
-          ],
-      },
-  ]
-
-  # TODO: Don't upload anything if we're in trial build.
-  build_steps.extend([
-      index_step,
-      {
-          # TODO(metzman): Make sure not to incldue other tars, and support .tar.gz
-          'name': get_uploader_image(),
-          'args': [
-              '-c', f'for tar in {build.out}/*.tar; '
-              f'do curl {curl_signed_args} -F key="{prefix}$(basename $tar)" '
-              f'-F file="@$tar" '
-              f'https://{signed_policy_document.bucket}.storage.googleapis.com;'
-              ' done'
-          ],
-          'entrypoint': 'bash',
-          'allowFailure': True,
-      },
-      build_lib.upload_using_signed_policy_document('/workspace/srcmap.json',
-                                                    f'{prefix}srcmap.json',
-                                                    signed_policy_document),
-  ] + push_image_steps)
-  return build_steps
+  tracer_steps = _create_build_steps(project,
+                                     build,
+                                     timestamp,
+                                     env,
+                                     build_type='tracer')
+  return build_steps + indexer_steps + tracer_steps
 
 
 def get_targets_list_upload_step(bucket, project, build, uploader_image):

--- a/infra/build/functions/build_project.py
+++ b/infra/build/functions/build_project.py
@@ -526,19 +526,17 @@ def _create_indexed_build_steps(project,
   if build_type == 'indexer':
     container_name = _INDEXED_CONTAINER_NAME
     image_name = _indexer_built_image_name(project.name)
-    # build_script_command = '/opt/indexer/index_build.py'
-    build_script_command = 'echo "SIMULATING INDEXER BUILD"'
+    build_script_command = '/opt/indexer/index_build.py'
     # Save the CDB fragments so we can re-use them for rebuilding indexes.
     artifact_commands = ['cp -r $$OUT/cdb /cdb']
   elif build_type == 'tracer':
     container_name = _TRACING_CONTAINER_NAME
     image_name = _tracer_built_image_name(project.name)
-    build_script_command = 'echo "SIMULATING TRACER BUILD"'
-    # build_script_command = (
-    #     '/opt/indexer/index_build.py '
-    #     '--fuzzing-engine=tracing_engine.cc '
-    #     '--coverage-flags=-fsanitize-coverage=trace-pc-guard,func '
-    #     '--binaries-only')
+    build_script_command = (
+        '/opt/indexer/index_build.py '
+        '--fuzzing-engine=tracing_engine.cc '
+        '--coverage-flags=-fsanitize-coverage=trace-pc-guard,func '
+        '--binaries-only')
     artifact_commands = []
   else:
     raise ValueError(f'Unknown build_type: {build_type}')

--- a/infra/build/functions/build_project.py
+++ b/infra/build/functions/build_project.py
@@ -526,17 +526,19 @@ def _create_indexed_build_steps(project,
   if build_type == 'indexer':
     container_name = _INDEXED_CONTAINER_NAME
     image_name = _indexer_built_image_name(project.name)
-    build_script_command = '/opt/indexer/index_build.py'
+    # build_script_command = '/opt/indexer/index_build.py'
+    build_script_command = 'echo "SIMULATING INDEXER BUILD"'
     # Save the CDB fragments so we can re-use them for rebuilding indexes.
     artifact_commands = ['cp -r $$OUT/cdb /cdb']
   elif build_type == 'tracer':
     container_name = _TRACING_CONTAINER_NAME
     image_name = _tracer_built_image_name(project.name)
-    build_script_command = (
-        '/opt/indexer/index_build.py '
-        '--fuzzing-engine=tracing_engine.cc '
-        '--coverage-flags=-fsanitize-coverage=trace-pc-guard,func '
-        '--binaries-only')
+    build_script_command = 'echo "SIMULATING TRACER BUILD"'
+    # build_script_command = (
+    #     '/opt/indexer/index_build.py '
+    #     '--fuzzing-engine=tracing_engine.cc '
+    #     '--coverage-flags=-fsanitize-coverage=trace-pc-guard,func '
+    #     '--binaries-only')
     artifact_commands = []
   else:
     raise ValueError(f'Unknown build_type: {build_type}')


### PR DESCRIPTION
This will create a separate build to allow tracing function calls when running the harness on testcases.