### PR TITLE
Update Dockerfile for open62541 on Ubuntu 24.04

### DIFF
--- a/projects/open62541/Dockerfile
+++ b/projects/open62541/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
-RUN apt-get update && apt-get install -y make cmake python-six wget
+RUN apt-get update && apt-get install -y make cmake six wget
 # We need libmbedtls > 2.5.1 otherwise it does not include the lib for static linking
 RUN wget https://open62541.org/libmbedtls/libmbedtls-dev_2.6.0-1_amd64.deb && \
     wget https://open62541.org/libmbedtls/libmbedcrypto0_2.6.0-1_amd64.deb && \


### PR DESCRIPTION
The package python-six does not exist on Ubuntu.
It is just called `six`.