### PR TITLE
ruby: disable logging in fuzzers

### DIFF
--- a/projects/ruby/Dockerfile
+++ b/projects/ruby/Dockerfile
@@ -27,4 +27,4 @@ RUN apt-get update && apt-get install -y \
     bison \
     wget
 RUN git clone --depth=1 --single-branch https://github.com/ruby/ruby $SRC/ruby
-COPY *.sh *.cpp *.c fuzz_prism.options $SRC/
+COPY *.sh *.cpp *.c *.options $SRC/

--- a/projects/ruby/build.sh
+++ b/projects/ruby/build.sh
@@ -182,4 +182,8 @@ else
 	find "$SRC/ruby" -type f -name '*.json' | head -n 100 | zip -@ "$OUT/fuzz_json_seed_corpus.zip"
 fi
 
-cp $SRC/fuzz_prism.options $OUT/
+# Copy ruby.options to each fuzzer
+ALL_FUZZERS="fuzz_regex fuzz_string fuzz_hash fuzz_bignum fuzz_array fuzz_iseq fuzz_pack fuzz_ruby_parser fuzz_prism fuzz_json"
+for fuzzer in $ALL_FUZZERS; do
+    cp "$SRC/ruby.options" "$OUT/${fuzzer}.options"
+done

--- a/projects/ruby/fuzz_array.cpp
+++ b/projects/ruby/fuzz_array.cpp
@@ -34,6 +34,8 @@ limitations under the License.
 
 static int ruby_initialized = 0;
 
+extern "C" VALUE ruby_verbose;
+
 // Wrapper functions for rb_protect - necessary to catch exceptions
 // Array operations can raise exceptions (e.g., index errors, frozen arrays)
 static VALUE call_array_aref(VALUE args) {
@@ -105,6 +107,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     if (!ruby_initialized) {
         ruby_init();
         ruby_initialized = 1;
+        
+        // Suppress Ruby warnings to avoid log noise
+        ruby_verbose = Qfalse;
     }
     
     if (size < 2) return 0;

--- a/projects/ruby/fuzz_bignum.cpp
+++ b/projects/ruby/fuzz_bignum.cpp
@@ -33,10 +33,15 @@ limitations under the License.
 
 static int ruby_initialized = 0;
 
+extern "C" VALUE ruby_verbose;
+
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     if (!ruby_initialized) {
         ruby_init();
         ruby_initialized = 1;
+        
+        // Suppress Ruby warnings to avoid log noise
+        ruby_verbose = Qfalse;
     }
     
     if (size < 2) return 0;

--- a/projects/ruby/fuzz_hash.cpp
+++ b/projects/ruby/fuzz_hash.cpp
@@ -32,6 +32,8 @@ limitations under the License.
 
 static int ruby_initialized = 0;
 
+extern "C" VALUE ruby_verbose;
+
 // Wrapper functions for rb_protect - necessary to catch exceptions
 // Hash operations can raise exceptions (e.g., frozen hash, recursive comparison)
 static VALUE call_hash_aref(VALUE args) {
@@ -99,6 +101,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     if (!ruby_initialized) {
         ruby_init();
         ruby_initialized = 1;
+        
+        // Suppress Ruby warnings to avoid log noise
+        ruby_verbose = Qfalse;
     }
     
     if (size < 2) return 0;

--- a/projects/ruby/fuzz_iseq.cpp
+++ b/projects/ruby/fuzz_iseq.cpp
@@ -18,6 +18,8 @@ limitations under the License.
 #include "ruby.h"
 
 static int ruby_initialized = 0;
+
+extern "C" VALUE ruby_verbose;
 static VALUE cInstructionSequence = Qnil;
 static ID id_load_from_binary = 0;
 

--- a/projects/ruby/fuzz_json.c
+++ b/projects/ruby/fuzz_json.c
@@ -25,6 +25,9 @@ limitations under the License.
 
 static int ruby_initialized = 0;
 
+// External declaration for ruby_verbose
+extern VALUE ruby_verbose;
+
 // JSON parser wrapper - parses JSON string with default config
 static VALUE json_fuzzer_parse(VALUE json_str) {
     JSON_ParserConfig config = {
@@ -65,6 +68,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     if (!ruby_initialized) {
         ruby_init();
         ruby_initialized = 1;
+        
+        // Suppress Ruby warnings to avoid log noise
+        ruby_verbose = Qfalse;
     }
     
     if (size == 0) {

--- a/projects/ruby/fuzz_pack.cpp
+++ b/projects/ruby/fuzz_pack.cpp
@@ -32,6 +32,8 @@ limitations under the License.
 
 static int ruby_initialized = 0;
 
+extern "C" VALUE ruby_verbose;
+
 // Test Array#pack with fuzzer-provided template
 static VALUE call_array_pack(VALUE arg) {
     VALUE *args = (VALUE *)arg;
@@ -77,6 +79,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     if (!ruby_initialized) {
         ruby_init();
         ruby_initialized = 1;
+        
+        // Suppress Ruby warnings to avoid log noise
+        ruby_verbose = Qfalse;
     }
     
     if (size < 2) {

--- a/projects/ruby/fuzz_prism.options
+++ b/projects/ruby/fuzz_prism.options
@@ -1,2 +1,0 @@
-[libfuzzer]
-detect_leaks = 0

--- a/projects/ruby/fuzz_ruby_parser.cpp
+++ b/projects/ruby/fuzz_ruby_parser.cpp
@@ -28,6 +28,7 @@ limitations under the License.
 extern "C" {
 extern VALUE rb_parser_new(void);
 extern VALUE rb_parser_compile_string(VALUE vparser, const char *f, VALUE s, int line);
+extern VALUE ruby_verbose;
 }
 
 /* Silence stderr output during fuzzing */
@@ -52,6 +53,9 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         ruby_init();
         ruby_init_loadpath();
         initialized = 1;
+        
+        // Suppress Ruby warnings to avoid log noise
+        ruby_verbose = Qfalse;
     }
     
     if (size == 0) {

--- a/projects/ruby/fuzz_string.cpp
+++ b/projects/ruby/fuzz_string.cpp
@@ -30,6 +30,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     if (!ruby_initialized) {
         ruby_init();
         ruby_initialized = 1;
+        
+        // Suppress Ruby warnings to avoid log noise
+        ruby_verbose = Qfalse;
     }
     
     if (size == 0) return 0;

--- a/projects/ruby/ruby.options
+++ b/projects/ruby/ruby.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+detect_leaks=0


### PR DESCRIPTION
and mitigate some memory leak crashes. The regex fuzzer needed some size limits. Also apply the `.options` file to all fuzzers.