### PR TITLE
Mass Migration: Batch 1 to Ubuntu 24.04

### DIFF
--- a/projects/abseil-py/Dockerfile
+++ b/projects/abseil-py/Dockerfile
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 RUN git clone https://github.com/abseil/abseil-py abseil-py
 COPY *.sh *py $SRC/
 WORKDIR $SRC/abseil-py

--- a/projects/abseil-py/project.yaml
+++ b/projects/abseil-py/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 fuzzing_engines:
 - libfuzzer
 homepage: https://github.com/abseil/abseil-py

--- a/projects/ada-url/Dockerfile
+++ b/projects/ada-url/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y make cmake
 RUN git clone --depth 1 https://github.com/ada-url/ada ada-url
 RUN cp ada-url/fuzz/build.sh $SRC/

--- a/projects/ada-url/project.yaml
+++ b/projects/ada-url/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://ada-url.github.io/ada"
 language: c++
 primary_contact: "yagiz@nizipli.com"

--- a/projects/adal/Dockerfile
+++ b/projects/adal/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 
 RUN git clone https://github.com/AzureAD/azure-activedirectory-library-for-python adsl
 WORKDIR adsl

--- a/projects/adal/project.yaml
+++ b/projects/adal/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 fuzzing_engines:
 - libfuzzer
 homepage: https://github.com/AzureAD/azure-activedirectory-library-for-python

--- a/projects/aiohttp/Dockerfile
+++ b/projects/aiohttp/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 RUN apt-get update && apt-get install -y \
   pkg-config \
   zlib1g \

--- a/projects/aiohttp/project.yaml
+++ b/projects/aiohttp/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 fuzzing_engines:
 - libfuzzer
 homepage: https://github.com/aio-libs/aiohttp

--- a/projects/ampproject/Dockerfile
+++ b/projects/ampproject/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
 # ! This project was pinned after a clang bump. Please remove the pin, Try to fix any build warnings and errors, as well as runtime errors
 RUN apt-get update && apt-get install -y make autoconf automake libtool libomp-dev libgomp1 nodejs
 COPY build.sh *.diff $SRC/

--- a/projects/ampproject/project.yaml
+++ b/projects/ampproject/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/ampproject/amphtml"
 language: c++
 main_repo: "https://github.com/ampproject/amphtml"

--- a/projects/angle/Dockerfile
+++ b/projects/angle/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
         lsb-release sudo pkg-config file

--- a/projects/angle/project.yaml
+++ b/projects/angle/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://chromium.googlesource.com/angle/angle"
 language: c++
 primary_contact: "arthur.chan@adalogics.com"

--- a/projects/angus-mail/Dockerfile
+++ b/projects/angus-mail/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \

--- a/projects/angus-mail/project.yaml
+++ b/projects/angus-mail/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://eclipse-ee4j.github.io/mail"
 language: jvm
 primary_contact: ""

--- a/projects/aniso8601/Dockerfile
+++ b/projects/aniso8601/Dockerfile
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 RUN pip3 install --upgrade pip
 RUN git clone https://codeberg.org/nielsenb-jf/aniso8601 aniso8601
 COPY *.sh *py $SRC/

--- a/projects/aniso8601/project.yaml
+++ b/projects/aniso8601/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: https://bitbucket.org/nielsenb/aniso8601
 main_repo: https://bitbucket.org/nielsenb/aniso8601
 language: python

--- a/projects/antlr3-java/Dockerfile
+++ b/projects/antlr3-java/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \

--- a/projects/antlr3-java/project.yaml
+++ b/projects/antlr3-java/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://www.antlr.org"
 language: jvm
 main_repo: "https://github.com/antlr/antlr3.git"

--- a/projects/antlr4-java/Dockerfile
+++ b/projects/antlr4-java/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \

--- a/projects/antlr4-java/project.yaml
+++ b/projects/antlr4-java/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://www.antlr.org"
 language: jvm
 main_repo: "https://github.com/antlr/antlr4.git"

--- a/projects/apache-commons-cli/Dockerfile
+++ b/projects/apache-commons-cli/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \

--- a/projects/apache-commons-cli/project.yaml
+++ b/projects/apache-commons-cli/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://commons.apache.org/proper/commons-cli/"
 language: jvm
 main_repo: "https://github.com/apache/commons-cli.git"

--- a/projects/apache-commons-codec/Dockerfile
+++ b/projects/apache-commons-codec/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \

--- a/projects/apache-commons-codec/project.yaml
+++ b/projects/apache-commons-codec/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 fuzzing_engines:
 - libfuzzer
 homepage: https://commons.apache.org/proper/commons-codec/

--- a/projects/apache-commons-collections/Dockerfile
+++ b/projects/apache-commons-collections/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip -o maven.zip && \
 unzip maven.zip -d $SRC/maven && \

--- a/projects/apache-commons-collections/project.yaml
+++ b/projects/apache-commons-collections/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 fuzzing_engines:
 - libfuzzer
 homepage: https://commons.apache.org/proper/commons-collections/

--- a/projects/apache-commons-compress/Dockerfile
+++ b/projects/apache-commons-compress/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.9.5/binaries/apache-maven-3.9.5-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \

--- a/projects/apache-commons-compress/project.yaml
+++ b/projects/apache-commons-compress/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://commons.apache.org"
 language: jvm
 main_repo: "https://github.com/apache/commons-compress"

--- a/projects/apache-commons-configuration/Dockerfile
+++ b/projects/apache-commons-configuration/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 
 # Install a working version of Maven
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip -o maven.zip && \

--- a/projects/apache-commons-configuration/project.yaml
+++ b/projects/apache-commons-configuration/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://commons.apache.org/proper/commons-configuration/"
 language: jvm
 main_repo: "https://gitbox.apache.org/repos/asf/commons-configuration.git"

--- a/projects/apache-commons-csv/Dockerfile
+++ b/projects/apache-commons-csv/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \

--- a/projects/apache-commons-csv/project.yaml
+++ b/projects/apache-commons-csv/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/apache/commons-csv"
 language: jvm
 primary_contact: "fuzz-testing@commons.apache.org"

--- a/projects/apache-commons-fileupload/Dockerfile
+++ b/projects/apache-commons-fileupload/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \

--- a/projects/apache-commons-fileupload/project.yaml
+++ b/projects/apache-commons-fileupload/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://commons.apache.org/proper/commons-fileupload/"
 language: jvm
 fuzzing_engines:

--- a/projects/apache-commons-io/Dockerfile
+++ b/projects/apache-commons-io/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \

--- a/projects/apache-commons-io/project.yaml
+++ b/projects/apache-commons-io/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 fuzzing_engines:
 - libfuzzer
 homepage: https://commons.apache.org/proper/commons-io/

--- a/projects/apache-commons-lang/Dockerfile
+++ b/projects/apache-commons-lang/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip -o maven.zip && \
 unzip maven.zip -d $SRC/maven && \

--- a/projects/apache-commons-lang/project.yaml
+++ b/projects/apache-commons-lang/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 fuzzing_engines:
 - libfuzzer
 homepage: https://github.com/apache/commons-lang

--- a/projects/apache-commons-net/Dockerfile
+++ b/projects/apache-commons-net/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 RUN apt-get update && apt-get install -y make autoconf automake libtool wget 
 
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.zip -o maven.zip && \

--- a/projects/apache-commons-net/project.yaml
+++ b/projects/apache-commons-net/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/apache/commons-net"
 language: jvm
 primary_contact: "fuzz-testing@commons.apache.org"

--- a/projects/apache-commons-text/Dockerfile
+++ b/projects/apache-commons-text/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \

--- a/projects/apache-commons-text/project.yaml
+++ b/projects/apache-commons-text/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/apache/commons-text/"
 language: jvm
 primary_contact: "fuzz-testing@commons.apache.org"

--- a/projects/apache-commons-validator/Dockerfile
+++ b/projects/apache-commons-validator/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 RUN apt-get update && apt-get install -y make autoconf automake libtool wget 
 
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.zip -o maven.zip && \

--- a/projects/apache-commons-validator/project.yaml
+++ b/projects/apache-commons-validator/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/apache/commons-validator"
 language: jvm
 primary_contact: "fuzz-testing@commons.apache.org"

--- a/projects/apache-cxf/Dockerfile
+++ b/projects/apache-cxf/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \

--- a/projects/apache-cxf/project.yaml
+++ b/projects/apache-cxf/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://cxf.apache.org/"
 language: jvm
 main_repo: "https://github.com/apache/cxf/"

--- a/projects/apache-felix-dev/Dockerfile
+++ b/projects/apache-felix-dev/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 
 ENV JAVA_HOME $JAVA_15_HOME
 ENV JVM_LD_LIBRARY_PATH $JAVA_HOME/lib/server

--- a/projects/apache-felix-dev/project.yaml
+++ b/projects/apache-felix-dev/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://felix.apache.org/"
 language: jvm
 main_repo: "https://github.com/apache/felix-dev.git"

--- a/projects/apache-httpd/Dockerfile
+++ b/projects/apache-httpd/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y make autoconf automake libtool wget \
                                          uuid-dev pkg-config libtool-bin \
                                          libbsd-dev

--- a/projects/apache-httpd/project.yaml
+++ b/projects/apache-httpd/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://httpd.apache.org/"
 language: c
 primary_contact: "david@adalogics.com"

--- a/projects/arduinojson/Dockerfile
+++ b/projects/arduinojson/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y make zip git
 RUN git clone --depth 1 https://github.com/bblanchon/ArduinoJson.git arduinojson
 WORKDIR arduinojson

--- a/projects/arduinojson/project.yaml
+++ b/projects/arduinojson/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/bblanchon/ArduinoJson"
 language: c++
 primary_contact: "benoit.blanchon@gmail.com"

--- a/projects/argcomplete/Dockerfile
+++ b/projects/argcomplete/Dockerfile
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 RUN pip3 install --upgrade pip
 RUN git clone https://github.com/kislyuk/argcomplete argcomplete
 COPY *.sh *py $SRC/

--- a/projects/argcomplete/project.yaml
+++ b/projects/argcomplete/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: https://github.com/kislyuk/argcomplete
 main_repo: https://github.com/kislyuk/argcomplete
 language: python

--- a/projects/args/Dockerfile
+++ b/projects/args/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 
 RUN apt-get update && \
     apt-get install -y \

--- a/projects/args/project.yaml
+++ b/projects/args/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://taywee.github.io/args/"
 main_repo: "https://github.com/Taywee/args"
 language: c++

--- a/projects/args4j/Dockerfile
+++ b/projects/args4j/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 
 RUN git clone --depth 1 https://github.com/kohsuke/args4j $SRC/args4j
 

--- a/projects/args4j/project.yaml
+++ b/projects/args4j/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/kohsuke/args4j"
 language: jvm
 fuzzing_engines:

--- a/projects/arrow-py/Dockerfile
+++ b/projects/arrow-py/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 ##########################################################################
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 RUN pip3 install --upgrade pip
 RUN git clone https://github.com/arrow-py/arrow arrow
 COPY *.sh *py $SRC/

--- a/projects/arrow-py/project.yaml
+++ b/projects/arrow-py/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: https://github.com/arrow-py/arrow
 main_repo: https://github.com/arrow-py/arrow
 language: python

--- a/projects/arrow/Dockerfile
+++ b/projects/arrow/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y -q && \

--- a/projects/arrow/project.yaml
+++ b/projects/arrow/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://arrow.apache.org/"
 language: c++
 primary_contact: "antoine@python.org"

--- a/projects/askama/Dockerfile
+++ b/projects/askama/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-rust
+FROM gcr.io/oss-fuzz-base/base-builder-rust:ubuntu-24-04
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/askama-rs/askama.git askama
 WORKDIR askama/fuzzing

--- a/projects/askama/project.yaml
+++ b/projects/askama/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://askama.readthedocs.io/"
 main_repo: "https://github.com/askama-rs/askama"
 language: rust

--- a/projects/asn1crypto/Dockerfile
+++ b/projects/asn1crypto/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/wbond/asn1crypto asn1crypto
 WORKDIR asn1crypto

--- a/projects/asn1crypto/project.yaml
+++ b/projects/asn1crypto/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 fuzzing_engines:
 - libfuzzer
 homepage: https://github.com/wbond/asn1crypto

