### PR TITLE
Migrate unicorn to Ubuntu 24.04

### DIFF
--- a/projects/unicorn/Dockerfile
+++ b/projects/unicorn/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y cmake pkg-config make python3
 RUN git clone -b dev --depth 1 https://github.com/unicorn-engine/unicorn.git
 WORKDIR $SRC

--- a/projects/unicorn/project.yaml
+++ b/projects/unicorn/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://www.unicorn-engine.org"
 language: c++
 primary_contact: "unicorn.emu@gmail.com"


### PR DESCRIPTION
### Summary

This pull request migrates the `unicorn` project to use the new `ubuntu-24-04` base image for fuzzing.

### Changes in this PR

1.  **`projects/unicorn/project.yaml`**: Sets the `base_os_version` property to `ubuntu-24-04`.
2.  **`projects/unicorn/Dockerfile`**: Updates the `FROM` instruction.

CC: unicorn.emu@gmail.com, p.antoine@catenacyber.fr, ch980501427@gmail.com, stalkr@stalkr.net, mio@lazym.io
