### PR TITLE
Migrate apache-commons-jxpath to Ubuntu 24.04

### DIFF
--- a/projects/apache-commons-jxpath/Dockerfile
+++ b/projects/apache-commons-jxpath/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \

--- a/projects/apache-commons-jxpath/project.yaml
+++ b/projects/apache-commons-jxpath/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 fuzzing_engines:
 - libfuzzer
 homepage: https://github.com/apache/commons-jxpath.git


### PR DESCRIPTION
### Summary

This pull request migrates the `apache-commons-jxpath` project to use the new `ubuntu-24-04` base image for fuzzing.

### Changes in this PR

1.  **`projects/apache-commons-jxpath/project.yaml`**: Sets the `base_os_version` property to `ubuntu-24-04`.
2.  **`projects/apache-commons-jxpath/Dockerfile`**: Updates the `FROM` instruction.

CC: fuzz-testing@commons.apache.org, security@commons.apache.org
