### PR TITLE
go coverage: align covermode and run only coverage test

### DIFF
--- a/infra/base-images/base-builder/compile_go_fuzzer
+++ b/infra/base-images/base-builder/compile_go_fuzzer
@@ -23,6 +23,10 @@ if [[ $#  -eq 4 ]]; then
   tags="-tags $4"
 fi
 
+# Import go_utils.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/go_utils.sh"
+
 # makes directory change temporary
 (
 cd $GOPATH/src/$path || true
@@ -57,7 +61,15 @@ if [[ $SANITIZER = *coverage* ]]; then
     abspath_repo=`go list -m $tags -f {{.Dir}} $GO_COV_ADD_PKG || go list $tags -f {{.Dir}} $GO_COV_ADD_PKG`
     echo "s=^$GO_COV_ADD_PKG"="$abspath_repo"= >> $OUT/$fuzzer.gocovpath
   fi
-  go test -run Test${function}Corpus -v $tags -coverpkg $fuzzed_repo/...$pkgaddcov -c -o $OUT/$fuzzer $path
+  go test $tags \
+    -c \
+    -o $OUT/$fuzzer \
+    -v \
+    -covermode=atomic \
+    -coverpkg $fuzzed_repo/...$pkgaddcov \
+    $path
+    function_names_file="$OUT/fuzzer_function_names.json"
+    save_function_name "$fuzzer" "Test${function}Corpus" "$function_names_file"
 else
   # Compile and instrument all Go files relevant to this fuzz target.
   echo "Running go-fuzz $tags -func $function -o $fuzzer.a $path"

--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -215,12 +215,16 @@ function run_go_fuzz_target {
   export FUZZ_CORPUS_DIR="$CORPUS_DIR/${target}/"
   export FUZZ_PROFILE_NAME="$DUMPS_DIR/$target.perf"
 
+  # "NAME" in testdata/fuzz/NAME needs to be the function
+  # name of the fuzz test in the compiled binary. We have
+  # stored that name in $OUT/fuzzer_function_names.json.
+  # We also need this parameter for go-fuzz fuzzers, to
+  # run only the single function. Otherwise, the test may
+  # run other tests that are included in the binary
+  function_names_file="$OUT/fuzzer_function_names.json"
+  function_name=$(get_function_name "$target" "$function_names_file")
+
   if [[ "$(is_std_lib_fuzzer "${target}")" == "true" ]]; then
-    # "NAME" om testdata/fuzz/NAME needs to be the function
-    # name of the fuzz test in the compiled binary. We have
-    # stored that name in $OUT/fuzzer_function_names.json.
-    function_names_file="$OUT/fuzzer_function_names.json"
-    function_name=$(get_function_name "$target" "$function_names_file")
 
     # Create the corpus dir testdata/fuzz/NAME
     mkdir -p "${OUT}/testdata/fuzz/${function_name}"
@@ -245,7 +249,7 @@ function run_go_fuzz_target {
     pushd $OUT
       timeout "$TIMEOUT" \
         "$OUT/$target" \
-        -test.run="$function_name" \
+        -test.run="^${function_name}\$" \
         -test.coverprofile "$DUMPS_DIR/$target.profdata" \
         &> "$LOGS_DIR/$target.log"
       if (( $? != 0 )); then
@@ -264,6 +268,7 @@ function run_go_fuzz_target {
   else
     timeout "$TIMEOUT" \
       "$OUT/$target" \
+      -test.run="^${function_name}\$" \
       -test.coverprofile "$DUMPS_DIR/$target.profdata" \
       &> "$LOGS_DIR/$target.log"
     if (( $? != 0 )); then


### PR DESCRIPTION
This PR does so that the go coverage build only runs the coverage test in the compiled binary. It does so by adding the `-test.run` flag when running go-fuzz fuzzers and by also storing the function name of go-fuzz fuzzers in `$OUT/fuzzer_function_names.json`.  Also, it limits the function name in `-test.run` to be specific to the actual name, since this is a regex and can include other functions depending on how they are named.

This PR also sets the go-fuzz fuzzers' covermode to `atomic` so that all coverage binaries are atomic. This avoids this failure: https://github.com/wadey/gocovmerge/blob/b5bfa59ec0adc420475f97f89b58045c721d761c/gocovmerge.go#L18.

This PR also removes `-run Test${function}Corpus` from `compile_go_fuzzer` since it doesn't do anything. Adding the flag when compiling the binary will not limit the compilation to only the specified test.