### PR TITLE
Migrate javaparser to Ubuntu 24.04

### DIFF
--- a/projects/javaparser/Dockerfile
+++ b/projects/javaparser/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04-jvm
 
 RUN apt-get update && apt-get install -y maven
 

--- a/projects/javaparser/project.yaml
+++ b/projects/javaparser/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://javaparser.org"
 language: jvm
 primary_contact: "MysterAitch@users.noreply.github.com"


### PR DESCRIPTION
### Summary

This pull request migrates the `javaparser` project to use the new `ubuntu-24-04` base image for fuzzing.

### Changes in this PR

1.  **`projects/javaparser/project.yaml`**: Sets the `base_os_version` property to `ubuntu-24-04`.
2.  **`projects/javaparser/Dockerfile`**: Updates the `FROM` instruction.

CC: MysterAitch@users.noreply.github.com, p.antoine@catenacyber.fr, jean-pierre.lerbscher@jperf.com
