### PR TITLE
arrow: Build cleanups

### DIFF
--- a/projects/arrow/Dockerfile
+++ b/projects/arrow/Dockerfile
@@ -16,22 +16,19 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y -q && \
     apt-get install -y -q --no-install-recommends \
         bison \
-        build-essential \
-        cmake \
         flex \
-        ninja-build \
-        python3
+        ninja-build
 
 RUN wget https://github.com/boostorg/boost/releases/download/boost-1.87.0/boost-1.87.0-cmake.tar.gz && \
     tar -xvf boost-1.87.0-cmake.tar.gz && \
     cd boost-1.87.0/ && \
     CFLAGS="" CXXFLAGS="" ./bootstrap.sh && \
     CFLAGS="" CXXFLAGS="" ./b2 headers && \
-    CFLAGS="" CXXFLAGS="" ./b2 runtime-link=static link=static variant=release install -j 10 && \
+    CFLAGS="" CXXFLAGS="" ./b2 --with-process runtime-link=static link=static variant=release install -j 10 && \
     cp -R -f boost/ /usr/include/
 
 RUN git clone --depth=1 --recurse-submodules \

--- a/projects/arrow/build.sh
+++ b/projects/arrow/build.sh
@@ -20,7 +20,6 @@ ARROW=${SRC}/arrow/cpp
 export BUILD_DIR=$SRC/build-dir
 mkdir -p ${BUILD_DIR}
 cd ${BUILD_DIR}
-#cd ${WORK}
 
 # The CMake build setup compiles and runs the Thrift compiler, but ASAN
 # would report leaks and error out.
@@ -35,28 +34,29 @@ cmake ${ARROW} -GNinja \
     -DCMAKE_C_FLAGS="${CFLAGS}" \
     -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
     -DARROW_EXTRA_ERROR_CONTEXT=off \
-    -DARROW_JEMALLOC=off \
-    -DARROW_MIMALLOC=off \
-    -DARROW_FILESYSTEM=off \
-    -DARROW_PARQUET=on \
+    \
     -DARROW_BUILD_SHARED=off \
     -DARROW_BUILD_STATIC=on \
-    -DARROW_BUILD_TESTS=on \
-    -DARROW_BUILD_INTEGRATION=off \
     -DARROW_BUILD_BENCHMARKS=off \
     -DARROW_BUILD_EXAMPLES=off \
+    -DARROW_BUILD_INTEGRATION=off \
+    -DARROW_BUILD_TESTS=on \
     -DARROW_BUILD_UTILITIES=off \
     -DARROW_TEST_LINKAGE=static \
     -DPARQUET_BUILD_EXAMPLES=off \
     -DPARQUET_BUILD_EXECUTABLES=off \
     -DPARQUET_REQUIRE_ENCRYPTION=off \
+    \
+    -DARROW_JEMALLOC=off \
+    -DARROW_MIMALLOC=off \
+    -DARROW_PARQUET=on \
     -DARROW_WITH_BROTLI=on \
     -DARROW_WITH_BZ2=off \
     -DARROW_WITH_LZ4=on \
     -DARROW_WITH_SNAPPY=on \
     -DARROW_WITH_ZLIB=on \
     -DARROW_WITH_ZSTD=on \
-    -DARROW_USE_GLOG=off \
+    \
     -DARROW_USE_ASAN=off \
     -DARROW_USE_UBSAN=off \
     -DARROW_USE_TSAN=off \


### PR DESCRIPTION
A couple minor cleanups to the Arrow build setup:
* fix deprecation warning about Dockefile ENV syntax
* remove manual install of tools already provided by the image (CMake, Python, build essentials)
* build only the required Boost components