### PR TITLE
hwloc: Add run_tests.sh

### DIFF
--- a/projects/hwloc/run_tests.sh
+++ b/projects/hwloc/run_tests.sh
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 ################################################################################
-make check
+make -C utils/hwloc check


### PR DESCRIPTION
Adds run_tests.sh for the hwloc project.

run_tests.sh is used as part of Chronos with cached builds:
https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests