### PR TITLE
Envoy Gateway: Fix corpus pruning timeout causing coverage build failures

### DIFF
--- a/projects/gateway/Dockerfile
+++ b/projects/gateway/Dockerfile
@@ -30,4 +30,4 @@ RUN cd $SRC/gateway && \
     mv temp-go/go/* /root/.go/ && \
     rm -rf temp-go go${GO_VERSION}.linux-amd64.tar.gz
 
-COPY build.sh $SRC/
+COPY build.sh default.options $SRC/

--- a/projects/gateway/build.sh
+++ b/projects/gateway/build.sh
@@ -16,3 +16,16 @@
 ################################################################################
 
 $SRC/gateway/test/fuzz/oss_fuzz_build.sh
+
+# Copy default.options to all fuzzers in $OUT if they don't have specific options files
+for fuzzer in "$OUT"/*; do
+  # Skip non-files and files with extensions
+  [[ ! -f "$fuzzer" ]] || [[ "$fuzzer" == *.* ]] && continue
+  
+  fuzzer_name=$(basename "$fuzzer")
+  options_file="$OUT/${fuzzer_name}.options"
+  
+  if [[ ! -f "$options_file" ]] && [[ -f "$SRC/default.options" ]]; then
+    cp "$SRC/default.options" "$options_file"
+  fi
+done

--- a/projects/gateway/default.options
+++ b/projects/gateway/default.options
@@ -1,0 +1,3 @@
+[libfuzzer]
+# Increase timeout for corpus pruning
+timeout = 300


### PR DESCRIPTION
### Problem
The coverage build would then fail when attempting to unpack the non-existent corpus backup. After some investigation, I found that the corpus backup is not getting created in **GCS**. I suspect this is because the **pruning tasks were timing out**, resulting in empty corpus backups in GCS. 
```
Step #5: Already have image (with digest): gcr.io/oss-fuzz-base/base-runner
Step #5: [/corpus/FuzzGatewayAPIToXDS.zip]
Step #5:   End-of-central-directory signature not found.  Either this file is not
Step #5:   a zipfile, or it constitutes one disk of a multi-part archive.  In the
Step #5:   latter case, the central directory and zipfile comment will be found on
Step #5:   the last disk(s) of this archive.
Step #5: unzip:  cannot find zipfile directory in one of /corpus/FuzzGatewayAPIToXDS.zip or
Step #5:         /corpus/FuzzGatewayAPIToXDS.zip.zip, and cannot find /corpus/FuzzGatewayAPIToXDS.zip.ZIP, period.
Step #5: Failed to unpack the corpus for FuzzGatewayAPIToXDS. This usually means that the corpus backup for a particular fuzz target does not exist. If a fuzz target was added in the last 24 hours, please wait one more day. Otherwise, something is wrong with the fuzz target or the infrastructure, and the corpus pruning task does not finish successfully.
```
Logs: https://oss-fuzz-build-logs.storage.googleapis.com/log-fbd373d9-165d-40e2-9ffb-2a5157333d37.txt

So, I am trying to increase the per-input timeout for the pruning task in an attempt to fix the corpus backup creation problem. 

Relevant issue https://github.com/google/oss-fuzz/issues/14263
