### PR TITLE
infra: Fix SyntaxWarning in `chronos/manager.py`

### DIFF
--- a/infra/experimental/chronos/manager.py
+++ b/infra/experimental/chronos/manager.py
@@ -73,8 +73,8 @@ def build_cached_project(project, cleanup=True, sanitizer='address'):
       f'-v={cwd}/build/out/{project}/:/out/',
       '-v=' + os.path.join(os.getcwd(), 'infra', 'experimental', 'chronos') +
       ':/chronos/', f'gcr.io/oss-fuzz/{project}', 'bash', '-c',
-      ('"export PATH=/ccache/bin:\$PATH && python3.11 -m pip install -r /chronos/requirements.txt && '
-       'rm -rf /out/* && compile && cp -n /usr/local/bin/replay_build.sh \$SRC/"'
+      (r'"export PATH=/ccache/bin:\$PATH && python3.11 -m pip install -r /chronos/requirements.txt && '
+       r'rm -rf /out/* && compile && cp -n /usr/local/bin/replay_build.sh \$SRC/"'
       )
   ]
 


### PR DESCRIPTION
Running `chronos/manager.py` would emit a Python syntax warning as `\$` is not a recognized escape sequence in Python:
```
/home/antoine/oss-fuzz/infra/experimental/chronos/manager.py:76: SyntaxWarning: invalid escape sequence '\$'
  ('"export PATH=/ccache/bin:\$PATH && python3.11 -m pip install -r /chronos/requirements.txt && '
/home/antoine/oss-fuzz/infra/experimental/chronos/manager.py:77: SyntaxWarning: invalid escape sequence '\$'
  'rm -rf /out/* && compile && cp -n /usr/local/bin/replay_build.sh \$SRC/"'
```

Make sure that Python does not try to unescape it, as it is intended as a shell escape sequence here.