### PR TITLE
monero: unpin old base builder and update flags

### DIFF
--- a/projects/monero/Dockerfile
+++ b/projects/monero/Dockerfile
@@ -17,7 +17,7 @@
 # Multistage docker build, requires docker 17.05
 
 # builder stage
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:d34b94e3cf868e49d2928c76ddba41fd4154907a1a381b3a263fafffb7c3dce0
+FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN set -ex && \
     apt-get update && \

--- a/projects/monero/build.sh
+++ b/projects/monero/build.sh
@@ -24,7 +24,7 @@ git submodule init
 git submodule update
 mkdir -p build
 cd build
-export CXXFLAGS="$CXXFLAGS -fPIC"
+export CXXFLAGS="${CXXFLAGS} -fPIC -DBOOST_NO_INCLASS_MEMBER_INITIALIZATION"
 cmake -D OSSFUZZ=ON -D STATIC=ON -D BUILD_TESTS=ON -D USE_LTO=OFF -D ARCH="default" ..
 
 TESTS="\


### PR DESCRIPTION
This solves the issues with BOOST not compiling. Will enable coverage coming back.