### PR TITLE
Migrate cifuzz-example to Ubuntu 24.04

### DIFF
--- a/projects/cifuzz-example/Dockerfile
+++ b/projects/cifuzz-example/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 
 RUN git clone https://github.com/jonathanmetzman/cifuzz-example.git --depth 1
 WORKDIR cifuzz-example

--- a/projects/cifuzz-example/project.yaml
+++ b/projects/cifuzz-example/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 language: c++
 sanitizers:
   - address


### PR DESCRIPTION
### Summary

This pull request migrates the `cifuzz-example` project to use the new `ubuntu-24-04` base image for fuzzing.

### Changes in this PR

1.  **`projects/cifuzz-example/project.yaml`**: Sets the `base_os_version` property to `ubuntu-24-04`.
2.  **`projects/cifuzz-example/Dockerfile`**: Updates the `FROM` instruction.

CC: fake@example.com
