### PR TITLE
pacemaker: fix broken build

### DIFF
--- a/projects/pacemaker/build.sh
+++ b/projects/pacemaker/build.sh
@@ -46,5 +46,5 @@ for FUZZER_SOURCE in lib/*/fuzzers/*.c; do
    ./lib/cib/.libs/libcib.a ./lib/pengine/.libs/libpe_rules.a              \
    ./lib/common/.libs/libcrmcommon.a -l:libqb.a                            \
    -l:libxslt.a -l:libxml2.a -l:libglib-2.0.a -l:libuuid.a -l:libicuuc.a   \
-   -l:libz.a -lgnutls -lbz2 -lrt -ldl -lc
+   -l:libz.a -lgnutls -lbz2 -lpcre -lrt -ldl -lc
 done


### PR DESCRIPTION
The -lpcre flag is missing in the linker command, resulting in the PCRE function required by the static GLib library not being found.  In the linker parameter of build.sh, this issue was resolved by adding -lpcre between -lbz2 and -lrt.