### PR TITLE
Fix(build): Handle build object from run_build

### DIFF
--- a/infra/build/functions/request_build.py
+++ b/infra/build/functions/request_build.py
@@ -98,10 +98,10 @@ def run_build(oss_fuzz_project,
               update_history=True):
   """Execute build on cloud build. Wrapper around build_project.py that also
   updates the db."""
-  build_id = build_project.run_build(oss_fuzz_project, build_steps, credentials,
-                                     build_type, cloud_project)
+  build = build_project.run_build(oss_fuzz_project, build_steps, credentials,
+                                  build_type, cloud_project)
   if update_history:
-    update_build_history(oss_fuzz_project, build_id, build_type)
+    update_build_history(oss_fuzz_project, build['id'], build_type)
 
 
 # pylint: disable=no-member

--- a/infra/build/functions/target_experiment.py
+++ b/infra/build/functions/target_experiment.py
@@ -267,14 +267,15 @@ def run_experiment(project_name,
   })
 
   credentials, _ = google.auth.default()
-  build_id = build_project.run_build(
-      project_name,
-      steps,
-      credentials,
-      'experiment',
-      experiment=True,
-      extra_tags=[experiment_name, project_name] + tags)
+  build = build_project.run_build(project_name,
+                                  steps,
+                                  credentials,
+                                  'experiment',
+                                  experiment=True,
+                                  extra_tags=[experiment_name, project_name] +
+                                  tags)
 
+  build_id = build['id']
   print('Waiting for build', build_id)
   try:
     build_lib.wait_for_build(build_id, credentials, 'oss-fuzz')


### PR DESCRIPTION
Fixes https://github.com/google/oss-fuzz/issues/14153

## What does this change do?

This change fixes a critical issue that has been preventing OSS-Fuzz projects from building since October 16th. The root cause was a change in the `build_project.run_build` function, which now returns a full build object from the Google Cloud Build API instead of just the build ID string.

The callers of this function were not updated to handle the new return format, resulting in a `google.cloud.ndb.exceptions.BadValueError` when attempting to save the build object to the Datastore, which expected a string.

This fix updates the affected locations to extract the build ID (`build['id']`) from the build object before using it, restoring the build functionality.

## Why is this change necessary?

To fix the build breakage and ensure that OSS-Fuzz projects can be built again.