### PR TITLE
vorbis: Add run_tests.sh

### DIFF
--- a/projects/vorbis/Dockerfile
+++ b/projects/vorbis/Dockerfile
@@ -24,4 +24,4 @@ RUN corpus-replicator -o decode_corpus audio_vorbis_ogg_libvorbis.yml audio
 RUN mkdir people.xiph.org/
 RUN touch people.xiph.org/dummy.ogg
 WORKDIR vorbis
-COPY build.sh $SRC/
+COPY run_tests.sh build.sh $SRC/

--- a/projects/vorbis/run_tests.sh
+++ b/projects/vorbis/run_tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -eu
+#
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+export ASAN_OPTIONS="detect_leaks=0"
+make check


### PR DESCRIPTION
Adds run_tests.sh for the vorbis project.

run_tests.sh is used as part of Chronos with cached builds:
https://github.com/google/oss-fuzz/tree/master/infra/chronos#chronos-feature--running-tests-of-a-project