### PR TITLE
boost-json: fix broken build

### DIFF
--- a/projects/boost-json/Dockerfile
+++ b/projects/boost-json/Dockerfile
@@ -22,27 +22,30 @@ RUN ls
 RUN git -C boost submodule update --init libs/json
 RUN git -C boost/libs/json checkout develop
 RUN git -C boost submodule update --init --depth 1 \
-libs/align/ \
-libs/assert \
-libs/config/ \
-libs/container \
-libs/container_hash/ \
-libs/core \
-libs/describe \
-libs/endian \
-libs/headers/ \
-libs/intrusive/ \
-libs/move/ \
-libs/mp11/ \
-libs/predef/ \
-libs/static_assert \
-libs/system/ \
-libs/throw_exception/ \
-libs/type_traits/ \
-libs/winapi/ \
-libs/variant2/ \
-tools/boost_install \
-tools/build
+    libs/align \
+    libs/assert \
+    libs/config \
+    libs/core \
+    libs/static_assert \
+    libs/type_traits \
+    libs/predef \
+    libs/headers
+RUN git -C boost submodule update --init --depth 1 \
+    libs/compat \
+    libs/system \
+    libs/throw_exception \
+    libs/winapi \
+    libs/variant2 \
+    libs/move \
+    libs/endian
+RUN git -C boost submodule update --init --depth 1 \
+    libs/container \
+    libs/container_hash \
+    libs/intrusive \
+    libs/describe \
+    libs/mp11 \
+    tools/boost_install \
+    tools/build
 
 WORKDIR boost
 COPY build.sh $SRC/


### PR DESCRIPTION
When initializing the submodule of the Boost repository (git submodule update --init), the key library libs/compat/ was omitted. Fix it by adding "libs/compat/ \" to the Dockerfile