### PR TITLE
Add Carlo Arenas as a CC of PCRE2 fuzzer reports

### DIFF
--- a/projects/pcre2/project.yaml
+++ b/projects/pcre2/project.yaml
@@ -13,5 +13,6 @@ architectures:
   - x86_64
   - i386
 auto_ccs:
+  - "carenas@gmail.com"
   - "me@addisoncrump.info"
   - "philip.hazel@gmail.com"


### PR DESCRIPTION
Carlo is a frequent contributor to the PCRE2 project and has requested access s.t. they may more easily access and address bugs found by OSS-Fuzz.

cc @carenas (added contributor) @NWilson (primary contact)