### PR TITLE
jsoup: bump Maven to 3.9.11 and build with Java 17

### DIFF
--- a/projects/jsoup/Dockerfile
+++ b/projects/jsoup/Dockerfile
@@ -16,11 +16,13 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 
-RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip -o maven.zip && \
+ARG MAVEN_VERSION=3.9.11
+
+RUN curl -L https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \
     rm -rf maven.zip
 
-ENV MVN $SRC/maven/apache-maven-3.6.3/bin/mvn
+ENV MVN $SRC/maven/apache-maven-$MAVEN_VERSION/bin/mvn
 
 RUN git clone --depth 1 https://github.com/google/fuzzing && \
     cat fuzzing/dictionaries/html.dict \

--- a/projects/jsoup/build.sh
+++ b/projects/jsoup/build.sh
@@ -18,9 +18,9 @@
 # Move seed corpus and dictionary.
 mv $SRC/{*.zip,*.dict,*.options} $OUT
 
-MAVEN_ARGS="-Dmaven.test.skip=true -Djavac.src.version=15 -Djavac.target.version=15"
-$MVN package org.apache.maven.plugins:maven-shade-plugin:3.2.4:shade $MAVEN_ARGS
-CURRENT_VERSION=$($MVN org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate \
+MAVEN_ARGS="-Dmaven.test.skip=true -Djavac.src.version=17 -Djavac.target.version=17"
+$MVN package org.apache.maven.plugins:maven-shade-plugin:3.6.1:shade $MAVEN_ARGS
+CURRENT_VERSION=$($MVN org.apache.maven.plugins:maven-help-plugin:3.5.1:evaluate \
  -Dexpression=project.version -q -DforceStdout)
 cp "target/jsoup-$CURRENT_VERSION.jar" $OUT/jsoup.jar
 


### PR DESCRIPTION
Updating Maven in particular so that I can merge https://github.com/jhy/jsoup/pull/2447 which requires a newer version.
