### PR TITLE
Batch Migration: 33 failing projects to Ubuntu 24.04

### DIFF
--- a/projects/abseil-cpp/Dockerfile
+++ b/projects/abseil-cpp/Dockerfile
@@ -14,6 +14,6 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN git clone --depth 1 https://github.com/abseil/abseil-cpp.git
 COPY BUILD WORKSPACE build.sh *_fuzzer.cc $SRC/

--- a/projects/abseil-cpp/project.yaml
+++ b/projects/abseil-cpp/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "abseil.io"
 language: c++
 primary_contact: "dmauro@google.com"

--- a/projects/argo/Dockerfile
+++ b/projects/argo/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-go
+FROM gcr.io/oss-fuzz-base/base-builder-go:ubuntu-24-04
 RUN apt-get update && apt-get install -y wget zip
 RUN git clone --depth 1 https://github.com/argoproj/argo-cd
 RUN git clone --depth 1 https://github.com/argoproj/argo-workflows

--- a/projects/argo/project.yaml
+++ b/projects/argo/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://argoproj.github.io/"
 main_repo: "https://github.com/argoproj"
 primary_contact: "terrytangyuan@gmail.com"

--- a/projects/augeas/Dockerfile
+++ b/projects/augeas/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y libreadline-dev libselinux1-dev \
     libxml2-dev make autoconf automake libtool pkg-config bison flex
 

--- a/projects/augeas/project.yaml
+++ b/projects/augeas/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: https://github.com/hercules-team/augeas
 language: c++
 primary_contact: lutter@watzmann.net

--- a/projects/bad_example/Dockerfile
+++ b/projects/bad_example/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 
 # Using a real zlib project, but with broken build script and/or fuzz target.

--- a/projects/bad_example/project.yaml
+++ b/projects/bad_example/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 disabled: true
 homepage: http://www.zlib.net/
 language: c++

--- a/projects/c-blosc2/Dockerfile
+++ b/projects/c-blosc2/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y cmake make
 RUN git clone --depth 1 https://github.com/Blosc/c-blosc2.git c-blosc2
 WORKDIR c-blosc2

--- a/projects/c-blosc2/project.yaml
+++ b/projects/c-blosc2/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/Blosc/c-blosc2"
 language: c++
 primary_contact: "blosc.oss.fuzz@gmail.com"

--- a/projects/clickhouse/Dockerfile
+++ b/projects/clickhouse/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 
 RUN apt-get update -y \
     && env DEBIAN_FRONTEND=noninteractive \

--- a/projects/clickhouse/project.yaml
+++ b/projects/clickhouse/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://clickhouse.com/"
 language: c++
 primary_contact: "security@clickhouse.com"

--- a/projects/containerd/Dockerfile
+++ b/projects/containerd/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-go
+FROM gcr.io/oss-fuzz-base/base-builder-go:ubuntu-24-04
 RUN apt-get update && apt-get install -y btrfs-progs libc-dev pkg-config libseccomp-dev gcc wget libbtrfs-dev
 RUN git clone --depth 1 https://github.com/containerd/containerd
 RUN git clone --depth=1 https://github.com/AdamKorcz/instrumentation

--- a/projects/containerd/project.yaml
+++ b/projects/containerd/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/containerd/containerd"
 main_repo: "https://github.com/containerd/containerd"
 primary_contact: "security@containerd.io"

--- a/projects/cosign/Dockerfile
+++ b/projects/cosign/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-go
+FROM gcr.io/oss-fuzz-base/base-builder-go:ubuntu-24-04
 RUN git clone --depth 1 https://github.com/sigstore/cosign
 # For json corpus
 RUN git clone --depth=1 https://github.com/dvyukov/go-fuzz-corpus

--- a/projects/cosign/project.yaml
+++ b/projects/cosign/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://sigstore.dev"
 main_repo: "https://github.com/sigstore/cosign"
 primary_contact: "security@sigstore.dev"

--- a/projects/grpc-httpjson-transcoding/Dockerfile
+++ b/projects/grpc-httpjson-transcoding/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 # Todo: unpin to support llvm 22
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:d34b94e3cf868e49d2928c76ddba41fd4154907a1a381b3a263fafffb7c3dce0
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04@sha256:d34b94e3cf868e49d2928c76ddba41fd4154907a1a381b3a263fafffb7c3dce0
 MAINTAINER nareddyt@google.com
 
 RUN apt-get update && apt-get install python3 -y

