### PR TITLE
[zlib] show configure.log when configure fails

### DIFF
--- a/projects/zlib/build.sh
+++ b/projects/zlib/build.sh
@@ -15,7 +15,11 @@
 #
 ################################################################################
 
-./configure
+if ! ./configure; then
+    cat configure.log
+    exit 1
+fi
+
 make -j$(nproc) clean
 make -j$(nproc) all
 make -j$(nproc) check


### PR DESCRIPTION
to make it easier to debug issues like
https://github.com/madler/zlib/issues/1084 and
https://github.com/google/oss-fuzz/issues/13969.

With this patch applied it shows
```
...
Checking for obsessive-compulsive compiler options...
=== ztest14.c ===
int foo() { return 0; }
===
/src/aflplusplus/afl-clang-fast -c -O1 -fno-omit-frame-pointer -gline-tables-only -Wno-error=incompatible-function-pointer-types -Wno-error=int-conversion -Wno-error=deprecated-declarations -Wno-error=implicit-function-declaration -Wno-error=implicit-int -Wno-error=unknown-warning-option -Wno-error=vla-cxx-extension -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=address -fsanitize-address-use-after-scope ztest14.c
error: unable to load plugin '/src/aflplusplus/SanitizerCoveragePCGUARD.so': 'Could not load library '/src/aflplusplus/SanitizerCoveragePCGUARD.so': /src/aflplusplus/SanitizerCoveragePCGUARD.so: cannot open shared object file: No such file or directory'
1 error generated.
(exit code 1)
Compiler error reporting is too harsh for ./configure (perhaps remove -Werror).
** ./configure aborting.
```