### PR TITLE
neovim: initial integration

### DIFF
--- a/projects/neovim/Dockerfile
+++ b/projects/neovim/Dockerfile
@@ -1,0 +1,42 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN apt-get update && apt-get install -y \
+    cmake \
+    ninja-build \
+    gettext \
+    libtool-bin \
+    autoconf \
+    automake \
+    pkg-config \
+    unzip \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 https://github.com/neovim/neovim $SRC/neovim
+
+COPY build.sh \
+     fuzz_nvim_vterm.c \
+     fuzz_nvim_base64.c \
+     fuzz_nvim_mpack.c \
+     fuzz_nvim_vterm.dict \
+     fuzz_nvim_base64.dict \
+     fuzz_nvim_mpack.dict \
+     $SRC/
+
+WORKDIR $SRC/neovim

--- a/projects/neovim/build.sh
+++ b/projects/neovim/build.sh
@@ -1,0 +1,114 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC/neovim
+
+# Strip sanitizer/fuzzer flags for building neovim itself.
+# Neovim's build uses luajit to generate code (via libnlua0.so),
+# and sanitizer flags like -fsanitize=fuzzer-no-link introduce
+# __sancov_lowest_stack which luajit can't resolve at load time.
+# We only need sanitizers when compiling our fuzz targets.
+NVIM_CFLAGS="-O1 -fno-omit-frame-pointer -gline-tables-only"
+
+# Build neovim's bundled dependencies (static libraries)
+cmake -S cmake.deps -B .deps -G Ninja \
+    -D CMAKE_BUILD_TYPE=Release \
+    -D CMAKE_C_COMPILER=$CC \
+    -D CMAKE_C_FLAGS="$NVIM_CFLAGS"
+cmake --build .deps
+
+# Build neovim itself (produces libnvim.a with all nvim code including vterm)
+# We use the same clean NVIM_CFLAGS here — no sanitizer, no coverage flags.
+# Coverage instrumentation in CMAKE_C_FLAGS would contaminate libnlua0.so
+# (the build-time code generator loaded by luajit), causing unresolved
+# __sanitizer_cov_trace_* symbols. The fuzz targets themselves are compiled
+# with full $CFLAGS (including coverage), which provides sufficient coverage.
+cmake -S . -B build -G Ninja \
+    -D CMAKE_BUILD_TYPE=Release \
+    -D CMAKE_C_COMPILER=$CC \
+    -D CMAKE_C_FLAGS="$NVIM_CFLAGS"
+cmake --build build --target libnvim
+
+# Collect include paths that neovim's build uses
+NVIM_INCLUDES="\
+    -I $SRC/neovim/build/src/nvim/auto \
+    -I $SRC/neovim/build/include \
+    -I $SRC/neovim/build/cmake.config \
+    -I $SRC/neovim/src \
+    -I $SRC/neovim/.deps/usr/include \
+    -I $SRC/neovim/.deps/usr/include/luajit-2.1"
+
+################################################################################
+# Target 1: fuzz_nvim_vterm — Terminal escape sequence parser
+#
+# The fuzzer defines xmalloc/xfree stubs that override libnvim.a's memory.c.
+# We use --allow-multiple-definition because libnvim.a's memory.c.o and main.c.o
+# get pulled in transitively (other .o files reference symbols they define).
+# Our fuzzer .o comes first, so the linker picks our simple stubs.
+################################################################################
+$CC $CFLAGS $NVIM_INCLUDES \
+    -c $SRC/fuzz_nvim_vterm.c -o $WORK/fuzz_nvim_vterm.o
+
+# Collect all static dependency libraries from .deps
+NVIM_DEPS=""
+for lib in $SRC/neovim/.deps/usr/lib/*.a; do
+    NVIM_DEPS="$NVIM_DEPS $lib"
+done
+
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE \
+    $WORK/fuzz_nvim_vterm.o \
+    -Wl,--allow-multiple-definition \
+    $SRC/neovim/build/lib/libnvim.a \
+    $NVIM_DEPS \
+    -lutil -lpthread -ldl -lm \
+    -o $OUT/fuzz_nvim_vterm
+
+################################################################################
+# Target 2: fuzz_nvim_base64 — Base64 encode/decode
+################################################################################
+$CC $CFLAGS $NVIM_INCLUDES \
+    -c $SRC/fuzz_nvim_base64.c -o $WORK/fuzz_nvim_base64.o
+
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE \
+    $WORK/fuzz_nvim_base64.o \
+    -Wl,--allow-multiple-definition \
+    $SRC/neovim/build/lib/libnvim.a \
+    $NVIM_DEPS \
+    -lutil -lpthread -ldl -lm \
+    -o $OUT/fuzz_nvim_base64
+
+################################################################################
+# Target 3: fuzz_nvim_mpack — MessagePack tokenizer (completely standalone)
+#
+# mpack under src/mpack/ has ZERO nvim dependencies — it's pure C with
+# no xmalloc, no nvim headers. We compile mpack_core.c directly.
+################################################################################
+$CC $CFLAGS -I $SRC/neovim/src \
+    -c $SRC/fuzz_nvim_mpack.c -o $WORK/fuzz_nvim_mpack.o
+
+$CC $CFLAGS -I $SRC/neovim/src \
+    -c $SRC/neovim/src/mpack/mpack_core.c -o $WORK/mpack_core.o
+
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE \
+    $WORK/fuzz_nvim_mpack.o \
+    $WORK/mpack_core.o \
+    -o $OUT/fuzz_nvim_mpack
+
+# Copy dictionaries (named to match fuzz targets for auto-association)
+cp $SRC/fuzz_nvim_vterm.dict $OUT/
+cp $SRC/fuzz_nvim_base64.dict $OUT/
+cp $SRC/fuzz_nvim_mpack.dict $OUT/

--- a/projects/neovim/fuzz_nvim_base64.c
+++ b/projects/neovim/fuzz_nvim_base64.c
@@ -1,0 +1,113 @@
+/* Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Fuzz neovim's base64 encode/decode implementation.
+ *
+ * Neovim has its own optimized base64 codec in src/nvim/base64.c that uses
+ * 8-byte-at-a-time processing with endian conversion. This fuzzer tests
+ * both decoding arbitrary (potentially malformed) input and round-tripping
+ * through encode→decode.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * Stub implementations of neovim's memory functions.
+ * Same rationale as in fuzz_nvim_vterm.c.
+ */
+void *xmalloc(size_t size) {
+  void *p = malloc(size ? size : 1);
+  if (!p) abort();
+  return p;
+}
+
+void xfree(void *p) {
+  free(p);
+}
+
+void *xcalloc(size_t count, size_t size) {
+  void *p = calloc(count ? count : 1, size ? size : 1);
+  if (!p) abort();
+  return p;
+}
+
+void *xrealloc(void *p, size_t size) {
+  void *r = realloc(p, size ? size : 1);
+  if (!r) abort();
+  return r;
+}
+
+void *xmallocz(size_t size) {
+  void *p = xmalloc(size + 1);
+  ((char *)p)[size] = '\0';
+  return p;
+}
+
+void *xmemdupz(const void *data, size_t len) {
+  void *p = xmallocz(len);
+  memcpy(p, data, len);
+  return p;
+}
+
+void preserve_exit(const char *errmsg) {
+  (void)errmsg;
+  abort();
+}
+
+/* Forward declarations from nvim/base64.h */
+char *base64_encode(const char *src, size_t src_len);
+char *base64_decode(const char *src, size_t src_len, size_t *out_lenp);
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  if (size < 1 || size > 4096)
+    return 0;
+
+  /* Mode 0: decode arbitrary data (test malformed input handling) */
+  /* Mode 1: encode then decode (round-trip consistency) */
+  int mode = data[0] & 1;
+  const char *input = (const char *)(data + 1);
+  size_t input_len = size - 1;
+
+  if (mode == 0) {
+    /* Try to decode potentially malformed base64 */
+    size_t out_len = 0;
+    char *decoded = base64_decode(input, input_len, &out_len);
+    if (decoded) {
+      xfree(decoded);
+    }
+  } else {
+    /* Encode raw bytes, then decode back and verify round-trip */
+    char *encoded = base64_encode(input, input_len);
+    if (encoded) {
+      size_t decoded_len = 0;
+      char *decoded = base64_decode(encoded, strlen(encoded), &decoded_len);
+      if (decoded) {
+        /* Verify round-trip: decoded output must match original input */
+        if (decoded_len != input_len ||
+            memcmp(decoded, input, input_len) != 0) {
+          abort(); /* Round-trip failure is a bug */
+        }
+        xfree(decoded);
+      }
+      xfree(encoded);
+    }
+  }
+
+  return 0;
+}

