### PR TITLE
mysql-server: fix broken build

### DIFF
--- a/projects/mysql-server/Dockerfile
+++ b/projects/mysql-server/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
-RUN apt-get update && apt-get install -y build-essential libssl-dev libncurses5-dev libncursesw5-dev make cmake perl bison pkg-config chrpath
+RUN apt-get update && apt-get install -y build-essential libssl-dev libncurses5-dev libncursesw5-dev make cmake perl bison pkg-config chrpath libtirpc-dev
 RUN git clone --depth 1 https://github.com/mysql/mysql-server
 WORKDIR $SRC
 COPY build.sh $SRC/


### PR DESCRIPTION
The build error is due to the removal of rpc support in glibc in the Linux environment. The issue of CMake not being able to find rpc/rpc.h can be resolved by explicitly installing the missing libtirpc-dev dependency library in the Dockerfile.