### PR TITLE
wasmtime: change the name of the `regalloc2` fuzzer

### DIFF
--- a/projects/wasmtime/build.sh
+++ b/projects/wasmtime/build.sh
@@ -65,7 +65,7 @@ eval $(opam env)
 
 build wasmtime "" "" target
 build wasm-tools wasm-tools- "" target --features wasmtime
-build regalloc2 regalloc2- ion_checker fuzz/target
+build regalloc2 regalloc2- ion fuzz/target
 
 # In coverage builds copy the opam header files into the output so coverage can
 # find the source files.


### PR DESCRIPTION
This change coordinates a name change to `regalloc2`'s fuzz targets introduced in [#244]. The `ion_checker` target is now simply named `ion`.

[#244]: https://github.com/bytecodealliance/regalloc2/pull/244