### PR TITLE
urllib3: Fix `fuzz_requests`

### DIFF
--- a/projects/urllib3/Dockerfile
+++ b/projects/urllib3/Dockerfile
@@ -15,7 +15,6 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder-python
-RUN pip3 install httpretty
 
 RUN git clone --depth 1 https://github.com/urllib3/urllib3
 

--- a/projects/urllib3/project.yaml
+++ b/projects/urllib3/project.yaml
@@ -6,6 +6,7 @@ main_repo: https://github.com/urllib3/urllib3
 sanitizers:
 - address
 - undefined
+primary_contact: "illia.volochii@gmail.com"
 vendor_ccs:
 - david@adalogics.com
 - sean@compactcloud.co.uk


### PR DESCRIPTION
urllib3's `fuzz_requests` has been broken for over a year because it uses HTTPretty which does not support modern urllib3 https://github.com/gabrielfalcao/HTTPretty/pull/485.

In this PR, I'm replacing HTTPretty with a simple server in a separate thread, the approach is borrowed from [a httpx fuzzer](https://github.com/google/oss-fuzz/blob/5b14ead1ed0b85d5a21ce30c993a22d71b415b35/projects/httpx/fuzz_api.py).

Also, I'm adding myself as the primary contact for urllib3 because I'm its current lead maintainer.