### PR TITLE
bitcoin-core: Pin pre-LLVM 22 image

### DIFF
--- a/projects/bitcoin-core/Dockerfile
+++ b/projects/bitcoin-core/Dockerfile
@@ -14,7 +14,8 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+# TODO: Fix build with LLVM 22 and unpin.
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:d34b94e3cf868e49d2928c76ddba41fd4154907a1a381b3a263fafffb7c3dce0
 
 # Packages taken from:
 # * https://github.com/bitcoin/bitcoin/blob/master/doc/build-unix.md#dependency-build-instructions


### PR DESCRIPTION
The recent changes in OSS-Fuzz infra (see https://github.com/google/oss-fuzz/pull/13915 and https://github.com/google/oss-fuzz/pull/13968) [broke Bitcoin Core fuzzing builds](https://oss-fuzz-build-logs.storage.googleapis.com/index.html#bitcoin-core).

While work on a proper fix [is ongoing](https://github.com/google/oss-fuzz/pull/13987), this PR restores builds by pinning the build image to its pre-LLVM 22 state.