### PR TITLE
Wolfssl: Add run_tests.sh

### DIFF
--- a/projects/wolfssl/Dockerfile
+++ b/projects/wolfssl/Dockerfile
@@ -45,4 +45,4 @@ RUN gsutil cp gs://libressl-backup.clusterfuzz-external.appspot.com/corpus/libFu
 
 WORKDIR wolfssl
 
-COPY build.sh $SRC/
+COPY run_tests.sh build.sh $SRC/

--- a/projects/wolfssl/run_tests.sh
+++ b/projects/wolfssl/run_tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+#
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+tests/unit.test


### PR DESCRIPTION
Adds run_tests.sh for the Wolfssl project.

run_tests.sh is used as part of Chronos with cached builds:
https://github.com/google/oss-fuzz/tree/master/infra/chronos#chronos-feature--running-tests-of-a-project