--- a/projects/neovim/fuzz_nvim_base64.dict
+++ b/projects/neovim/fuzz_nvim_base64.dict
@@ -1,0 +1,33 @@
+# Base64 alphabet and special characters
+"A"
+"Z"
+"a"
+"z"
+"0"
+"9"
+"+"
+"/"
+"="
+"=="
+# Valid base64 strings
+"AA=="
+"AAA="
+"AAAA"
+"QUJD"
+"/+//"
+"//8="
+# Edge cases
+"AB"
+"ABC"
+"ABCD"
+# Invalid base64
+"@@@@"
+"!!!!"
+"A==="
+"=AAA"
+# Long padding
+"========"
+# Whitespace (should be rejected)
+" "
+"\x0a"
+"\x0d\x0a"

--- a/projects/neovim/fuzz_nvim_mpack.c
+++ b/projects/neovim/fuzz_nvim_mpack.c
@@ -1,0 +1,59 @@
+/* Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Fuzz neovim's bundled mpack (MessagePack) tokenizer.
+ *
+ * Neovim uses MessagePack as the wire format for its RPC API (the protocol
+ * between neovim and UI clients, plugins, etc.). The mpack library under
+ * src/mpack/ is a minimal C implementation that tokenizes msgpack data.
+ *
+ * This fuzzer is completely standalone — mpack has NO dependencies on
+ * neovim internals (no xmalloc, no nvim headers). It only uses standard C.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+/* mpack API — include the header directly from neovim's source tree */
+#include "mpack/mpack_core.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  if (size < 1 || size > 8192)
+    return 0;
+
+  mpack_tokbuf_t tokbuf;
+  mpack_token_t tok;
+
+  mpack_tokbuf_init(&tokbuf);
+
+  const char *buf = (const char *)data;
+  size_t buflen = size;
+
+  /* Read all tokens from the msgpack data until exhausted or error */
+  while (buflen > 0) {
+    int rc = mpack_read(&tokbuf, &buf, &buflen, &tok);
+    if (rc == MPACK_ERROR) {
+      break; /* Invalid msgpack — expected for fuzz input */
+    }
+    if (rc == MPACK_EOF) {
+      break; /* Need more data — input exhausted */
+    }
+    /* MPACK_OK — token parsed successfully, continue */
+  }
+
+  return 0;
+}

