### PR TITLE
nettle: refactor and fix broken build

### DIFF
--- a/projects/nettle/Dockerfile
+++ b/projects/nettle/Dockerfile
@@ -16,12 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder@sha256:19782f7fe8092843368894dbc471ce9b30dd6a2813946071a36e8b05f5b1e27e
 # ! Project pinned after a clang update and an afl link error. Log: https://oss-fuzz-gcb-logs.storage.googleapis.com/log-e701b6fa-f3a0-414e-ad6e-0223e6d42ebd.txt
-RUN apt-get update && apt-get install -y software-properties-common make autoconf build-essential wget lzip libtool python
+RUN apt-get update && apt-get install -y software-properties-common make autoconf build-essential wget lzip libtool
 RUN git clone --depth 1 https://git.lysator.liu.se/nettle/nettle
-RUN git clone --depth 1 https://github.com/randombit/botan.git
-RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz
-RUN git clone --depth 1 https://github.com/guidovranken/cryptofuzz-corpora
-RUN wget https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.bz2
-RUN wget https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz
-RUN test "$(sha256sum gmp-6.2.1.tar.lz)" = "2c7f4f0d370801b2849c48c9ef3f59553b5f1d3791d070cffb04599f9fc67b41  gmp-6.2.1.tar.lz"
+COPY fuzz_*.c $SRC/
 COPY build.sh $SRC/

--- a/projects/nettle/build.sh
+++ b/projects/nettle/build.sh
@@ -15,136 +15,36 @@
 #
 ################################################################################
 
-export LINK_FLAGS=""
-
-# Not using OpenSSL
-    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NO_OPENSSL"
-
-# Install Boost headers
-    cd $SRC/
-    tar jxf boost_1_84_0.tar.bz2
-    cd boost_1_84_0/
-    CFLAGS="" CXXFLAGS="" ./bootstrap.sh
-    CFLAGS="" CXXFLAGS="" ./b2 headers
-    cp -R boost/ /usr/include/
-
-
-# Generate lookup tables. This only needs to be done once.
-    cd $SRC/cryptofuzz
-    python gen_repository.py
+# Build Nettle with mini-gmp (no external gmp dependency)
+cd $SRC/nettle
+bash .bootstrap
 
 if [[ $CFLAGS != *sanitize=memory* ]]
 then
-    # Compile libgmp
-        cd $SRC/
-        lzip -d gmp-6.2.1.tar.lz
-        tar xf gmp-6.2.1.tar
-
-        cd gmp-6.2.1/
-        autoreconf -ivf
-        if [[ $CFLAGS != *-m32* ]]
-        then
-            ./configure --enable-maintainer-mode
-        else
-            setarch i386 ./configure --enable-maintainer-mode
-        fi
-        make -j$(nproc)
-        make install
-
-    # Compile Nettle (with libgmp)
-        mkdir $SRC/nettle-with-libgmp-install/
-        cp -R $SRC/nettle $SRC/nettle-with-libgmp/
-        cd $SRC/nettle-with-libgmp/
-        bash .bootstrap
-        export NETTLE_LIBDIR=`realpath ../nettle-with-libgmp-install`/lib
-        if [[ $CFLAGS != *sanitize=memory* ]]
-        then
-            ./configure --disable-documentation --disable-openssl --prefix=`realpath ../nettle-with-libgmp-install` --libdir="$NETTLE_LIBDIR"
-        else
-            ./configure --disable-documentation --disable-openssl --disable-assembler --prefix=`realpath ../nettle-with-libgmp-install` --libdir="$NETTLE_LIBDIR"
-        fi
-        make -j$(nproc)
-        make install
-
-        export LIBNETTLE_A_PATH=$NETTLE_LIBDIR/libnettle.a
-        export LIBHOGWEED_A_PATH=$NETTLE_LIBDIR/libhogweed.a
-        export NETTLE_INCLUDE_PATH=`realpath ../nettle-with-libgmp-install/include`
-        export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NETTLE"
-        export LINK_FLAGS="$LINK_FLAGS /usr/local/lib/libgmp.a"
-
-        # Compile Cryptofuzz Nettle module
-        cd $SRC/cryptofuzz/modules/nettle
-        make -f Makefile-hogweed -B
-
-    ##############################################################################
-    # Compile Botan
-        cd $SRC/botan
-        if [[ $CFLAGS != *-m32* ]]
-        then
-            ./configure.py --cc-bin=$CXX --cc-abi-flags="$CXXFLAGS" --disable-shared --disable-modules=locking_allocator --build-targets=static --without-documentation
-        else
-            ./configure.py --cpu=x86_32 --cc-bin=$CXX --cc-abi-flags="$CXXFLAGS" --disable-shared --disable-modules=locking_allocator --build-targets=static --without-documentation
-        fi
-        make -j$(nproc)
-
-        export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_BOTAN"
-        export LIBBOTAN_A_PATH="$SRC/botan/libbotan-3.a"
-        export BOTAN_INCLUDE_PATH="$SRC/botan/build/include"
-
-        # Compile Cryptofuzz Botan module
-        cd $SRC/cryptofuzz/modules/botan
-        make -B
-
-    # Compile Cryptofuzz
-        cd $SRC/cryptofuzz
-        LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" make -B -j$(nproc) >/dev/null
-
-        # Generate dictionary
-        ./generate_dict
-
-        # Copy fuzzer
-        cp $SRC/cryptofuzz/cryptofuzz $OUT/cryptofuzz-nettle-with-libgmp
-        # Copy dictionary
-        cp $SRC/cryptofuzz/cryptofuzz-dict.txt $OUT/cryptofuzz-nettle-with-libgmp.dict
-        # Copy seed corpus
-        cp $SRC/cryptofuzz-corpora/libressl_latest.zip $OUT/cryptofuzz-nettle-with-libgmp_seed_corpus.zip
+    ./configure --enable-mini-gmp --disable-documentation --disable-openssl --prefix=$SRC/nettle-install
+else
+    ./configure --enable-mini-gmp --disable-documentation --disable-openssl --disable-assembler --prefix=$SRC/nettle-install
 fi
 
