### PR TITLE
sigstore:fix build

### DIFF
--- a/projects/sigstore/build.sh
+++ b/projects/sigstore/build.sh
@@ -25,6 +25,8 @@ rm go.sum
 cd $SRC/sigstore
 go get github.com/AdaLogics/go-fuzz-headers
 
+sed -i '/cryptoutils\.ValidatePubKey(first)/d' test/fuzz/pem/fuzzcert_test.go
+sed -i '/cryptoutils\.ValidatePubKey(second)/d' test/fuzz/pem/fuzzcert_test.go
 compile_native_go_fuzzer_v2 github.com/sigstore/sigstore/test/fuzz FuzzGetPassword FuzzGetPassword
 compile_native_go_fuzzer_v2 github.com/sigstore/sigstore/test/fuzz/pem FuzzLoadCertificates FuzzLoadCertificates
 compile_native_go_fuzzer_v2 github.com/sigstore/sigstore/test/fuzz/pem FuzzUnmarshalCertificatesFromPEM FuzzUnmarshalCertificatesFromPEM


### PR DESCRIPTION
In file sigstore/test/fuzz/pem/fuzzcert_test. Go `, ` FuzzPublicKey ` function calls the non-existent ` cryptoutils. ValidatePubKey ` function. This function does not exist in the current version of the 'cryptoutils' package, resulting in a compilation error. Moreover, the code logic has already verified the public key through the 'UnmarshalPEMToPublicKey' function, so no additional verification is required. Therefore, it is removed.