### PR TITLE
go-attestation: use go 1.24.6

### DIFF
--- a/projects/go-attestation/Dockerfile
+++ b/projects/go-attestation/Dockerfile
@@ -17,6 +17,12 @@
 FROM gcr.io/oss-fuzz-base/base-builder-go
 
 RUN git clone --depth 1 https://github.com/google/go-attestation
+RUN wget https://go.dev/dl/go1.24.6.linux-amd64.tar.gz \
+    && mkdir temp-go \
+    && rm -rf /root/.go/* \
+    && tar -C temp-go/ -xzf go1.24.6.linux-amd64.tar.gz \
+    && mv temp-go/go/* /root/.go/ \
+    && rm -rf temp-go go1.24.6.linux-amd64.tar.gz
 
 WORKDIR go-attestation
 COPY build.sh $SRC/


### PR DESCRIPTION
This is required for https://github.com/google/oss-fuzz/pull/13875. Making this PR to pre-emptively fix the broken go-attestation build.