--- a/projects/assimp/Dockerfile
+++ b/projects/assimp/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y cmake ninja-build
 RUN git clone --depth 1 --recursive https://github.com/assimp/assimp.git
 WORKDIR assimp

--- a/projects/assimp/project.yaml
+++ b/projects/assimp/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/assimp/assimp"
 language: c++
 primary_contact: "kim.kulling@googlemail.com"

--- a/projects/astc-encoder/Dockerfile
+++ b/projects/astc-encoder/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/ARM-software/astc-encoder
 WORKDIR astc-encoder/Source

--- a/projects/astc-encoder/project.yaml
+++ b/projects/astc-encoder/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/ARM-software/astc-encoder"
 language: c++
 primary_contact: "peter.harris@arm.com"

--- a/projects/asteval/Dockerfile
+++ b/projects/asteval/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 ##########################################################################
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 RUN pip3 install --upgrade pip
 RUN git clone https://github.com/newville/asteval asteval
 COPY *.sh *py $SRC/

--- a/projects/asteval/project.yaml
+++ b/projects/asteval/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: https://github.com/newville/asteval
 main_repo: https://github.com/newville/asteval
 language: python

--- a/projects/asttokens/Dockerfile
+++ b/projects/asttokens/Dockerfile
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 RUN pip3 install --upgrade pip
 RUN git clone https://github.com/gristlabs/asttokens asttokens
 COPY *.sh *py $SRC/

--- a/projects/asttokens/project.yaml
+++ b/projects/asttokens/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: https://github.com/gristlabs/asttokens
 main_repo: https://github.com/gristlabs/asttokens
 language: python

--- a/projects/async-http-client/Dockerfile
+++ b/projects/async-http-client/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \

--- a/projects/async-http-client/project.yaml
+++ b/projects/async-http-client/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/AsyncHttpClient/async-http-client/"
 language: jvm
 primary_contact: "aayush@shieldblaze.com"

--- a/projects/atomic/Dockerfile
+++ b/projects/atomic/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-go
+FROM gcr.io/oss-fuzz-base/base-builder-go:ubuntu-24-04
 RUN git clone --depth 1 https://github.com/uber-go/atomic
 WORKDIR $SRC/atomic
 COPY build.sh fuzz_test.go $SRC/

--- a/projects/atomic/project.yaml
+++ b/projects/atomic/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/uber-go/atomic"
 language: go
 main_repo: "https://github.com/uber-go/atomic"

--- a/projects/attrs/Dockerfile
+++ b/projects/attrs/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 ##########################################################################
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 RUN git clone https://github.com/python-attrs/attrs.git
 COPY *.sh *py $SRC/
 WORKDIR $SRC/attrs

--- a/projects/attrs/project.yaml
+++ b/projects/attrs/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 fuzzing_engines:
 - libfuzzer
 homepage: https://www.attrs.org

--- a/projects/autoflake/Dockerfile
+++ b/projects/autoflake/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 ##########################################################################
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 RUN pip3 install --upgrade pip
 RUN git clone https://www.github.com/PyCQA/autoflake autoflake
 COPY *.sh *py $SRC/

--- a/projects/autoflake/project.yaml
+++ b/projects/autoflake/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: https://www.github.com/PyCQA/autoflake
 main_repo: https://www.github.com/PyCQA/autoflake
 language: python

--- a/projects/autopep8/Dockerfile
+++ b/projects/autopep8/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 ##########################################################################
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 RUN pip3 install --upgrade pip
 RUN git clone https://github.com/hhatto/autopep8 autopep8
 COPY *.sh *py $SRC/

--- a/projects/autopep8/project.yaml
+++ b/projects/autopep8/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: https://github.com/hhatto/autopep8
 main_repo: https://github.com/hhatto/autopep8
 language: python

--- a/projects/azure-sdk-for-python/Dockerfile
+++ b/projects/azure-sdk-for-python/Dockerfile
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 RUN git clone https://github.com/azure/azure-sdk-for-python azure-sdk-for-python
 COPY *.sh *py $SRC/
 WORKDIR $SRC/azure-sdk-for-python

--- a/projects/azure-sdk-for-python/project.yaml
+++ b/projects/azure-sdk-for-python/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 fuzzing_engines:
 - libfuzzer
 homepage: https://github.com/azure/azure-sdk-for-python

--- a/projects/babel/Dockerfile
+++ b/projects/babel/Dockerfile
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 RUN pip3 install --upgrade pip && pip3 install cython
 RUN git clone https://github.com/python-babel/babel babel
 COPY *.sh *py $SRC/

--- a/projects/babel/project.yaml
+++ b/projects/babel/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: https://github.com/python-babel/babel
 main_repo: https://github.com/python-babel/babel
 language: python

--- a/projects/behaviortreecpp/Dockerfile
+++ b/projects/behaviortreecpp/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y make autoconf automake libtool cmake pkg-config wget libsodium-dev libgtest-dev
 RUN git clone --depth 1 https://github.com/BehaviorTree/BehaviorTree.CPP.git behaviortreecpp
 WORKDIR behaviortreecpp

--- a/projects/behaviortreecpp/project.yaml
+++ b/projects/behaviortreecpp/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://www.behaviortree.dev/"
 language: c++
 primary_contact: "christopher.krah@tii.ae"

--- a/projects/bincode/Dockerfile
+++ b/projects/bincode/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 ################################################################################
-FROM gcr.io/oss-fuzz-base/base-builder-rust as builder
+FROM gcr.io/oss-fuzz-base/base-builder-rust:ubuntu-24-04 as builder
 RUN apt-get update
 RUN git clone --depth 1 https://git.sr.ht/~stygianentity/bincode
 ENV RUSTUP_TOOLCHAIN nightly-2025-01-10

--- a/projects/bincode/project.yaml
+++ b/projects/bincode/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://git.sr.ht/~stygianentity/bincode"
 language: rust
 primary_contact: "nathan@mccarty.io"

--- a/projects/binutils/Dockerfile
+++ b/projects/binutils/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y make texinfo libgmp-dev libmpfr-dev
 RUN apt-get install -y flex bison
 RUN git clone --depth=1 https://github.com/DavidKorczynski/binary-samples binary-samples

--- a/projects/binutils/project.yaml
+++ b/projects/binutils/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://www.gnu.org/software/binutils/"
 main_repo: "https://github.com/bminor/binutils-gdb"
 language: c++

--- a/projects/black/Dockerfile
+++ b/projects/black/Dockerfile
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 RUN pip3 install --upgrade pip
 RUN git clone https://github.com/psf/black black
 COPY *.sh *py $SRC/

--- a/projects/black/project.yaml
+++ b/projects/black/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: https://github.com/psf/black
 main_repo: https://github.com/psf/black
 language: python

--- a/projects/blackfriday/Dockerfile
+++ b/projects/blackfriday/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-go
+FROM gcr.io/oss-fuzz-base/base-builder-go:ubuntu-24-04
 RUN git clone --depth 1 --branch v2 https://github.com/russross/blackfriday
 RUN wget https://go.dev/dl/go1.23.4.linux-amd64.tar.gz \
     && mkdir temp-go \

--- a/projects/blackfriday/project.yaml
+++ b/projects/blackfriday/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/russross/blackfriday"
 main_repo: "https://github.com/russross/blackfriday"
 primary_contact: "security-tps@google.com"

--- a/projects/bleach/Dockerfile
+++ b/projects/bleach/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 
 RUN git clone \
 	--depth 1 \

--- a/projects/bleach/project.yaml
+++ b/projects/bleach/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/mozilla/bleach"
 main_repo: "https://github.com/mozilla/bleach"
 language: python

--- a/projects/bloaty/Dockerfile
+++ b/projects/bloaty/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y cmake ninja-build g++ libz-dev
 RUN git clone --depth 1 https://github.com/google/bloaty.git bloaty
 WORKDIR bloaty

--- a/projects/bloaty/project.yaml
+++ b/projects/bloaty/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/google/bloaty"
 language: c++
 primary_contact: "jhaberman@gmail.com"

--- a/projects/bluez/Dockerfile
+++ b/projects/bluez/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 
 # Install necessary packages
 RUN apt-get update && apt-get install -y \

--- a/projects/bluez/project.yaml
+++ b/projects/bluez/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/bluez/bluez"
 language: c
 primary_contact: "bluez.test.bot@gmail.com"

--- a/projects/boost-beast/Dockerfile
+++ b/projects/boost-beast/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/oss-fuzz-base/base-builder:v1
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 
 RUN git clone --depth 1 --single-branch --branch master https://github.com/boostorg/boost.git
 WORKDIR boost

--- a/projects/boost-beast/project.yaml
+++ b/projects/boost-beast/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://www.boost.org/"
 language: c++
 primary_contact: "vinnie.falco@gmail.com"

--- a/projects/boost-json/Dockerfile
+++ b/projects/boost-json/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 
 RUN git clone --depth 1 --single-branch --branch master https://github.com/boostorg/boost.git
 RUN pwd

--- a/projects/boost-json/project.yaml
+++ b/projects/boost-json/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "http://www.boost.org/"
 language: c++
 primary_contact: "pauldreikossfuzz@gmail.com"

--- a/projects/boost/Dockerfile
+++ b/projects/boost/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y g++ python
 
 RUN git clone --recursive https://github.com/boostorg/boost.git

--- a/projects/boost/project.yaml
+++ b/projects/boost/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "http://www.boost.org/"
 language: c++
 primary_contact: "mclow@boost.org"

--- a/projects/boringssl/Dockerfile
+++ b/projects/boringssl/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-go
+FROM gcr.io/oss-fuzz-base/base-builder-go:ubuntu-24-04
 RUN apt-get update && apt-get install -y wget \
     binutils cmake ninja-build liblzma-dev libz-dev \
     pkg-config autoconf libtool

--- a/projects/boringssl/project.yaml
+++ b/projects/boringssl/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://boringssl.googlesource.com/boringssl/"
 language: c++
 primary_contact: "agl@google.com"

--- a/projects/botan/Dockerfile
+++ b/projects/botan/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y make python
 RUN git clone --depth 1 https://github.com/randombit/botan.git botan
 RUN git clone --depth 1 https://github.com/randombit/crypto-corpus.git fuzzer_corpus

--- a/projects/botan/project.yaml
+++ b/projects/botan/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://botan.randombit.net"
 language: c++
 primary_contact: "jack.lloyd@gmail.com"

--- a/projects/botocore/Dockerfile
+++ b/projects/botocore/Dockerfile
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 RUN git clone --depth=1 https://github.com/boto/botocore botocore
 COPY *.sh *py $SRC/
 WORKDIR $SRC/botocore

--- a/projects/botocore/project.yaml
+++ b/projects/botocore/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 fuzzing_engines:
 - libfuzzer
 homepage: https://github.com/boto/botocore

--- a/projects/bottleneck/Dockerfile
+++ b/projects/bottleneck/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN pip3 install --upgrade pip && pip3 install cython numpy
 RUN git clone --depth 1 https://github.com/pydata/bottleneck

--- a/projects/bottleneck/project.yaml
+++ b/projects/bottleneck/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 fuzzing_engines:
 - libfuzzer
 homepage: https://github.com/pydata/bottleneck

--- a/projects/brotli-java/Dockerfile
+++ b/projects/brotli-java/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 RUN apt-get update && apt-get install -y make autoconf automake libtool wget
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \

--- a/projects/brotli-java/project.yaml
+++ b/projects/brotli-java/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/google/brotli/tree/master/java"
 language: jvm
 primary_contact: "eustas@chromium.org"

--- a/projects/brotli/Dockerfile
+++ b/projects/brotli/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y cmake libtool make
 
 RUN git clone --depth 1 https://github.com/google/brotli.git

--- a/projects/brotli/project.yaml
+++ b/projects/brotli/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/google/brotli"
 language: c++
 primary_contact: "eustas@chromium.org"

--- a/projects/brpc/Dockerfile
+++ b/projects/brpc/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 ################################################################################
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y cmake libgflags-dev libprotobuf-dev libprotoc-dev protobuf-compiler libleveldb-dev libgtest-dev libgoogle-perftools-dev libsnappy-dev
 RUN git clone --depth 1 https://github.com/apache/brpc.git
 RUN cp $SRC/brpc/test/fuzzing/oss-fuzz.sh $SRC/build.sh