--- a/projects/neovim/fuzz_nvim_mpack.dict
+++ b/projects/neovim/fuzz_nvim_mpack.dict
@@ -1,0 +1,62 @@
+# MessagePack format bytes
+# Positive fixint (0x00-0x7f)
+"\x00"
+"\x7f"
+# Fixmap (0x80-0x8f)
+"\x80"
+"\x81"
+"\x8f"
+# Fixarray (0x90-0x9f)
+"\x90"
+"\x91"
+"\x9f"
+# Fixstr (0xa0-0xbf)
+"\xa0"
+"\xa1"
+"\xbf"
+# nil
+"\xc0"
+# false
+"\xc2"
+# true
+"\xc3"
+# bin 8/16/32
+"\xc4"
+"\xc5"
+"\xc6"
+# ext 8/16/32
+"\xc7"
+"\xc8"
+"\xc9"
+# float 32/64
+"\xca"
+"\xcb"
+# uint 8/16/32/64
+"\xcc"
+"\xcd"
+"\xce"
+"\xcf"
+# int 8/16/32/64
+"\xd0"
+"\xd1"
+"\xd2"
+"\xd3"
+# fixext 1/2/4/8/16
+"\xd4"
+"\xd5"
+"\xd6"
+"\xd7"
+"\xd8"
+# str 8/16/32
+"\xd9"
+"\xda"
+"\xdb"
+# array 16/32
+"\xdc"
+"\xdd"
+# map 16/32
+"\xde"
+"\xdf"
+# Negative fixint (0xe0-0xff)
+"\xe0"
+"\xff"

