### PR TITLE
distribution: use go 1.23.4

### DIFF
--- a/projects/distribution/Dockerfile
+++ b/projects/distribution/Dockerfile
@@ -18,5 +18,11 @@ FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN git clone --depth 1 https://github.com/distribution/distribution
 RUN git clone --depth 1 https://github.com/cncf/cncf-fuzzing
 RUN git clone --depth 1 https://github.com/AdamKorcz/go-118-fuzz-build --branch=november-backup
+RUN wget https://go.dev/dl/go1.23.4.linux-amd64.tar.gz \
+    && mkdir temp-go \
+    && rm -rf /root/.go/* \
+    && tar -C temp-go/ -xzf go1.23.4.linux-amd64.tar.gz \
+    && mv temp-go/go/* /root/.go/ \
+    && rm -rf temp-go go1.23.4.linux-amd64.tar.gz
 COPY build.sh $SRC/
 WORKDIR $SRC/distribution


### PR DESCRIPTION
This is required for https://github.com/google/oss-fuzz/pull/13875. Making this PR to pre-emptively fix the broken distribution build.