### PR TITLE
gateway: fix broken fuzzing build by upgrading Golang version.

### DIFF
--- a/projects/gateway/Dockerfile
+++ b/projects/gateway/Dockerfile
@@ -16,15 +16,18 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
 
-RUN wget https://go.dev/dl/go1.25.3.linux-amd64.tar.gz \
-    && mkdir temp-go \
-    && rm -rf /root/.go/* \
-    && tar -C temp-go/ -xzf go1.25.3.linux-amd64.tar.gz \
-    && mv temp-go/go/* /root/.go/ \
-    && rm -rf temp-go go1.25.3.linux-amd64.tar.gz \
-    && apt-get update \
+RUN apt-get update \
     && apt-get install -y btrfs-progs libbtrfs-dev
 
 RUN git clone --depth 1 https://github.com/envoyproxy/gateway.git
+
+RUN cd $SRC/gateway && \
+    GO_VERSION=$(grep -oP '^go \K[0-9]+\.[0-9]+(\.[0-9]+)?' go.mod | head -1) && \
+    wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz && \
+    mkdir temp-go && \
+    rm -rf /root/.go/* && \
+    tar -C temp-go/ -xzf go${GO_VERSION}.linux-amd64.tar.gz && \
+    mv temp-go/go/* /root/.go/ && \
+    rm -rf temp-go go${GO_VERSION}.linux-amd64.tar.gz
 
 COPY build.sh $SRC/


### PR DESCRIPTION
Fixes #14190

After [AdamKorcz](https://github.com/AdamKorcz) suggested checking the dependency installation step in the fuzzing build, I reviewed the build script.

These dependencies are required to build Envoy/Gateway, so we can’t remove them. However, upgrading their Go versions to `1.25.3` resolves the issue. Tested with:

```
python3 infra/helper.py build_image gateway
python3 infra/helper.py build_fuzzers gateway
```
