### PR TITLE
arrow: Fix OpenSSL build directory

### DIFF
--- a/docs/further-reading/fuzzer_environment.md
+++ b/docs/further-reading/fuzzer_environment.md
@@ -29,6 +29,7 @@ If you need these dependencies in the runtime environment, you can either:
 - (recommended) Build the dependencies statically in
 [build.sh]({{ site.baseurl }}/getting-started/new-project-guide/#buildsh)
 ([example](https://github.com/google/oss-fuzz/blob/64f8b6593da141b97c98c7bc6f07df92c42ee010/projects/ffmpeg/build.sh#L26)).
+Their source code should be inside the `$SRC` directory so that coverage can find it.
 
 - Or install the packages via Dockerfile
 ([example](https://github.com/google/oss-fuzz/blob/2d5e2ef84f281e6ab789055aa735606d3122fda9/projects/tor/Dockerfile#L19))

--- a/projects/arrow/build.sh
+++ b/projects/arrow/build.sh
@@ -19,11 +19,12 @@
 
 OPENSSL_VERSION=3.5.4
 
-cd /root
+cd ${SRC}
 wget https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz
 tar -xf openssl-${OPENSSL_VERSION}.tar.gz
 cd openssl-${OPENSSL_VERSION}
-./Configure no-apps no-docs no-tests no-shared
+# Assembler snippets would not be instrumented, disable them
+./Configure no-apps no-docs no-tests no-shared no-asm
 make -j
 make install
 


### PR DESCRIPTION
It looks like coverage runs expect the source code of dependencies to be inside `$SRC`.

Also mention this requirement in the docs.