### PR TITLE
strongswan: Update Dockerfile

### DIFF
--- a/projects/strongswan/Dockerfile
+++ b/projects/strongswan/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y automake autoconf libtool pkg-config gettext perl python flex bison gperf lcov libgmp3-dev
-RUN git clone --depth 1 https://github.com/strongswan/strongswan.git strongswan
+RUN git clone --depth 1 --no-single-branch https://github.com/strongswan/strongswan.git strongswan
 RUN git clone --depth 1 https://github.com/strongswan/fuzzing-corpora.git strongswan/fuzzing-corpora
 WORKDIR strongswan
 COPY build.sh $SRC/


### PR DESCRIPTION
This PR updates the Dockerfile to add the `--no-single-branch` flag, ensuring all branches are cloned from the main repository. This allows CIFuzz to work on push events in strongSwan.