### PR TITLE
adding cloud ti bugs group as cc for related projects

### DIFF
--- a/projects/bios-bmc-smm-error-logger/project.yaml
+++ b/projects/bios-bmc-smm-error-logger/project.yaml
@@ -3,6 +3,7 @@ language: c++
 primary_contact: "javanlacerda@google.com"
 auto_ccs:
   - pedroysb@google.com
+  - cloud-ti-fuzzing+bugs@google.com
 
 main_repo: "https://github.com/javanlacerda/bios-bmc-smm-error-logger"
 fuzzing_engines:

--- a/projects/iperf/project.yaml
+++ b/projects/iperf/project.yaml
@@ -9,4 +9,6 @@ primary_contact: "javanlacerda@google.com"
 auto_ccs:
 - "pedroysb@google.com"
 - "david@adalogics.com"
+- "cloud-ti-fuzzing+bugs@google.com"
+
 base_os_version: ubuntu-24-04

--- a/projects/radvd/project.yaml
+++ b/projects/radvd/project.yaml
@@ -8,5 +8,7 @@ primary_contact: "javanlacerda@google.com"
 auto_ccs:
 - "pedroysb@google.com"
 - "david@adalogics.com"
+- "cloud-ti-fuzzing+bugs@google.com"
+
 main_repo: "http://www.litech.org/radvd"
 base_os_version: ubuntu-24-04


### PR DESCRIPTION
Adding the Cloud TI fuzzing group as CC for bios-bmc-smm-error-logger, radvd and iperf projects.