### PR TITLE
libxml2: Add run_tests.sh

### DIFF
--- a/projects/libxml2/Dockerfile
+++ b/projects/libxml2/Dockerfile
@@ -31,4 +31,4 @@ RUN curl -LO http://mirrors.kernel.org/ubuntu/pool/main/a/automake-1.16/automake
     apt install ./automake_1.16.5-1.3_all.deb
 RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/libxml2.git
 WORKDIR libxml2
-COPY build.sh $SRC/
+COPY run_tests.sh build.sh $SRC/

--- a/projects/libxml2/run_tests.sh
+++ b/projects/libxml2/run_tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -eu
+#
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+make -j$(nproc) testchar testdict testlimits testparser testrecurse && \
+./testchar && ./testdict && ./testlimits && ./testparser && ./testrecurse


### PR DESCRIPTION
Adds run_tests.sh for the libxml2 project.

run_tests.sh is used as part of Chronos with cached builds:
https://github.com/google/oss-fuzz/tree/master/infra/chronos#chronos-feature--running-tests-of-a-project