### PR TITLE
infra: remove `-pull` from all.sh

### DIFF
--- a/infra/base-images/all.sh
+++ b/infra/base-images/all.sh
@@ -62,7 +62,7 @@ for image_name in ${IMAGE_LIST}; do
   fi
 
   echo "Building ${tag} from ${dockerfile}..."
-  docker build --pull -t "${tag}" -f "${dockerfile}" "${image_dir}"
+  docker build -t "${tag}" -f "${dockerfile}" "${image_dir}"
 done
 
 echo "All builds for version ${VERSION_TAG} completed successfully."


### PR DESCRIPTION
in https://github.com/google/oss-fuzz/pull/13964 `--pull` was added to `docker build`. However, this causes issues when developing the images locally, as we always end up pulling upstream images causing issues when building changes that carry through several base images. Removing `--pull` from this.

Was running into this when debugging https://github.com/google/oss-fuzz/pull/14315