### PR TITLE
bitcoin-core: use lld to work around link failures

### DIFF
--- a/projects/bitcoin-core/build.sh
+++ b/projects/bitcoin-core/build.sh
@@ -37,6 +37,9 @@ fi
 # export CXXFLAGS="$CXXFLAGS -flto=thin"
 # export LDFLAGS="-flto=thin"
 
+# Use lld to workaround <module> referenced in <section> of /tmp/lto-llvm-*.o: defined in discarded section
+export LDFLAGS="-fuse-ld=lld"
+
 export CPPFLAGS="-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE"
 
 (

--- a/projects/bitcoin-core/project.yaml
+++ b/projects/bitcoin-core/project.yaml
@@ -14,7 +14,7 @@ sanitizers:
   - memory
 architectures:
   - x86_64
-  - i386
+#  - i386 disabled for now: https://github.com/google/clusterfuzz/pull/4773
 selective_unpack: true  # Required to avoid out-of-space when executing AFL on clusterfuzz bots
 fuzzing_engines:
   - afl


### PR DESCRIPTION
See
https://oss-fuzz-build-logs.storage.googleapis.com/log-08166704-3ba3-406e-9e55-637c906d1fd2.txt:
```bash
Step #3 - "compile-afl-address-x86_64": `.text.asan.module_dtor.124671' referenced in section `.fini_array.1[asan.module_dtor.124671]' of /tmp/lto-llvm-b064c1.o: defined in discarded section `.text.asan.module_dtor.124671[asan.module_dtor]' of /tmp/lto-llvm-b064c1.o
Step #3 - "compile-afl-address-x86_64": clang++: �[0;1;31merror: �[0m�[1mlinker command failed with exit code 1 (use -v to see invocation)�[0m
Step #3 - "compile-afl-address-x86_64": make[2]: *** [src/test/fuzz/CMakeFiles/fuzz.dir/build.make:2268: bin/fuzz] Error 1
Step #3 - "compile-afl-address-x86_64": make[1]: *** [CMakeFiles/Makefile2:854: src/test/fuzz/CMakeFiles/fuzz.dir/all] Error 2
Step #3 - "compile-afl-address-x86_64": make: *** [Makefile:91: all] Error 2
```

Closes https://github.com/bitcoin/bitcoin/issues/33366.