### PR TITLE
Migrate curl to Ubuntu 24.04

### DIFF
--- a/projects/curl/Dockerfile
+++ b/projects/curl/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 
 RUN git clone --depth 1 https://github.com/curl/curl.git /src/curl
 RUN git clone --depth 1 https://github.com/curl/curl-fuzzer.git /src/curl_fuzzer

--- a/projects/curl/project.yaml
+++ b/projects/curl/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://curl.haxx.se/"
 language: c++
 primary_contact: "daniel@haxx.se"


### PR DESCRIPTION
### Summary

This pull request migrates the `curl` project to use the new `ubuntu-24-04` base image for fuzzing.

### Changes in this PR

1.  **`projects/curl/project.yaml`**: Sets the `base_os_version` property to `ubuntu-24-04`.
2.  **`projects/curl/Dockerfile`**: Updates the `FROM` instruction.

CC: daniel@haxx.se, daniel.haxx@gmail.com, cmeister2@gmail.com, stefan.eissing@gmail.com