--- a/projects/brpc/project.yaml
+++ b/projects/brpc/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://brpc.apache.org"
 language: c++
 primary_contact: "security@apache.org"

--- a/projects/brunsli/Dockerfile
+++ b/projects/brunsli/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y cmake libtool make
 
 RUN git clone --depth 1 https://github.com/google/brunsli.git && \

--- a/projects/brunsli/project.yaml
+++ b/projects/brunsli/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/google/brunsli"
 language: c++
 primary_contact: "eustas@chromium.org"

--- a/projects/bson-rust/Dockerfile
+++ b/projects/bson-rust/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-rust
+FROM gcr.io/oss-fuzz-base/base-builder-rust:ubuntu-24-04
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/mongodb/bson-rust bson-rust
 WORKDIR bson-rust

--- a/projects/bson-rust/project.yaml
+++ b/projects/bson-rust/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/mongodb/bson-rust"
 language: rust
 main_repo: "https://github.com/mongodb/bson-rust"

--- a/projects/burntsushi-toml/Dockerfile
+++ b/projects/burntsushi-toml/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-go
+FROM gcr.io/oss-fuzz-base/base-builder-go:ubuntu-24-04
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/BurntSushi/toml toml
 COPY build.sh $SRC/

--- a/projects/burntsushi-toml/project.yaml
+++ b/projects/burntsushi-toml/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/BurntSushi/toml"
 language: go
 main_repo: "https://github.com/BurntSushi/toml"

--- a/projects/bz2file/Dockerfile
+++ b/projects/bz2file/Dockerfile
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 RUN pip3 install --upgrade pip
 RUN git clone https://github.com/nvawda/bz2file bz2file
 COPY *.sh *py $SRC/

--- a/projects/bz2file/project.yaml
+++ b/projects/bz2file/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: https://github.com/nvawda/bz2file
 main_repo: https://github.com/nvawda/bz2file
 language: python

--- a/projects/bzip2/Dockerfile
+++ b/projects/bzip2/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN git clone git://sourceware.org/git/bzip2.git
 RUN git clone git://sourceware.org/git/bzip2-tests.git
 COPY build.sh *.c $SRC/

--- a/projects/bzip2/project.yaml
+++ b/projects/bzip2/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://sourceware.org/bzip2/"
 language: c++
 primary_contact: "bzip2fuzzer@gmail.com"

--- a/projects/c-ares/Dockerfile
+++ b/projects/c-ares/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config
 RUN git clone --depth 1 https://github.com/c-ares/c-ares.git
 RUN git clone --depth 1 https://github.com/google/googletest

--- a/projects/c-ares/project.yaml
+++ b/projects/c-ares/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://c-ares.haxx.se/"
 language: c++
 primary_contact: "drysdale@google.com"

--- a/projects/c-blosc/Dockerfile
+++ b/projects/c-blosc/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y cmake make
 RUN git clone --depth 1 https://github.com/Blosc/c-blosc.git c-blosc
 WORKDIR c-blosc

--- a/projects/c-blosc/project.yaml
+++ b/projects/c-blosc/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/Blosc/c-blosc"
 language: c++
 primary_contact: "blosc.oss.fuzz@gmail.com"

--- a/projects/cachetools/Dockerfile
+++ b/projects/cachetools/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 RUN git clone https://github.com/tkem/cachetools/
 COPY build.sh *.py $SRC/
 WORKDIR cachetools

--- a/projects/cachetools/project.yaml
+++ b/projects/cachetools/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 fuzzing_engines:
 - libfuzzer
 homepage: https://github.com/tkem/cachetools/

--- a/projects/caddy/Dockerfile
+++ b/projects/caddy/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-go
+FROM gcr.io/oss-fuzz-base/base-builder-go:ubuntu-24-04
 
 RUN git clone --depth 1  https://github.com/caddyserver/caddy caddy
 

--- a/projects/caddy/project.yaml
+++ b/projects/caddy/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://caddyserver.com/"
 language: go
 primary_contact: "msaa1990@gmail.com"

--- a/projects/caffeine/Dockerfile
+++ b/projects/caffeine/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 
 RUN git clone --depth 1 https://github.com/ben-manes/caffeine
 

--- a/projects/caffeine/project.yaml
+++ b/projects/caffeine/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/ben-manes/caffeine"
 language: jvm
 main_repo: "https://github.com/ben-manes/caffeine.git"

--- a/projects/cairo/Dockerfile
+++ b/projects/cairo/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 ################################################################################
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && \
     apt-get install -y python3-pip gtk-doc-tools libffi-dev autotools-dev libtool gperf
 RUN pip3 install -U meson==1.4.0 ninja packaging

--- a/projects/cairo/project.yaml
+++ b/projects/cairo/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: https://gitlab.freedesktop.org/cairo/cairo
 language: c
 primary_contact: security-tps@google.com

--- a/projects/calcite-avatica/Dockerfile
+++ b/projects/calcite-avatica/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 ##########################################################################
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 RUN git clone --depth 1 https://github.com/apache/calcite-avatica calcite-avatica
 COPY *.sh *.java $SRC/
 WORKDIR $SRC/calcite-avatica

--- a/projects/calcite-avatica/project.yaml
+++ b/projects/calcite-avatica/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: https://github.com/apache/calcite-avatica
 main_repo: https://github.com/apache/calcite-avatica
 language: jvm

--- a/projects/calcite/Dockerfile
+++ b/projects/calcite/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \

--- a/projects/calcite/project.yaml
+++ b/projects/calcite/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://calcite.apache.org/"
 language: jvm
 fuzzing_engines:

--- a/projects/capnproto/Dockerfile
+++ b/projects/capnproto/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y autoconf automake libtool zlib1g-dev
 RUN git clone --depth 1 https://github.com/capnproto/capnproto
 WORKDIR $SRC/capnproto

--- a/projects/capnproto/project.yaml
+++ b/projects/capnproto/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://capnproto.org"
 language: c++
 primary_contact: "security@sandstorm.io"

