### PR TITLE
Migrate fastjson2 to Ubuntu 24.04

### DIFF
--- a/projects/fastjson2/Dockerfile
+++ b/projects/fastjson2/Dockerfile
@@ -15,7 +15,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 RUN apt-get update && apt-get install -y maven
 
 RUN git clone --depth 1 https://github.com/google/fuzzing && \

--- a/projects/fastjson2/project.yaml
+++ b/projects/fastjson2/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/alibaba/fastjson2"
 language: jvm
 primary_contact: "shaojin.wensj@alibaba-inc.com"


### PR DESCRIPTION
### Summary

This pull request migrates the `fastjson2` project to use the new `ubuntu-24-04` base image for fuzzing.

### Changes in this PR

1.  **`projects/fastjson2/project.yaml`**: Sets the `base_os_version` property to `ubuntu-24-04`.
2.  **`projects/fastjson2/Dockerfile`**: Updates the `FROM` instruction.

CC: shaojin.wensj@alibaba-inc.com
