### PR TITLE
add llvm-link to base-clang

### DIFF
--- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
@@ -190,6 +190,7 @@ function free_disk_space {
       /usr/local/bin/llvm-as \
       /usr/local/bin/llvm-config \
       /usr/local/bin/llvm-cov \
+      /usr/local/bin/llvm-link \
       /usr/local/bin/llvm-objcopy \
       /usr/local/bin/llvm-nm \
       /usr/local/bin/llvm-profdata \


### PR DESCRIPTION
It takes up 5mb

Fixes: https://github.com/google/oss-fuzz/issues/13977