### PR TITLE
projects/libpng: make sure master branch is used

### DIFF
--- a/projects/libpng/Dockerfile
+++ b/projects/libpng/Dockerfile
@@ -19,6 +19,6 @@ RUN apt-get update && \
     apt-get install -y make autoconf automake libtool zlib1g-dev
 
 RUN git clone --depth 1 https://github.com/madler/zlib.git
-RUN git clone --depth 1 https://github.com/pnggroup/libpng.git
+RUN git clone -b master --depth 1 https://github.com/pnggroup/libpng.git
 RUN cp libpng/contrib/oss-fuzz/build.sh $SRC
 WORKDIR libpng


### PR DESCRIPTION
Without this fix:
```
=> [4/6] RUN git clone --depth 1 https://github.com/pnggroup/libpng.git                                                                                                                                                                  1.4s
 => ERROR [5/6] RUN cp libpng/contrib/oss-fuzz/build.sh /src                                                                                                                                                                              0.3s
------
 > [5/6] RUN cp libpng/contrib/oss-fuzz/build.sh /src:
0.280 cp: cannot stat 'libpng/contrib/oss-fuzz/build.sh': No such file or directory
------

 1 warning found (use docker --debug to expand):
 - WorkdirRelativePath: Relative workdir "libpng" can have unexpected results if the base image changes (line 24)
Dockerfile:23
--------------------
  21 |     RUN git clone --depth 1 https://github.com/madler/zlib.git
  22 |     RUN git clone --depth 1 https://github.com/pnggroup/libpng.git
  23 | >>> RUN cp libpng/contrib/oss-fuzz/build.sh $SRC
  24 |     WORKDIR libpng
  25 |
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c cp libpng/contrib/oss-fuzz/build.sh $SRC" did not complete successfully: exit code: 1
```

As far as I can understand, this is probably due to libpng repository changing the default branch to `libpng18` (https://github.com/pnggroup/libpng/tree/libpng18), which does not contain `contrib/oss-fuzz`, but I'm not a maintainer/I'm not involved with libpng at all.