### PR TITLE
libcoap: Enable oscore server build for new fuzzer

### DIFF
--- a/projects/libcoap/build.sh
+++ b/projects/libcoap/build.sh
@@ -21,6 +21,8 @@ fi
 
 ./autogen.sh && ./configure --disable-doxygen --disable-manpages \
                             --disable-dtls --enable-tests        \
+                            --with-openssl --enable-oscore       \
+                            --enable-server                      \
     && make -j$(nproc)
 
 # build all fuzzer targets


### PR DESCRIPTION
This PR fixes the build script for libcoap to enable oscore server for the new fuzzer.