### PR TITLE
moby: fix broken build

### DIFF
--- a/projects/moby/Dockerfile
+++ b/projects/moby/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN apt-get update && apt-get install -y clang libbtrfs-dev pkg-config libdevmapper-dev
 RUN git clone --depth 1 https://github.com/moby/moby
 RUN git clone --depth 1 https://github.com/moby/go-archive
-RUN git clone --depth 1 https://github.com/AdamKorcz/go-118-fuzz-build --branch=november-backup
+RUN git clone --depth 1 https://github.com/AdamKorcz/go-118-fuzz-build --branch=v2_2
 COPY build.sh $SRC/
 COPY *_fuzzer.go $SRC/
 

--- a/projects/moby/build.sh
+++ b/projects/moby/build.sh
@@ -61,6 +61,8 @@ compile_native_go_fuzzer_v2 github.com/moby/moby/v2/daemon/logger/jsonfilelog/js
 cp $SRC/*.options $OUT/
 
 cd $SRC/go-archive
+go mod tidy
+go get github.com/AdamKorcz/go-118-fuzz-build/testing
 compile_native_go_fuzzer github.com/moby/go-archive/compression FuzzDecompressStream FuzzDecompressStream
 compile_native_go_fuzzer github.com/moby/go-archive FuzzApplyLayer FuzzApplyLayer
 compile_native_go_fuzzer github.com/moby/go-archive FuzzUntar FuzzUntar

--- a/projects/moby/build.sh
+++ b/projects/moby/build.sh
@@ -15,21 +15,6 @@
 #
 ################################################################################
 
-# This part is temporary. I (AdamKorcz)
-# will remove it.
-cd $SRC/go-118-fuzz-build
-go build
-mv go-118-fuzz-build $GOPATH/bin/go-118-fuzz-build_v2
-
-pushd cmd/convertLibFuzzerTestcaseToStdLibGo
-  go build . && mv convertLibFuzzerTestcaseToStdLibGo $GOPATH/bin/
-popd
-pushd cmd/addStdLibCorpusToFuzzer
-  go build . && mv addStdLibCorpusToFuzzer $GOPATH/bin/
-popd
-
-cd $SRC/moby
-
 # Temporarily disable coverage build in OSS-Fuzz's CI
 if [ -n "${OSS_FUZZ_CI-}" ]
 then
@@ -76,6 +61,6 @@ compile_native_go_fuzzer_v2 github.com/moby/moby/v2/daemon/logger/jsonfilelog/js
 cp $SRC/*.options $OUT/
 
 cd $SRC/go-archive
-compile_native_go_fuzzer_v2 github.com/moby/go-archive/compression FuzzDecompressStream FuzzDecompressStream
-compile_native_go_fuzzer_v2 github.com/moby/go-archive FuzzApplyLayer FuzzApplyLayer
-compile_native_go_fuzzer_v2 github.com/moby/go-archive FuzzUntar FuzzUntar
+compile_native_go_fuzzer github.com/moby/go-archive/compression FuzzDecompressStream FuzzDecompressStream
+compile_native_go_fuzzer github.com/moby/go-archive FuzzApplyLayer FuzzApplyLayer
+compile_native_go_fuzzer github.com/moby/go-archive FuzzUntar FuzzUntar

--- a/projects/moby/daemon_fuzzer.go
+++ b/projects/moby/daemon_fuzzer.go
@@ -23,12 +23,12 @@ import (
 	"github.com/moby/sys/mount"
 	"github.com/sirupsen/logrus"
 
-	"github.com/moby/moby/api/types/backend"
-	"github.com/docker/docker/daemon/container"
-	"github.com/docker/docker/daemon/config"
-	"github.com/docker/docker/daemon/images"
-	"github.com/docker/docker/image"
-	dockerreference "github.com/docker/docker/reference"
+	"github.com/moby/moby/v2/daemon/server/backend"
+	"github.com/moby/moby/v2/daemon/container"
+	"github.com/moby/moby/v2/daemon/config"
+	"github.com/moby/moby/v2/daemon/images"
+	"github.com/moby/moby/v2/daemon/internal/image"
+	dockerreference "github.com/moby/moby/v2/daemon/internal/refstore"
 	"github.com/opencontainers/go-digest"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
@@ -120,7 +120,7 @@ func FuzzDaemonSimple(data []byte) int {
 
 	d := &Daemon{
 		root:         cfg.Root,
-		imageService: images.NewImageService(images.ImageServiceConfig{ReferenceStore: rStore, ImageStore: is}),
+		imageService: images.NewImageService(context.Background(), images.ImageServiceConfig{ReferenceStore: rStore, ImageStore: is}),
 		containers:   container.NewMemoryStore(),
 	}
 


### PR DESCRIPTION
1. Fix broken build.
2. Remove dependency on `github.com/AdamKorcz/go-118-fuzz-build/testing`

The `FuzzDisplayJSONMessagesStream` is giving me some trouble. I have commented it out for now and will follow up with a fix.