### PR TITLE
wasmtime: fix broken build

### DIFF
--- a/projects/wasmtime/Dockerfile
+++ b/projects/wasmtime/Dockerfile
@@ -38,6 +38,7 @@ WORKDIR wasmtime
 
 # The default toolchain used by OSS-Fuzz is too old to build Wasmtime at this
 # time.
-ENV RUSTUP_TOOLCHAIN nightly-2025-07-16
+ENV RUSTUP_TOOLCHAIN=nightly-2025-07-16
+RUN rustup target add wasm32-unknown-unknown wasm32-wasip1 --toolchain nightly-2025-07-16
 
 COPY build.sh *.options $SRC/


### PR DESCRIPTION
The build error occurs because the build environment lacks the Rust cross-compilation targets wasm32-unknown-unknown and wasm32-wasip1 required to compile the WASM test component, causing the compiler to be unable to find the corresponding core libraries.
Explicitly install these missing targets and complete the build dependencies to fix them.