### PR TITLE
nss: fix broken build

### DIFF
--- a/projects/nss/Dockerfile
+++ b/projects/nss/Dockerfile
@@ -15,7 +15,8 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make mercurial zlib1g-dev gyp ninja-build libssl-dev python
+RUN apt-get update && \
+    apt-get install -y make mercurial zlib1g-dev gyp ninja-build libssl-dev python libboost-dev libsqlite3-dev
 
 RUN hg clone https://hg.mozilla.org/projects/nspr nspr
 RUN hg clone https://hg.mozilla.org/projects/nss nss

--- a/projects/nss/build.sh
+++ b/projects/nss/build.sh
@@ -15,8 +15,8 @@
 #
 ################################################################################
 
-export CFLAGS="${CFLAGS} -Wno-error=unknown-warning-option -Wno-error=character-conversion"
-export CXXFLAGS="${CXXFLAGS} -Wno-error=unknown-warning-option -Wno-error=character-conversion"
+export CFLAGS="${CFLAGS} -Wno-error=unknown-warning-option -Wno-error=character-conversion -Wno-error=deprecated-literal-operator -D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION"
+export CXXFLAGS="${CXXFLAGS} -Wno-error=unknown-warning-option -Wno-error=character-conversion -Wno-error=deprecated-literal-operator -D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION"
 
 sed -i 's/--disable-tests//g' automation/ossfuzz/build.sh
 


### PR DESCRIPTION
The latest NSS build broke due to missing boost library headers: https://oss-fuzz-build-logs.storage.googleapis.com/log-b9fec823-082c-46fa-88a8-d49fccc0e459.txt