### PR TITLE
[dbus-broker] bring rustc and bindgen

### DIFF
--- a/projects/dbus-broker/Dockerfile
+++ b/projects/dbus-broker/Dockerfile
@@ -14,7 +14,8 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder-rust
 RUN git clone --depth 1 https://github.com/bus1/dbus-broker
+RUN cargo install bindgen-cli
 WORKDIR dbus-broker
 COPY *.c build.sh $SRC/

--- a/projects/dbus-broker/build.sh
+++ b/projects/dbus-broker/build.sh
@@ -34,9 +34,15 @@ if [[ "$SANITIZER" == introspector ]]; then
 fi
 
 apt-get update -y
+apt-get install -y libclang-dev
 
 if [[ "$ARCHITECTURE" == i386 ]]; then
     apt-get install -y pkg-config:i386
+
+    RUST_TARGET=i686-unknown-linux-gnu
+    rustup target add "$RUST_TARGET"
+    export RUSTC="rustc --target=$RUST_TARGET"
+    export BINDGEN_EXTRA_CLANG_ARGS="--target=$RUST_TARGET"
 else
     apt-get install -y pkg-config
 fi

--- a/projects/dbus-broker/project.yaml
+++ b/projects/dbus-broker/project.yaml
@@ -1,4 +1,3 @@
-disabled: true
 homepage: "https://github.com/bus1/dbus-broker"
 language: c
 primary_contact: "david.rheinsberg@gmail.com"


### PR DESCRIPTION
Now that LLVM and RUSTUP_TOOLCHAIN are bumped it should work.

Closes https://issues.oss-fuzz.com/issues/432299042