### PR TITLE
shaderc: add several owners

### DIFF
--- a/projects/shaderc/project.yaml
+++ b/projects/shaderc/project.yaml
@@ -5,6 +5,10 @@ language: c++
 sanitizers:
 - address
 auto_ccs:
-- "fuzzing@fuchsia.dev"
-- "arthur.chan@adalogics.com"
 - "adam@adalogics.com"
+- "arthur.chan@adalogics.com"
+- "dneto@google.com"
+- "dsinclair@google.com"
+- "fuzzing@fuchsia.dev"
+- "nathangauer@google.com"
+- "stevenperron@google.com"


### PR DESCRIPTION
Adds some Googlers participating in the ShaderC maintenance.