### PR TITLE
scorecard-web: upgrade tooling

### DIFF
--- a/projects/scorecard-web/build.sh
+++ b/projects/scorecard-web/build.sh
@@ -15,7 +15,5 @@
 #
 ################################################################################
 
-go get github.com/AdamKorcz/go-118-fuzz-build/testing
-
-compile_native_go_fuzzer github.com/ossf/scorecard-webapp/app/server FuzzVerifyWorkflow FuzzVerifyWorkflow
-compile_native_go_fuzzer github.com/ossf/scorecard-webapp/app/server FuzzExtractCertInfo FuzzLoadCertificates
+compile_native_go_fuzzer_v2 github.com/ossf/scorecard-webapp/app/server FuzzVerifyWorkflow FuzzVerifyWorkflow
+compile_native_go_fuzzer_v2 github.com/ossf/scorecard-webapp/app/server FuzzExtractCertInfo FuzzLoadCertificates


### PR DESCRIPTION
use `compile_native_go_fuzzer_v2` instead of `compile_native_go_fuzzer`.