### PR TITLE
[wamr] Update toolkits

### DIFF
--- a/projects/wamr/Dockerfile
+++ b/projects/wamr/Dockerfile
@@ -17,10 +17,10 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN apt-get update && apt upgrade -y \
-  && apt install -y build-essential clang ninja-build
+  && apt install -y build-essential clang ninja-build zlib1g-dev libncurses5-dev
 
 # install llvm
-ARG LLVM_VER=15.0.6
+ARG LLVM_VER=18.1.8
 RUN cd /opt \
   && wget --progress=dot:giga https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VER}/clang+llvm-${LLVM_VER}-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 RUN cd /opt \
@@ -29,7 +29,7 @@ RUN cd /opt \
   && rm clang+llvm-${LLVM_VER}-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 
 # install wasm-tools
-ARG WASM_TOOLS_VER=1.205.0
+ARG WASM_TOOLS_VER=1.243.0
 RUN cd /opt \
   && wget --progress=dot:giga https://github.com/bytecodealliance/wasm-tools/releases/download/v${WASM_TOOLS_VER}/wasm-tools-${WASM_TOOLS_VER}-x86_64-linux.tar.gz
 RUN cd /opt \

--- a/projects/wamr/build.sh
+++ b/projects/wamr/build.sh
@@ -40,6 +40,14 @@ cmake_args=(
   -DCMAKE_EXE_LINKER_FLAGS="${LDFLAGS}"
   -DCMAKE_MODULE_LINKER_FLAGS="${LDFLAGS}"
   -DCMAKE_SHARED_LINKER_FLAGS="${LDFLAGS}"
+
+  # ZLIB Configuration
+  -DZLIB_INCLUDE_DIR=/usr/include
+  -DZLIB_LIBRARY=/usr/lib/x86_64-linux-gnu/libz.so
+
+  # Terminfo Configuration
+  -DTerminfo_LIBRARIES=/usr/lib/x86_64-linux-gnu/libncurses.so
+  -DTerminfo_INCLUDE_DIRS=/usr/include
 )
 
 # CORPUS
@@ -60,7 +68,7 @@ cmake_args=(
 
   cmake -S . -B build-classic-interp \
       -DCMAKE_TOOLCHAIN_FILE=./clang_toolchain.cmake \
-      -DLLVM_DIR=/opt/llvm-15.0.6/lib/cmake/llvm \
+      -DLLVM_DIR=/opt/llvm-18.1.8/lib/cmake/llvm \
       -G Ninja \
       -DWAMR_BUILD_FAST_INTERP=0 \
       "${cmake_args[@]}" \
@@ -77,7 +85,7 @@ cmake_args=(
 
   cmake -S . -B build-fast-interp \
       -DCMAKE_TOOLCHAIN_FILE=./clang_toolchain.cmake \
-      -DLLVM_DIR=/opt/llvm-15.0.6/lib/cmake/llvm \
+      -DLLVM_DIR=/opt/llvm-18.1.8/lib/cmake/llvm \
       -G Ninja \
       "${cmake_args[@]}" \
     && cmake --build build-fast-interp
@@ -93,7 +101,7 @@ cmake_args=(
 
   cmake -S . -B build-llvm-jit \
       -DCMAKE_TOOLCHAIN_FILE=./clang_toolchain.cmake \
-      -DLLVM_DIR=/opt/llvm-15.0.6/lib/cmake/llvm \
+      -DLLVM_DIR=/opt/llvm-18.1.8/lib/cmake/llvm \
       -G Ninja \
       -DWAMR_BUILD_FAST_INTERP=0 \
       -DWAMR_BUILD_JIT=1 \
@@ -111,7 +119,7 @@ cmake_args=(
 
   cmake -S . -B build-aot-compiler \
       -DCMAKE_TOOLCHAIN_FILE=./clang_toolchain.cmake \
-      -DLLVM_DIR=/opt/llvm-15.0.6/lib/cmake/llvm \
+      -DLLVM_DIR=/opt/llvm-18.1.8/lib/cmake/llvm \
       -G Ninja \
       "${cmake_args[@]}" \
     && cmake --build build-aot-compiler --target aot_compiler_fuzz


### PR DESCRIPTION
- Update LLVM version from 15.0.6 to 18.1.8
- Update wasm-tools version from 1.205.0 to 1.243.0
- Add zlib1g-dev and libncurses5-dev package dependencies
- Configure ZLIB and Terminfo library paths in CMake build