### PR TITLE
ox-ruby: provide absolute path to Ruzzy

### DIFF
--- a/projects/ox-ruby/build.sh
+++ b/projects/ox-ruby/build.sh
@@ -46,7 +46,7 @@ echo "Showing this dir:"
 ls -la \$this_dir
 
 
-ruzzy \$this_dir/fuzz_parse.rb \$@""" > $OUT/fuzz_parse
+/usr/bin/ruzzy \$this_dir/fuzz_parse.rb \$@""" > $OUT/fuzz_parse
 
 chmod +x $OUT/fuzz_parse
 


### PR DESCRIPTION
Ruzzy is located in /usr/bin/* https://github.com/google/oss-fuzz/blob/4b541c7c4d0671a59a9bee4999e6fc4c36483bc1/infra/base-images/base-runner/Dockerfile#L115

It should probably be placed in /usr/local/bin/ similar to the rest of the commands: https://github.com/google/oss-fuzz/blob/4b541c7c4d0671a59a9bee4999e6fc4c36483bc1/infra/base-images/base-runner/Dockerfile#L138

Testing this to see if it works.