### PR TITLE
spdk: fix broken build

### DIFF
--- a/projects/spdk/Dockerfile
+++ b/projects/spdk/Dockerfile
@@ -15,8 +15,8 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make curl yasm autoconf libtool meson nasm
-RUN pip3 install --upgrade pip
+RUN apt-get update && apt-get install -y make curl yasm autoconf libtool nasm ninja-build
+RUN pip3 install --upgrade pip meson
 RUN git clone --depth 1 https://github.com/spdk/spdk && \
     cd spdk && \
     git submodule update --init

--- a/projects/spdk/build.sh
+++ b/projects/spdk/build.sh
@@ -18,7 +18,7 @@
 # Build spdk
 export LDFLAGS="${CFLAGS}"
 ./scripts/pkgdep.sh
-./configure --without-shared
+./configure --without-shared --disable-tests --disable-unit-tests
 make -j$(nproc)
 
 # Build fuzzers


### PR DESCRIPTION
The build needed a newer version of meson. I then found that the tests failed at build time so I disabled them.