### PR TITLE
infra: don't run tests for chronos changes

### DIFF
--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -435,6 +435,7 @@ def run_nonbuild_tests(parallel):
       '--ignore-glob=infra/build/*',
       '--ignore-glob=projects/*',
       '--ignore-glob=infra/experimental/contrib/*',
+      '--ignore-glob=infra/experimental/chronos/*',
   ]
   if parallel:
     command.extend(['-n', 'auto'])


### PR DESCRIPTION
To avoid PRs being blocked by failing tests, as they will be non-related.

Ref: https://github.com/google/oss-fuzz/pull/14194