### PR TITLE
proton-bridge: use go 1.24.6

### DIFF
--- a/projects/proton-bridge/Dockerfile
+++ b/projects/proton-bridge/Dockerfile
@@ -24,5 +24,11 @@ RUN apt-get update && \
 
 RUN git clone --depth 1 https://github.com/ProtonMail/proton-bridge.git
 RUN git clone --depth=1 https://github.com/AdamKorcz/go-118-fuzz-build --branch=include-all-test-files
+RUN wget https://go.dev/dl/go1.24.6.linux-amd64.tar.gz \
+    && mkdir temp-go \
+    && rm -rf /root/.go/* \
+    && tar -C temp-go/ -xzf go1.24.6.linux-amd64.tar.gz \
+    && mv temp-go/go/* /root/.go/ \
+    && rm -rf temp-go go1.24.6.linux-amd64.tar.gz
 COPY build.sh $SRC/
 WORKDIR $SRC/proton-bridge


### PR DESCRIPTION
This is required for https://github.com/google/oss-fuzz/pull/13875. Making this PR to pre-emptively fix the broken juju build.