### PR TITLE
[build] Remove 'wycheproof' engine configuration

### DIFF
--- a/infra/build/functions/build_lib.py
+++ b/infra/build/functions/build_lib.py
@@ -95,10 +95,6 @@ ENGINE_INFO = {
         EngineInfo(upload_bucket='clusterfuzz-builds-no-engine',
                    supported_sanitizers=['address'],
                    supported_architectures=['x86_64']),
-    'wycheproof':
-        EngineInfo(upload_bucket='clusterfuzz-builds-wycheproof',
-                   supported_sanitizers=['none'],
-                   supported_architectures=['x86_64']),
     'centipede':
         EngineInfo(upload_bucket='clusterfuzz-builds-centipede',
                    supported_sanitizers=['address', 'none'],


### PR DESCRIPTION
Removed 'wycheproof' engine configuration. It has never been used.