### PR TITLE
pjsip: Fix build to enable audio codec build for new fuzzer

### DIFF
--- a/projects/pjsip/build.sh
+++ b/projects/pjsip/build.sh
@@ -20,8 +20,7 @@ export LDFLAGS="$CFLAGS"
 
 ./configure \
 --disable-ffmpeg --disable-ssl \
---disable-speex-aec --disable-speex-codec \
---disable-g7221-codec --disable-gsm-codec --disable-ilbc-codec \
+--disable-speex-aec --disable-g7221-codec \
 --disable-resample --disable-libwebrtc --disable-libyuv
 
 make dep


### PR DESCRIPTION
This PR fixes the build configuration to enable build for new audio codec fuzzer.