### PR TITLE
Add fuzzing integration for x509-certificate

### DIFF
--- a/projects/x509-certificate/Dockerfile
+++ b/projects/x509-certificate/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+
+RUN git clone --depth 1 https://github.com/indygreg/cryptography-rs
+
+WORKDIR cryptography-rs/x509-certificate
+COPY build.sh $SRC/

--- a/projects/x509-certificate/build.sh
+++ b/projects/x509-certificate/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -eu
+
+cd $SRC/cryptography-rs/x509-certificate
+
+# Build fuzz targets
+cargo fuzz build -O --debug-assertions
+
+# Copy fuzz targets to output directory
+FUZZ_TARGET_OUTPUT_DIR=$SRC/cryptography-rs/x509-certificate/fuzz/target/x86_64-unknown-linux-gnu/release
+for f in fuzz_certificate_der fuzz_certificate_pem fuzz_time_parsing fuzz_csr_parse fuzz_name_parsing fuzz_extensions; do
+    cp $FUZZ_TARGET_OUTPUT_DIR/$f $OUT/
+done
+
+# Copy seed corpus if it exists
+if [ -d fuzz/corpus ]; then
+    for target in fuzz_certificate_der fuzz_certificate_pem fuzz_time_parsing fuzz_csr_parse fuzz_name_parsing fuzz_extensions; do
+        if [ -d fuzz/corpus/$target ]; then
+            zip -r $OUT/${target}_seed_corpus.zip fuzz/corpus/$target/
+        fi
+    done
+fi
+
+# Copy dictionary if it exists
+if [ -f fuzz/fuzz.dict ]; then
+    cp fuzz/fuzz.dict $OUT/fuzz_time_parsing.dict
+    cp fuzz/fuzz.dict $OUT/fuzz_certificate_der.dict
+    cp fuzz/fuzz.dict $OUT/fuzz_certificate_pem.dict
+fi

--- a/projects/x509-certificate/project.yaml
+++ b/projects/x509-certificate/project.yaml
@@ -1,0 +1,15 @@
+homepage: "https://github.com/indygreg/cryptography-rs"
+language: rust
+primary_contact: "jaredreyespt@gmail.com"
+main_repo: "https://github.com/indygreg/cryptography-rs"
+file_github_issue: true
+
+sanitizers:
+  - address
+  - undefined
+
+fuzzing_engines:
+  - libfuzzer
+
+vendor_ccs:
+  - "gregory.szorc@gmail.com"


### PR DESCRIPTION
## Project Information
**Homepage:** https://github.com/indygreg/cryptography-rs  
**Primary contact:** jaredreyespt@gmail.com  
**Main repository:** https://github.com/indygreg/cryptography-rs  
**Package:** x509-certificate  
**Language:** Rust  
**Downloads:** 16.2M total, 3.5M recent  

## Security Bug Found and Fixed

This fuzzing integration has discovered and fixed **1 critical security bug**:

### Integer Overflow in GeneralizedTime Fractional Seconds Parsing
- **Issue:** https://github.com/indygreg/cryptography-rs/issues/74
- **Fix PR:** https://github.com/indygreg/cryptography-rs/pull/75
- **Severity:** High - Certificate validation crash
- **Type:** Integer overflow (subtraction with overflow)
- **Location:** `src/asn1time.rs:216:64`
- **Impact:** Malformed timestamps in certificates cause panic during validation
- **Found by:** `fuzz_time_parsing` target at iteration 2,834

### Technical Details
The ASN.1 time parser attempts to calculate fractional seconds with `9 - digits_count`, but doesn't validate that `digits_count <= 9`. When a timestamp contains more than 9 fractional digits, this causes an integer underflow panic.

**Crash input:** `"20220130204612.2013600332201~303Z"` (33 bytes with 13 fractional digits)

**Root cause:** Unchecked subtraction when digits_count > 9

**Fix:** Added bounds checking before subtraction operation

## Fuzzing Infrastructure

### 6 Comprehensive Fuzz Targets:
1. **fuzz_certificate_der** - X.509 certificate DER parsing
2. **fuzz_certificate_pem** - X.509 certificate PEM parsing  
3. **fuzz_time_parsing** - ASN.1 GeneralizedTime/UTCTime parsing (bug found here)
4. **fuzz_csr_parse** - Certificate Signing Request parsing
5. **fuzz_name_parsing** - X.509 Distinguished Name parsing
6. **fuzz_extensions** - X.509 certificate extension parsing

### Corpus and Dictionary
- **82 seed corpus files** from real CA certificates (Let's Encrypt, DigiCert, etc.)
- **Dictionary file** with ASN.1/X.509 keywords for improved fuzzing
- **CIFuzz workflow** enabled for continuous fuzzing

## Security Impact

The x509-certificate crate is used for:
- TLS certificate validation
- Certificate chain verification  
- Code signing certificate processing
- Document signing validation

The discovered bug affects any application parsing X.509 certificates with malformed time fields, which could be used for denial-of-service attacks against certificate validation.

## Integration Status
- ✅ **Upstream PR:** https://github.com/indygreg/cryptography-rs/pull/75 (includes fuzz targets + fix)
- ✅ **Bug found:** Issue #74
- ✅ **Bug fixed:** PR #75  
- ✅ **CIFuzz enabled:** Continuous fuzzing workflow
- ✅ **Coverage:** Estimated 45-60% across ASN.1 parsing code

## Documentation Note

The project documentation explicitly states:
> "The ASN.1 parser isn't hardened against malicious inputs"
> "Some ASN.1 types will result in panics"

This makes it an **ideal candidate for continuous fuzzing** to harden the parser against malicious inputs.

## Testing

All fuzz targets have been tested locally:
- Smoke tests: 1M+ iterations per target  
- Extended fuzzing: 24-48 hours on cloud infrastructure
- Bug discovered and reproduced reliably
- Fix validated through fuzzing

---
**Contact:** jaredreyespt@gmail.com