### PR TITLE
Add fuzzing integration for rust-url

### DIFF
--- a/projects/rust-url/Dockerfile
+++ b/projects/rust-url/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2025 Google Inc.
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/rust-url/build.sh
+++ b/projects/rust-url/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2025 Google Inc.
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/rust-url/project.yaml
+++ b/projects/rust-url/project.yaml
@@ -1,11 +1,11 @@
 homepage: "https://github.com/servo/rust-url"
+language: rust
 primary_contact: "manishsmail@gmail.com"
-main_repo: "https://github.com/servo/rust-url"
+auto_ccs:
+  - "jaredreyespt@gmail.com"
+vendor_ccs:
+  - "jaredreyespt@gmail.com"
 sanitizers:
   - address
   - undefined
-fuzzing_engines:
-  - libfuzzer
-language: rust
-auto_ccs:
-  - "jaredreyes.dev@gmail.com"
+main_repo: "https://github.com/servo/rust-url"


### PR DESCRIPTION
## Summary

- Add OSS-Fuzz integration for [rust-url](https://github.com/servo/rust-url), the WHATWG URL Standard implementation for Rust
- 7 fuzz targets covering the entire workspace: `url`, `idna`, `percent-encoding`, `form_urlencoded`, `data-url`
- Targets use roundtrip invariant checking, differential testing, and mutation testing strategies
- Includes seed corpus and fuzzing dictionary

## Upstream PR

Fuzz targets live upstream: https://github.com/servo/rust-url/pull/1100

## Project Details

- **Homepage**: https://github.com/servo/rust-url
- **Language**: Rust
- **Sanitizers**: address, undefined
- **Fuzzing engine**: libfuzzer

## Fuzz Targets

| Target | Crate(s) | Strategy |
|--------|----------|----------|
| `fuzz_url_parse_roundtrip` | `url` | Parse → serialize → re-parse roundtrip |
| `fuzz_url_differential` | `url` | Relative URL resolution roundtrip |
| `fuzz_url_setters` | `url` | Mutation via setters + validity invariant |
| `fuzz_idna` | `idna` | domain_to_ascii ↔ domain_to_unicode roundtrip |
| `fuzz_data_url` | `data-url` | DataUrl::process + base64 decoding |
| `fuzz_form_urlencoded` | `form_urlencoded` | Parse → serialize → re-parse roundtrip |
| `fuzz_percent_encoding` | `percent-encoding` | Encode → decode roundtrip |