### PR TITLE
Fix facebook/time leaphash fuzzing

### DIFF
--- a/projects/time/build.sh
+++ b/projects/time/build.sh
@@ -24,6 +24,7 @@ go get github.com/facebook/time/fbclock/daemon
 
 # FuzzCompute
 sed -i -e '/func TestHashShouldMatch(/,/^}/ s/^/\/\//' leaphash/leaphash_test.go
+sed -i -e '/\"github.com\/stretchr\/testify\/require\"/ s/^/\/\//' leaphash/leaphash_test.go
 
 # FuzzBytesToPacket
 sed -i -e '/func Benchmark.*(/,/^}/ s/^/\/\//' ntp/protocol/ntp_test.go


### PR DESCRIPTION
Fuzzing for facebook/time/leaphash  is broken : https://github.com/facebook/time/actions/runs/18468217446/job/52615356061?pr=476 
Commenting out the test function breaks go build due to an unused import on fuzzing, comment out unnecessary import