### PR TITLE
jackson-datatypes-collections: fix and refactor broken build

### DIFF
--- a/projects/jackson-datatypes-collections/Dockerfile
+++ b/projects/jackson-datatypes-collections/Dockerfile
@@ -18,10 +18,10 @@ FROM gcr.io/oss-fuzz-base/base-builder-jvm:ubuntu-24-04
 
 RUN git clone --depth 1 https://github.com/FasterXML/jackson-datatypes-collections $SRC/jackson-datatypes-collections
 
-RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.zip -o maven.zip && \
+RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \
     rm -rf maven.zip
-ENV MVN $SRC/maven/apache-maven-3.8.7/bin/mvn
+ENV MVN $SRC/maven/apache-maven-3.9.9/bin/mvn
 
 COPY build.sh $SRC/
 COPY *Fuzzer.java $SRC/

--- a/projects/jackson-datatypes-collections/EclipseCollectionsDeserializerFuzzer.java
+++ b/projects/jackson-datatypes-collections/EclipseCollectionsDeserializerFuzzer.java
@@ -14,9 +14,10 @@
 //
 ///////////////////////////////////////////////////////////////////////////
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.eclipsecollections.EclipseCollectionsModule;
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.datatype.eclipsecollections.EclipseCollectionsModule;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,7 +28,9 @@ public class EclipseCollectionsDeserializerFuzzer {
 
   public static void fuzzerInitialize() {
     // Register the EclipseCollectionsModule for the deserialization
-    mapper = new ObjectMapper().registerModule(new EclipseCollectionsModule());
+    mapper = JsonMapper.builder()
+        .addModule(new EclipseCollectionsModule())
+        .build();
     initializeClassChoice();
   }
 
@@ -37,8 +40,7 @@ public class EclipseCollectionsDeserializerFuzzer {
       Class type = data.pickValue(choice);
       String value = data.consumeRemainingAsString();
       mapper.readValue(value, type);
-      mapper.readTree(value);
-    } catch (IOException | IllegalArgumentException e) {
+    } catch (JacksonException e) {
       // Known exception
     }
   }

--- a/projects/jackson-datatypes-collections/EclipseCollectionsSerializerFuzzer.java
+++ b/projects/jackson-datatypes-collections/EclipseCollectionsSerializerFuzzer.java
@@ -15,10 +15,11 @@
 ///////////////////////////////////////////////////////////////////////////
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.eclipsecollections.EclipseCollectionsModule;
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.datatype.eclipsecollections.EclipseCollectionsModule;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.map.MutableMap;
@@ -41,7 +42,9 @@ public class EclipseCollectionsSerializerFuzzer {
 
   public static void fuzzerInitialize() {
     // Register the EclipseCollectionsModule for the serialization
-    mapper = new ObjectMapper().registerModule(new EclipseCollectionsModule());
+    mapper = JsonMapper.builder()
+        .addModule(new EclipseCollectionsModule())
+        .build();
   }
 
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
@@ -62,9 +65,6 @@ public class EclipseCollectionsSerializerFuzzer {
               new PrimitiveIterativeObject(ByteLists.immutable.of(byteArray)));
           break;
         case 3:
-          mapper =
-              mapper.configure(
-                  SerializationFeature.WRITE_CHAR_ARRAYS_AS_JSON_ARRAYS, data.consumeBoolean());
           char[] charArray = data.consumeRemainingAsString().toCharArray();
           mapper.writeValueAsString(CharLists.immutable.of(charArray));
           mapper.writeValueAsString(
@@ -164,7 +164,7 @@ public class EclipseCollectionsSerializerFuzzer {
           mapper.writeValueAsString(IntObjectMaps.immutable.of(0, data.consumeRemainingAsBytes()));
           break;
       }
-    } catch (IOException e) {
+    } catch (JacksonException e) {
       // Known exception
     }
   }

--- a/projects/jackson-datatypes-collections/GuavaDeserializerFuzzer.java
+++ b/projects/jackson-datatypes-collections/GuavaDeserializerFuzzer.java
@@ -15,9 +15,11 @@
 ///////////////////////////////////////////////////////////////////////////
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.datatype.guava.GuavaModule;
 import com.google.common.cache.Cache;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.HashMultimap;
