### PR TITLE
binutils: Fix fuzz_strings achieving 0% coverage

### DIFF
--- a/projects/binutils/build.sh
+++ b/projects/binutils/build.sh
@@ -35,6 +35,12 @@ sed -i '/^%%$/i%destructor { free (\$\$); } ID' defparse.y
 
 cd ../
 
+# bfd_sym_read_header_v34 in bfd/xsym.c calls abort() for unimplemented
+# v3.4/v3.5 xSYM format support. Replace with return -1 to avoid killing
+# the fuzzer on malformed xSYM files.
+# See: https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=bfd/xsym.c;hb=c8f306af2f57ca2abf602005e768c37de7649a9e#l209
+sed -i 's/abort ();/return -1;/' bfd/xsym.c
+
 ./configure --disable-gdb --disable-gdbserver --disable-gdbsupport \
 	    --disable-libdecnumber --disable-readline --disable-sim \
 	    --disable-libbacktrace --disable-gas --disable-ld --disable-werror \

--- a/projects/binutils/build.sh
+++ b/projects/binutils/build.sh
@@ -178,7 +178,7 @@ then
 fi
 
 # Copy seeds out
-for fuzzname in readelf_pef readelf_elf32_csky readelf_elf64_mmix readelf_elf32_littlearm readelf_elf32_bigarm objdump objdump_safe nm objcopy bfd windres addr2line dwarf; do
+for fuzzname in readelf_pef readelf_elf32_csky readelf_elf64_mmix readelf_elf32_littlearm readelf_elf32_bigarm objdump objdump_safe nm objcopy bfd windres addr2line dwarf strings; do
   cp $SRC/binary-samples/oss-fuzz-binutils/general_seeds.zip $OUT/fuzz_${fuzzname}_seed_corpus.zip
 done
 

--- a/projects/binutils/fuzz_strings.c
+++ b/projects/binutils/fuzz_strings.c
@@ -32,7 +32,29 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
   fwrite(data, size, 1, fp);
   fclose(fp);
 
+  setlocale (LC_ALL, "");
+  bindtextdomain (PACKAGE, LOCALEDIR);
+  textdomain (PACKAGE);
+
   program_name = "fuzz_strings";
+  xmalloc_set_program_name (program_name);
+  bfd_set_error_program_name (program_name);
+
+
+  string_min = 4;
+  include_all_whitespace = false;
+  print_addresses = false;
+  print_filenames = false;
+  datasection_only = true;
+  target = NULL;
+  encoding = 's';
+  output_separator = NULL;
+  encoding_bytes = 1;
+
+  if (bfd_init () != BFD_INIT_MAGIC)
+    fatal (_("fatal error: libbfd ABI mismatch"));
+  set_default_bfd_target ();
+
 
   string_min = 4;
   encoding = 's';


### PR DESCRIPTION
## Summary

Fix binutils `fuzz_strings` fuzzer which was achieving 0% coverage due to missing initialization.

## Main Change

**Fix missing global variable initialization in `fuzz_strings.c`**

The harness was not initializing important global variables, most importantly `string_min` (minimum string length to print) which defaults to 0. This causes `strings` to get stuck in an endless loop printing zero-length strings, likely explaining the 0% coverage.

## Further Changes

- **Patch `abort()` in `bfd/xsym.c`** - When `--enable-targets=all` is set, `bfd_sym_read_header_v34()` calls `abort()` for unimplemented v3.4/v3.5 xSYM format support, killing the fuzzer on malformed xSYM files. Replaced with `return -1` to fall back to internal error handling.
- **Add seed corpus for strings fuzzer** - Added binary-samples corpus similar to other binutils fuzzers.

## Testing

```bash
python3 infra/helper.py build_image binutils --pull
python3 infra/helper.py build_fuzzers binutils --clean
python3 infra/helper.py run_fuzzer --corpus-dir ./corpus binutils fuzz_strings -- -fork=6 -ignore_crashes=1 -max_total_time=86400
python3 infra/helper.py build_fuzzers --sanitizer coverage binutils
python3 infra/helper.py coverage binutils --no-serve --corpus-dir ./corpus --fuzz-target fuzz_strings
```

24h test run coverage results:

| Path | Line Coverage | Function Coverage | Region Coverage |
|------|---------------|-------------------|-----------------|
| fuzz_strings.h | 13.12% (111/846) | 37.50% (6/16) | 15.73% (123/782) |

## Related

@DavidKorczynski - Sorry for the ping: The old seed corpus for strings was removed in https://github.com/google/oss-fuzz/pull/6717. What was the reasoning behind that? Was this AFL-specific, or is this still relevant now? Thanks!
