### PR TITLE
bitcoin: re-enable -flto=thin

### DIFF
--- a/projects/bitcoin-core/build.sh
+++ b/projects/bitcoin-core/build.sh
@@ -28,17 +28,11 @@ else
   export BUILD_TRIPLET="x86_64-pc-linux-gnu"
 fi
 
-# Build using ThinLTO, to avoid OOM, and other LLVM issues.
-# See https://github.com/google/oss-fuzz/pull/10123.
-# Skip CFLAGS for now, to avoid:
-# "/usr/bin/ld: error: Failed to link module lib/libevent.a.llvm.17822.buffer.c: Expected at most one ThinLTO module per bitcode file".
-# export CFLAGS="$CFLAGS -flto=thin"
-# Skip CXXFLAGS for now, to avoid: undefined reference to __sancov_gen_.
-# export CXXFLAGS="$CXXFLAGS -flto=thin"
-# export LDFLAGS="-flto=thin"
 
+export CFLAGS="$CFLAGS -flto=full"
+export CXXFLAGS="$CXXFLAGS -flto=full"
 # Use lld to workaround <module> referenced in <section> of /tmp/lto-llvm-*.o: defined in discarded section
-export LDFLAGS="-fuse-ld=lld"
+export LDFLAGS="-fuse-ld=lld -flto=full"
 
 export CPPFLAGS="-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE"
 


### PR DESCRIPTION
Now that we are using `lld` (some) local builds point to this working.