### PR TITLE
[elfutils] no longer send notifications to the elfutils mailing list

### DIFF
--- a/projects/elfutils/project.yaml
+++ b/projects/elfutils/project.yaml
@@ -1,7 +1,7 @@
 homepage: "https://sourceware.org/elfutils/"
 language: c++
 builds_per_day: 4
-primary_contact: "elfutils-devel@sourceware.org"
+primary_contact: "david@adalogics.com"
 main_repo: "https://sourceware.org/git/elfutils.git"
 fuzzing_engines:
   - libfuzzer
@@ -16,6 +16,4 @@ architectures:
   - i386
 view_restrictions: none
 auto_ccs:
-  - evverx@gmail.com
   - izzeem@google.com
-  - david@adalogics.com


### PR DESCRIPTION
as requested in https://sourceware.org/pipermail/elfutils-devel/2025q3/008514.html

I can keep track of bugs the fuzz targets can discover elsewhere so there is no need to keep my email address there either.

Ideally it would be great if bugs were reported to the elfutils bug tracker. It would also be useful if backtraces were attached to bug reports on https://issues.oss-fuzz.com/ so that it wouldn't be necessary to have Google accounts to view them on https://oss-fuzz.com. view_restrictions is none there so all the stuff related to disclosures isn't relevant.