### PR TITLE
maven: fix build

### DIFF
--- a/projects/maven/Dockerfile
+++ b/projects/maven/Dockerfile
@@ -16,11 +16,11 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 
-RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip -o maven.zip && \
-unzip maven.zip -d $SRC/maven-3.6.3 && \
+RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.zip -o maven.zip && \
+unzip maven.zip -d $SRC/maven-3.8.8 && \
 rm -rf maven.zip
 
-ENV MVN $SRC/maven-3.6.3/apache-maven-3.6.3/bin/mvn
+ENV MVN $SRC/maven-3.8.8/apache-maven-3.8.8/bin/mvn
 
 WORKDIR ${SRC}
 #


### PR DESCRIPTION
The Maven plugin of JAPicm-Maven-Plugin used in the project, version 0.25.0, requires that the Maven version be at least 3.8.1. The Maven 3.6.3 currently in use does not meet this requirement, resulting in the failure of the build.