### PR TITLE
openssl: Don't git clean in a cache build.

### DIFF
--- a/projects/openssl/build.sh
+++ b/projects/openssl/build.sh
@@ -78,7 +78,9 @@ function build_fuzzers() {
     fi
 
     df -h
-    git clean -dfx
+    if [[ -z "${CAPTURE_REPLAY_SCRIPT:-}" ]]; then
+      git clean -dfx
+    fi
     df -h
 }
 


### PR DESCRIPTION
Otherwise we lose all of our configure results and build artifacts.