### PR TITLE
caffeine: only use fuzzers in the ossfuzz repository

### DIFF
--- a/projects/caffeine/build.sh
+++ b/projects/caffeine/build.sh
@@ -34,7 +34,7 @@ RUNTIME_CLASSPATH=$(echo $ALL_JARS | xargs printf -- "\$this_dir/%s:"):\$this_di
 javac --release 11 -cp $SRC:$BUILD_CLASSPATH -g $SRC/*.java
 cp $SRC/*.class $OUT/
 
-for fuzzer in $(find $SRC -name '*Fuzzer.java'); do
+for fuzzer in $(find $SRC -maxdepth 1 -name '*Fuzzer.java'); do
   fuzzer_basename=$(basename -s .java $fuzzer)
 
   # Create an execution wrapper that executes Jazzer with the correct arguments.


### PR DESCRIPTION
https://issues.oss-fuzz.com/issues/461367396

```console
ERROR: 'FrequencySketchFuzzer' not found on classpath:

/tmp/not-out/tmpoea6rc5f/caffeine.jar::/tmp/not-out/tmpoea6rc5f:/tmp/not-out/tmpoea6rc5f/jazzer_agent_deploy.jar

All required classes must be on the classpath specified via --cp.
```

The error indicates that the build script is finding the test classes in the project.

```console
find $SRC -name '*Fuzzer.java'
/Users/ben/projects/oss-fuzz/projects/caffeine/caffeine/caffeine/src/fuzzTest/java/com/github/benmanes/caffeine/cache/FrequencySketchFuzzer.java
/Users/ben/projects/oss-fuzz/projects/caffeine/caffeine/caffeine/src/fuzzTest/java/com/github/benmanes/caffeine/cache/CaffeineSpecFuzzer.java
/Users/ben/projects/oss-fuzz/projects/caffeine/CaffeineSpecFuzzer.java
```

I believe the fix is to use only the top level directory.

```console
find $SRC -maxdepth 1 -name '*Fuzzer.java'
/Users/ben/projects/oss-fuzz/projects/caffeine/CaffeineSpecFuzzer.java
```

I was unable to run oss-fuzz due to it using amd64 and I am on an arm64 laptop. However this seems safe and correct.