-# Compile Nettle (with mini gmp)
-    mkdir $SRC/nettle-with-mini-gmp-install/
-    cp -R $SRC/nettle $SRC/nettle-with-mini-gmp/
-    cd $SRC/nettle-with-mini-gmp/
-    bash .bootstrap
-    export NETTLE_LIBDIR=`realpath ../nettle-with-mini-gmp-install`/lib
-    if [[ $CFLAGS != *sanitize=memory* ]]
-    then
-        ./configure --enable-mini-gmp --disable-documentation --disable-openssl --prefix=`realpath ../nettle-with-mini-gmp-install` --libdir="$NETTLE_LIBDIR"
-    else
-        ./configure --enable-mini-gmp --disable-documentation --disable-openssl --disable-assembler --prefix=`realpath ../nettle-with-mini-gmp-install` --libdir="$NETTLE_LIBDIR"
-    fi
-    make -j$(nproc)
-    make install
+make -j$(nproc)
+make install
 
-    export LIBNETTLE_A_PATH=$NETTLE_LIBDIR/libnettle.a
-    export LIBHOGWEED_A_PATH=$NETTLE_LIBDIR/libhogweed.a
-    export NETTLE_INCLUDE_PATH=`realpath ../nettle-with-mini-gmp-install/include`
-    export LINK_FLAGS=""
-    export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_NETTLE"
+# Build all fuzzers
+FUZZERS="
+fuzz_dsa_sha1_keypair_from_sexp
+fuzz_dsa_sha256_keypair_from_sexp
+fuzz_dsa_signature_from_sexp
+fuzz_dsa_openssl_private_key_from_der
+fuzz_rsa_keypair_from_sexp
+fuzz_rsa_keypair_from_der
+fuzz_rsa_public_key_from_der
+"
 
-    # Compile Cryptofuzz Nettle module
-    cd $SRC/cryptofuzz/modules/nettle
-    make -f Makefile-hogweed -B
+for fuzzer in $FUZZERS; do
+    $CC $CFLAGS -I$SRC/nettle-install/include -c $SRC/${fuzzer}.c -o $SRC/${fuzzer}.o
+    $CXX $CXXFLAGS $SRC/${fuzzer}.o -o $OUT/${fuzzer} \
+        $LIB_FUZZING_ENGINE \
+        $SRC/nettle-install/lib/libhogweed.a \
+        $SRC/nettle-install/lib/libnettle.a
+done
 
-# Compile Cryptofuzz
-    cd $SRC/cryptofuzz
-    LIBFUZZER_LINK="$LIB_FUZZING_ENGINE" make -B -j$(nproc) >/dev/null
-
-    # Generate dictionary
-    ./generate_dict
-
-    # Copy fuzzer
-    cp $SRC/cryptofuzz/cryptofuzz $OUT/cryptofuzz-nettle-with-mini-gmp
-    # Copy dictionary
-    cp $SRC/cryptofuzz/cryptofuzz-dict.txt $OUT/cryptofuzz-nettle-with-mini-gmp.dict
-    # Copy seed corpus
-    cp $SRC/cryptofuzz-corpora/libressl_latest.zip $OUT/cryptofuzz-nettle-with-mini-gmp_seed_corpus.zip

--- a/projects/nettle/fuzz_dsa_openssl_private_key_from_der.c
+++ b/projects/nettle/fuzz_dsa_openssl_private_key_from_der.c
@@ -1,0 +1,35 @@
+// Copyright 2025 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdint.h>
+#include <stddef.h>
+#include <nettle/dsa.h>
+#include <nettle/bignum.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    struct dsa_params params;
+    mpz_t pub, priv;
+
+    dsa_params_init(&params);
+    mpz_init(pub);
+    mpz_init(priv);
+
+    dsa_openssl_private_key_from_der(&params, pub, priv, 0, size, data);
+
+    mpz_clear(priv);
+    mpz_clear(pub);
+    dsa_params_clear(&params);
+    return 0;
+}
+

