### PR TITLE
fix(infra): Remove local file check in base_images Cloud Function

### DIFF
--- a/infra/build/functions/base_images.py
+++ b/infra/build/functions/base_images.py
@@ -99,11 +99,8 @@ class ImageConfig:
     if self.version != 'legacy':
       versioned_dockerfile = os.path.join(self.path,
                                           f'{self.version}.Dockerfile')
-      if os.path.exists(versioned_dockerfile):
-        logging.info('Using versioned Dockerfile: %s', versioned_dockerfile)
-        return versioned_dockerfile
-      raise FileNotFoundError(
-          f'Versioned Dockerfile not found for {self.name}:{self.version}')
+      logging.info('Using versioned Dockerfile: %s', versioned_dockerfile)
+      return versioned_dockerfile
 
     legacy_dockerfile = os.path.join(self.path, 'Dockerfile')
     logging.info('Using legacy Dockerfile: %s', legacy_dockerfile)


### PR DESCRIPTION
The Cloud Function environment does not include the full repository, so checking for the existence of Dockerfiles locally (os.path.exists) causes a FileNotFoundError and crashes the function.

This change assumes that if a supported version is requested (e.g. ubuntu-20-04), the corresponding Dockerfile exists, which is verified by the project structure.