### PR TITLE
netcdf: fix broken build

### DIFF
--- a/projects/netcdf/Dockerfile
+++ b/projects/netcdf/Dockerfile
@@ -17,5 +17,5 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y cmake m4 zlib1g-dev libcurlpp-dev libcurl4-openssl-dev
 RUN git clone --depth 1 https://github.com/Unidata/netcdf-c
-COPY run_tests.sh build.sh $SRC
+COPY run_tests.sh build.sh $SRC/
 WORKDIR $SRC/netcdf-c


### PR DESCRIPTION
In the Dockerfile, when the COPY instruction is used to copy multiple files, the target path $SRC lacks the trailing slash /. This results in a syntax error. The solution is to add a slash at the end of the target path.