### PR TITLE
[systemd] turn off afl for now

### DIFF
--- a/projects/systemd/project.yaml
+++ b/projects/systemd/project.yaml
@@ -7,7 +7,6 @@ sanitizers:
   - undefined
   - memory
 fuzzing_engines:
-  - afl
   - honggfuzz
   - libfuzzer
 auto_ccs:


### PR DESCRIPTION
All systemd fuzz targets started to time out in bad_build_check when AFL++ was bumped in https://github.com/google/oss-fuzz/pull/13968. It can be turned off until https://github.com/google/oss-fuzz/issues/13975 is addressed one way or another to keep fuzzing systemd using the other fuzzing engines.

cc @yuwata just in case