### PR TITLE
go-dns: use go 1.24.6

### DIFF
--- a/projects/go-dns/Dockerfile
+++ b/projects/go-dns/Dockerfile
@@ -17,6 +17,12 @@
 #FROM gcr.io/oss-fuzz-base/base-builder-go
 FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN git clone https://github.com/miekg/dns.git
+RUN wget https://go.dev/dl/go1.24.6.linux-amd64.tar.gz \
+    && mkdir temp-go \
+    && rm -rf /root/.go/* \
+    && tar -C temp-go/ -xzf go1.24.6.linux-amd64.tar.gz \
+    && mv temp-go/go/* /root/.go/ \
+    && rm -rf temp-go go1.24.6.linux-amd64.tar.gz
 
 COPY build.sh $SRC/
 WORKDIR $SRC/dns


### PR DESCRIPTION
This is required for https://github.com/google/oss-fuzz/pull/13875. Making this PR to pre-emptively fix the broken go-dns build.