--- a/projects/grpc-httpjson-transcoding/project.yaml
+++ b/projects/grpc-httpjson-transcoding/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/grpc-ecosystem/grpc-httpjson-transcoding"
 main_repo: "https://github.com/grpc-ecosystem/grpc-httpjson-transcoding.git"
 language: c++

--- a/projects/hugo/Dockerfile
+++ b/projects/hugo/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-go
+FROM gcr.io/oss-fuzz-base/base-builder-go:ubuntu-24-04
 
 RUN git clone https://github.com/gohugoio/hugo
 COPY build.sh fuzz_pageparser.go $SRC/

--- a/projects/hugo/project.yaml
+++ b/projects/hugo/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/gohugoio/hugo"
 primary_contact: "bjorn.erik.pedersen@gmail.com"
 auto_ccs :

--- a/projects/ipfs/Dockerfile
+++ b/projects/ipfs/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-go
+FROM gcr.io/oss-fuzz-base/base-builder-go:ubuntu-24-04
 RUN git clone --depth 1 https://github.com/ipfs/go-datastore
 
 COPY build.sh $SRC/

--- a/projects/ipfs/project.yaml
+++ b/projects/ipfs/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/ipfs/go-datastore"
 primary_contact: "will.scott@protocol.ai"
 auto_ccs :

--- a/projects/istio/Dockerfile
+++ b/projects/istio/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 # Setup the builder for Istio. The standard Go builder is sufficient.
-FROM gcr.io/oss-fuzz-base/base-builder-go
+FROM gcr.io/oss-fuzz-base/base-builder-go:ubuntu-24-04
 RUN git clone --depth 1 https://github.com/istio/istio
 RUN git clone --depth 1 --branch oss-fuzz-build-ref https://github.com/AdamKorcz/istio $SRC/temp-istio
 RUN git clone --depth 1 https://github.com/AdamKorcz/go-118-fuzz-build --branch=v2_2

--- a/projects/istio/project.yaml
+++ b/projects/istio/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/istio/istio"
 primary_contact: "istio-security-vulnerability-reports@googlegroups.com"
 auto_ccs :

--- a/projects/jsonschema/Dockerfile
+++ b/projects/jsonschema/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 RUN pip3 install --upgrade pip hypothesis rpds
 
 RUN git clone --depth=1 https://github.com/Julian/jsonschema

--- a/projects/jsonschema/project.yaml
+++ b/projects/jsonschema/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/Julian/jsonschema"
 language: python
 primary_contact: "Julian+Security@GrayVines.com"

--- a/projects/knot-dns/Dockerfile
+++ b/projects/knot-dns/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y \
  autoconf \
  autogen \

--- a/projects/knot-dns/project.yaml
+++ b/projects/knot-dns/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://www.knot-dns.cz/"
 main_repo: "https://gitlab.nic.cz/knot/knot-dns.git"
 language: c++

--- a/projects/libgit2/Dockerfile
+++ b/projects/libgit2/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y cmake make
 RUN git clone --depth 1 https://github.com/libgit2/libgit2 libgit2
 WORKDIR libgit2

--- a/projects/libgit2/project.yaml
+++ b/projects/libgit2/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://libgit2.github.com/"
 language: c++
 primary_contact: "ps@pks.im"

--- a/projects/libprotobuf-mutator/Dockerfile
+++ b/projects/libprotobuf-mutator/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config cmake \
     ninja-build liblzma-dev libz-dev docbook2x
 

--- a/projects/libprotobuf-mutator/project.yaml
+++ b/projects/libprotobuf-mutator/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/google/libprotobuf-mutator"
 language: c++
 primary_contact: "vitalybuka@chromium.org"

--- a/projects/libra/Dockerfile
+++ b/projects/libra/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 # google oss-fuzz stuff
-FROM gcr.io/oss-fuzz-base/base-builder-rust
+FROM gcr.io/oss-fuzz-base/base-builder-rust:ubuntu-24-04
 
 # install other tools we might need
 RUN apt-get update && apt-get install -y cmake curl

--- a/projects/libra/project.yaml
+++ b/projects/libra/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 disabled: true
 fuzzing_engines:
 - libfuzzer

--- a/projects/llvm_libcxx/Dockerfile
+++ b/projects/llvm_libcxx/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 ################################################################################
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN git clone --depth 1 https://github.com/llvm/llvm-project.git
 WORKDIR llvm-project
 COPY build.sh $SRC/

