### PR TITLE
Support C/C++ coverage for Lua tests

### DIFF
--- a/infra/base-images/base-runner/coverage
+++ b/infra/base-images/base-runner/coverage
@@ -122,15 +122,30 @@ function run_fuzz_target {
     # Extract fuzztest binary name from fuzztest wrapper script.
     target=(${target//@/ }[0])
   fi
-  profraw_update.py $OUT/$target -i $profraw_file_mask
+  # XXX: readelf: Error: Not an ELF file - it has the wrong magic
+  # bytes at the start.
+  grep -q "luarocks" "$target"
+  is_lua=$?
+  if [[ "$is_lua" -ne 0 ]]; then
+    profraw_update.py $OUT/$target -i $profraw_file_mask
+  fi
   llvm-profdata merge -j=1 -sparse $profraw_file_mask -o $profdata_file
 
   # Delete unnecessary and (potentially) large .profraw files.
   rm $profraw_file_mask
 
-  shared_libraries=$(coverage_helper shared_libs -build-dir=$OUT -object=$target)
+  # `coverage_helper shared_libraries` raise an exception because
+  # it runs `ldd` on a test wrapper and `ldd` returns a non-zero
+  # exit code.
+  test_dir=$(dirname $(realpath "$target"))
+  if [[ "$is_lua" -ne 0 ]]; then
+    shared_libraries=$(coverage_helper shared_libs -build-dir=$OUT -object=$objects)
+  else
+    shared_libraries=$(find $test_dir -name "*.so" ! -name 'luzer_impl.so' ! -name 'libfuzzer_with_ubsan.so' ! -name 'libcustom_mutator.so' ! -name 'libfuzzer_with_asan.so' -type f -print | tr "\n" " ")
+  fi
 
-  llvm-cov export -summary-only -instr-profile=$profdata_file -object=$target \
+  # Lua runtime must have name `lua`.
+  llvm-cov export -summary-only -instr-profile=$profdata_file -object=$test_dir/lua \
       $shared_libraries $LLVM_COV_COMMON_ARGS > $FUZZER_STATS_DIR/$target.json
 
   # If grep returned zero an error was matched.
@@ -624,7 +639,17 @@ else
 
   # TODO(mmoroz): add script from Chromium for rendering directory view reports.
   # The first path in $objects does not have -object= prefix (llvm-cov format).
-  shared_libraries=$(coverage_helper shared_libs -build-dir=$OUT -object=$objects)
+  # `coverage_helper shared_libraries` raise an exception because
+  # it runs `ldd` on a test wrapper and `ldd` returns a non-zero
+  # exit code.
+  grep -q "luarocks" "$target"
+  is_lua=$?
+  if [[ "$is_lua" -ne 0 ]]; then
+    shared_libraries=$(coverage_helper shared_libs -build-dir=$OUT -object=$objects)
+  else
+    test_dir=$(dirname $(realpath "$target"))
+    shared_libraries=$(find $test_dir -name "*.so" ! -name 'luzer_impl.so' ! -name 'libfuzzer_with_ubsan.so' ! -name 'libcustom_mutator.so' ! -name 'libfuzzer_with_asan.so' -type f -print | tr "\n" " ")
+  fi
   objects="$objects $shared_libraries"
 
   generate_html $PROFILE_FILE "$shared_libraries" "$objects" "$REPORT_ROOT_DIR"

--- a/projects/tarantool/build.sh
+++ b/projects/tarantool/build.sh
@@ -48,7 +48,7 @@ fi
 : ${LDFLAGS:="${CXXFLAGS}"}  # to make sure we link with sanitizer runtime
 
 FUZZER_ARGS=""
-if [[ "$FUZZING_ENGINE" == libfuzzer ]]; then
+if [[ "$FUZZING_ENGINE" == libfuzzer && "$SANITIZER" != "coverage" ]]; then
   FUZZER_ARGS="-DENABLE_LIBFUZZER_STATIC_LINKAGE=ON"
 fi
 
@@ -132,8 +132,9 @@ fi
 # see FUZZING_ENGINE environment variable.
 cmake --build build --target tarantool --parallel --verbose
 
-LUA_RUNTIME_NAME=tarantool
-TARANTOOL_PATH=build/src/$LUA_RUNTIME_NAME
+# XXX: Code coverage scripts relies on that.
+LUA_RUNTIME_NAME=lua
+TARANTOOL_PATH=build/src/tarantool
 LUA_MODULES_DIR=lua_modules
 
 apt install -y luarocks liblua5.1-0 liblua5.1-0-dev liblua5.1-0-dbg lua5.1


### PR DESCRIPTION
Closes #14859
Follows up #13782

--------

```
sudo docker image tag 64b2404f16ef gcr.io/oss-fuzz-base/base-runner
sudo docker build -t gcr.io/oss-fuzz-base/base-runner infra/base-images/base-runner/

sudo -E python ./infra/helper.py build_fuzzers --sanitizer coverage tarantool
sudo -E python ./infra/helper.py run_fuzzer --sanitizer coverage tarantool math_acos_test
sudo -E python ./infra/helper.py coverage --no-corpus-download --fuzz-target math_acos_test tarantool

sudo docker run --privileged --shm-size=2g --platform linux/amd64 --rm -i -e FUZZING_ENGINE=libfuzzer -e HELPER=True -e FUZZING_LANGUAGE=c -e PROJECT=tarantool -e SANITIZER=coverage -e 'COVERAGE_EXTRA_ARGS= ' -e ARCHITECTURE=x86_64 -e HTTP_PORT=8008 -p 8008:8008 -v /home/sergeyb/sources/oss-fuzz/build/corpus/tarantool:/corpus -v /home/sergeyb/sources/oss-fuzz/build/out/tarantool:/out -t gcr.io/oss-fuzz-base/base-runner:latest bash
```