### PR TITLE
varnish: fix broken build

### DIFF
--- a/projects/varnish/Dockerfile
+++ b/projects/varnish/Dockerfile
@@ -17,5 +17,5 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt install -y automake autoconf libtool pkg-config python3-docutils python3-sphinx libedit-dev libpcre2-dev libncurses-dev
 RUN git clone --depth 1 --recursive https://github.com/varnishcache/varnish-cache
-COPY run_tests.sh build.sh $SRC
+COPY run_tests.sh build.sh $SRC/
 WORKDIR $SRC/varnish-cache


### PR DESCRIPTION
In the Dockerfile, when the COPY instruction is used to copy multiple files, the target path $SRC lacks the trailing slash /. This results in a syntax error. The solution is to add a slash at the end of the target path.