--- a/projects/llvm_libcxx/project.yaml
+++ b/projects/llvm_libcxx/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://libcxx.llvm.org/"
 language: c++
 primary_contact: "mclow.lists@gmail.com"

--- a/projects/loki/Dockerfile
+++ b/projects/loki/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-go
+FROM gcr.io/oss-fuzz-base/base-builder-go:ubuntu-24-04
 RUN git clone --depth 1 https://github.com/grafana/loki/
 COPY build.sh $SRC/
 WORKDIR $SRC/loki

--- a/projects/loki/project.yaml
+++ b/projects/loki/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/grafana/loki"
 primary_contact: "cyril.tovena@grafana.com"
 auto_ccs :

--- a/projects/lwan/Dockerfile
+++ b/projects/lwan/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update
 RUN apt-get install -y build-essential cmake git ninja-build zlib1g-dev
 

--- a/projects/lwan/project.yaml
+++ b/projects/lwan/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/lpereira/lwan"
 language: c++
 primary_contact: "leandro.pereira@gmail.com"

--- a/projects/mysql-server/Dockerfile
+++ b/projects/mysql-server/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y build-essential libssl-dev libncurses5-dev libncursesw5-dev make cmake perl bison pkg-config chrpath
 RUN git clone --depth 1 https://github.com/mysql/mysql-server
 WORKDIR $SRC

--- a/projects/mysql-server/project.yaml
+++ b/projects/mysql-server/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://www.mysql.com"
 language: c++
 primary_contact: "secalert_us@oracle.com"

--- a/projects/neomutt/Dockerfile
+++ b/projects/neomutt/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 
 RUN	apt-get update && \
 	apt-get install -y libncursesw5-dev libtinfo5 libtool make pkgconf libidn2-0-dev libsqlite3-dev

--- a/projects/neomutt/project.yaml
+++ b/projects/neomutt/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://neomutt.org"
 language: c++
 primary_contact: "joseph.bisch@gmail.com"

--- a/projects/ossf-scorecard/Dockerfile
+++ b/projects/ossf-scorecard/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-go
+FROM gcr.io/oss-fuzz-base/base-builder-go:ubuntu-24-04
 RUN git clone --depth 1 https://github.com/ossf/scorecard
 COPY build.sh yaml_fuzzer.go probes_fuzzer.go $SRC/
 WORKDIR $SRC/scorecard

--- a/projects/ossf-scorecard/project.yaml
+++ b/projects/ossf-scorecard/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://openssf.org/"
 main_repo: "https://github.com/ossf/scorecard"
 primary_contact: "hey@auggie.dev" # <-- IAM / commits: foo@auggie.dev

--- a/projects/pigweed/Dockerfile
+++ b/projects/pigweed/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y git build-essential python python3
 RUN git clone 'https://pigweed.googlesource.com/pigweed/pigweed'  --depth 1
 

--- a/projects/pigweed/project.yaml
+++ b/projects/pigweed/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://pigweed.dev/"
 language: c++
 primary_contact: "keir@google.com"

--- a/projects/pngquant/Dockerfile
+++ b/projects/pngquant/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y make libpng-dev autoconf libtool
 RUN git clone --depth 1 https://github.com/kornelski/pngquant
 RUN git clone --depth 1 https://github.com/glennrp/libpng.git $SRC/pngquant/libpng

--- a/projects/pngquant/project.yaml
+++ b/projects/pngquant/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://pngquant.org"
 main_repo: "https://github.com/kornelski/pngquant"
 language: c

--- a/projects/postgresql/Dockerfile
+++ b/projects/postgresql/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 
 RUN apt-get update && apt-get install -y make libreadline-dev zlib1g-dev bison\
     flex pkg-config libicu-dev

--- a/projects/postgresql/project.yaml
+++ b/projects/postgresql/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://postgresql.org"
 main_repo: "https://git.postgresql.org/git/postgresql"
 primary_contact: "sfrost@snowman.net"

--- a/projects/proxygen/Dockerfile
+++ b/projects/proxygen/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 
 # Install packages we need to build dependencies
 RUN apt-get update && \

--- a/projects/proxygen/project.yaml
+++ b/projects/proxygen/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/facebook/proxygen"
 language: c++
 primary_contact: "axxu@fb.com"

