### PR TITLE
cairo: Add run_tests.sh

### DIFF
--- a/projects/cairo/Dockerfile
+++ b/projects/cairo/Dockerfile
@@ -29,4 +29,4 @@ ADD https://raw.githubusercontent.com/google/fuzzing/master/dictionaries/svg.dic
 
 WORKDIR $SRC/cairo
 COPY targets $SRC/fuzz
-COPY build.sh $SRC/
+COPY build.sh run_tests.sh $SRC/

--- a/projects/cairo/run_tests.sh
+++ b/projects/cairo/run_tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC/cairo
+meson test -C _builddir


### PR DESCRIPTION
Adds run_tests.sh for the cairo project.

run_tests.sh is used as part of Chronos with cached builds:
https://github.com/google/oss-fuzz/tree/master/infra/experimental/chronos#check-tests