--- a/projects/capstone/Dockerfile
+++ b/projects/capstone/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 RUN apt-get update && apt-get install -y make cmake
 RUN pip3 install --upgrade setuptools build wheel pip
 RUN git clone --depth 1 --branch v5 https://github.com/capstone-engine/capstone.git capstonev5

--- a/projects/capstone/project.yaml
+++ b/projects/capstone/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://www.capstone-engine.org"
 language: c++
 primary_contact: "capstone.engine@gmail.com"

--- a/projects/cascadia/Dockerfile
+++ b/projects/cascadia/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-go
+FROM gcr.io/oss-fuzz-base/base-builder-go:ubuntu-24-04
 RUN git clone https://github.com/andybalholm/cascadia
 
 COPY build.sh $SRC/

--- a/projects/cascadia/project.yaml
+++ b/projects/cascadia/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/andybalholm/cascadia"
 primary_contact: "cascadia@balholm.com"
 auto_ccs :

--- a/projects/casync/Dockerfile
+++ b/projects/casync/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && \
     apt-get install -y \
         python3-pip pkg-config wget \

--- a/projects/casync/project.yaml
+++ b/projects/casync/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/casync/casync"
 language: c++
 primary_contact: "lennart@poettering.net"

--- a/projects/cbor-java/Dockerfile
+++ b/projects/cbor-java/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 RUN apt-get update && apt-get install -y make autoconf automake libtool wget
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \

--- a/projects/cbor-java/project.yaml
+++ b/projects/cbor-java/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://android.googlesource.com/platform/external/cbor-java/+/refs/heads/master"
 language: jvm
 primary_contact: "constantin.rack@gmail.com"

--- a/projects/cbor2/Dockerfile
+++ b/projects/cbor2/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 RUN git clone --depth 1 https://github.com/agronholm/cbor2.git
 WORKDIR cbor2
 COPY build.sh *.py $SRC/

--- a/projects/cbor2/project.yaml
+++ b/projects/cbor2/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/agronholm/cbor2"
 main_repo: "https://github.com/agronholm/cbor2"
 language: python

--- a/projects/cctz/Dockerfile
+++ b/projects/cctz/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y make autoconf libgtest-dev
 RUN git clone --depth 1 https://github.com/google/cctz
 WORKDIR $SRC/cctz

--- a/projects/cctz/project.yaml
+++ b/projects/cctz/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: https://github.com/google/cctz
 main_repo: https://github.com/google/cctz
 language: c++

--- a/projects/cel-go/Dockerfile
+++ b/projects/cel-go/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-go
+FROM gcr.io/oss-fuzz-base/base-builder-go:ubuntu-24-04
 RUN git clone --depth 1 https://github.com/google/cel-go
 
 RUN apt-get update && apt-get install -y protobuf-compiler libprotobuf-dev binutils cmake \

--- a/projects/cel-go/project.yaml
+++ b/projects/cel-go/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://opensource.google/projects/cel"
 primary_contact: "tswadell@google.com"
 auto_ccs:

--- a/projects/cert-manager/Dockerfile
+++ b/projects/cert-manager/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-go
+FROM gcr.io/oss-fuzz-base/base-builder-go:ubuntu-24-04
 RUN git clone https://github.com/cert-manager/cert-manager --depth=1
 COPY build.sh pki_fuzzer.go $SRC/
 WORKDIR $SRC/cert-manager

--- a/projects/cert-manager/project.yaml
+++ b/projects/cert-manager/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://cert-manager.io"
 # Send reports to the cert-manager-security distribution list.
 # - https://cert-manager.io/docs/contributing/security/

--- a/projects/cfengine/Dockerfile
+++ b/projects/cfengine/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y \
   build-essential libpcre2-dev libtool autoconf automake bison flex libssl-dev \
   libbison-dev libacl1 libacl1-dev lmdb-utils liblmdb-dev libpam0g-dev libtool \

--- a/projects/cfengine/project.yaml
+++ b/projects/cfengine/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/cfengine/core"
 main_repo: "https://github.com/cfengine/core"
 language: c++

--- a/projects/cffi/Dockerfile
+++ b/projects/cffi/Dockerfile
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 RUN apt-get install -y libffi-dev mercurial
 RUN hg clone https://foss.heptapod.net/pypy/cffi cffi
 COPY *.sh *py $SRC/

--- a/projects/cffi/project.yaml
+++ b/projects/cffi/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 fuzzing_engines:
 - libfuzzer
 homepage: https://foss.heptapod.net/pypy/cffi

--- a/projects/cgif/Dockerfile
+++ b/projects/cgif/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y python3-pip zip
 RUN pip3 install meson ninja
 RUN git clone --depth 1 https://github.com/dloebl/cgif.git

--- a/projects/cgif/project.yaml
+++ b/projects/cgif/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/dloebl/cgif"
 language: c
 primary_contact: "dloebl.2000@gmail.com"

--- a/projects/chardet/Dockerfile
+++ b/projects/chardet/Dockerfile
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 RUN git clone https://github.com/erikrose/chardet chardet
 COPY *.sh *py $SRC/
 WORKDIR $SRC/chardet

--- a/projects/chardet/project.yaml
+++ b/projects/chardet/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 fuzzing_engines:
 - libfuzzer
 homepage: https://github.com/erikrose/chardet

--- a/projects/charset_normalizer/Dockerfile
+++ b/projects/charset_normalizer/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/jawah/charset_normalizer charset_normalizer
 WORKDIR charset_normalizer

--- a/projects/charset_normalizer/project.yaml
+++ b/projects/charset_normalizer/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 fuzzing_engines:
 - libfuzzer
 homepage: https://github.com/jawah/charset_normalizer

--- a/projects/checkstyle/Dockerfile
+++ b/projects/checkstyle/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 ##########################################################################
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip \
   -o maven.zip && \
   unzip maven.zip -d $SRC/maven && \

--- a/projects/checkstyle/project.yaml
+++ b/projects/checkstyle/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 fuzzing_engines:
 - libfuzzer
 homepage: https://github.com/checkstyle/checkstyle

