### PR TITLE
Migrate metadata-extractor to Ubuntu 24.04

### DIFF
--- a/projects/metadata-extractor/Dockerfile
+++ b/projects/metadata-extractor/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \

--- a/projects/metadata-extractor/project.yaml
+++ b/projects/metadata-extractor/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/drewnoakes/metadata-extractor"
 language: jvm
 primary_contact: ""


### PR DESCRIPTION
### Summary

This pull request migrates the `metadata-extractor` project to use the new `ubuntu-24-04` base image for fuzzing.

### Changes in this PR

1.  **`projects/metadata-extractor/project.yaml`**: Sets the `base_os_version` property to `ubuntu-24-04`.
2.  **`projects/metadata-extractor/Dockerfile`**: Updates the `FROM` instruction.

CC: 
