### PR TITLE
[envoy] Update internal WORKSPACE file

### DIFF
--- a/projects/envoy/WORKSPACE
+++ b/projects/envoy/WORKSPACE
@@ -12,6 +12,10 @@ load("//bazel:repositories.bzl", "envoy_dependencies")
 
 envoy_dependencies()
 
+load("//bazel:bazel_deps.bzl", "envoy_bazel_dependencies")
+
+envoy_bazel_dependencies()
+
 load("//bazel:repositories_extra.bzl", "envoy_dependencies_extra")
 
 envoy_dependencies_extra(ignore_root_user_error=True)


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/pull/41894 updated Envoy's WORKSPACE file, which caused the following oss-fuzz build error:
```
ERROR: Failed to load Starlark extension '@@bazel_features_version//:version.bzl'.
Cycle in the workspace file detected. This indicates that a repository is used prior to being defined.
The following chain of repository dependencies lead to the missing definition.
 - @@bazel_features_version
This could either mean you have to add the '@@bazel_features_version' repository with a statement like `http_archive` in your WORKSPACE file (note that transitive dependencies are not added automatically), or move an existing definition earlier in your WORKSPACE file.
ERROR: Error computing the main repository mapping: cycles detected during computation of main repo mapping
Computing main repo mapping:
ERROR:__main__:Building fuzzers failed.
```

This fix updates the WORKSPACE files, as is done in https://github.com/envoyproxy/envoy/pull/41894
