### PR TITLE
Remove wycheproof engine from project tests

### DIFF
--- a/.github/workflows/project_tests.yml
+++ b/.github/workflows/project_tests.yml
@@ -41,9 +41,6 @@ jobs:
           - engine: none
             sanitizer: address
             architecture: x86_64
-          - engine: wycheproof
-            sanitizer: none
-            architecture: x86_64
           - engine: centipede
             sanitizer: address
             architecture: x86_64


### PR DESCRIPTION
Removed wycheproof engine configuration from tests. It's deprecated.