### PR TITLE
Add fuzzing for sqlx (launchbadge/sqlx)

### DIFF
--- a/projects/sqlx/Dockerfile
+++ b/projects/sqlx/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+RUN git clone --depth 1 https://github.com/launchbadge/sqlx.git sqlx
+WORKDIR sqlx
+COPY build.sh $SRC/

--- a/projects/sqlx/build.sh
+++ b/projects/sqlx/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC/sqlx/fuzz
+
+# Build all fuzz targets
+cargo fuzz build -O
+
+# Copy fuzz targets to output directory
+FUZZ_TARGET_OUTPUT_DIR=target/x86_64-unknown-linux-gnu/release
+for f in fuzz_targets/*.rs; do
+    FUZZ_TARGET_NAME=$(basename ${f%%.rs})
+    cp $FUZZ_TARGET_OUTPUT_DIR/$FUZZ_TARGET_NAME $OUT/
+done

--- a/projects/sqlx/project.yaml
+++ b/projects/sqlx/project.yaml
@@ -1,0 +1,11 @@
+homepage: "https://github.com/launchbadge/sqlx"
+language: rust
+primary_contact: "austin.bonander@gmail.com"
+auto_ccs:
+  - "jaredreyespt@gmail.com"
+sanitizers:
+  - address
+  - undefined
+vendor_ccs:
+  - "jaredreyespt@gmail.com"
+main_repo: 'https://github.com/launchbadge/sqlx.git'


### PR DESCRIPTION
## Project Information

**Repository:** https://github.com/launchbadge/sqlx  
**Language:** Rust  
**Downloads:** 54.9M  
**Reverse Dependencies:** 1,503  
**Estimated Criticality Score:** 0.75-0.85 (high ecosystem impact)

## Description

SQLx is an async SQL toolkit for Rust supporting PostgreSQL, MySQL, and SQLite. It's the most popular database library in the Rust ecosystem with widespread use across production systems.

## Security Criticality

- **Untrusted Input Handling:** Parses binary protocol data from database servers
- **Known Vulnerabilities:** RUSTSEC-2024-0363 (Binary Protocol Misinterpretation/SQL format-injection)
- **Attack Surface:** MySQL wire protocol, PostgreSQL wire protocol, SQLite
- **Impact:** 1,503 dependent crates rely on secure protocol handling

## Fuzzing Targets

1. `fuzz_mysql_lenenc`: MySQL length-encoded integer parsing (RUSTSEC-2024-0363 vulnerability area)
2. `fuzz_mysql_row_binary`: Binary protocol row parsing with null bitmaps
3. `fuzz_mysql_handshake`: Connection handshake and authentication
4. `fuzz_postgres_data_row`: PostgreSQL data row parsing
5. `fuzz_postgres_response`: Error/notice response parsing

## Upstream Integration

Upstream PR: https://github.com/launchbadge/sqlx/pull/4156

Contributed by: Jared Reyes (jaredreyespt@gmail.com)