### PR TITLE
Migrate zlib to Ubuntu 24.04

### DIFF
--- a/projects/zlib/Dockerfile
+++ b/projects/zlib/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone --depth 1 -b develop https://github.com/madler/zlib.git
 WORKDIR zlib

--- a/projects/zlib/project.yaml
+++ b/projects/zlib/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: "ubuntu-24-04"
 homepage: "https://www.zlib.net/"
 language: c++
 primary_contact: "glennrp@gmail.com"


### PR DESCRIPTION
### Summary

This pull request migrates the `zlib` project to use the new `ubuntu-24-04` base image for fuzzing.

### Changes in this PR

1.  **`projects/zlib/project.yaml`**: Sets the `base_os_version` property to `"ubuntu-24-04"`.
2.  **`projects/zlib/Dockerfile`**: Updates the `FROM` instruction.

CC: glennrp@gmail.com, sebpop@gmail.com, cblume@google.com
