### PR TITLE
Install Hypothesis, liblzma, and libzstd

### DIFF
--- a/projects/python3-libraries/Dockerfile
+++ b/projects/python3-libraries/Dockerfile
@@ -16,7 +16,8 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && \
-    apt-get install -y build-essential libncursesw5-dev libreadline-dev libssl-dev libgdbm-dev libc6-dev libsqlite3-dev tk-dev libbz2-dev zlib1g-dev libffi-dev
-RUN git clone https://github.com/python/cpython.git cpython
-RUN git clone --depth 1 https://github.com/python/library-fuzzers.git
+    apt-get install -y build-essential libncursesw5-dev libreadline-dev libssl-dev libgdbm-dev libc6-dev libsqlite3-dev tk-dev libbz2-dev zlib1g-dev libffi-dev liblzma-dev libzstd-dev
+RUN git clone --depth 1 --branch main https://github.com/python/cpython.git cpython
+RUN git clone --depth 1 --branch main https://github.com/python/library-fuzzers.git
 COPY run_tests.sh build.sh $SRC/
+

--- a/projects/python3-libraries/build.sh
+++ b/projects/python3-libraries/build.sh
@@ -57,6 +57,7 @@ make -j$(nproc)
 make install
 
 cp -R $CPYTHON_INSTALL_PATH $OUT/
+$OUT/cpython-install/bin/python3 -m pip install hypothesis
 
 cd $SRC/library-fuzzers
 make
@@ -108,8 +109,14 @@ cp $SRC/library-fuzzers/re.py $OUT/
 cp $SRC/library-fuzzers/fuzzer-zipfile $OUT/
 cp $SRC/library-fuzzers/zipfile.py $OUT/
 
+cp $SRC/library-fuzzers/fuzzer-zipfile-hypothesis $OUT/
+cp $SRC/library-fuzzers/zipfile_hypothesis.py $OUT/
+
 cp $SRC/library-fuzzers/fuzzer-tarfile $OUT/
 cp $SRC/library-fuzzers/tarfile.py $OUT/
+
+cp $SRC/library-fuzzers/fuzzer-tarfile-hypothesis $OUT/
+cp $SRC/library-fuzzers/tarfile_hypothesis.py $OUT/
 
 cp $SRC/library-fuzzers/fuzzer-configparser $OUT/
 cp $SRC/library-fuzzers/configparser.py $OUT/


### PR DESCRIPTION
Adds the new Hypothesis fuzz tests to the `python3-libraries` project. To support the new [Hypothesis](https://github.com/python/library-fuzzers/pull/3) [property tests](https://github.com/python/library-fuzzers/pull/4), Hypothesis needs to be installed during the build step.