### PR TITLE
Disable jopt-simple

### DIFF
--- a/projects/jopt-simple/project.yaml
+++ b/projects/jopt-simple/project.yaml
@@ -5,6 +5,7 @@ fuzzing_engines:
   - libfuzzer
 sanitizers:
   - address
+disabled: true
 vendor_ccs:
   - "wagner@code-intelligence.com"
   - "yakdan@code-intelligence.com"


### PR DESCRIPTION
Throwing a very frequent error: FuzzTargetNotFoundError: None is not found. https://github.com/google/clusterfuzz/pull/5102 is probably the correct fix. I don't know what can go wrong by doing it though so I'd rather be conservative and just disable a misbehaving project using .sh as suffix for fuzz targets.