--- a/projects/chrono/Dockerfile
+++ b/projects/chrono/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-rust
+FROM gcr.io/oss-fuzz-base/base-builder-rust:ubuntu-24-04
 
 RUN git clone --depth 1 https://github.com/chronotope/chrono chrono
 WORKDIR $SRC

--- a/projects/chrono/project.yaml
+++ b/projects/chrono/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/chronotope/chrono"
 main_repo: "https://github.com/chronotope/chrono.git"
 language: rust

--- a/projects/circl/Dockerfile
+++ b/projects/circl/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-go
+FROM gcr.io/oss-fuzz-base/base-builder-go:ubuntu-24-04
 
 RUN apt-get update && apt-get install -y make autoconf automake libtool wget python
 RUN git clone --depth 1 https://github.com/MozillaSecurity/cryptofuzz

--- a/projects/circl/project.yaml
+++ b/projects/circl/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/cloudflare/circl"
 language: c++
 primary_contact: "guidovranken@gmail.com"

--- a/projects/civetweb/Dockerfile
+++ b/projects/civetweb/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y zlib1g-dev
 RUN git clone https://github.com/civetweb/civetweb
 

--- a/projects/civetweb/project.yaml
+++ b/projects/civetweb/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/civetweb/civetweb"
 primary_contact: "bel2125@gmail.com"
 language: c

--- a/projects/cjson/Dockerfile
+++ b/projects/cjson/Dockerfile
@@ -15,7 +15,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 
 
 RUN apt-get update && apt-get install -y cmake

--- a/projects/cjson/project.yaml
+++ b/projects/cjson/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/DaveGamble/cJSON"
 language: c++
 primary_contact: "max@maxbruckner.de"

--- a/projects/clamav/Dockerfile
+++ b/projects/clamav/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-rust
+FROM gcr.io/oss-fuzz-base/base-builder-rust:ubuntu-24-04
 RUN apt-get update && apt-get install -y \
     flex bison \
     python3-dev \

--- a/projects/clamav/project.yaml
+++ b/projects/clamav/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://www.clamav.net/"
 language: c++
 primary_contact: "clamav.fuzz@gmail.com"

--- a/projects/clib/Dockerfile
+++ b/projects/clib/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y make cmake libcurl4-gnutls-dev -qq
 RUN git clone --depth 1 https://github.com/clibs/clib
 WORKDIR $SRC/

--- a/projects/clib/project.yaml
+++ b/projects/clib/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/clibs/clib"
 language: c
 primary_contact: "joseph.werle@gmail.com"

--- a/projects/click/Dockerfile
+++ b/projects/click/Dockerfile
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/oss-fuzz-base/base-builder-python
+FROM gcr.io/oss-fuzz-base/base-builder-python:ubuntu-24-04
 RUN git clone https://github.com/pallets/click click
 COPY *.sh *py $SRC/
 WORKDIR $SRC/click

--- a/projects/click/project.yaml
+++ b/projects/click/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 fuzzing_engines:
 - libfuzzer
 homepage: https://github.com/pallets/click

--- a/projects/clock/Dockerfile
+++ b/projects/clock/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-go
+FROM gcr.io/oss-fuzz-base/base-builder-go:ubuntu-24-04
 RUN git clone --depth 1 https://github.com/benbjohnson/clock
 WORKDIR clock
 COPY build.sh fuzz_test.go $SRC/

--- a/projects/clock/project.yaml
+++ b/projects/clock/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/benbjohnson/clock"
 language: go
 main_repo: "https://github.com/benbjohnson/clock"

--- a/projects/closure-library/Dockerfile
+++ b/projects/closure-library/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-javascript
+FROM gcr.io/oss-fuzz-base/base-builder-javascript:ubuntu-24-04
 
 COPY build.sh $SRC/
 

--- a/projects/closure-library/project.yaml
+++ b/projects/closure-library/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: https://developers.google.com/closure/library/
 language: javascript
 main_repo: https://github.com/google/closure-library

--- a/projects/cloud-hypervisor/Dockerfile
+++ b/projects/cloud-hypervisor/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 ################################################################################
-FROM gcr.io/oss-fuzz-base/base-builder-rust as builder
+FROM gcr.io/oss-fuzz-base/base-builder-rust:ubuntu-24-04 as builder
 
 ## Install build dependencies.
 RUN apt-get update

--- a/projects/cloud-hypervisor/project.yaml
+++ b/projects/cloud-hypervisor/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/cloud-hypervisor/cloud-hypervisor"
 language: rust
 primary_contact: "bo.arvin.chen@gmail.com"


### PR DESCRIPTION
### Mass Migration to Ubuntu 24.04

This Pull Request migrates a batch of OSS-Fuzz projects to Ubuntu 24.04.

#### Rationale
Support for Ubuntu 20.04 is ending. To ensure continued security updates and access to modern toolchains, we are migrating all OSS-Fuzz projects to Ubuntu 24.04.

**Verification:**
These projects have been **extensively tested** for build and testcase reproduction on Google Cloud Build. We verified that:
1.  The project builds successfully with the new Ubuntu 24.04 base image.
2.  Existing testcases (if any) can be reproduced successfully.

We do not anticipate significant issues.

#### Rollback Instructions
If you encounter any issues, rolling back is simple:
1.  Remove the `base_os_version: ubuntu-24-04` line from `project.yaml`.
2.  Revert the `Dockerfile` base image tag to its previous state (e.g., remove `:ubuntu-24-04`).

We will maintain the Ubuntu 20.04 build pool for a few weeks to allow time for any necessary fixes or rollbacks.

#### Support
We are available to support you during this transition. Please comment on this PR or reach out if you have questions.

