### PR TITLE
spring-framework: fix broken build

### DIFF
--- a/projects/spring-framework/Dockerfile
+++ b/projects/spring-framework/Dockerfile
@@ -16,9 +16,22 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 
-RUN apt update && apt install -y openjdk-17-jdk
+# Spring Framework main branch requires Java 25
+# Download and install OpenJDK 25 GA
+RUN apt update && apt install -y wget && \
+    wget -q https://download.java.net/java/GA/jdk25.0.1/2fbf10d8c78e40bd87641c434705079d/8/GPL/openjdk-25.0.1_linux-x64_bin.tar.gz -O /tmp/openjdk25.tar.gz && \
+    mkdir -p /usr/lib/jvm && \
+    tar -xzf /tmp/openjdk25.tar.gz -C /usr/lib/jvm && \
+    mv /usr/lib/jvm/jdk-25.0.1 /usr/lib/jvm/java-25-openjdk-amd64 && \
+    rm /tmp/openjdk25.tar.gz && \
+    update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-25-openjdk-amd64/bin/java 1 && \
+    update-alternatives --install /usr/bin/javac javac /usr/lib/jvm/java-25-openjdk-amd64/bin/javac 1 && \
+    update-alternatives --set java /usr/lib/jvm/java-25-openjdk-amd64/bin/java && \
+    update-alternatives --set javac /usr/lib/jvm/java-25-openjdk-amd64/bin/javac
 
-RUN git clone https://github.com/spring-projects/spring-framework
+ENV JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64
+
+RUN git clone --depth 1 https://github.com/spring-projects/spring-framework
 
 COPY . $SRC/
 

--- a/projects/spring-framework/add-shadow-context.diff
+++ b/projects/spring-framework/add-shadow-context.diff
@@ -6,7 +6,7 @@ index 5f5ac1001e..bff2f80935 100644
  
  description = "Spring Context"
  
