### PR TITLE
Migrate CIFuzz and ClusterFuzzLite to Ubuntu 24.04

### DIFF
--- a/docs/getting-started/continuous_integration.md
+++ b/docs/getting-started/continuous_integration.md
@@ -234,6 +234,21 @@ You can checkout CIFuzz configs for OSS-Fuzz projects. Example -
 [systemd](https://github.com/systemd/systemd/blob/main/.github/workflows/cifuzz.yml),
 [curl](https://github.com/curl/curl/blob/master/.github/workflows/fuzz.yml).
 
+## Ubuntu 24.04 Support
+
+CIFuzz supports building and running fuzzers in an Ubuntu 24.04 environment.
+Existing projects will continue to use the legacy environment (Ubuntu 20.04) by default,
+preserving current behavior.
+
+To migrate your project to Ubuntu 24.04, add the following line to your `project.yaml`:
+
+```yaml
+base_os_version: ubuntu-24-04
+```
+
+For OSS-Fuzz projects, this file is located at `projects/<project_name>/project.yaml`.
+For external projects (ClusterFuzzLite), this file is typically located at `.clusterfuzzlite/project.yaml`.
+
 ## Understanding results
 
 The results of CIFuzz can be found in two different places.

--- a/infra/build_fuzzers.ubuntu-24-04.Dockerfile
+++ b/infra/build_fuzzers.ubuntu-24-04.Dockerfile
@@ -1,0 +1,31 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+# Docker image to run fuzzers for CIFuzz (the run_fuzzers action on GitHub
+# actions).
+
+FROM gcr.io/oss-fuzz-base/cifuzz-base:ubuntu-24-04
+
+# Python file to execute when the docker container starts up
+# We can't use the env var $OSS_FUZZ_ROOT here. Since it's a constant env var,
+# just expand to '/opt/oss-fuzz'.
+ENTRYPOINT ["python3", "/opt/oss-fuzz/infra/cifuzz/build_fuzzers_entrypoint.py"]
+
+WORKDIR ${OSS_FUZZ_ROOT}/infra
+
+# Update infra source code.
+ADD . ${OSS_FUZZ_ROOT}/infra
+
+RUN python3 -m pip install -r ${OSS_FUZZ_ROOT}/infra/cifuzz/requirements.txt

--- a/infra/cifuzz/build-images.sh
+++ b/infra/cifuzz/build-images.sh
@@ -22,6 +22,7 @@ OSS_FUZZ_ROOT=$(realpath $INFRA_DIR/..)
 
 # Build cifuzz-base.
 docker build --tag gcr.io/oss-fuzz-base/cifuzz-base --file $CIFUZZ_DIR/cifuzz-base/Dockerfile $OSS_FUZZ_ROOT
+docker build --tag gcr.io/oss-fuzz-base/cifuzz-base:ubuntu-24-04 --file $CIFUZZ_DIR/cifuzz-base/ubuntu-24-04.Dockerfile $OSS_FUZZ_ROOT
 
 # Build run-fuzzers and build-fuzzers images.
 docker build \
@@ -29,6 +30,14 @@ docker build \
   --tag gcr.io/oss-fuzz-base/clusterfuzzlite-build-fuzzers:v1 \
   --file $INFRA_DIR/build_fuzzers.Dockerfile $INFRA_DIR
 docker build \
+  --tag gcr.io/oss-fuzz-base/clusterfuzzlite-build-fuzzers-test:ubuntu-24-04-v1 \
+  --tag gcr.io/oss-fuzz-base/clusterfuzzlite-build-fuzzers:ubuntu-24-04-v1 \
+  --file $INFRA_DIR/build_fuzzers.ubuntu-24-04.Dockerfile $INFRA_DIR
+docker build \
   --tag gcr.io/oss-fuzz-base/clusterfuzzlite-run-fuzzers:v1 \
   --tag gcr.io/oss-fuzz-base/clusterfuzzlite-run-fuzzers-test:v1 \
   --file $INFRA_DIR/run_fuzzers.Dockerfile $INFRA_DIR
+docker build \
+  --tag gcr.io/oss-fuzz-base/clusterfuzzlite-run-fuzzers:ubuntu-24-04-v1 \
+  --tag gcr.io/oss-fuzz-base/clusterfuzzlite-run-fuzzers-test:ubuntu-24-04-v1 \
+  --file $INFRA_DIR/run_fuzzers.ubuntu-24-04.Dockerfile $INFRA_DIR

--- a/infra/cifuzz/build_fuzzers_entrypoint.py
+++ b/infra/cifuzz/build_fuzzers_entrypoint.py
@@ -29,6 +29,13 @@ def build_fuzzers_entrypoint():
   """Builds OSS-Fuzz project's fuzzers for CI tools."""
   config = config_utils.BuildFuzzersConfig()
 
+  if config.base_os_version == 'ubuntu-24-04':
+    result = config_utils.pivot_to_ubuntu_24_04(
+        'build-fuzzers',
+        '/opt/oss-fuzz/infra/cifuzz/build_fuzzers_entrypoint.py')
+    if result is not None:
+      return result
+
   if config.dry_run:
     # Sets the default return code on error to success.
     returncode = 0

--- a/infra/cifuzz/cifuzz-base/ubuntu-24-04.Dockerfile
+++ b/infra/cifuzz/cifuzz-base/ubuntu-24-04.Dockerfile
@@ -1,0 +1,44 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-runner:ubuntu-24-04
+
+RUN apt-get update && \
+    apt-get install -y systemd && \
+    wget https://download.docker.com/linux/ubuntu/dists/noble/pool/stable/amd64/docker-ce-cli_26.0.0-1~ubuntu.24.04~noble_amd64.deb -O /tmp/docker-ce.deb && \
+    dpkg -i /tmp/docker-ce.deb && \
+    rm /tmp/docker-ce.deb
+
+ENV PATH=/opt/gcloud/google-cloud-sdk/bin/:$PATH
+ENV OSS_FUZZ_ROOT=/opt/oss-fuzz
+
+# Do this step before copying to make rebuilding faster when developing.
+COPY ./infra/cifuzz/requirements.txt /tmp/requirements.txt
+RUN python3 -m pip install -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
+ADD . ${OSS_FUZZ_ROOT}
+# Don't use the default npm location since jazzer.js can break us.
+# This means javascript needed by cifuzz/clusterfuzzlite must be executed in
+# OSS_FUZZ_ROOT.
+RUN cd ${OSS_FUZZ_ROOT} && npm install ${OSS_FUZZ_ROOT}/infra/cifuzz
+
+
+ENV PYTHONUNBUFFERED=1
+
+# Python file to execute when the docker container starts up.
+# We can't use the env var $OSS_FUZZ_ROOT here. Since it's a constant env var,
+# just expand to '/opt/oss-fuzz'.
+ENTRYPOINT ["python3", "/opt/oss-fuzz/infra/cifuzz/cifuzz_combined_entrypoint.py"]

--- a/infra/cifuzz/cloudbuild.yaml
+++ b/infra/cifuzz/cloudbuild.yaml
@@ -38,6 +38,34 @@ steps:
   - '-f'
   - infra/run_fuzzers.Dockerfile
   - infra
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - build
+  - '-t'
+  - gcr.io/oss-fuzz-base/cifuzz-base:ubuntu-24-04-v1
+  - '-f'
+  - infra/cifuzz/cifuzz-base/ubuntu-24-04.Dockerfile
+  - .
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - build
+  - '-t'
+  - gcr.io/oss-fuzz-base/clusterfuzzlite-build-fuzzers:ubuntu-24-04-v1
+  - '-t'
+  - gcr.io/oss-fuzz-base/cifuzz-build-fuzzers:ubuntu-24-04-v1
+  - '-f'
+  - infra/build_fuzzers.ubuntu-24-04.Dockerfile
+  - infra
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - build
+  - '-t'
+  - gcr.io/oss-fuzz-base/clusterfuzzlite-run-fuzzers:ubuntu-24-04-v1
+  - '-t'
+  - gcr.io/oss-fuzz-base/cifuzz-run-fuzzers:ubuntu-24-04-v1
+  - '-f'
+  - infra/run_fuzzers.ubuntu-24-04.Dockerfile
+  - infra
 images:
 - gcr.io/oss-fuzz-base/cifuzz-base
 - gcr.io/oss-fuzz-base/cifuzz-base:v1
@@ -49,4 +77,9 @@ images:
 - gcr.io/oss-fuzz-base/clusterfuzzlite-build-fuzzers:v1
 - gcr.io/oss-fuzz-base/clusterfuzzlite-run-fuzzers
 - gcr.io/oss-fuzz-base/clusterfuzzlite-run-fuzzers:v1
+- gcr.io/oss-fuzz-base/cifuzz-base:ubuntu-24-04-v1
+- gcr.io/oss-fuzz-base/cifuzz-run-fuzzers:ubuntu-24-04-v1
+- gcr.io/oss-fuzz-base/cifuzz-build-fuzzers:ubuntu-24-04-v1
+- gcr.io/oss-fuzz-base/clusterfuzzlite-run-fuzzers:ubuntu-24-04-v1
+- gcr.io/oss-fuzz-base/clusterfuzzlite-build-fuzzers:ubuntu-24-04-v1
 timeout: 1800s

--- a/infra/cifuzz/config_utils.py
+++ b/infra/cifuzz/config_utils.py
@@ -229,7 +229,7 @@ class BaseConfig:
 def pivot_to_ubuntu_24_04(image_suffix, script_path, check_result=True):
   """Pivots execution to an Ubuntu 24.04 container if needed."""
   with open('/etc/os-release') as file_handle:
-    if 'Noble Numbat' not in file_handle.read():
+    if '24.04' not in file_handle.read():
       logging.info(
           'Base OS version is Ubuntu 24.04, but running in a different OS. Pivoting to Ubuntu 24.04 container.'
       )

--- a/infra/cifuzz/config_utils.py
+++ b/infra/cifuzz/config_utils.py
@@ -26,8 +26,11 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import platform_config
 import constants
+import re
+import subprocess
 
 SANITIZERS = ['address', 'memory', 'undefined', 'coverage']
+BASE_OS_VERSION_REGEX = re.compile(r'\s*base_os_version\s*:\s*([^\s]+)')
 
 # TODO(metzman): Set these on config objects so there's one source of truth.
 DEFAULT_ENGINE = 'libfuzzer'
@@ -195,6 +198,72 @@ class BaseConfig:
     """Returns True if this CIFuzz run (building fuzzers and running them) for
     generating a coverage report."""
     return self.sanitizer == 'coverage'
+
+  @property
+  def base_os_version(self):
+    """Returns the project's base OS version."""
+    if self.oss_fuzz_project_name:
+      # Internal/OSS-Fuzz project.
+      project_yaml_path = os.path.join('/opt/oss-fuzz/projects',
+                                       self.oss_fuzz_project_name,
+                                       'project.yaml')
+    else:
+      # External project.
+      project_yaml_path = os.path.join(self.project_src_path,
+                                       self.build_integration_path,
+                                       'project.yaml')
+
+    if not os.path.exists(project_yaml_path):
+      return 'legacy'
+
+    with open(project_yaml_path) as file_handle:
+      content = file_handle.read()
+      for line in content.splitlines():
+        match = BASE_OS_VERSION_REGEX.match(line)
+        if match:
+          return match.group(1).strip('\'"')
+
+    return 'legacy'
+
+
+def pivot_to_ubuntu_24_04(image_suffix, script_path, check_result=True):
+  """Pivots execution to an Ubuntu 24.04 container if needed."""
+  with open('/etc/os-release') as file_handle:
+    if 'Noble Numbat' not in file_handle.read():
+      logging.info(
+          'Base OS version is Ubuntu 24.04, but running in a different OS. Pivoting to Ubuntu 24.04 container.'
+      )
+      env = os.environ.copy()
+      # Ensure we don't loop indefinitely.
+      env['CIFUZZ_PIVOTED'] = '1'
+      command = [
+          'docker', 'run', '--rm', '--privileged', '--volumes-from',
+          os.environ.get('HOSTNAME', ''), '-e', 'CIFUZZ_PIVOTED=1'
+      ]
+      # Propagate environment variables.
+      for key, value in os.environ.items():
+        command.extend(['-e', f'{key}={value}'])
+
+      # Use the ubuntu-24-04 version of the image.
+      command.append('--entrypoint')
+      command.append('python3')
+      command.append(
+          f'gcr.io/oss-fuzz-base/clusterfuzzlite-{image_suffix}:ubuntu-24-04-v1'
+      )
+
+      # Run the same command.
+      command.append(script_path)
+
+      if check_result:
+        subprocess.check_call(command)
+        return 0
+      else:
+        try:
+          subprocess.check_call(command)
+        except subprocess.CalledProcessError as e:
+          return e.returncode
+        return 0
+  return None
 
 
 def _get_platform_config(cfl_platform):

--- a/infra/cifuzz/config_utils_test.py
+++ b/infra/cifuzz/config_utils_test.py
@@ -28,6 +28,7 @@ class BaseConfigTest(unittest.TestCase):
 
   def setUp(self):
     test_helpers.patch_environ(self)
+    os.environ['CIFUZZ_TEST'] = '1'
 
   def _create_config(self):
     return config_utils.BuildFuzzersConfig()
@@ -95,12 +96,48 @@ class BaseConfigTest(unittest.TestCase):
     config = self._create_config()
     self.assertTrue(config.validate())
 
+  def test_base_os_version_external(self):
+    """Tests that base_os_version is read correctly for external projects."""
+    os.environ['PROJECT_SRC_PATH'] = '/src'
+    # Use patch to mock os.path.exists and open for the project.yaml
+    with mock.patch('os.path.exists', return_value=True) as mock_exists:
+      with mock.patch(
+          'builtins.open',
+          mock.mock_open(
+              read_data='base_os_version: ubuntu-24-04')) as mock_open:
+        config = self._create_config()
+        self.assertEqual(config.base_os_version, 'ubuntu-24-04')
+        # Verify it looked in the right place (PROJECT_SRC_PATH + .clusterfuzzlite)
+        expected_path = os.path.join('/src', '.clusterfuzzlite', 'project.yaml')
+        # We can't easily check the exact path without more mocking, but we can check it was called
+        mock_open.assert_called()
+
+  def test_base_os_version_external_quoted(self):
+    """Tests that base_os_version handles quoted values for external projects."""
+    os.environ['PROJECT_SRC_PATH'] = '/src'
+    # Use patch to mock os.path.exists and open for the project.yaml
+    with mock.patch('os.path.exists', return_value=True) as mock_exists:
+      with mock.patch(
+          'builtins.open',
+          mock.mock_open(
+              read_data='base_os_version: "ubuntu-24-04"')) as mock_open:
+        config = self._create_config()
+        self.assertEqual(config.base_os_version, 'ubuntu-24-04')
+
+  def test_base_os_version_default(self):
+    """Tests that base_os_version defaults to legacy if not present."""
+    os.environ['PROJECT_SRC_PATH'] = '/src'
+    with mock.patch('os.path.exists', return_value=False):
+      config = self._create_config()
+      self.assertEqual(config.base_os_version, 'legacy')
+
 
 class BuildFuzzersConfigTest(unittest.TestCase):
   """Tests for BuildFuzzersConfig."""
 
   def setUp(self):
     test_helpers.patch_environ(self)
+    os.environ['CIFUZZ_TEST'] = '1'
 
   def _create_config(self):
     return config_utils.BuildFuzzersConfig()
@@ -140,6 +177,7 @@ class RunFuzzersConfigTest(unittest.TestCase):
 
   def setUp(self):
     test_helpers.patch_environ(self)
+    os.environ['CIFUZZ_TEST'] = '1'
 
   def _create_config(self):
     return config_utils.RunFuzzersConfig()

--- a/infra/cifuzz/run_fuzzers_entrypoint.py
+++ b/infra/cifuzz/run_fuzzers_entrypoint.py
@@ -52,6 +52,15 @@ def run_fuzzers_entrypoint():
   This action can be added to any OSS-Fuzz project's workflow that uses
   Github."""
   config = config_utils.RunFuzzersConfig()
+
+  if config.base_os_version == 'ubuntu-24-04':
+    result = config_utils.pivot_to_ubuntu_24_04(
+        'run-fuzzers',
+        '/opt/oss-fuzz/infra/cifuzz/run_fuzzers_entrypoint.py',
+        check_result=not config.dry_run)
+    if result is not None:
+      return result
+
   # The default return code when an error occurs.
   returncode = 1
   if config.dry_run:

--- a/infra/run_fuzzers.ubuntu-24-04.Dockerfile
+++ b/infra/run_fuzzers.ubuntu-24-04.Dockerfile
@@ -1,0 +1,31 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+# Docker image for running fuzzers on CIFuzz (the run_fuzzers action on GitHub
+# actions).
+
+FROM gcr.io/oss-fuzz-base/cifuzz-base:ubuntu-24-04
+
+# Python file to execute when the docker container starts up.
+# We can't use the env var $OSS_FUZZ_ROOT here. Since it's a constant env var,
+# just expand to '/opt/oss-fuzz'.
+ENTRYPOINT ["python3", "/opt/oss-fuzz/infra/cifuzz/run_fuzzers_entrypoint.py"]
+
+WORKDIR ${OSS_FUZZ_ROOT}/infra
+
+# Copy infra source code.
+ADD . ${OSS_FUZZ_ROOT}/infra
+
+RUN python3 -m pip install -r ${OSS_FUZZ_ROOT}/infra/cifuzz/requirements.txt


### PR DESCRIPTION
## Description
This PR migrates CIFuzz and ClusterFuzzLite to support Ubuntu 24.04. This allows projects to opt-in to a newer build environment by adding `base_os_version: ubuntu-24-04` to their `project.yaml`.

## Changes
- Created new Dockerfiles for Ubuntu 24.04 support:
    - `infra/cifuzz/cifuzz-base/ubuntu-24-04.Dockerfile`
    - `infra/build_fuzzers.ubuntu-24-04.Dockerfile`
    - `infra/run_fuzzers.ubuntu-24-04.Dockerfile`
- Updated `infra/cifuzz/build-images.sh` to build the new images.
- Updated `infra/cifuzz/build_fuzzers_entrypoint.py` and `infra/cifuzz/run_fuzzers_entrypoint.py` to support pivoting to Ubuntu 24.04.
- Updated `infra/cifuzz/config_utils.py` to handle the new base OS version.
- Updated documentation in `docs/getting-started/continuous_integration.md`.

## Evidence
Verified the changes by running an external project (zlib) with Ubuntu 24.04.

### Build Log Snippet (Ubuntu 24.04)
```
=> [internal] load metadata for gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
...
=> [5/5] COPY run_tests.sh build.sh *_fuzzer.c* /src/
...
Exit code: 0
```

### Run Log Snippet
```
#3554   NEW    cov: 609 ft: 2821 corp: 466/57Mb lim: 933840 exec/s: 57 rss: 139Mb L: 195443/933840 MS: 3 InsertByte-ChangeASCIIInt-PersAutoDict- DE: "P?\000\000"-
...
```
