### PR TITLE
glib: Re-enable memory sanitizer

### DIFF
--- a/projects/glib/0001-deflate-Zero-initialise-the-prev-and-window-buffers.patch
+++ b/projects/glib/0001-deflate-Zero-initialise-the-prev-and-window-buffers.patch
@@ -1,0 +1,49 @@
+From 73aa394ed2e45876945ae90d1e2fd0fb0dfb84b7 Mon Sep 17 00:00:00 2001
+From: Philip Withnall <pwithnall@gnome.org>
+Date: Mon, 1 Dec 2025 19:16:55 +0000
+Subject: [PATCH] deflate: Zero-initialise the prev and window buffers
+
+This is the combination of patches:
+ - https://github.com/chromium/chromium/blob/main/third_party/zlib/patches/0003-uninitializedjump.patch
+ - https://github.com/chromium/chromium/blob/main/third_party/zlib/patches/0007-zero-init-deflate-window.patch
+ - https://github.com/chromium/chromium/blob/main/third_party/zlib/patches/0017-deflate-move-zmemzero-after-null-check.patch
+
+authored by Adenilson Cavalcanti, Hans Wennborg and pedro martelletto
+for Chromium.
+
+They needed to be combined and re-rolled as a patch to avoid having to
+apply all the other Chromium zlib patches so they would apply properly.
+
+They fix some msan errors from deflate which have been reported to zlib
+upstream but not fixed yet. See the original patches for details.
+
+Also clear the `head` and `pending_buf` buffers similarly (my own
+changes).
+---
+ deflate.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/deflate.c b/deflate.c
+index 012ea81..e626727 100644
+--- a/deflate.c
++++ b/deflate.c
+@@ -503,6 +503,16 @@ int ZEXPORT deflateInit2_(z_streamp strm, int level, int method,
+         deflateEnd (strm);
+         return Z_MEM_ERROR;
+     }
++    /* Avoid use of unitialized values in the window, see crbug.com/1137613 and
++     * crbug.com/1144420 */
++    zmemzero(s->window, s->w_size * (2 * sizeof(Byte)));
++    /* Avoid use of uninitialized value, see:
++     * https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=11360
++     */
++    zmemzero(s->prev, s->w_size * sizeof(Pos));
++    /* Same for the other buffers */
++    zmemzero(s->head, s->hash_size * sizeof(Pos));
++    zmemzero(s->pending_buf, s->lit_bufsize * LIT_BUFS);
+ #ifdef LIT_MEM
+     s->d_buf = (ushf *)(s->pending_buf + (s->lit_bufsize << 1));
+     s->l_buf = s->pending_buf + (s->lit_bufsize << 2);
+-- 
+2.51.1
+

--- a/projects/glib/Dockerfile
+++ b/projects/glib/Dockerfile
@@ -15,8 +15,10 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y python3-pip
+RUN apt-get update && apt-get install -y autoconf automake libtool pkg-config python3-pip
 RUN unset CFLAGS CXXFLAGS && pip3 install -U meson ninja packaging
-RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/glib
+RUN git clone --depth 1 --branch v1.3.1 --no-tags https://github.com/madler/zlib.git
+RUN git clone --depth 1 --no-tags https://gitlab.gnome.org/GNOME/glib
 WORKDIR glib
 COPY build.sh $SRC/
+COPY 0001-deflate-Zero-initialise-the-prev-and-window-buffers.patch $SRC/

--- a/projects/glib/project.yaml
+++ b/projects/glib/project.yaml
@@ -11,8 +11,7 @@ auto_ccs:
 - tcullum@redhat.com
 sanitizers:
 - address
+- memory
 - undefined
-# Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
-#  - memory
 help_url: https://gitlab.gnome.org/GNOME/glib/tree/master/fuzzing#how-to-reproduce-oss-fuzz-bugs-locally
 main_repo: 'https://gitlab.gnome.org/GNOME/glib'


### PR DESCRIPTION
Let’s try it out and see if it works again for GLib now.