### PR TITLE
mosquitto: fix broken build

### DIFF
--- a/projects/mosquitto/Dockerfile
+++ b/projects/mosquitto/Dockerfile
@@ -18,6 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 
 # Main repo
 RUN git clone --depth 1 -b develop https://github.com/eclipse/mosquitto ${SRC}/mosquitto
+RUN sed -i 's|/src/libprotobuf-mutator/external.protobuf/bin/protoc|${SRC}/LPM/external.protobuf/bin/protoc|g' ${SRC}/mosquitto/fuzzing/libcommon/Makefile
 
 # Get dependencies
 RUN $SRC/mosquitto/fuzzing/scripts/oss-fuzz-dependencies.sh


### PR DESCRIPTION
The fuzzing/libcommon/Makefile PROTOBUF_LIBS use ${SRC} / LPM/SRC/libfuzzer/libprotobuf - mutator - libfuzzer. a... But PROTOC points to /src/libprotobuf-mutator/... . This is an old or wrong path. In the current environment, the construction of a protoc actually in ${SRC} / LPM/external protobuf/bin/protoc