### PR TITLE
infra: update ruby integration

### DIFF
--- a/infra/base-images/base-runner/Dockerfile
+++ b/infra/base-images/base-runner/Dockerfile
@@ -112,7 +112,7 @@ RUN /install_javascript.sh && rm /install_javascript.sh
 # Copy built ruby and ruzzy from builder
 COPY --from=base-ruby /usr/local/rvm /usr/local/rvm
 COPY --from=base-ruby /install/ruzzy /install/ruzzy
-COPY ruzzy /usr/bin/ruzzy
+COPY ruzzy /usr/local/bin/ruzzy
 ENV PATH="$PATH:/usr/local/rvm/rubies/ruby-3.3.1/bin"
 # RubyGems installation directory
 ENV GEM_HOME="$OUT/fuzz-gem"

--- a/projects/ox-ruby/build.sh
+++ b/projects/ox-ruby/build.sh
@@ -46,7 +46,7 @@ echo "Showing this dir:"
 ls -la \$this_dir
 
 
-/usr/bin/ruzzy \$this_dir/fuzz_parse.rb \$@""" > $OUT/fuzz_parse
+/usr/local/bin/ruzzy \$this_dir/fuzz_parse.rb \$@""" > $OUT/fuzz_parse
 
 chmod +x $OUT/fuzz_parse
 


### PR DESCRIPTION
Moving the ruzzy runtime to /usr/local/bin/ruzzy in a hope to overcome the runtime issues ox-ruby is having.