### PR TITLE
quiche-cloudflare: do not use specific rust

### DIFF
--- a/projects/quiche-cloudflare/Dockerfile
+++ b/projects/quiche-cloudflare/Dockerfile
@@ -17,6 +17,4 @@ FROM gcr.io/oss-fuzz-base/base-builder-rust
 
 RUN git clone --recursive --depth 1 https://github.com/cloudflare/quiche quiche
 COPY build.sh $SRC/
-ENV RUSTUP_TOOLCHAIN nightly-2025-01-10
-RUN rustup update
 WORKDIR $SRC/quiche


### PR DESCRIPTION
Hoping to fix coverage report

I see 
> Step #5: Coverage error, creating log file: /workspace/out/libfuzzer-coverage-x86_64/fuzzer_stats/packet_recv_server_error.log

in https://oss-fuzz-build-logs.storage.googleapis.com/log-f18ff965-9d36-4598-a47e-0447c5f8895b.txt

Where can I see the contents of packet_recv_server_error.log ?