### PR TITLE
protobuf-c: add new fuzzer to fix broken build

### DIFF
--- a/projects/protobuf-c/Dockerfile
+++ b/projects/protobuf-c/Dockerfile
@@ -27,6 +27,4 @@ RUN apt-get update && apt-get install -y \
   libprotoc-dev
 
 RUN git clone --depth 1 https://github.com/protobuf-c/protobuf-c.git -b next
-RUN git clone --depth 1 https://github.com/guidovranken/fuzzing-headers.git
-RUN git clone --depth 1 https://github.com/guidovranken/protobuf-c-fuzzers.git
-COPY build.sh $SRC/
+COPY build.sh unpack_fuzzer.c $SRC/

--- a/projects/protobuf-c/build.sh
+++ b/projects/protobuf-c/build.sh
@@ -44,14 +44,11 @@ cd $SRC/protobuf-c/
 make -j$(nproc)
 make install
 
-cd $SRC/fuzzing-headers/
-./install.sh
+# Generate C code from proto file
+cd $SRC/protobuf-c/
+protoc --c_out=. -I. -I/usr/local/include t/test-full.proto
 
-cd $SRC/protobuf-c-fuzzers/
-cp $SRC/protobuf-c/t/test-full.proto $SRC/protobuf-c-fuzzers/
-export PATH=$PATH:$SRC/protobuf-c/protoc-c
-protoc --c_out=. -I. -I/usr/local/include test-full.proto
-
-CXXFLAGS="${OLD_CXXFLAGS}"
-$CC $CFLAGS test-full.pb-c.c -I $SRC/protobuf-install -I $SRC/protobuf-c -c -o test-full.pb-c.o
-$CXX $CXXFLAGS fuzzer.cpp -I $SRC/protobuf-install -I $SRC/protobuf-c test-full.pb-c.o $SRC/protobuf-c/protobuf-c/.libs/libprotobuf-c.a $LIB_FUZZING_ENGINE -o $OUT/fuzzer
+# Build the unpack fuzzer
+$CC $CFLAGS -I. -I/usr/local/include -c t/test-full.pb-c.c -o test-full.pb-c.o
+$CC $CFLAGS -I. -I/usr/local/include $SRC/unpack_fuzzer.c test-full.pb-c.o \
+    protobuf-c/.libs/libprotobuf-c.a $LIB_FUZZING_ENGINE -o $OUT/unpack_fuzzer

--- a/projects/protobuf-c/unpack_fuzzer.c
+++ b/projects/protobuf-c/unpack_fuzzer.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include <protobuf-c/protobuf-c.h>
+#include "t/test-full.pb-c.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    /*
+     * Test the core protobuf-c parsing by unpacking as TestMess.
+     * This message type contains repeated fields of all types including
+     * nested messages, which exercises all parsing code paths in
+     * protobuf_c_message_unpack().
+     */
+    ProtobufCMessage *msg = protobuf_c_message_unpack(
+        &foo__test_mess__descriptor, NULL, size, data);
+    if (msg != NULL) {
+        protobuf_c_message_free_unpacked(msg, NULL);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
The repository with the fuzzer was removed a while ago. Adding another fuzzer that targets a central API in protobuf-c.