### PR TITLE
crow: fix run_tests.sh

### DIFF
--- a/projects/crow/Dockerfile
+++ b/projects/crow/Dockerfile
@@ -19,5 +19,6 @@ RUN apt-get update && apt-get install -y cmake make libasio-dev
 
 RUN git clone --depth 1 https://github.com/CrowCpp/Crow.git crow
 RUN cp $SRC/crow/tests/fuzz/build.sh $SRC/
+COPY run_tests.sh $SRC/run_tests.sh
 WORKDIR crow
 


### PR DESCRIPTION
```
python3 infra/experimental/chronos/manager.py check-tests --integrity-check crow
...

100% tests passed, 0 tests failed out of 2

Total Test time (real) =  60.80 sec
INFO:__main__:Successfully ran run_tests.sh for project: crow
INFO:__main__:Checking diffing patch for project: crow
Test project /src/crow/build
    Start 1: crow_test
    Start 2: template_test
1/2 Test #2: template_test ....................   Passed    0.55 sec
2/2 Test #1: crow_test ........................   Passed   48.39 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) =  48.40 sec
INFO:__main__:succeeded patch: True
INFO:__main__:run_tests.sh result succeeded: does not patch source control
INFO:__main__:crow test completion succeeded: Duration of run_tests.sh: 112.23 seconds
```