### PR TITLE
git: Add run_tests.sh

### DIFF
--- a/projects/git/Dockerfile
+++ b/projects/git/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && \
 RUN git clone --depth 1 https://github.com/git/git git
 RUN git clone --depth 1 https://github.com/madler/zlib
 WORKDIR $SRC/git
-COPY build.sh $SRC/
+COPY run_tests.sh build.sh $SRC/
 # This is to fix Fuzz Introspector build by using LLVM old pass manager
 # re https://github.com/ossf/fuzz-introspector/issues/305
 ENV OLD_LLVMPASS=1

--- a/projects/git/run_tests.sh
+++ b/projects/git/run_tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+#
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+make test -j$(nproc)


### PR DESCRIPTION
Adds run_tests.sh for the git project.

run_tests.sh is used as part of Chronos with cached builds:
https://github.com/google/oss-fuzz/tree/master/infra/chronos#chronos-feature--running-tests-of-a-project
