### PR TITLE
airflow: fix build

### DIFF
--- a/projects/airflow/Dockerfile
+++ b/projects/airflow/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y sqlite3
 RUN pip3 install --upgrade pip
 
 RUN git clone --depth 1 https://github.com/apache/airflow $SRC/airflow
+
 WORKDIR airflow
 
 COPY build.sh dag_fuzz.py $SRC/

--- a/projects/airflow/build.sh
+++ b/projects/airflow/build.sh
@@ -20,6 +20,8 @@ cd $SRC/airflow
 pip3 install --upgrade pip
 pip3 install colorlog
 pip3 install ./task-sdk ./airflow-core .
+
 # Build fuzzers in $OUT.
 cd $SRC
-compile_python_fuzzer dag_fuzz.py
+CONFIG_TEMPLATES_PATH=$(python3 -c "import os, airflow; print(os.path.join(os.path.dirname(airflow.__file__), 'config_templates'))")
+compile_python_fuzzer dag_fuzz.py --add-data "$CONFIG_TEMPLATES_PATH:airflow/config_templates" --hidden-import="airflow.utils.log.timezone_aware" --hidden-import="aiosqlite"


### PR DESCRIPTION
The reason for the airflow fuzzing build error is that pip attempts to download airflow-core from PyPI, but cannot find the locally developed version (3.2.0+), thus resulting in the error. The new solution provides the appropriate version of airflow-core to solve the problem by installing./task-sdk,./airflow core and the current directory.