### PR TITLE
fix: Unbreak `neqo` compilation

### DIFF
--- a/projects/neqo/Dockerfile
+++ b/projects/neqo/Dockerfile
@@ -16,23 +16,24 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-rust
 
-RUN git clone --depth 1 https://github.com/nss-dev/nspr $SRC/nspr
-RUN git clone --depth 1 https://github.com/nss-dev/nss $SRC/nss
-RUN git clone --depth 1 https://github.com/mozilla/neqo $SRC/neqo
-RUN ls -l $SRC
-
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        libclang-dev gyp ninja-build python-is-python3 zlib1g-dev \
+        libclang-dev gyp ninja-build python-is-python3 zlib1g-dev mercurial \
         && apt-get autoremove -y && apt-get clean -y \
         && rm -rf /var/lib/apt/lists/*
 
 # We unfortunately need to build NSS from source, because the Debian package
 # in the base distribution is too old.
+RUN hg clone https://hg.mozilla.org/projects/nspr $SRC/nspr
+RUN git clone --depth 1 https://github.com/nss-dev/nss $SRC/nss
+RUN git clone --depth 1 https://github.com/mozilla/neqo $SRC/neqo
 ENV NSS_DIR=$SRC/nss NSS_PREBUILT=1
 
 # FIXME: Optimized NSS build fails with assembler errors.
 # Maybe not critical since the fuzzer uses AeadNull.
-RUN CXX="$CXX -stdlib=libc++" $SRC/nss/build.sh --static --disable-tests
+RUN CXX="$CXX -stdlib=libc++" $NSS_DIR/build.sh --static -Ddisable_tests=1 -Ddisable_dbm=1 -Ddisable_libpkix=1 -Ddisable_ckbi=1 -Ddisable_fips=1
+
+# neqo expects a Release build of NSS, but (see above) that is failing. Work around this.
+RUN ln -s $SRC/dist/Debug $SRC/dist/Release
 
 RUN rustup default nightly
 RUN rustup component add --toolchain nightly rust-src


### PR DESCRIPTION
As described in https://github.com/mozilla/neqo/issues/3147, we made changes to assume a release build of NSS to be present for neqo, which is failing in `oss-fuzz` due to toolchain issues. Work around this.

Also switch to pulling NSPR from the Mercurial repository, as the GitHub mirror is not being updated it seems.

Finally, build NSS like we do for neqo, modulo not doing a release build.