### PR TITLE
trafficserver: Update Dockerfile to use Ubuntu 24.04 base image

### DIFF
--- a/projects/trafficserver/Dockerfile
+++ b/projects/trafficserver/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 ################################################################################
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y libpcre3-dev zlib1g-dev cmake libssl-dev libpcre2-dev pkg-config
 RUN git clone --depth 1 https://github.com/apache/trafficserver.git
 RUN cp $SRC/trafficserver/tests/fuzzing/oss-fuzz.sh $SRC/build.sh


### PR DESCRIPTION
The current run is failing and this is part of the fix to bring the run back up again. 