### PR TITLE
[envoy] Update the internal workspace file to include toolchains

### DIFF
--- a/projects/envoy/WORKSPACE
+++ b/projects/envoy/WORKSPACE
@@ -16,14 +16,6 @@ load("//bazel:bazel_deps.bzl", "envoy_bazel_dependencies")
 
 envoy_bazel_dependencies()
 
-load("//bazel:repo.bzl", "envoy_repo")
-
-envoy_repo()
-
-load("//bazel:toolchains.bzl", "envoy_toolchains")
-
-envoy_toolchains()
-
 load("//bazel:repositories_extra.bzl", "envoy_dependencies_extra")
 
 envoy_dependencies_extra(ignore_root_user_error=True)
@@ -35,3 +27,11 @@ envoy_python_dependencies()
 load("//bazel:dependency_imports.bzl", "envoy_dependency_imports")
 
 envoy_dependency_imports()
+
+load("//bazel:repo.bzl", "envoy_repo")
+
+envoy_repo()
+
+load("//bazel:toolchains.bzl", "envoy_toolchains")
+
+envoy_toolchains()


### PR DESCRIPTION
The Envoy fuzzers are currently broken with the following error:
```
ERROR: [0m/root/.cache/bazel/_bazel_root/4e9824db8e7d11820cfa25090ed4ed10/external/rules_fuzzing/fuzzing/tools/BUILD:32:10: While resolving toolchains for target @@rules_fuzzing//fuzzing/tools:make_corpus_dir (a2cc2bf): invalid registered toolchain '@envoy//bazel/rbe/toolchains/configs/linux/clang/config:cc-toolchain-arm64': error loading package 'bazel/rbe/toolchains/configs/linux/clang/config': Unable to find package for @@envoy_repo//:containers.bzl: The repository '@@envoy_repo' could not be resolved: Repository '@@envoy_repo' is not defined.
```

This update is inspired by the changes in https://github.com/envoyproxy/envoy/commit/c175facb013e2e6566a25eb763e30398f12c6104.