### PR TITLE
Also fetch submodules.

### DIFF
--- a/projects/swift-protobuf/Dockerfile
+++ b/projects/swift-protobuf/Dockerfile
@@ -16,6 +16,6 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-swift
 
-RUN git clone --depth 1 https://github.com/apple/swift-protobuf.git
+RUN git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/apple/swift-protobuf.git
 COPY build.sh $SRC
 WORKDIR $SRC/swift-protobuf


### PR DESCRIPTION
Last year the repo picked up two submodules, I haven't seen any failures, but looking at the logs on https://github.com/google/oss-fuzz/pull/14486, it seems like maybe the submodules are causing problems?