### PR TITLE
exprtk: Add run_tests.sh

### DIFF
--- a/projects/exprtk/build.sh
+++ b/projects/exprtk/build.sh
@@ -22,6 +22,3 @@ CXXFLAGS="${CXXFLAGS} -O2 -fno-sanitize=integer-divide-by-zero,float-divide-by-z
 $CXX -std=c++11 $CXXFLAGS -I. -I$SRC/exprtk \
      $SRC/exprtk_fuzzer.cpp -o $OUT/exprtk_fuzzer \
      $LIB_FUZZING_ENGINE
-
-# Build unit tests
-make exprtk_test -j$(nproc)

--- a/projects/exprtk/run_tests.sh
+++ b/projects/exprtk/run_tests.sh
@@ -15,5 +15,8 @@
 #
 ################################################################################
 
+# Build unit tests
+make exprtk_test -j$(nproc)
+
 # Run exprtk unit test
 ./exprtk_test


### PR DESCRIPTION
This PR is a second attempt to add run_tests.sh to the exprtk project, following suggestions in #14581 and #14613.

@ArashPartow, apologies for rushing my previous PR and for not considering the impact on build size and build time. I have changed the script so that only the exprtk_test unit tests are built, to minimise the impact on build size and build time.

run_tests.sh is used as part of Chronos with cached builds:
https://github.com/google/oss-fuzz/tree/master/infra/chronos#chronos-feature--running-tests-of-a-project