### PR TITLE
git ignore: avoid ccaches stored for Chronos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ infra/base-images/base-builder/indexer/fuzzing_engine.a
 # IntelliJ IDEA
 /.idea
 **/*.iml
+
+# Chronos
+ccaches/


### PR DESCRIPTION
We use the `ccaches` folder to store ccaches when testing `replay_build.sh`. We don't want these committed though.