### PR TITLE
opentelemtry-go: use compile_native_go_fuzzer_v2

### DIFF
--- a/projects/opentelemetry-go/Dockerfile
+++ b/projects/opentelemetry-go/Dockerfile
@@ -16,5 +16,5 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN git clone --depth=1 https://github.com/open-telemetry/opentelemetry-go
-RUN git clone --depth=1 --branch=november-backup https://github.com/AdamKorcz/go-118-fuzz-build
+WORKDIR $SRC/opentelemetry-go
 COPY build.sh $SRC/

--- a/projects/opentelemetry-go/build.sh
+++ b/projects/opentelemetry-go/build.sh
@@ -15,15 +15,6 @@
 #
 ################################################################################
 
-cd $SRC/go-118-fuzz-build
-go build .
-mv go-118-fuzz-build /root/go/bin/
-
-cd $SRC/opentelemetry-go
-
 pushd sdk/metric/internal/aggregate
-printf "package aggregate \nimport _ \"github.com/AdamKorcz/go-118-fuzz-build/testing\"\n" > ./fuzz-register.go
-go mod edit -replace github.com/AdamKorcz/go-118-fuzz-build=$SRC/go-118-fuzz-build
-go mod tidy
-compile_native_go_fuzzer $(go list) FuzzGetBin FuzzGetBin
+compile_native_go_fuzzer_v2 $(go list) FuzzGetBin FuzzGetBin
 popd


### PR DESCRIPTION
to use the newer function.