### PR TITLE
Add axis2c project

### DIFF
--- a/projects/axis2c/Dockerfile
+++ b/projects/axis2c/Dockerfile
@@ -1,0 +1,7 @@
+FROM gcr.io/oss-fuzz-base/base-builder 
+RUN apt-get update && apt-get install -y \
+    autoconf automake libtool pkg-config \
+    libxml2-dev libjson-c-dev libssl-dev zlib1g-dev
+RUN git clone --depth 1 https://github.com/apache/axis-axis2-c-core.git axis2c         
+WORKDIR axis2c
+COPY build.sh $SRC/

--- a/projects/axis2c/build.sh
+++ b/projects/axis2c/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -eu
+cd $SRC/axis2c
+exec bash fuzz/oss-fuzz/build.sh

--- a/projects/axis2c/project.yaml
+++ b/projects/axis2c/project.yaml
@@ -1,0 +1,5 @@
+homepage: "https://axis.apache.org/axis2/c/core/"
+language: c
+primary_contact: "c-dev@axis.apache.org"
+vendor_ccs: "robertlazarski@gmail.com"
+main_repo: "https://github.com/apache/axis-axis2-c-core.git"


### PR DESCRIPTION
 ## Summary                                                     
  Add Apache Axis2/C Web services engine for fuzzing.            
                                                                 
  **Project:** https://axis.apache.org/axis2/c/core/             
  **Repo:** https://github.com/apache/axis-axis2-c-core          
                                                                 
  ## Fuzzers                                                     
  - `fuzz_json_reader` - JSON to AXIOM conversion                
  - `fuzz_json_parser` - Direct json-c parsing                   
  - `fuzz_xml_parser` - XML/SOAP parsing                         
  - `fuzz_http_header` - HTTP header parsing                     
  - `fuzz_url_parser` - URL parsing                              
                                                                 
  ## Local Testing                                               
  All fuzzers build and run successfully with libFuzzer +        
  AddressSanitizer.   