--- a/projects/nettle/fuzz_dsa_sha1_keypair_from_sexp.c
+++ b/projects/nettle/fuzz_dsa_sha1_keypair_from_sexp.c
@@ -1,0 +1,35 @@
+// Copyright 2025 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdint.h>
+#include <stddef.h>
+#include <nettle/dsa.h>
+#include <nettle/bignum.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    struct dsa_params params;
+    mpz_t pub, priv;
+
+    dsa_params_init(&params);
+    mpz_init(pub);
+    mpz_init(priv);
+
+    dsa_sha1_keypair_from_sexp(&params, pub, priv, 0, size, data);
+
+    mpz_clear(priv);
+    mpz_clear(pub);
+    dsa_params_clear(&params);
+    return 0;
+}
+

--- a/projects/nettle/fuzz_dsa_sha256_keypair_from_sexp.c
+++ b/projects/nettle/fuzz_dsa_sha256_keypair_from_sexp.c
@@ -1,0 +1,35 @@
+// Copyright 2025 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdint.h>
+#include <stddef.h>
+#include <nettle/dsa.h>
+#include <nettle/bignum.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    struct dsa_params params;
+    mpz_t pub, priv;
+
+    dsa_params_init(&params);
+    mpz_init(pub);
+    mpz_init(priv);
+
+    dsa_sha256_keypair_from_sexp(&params, pub, priv, 0, size, data);
+
+    mpz_clear(priv);
+    mpz_clear(pub);
+    dsa_params_clear(&params);
+    return 0;
+}
+

--- a/projects/nettle/fuzz_dsa_signature_from_sexp.c
+++ b/projects/nettle/fuzz_dsa_signature_from_sexp.c
@@ -1,0 +1,34 @@
+// Copyright 2025 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdint.h>
+#include <stddef.h>
+#include <nettle/dsa.h>
+#include <nettle/sexp.h>
+#include <nettle/bignum.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    struct dsa_signature sig;
+    struct sexp_iterator iter;
+
+    dsa_signature_init(&sig);
+
+    if (sexp_iterator_first(&iter, size, data)) {
+        dsa_signature_from_sexp(&sig, &iter, 256);
+    }
+
+    dsa_signature_clear(&sig);
+    return 0;
+}
+

--- a/projects/nettle/fuzz_rsa_keypair_from_der.c
+++ b/projects/nettle/fuzz_rsa_keypair_from_der.c
@@ -1,0 +1,33 @@
+// Copyright 2025 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdint.h>
+#include <stddef.h>
+#include <nettle/rsa.h>
+#include <nettle/bignum.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    struct rsa_public_key pub;
+    struct rsa_private_key priv;
+
+    rsa_public_key_init(&pub);
+    rsa_private_key_init(&priv);
+
+    rsa_keypair_from_der(&pub, &priv, 0, size, data);
+
+    rsa_private_key_clear(&priv);
+    rsa_public_key_clear(&pub);
+    return 0;
+}
+

--- a/projects/nettle/fuzz_rsa_keypair_from_sexp.c
+++ b/projects/nettle/fuzz_rsa_keypair_from_sexp.c
@@ -1,0 +1,33 @@
+// Copyright 2025 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdint.h>
+#include <stddef.h>
+#include <nettle/rsa.h>
+#include <nettle/bignum.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    struct rsa_public_key pub;
+    struct rsa_private_key priv;
+
+    rsa_public_key_init(&pub);
+    rsa_private_key_init(&priv);
+
+    rsa_keypair_from_sexp(&pub, &priv, 0, size, data);
+
+    rsa_private_key_clear(&priv);
+    rsa_public_key_clear(&pub);
+    return 0;
+}
+

--- a/projects/nettle/fuzz_rsa_public_key_from_der.c
+++ b/projects/nettle/fuzz_rsa_public_key_from_der.c
@@ -1,0 +1,34 @@
+// Copyright 2025 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdint.h>
+#include <stddef.h>
+#include <nettle/rsa.h>
+#include <nettle/asn1.h>
+#include <nettle/bignum.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    struct rsa_public_key pub;
+    struct asn1_der_iterator iter;
+
+    rsa_public_key_init(&pub);
+
+    if (asn1_der_iterator_first(&iter, size, data) == ASN1_ITERATOR_CONSTRUCTED) {
+        rsa_public_key_from_der_iterator(&pub, 0, &iter);
+    }
+
+    rsa_public_key_clear(&pub);
+    return 0;
+}
+


### PR DESCRIPTION
Fixes Nettles broken build by refactoring away cryptofuzz. The PR replaces the cryptofuzz fuzzer with a few new ones that call Nettle directly.