### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/infra_tests.yml
+++ b/.github/workflows/infra_tests.yml
@@ -43,7 +43,7 @@ jobs:
           sudo env "PATH=$PATH" pip install -r infra/build/functions/requirements.txt
           sudo env "PATH=$PATH" pip install -r infra/cifuzz/requirements.txt
 
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@v3
         with:
           version: '523.0.0'
       - run: |


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `google-github-actions/setup-gcloud` | [`v2`](https://github.com/google-github-actions/setup-gcloud/releases/tag/v2) | [`v3`](https://github.com/google-github-actions/setup-gcloud/releases/tag/v3) | [Release](https://github.com/google-github-actions/setup-gcloud/releases/tag/v3) | infra_tests.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
