### PR TITLE
Migrate keystone to Ubuntu 24.04

### DIFF
--- a/projects/keystone/Dockerfile
+++ b/projects/keystone/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y make cmake
 RUN git clone --depth 1 https://github.com/keystone-engine/keystone.git
 # Prepare tests

--- a/projects/keystone/project.yaml
+++ b/projects/keystone/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://www.keystone-engine.org"
 language: c++
 primary_contact: "keystone.engine@gmail.com"


### PR DESCRIPTION
### Summary

This pull request migrates the `keystone` project to use the new `ubuntu-24-04` base image for fuzzing.

### Changes in this PR

1.  **`projects/keystone/project.yaml`**: Sets the `base_os_version` property to `ubuntu-24-04`.
2.  **`projects/keystone/Dockerfile`**: Updates the `FROM` instruction.

CC: keystone.engine@gmail.com
