### PR TITLE
pigweed: fix broken build

### DIFF
--- a/projects/pigweed/Dockerfile
+++ b/projects/pigweed/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
-RUN apt-get update && apt-get install -y git build-essential python python3
+RUN apt-get update && apt-get install -y git build-essential python-is-python3 python3
 RUN git clone 'https://pigweed.googlesource.com/pigweed/pigweed'  --depth 1
 
 COPY build.sh $SRC/


### PR DESCRIPTION
Ubuntu 24.04 has removed the default python package name. Therefore, use Python-is-Python 3 provided by Ubuntu.