#### Migrated Projects
| # | Project |
| :--- | :--- |
| 1 | abseil-py |
| 2 | ada-url |
| 3 | adal |
| 4 | aiohttp |
| 5 | ampproject |
| 6 | angle |
| 7 | angus-mail |
| 8 | aniso8601 |
| 9 | antlr3-java |
| 10 | antlr4-java |
| 11 | apache-commons-cli |
| 12 | apache-commons-codec |
| 13 | apache-commons-collections |
| 14 | apache-commons-compress |
| 15 | apache-commons-configuration |
| 16 | apache-commons-csv |
| 17 | apache-commons-fileupload |
| 18 | apache-commons-io |
| 19 | apache-commons-lang |
| 20 | apache-commons-net |
| 21 | apache-commons-text |
| 22 | apache-commons-validator |
| 23 | apache-cxf |
| 24 | apache-felix-dev |
| 25 | apache-httpd |
| 26 | arduinojson |
| 27 | argcomplete |
| 28 | args |
| 29 | args4j |
| 30 | arrow |
| 31 | arrow-py |
| 32 | askama |
| 33 | asn1crypto |
| 34 | assimp |
| 35 | astc-encoder |
| 36 | asteval |
| 37 | asttokens |
| 38 | async-http-client |
| 39 | atomic |
| 40 | attrs |
| 41 | autoflake |
| 42 | autopep8 |
| 43 | azure-sdk-for-python |
| 44 | babel |
| 45 | behaviortreecpp |
| 46 | bincode |
| 47 | binutils |
| 48 | black |
| 49 | blackfriday |
| 50 | bleach |
| 51 | bloaty |
| 52 | bluez |
| 53 | boost |
| 54 | boost-beast |
| 55 | boost-json |
| 56 | boringssl |
| 57 | botan |
| 58 | botocore |
| 59 | bottleneck |
| 60 | brotli |
| 61 | brotli-java |
| 62 | brpc |
| 63 | brunsli |
| 64 | bson-rust |
| 65 | burntsushi-toml |
| 66 | bz2file |
| 67 | bzip2 |
| 68 | c-ares |
| 69 | c-blosc |
| 70 | cachetools |
| 71 | caddy |
| 72 | caffeine |
| 73 | cairo |
| 74 | calcite |
| 75 | calcite-avatica |
| 76 | capnproto |
| 77 | capstone |
| 78 | cascadia |
| 79 | casync |
| 80 | cbor-java |
| 81 | cbor2 |
| 82 | cctz |
| 83 | cel-go |
| 84 | cert-manager |
| 85 | cfengine |
| 86 | cffi |
| 87 | cgif |
| 88 | chardet |
| 89 | charset_normalizer |
| 90 | checkstyle |
| 91 | chrono |
| 92 | circl |
| 93 | civetweb |
| 94 | cjson |
| 95 | clamav |
| 96 | clib |
| 97 | click |
| 98 | clock |
| 99 | closure-library |
| 100 | cloud-hypervisor |

CC: Adam@adalogics.com, Henry.Wang@arm.com, aayush@shieldblaze.com, adam@adalogics.com, agl@google.com, ajsinghyadav00@gmail.com, alex.gronholm@nextday.fi, antoine@python.org, armfazh@cloudflare.com, arthur.chan@adalogics.com, ashtumashtum@gmail.com, bas@cloudflare.com, bbe@google.com, bel2125@gmail.com, ben.manes@gmail.com, bengilgit@gmail.com, benoit.blanchon@gmail.com, blosc.oss.fuzz@gmail.com, bluez.test.bot@gmail.com, bo.arvin.chen@gmail.com, boards@gmail.com, brad@brad-house.com, brunodepaulak@gmail.com, bshas3@gmail.com, bug-binutils@gnu.org, bzip2fuzzer@gmail.com, capstone.engine@gmail.com, cascadia@balholm.com, cert-manager-security@googlegroups.com, christopher.krah@tii.ae, clamav-bugs@external.cisco.com, clamav.fuzz@gmail.com, constantin.rack@gmail.com, covener@gmail.com, cpovirk@google.com, daniel.haxx@gmail.com, daniel@lemire.me, david@adalogics.com, davidben@google.com, dewey.dunnington@gmail.com, dirkjan@ochtman.nl, dloebl.2000@gmail.com, droelf@googlemail.com, drysdale@google.com, emkornfield@gmail.com, eustas@chromium.org, fabduchene@microsoft.com, felipekde@gmail.com, fsaintjacques@gmail.com, fsumsal@redhat.com, fuzz-testing@commons.apache.org, garydgregory@gmail.com, gguthe@gmail.com, github@trangar.com, grisumbras@gmail.com, guidovranken@gmail.com, guillaume1.gomez@gmail.com, hj.tedd.an@gmail.com, ipudney@google.com, irali@google.com, isty001@gmail.com, jack.lloyd@gmail.com, jhaberman@gmail.com, jinpengz@google.com, joseph.werle@gmail.com, kabeor00@gmail.com, kenton@cloudflare.com, kim.kulling@googlemail.com, lennart@poettering.net, liuwe@microsoft.com, maplewish117@gmail.com, matthias.loebl@rwth-aachen.de, max@maxbruckner.de, mclow@boost.org, me@krisfremen.com, micahk@google.com, michael2012zhao@hotmail.com, msaa1990@gmail.com, muraken@gmail.com, nathan.moinvaziri@gmail.com, nathan@mccarty.io, nistephe@microsoft.com, norritt@bytefortress.de, p.antoine@catenacyber.fr, panahi@google.com, pauldreikossfuzz@gmail.com, pdimov@gmail.com, peter.harris@arm.com, peteralfredlee@gmail.com, poettering@gmail.com, psychon@znc.in, randy440088@gmail.com, raulcumplido@gmail.com, rbradford@rivosinc.com, re.korthaus@googlemail.com, rene.kijewski@fu-berlin.de, samuel.e.ortiz@protonmail.com, seb@rivosinc.com, security-tps@google.com, security@apache.org, security@commons.apache.org, security@sandstorm.io, stalkr@stalkr.net, stefan.eissing@gmail.com, svaldez@google.com, szucs.krisztian@gmail.com, tahri.ahmed@proton.me, taylor@axfive.net, terrence.parr@gmail.com, tswadell@google.com, ty@pre-alpha.com, ustcwg@gmail.com, vinnie.falco@gmail.com, vratislav.podzimek@northern.tech, wesmckinn@gmail.com, will.jones127@gmail.com, will@wbond.net, wkahngreene@mozilla.com, wp_scut@163.com, xhochy@gmail.com, xt4ubq@gmail.com, yagiz@nizipli.com, ylavic.dev@gmail.com, zanmato1984@gmail.com, zbyszek@in.waw.pl, zoey@dos.cafe, zotthewizard@gmail.com