### PR TITLE
bc-java: fix build

### DIFF
--- a/projects/bc-java/build.sh
+++ b/projects/bc-java/build.sh
@@ -15,7 +15,11 @@
 #
 ################################################################################
 
-$GRADLE jar
+# Set encoding to UTF-8 for Java compilation
+export JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF-8"
+
+# Build only Java 8/11/15 compatible versions, skip Java 21 tasks
+$GRADLE jar -x compileJava21Java -x java21Classes
 find . -name "core*.jar" -exec cp {} $OUT/core.jar \;
 find . -name "bcpkix*.jar" -exec cp {} $OUT/bcpkix.jar \;
 find . -name "bcutil*.jar" -exec cp {} $OUT/bcutil.jar \;
@@ -33,7 +37,7 @@ RUNTIME_CLASSPATH=$(echo $ALL_JARS | xargs printf -- "\$this_dir/%s:"):\$this_di
 
 for fuzzer in $(find $SRC -name '*Fuzzer.java'); do
   fuzzer_basename=$(basename -s .java $fuzzer)
-  javac -cp $BUILD_CLASSPATH $fuzzer
+  javac -encoding UTF-8 -cp $BUILD_CLASSPATH $fuzzer
   cp $SRC/$fuzzer_basename.class $OUT/
 
 


### PR DESCRIPTION
Set UTF-8 encoding for Java compilation and skip Java 21 tasks during build.