### PR TITLE
strongswan: Disable debug log

### DIFF
--- a/projects/strongswan/build.sh
+++ b/projects/strongswan/build.sh
@@ -17,7 +17,7 @@
 
 ./autogen.sh
 
-./configure CFLAGS="$CFLAGS -DNO_CHECK_MEMWIPE" \
+./configure CFLAGS="$CFLAGS -DNO_CHECK_MEMWIPE -DDEBUG_LEVEL=-1" \
 	--enable-imc-test \
 	--enable-tnccs-20 \
 	--enable-fuzzing \


### PR DESCRIPTION
This PR fixes the strongswan build to disable debug log that crash new fuzzers.