### PR TITLE
libcoap: Fix the build to not enable openssh

### DIFF
--- a/projects/libcoap/build.sh
+++ b/projects/libcoap/build.sh
@@ -21,8 +21,7 @@ fi
 
 ./autogen.sh && ./configure --disable-doxygen --disable-manpages \
                             --disable-dtls --enable-tests        \
-                            --with-openssl --enable-oscore       \
-                            --enable-server                      \
+                            --enable-server --enable-oscore      \
     && make -j$(nproc)
 
 # build all fuzzer targets


### PR DESCRIPTION
This PR fixes the build script to avoid enabling of unnecessary openssl to avoid a configuration warning.