### PR TITLE
libcss: add oss-fuzz support for libcss

### DIFF
--- a/projects/libcss/Dockerfile
+++ b/projects/libcss/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN apt-get update && apt-get install -y python3-pip ninja-build
+RUN pip3 install meson
+RUN git clone --depth 1 https://gitlab.collabora.com/libcss/libcss.git libcss
+RUN git clone --depth 1 https://gitlab.collabora.com/libcss/libcss-tests.git libcss-tests
+WORKDIR libcss
+COPY build.sh $SRC/
+
+

--- a/projects/libcss/build.sh
+++ b/projects/libcss/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -eu
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Build libcss and dependencies
+cd $SRC/libcss
+cd build
+meson setup .. --default-library=static
+ninja -j$(nproc)
+ninja install
+cd ../..
+
+
+# Set executable permissions for fuzzer build scripts
+chmod +x $SRC/libcss/test/fuzzers/build_google_oss_fuzzers.sh
+chmod +x $SRC/libcss/test/fuzzers/build_seed_corpus.sh
+
+# Build fuzzers and seed corpus
+$SRC/libcss/test/fuzzers/build_google_oss_fuzzers.sh
+$SRC/libcss/test/fuzzers/build_seed_corpus.sh

--- a/projects/libcss/project.yaml
+++ b/projects/libcss/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://gitlab.collabora.com/libcss"
+primary_contact: "aaron.boxer@collabora.com"
+language: c
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+sanitizers:
+  - address
+  - memory
+  - undefined
+main_repo: 'https://gitlab.collabora.com/libcss/libcss.git'


### PR DESCRIPTION
Libcss is a lightweight, open-source CSS parsing and selection library from the NetSurf project. It processes CSS inputs, handling parsing, preprocessing (e.g., ::cue, ID selectors), and style selection via libcss APIs. Fuzzing libcss is critical due to its exposure to untrusted CSS inputs in multimedia pipelines, where malformed stylesheets could trigger crashes, memory corruption, or undefined behavior. Adding this fuzzer to OSS-Fuzz enhances security by testing the parser against random inputs, covering key functions like css_stylesheet_append_data and css_select_style, and detecting potential vulnerabilities in real-world use cases.

The fuzzer, css_parse_fuzzer.cc, targets the core parsing logic from gstcssparse.c and uses Meson for building libcss and its submodules (libwapcaplet, libparserutils).