### PR TITLE
Revert "[dbus-broker] pin meson to 1.7.2 for now (#13286)"

### DIFF
--- a/projects/dbus-broker/build.sh
+++ b/projects/dbus-broker/build.sh
@@ -56,8 +56,7 @@ if [[ "$SANITIZER" == undefined ]]; then
     MESON_CXXFLAGS+=" $UBSAN_FLAGS"
 fi
 
-# meson is pinned to get around https://github.com/mesonbuild/meson/issues/14533
-pip3 install meson==1.7.2 ninja
+pip3 install meson ninja
 
 if ! CFLAGS="$MESON_CFLAGS" CXXFLAGS="$MESON_CXXFLAGS" LDFLAGS="$MESON_LDFLAGS" meson -Db_lundef=false -Dlauncher=false build; then
     cat build/meson-logs/meson-log.txt


### PR DESCRIPTION
This reverts commit 57fcdcd7b1fb067d2c375a53abbad8d92ca6b8c1.

https://github.com/mesonbuild/meson/issues/14533 was addressed so it should be fine to roll it forward again.