### PR TITLE
Remove 'drott@chromium.org' from FreeType contributors

### DIFF
--- a/projects/freetype2/project.yaml
+++ b/projects/freetype2/project.yaml
@@ -7,7 +7,6 @@ auto_ccs:
   - "ewaldhew@gmail.com"
   - "apodtele@gmail.com"
   - "prince.cherusker@gmail.com"
-  - "drott@chromium.org"
   - "bungeman@chromium.org"
 vendor_ccs:
   - "jkew@mozilla.com"


### PR DESCRIPTION
I no longer intend to track FreeType security issues as we have moved to Fontations in Chromium.