### PR TITLE
digest: Fix fuzz test

### DIFF
--- a/projects/digest/fuzz_digest.py
+++ b/projects/digest/fuzz_digest.py
@@ -28,6 +28,12 @@ def TestOneInput(data):
         s1 = digest.digest(io.BytesIO(b1), alg, len(b1))
     except SystemExit:
         pass
+    except digest.DigestError as e:
+        if "unsupported hash type" in str(e):
+            # Uninteresting bug
+            pass
+        else:
+            raise e
     except TypeError as e:
         if "name must be a string" in str(e):
             # non-interesting bug. Let the fuzzer continue


### PR DESCRIPTION
Digest was throwing a different type of exception for invalid algorithm names, which was causing the basic sanity checks to fail.

Now it builds and checks locally.