### PR TITLE
[django] Bump Python to 3.12.12

### DIFF
--- a/projects/django/Dockerfile
+++ b/projects/django/Dockerfile
@@ -33,13 +33,13 @@ RUN apt-get update && apt-get install -y \
 
 # Build and install Python 3.12 from source (Django main branch requires Python 3.12+)
 RUN cd /tmp && \
-    curl -O https://www.python.org/ftp/python/3.12.8/Python-3.12.8.tgz && \
-    tar -xzf Python-3.12.8.tgz && \
-    cd Python-3.12.8 && \
+    curl -O https://www.python.org/ftp/python/3.12.12/Python-3.12.12.tgz && \
+    tar -xzf Python-3.12.12.tgz && \
+    cd Python-3.12.12 && \
     ./configure --enable-optimizations --enable-shared --prefix=/usr/local/python3.12 && \
     make -j$(nproc) && \
     make install && \
-    rm -rf /tmp/Python-3.12.8*
+    rm -rf /tmp/Python-3.12.12*
 
 # Add Python 3.12 libs to LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH="/usr/local/python3.12/lib:$LD_LIBRARY_PATH"


### PR DESCRIPTION
There were security fixes in HTMLParser in 3.12.12, see: https://github.com/python/cpython/commit/1d53c3e7343bddb064182e02c21b13be9b63390f.

I want to rule out any upstream issues that have already been solved before looking at any failures in the Django fuzzer.

See also this in Django's test suite: https://github.com/django/django/commit/2980627502c84a9fd09272e1349dc574a2ff1fb1