### PR TITLE
go-shlex: upgrade tooling

### DIFF
--- a/projects/go-shlex/build.sh
+++ b/projects/go-shlex/build.sh
@@ -17,7 +17,4 @@
 
 cp $SRC/fuzz_test.go ./
 go mod tidy
-printf "package shlex\nimport _ \"github.com/AdamKorcz/go-118-fuzz-build/testing\"\n" > register.go
-go mod tidy
-echo building
-compile_native_go_fuzzer github.com/google/shlex FuzzLexer FuzzLexer
+compile_native_go_fuzzer_v2 github.com/google/shlex FuzzLexer FuzzLexer


### PR DESCRIPTION
use `compile_native_go_fuzzer_v2` instead of `compile_native_go_fuzzer`