### PR TITLE
opentelemtry-go-contrib: use compile_native_go_fuzzer_v2

### DIFF
--- a/projects/opentelemetry-go-contrib/Dockerfile
+++ b/projects/opentelemetry-go-contrib/Dockerfile
@@ -15,6 +15,6 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
-RUN go install github.com/AdamKorcz/go-118-fuzz-build@latest
 RUN git clone --depth 1 https://github.com/open-telemetry/opentelemetry-go-contrib
+WORKDIR $SRC/opentelemetry-go-contrib
 COPY build.sh $SRC/

--- a/projects/opentelemetry-go-contrib/build.sh
+++ b/projects/opentelemetry-go-contrib/build.sh
@@ -15,10 +15,7 @@
 #
 ################################################################################
 
-cd $SRC/opentelemetry-go-contrib
-
 pushd otelconf/v0.3.0
-go get github.com/AdamKorcz/go-118-fuzz-build/testing
-compile_native_go_fuzzer $(go list) FuzzJSON FuzzJSON
-compile_native_go_fuzzer $(go list) FuzzYAML FuzzYAML
+compile_native_go_fuzzer_v2 $(go list) FuzzJSON FuzzJSON
+compile_native_go_fuzzer_v2 $(go list) FuzzYAML FuzzYAML
 popd


### PR DESCRIPTION
Follows https://github.com/google/oss-fuzz/pull/14010 and https://github.com/google/oss-fuzz/pull/13835

Posssibly addresses https://github.com/google/oss-fuzz/pull/14233#issuecomment-3481048089