### PR TITLE
[openvswitch] Prepare for 24.04 base image upgrade (#14456)

### DIFF
--- a/projects/openvswitch/Dockerfile
+++ b/projects/openvswitch/Dockerfile
@@ -16,8 +16,8 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake \
-    libtool python python3-pip \
-    libz-dev libssl-dev libssl1.1 wget
+    libtool python3 python3-pip \
+    libz-dev libssl-dev wget
 RUN pip3 install six
 RUN git clone --depth 1 https://github.com/openvswitch/ovs.git openvswitch
 RUN git clone --depth 1 https://github.com/openvswitch/ovs-fuzzing-corpus.git \


### PR DESCRIPTION
'python' and 'libssl1.1' are not available in 24.04, it's 'python3' and 'libssl3' instead. 
But we also don't really need to install 'libssl3' separately.

This change is compatible with the currnet Ubuntu 20.04 as well.

Fixes: https://github.com/google/oss-fuzz/issues/14456