### PR TITLE
zlib: Fix buffer overflow in zlib_uncompress3_fuzzer by clamping output length

### DIFF
--- a/projects/zlib/zlib_uncompress3_fuzzer.cc
+++ b/projects/zlib/zlib_uncompress3_fuzzer.cc
@@ -29,7 +29,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   uLong multiplier0 = size ? (--size, *data++) : 1;
   uLong multiplier1 = size ? (--size, *data++) : 1;
 
-  uLongf buffer_length = static_cast<uLongf>(basesz * multiplier0 * multiplier1);
+  uLongf buffer_length = sizeof(buffer);
   uLong buf_size = static_cast<uLong>(size);
   // Ignore return code.
   uncompress2(buffer, &buffer_length, data, &buf_size);


### PR DESCRIPTION
The fuzzer computes buffer_length as:
  basesz * multiplier0 * multiplier1

This can exceed the static 256KB buffer, leading to
global-buffer-overflow in inflate/inflate_fast.

Clamp buffer_length to sizeof(buffer) to prevent
out-of-bounds writes in the harness.