### PR TITLE
apache-commons-logging: bump Maven version and fix broken build

### DIFF
--- a/projects/apache-commons-logging/Dockerfile
+++ b/projects/apache-commons-logging/Dockerfile
@@ -16,14 +16,13 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 
-RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip -o maven.zip && \
+RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.zip -o maven.zip && \
 unzip maven.zip -d $SRC/maven && \
 rm -rf maven.zip
 
-ENV MVN $SRC/maven/apache-maven-3.6.3/bin/mvn
+ENV MVN $SRC/maven/apache-maven-3.9.11/bin/mvn
 
 RUN git clone https://github.com/apache/commons-logging
-
 COPY build.sh $SRC/
 COPY *.java *.xml $SRC/
 COPY Package $SRC/Package/

--- a/projects/apache-commons-logging/build.sh
+++ b/projects/apache-commons-logging/build.sh
@@ -28,11 +28,10 @@ pushd "${SRC}/commons-logging"
 	ALL_JARS="${ALL_JARS} commons-logging.jar"
 popd
 
-LOG4J_VERSION=$(echo $(curl -s 'https://api.github.com/repos/apache/logging-log4j2/tags?per_page=1' | jq -r .[].name) | sed 's/^[^0-9]*//')
-curl "https://dlcdn.apache.org/logging/log4j/$LOG4J_VERSION/apache-log4j-$LOG4J_VERSION-bin.tar.gz" -o apache-log4j-bin.tar.gz
-tar xf apache-log4j-bin.tar.gz
-unlink apache-log4j-bin.tar.gz
-mv apache-log4j-$LOG4J_VERSION-bin $SRC
+LOG4J_VERSION=$(curl -s 'https://api.github.com/repos/apache/logging-log4j2/tags?per_page=20' | jq -r '.[].name' | grep -E '^rel/2\.[0-9]+\.[0-9]+$' | head -1 | sed 's/^rel\///')
+curl "https://archive.apache.org/dist/logging/log4j/$LOG4J_VERSION/apache-log4j-$LOG4J_VERSION-bin.zip" -o apache-log4j-bin.zip
+unzip -q -o apache-log4j-bin.zip -d $SRC/apache-log4j-$LOG4J_VERSION-bin
+unlink apache-log4j-bin.zip
 
 for jarFile in ${SRC}/apache-log4j-$LOG4J_VERSION-bin/log4j-api-$LOG4J_VERSION.jar ${SRC}/apache-log4j-$LOG4J_VERSION-bin/log4j-core-$LOG4J_VERSION.jar ${SRC}/apache-log4j-$LOG4J_VERSION-bin/log4j-1.2-api-$LOG4J_VERSION.jar ; do
 	cp -v ${jarFile} "$OUT/$(basename ${jarFile})"


### PR DESCRIPTION
The build needed an update for how it retrieved the log4j version.