### PR TITLE
Migrate go-json-iterator to Ubuntu 24.04

### DIFF
--- a/projects/go-json-iterator/Dockerfile
+++ b/projects/go-json-iterator/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-go
+FROM gcr.io/oss-fuzz-base/base-builder-go:ubuntu-24-04
 RUN git clone https://github.com/json-iterator/go json-iterator
 
 COPY fuzz_json.go $SRC/json-iterator/

--- a/projects/go-json-iterator/project.yaml
+++ b/projects/go-json-iterator/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://jsoniter.com"
 main_repo: "https://github.com/json-iterator/go"
 primary_contact: "taowen@gmail.com"


### PR DESCRIPTION
### Summary

This pull request migrates the `go-json-iterator` project to use the new `ubuntu-24-04` base image for fuzzing.

### Changes in this PR

1.  **`projects/go-json-iterator/project.yaml`**: Sets the `base_os_version` property to `ubuntu-24-04`.
2.  **`projects/go-json-iterator/Dockerfile`**: Updates the `FROM` instruction.

CC: taowen@gmail.com
