### PR TITLE
xpdf: Fix build

### DIFF
--- a/projects/xpdf/fuzz_pdfload.cc
+++ b/projects/xpdf/fuzz_pdfload.cc
@@ -112,7 +112,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             splashOut->setNoComposite(gTrue);
             splashOut->startDoc(doc.getXRef());
             for (size_t i = 1; i <= doc.getNumPages(); ++i) {
-              doc.displayPage(splashOut, i, hdpi, vdpi, rotate, useMediaBox, crop, printing);
+              doc.displayPage(splashOut, NULL, i, hdpi, vdpi, rotate, useMediaBox, crop, printing);
             }
             (void)splashOut->getBitmap();
 


### PR DESCRIPTION
Update call to displayPage to include a NULL value for localParams that is now required.