### PR TITLE
libvips: add libjxl dependency

### DIFF
--- a/projects/libvips/Dockerfile
+++ b/projects/libvips/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y \
   curl \
   gettext \
   glib2.0-dev \
+  libbrotli-dev \
   libexpat1-dev \
   libffi-dev \
   libfftw3-dev \
@@ -45,6 +46,7 @@ RUN git clone --depth 1 https://chromium.googlesource.com/webm/libwebp
 RUN git clone --depth 1 https://gitlab.com/libtiff/libtiff.git
 RUN git clone --depth 1 https://aomedia.googlesource.com/aom
 RUN git clone --depth 1 https://github.com/strukturag/libheif.git
+RUN git clone --depth 1 https://github.com/libjxl/libjxl.git
 RUN git clone --depth 1 https://github.com/lovell/libimagequant.git
 RUN git clone --depth 1 https://github.com/dloebl/cgif.git
 RUN git clone --depth 1 https://github.com/google/highway.git


### PR DESCRIPTION
In preparation for https://github.com/libvips/libvips/pull/4743.

This partially reverts commit 890953f0a0029ef889c8c866c674bb8609f90bd0.