### PR TITLE
libjpeg-turbo: Add run_tests.sh

### DIFF
--- a/projects/libjpeg-turbo/Dockerfile
+++ b/projects/libjpeg-turbo/Dockerfile
@@ -33,4 +33,4 @@ RUN cat fuzz/branches.txt | while read branch; do \
     done
 RUN rm -rf seed-corpora
 
-COPY build.sh $SRC/
+COPY run_tests.sh build.sh $SRC/

--- a/projects/libjpeg-turbo/run_tests.sh
+++ b/projects/libjpeg-turbo/run_tests.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+#
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Run unit testing for all branches, exit early if any of them failed
+cat fuzz/branches.txt | while read branch; do
+        ctest --test-dir libjpeg-turbo.$branch -j$(nproc) || exit $?
+done


### PR DESCRIPTION
Adds run_tests.sh for the libjpeg-turbo project.

run_tests.sh is used as part of Chronos with cached builds:
https://github.com/google/oss-fuzz/tree/master/infra/chronos#chronos-feature--running-tests-of-a-project

Remark: This PR requires https://github.com/google/oss-fuzz/pull/14689 to be merged because it contains 2 active project directories in the $SRC location.