### PR TITLE
astroid: ignore RecursionErrors in the fuzz_parse target

### DIFF
--- a/projects/astroid/fuzz_parse.py
+++ b/projects/astroid/fuzz_parse.py
@@ -33,6 +33,7 @@ def TestOneInput(data):
       astroid.modutils.NoSourceFile,
       astroid.exceptions.AstroidError,
       astroid.exceptions.UseInferenceDefault,
+      RecursionError,
   ):
     pass
 


### PR DESCRIPTION
Astroid consumers are expected to handle raised RecursionErrors: https://github.com/pylint-dev/astroid/issues/2520#issuecomment-3796928982