### PR TITLE
Install Java 25 in runners

### DIFF
--- a/infra/base-images/base-builder-jvm/Dockerfile
+++ b/infra/base-images/base-builder-jvm/Dockerfile
@@ -18,6 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder AS base
 
 ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64
 ENV JAVA_15_HOME /usr/lib/jvm/java-15-openjdk-amd64
+ENV JAVA_25_HOME /usr/lib/jvm/java-25-openjdk-amd64
 ENV JVM_LD_LIBRARY_PATH $JAVA_HOME/lib/server
 ENV PATH $PATH:$JAVA_HOME/bin
 ENV JAZZER_API_PATH "/usr/local/lib/jazzer_api_deploy.jar"

--- a/infra/base-images/base-builder-jvm/ubuntu-20-04.Dockerfile
+++ b/infra/base-images/base-builder-jvm/ubuntu-20-04.Dockerfile
@@ -18,6 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-20-04 AS base
 
 ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64
 ENV JAVA_15_HOME /usr/lib/jvm/java-15-openjdk-amd64
+ENV JAVA_25_HOME /usr/lib/jvm/java-25-openjdk-amd64
 ENV JVM_LD_LIBRARY_PATH $JAVA_HOME/lib/server
 ENV PATH $PATH:$JAVA_HOME/bin
 ENV JAZZER_API_PATH "/usr/local/lib/jazzer_api_deploy.jar"

--- a/infra/base-images/base-builder-jvm/ubuntu-24-04.Dockerfile
+++ b/infra/base-images/base-builder-jvm/ubuntu-24-04.Dockerfile
@@ -18,6 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04 AS base
 
 ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64
 ENV JAVA_15_HOME /usr/lib/jvm/java-15-openjdk-amd64
+ENV JAVA_25_HOME /usr/lib/jvm/java-25-openjdk-amd64
 ENV JVM_LD_LIBRARY_PATH $JAVA_HOME/lib/server
 ENV PATH $PATH:$JAVA_HOME/bin
 ENV JAZZER_API_PATH "/usr/local/lib/jazzer_api_deploy.jar"

--- a/infra/base-images/base-builder/install_java.sh
+++ b/infra/base-images/base-builder/install_java.sh
@@ -29,3 +29,9 @@ mkdir -p $JAVA_15_HOME
 tar -xz --strip-components=1 -f openjdk-15.0.2_linux-x64_bin.tar.gz --directory $JAVA_15_HOME && \
 rm -f openjdk-15.0.2_linux-x64_bin.tar.gz
 rm -rf $JAVA_15_HOME/jmods $JAVA_15_HOME/lib/src.zip
+
+curl --silent -L -O https://corretto.aws/downloads/latest/amazon-corretto-25-x64-linux-jdk.tar.gz && \
+mkdir -p $JAVA_25_HOME
+tar -xz --strip-components=1 -f amazon-corretto-25-x64-linux-jdk.tar.gz --directory $JAVA_25_HOME && \
+rm -f amazon-corretto-25-x64-linux-jdk.tar.gz
+rm -rf $JAVA_25_HOME/jmods $JAVA_25_HOME/lib/src.zip

--- a/infra/base-images/base-runner/Dockerfile
+++ b/infra/base-images/base-runner/Dockerfile
@@ -94,6 +94,7 @@ RUN /install_go.sh && rm -rf /install_go.sh /root/.go
 # Install OpenJDK 15 and trim its size by removing unused components.
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 ENV JAVA_15_HOME=/usr/lib/jvm/java-15-openjdk-amd64
+ENV JAVA_25_HOME=/usr/lib/jvm/java-25-openjdk-amd64
 ENV JVM_LD_LIBRARY_PATH=$JAVA_HOME/lib/server
 ENV PATH=$PATH:$JAVA_HOME/bin
 

--- a/infra/base-images/base-runner/install_java.sh
+++ b/infra/base-images/base-runner/install_java.sh
@@ -44,3 +44,9 @@ mkdir -p $JAVA_15_HOME
 tar -xz --strip-components=1 -f openjdk-15.0.2_linux-"$ARCHITECTURE"_bin.tar.gz --directory $JAVA_15_HOME
 rm -f openjdk-15.0.2_linux-"$ARCHITECTURE"_bin.tar.gz
 rm -rf $JAVA_15_HOME/jmods $JAVA_15_HOME/lib/src.zip
+
+curl --silent -L -O https://corretto.aws/downloads/latest/amazon-corretto-25-"$ARCHITECTURE"-linux-jdk.tar.gz && \
+mkdir -p $JAVA_25_HOME
+tar -xz --strip-components=1 -f amazon-corretto-25-"$ARCHITECTURE"-linux-jdk.tar.gz --directory $JAVA_25_HOME && \
+rm -f amazon-corretto-25-"$ARCHITECTURE"-linux-jdk.tar.gz
+rm -rf $JAVA_25_HOME/jmods $JAVA_25_HOME/lib/src.zip

--- a/infra/base-images/base-runner/ubuntu-20-04.Dockerfile
+++ b/infra/base-images/base-runner/ubuntu-20-04.Dockerfile
@@ -94,6 +94,7 @@ RUN /install_go.sh && rm -rf /install_go.sh /root/.go
 # Install OpenJDK 15 and trim its size by removing unused components.
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 ENV JAVA_15_HOME=/usr/lib/jvm/java-15-openjdk-amd64
+ENV JAVA_25_HOME=/usr/lib/jvm/java-25-openjdk-amd64
 ENV JVM_LD_LIBRARY_PATH=$JAVA_HOME/lib/server
 ENV PATH=$PATH:$JAVA_HOME/bin
 

--- a/infra/base-images/base-runner/ubuntu-24-04.Dockerfile
+++ b/infra/base-images/base-runner/ubuntu-24-04.Dockerfile
@@ -94,6 +94,7 @@ RUN /install_go.sh && rm -rf /install_go.sh /root/.go
 # Install OpenJDK 15 and trim its size by removing unused components.
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 ENV JAVA_15_HOME=/usr/lib/jvm/java-15-openjdk-amd64
+ENV JAVA_25_HOME=/usr/lib/jvm/java-25-openjdk-amd64
 ENV JVM_LD_LIBRARY_PATH=$JAVA_HOME/lib/server
 ENV PATH=$PATH:$JAVA_HOME/bin
 


### PR DESCRIPTION
The latest Java version available on oss-fuzz is 17. Some Java frameworks and libraries are now moving beyond Java 17 as the earliest supported version, mostly to Java 21.

This PR adds Java 25 to the base-runner and base-builder-jvm containers, under JAVA_25_HOME. This should be a reasonable option for a few years.

I've chosen corretto as the OpenJDK build because temurin is apparently not yet available for normal linux, and because corretto has a permalink that always downloads the latest Java 25 version, so we will get bugfixes without changing the install scripts further.