--- a/projects/spirv-tools/Dockerfile
+++ b/projects/spirv-tools/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y make autoconf automake libtool ninja-build
 RUN git clone --filter=tree:0 https://github.com/KhronosGroup/SPIRV-Tools.git spirv-tools
 WORKDIR spirv-tools

--- a/projects/spirv-tools/project.yaml
+++ b/projects/spirv-tools/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: https://github.com/KhronosGroup/SPIRV-Tools
 language: c++
 primary_contact: rharrison@google.com

--- a/projects/tdengine/Dockerfile
+++ b/projects/tdengine/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y  libtool build-essential wget pkg-config zlib1g-dev liblzma-dev libjansson-dev
 RUN git clone --depth 1 https://github.com/taosdata/TDengine tdengine
 RUN cd /tmp \

--- a/projects/tdengine/project.yaml
+++ b/projects/tdengine/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://www.taosdata.com/en/documentation/"
 language: c
 primary_contact: "sangshuduo@gmail.com"

--- a/projects/tidy-html5/Dockerfile
+++ b/projects/tidy-html5/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/projects/tidy-html5/project.yaml
+++ b/projects/tidy-html5/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "http://www.html-tidy.org/"
 language: c++
 primary_contact: "balthisar@gmail.com"

--- a/projects/vitess/Dockerfile
+++ b/projects/vitess/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-go
+FROM gcr.io/oss-fuzz-base/base-builder-go:ubuntu-24-04
 RUN git clone --depth 1 https://github.com/vitessio/vitess
 RUN git clone --depth 1 https://github.com/cncf/cncf-fuzzing
 COPY build.sh $SRC/

--- a/projects/vitess/project.yaml
+++ b/projects/vitess/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/vitessio/vitess" 
 primary_contact: "andres@planetscale.com"
 auto_ccs :

--- a/projects/wget2/Dockerfile
+++ b/projects/wget2/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y \
  make \
  pkg-config \

--- a/projects/wget2/project.yaml
+++ b/projects/wget2/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://gitlab.com/gnuwget/wget2"
 language: c++
 primary_contact: "rockdaboot@gmail.com"

--- a/projects/xmlsec/Dockerfile
+++ b/projects/xmlsec/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config \
     libssl-dev wget liblzma-dev python-dev python3-dev
 # Build requires automake 1.16.3

--- a/projects/xmlsec/project.yaml
+++ b/projects/xmlsec/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://www.aleksey.com/xmlsec/"
 language: c++
 primary_contact: "aleksey@aleksey.com"


### PR DESCRIPTION
### Batch Migration to Ubuntu 24.04

This PR migrates projects that have failed their last 3 GCB builds.

| Project | Last Successful Build | Link |
| :--- | :--- | :--- |
| spirv-tools | 2022-04-13T06:08:13.463885270Z | [Build](https://console.cloud.google.com/cloud-build/builds/8b289607-0358-4cea-956c-0b7cacd670c1?project=608308004811) |
| istio | 2022-04-11T06:06:52.265179932Z | [Build](https://console.cloud.google.com/cloud-build/builds/ed331d88-f24e-47ba-a3d2-7fff5ec4e179?project=608308004811) |
| clickhouse | N/A | N/A |
| knot-dns | N/A | N/A |
| libprotobuf-mutator | N/A | N/A |
| tdengine | N/A | N/A |
| vitess | N/A | N/A |
| jsonschema | N/A | N/A |
| libgit2 | N/A | N/A |
| llvm_libcxx | N/A | N/A |
| containerd | N/A | N/A |
| pngquant | N/A | N/A |
| bad_example | N/A | N/A |
| grpc-httpjson-transcoding | N/A | N/A |
| abseil-cpp | N/A | N/A |
| neomutt | N/A | N/A |
| xmlsec | N/A | N/A |
| pigweed | N/A | N/A |
| ossf-scorecard | N/A | N/A |
| libra | N/A | N/A |
| augeas | N/A | N/A |
| wget2 | N/A | N/A |
| c-blosc2 | N/A | N/A |
| proxygen | N/A | N/A |
| cosign | N/A | N/A |
| hugo | N/A | N/A |
| ipfs | N/A | N/A |
| loki | N/A | N/A |
| argo | N/A | N/A |
| mysql-server | N/A | N/A |
| postgresql | N/A | N/A |
| lwan | N/A | N/A |
| tidy-html5 | N/A | N/A |
| fastjson2 | N/A | N/A |