--- a/projects/neovim/fuzz_nvim_vterm.c
+++ b/projects/neovim/fuzz_nvim_vterm.c
@@ -1,0 +1,113 @@
+/* Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Fuzz the neovim bundled libvterm terminal escape sequence parser.
+ *
+ * vterm_input_write() is the main entry point for all terminal input data.
+ * It parses CSI, OSC, DCS, ESC sequences, UTF-8 text, and C0/C1 controls.
+ * This is the code path that processes untrusted terminal output from
+ * programs running inside neovim's :terminal.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * Provide stub implementations of neovim's memory functions.
+ * These must be defined BEFORE any neovim headers are included and must
+ * appear in the final link BEFORE libnvim.a so the linker uses our stubs
+ * instead of pulling in memory.o (which has deep dependency chains).
+ *
+ * These are intentionally NOT weak symbols so that our stubs take priority.
+ * The linker resolves symbols in order: our .o first, then the archive.
+ * Symbols already resolved won't cause the archive member to be pulled in.
+ */
+void *xmalloc(size_t size) {
+  void *p = malloc(size ? size : 1);
+  if (!p) abort();
+  return p;
+}
+
+void xfree(void *p) {
+  free(p);
+}
+
+void *xcalloc(size_t count, size_t size) {
+  void *p = calloc(count ? count : 1, size ? size : 1);
+  if (!p) abort();
+  return p;
+}
+
+void *xrealloc(void *p, size_t size) {
+  void *r = realloc(p, size ? size : 1);
+  if (!r) abort();
+  return r;
+}
+
+void *xmallocz(size_t size) {
+  void *p = xmalloc(size + 1);
+  ((char *)p)[size] = '\0';
+  return p;
+}
+
+void *xmemdupz(const void *data, size_t len) {
+  void *p = xmallocz(len);
+  memcpy(p, data, len);
+  return p;
+}
+
+void preserve_exit(const char *errmsg) {
+  (void)errmsg;
+  abort();
+}
+
+/* Forward declarations for vterm API (from nvim/vterm/vterm.h) */
+typedef struct VTerm VTerm;
+typedef struct VTermScreen VTermScreen;
+
+VTerm *vterm_new(int rows, int cols);
+void vterm_free(VTerm *vt);
+void vterm_set_utf8(VTerm *vt, int is_utf8);
+size_t vterm_input_write(VTerm *vt, const char *bytes, size_t len);
+VTermScreen *vterm_obtain_screen(VTerm *vt);
+void vterm_screen_reset(VTermScreen *screen, int hard);
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  if (size < 1 || size > 8192)
+    return 0;
+
+  /* Use first byte to select terminal size and UTF-8 mode */
+  int rows = (data[0] & 0x1f) + 1;       /* 1-32 */
+  int cols = ((data[0] >> 5) & 0x07) * 20 + 20; /* 20-160 */
+  int utf8 = (data[0] & 0x80) ? 1 : 0;
+
+  VTerm *vt = vterm_new(rows, cols);
+  if (!vt)
+    return 0;
+
+  vterm_set_utf8(vt, utf8);
+
+  VTermScreen *screen = vterm_obtain_screen(vt);
+  vterm_screen_reset(screen, 1);
+
+  /* Feed the rest of the input to the terminal parser */
+  vterm_input_write(vt, (const char *)(data + 1), size - 1);
+
+  vterm_free(vt);
+  return 0;
+}

--- a/projects/neovim/fuzz_nvim_vterm.dict
+++ b/projects/neovim/fuzz_nvim_vterm.dict
@@ -1,0 +1,70 @@
+# Neovim vterm terminal escape sequences
+# CSI (Control Sequence Introducer)
+"\x1b["
+# OSC (Operating System Command)
+"\x1b]"
+# DCS (Device Control String)
+"\x1bP"
+# APC (Application Program Command)
+"\x1b_"
+# PM (Privacy Message)
+"\x1b^"
+# SOS (Start of String)
+"\x1bX"
+# ST (String Terminator)
+"\x1b\\"
+# SS2, SS3
+"\x1bN"
+"\x1bO"
+# BEL (alternative ST)
+"\x07"
+# Common CSI sequences
+"\x1b[m"
+"\x1b[0m"
+"\x1b[1m"
+"\x1b[4m"
+"\x1b[7m"
+"\x1b[H"
+"\x1b[J"
+"\x1b[K"
+"\x1b[2J"
+"\x1b[?25h"
+"\x1b[?25l"
+"\x1b[?1049h"
+"\x1b[?1049l"
+# SGR (Select Graphic Rendition) parameters
+"\x1b[38;5;"
+"\x1b[48;5;"
+"\x1b[38;2;"
+"\x1b[48;2;"
+# Cursor movement
+"\x1b[A"
+"\x1b[B"
+"\x1b[C"
+"\x1b[D"
+# Scroll
+"\x1b[S"
+"\x1b[T"
+# Window manipulation
+"\x1b[8;"
+# OSC sequences
+"\x1b]0;"
+"\x1b]2;"
+"\x1b]52;"
+# C0 controls
+"\x00"
+"\x08"
+"\x09"
+"\x0a"
+"\x0d"
+"\x0e"
+"\x0f"
+# C1 controls (8-bit)
+"\x90"
+"\x9b"
+"\x9d"
+"\x9c"
+# UTF-8 sequences
+"\xc0\x80"
+"\xe0\xa0\x80"
+"\xf0\x90\x80\x80"

--- a/projects/neovim/project.yaml
+++ b/projects/neovim/project.yaml
@@ -1,0 +1,14 @@
+homepage: https://neovim.io
+language: c
+primary_contact: "peter.john.henggeler@gmail.com"
+main_repo: 'https://github.com/neovim/neovim'
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+  - centipede
+sanitizers:
+  - address
+  - undefined
+  - memory:
+      experimental: True


### PR DESCRIPTION
Add fuzzing integration for neovim with three fuzz targets:
- fuzz_nvim_vterm: Fuzzes the VTerm terminal emulator parser
- fuzz_nvim_base64: Fuzzes base64 encode/decode with round-trip checks
- fuzz_nvim_mpack: Fuzzes the standalone msgpack tokenizer

All targets include dictionaries for improved coverage.