### PR TITLE
bitcoin: update comment about disable IPC 

### DIFF
--- a/projects/bitcoin-core/build.sh
+++ b/projects/bitcoin-core/build.sh
@@ -39,7 +39,9 @@ export CPPFLAGS="-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -DBOOST_M
 (
   cd depends
   sed -i --regexp-extended '/.*rm -rf .*extract_dir.*/d' ./funcs.mk  # Keep extracted source
-  # Disable IPC pending https://github.com/google/oss-fuzz/pull/13018
+  # Disable IPC until a fuzz test actually needs it
+  # At that point, as workaround can be added to remove capnps
+  # internal oss-fuzz detection: https://github.com/google/oss-fuzz/pull/14203#issuecomment-3461008642
   make HOST=$BUILD_TRIPLET DEBUG=1 NO_QT=1 NO_ZMQ=1 NO_USDT=1 \
        NO_IPC=1 \
        AR=llvm-ar NM=llvm-nm RANLIB=llvm-ranlib STRIP=llvm-strip \


### PR DESCRIPTION
The newer images are usable, however re-enabling IPC means working
around capnps internal oss-fuzz detection. So leave it disabled until a
IPC fuzz test exists.