### PR TITLE
apache-commons-bcel: bump Maven

### DIFF
--- a/projects/apache-commons-bcel/Dockerfile
+++ b/projects/apache-commons-bcel/Dockerfile
@@ -16,11 +16,11 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 
-RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip -o maven.zip && \
+RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.zip -o maven.zip && \
 unzip maven.zip -d $SRC/maven && \
 rm -rf maven.zip
 
-ENV MVN $SRC/maven/apache-maven-3.6.3/bin/mvn
+ENV MVN $SRC/maven/apache-maven-3.9.9/bin/mvn
 
 WORKDIR ${SRC}
 #


### PR DESCRIPTION
from 3.6.3 (Released Nov 2019) to 3.9.9 (Released Aug 2024)