### PR TITLE
tarantool: use ubuntu-24-04

### DIFF
--- a/projects/tarantool/Dockerfile
+++ b/projects/tarantool/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y \
 	build-essential cmake make coreutils sed lld \
 	autoconf automake libtool zlib1g-dev \

--- a/projects/tarantool/project.yaml
+++ b/projects/tarantool/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://www.tarantool.io/en/"
 language: c
 builds_per_day: 4


### PR DESCRIPTION
Fuzz Introspector has issues when running for Tarantool and a couple other projects. The problem cannot be reproduced locally, and there are many hypotheses why this can happen. One of the hypotheses is a problems in multiprocessing Python module in Python 3.11. The patch bumps Ubuntu version used in Docker images to 24.04 because 24.04 includes Python 3.12 as default version.

Related to #13226