### PR TITLE
lz4-java: New project submission

### DIFF
--- a/projects/lz4-java/project.yaml
+++ b/projects/lz4-java/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/yawkat/lz4-java"
+main_repo: "https://github.com/yawkat/lz4-java"
+language: java
+primary_contact: "jonas.konrad@oracle.com"
+auto_ccs:
+  - "me@yawk.at"


### PR DESCRIPTION
I would like to submit my lz4-java fork for OSS-Fuzz.

lz4-java itself has an OSSF criticality score of only 0.56. However it is a [dependency of some important OSS infrastructure](https://mvnrepository.com/artifact/org.lz4/lz4-java/usages), such as hadoop, spark, kafka and netty.

[CVE-2025-12183](https://sites.google.com/sonatype.com/vulnerabilities/cve-2025-12183) was discovered using OSS-Fuzz, but the path was very indirect: A Micronaut fuzz test was exercising a netty class (micronaut depends on netty) which in turn found the bug in lz4-java. Additional local fuzzing of lz4-java found numerous further subtle security issues that were also addressed in the CVE.

The project governance is problematic. The original maintainer was not reachable, and the lz4 organization decided to close the project. My fork is linked [in the README](https://github.com/lz4/lz4-java) as the community continuation of the project. That is why I am submitting my fork, not the original.

The combination of high impact (many people decompress untrusted data), poor security hardening, and demonstrated previous discoveries make an OSS-Fuzz integration sensible, even if circumstances are unusual.

I am not looking for integration awards.