### PR TITLE
Initial cirq project integration

### DIFF
--- a/projects/cirq/Dockerfile
+++ b/projects/cirq/Dockerfile
@@ -1,0 +1,42 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-python
+
+RUN git clone \
+   --depth 1 \
+   --branch main \
+   https://github.com/quantumlib/Cirq.git
+
+WORKDIR $SRC/Cirq
+
+RUN apt-get update
+RUN cat apt-system-requirements.txt dev_tools/conf/apt-list-dev-tools.txt | xargs apt-get install -y
+
+# Install cirq dependencies
+RUN pip3 install --upgrade pip
+RUN pip3 install -r dev_tools/requirements/dev.env.txt
+
+# Install cirq related modules
+RUN pip3 install \
+   ./cirq-core \
+   ./cirq-aqt \
+   ./cirq-web \
+   ./cirq-ionq \
+   ./cirq-google \
+   ./cirq-pasqal
+
+COPY build.sh fuzz_circuit.py $SRC/

--- a/projects/cirq/build.sh
+++ b/projects/cirq/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -eu
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+pip3 install .
+
+for fuzzer in $(find $SRC -name 'fuzz_*.py'); do
+ fuzzer_basename=$(basename -s .py $fuzzer)
+ fuzzer_package=${fuzzer_basename}.pkg
+
+ pyinstaller --distpath $OUT --onefile --name $fuzzer_package --hidden-import "scipy._cyutility" --hidden-import "numpy._core._exceptions" $fuzzer
+
+ echo "#!/bin/sh
+# LLVMFuzzerTestOneInput for fuzzer detection.
+this_dir=\$(dirname \"\$0\")
+LD_PRELOAD=\$this_dir/sanitizer_with_fuzzer.so \
+ASAN_OPTIONS=\$ASAN_OPTIONS:symbolize=1:external_symbolizer_path=\$this_dir/llvm-symbolizer:detect_leaks=0 \
+\$this_dir/$fuzzer_package \$@" > $OUT/$fuzzer_basename
+ chmod +x $OUT/$fuzzer_basename
+done

--- a/projects/cirq/fuzz_circuit.py
+++ b/projects/cirq/fuzz_circuit.py
@@ -1,0 +1,88 @@
+#!/usr/bin/python3
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+import atheris
+import sys
+import cirq
+
+
+@atheris.instrument_func
+def TestOneInput(data):
+    """Fuzzing target for Cirq circuit operations."""
+    fdp = atheris.FuzzedDataProvider(data)
+
+    # Test basic circuit creation
+    circuit = cirq.Circuit()
+
+    # Generate random number of qubits
+    num_qubits = fdp.ConsumeIntInRange(1, 3)
+    qubits = cirq.LineQubit.range(num_qubits)
+
+    # Generate random number of operations
+    num_ops = fdp.ConsumeIntInRange(1, 5)
+
+    for _ in range(num_ops):
+        if not fdp.remaining_bytes():
+            break
+
+        # Choose random gate type
+        gate_type = fdp.ConsumeIntInRange(0, 5)
+
+        if gate_type == 0 and len(qubits) >= 1:
+            # Single qubit X gate
+            qubit_idx = fdp.ConsumeIntInRange(0, len(qubits) - 1)
+            circuit.append(cirq.X(qubits[qubit_idx]))
+
+        elif gate_type == 1 and len(qubits) >= 1:
+            # Single qubit Y gate
+            qubit_idx = fdp.ConsumeIntInRange(0, len(qubits) - 1)
+            circuit.append(cirq.Y(qubits[qubit_idx]))
+
+        elif gate_type == 2 and len(qubits) >= 1:
+            # Single qubit Z gate
+            qubit_idx = fdp.ConsumeIntInRange(0, len(qubits) - 1)
+            circuit.append(cirq.Z(qubits[qubit_idx]))
+
+        elif gate_type == 3 and len(qubits) >= 1:
+            # Hadamard gate
+            qubit_idx = fdp.ConsumeIntInRange(0, len(qubits) - 1)
+            circuit.append(cirq.H(qubits[qubit_idx]))
+
+        elif gate_type == 4 and len(qubits) >= 2:
+            # CNOT gate
+            control_idx = fdp.ConsumeIntInRange(0, len(qubits) - 1)
+            target_idx = fdp.ConsumeIntInRange(0, len(qubits) - 1)
+            if control_idx != target_idx:
+                circuit.append(cirq.CNOT(qubits[control_idx], qubits[target_idx]))
+
+        elif gate_type == 5 and len(qubits) >= 2:
+            # CZ gate
+            control_idx = fdp.ConsumeIntInRange(0, len(qubits) - 1)
+            target_idx = fdp.ConsumeIntInRange(0, len(qubits) - 1)
+            if control_idx != target_idx:
+                circuit.append(cirq.CZ(qubits[control_idx], qubits[target_idx]))
+
+    simulator = cirq.Simulator()
+    simulator.simulate(circuit)
+
+def main():
+    """Main entry point for the fuzzer."""
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+if __name__ == "__main__":
+    main()

--- a/projects/cirq/project.yaml
+++ b/projects/cirq/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://github.com/quantumlib/Cirq"
+language: python
+primary_contact: "quantum-oss-maintainers@google.com"
+auto_ccs:
+  - "mhucka@google.com"
+  - "mrtoastcheng@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+  - undefined
+main_repo: "https://github.com/quantumlib/Cirq.git"


### PR DESCRIPTION
This PR adds the [Cirq](https://github.com/quantumlib/Cirq) project, it's configuration and build.sh. It also includes a fuzzer on 5 basic quantum gates.
