### PR TITLE
base-images: add honggfuzz dependencies

### DIFF
--- a/infra/base-images/base-builder/install_deps_ubuntu-24-04.sh
+++ b/infra/base-images/base-builder/install_deps_ubuntu-24-04.sh
@@ -35,8 +35,7 @@ apt-get update && \
         patchelf \
         rsync \
         subversion \
-        zip \
-        libunwind-dev libblocksruntime-dev # needed for Honggfuzz
+        zip
 
 case $(uname -m) in
     x86_64)


### PR DESCRIPTION
We need libunwind-dev libblocksruntime-dev for ubuntu 24 to work with honggfuzz.