### PR TITLE
osquery: fix broken build

### DIFF
--- a/projects/osquery/Dockerfile
+++ b/projects/osquery/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder@sha256:d34b94e3cf868e49d2928c76ddba41fd4154907a1a381b3a263fafffb7c3dce0
-RUN apt-get update && apt-get install -y --no-install-recommends python python3 bison flex make wget xz-utils libunwind-dev lsb-release build-essential libssl-dev
+RUN apt-get update && apt-get install -y --no-install-recommends python python3 bison flex make wget xz-utils libunwind-dev lsb-release build-essential libssl-dev libcurl4-openssl-dev libncurses-dev libaudit-dev libcap-dev libelf-dev libseccomp-dev libsystemd-dev pkg-config
 
 # osquery now needs at least version 3.21.4.
 ENV cmakeVer 3.21.4


### PR DESCRIPTION
The build failed due to the absence of system-level dependent libraries (such as libaudit, util-linux), which caused the CMake configuration of osquery to attempt to download the source code of these libraries through git submodule for local compilation, thereby triggering a network timeout error. The fuzzing build error can be fixed by downloading these dependent libraries in the Dockerfile.