### PR TITLE
Revert "bitcoin-core: Switch to Ubuntu 24.04 (#14457)"

### DIFF
--- a/projects/bitcoin-core/Dockerfile
+++ b/projects/bitcoin-core/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
+FROM gcr.io/oss-fuzz-base/base-builder
 
 # Packages taken from:
 # * https://github.com/bitcoin/bitcoin/blob/master/doc/build-unix.md#dependency-build-instructions

--- a/projects/bitcoin-core/project.yaml
+++ b/projects/bitcoin-core/project.yaml
@@ -21,4 +21,3 @@ fuzzing_engines:
 #  - centipede # temporarily disabled due to spurious "Step #22 - "build-check-centipede-none-x86_64": OSError: [Errno 28] No space left on device"
   - libfuzzer
   - honggfuzz
-base_os_version: ubuntu-24-04


### PR DESCRIPTION
This broke msan+libfuzzer, so revert it temporarily.

Also, ref https://github.com/bitcoin/bitcoin/pull/33666