### PR TITLE
Migrate serenity to Ubuntu 24.04

### DIFF
--- a/projects/serenity/Dockerfile
+++ b/projects/serenity/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y build-essential cmake curl ninja-build
 RUN git clone https://github.com/SerenityOS/serenity
 COPY build.sh $SRC/

--- a/projects/serenity/project.yaml
+++ b/projects/serenity/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: "ubuntu-24-04"
 homepage: "https://github.com/SerenityOS/serenity"
 language: c++
 primary_contact: "jelle@gmta.nl"


### PR DESCRIPTION
### Summary

This pull request migrates the `serenity` project to use the new `ubuntu-24-04` base image for fuzzing.

### Changes in this PR

1.  **`projects/serenity/project.yaml`**: Sets the `base_os_version` property to `"ubuntu-24-04"`.
2.  **`projects/serenity/Dockerfile`**: Updates the `FROM` instruction.

CC: jelle@gmta.nl, david@adalogics.com, mail@linusgroh.de, ali.mpfard@gmail.com, luke.wilde@live.co.uk, bugaevc@serenityos.org, b.gianfo@gmail.com, idan.horowitz@gmail.com, timledbetter@gmail.com, thakis@chromium.org, lucas.chollet@serenityos.org
