### PR TITLE
Don't disable ensurepip, as pip is used later

### DIFF
--- a/projects/python3-libraries/build.sh
+++ b/projects/python3-libraries/build.sh
@@ -30,9 +30,6 @@ case $SANITIZER in
     ;;
   memory)
     FLAGS+=("--with-memory-sanitizer")
-    # installing ensurepip takes a while with MSAN instrumentation, so
-    # we disable it here
-    FLAGS+=("--without-ensurepip")
     # -msan-keep-going is needed to allow MSAN's halt_on_error to function
     FLAGS+=("CFLAGS=-mllvm -msan-keep-going=1")
     ;;


### PR DESCRIPTION
The build script for the memory sanitizer was failing as we used `--without-ensurepip` and then using `pip` later to install hypothesis. This previously wasn't an issue because we weren't using `pip` yet. Going to ping @DavidKorczynski as this is blocking some PRs on CPython now that we're running it in CI.