### PR TITLE
immer: fix change in name of BoehmGC-related CMake variables

### DIFF
--- a/projects/immer/build.sh
+++ b/projects/immer/build.sh
@@ -19,8 +19,8 @@
 mkdir build
 cd build
 cmake .. \
-      -DBOEHM_GC_INCLUDE_DIR=/usr/include \
-      -DBOEHM_GC_LIBRARIES=/usr/lib/x86_64-linux-gnu/libgc.a \
+      -DBoehmGC_INCLUDE_DIR=/usr/include \
+      -DBoehmGC_LIBRARIES=/usr/lib/x86_64-linux-gnu/libgc.a \
       -Dimmer_BUILD_TESTS=OFF
 make -j$(nproc) fuzzers
 


### PR DESCRIPTION
This brings back compatibility with the changes introduced in this PR: https://github.com/arximboldi/immer/pull/317