### PR TITLE
disabling the memory sanitizer for project simdjson

### DIFF
--- a/projects/simdjson/project.yaml
+++ b/projects/simdjson/project.yaml
@@ -6,7 +6,6 @@ auto_ccs:
 sanitizers:
 - address
 - undefined
-- memory
 main_repo: 'https://github.com/simdjson/simdjson.git'
 
 fuzzing_engines:


### PR DESCRIPTION
The memory sanitizer does not work sensibly for this project. It detects too many false positives. I can trigger `Use-of-uninitialized-value` by simply using textbook C++ code using nothing more than the standard library. I am not sure what is causing all the false positives but it is unhelpful.

Example:
https://issues.oss-fuzz.com/issues/42534941



cc @pauldreik 