### PR TITLE
blackfriday: use go 1.23.4

### DIFF
--- a/projects/blackfriday/Dockerfile
+++ b/projects/blackfriday/Dockerfile
@@ -16,5 +16,11 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN git clone --depth 1 --branch v2 https://github.com/russross/blackfriday
+RUN wget https://go.dev/dl/go1.23.4.linux-amd64.tar.gz \
+    && mkdir temp-go \
+    && rm -rf /root/.go/* \
+    && tar -C temp-go/ -xzf go1.23.4.linux-amd64.tar.gz \
+    && mv temp-go/go/* /root/.go/ \
+    && rm -rf temp-go go1.23.4.linux-amd64.tar.gz
 COPY build.sh render_fuzzer.go $SRC/
 WORKDIR $SRC/blackfriday


### PR DESCRIPTION
This is required for https://github.com/google/oss-fuzz/pull/13875. Making this PR to pre-emptively fix the broken blackfriday build.