### PR TITLE
[GDAL] Pull again OSGeo/GDAL master

### DIFF
--- a/projects/gdal/Dockerfile
+++ b/projects/gdal/Dockerfile
@@ -19,10 +19,7 @@ FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && \
     apt-get install -y make autoconf automake libtool g++ curl cmake sqlite3 pkg-config
 
-# Using this temporary branch while the pull request in google/ossfuzz has not been yet merged
-# Once it has been, this ossfuzz_ubuntu_2404 branch will be merged back to OSGeo/gdal master
-RUN git clone --depth 1 --branch ossfuzz_ubuntu_2404 https://github.com/rouault/gdal gdal
-#RUN git clone --depth 1 https://github.com/OSGeo/gdal gdal
+RUN git clone --depth 1 https://github.com/OSGeo/gdal gdal
 
 RUN cp gdal/fuzzers/build.sh $SRC/
 


### PR DESCRIPTION
In https://github.com/google/oss-fuzz/pull/14838, the first stage of the transition to switching to ubuntu-24.04 was done by pointing the GDAL repository to my own fork.

Now I've merged it into OSGeo/GDAL master per https://github.com/OSGeo/gdal/commit/7d05b7a871eea9b4107f86212cffaff066a021e6 so we can now point back to OSGeo/GDAL