### PR TITLE
cups-filters: Add run_tests.sh

### DIFF
--- a/projects/cups-filters/Dockerfile
+++ b/projects/cups-filters/Dockerfile
@@ -33,3 +33,4 @@ RUN git clone --depth 1 https://github.com/OpenPrinting/fuzzing.git
 RUN cp $SRC/fuzzing/projects/cups-filters/oss_fuzz_build.sh $SRC/build.sh
 
 WORKDIR $SRC/cups-filters                   
+COPY run_tests.sh $SRC/

--- a/projects/cups-filters/run_tests.sh
+++ b/projects/cups-filters/run_tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+#
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+make check


### PR DESCRIPTION
Adds run_tests.sh for the cups-filters project.

run_tests.sh is used as part of Chronos with cached builds:
https://github.com/google/oss-fuzz/tree/master/infra/chronos#chronos-feature--running-tests-of-a-project