### PR TITLE
xstream:fix build

### DIFF
--- a/projects/xstream/build.sh
+++ b/projects/xstream/build.sh
@@ -18,7 +18,7 @@
 mv $SRC/{*.zip,*.dict} $OUT
 
 MAVEN_ARGS="-DskipTests -Djavac.src.version=15 -Djavac.target.version=15"
-$MVN package org.apache.maven.plugins:maven-shade-plugin:3.2.4:shade $MAVEN_ARGS
+$MVN -pl xstream package org.apache.maven.plugins:maven-shade-plugin:3.2.4:shade $MAVEN_ARGS
 CURRENT_VERSION=$($MVN org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate \
  -Dexpression=project.version -q -DforceStdout)
 cp "xstream/target/xstream-$CURRENT_VERSION.jar" $OUT/xstream.jar


### PR DESCRIPTION
Due to the recent maintenance of this project, the xstream-its module has been reactivated. This module only contains test code and no main artifact. The command "$MVN package org.apache.maven.plugins:maven-shade-plugin:3.2.4:shade $MAVEN_ARGS" attempts to build all modules, resulting in a fuzzing build error.
[https://github.com/x-stream/xstream/commit/15dfc4ea803be549eda331073468126a2b991bfe](url)