### PR TITLE
swift-nio: fix broken build

### DIFF
--- a/projects/swift-nio/Dockerfile
+++ b/projects/swift-nio/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder-swift
 
 # specific swift-nio
 RUN git clone --depth 1 https://github.com/google/fuzzing
-RUN git clone --depth 1 https://github.com/apple/swift-nio.git
+RUN git clone --depth 1 --branch 2.55.0 https://github.com/apple/swift-nio.git
 COPY build.sh $SRC
 COPY *.swift $SRC/
 WORKDIR $SRC/swift-nio


### PR DESCRIPTION
The fuzzing build error occurs because the latest source code of the project has been updated to require the Swift 6.0 toolchain, while the OSS-Fuzz base image currently only provides Swift 5.10.1, resulting in a version mismatch error.
By modifying the Dockerfile, a specific older version code compatible with Swift 5.10 (Tag 2.55.0) was forcibly checked out, thus avoiding toolchain conflicts caused by upstream dependency upgrades and enabling the build to be successful.