### PR TITLE
strongswan: Fix build for new fuzzer

### DIFF
--- a/projects/strongswan/build.sh
+++ b/projects/strongswan/build.sh
@@ -20,6 +20,7 @@
 ./configure CFLAGS="$CFLAGS -DNO_CHECK_MEMWIPE -DDEBUG_LEVEL=-1" \
 	--enable-imc-test \
 	--enable-tnccs-20 \
+	--enable-libipsec \
 	--enable-fuzzing \
 	--with-libfuzzer=$LIB_FUZZING_ENGINE \
 	--enable-monolithic \


### PR DESCRIPTION
This PR fixes the build script for strongswan project to activate libipsec building for the new fuzzer targeting libipsec module.