### PR TITLE
Ignore the Swift `.build` directory for coverage reports.

### DIFF
--- a/projects/swift-protobuf/project.yaml
+++ b/projects/swift-protobuf/project.yaml
@@ -11,5 +11,7 @@ fuzzing_engines:
 sanitizers:
 - address
 - thread
-coverage_extra_args: -ignore-filename-regex=.*.pb.swift
+coverage_extra_args: >
+  -ignore-filename-regex=.*\.pb\.swift
+  -ignore-filename-regex=.*/\.build/.*
 main_repo: 'https://github.com/apple/swift-protobuf.git'


### PR DESCRIPTION
SwiftPM generates some sources, and that coverage info isn't useful.