### PR TITLE
Increase timeout for quic-srtm fuzzer

### DIFF
--- a/projects/openssl/quic-srtm.options
+++ b/projects/openssl/quic-srtm.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+timeout = 120


### PR DESCRIPTION
The quic-srtm fuzzer can run for quite some time in a single call to FuzzerTestOneInput.  This occurs for two reasons:
1) The input buffer is consumed only a few bytes at a time, using a
   single byte to determine a command to run, and just a few more as
   input data.

2) The test mutates a hash table that can grow quite large based on the
   input data, and some commands iterate over the hash table multiple
   times. with each of two hash tables often growing to 4000-5000
   entries.

The sum total of this is that a single call to FuzzerTestOneInput may result in the function running for more than 60 secnods, triggering a timeout

So lets address that by...waiting longer.  Up the timeout of the test to 120 seconds, which should be sufficient to complete an iteration.

This should address:
https://oss-fuzz.com/testcase-detail/4785309438246912