### PR TITLE
wasmi: use `all-features` for `differential` fuzzing

### DIFF
--- a/projects/wasmi/build.sh
+++ b/projects/wasmi/build.sh
@@ -20,7 +20,7 @@ nightly="+$RUSTUP_TOOLCHAIN"
 
 cargo $nightly fuzz build translate -O
 cargo $nightly fuzz build execute -O
-cargo $nightly fuzz build differential --features=differential -O
+cargo $nightly fuzz build differential --all-features -O
 
 FUZZ_TARGET_OUTPUT_DIR=target/x86_64-unknown-linux-gnu/release
 for f in fuzz/fuzz_targets/*.rs


### PR DESCRIPTION
A [recent update](https://github.com/wasmi-labs/wasmi/pull/1758) made all oracles optional. At least one oracle needs to be enabled for compilation to succeed. With `all-features` we simply always enable all available oracles.