### PR TITLE
arrow: add manual replay build script

### DIFF
--- a/projects/arrow/replay_build.sh
+++ b/projects/arrow/replay_build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eux
-# Copyright 2020 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Automated `replay_build.sh` is failing due to the `build.sh` relying on network connection. This `replay_build.sh` removes usage of this.