### PR TITLE
Migrate ngolo-fuzzing to Ubuntu 24.04

### DIFF
--- a/projects/ngolo-fuzzing/Dockerfile
+++ b/projects/ngolo-fuzzing/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-go
+FROM gcr.io/oss-fuzz-base/base-builder-go:ubuntu-24-04
 
 RUN apt-get update && apt-get install -y protobuf-compiler libprotobuf-dev binutils cmake \
    ninja-build liblzma-dev libz-dev pkg-config autoconf libtool

--- a/projects/ngolo-fuzzing/project.yaml
+++ b/projects/ngolo-fuzzing/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "'https://github.com/catenacyber/ngolo-fuzzing"
 primary_contact: "p.antoine@catenacyber.fr"
 language: go


### PR DESCRIPTION
### Summary

This pull request migrates the `ngolo-fuzzing` project to use the new `ubuntu-24-04` base image for fuzzing.

### Changes in this PR

1.  **`projects/ngolo-fuzzing/project.yaml`**: Sets the `base_os_version` property to `ubuntu-24-04`.
2.  **`projects/ngolo-fuzzing/Dockerfile`**: Updates the `FROM` instruction.

CC: p.antoine@catenacyber.fr
