### PR TITLE
cpython3: enable building of more modules

### DIFF
--- a/projects/cpython3/Dockerfile
+++ b/projects/cpython3/Dockerfile
@@ -18,8 +18,10 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && \
     apt-get install -y build-essential libncursesw5-dev \
 	libreadline-dev libssl-dev libgdbm-dev \
-	libc6-dev libsqlite3-dev tk-dev libbz2-dev \
-	zlib1g-dev libffi-dev
+	libc6-dev libsqlite3-dev libbz2-dev \
+	zlib1g-dev libffi-dev libmpdec-dev \
+	liblzma-dev libzstd-dev uuid-dev \
+	libgdbm-compat-dev
 
 RUN git clone https://github.com/python/cpython.git cpython3
 WORKDIR cpython3


### PR DESCRIPTION
I am preparing a set of fuzzers for cpython's modules. Currently, the `build.sh` file does not build and link many of the cpython modules. This PR adds more modules to the cpython OSS-Fuzz build in preparation of fuzzing them.

@ammaraskar @alex @gpshead for info