### PR TITLE
libunwind: Add run_tests.sh

### DIFF
--- a/projects/libunwind/Dockerfile
+++ b/projects/libunwind/Dockerfile
@@ -18,4 +18,4 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone --depth 1 https://github.com/libunwind/libunwind libunwind
 WORKDIR libunwind
-COPY build.sh *.c $SRC/
+COPY run_tests.sh build.sh *.c $SRC/

--- a/projects/libunwind/run_tests.sh
+++ b/projects/libunwind/run_tests.sh
@@ -1,0 +1,61 @@
+#!/bin/bash -eu
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Only include tests that are not failing
+TESTS="test-strerror
+test-proc-info
+test-static-link
+test-flush-cache
+Gtest-bt
+Ltest-init
+Ltest-varargs
+Ltest-sig-context
+test-init-remote
+Ltest-bt
+Ltest-init-local-signal
+Gtest-init
+Gtest-resume-sig
+Ltest-resume-sig-rt
+test-reg-state
+Lx64-test-dwarf-expressions
+Gtest-sig-context
+Ltest-exc
+test-setjmp
+Gx64-test-dwarf-expressions
+Gtest-exc
+x64-unwind-badjmp-signal-frame
+Gtest-resume-sig-rt
+Ltest-resume-sig
+Gtest-concurrent
+Ltest-concurrent
+Lrs-race
+test-ptrace
+test-async-sig"
+
+# Temporarily disabled failing unit test cases
+DISABLED_TESTS="Ltest-nomalloc
+Gtest-trace
+test-mem
+Ltest-trace
+Ltest-nocalloc
+SKIP: run-coredump-unwind
+check-namespace.sh
+run-ptrace-mapper
+run-ptrace-misc"
+
+# Run unit testing that are success
+make check -j$(nproc) TESTS="$TESTS"


### PR DESCRIPTION
Adds run_tests.sh for the libunwind project.

run_tests.sh is used as part of Chronos with cached builds:
https://github.com/google/oss-fuzz/tree/master/infra/chronos#chronos-feature--running-tests-of-a-project