### PR TITLE
dgraph: fix broken build

### DIFF
--- a/projects/dgraph/build.sh
+++ b/projects/dgraph/build.sh
@@ -18,4 +18,4 @@
 mv $SRC/fuzz_parser_test.go $SRC/dgraph/dql/
 printf "package dql\nimport _ \"github.com/AdamKorcz/go-118-fuzz-build/testing\"\n" > dql/register.go
 go mod tidy
-compile_native_go_fuzzer github.com/hypermodeinc/dgraph/v25/dql FuzzParserTest parser_fuzzer
+compile_native_go_fuzzer github.com/dgraph-io/dgraph/v25/dql FuzzParserTest parser_fuzzer


### PR DESCRIPTION
In dgraph Commit 20d2832, I discover that "github.com/hypermodeinc/" is changed to "docs.dgraph.io/". Fuzzing build can be fixed simply by replacing "github.com/hypermodeinc/dgraph/v25/dql" with "github.com/dgraph-io/dgraph/v25/dql". I have already verified this fix in my local environment.