@@ -55,7 +57,9 @@ public class GuavaDeserializerFuzzer {
     // Register the GuavaModule for the deserialization
     GuavaModule module = new GuavaModule();
     module.configureAbsentsAsNulls(false);
-    mapper = new ObjectMapper().registerModule(module);
+    mapper = JsonMapper.builder()
+        .addModule(module)
+        .build();
     initializeClassChoice();
   }
 
@@ -65,7 +69,7 @@ public class GuavaDeserializerFuzzer {
       TypeReference type = data.pickValue(choice);
       String value = data.consumeRemainingAsString();
       mapper.readValue(value, type);
-    } catch (IOException | IllegalArgumentException e) {
+    } catch (JacksonException e) {
       // Known exception
     }
   }

--- a/projects/jackson-datatypes-collections/HppcDeserializerFuzzer.java
+++ b/projects/jackson-datatypes-collections/HppcDeserializerFuzzer.java
@@ -20,9 +20,10 @@ import com.carrotsearch.hppc.IntHashSet;
 import com.carrotsearch.hppc.IntIndexedContainer;
 import com.carrotsearch.hppc.IntSet;
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.hppc.HppcModule;
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.datatype.hppc.HppcModule;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,7 +34,9 @@ public class HppcDeserializerFuzzer {
 
   public static void fuzzerInitialize() {
     // Register the Hppc for the deserialization
-    mapper = new ObjectMapper().registerModule(new HppcModule());
+    mapper = JsonMapper.builder()
+        .addModule(new HppcModule())
+        .build();
     initializeClassChoice();
   }
 
@@ -43,7 +46,7 @@ public class HppcDeserializerFuzzer {
       Class type = data.pickValue(choice);
       String value = data.consumeRemainingAsString();
       mapper.readValue(value, type);
-    } catch (IOException e) {
+    } catch (JacksonException e) {
       // Known exception
     }
   }

--- a/projects/jackson-datatypes-collections/HppcSerializerFuzzer.java
+++ b/projects/jackson-datatypes-collections/HppcSerializerFuzzer.java
@@ -26,9 +26,10 @@ import com.carrotsearch.hppc.LongHashSet;
 import com.carrotsearch.hppc.ShortArrayList;
 import com.carrotsearch.hppc.ShortHashSet;
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.hppc.HppcModule;
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.datatype.hppc.HppcModule;
 
 /** This fuzzer targets the serialization methods of Hppc objects */
 public class HppcSerializerFuzzer {
@@ -36,7 +37,9 @@ public class HppcSerializerFuzzer {
 
   public static void fuzzerInitialize() {
     // Register the HppcModule for the serialization
-    mapper = new ObjectMapper().registerModule(new HppcModule());
+    mapper = JsonMapper.builder()
+        .addModule(new HppcModule())
+        .build();
   }
 
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
@@ -113,7 +116,7 @@ public class HppcSerializerFuzzer {
           mapper.writeValueAsString(bitSet);
           break;
       }
-    } catch (IOException e) {
+    } catch (JacksonException e) {
       // Known exception
     }
   }

--- a/projects/jackson-datatypes-collections/PCollectionsFuzzer.java
+++ b/projects/jackson-datatypes-collections/PCollectionsFuzzer.java
@@ -14,10 +14,11 @@
 //
 ///////////////////////////////////////////////////////////////////////////
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.pcollections.PCollectionsModule;
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.datatype.pcollections.PCollectionsModule;
 import java.util.ArrayList;
 import java.util.List;
 import org.pcollections.ConsPStack;
@@ -41,7 +42,9 @@ public class PCollectionsFuzzer {
 
   public static void fuzzerInitialize() {
     // Register the PCollectionsModule for fuzzing
-    mapper = new ObjectMapper().registerModule(new PCollectionsModule());
+    mapper = JsonMapper.builder()
+        .addModule(new PCollectionsModule())
+        .build();
     initializeClassChoice();
   }
 
@@ -51,7 +54,7 @@ public class PCollectionsFuzzer {
       TypeReference type = data.pickValue(choice);
       String value = data.consumeRemainingAsString();
       mapper.readValue(value, type);
-    } catch (IOException e) {
+    } catch (JacksonException e) {
       // Known exception
     }
   }


### PR DESCRIPTION
Several fuzzers were broken because they haven't been updated based on upstream code changes.