### PR TITLE
[GDAL] Update to ubuntu 24.04 image

### DIFF
--- a/projects/gdal/Dockerfile
+++ b/projects/gdal/Dockerfile
@@ -14,11 +14,15 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
+
 RUN apt-get update && \
     apt-get install -y make autoconf automake libtool g++ curl cmake sqlite3 pkg-config
 
-RUN git clone --depth 1 https://github.com/OSGeo/gdal gdal
+# Using this temporary branch while the pull request in google/ossfuzz has not been yet merged
+# Once it has been, this ossfuzz_ubuntu_2404 branch will be merged back to OSGeo/gdal master
+RUN git clone --depth 1 --branch ossfuzz_ubuntu_2404 https://github.com/rouault/gdal gdal
+#RUN git clone --depth 1 https://github.com/OSGeo/gdal gdal
 
 RUN cp gdal/fuzzers/build.sh $SRC/
 

--- a/projects/gdal/project.yaml
+++ b/projects/gdal/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://gdal.org"
 language: c++
 primary_contact: "even.rouault@gmail.com"
@@ -20,4 +21,3 @@ fuzzing_engines:
   - afl
   - honggfuzz
   - libfuzzer
-


### PR DESCRIPTION
This will be a 3-phase process:

1. This PR will temporarily point to my fork at https://github.com/rouault/gdal/tree/ossfuzz_ubuntu_2404 that contains the needed GDAL side changes: https://github.com/rouault/gdal/commit/2c2ab243f88b65ed91c2e083006c20fccde443d7

2. Once this PR is merged, I will merge the above commit into GDAL master

3. And I will issue a new PR here pointing back to GDAL master

This way this will not break things

I've tested locally that fuzzers build and run in x86_64 and i386 mode