### PR TITLE
Migrate gopacket to Ubuntu 24.04

### DIFF
--- a/projects/gopacket/Dockerfile
+++ b/projects/gopacket/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-go
+FROM gcr.io/oss-fuzz-base/base-builder-go:ubuntu-24-04
 RUN git clone https://github.com/google/gopacket.git
 
 COPY build.sh $SRC/

--- a/projects/gopacket/project.yaml
+++ b/projects/gopacket/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/google/gopacket"
 primary_contact: "gconnell@google.com"
 auto_ccs :


### PR DESCRIPTION
### Summary

This pull request migrates the `gopacket` project to use the new `ubuntu-24-04` base image for fuzzing.

### Changes in this PR

1.  **`projects/gopacket/project.yaml`**: Sets the `base_os_version` property to `ubuntu-24-04`.
2.  **`projects/gopacket/Dockerfile`**: Updates the `FROM` instruction.

CC: gconnell@google.com
