### PR TITLE
[skia] Link using lld

### DIFF
--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -65,7 +65,7 @@ export CFLAGS="$CFLAGS $DISABLE -I$SWIFTSHADER_INCLUDE_PATH \
  -fno-sanitize=vptr -DSK_BUILD_FOR_LIBFUZZER -DSK_BUILD_FOR_FUZZER"
 export CXXFLAGS="$CXXFLAGS $DISABLE -I$SWIFTSHADER_INCLUDE_PATH \
  -fno-sanitize=vptr -DSK_BUILD_FOR_LIBFUZZER -D SK_BUILD_FOR_FUZZER"
-export LDFLAGS="$LIB_FUZZING_ENGINE $CXXFLAGS -L$SWIFTSHADER_LIB_PATH"
+export LDFLAGS="$LIB_FUZZING_ENGINE $CXXFLAGS -L$SWIFTSHADER_LIB_PATH -fuse-ld=lld"
 
 # This splits a space separated list into a quoted, comma separated list for gn.
 export CFLAGS_ARR=`echo $CFLAGS | sed -e "s/\s/\",\"/g"`


### PR DESCRIPTION
We are seeing a link error like:
```
/src/skia/out/FuzzDebug/../../src/gpu/graphite/vk/VulkanSpirvTransforms.cpp:512: undefined reference to `SkSL::ValidateSPIRV(SkSL::ErrorReporter&, SkSpan<unsigned int const>)'
Step #3 - "compile-afl-address-x86_64": clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```
And I think the easiest way to fix that is to use lld which is less sensitive to the order libraries end up on the DEPS line.