### PR TITLE
[wolfssl] add Sean to email list for access

### DIFF
--- a/projects/wolfssl/project.yaml
+++ b/projects/wolfssl/project.yaml
@@ -9,12 +9,12 @@ auto_ccs:
   - "testing@wolfssl.com"
   - "dgarske80@gmail.com"
   - "douzzer@mega.nu"
-  - "guidovranken@gmail.com"
   - "jordan@wolfssl.com"
   - "jordanjphillips1@gmail.com"
   - "anthony@wolfssl.com"
   - "anthony.hu.76@gmail.com"
   - "kareem@wolfssl.com"
+  - "sean@wolfssl.com"
 fuzzing_engines:
   - libfuzzer
   - honggfuzz


### PR DESCRIPTION
I'd like to give Sean (sean (at) wolfssl.com) access to view oss-fuzz reports. I think we have a bad repo link with `https://github.com/guidovranken/fuzzing-headers.git`. Is it okay if I open a PR later with that fix? Not sure yet if we want to host it or rewrite the framework to remove it.