### PR TITLE
Migrate astro-compiler to Ubuntu 24.04

### DIFF
--- a/projects/astro-compiler/Dockerfile
+++ b/projects/astro-compiler/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-go
+FROM gcr.io/oss-fuzz-base/base-builder-go:ubuntu-24-04
 RUN git clone --depth 1 https://github.com/withastro/compiler.git
 
 RUN go install github.com/AdamKorcz/go-118-fuzz-build@latest

--- a/projects/astro-compiler/project.yaml
+++ b/projects/astro-compiler/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/withastro/compiler"
 language: go
 main_repo: "https://github.com/withastro/compiler"


### PR DESCRIPTION
### Summary

This pull request migrates the `astro-compiler` project to use the new `ubuntu-24-04` base image for fuzzing.

### Changes in this PR

1.  **`projects/astro-compiler/project.yaml`**: Sets the `base_os_version` property to `ubuntu-24-04`.
2.  **`projects/astro-compiler/Dockerfile`**: Updates the `FROM` instruction.

CC: cable023@gmail.com
