### PR TITLE
osquery: remove base builder pinning

### DIFF
--- a/projects/osquery/Dockerfile
+++ b/projects/osquery/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:d34b94e3cf868e49d2928c76ddba41fd4154907a1a381b3a263fafffb7c3dce0
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y --no-install-recommends python python3 bison flex make wget xz-utils libunwind-dev lsb-release build-essential libssl-dev
 
 # osquery now needs at least version 3.21.4.

--- a/projects/osquery/build.sh
+++ b/projects/osquery/build.sh
@@ -15,6 +15,8 @@
 #
 ################################################################################
 
+export CXXFLAGS="${CXXFLAGS} -DBOOST_NO_INCLASS_MEMBER_INITIALIZATION"
+
 PROJECT=osquery
 
 # Ensure xlocale.h is found.


### PR DESCRIPTION
Fixes boost build failures