### PR TITLE
Removes persistent store fuzz target for OpenSK

### DIFF
--- a/projects/opensk/build.sh
+++ b/projects/opensk/build.sh
@@ -32,9 +32,6 @@ cd OpenSK
 # CTAP library fuzzing targets
 build_and_copy libraries/opensk
 
-# persistent storage library
-build_and_copy libraries/persistent_store
-
 # CBOR crate
 build_and_copy libraries/cbor
 


### PR DESCRIPTION
This library has moved to Wasefire [1] and is available on crates.io [2]. Therefore we won't fuzz it inside OpenSK anymore.

[1] https://github.com/google/wasefire/tree/main/crates/store
[2] https://crates.io/crates/wasefire-store