### PR TITLE
[qt] turn off afl for now

### DIFF
--- a/projects/qt/project.yaml
+++ b/projects/qt/project.yaml
@@ -13,7 +13,6 @@ architectures:
 help_url: "https://code.qt.io/cgit/qt/qtbase.git/plain/tests/libfuzzer/README"
 
 fuzzing_engines:
-  - afl
   - honggfuzz
   - libfuzzer
 


### PR DESCRIPTION
On September 9th, configure's check for working CXX compiler started failing for compile-afl-address-x86_64. It can be turned off until the issue is addressed one way or another to keep fuzzing Qt using the other fuzzing engines.