### PR TITLE
Add cary@ilm.com to cc list

### DIFF
--- a/projects/openexr/project.yaml
+++ b/projects/openexr/project.yaml
@@ -2,6 +2,7 @@ homepage: "https://openexr.com"
 language: c++
 primary_contact: "twodeecoda@gmail.com"
 auto_ccs:
+  - "cary@ilm.com"
   - "cbpilm@gmail.com"
   - "security@openexr.org"
 main_repo: 'https://github.com/AcademySoftwareFoundation/openexr'


### PR DESCRIPTION
I am a maintainer of OpenEXR and chair of the project steering committee. cary@ilm.com is my primary mail associated with my github account. cbpilm@gmail.com is a secondary account I would like to deprecate.