### PR TITLE
Fix build breakage caused by #14140.

### DIFF
--- a/infra/build/functions/build_project.py
+++ b/infra/build/functions/build_project.py
@@ -775,14 +775,15 @@ def run_build(oss_fuzz_project,
       'logsBucket': bucket,
       'queueTtl': str(QUEUE_TTL_SECONDS) + 's',
   }
-  return build_lib.run_build(oss_fuzz_project,
-                             build_steps,
-                             credentials,
-                             cloud_project,
-                             timeout,
-                             body_overrides=body_overrides,
-                             tags=tags,
-                             experiment=experiment)
+  build = build_lib.run_build(oss_fuzz_project,
+                              build_steps,
+                              credentials,
+                              cloud_project,
+                              timeout,
+                              body_overrides=body_overrides,
+                              tags=tags,
+                              experiment=experiment)
+  return build['id']
 
 
 def parse_args(description, args):


### PR DESCRIPTION
The return type of `build_lib.run_build` was changed, without changing all the callers. In particular, `build_project.run_build` was expected to still return an ID.

```
> git grep build_project.run_build
infra/build/functions/project_experiment.py:  return build_project.run_build(project_name,
infra/build/functions/request_build.py:  build_id = build_project.run_build(oss_fuzz_project, build_steps, credentials,
infra/build/functions/target_experiment.py:  build_id = build_project.run_build(
infra/build/functions/trial_build.py:      build_ids[project_name] = (build_project.run_build(
infra/build/functions/trial_build_test.py:  @mock.patch('build_project.run_build')
```

Fixes #14153