### PR TITLE
juju: use go 1.23.4

### DIFF
--- a/projects/juju/Dockerfile
+++ b/projects/juju/Dockerfile
@@ -16,5 +16,11 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN git clone --depth 1 https://github.com/juju/juju
+RUN wget https://go.dev/dl/go1.23.4.linux-amd64.tar.gz \
+    && mkdir temp-go \
+    && rm -rf /root/.go/* \
+    && tar -C temp-go/ -xzf go1.23.4.linux-amd64.tar.gz \
+    && mv temp-go/go/* /root/.go/ \
+    && rm -rf temp-go go1.23.4.linux-amd64.tar.gz
 COPY build.sh devices_fuzzer.go $SRC/
 WORKDIR $SRC/juju


### PR DESCRIPTION
This is required for https://github.com/google/oss-fuzz/pull/13875. Making this PR to pre-emptively fix the broken juju build.