### PR TITLE
jbig2dec: Add run_tests.sh

### DIFF
--- a/projects/jbig2dec/Dockerfile
+++ b/projects/jbig2dec/Dockerfile
@@ -26,4 +26,4 @@ RUN rm -rf tests
 COPY *.dict $SRC/
 WORKDIR jbig2dec
 COPY *.cc $SRC/
-COPY build.sh *.options $SRC/
+COPY run_tests.sh build.sh *.options $SRC/

--- a/projects/jbig2dec/run_tests.sh
+++ b/projects/jbig2dec/run_tests.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+#
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+make check -C $WORK/jbig2dec


### PR DESCRIPTION
Adds run_tests.sh for the jbig2dec project.

run_tests.sh is used as part of Chronos with cached builds:
https://github.com/google/oss-fuzz/tree/master/infra/chronos#chronos-feature--running-tests-of-a-project