### PR TITLE
pffft: fix broken build

### DIFF
--- a/projects/pffft/Dockerfile
+++ b/projects/pffft/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y mercurial
 RUN python -m pip install numpy
 RUN git clone https://bitbucket.org/jpommier/pffft $SRC/pffft
 WORKDIR pffft
-COPY run_tests.sh build.sh $SRC
+COPY run_tests.sh build.sh $SRC/
 # TODO(alessiob): Move the fuzzing source code to pffft upstream.
 COPY generate_seed_corpus.py $SRC/pffft
 COPY pffft_fuzzer.cc $SRC/pffft


### PR DESCRIPTION
In the Dockerfile, when the COPY instruction is used to copy multiple files, the target path $SRC lacks the trailing slash /. This results in a syntax error. The solution is to add a slash at the end of the target path.