### PR TITLE
thrift: update primary_contact to gmail address

### DIFF
--- a/projects/thrift-c_glib/project.yaml
+++ b/projects/thrift-c_glib/project.yaml
@@ -1,9 +1,6 @@
 homepage: "https://thrift.apache.org/"
 language: c
-primary_contact: "mhlakhani@apache.org"
-auto_ccs:
-- "m.hasnain.lakhani@gmail.com"
-- "jensg@apache.org"
+primary_contact: "m.hasnain.lakhani@gmail.com"
 
 fuzzing_engines:
   - libfuzzer

--- a/projects/thrift-cpp/project.yaml
+++ b/projects/thrift-cpp/project.yaml
@@ -1,9 +1,6 @@
 homepage: "https://thrift.apache.org/"
 language: c++
-primary_contact: "mhlakhani@apache.org"
-auto_ccs:
-- "jensg@apache.org"
-- "m.hasnain.lakhani@gmail.com"
+primary_contact: "m.hasnain.lakhani@gmail.com"
 
 fuzzing_engines:
   - libfuzzer

--- a/projects/thrift-go/project.yaml
+++ b/projects/thrift-go/project.yaml
@@ -1,9 +1,7 @@
 homepage: "https://thrift.apache.org/"
 language: go
-primary_contact: "mhlakhani@apache.org"
+primary_contact: "m.hasnain.lakhani@gmail.com"
 auto_ccs:
-- "jensg@apache.org"
-- "m.hasnain.lakhani@gmail.com"
 - "p.antoine@catenacyber.fr"
 
 fuzzing_engines:

--- a/projects/thrift-java/project.yaml
+++ b/projects/thrift-java/project.yaml
@@ -1,9 +1,6 @@
 homepage: "https://thrift.apache.org/"
 language: jvm
-primary_contact: "mhlakhani@apache.org"
-auto_ccs:
-- "jensg@apache.org"
-- "m.hasnain.lakhani@gmail.com"
+primary_contact: "m.hasnain.lakhani@gmail.com"
 
 fuzzing_engines:
   - libfuzzer

--- a/projects/thrift-js/project.yaml
+++ b/projects/thrift-js/project.yaml
@@ -1,9 +1,6 @@
 homepage: "https://thrift.apache.org/"
 language: javascript
-primary_contact: "mhlakhani@apache.org"
-auto_ccs:
-- "jensg@apache.org"
-- "m.hasnain.lakhani@gmail.com"
+primary_contact: "m.hasnain.lakhani@gmail.com"
 
 fuzzing_engines:
   - libfuzzer

--- a/projects/thrift-py/project.yaml
+++ b/projects/thrift-py/project.yaml
@@ -1,9 +1,6 @@
 homepage: "https://thrift.apache.org/"
 language: python
-primary_contact: "mhlakhani@apache.org"
-auto_ccs:
-- "jensg@apache.org"
-- "m.hasnain.lakhani@gmail.com"
+primary_contact: "m.hasnain.lakhani@gmail.com"
 
 fuzzing_engines:
   - libfuzzer

--- a/projects/thrift-rust/project.yaml
+++ b/projects/thrift-rust/project.yaml
@@ -1,9 +1,6 @@
 homepage: "https://thrift.apache.org/"
 language: rust
-primary_contact: "mhlakhani@apache.org"
-auto_ccs:
-- "jensg@apache.org"
-- "m.hasnain.lakhani@gmail.com"
+primary_contact: "m.hasnain.lakhani@gmail.com"
 
 fuzzing_engines:
   - libfuzzer


### PR DESCRIPTION
Non-gmail addresses cause issues with bug filing (see issue #14815). 

Update primary_contact from mhlakhani@apache.org to m.hasnain.lakhani@gmail.com and remove non-gmail addresses from auto_ccs.