### PR TITLE
Migrate apache-commons-imaging to Ubuntu 24.04

### DIFF
--- a/projects/apache-commons-imaging/Dockerfile
+++ b/projects/apache-commons-imaging/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \

--- a/projects/apache-commons-imaging/project.yaml
+++ b/projects/apache-commons-imaging/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://commons.apache.org"
 language: jvm
 main_repo: "https://github.com/apache/commons-imaging"


### PR DESCRIPTION
### Summary

This pull request migrates the `apache-commons-imaging` project to use the new `ubuntu-24-04` base image for fuzzing.

### Changes in this PR

1.  **`projects/apache-commons-imaging/project.yaml`**: Sets the `base_os_version` property to `ubuntu-24-04`.
2.  **`projects/apache-commons-imaging/Dockerfile`**: Updates the `FROM` instruction.

CC: fuzz-testing@commons.apache.org, security@commons.apache.org, brunodepaulak@gmail.com, peteralfredlee@gmail.com, boards@gmail.com