-+apply plugin: "com.github.johnrengelman.shadow"
++apply plugin: "com.gradleup.shadow"
  apply plugin: "kotlin"
  
  dependencies {

--- a/projects/spring-framework/add-shadow-core.diff
+++ b/projects/spring-framework/add-shadow-core.diff
@@ -6,7 +6,7 @@ index 25c6f7ce78..aba0c7f1cb 100644
  
  description = "Spring Core"
  
-+apply plugin: "com.github.johnrengelman.shadow"
++apply plugin: "com.gradleup.shadow"
  apply plugin: "kotlin"
  apply plugin: "kotlinx-serialization"
  

--- a/projects/spring-framework/add-shadow-jdbc.diff
+++ b/projects/spring-framework/add-shadow-jdbc.diff
@@ -5,7 +5,7 @@ index 389462f3bb..98a4e93d92 100644
 @@ -1,5 +1,6 @@
  description = "Spring JDBC"
  
-+apply plugin: "com.github.johnrengelman.shadow"
++apply plugin: "com.gradleup.shadow"
  apply plugin: "kotlin"
  
  dependencies {

--- a/projects/spring-framework/add-shadow-jms.diff
+++ b/projects/spring-framework/add-shadow-jms.diff
@@ -1,18 +1,28 @@
 diff --git a/spring-jms/spring-jms.gradle b/spring-jms/spring-jms.gradle
-index 6757f90eca..32587faf7d 100644
 --- a/spring-jms/spring-jms.gradle
 +++ b/spring-jms/spring-jms.gradle
-@@ -1,11 +1,12 @@
+@@ -1,5 +1,16 @@
  description = "Spring JMS"
  
-+apply plugin: "com.github.johnrengelman.shadow"
++apply plugin: "com.gradleup.shadow"
++
++configurations {
++	shadow
++}
++
++shadowJar {
++	configurations = [project.configurations.shadow, project.configurations.runtimeClasspath]
++	mergeServiceFiles()
++}
++
  dependencies {
  	api(project(":spring-beans"))
  	api(project(":spring-core"))
- 	api(project(":spring-messaging"))
- 	api(project(":spring-tx"))
--	compileOnly("jakarta.jms:jakarta.jms-api")
-+	api("jakarta.jms:jakarta.jms-api")
+@@ -8,6 +19,7 @@ dependencies {
+ 	api("io.micrometer:micrometer-observation")
+ 	compileOnly("jakarta.jms:jakarta.jms-api")
  	optional(project(":spring-aop"))
++	shadow("jakarta.jms:jakarta.jms-api:3.1.0")
  	optional(project(":spring-context"))
  	optional(project(":spring-oxm"))
+ 	optional("com.fasterxml.jackson.core:jackson-databind")

--- a/projects/spring-framework/add-shadow-messaging.diff
+++ b/projects/spring-framework/add-shadow-messaging.diff
@@ -5,7 +5,7 @@ index cb54d42e59..e48a0d00a7 100644
 @@ -1,5 +1,6 @@
  description = "Spring Messaging"
  
-+apply plugin: "com.github.johnrengelman.shadow"
++apply plugin: "com.gradleup.shadow"
  apply plugin: "kotlin"
  apply plugin: "kotlinx-serialization"
  

--- a/projects/spring-framework/add-shadow-orm.diff
+++ b/projects/spring-framework/add-shadow-orm.diff
@@ -5,7 +5,7 @@ index c2c5a4afc9..5151f30de5 100644
 @@ -1,5 +1,7 @@
  description = "Spring Object/Relational Mapping"
  
-+apply plugin: "com.github.johnrengelman.shadow"
++apply plugin: "com.gradleup.shadow"
 +
  dependencies {
  	api(project(":spring-beans"))

--- a/projects/spring-framework/add-shadow-oxm.diff
+++ b/projects/spring-framework/add-shadow-oxm.diff
@@ -1,20 +1,11 @@
+diff --git a/spring-oxm/spring-oxm.gradle b/spring-oxm/spring-oxm.gradle
 --- a/spring-oxm/spring-oxm.gradle
 +++ b/spring-oxm/spring-oxm.gradle
-@@ -2,6 +2,8 @@ plugins {
- 	id "org.unbroken-dome.xjc"
+@@ -1,6 +1,7 @@
+ plugins {
+ 	id "com.github.bjornvester.xjc"
++	id "com.gradleup.shadow"
  }
  
-+apply plugin: "com.github.johnrengelman.shadow"
-+
  description = "Spring Object/XML Marshalling"
  
- xjc {
-@@ -19,7 +21,7 @@ dependencies {
- 	api(project(":spring-core"))
- 	optional("jakarta.xml.bind:jakarta.xml.bind-api")
- 	optional("jakarta.activation:jakarta.activation-api")
--	optional("com.thoughtworks.xstream:xstream")
-+	implementation("com.thoughtworks.xstream:xstream")
- 	testImplementation(project(":spring-context"))
- 	testImplementation(testFixtures(project(":spring-core")))
- 	testImplementation("org.codehaus.jettison:jettison") {

--- a/projects/spring-framework/add-shadow-test.diff
+++ b/projects/spring-framework/add-shadow-test.diff
@@ -3,7 +3,7 @@
 @@ -1,5 +1,6 @@
  description = "Spring TestContext Framework"
  
-+apply plugin: "com.github.johnrengelman.shadow"
++apply plugin: "com.gradleup.shadow"
  apply plugin: "kotlin"
  
  dependencies {

--- a/projects/spring-framework/add-shadow-tx.diff
+++ b/projects/spring-framework/add-shadow-tx.diff
@@ -5,7 +5,7 @@ index 75d1b22a94..84a13262ab 100644
 @@ -1,5 +1,6 @@
  description = "Spring Transaction"
  
-+apply plugin: "com.github.johnrengelman.shadow"
++apply plugin: "com.gradleup.shadow"
  apply plugin: "kotlin"
  
  dependencies {

--- a/projects/spring-framework/add-shadow-web.diff
+++ b/projects/spring-framework/add-shadow-web.diff
@@ -3,7 +3,7 @@
 @@ -1,5 +1,6 @@
  description = "Spring Web"
  
-+apply plugin: "com.github.johnrengelman.shadow"
++apply plugin: "com.gradleup.shadow"
  apply plugin: "kotlin"
  apply plugin: "kotlinx-serialization"
  

--- a/projects/spring-framework/add-shadow-webmvc.diff
+++ b/projects/spring-framework/add-shadow-webmvc.diff
@@ -1,9 +1,11 @@
+diff --git a/spring-webmvc/spring-webmvc.gradle b/spring-webmvc/spring-webmvc.gradle
 --- a/spring-webmvc/spring-webmvc.gradle
 +++ b/spring-webmvc/spring-webmvc.gradle
-@@ -1,5 +1,6 @@
+@@ -1,6 +1,7 @@
  description = "Spring Web MVC"
  
-+apply plugin: "com.github.johnrengelman.shadow"
  apply plugin: "kotlin"
++apply plugin: "com.gradleup.shadow"
+ apply plugin: "kotlinx-serialization"
  
  dependencies {

--- a/projects/spring-framework/add-shadow-websocket.diff
+++ b/projects/spring-framework/add-shadow-websocket.diff
@@ -5,7 +5,7 @@ index 3c9d011b4a..7eec687c0c 100644
 @@ -1,6 +1,10 @@
  description = "Spring WebSocket"
  
-+apply plugin: "com.github.johnrengelman.shadow"
++apply plugin: "com.gradleup.shadow"
 +
  dependencies {
 +	implementation 'org.mockito:mockito-core:4.7.0'

--- a/projects/spring-framework/spring-expression/SpelExpressionFuzzer.java
+++ b/projects/spring-framework/spring-expression/SpelExpressionFuzzer.java
@@ -52,11 +52,16 @@ public class SpelExpressionFuzzer {
         StandardEvaluationContext context = new StandardEvaluationContext();
         context.setRootObject(dummyObject);
 
+        String expressionString = data.consumeRemainingAsString();
+        if (expressionString == null || expressionString.isBlank()) {
+            return;  // Early return for empty/blank input
+        }
+
         try {
-            Expression expr = parser.parseExpression(data.consumeRemainingAsString());
+            Expression expr = parser.parseExpression(expressionString);
             expr.getValue();
             expr.getValue(dummyObject);
-        } catch (SpelEvaluationException | SpelParseException ignored) {}
+        } catch (SpelEvaluationException | SpelParseException | IllegalArgumentException ignored) {}
     }
 
     public static class DummyClass {

--- a/projects/spring-framework/spring-jdbc/Server.java
+++ b/projects/spring-framework/spring-jdbc/Server.java
@@ -30,6 +30,14 @@ public abstract class Server extends org.hsqldb.server.Server implements AutoClo
 	private PrintWriter m_stderr = null;
 	private PrintWriter m_stdout = null;
 
+	static {
+		try {
+			Class.forName("org.hsqldb.jdbc.JDBCDriver");
+		} catch (ClassNotFoundException e) {
+			throw new RuntimeException("Failed to load HSQLDB driver", e);
+		}
+	}
+
 	public Server(boolean verbose, String databaseName) {
 		super();
 		setVerbose(verbose);


### PR DESCRIPTION
The build had quite a few things that needed repair: 

1. Patches needed different modules.
2. The build requires java25.
3. `gradlew` would use the daemon which would hang if it didn't succeed and never fail the build.
4. The `XStreamMarshallerFuzzer` and `JdbcCoreMapperFuzzer` had errors that I resolved by disabling some hooks.
5. The call in `SpelExpressionFuzzer.java` crashes immediately on empty strings and would fail `check_build`, so I added a check for empty strings.
6. The missing `org.hsqldb.jdbc.JDBCDriver` class would also fail `check_build`. Added a check. This may need further investigation, but at least it doesn't break the entire build now.
7. Could clone with a `depth` of `1` to speed up the build.