### PR TITLE
pyyaml: extend loader fuzzer to exercise yaml.safe_load

### DIFF
--- a/projects/pyyaml/fuzz_loader.py
+++ b/projects/pyyaml/fuzz_loader.py
@@ -30,6 +30,12 @@ def TestOneInput(input_bytes):
     return
   except RecursionError:
     return
+  
+  try:
+      yaml.safe_load(input_bytes)
+  except Exception:
+      pass
+  
   # Anything that is loadable should be emitable.
   try:
     listed_context = list(context)


### PR DESCRIPTION
This PR extends the existing PyYAML loader fuzzer to also exercise
`yaml.safe_load`, which is one of the most commonly used public APIs.

The change is intentionally minimal and reuses the existing fuzzer
infrastructure. The goal is to increase coverage of user-facing parsing
paths and ensure that `safe_load` does not crash on malformed input.

No behavior changes are intended outside of fuzzing coverage.
