### PR TITLE
Kea maintainers list updated

### DIFF
--- a/projects/kea/project.yaml
+++ b/projects/kea/project.yaml
@@ -5,6 +5,10 @@ primary_contact: "david@adalogics.com"
 auto_ccs:
   - "adam@adalogics.com"
   - "arthur.chan@adalogics.com"
+  - "tomek@isc.org"
+  - "razvan@isc.org"
+  - "andrei@isc.org"
+  - "wlodek.wencel@gmail.com"
 main_repo: 'https://gitlab.isc.org/isc-projects/kea'
 fuzzing_engines:
   - libfuzzer


### PR DESCRIPTION
The goal of this change is to add several new maintainers for the Kea project. The people being added are upstream Kea developers from ISC. This change was discussed with @DavidKorczynski.