### PR TITLE
prometheus: use go 1.24.6

### DIFF
--- a/projects/prometheus/Dockerfile
+++ b/projects/prometheus/Dockerfile
@@ -17,6 +17,12 @@
 FROM gcr.io/oss-fuzz-base/base-builder-go
 ENV GO111MODULE=on
 RUN git clone https://github.com/prometheus/prometheus $GOPATH/src/github.com/prometheus/prometheus
+RUN wget https://go.dev/dl/go1.24.6.linux-amd64.tar.gz \
+    && mkdir temp-go \
+    && rm -rf /root/.go/* \
+    && tar -C temp-go/ -xzf go1.24.6.linux-amd64.tar.gz \
+    && mv temp-go/go/* /root/.go/ \
+    && rm -rf temp-go go1.24.6.linux-amd64.tar.gz
 COPY build.sh $SRC/
 # Required to avoid 'working directory is not part of a module' error.
 WORKDIR $GOPATH/src/github.com/prometheus/prometheus

--- a/projects/prometheus/build.sh
+++ b/projects/prometheus/build.sh
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 ################################################################################
+# Wrong naming in this fuzzer breaks the coverage build
+rm promql/fuzz_test.go
 
 compile_go_fuzzer github.com/prometheus/prometheus/promql FuzzParseMetric fuzzParseMetric
 compile_go_fuzzer github.com/prometheus/prometheus/promql FuzzParseOpenMetric fuzzParseOpenMetric


### PR DESCRIPTION
This is required for https://github.com/google/oss-fuzz/pull/13875. Making this PR to pre-emptively fix the broken prometheus build.