### PR TITLE
Change email address to '@pyfound.org' address

### DIFF
--- a/projects/cpython3/project.yaml
+++ b/projects/cpython3/project.yaml
@@ -1,6 +1,6 @@
 homepage: "https://python.org/"
 language: c++
-primary_contact: "seth@python.org"
+primary_contact: "seth.larson@pyfound.org"
 main_repo: "https://github.com/python/cpython"
 auto_ccs:
  - "alex.gaynor@gmail.com"

--- a/projects/python3-libraries/project.yaml
+++ b/projects/python3-libraries/project.yaml
@@ -1,7 +1,7 @@
 homepage: "https://www.python.org/"
 main_repo: "https://github.com/python/cpython"
 language: c
-primary_contact: "seth@python.org"
+primary_contact: "seth.larson@pyfound.org"
 auto_ccs:
  - "greg@krypto.org"
  - "alex.gaynor@gmail.com"


### PR DESCRIPTION
I'm not sure if this has any effect on the OSS-Fuzz issue tracker, but I was unable to sign in with my `@pyfound.org` GSuite address. Maybe this is due to me using the `@python.org` alias for the `pyfound.org` address in the `projects.yaml` configuration? I'm not sure how to get my email address recognized within the OSS-Fuzz issue tracker.