### PR TITLE
Migrate starlark-rust to Ubuntu 24.04

### DIFF
--- a/projects/starlark-rust/Dockerfile
+++ b/projects/starlark-rust/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-rust
+FROM gcr.io/oss-fuzz-base/base-builder-rust:ubuntu-24-04
 RUN git clone --depth 1 https://github.com/facebookexperimental/starlark-rust.git starlark-rust
 RUN rustup update nightly
 WORKDIR starlark-rust

--- a/projects/starlark-rust/project.yaml
+++ b/projects/starlark-rust/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/facebookexperimental/starlark-rust/"
 language: rust
 


### PR DESCRIPTION
### Summary

This pull request migrates the `starlark-rust` project to use the new `ubuntu-24-04` base image for fuzzing.

### Changes in this PR

1.  **`projects/starlark-rust/project.yaml`**: Sets the `base_os_version` property to `ubuntu-24-04`.
2.  **`projects/starlark-rust/Dockerfile`**: Updates the `FROM` instruction.

CC: ndmitchell@gmail.com, nathaniel.brough@gmail.com
