### PR TITLE
igraph: use 'main' branch

### DIFF
--- a/projects/igraph/Dockerfile
+++ b/projects/igraph/Dockerfile
@@ -16,6 +16,6 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y cmake bison flex
-RUN git clone --branch develop  https://github.com/igraph/igraph
+RUN git clone --branch main  https://github.com/igraph/igraph
 WORKDIR igraph
 RUN cp $SRC/igraph/fuzzing/build.sh $SRC/build.sh


### PR DESCRIPTION
We are preparing for a big release, renamed some branches and moving development primarily to the `main` branch.