### PR TITLE
Limit binutils fuzzing input size

### DIFF
--- a/projects/binutils/fuzz_addr2line.c
+++ b/projects/binutils/fuzz_addr2line.c
@@ -21,6 +21,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
 int
 LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
+  if (size > 16384)
+    return 0;
   char filename[256];
   sprintf(filename, "/tmp/libfuzzer.%d", getpid());
   FILE *fp = fopen(filename, "wb");

--- a/projects/binutils/fuzz_as.c
+++ b/projects/binutils/fuzz_as.c
@@ -32,6 +32,8 @@ xatexit (void (*fn) (void) ATTRIBUTE_UNUSED)
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  if (size > 1024)
+    return 0;
   char filename[256];
   sprintf(filename, "/tmp/libfuzzer-%d.s", getpid());
   FILE *fp = fopen(filename, "wb");

--- a/projects/binutils/fuzz_bfd.c
+++ b/projects/binutils/fuzz_bfd.c
@@ -39,6 +39,8 @@ static int bufferToFile(char * name, const uint8_t *Data, size_t Size) {
 char *target = NULL;
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+  if (Size > 16384)
+    return 0;
     char tmpfilename[32];
 
     if (bfd_init() != BFD_INIT_MAGIC)

--- a/projects/binutils/fuzz_bfd_ext.c
+++ b/projects/binutils/fuzz_bfd_ext.c
@@ -42,6 +42,8 @@ static int bufferToFile(char *name, const uint8_t *Data, size_t Size) {
 }
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+  if (Size > 16384)
+    return 0;
   char tmpfilename[32];
 
   if (bfd_init() != BFD_INIT_MAGIC)

--- a/projects/binutils/fuzz_dlltool.c
+++ b/projects/binutils/fuzz_dlltool.c
@@ -60,9 +60,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
 int
 LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-  if (size < 512) {
+  if (size < 512 || size > 16384)
     return 0;
-  }
 
   /* def file */
   char filename[256];

--- a/projects/binutils/fuzz_dwarf.c
+++ b/projects/binutils/fuzz_dwarf.c
@@ -20,6 +20,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
 int
 LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
+  if (size > 16384)
+    return 0;
   char filename[256];
   sprintf(filename, "/tmp/libfuzzer.%d", getpid());
   FILE *fp = fopen(filename, "wb");

--- a/projects/binutils/fuzz_nm.c
+++ b/projects/binutils/fuzz_nm.c
@@ -21,6 +21,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
 int
 LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
+  if (size > 16384)
+    return 0;
   char filename[256];
   sprintf(filename, "/tmp/libfuzzer.%d", getpid());
   FILE *fp = fopen(filename, "wb");

--- a/projects/binutils/fuzz_objcopy.c
+++ b/projects/binutils/fuzz_objcopy.c
@@ -94,6 +94,8 @@ init_objcopy_global_state() {
 int
 LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
+  if (size > 16384)
+    return 0;
   char filename[256];
   sprintf(filename, "/tmp/libfuzzer.%d", getpid());
   FILE *fp = fopen(filename, "wb");

--- a/projects/binutils/fuzz_objdump.c
+++ b/projects/binutils/fuzz_objdump.c
@@ -39,6 +39,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
 int
 LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
+  if (size > 16384)
+    return 0;
   char filename[256];
   sprintf(filename, "/tmp/libfuzzer.%d", getpid());
   FILE *fp = fopen(filename, "wb");

--- a/projects/binutils/fuzz_ranlib_simulation.c
+++ b/projects/binutils/fuzz_ranlib_simulation.c
@@ -31,6 +31,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
 int
 LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
+  if (size > 16384)
+    return 0;
   char filename[256];
   sprintf(filename, "/tmp/libfuzzer.%d", getpid());
   FILE *fp = fopen(filename, "wb");

--- a/projects/binutils/fuzz_readelf.c
+++ b/projects/binutils/fuzz_readelf.c
@@ -63,6 +63,8 @@ int check_architecture(char *tmpfilename, char *arch_string) {
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  if (size > 16384)
+    return 0;
   char filename[256];
   sprintf(filename, "/tmp/libfuzzer.%d", getpid());
 

--- a/projects/binutils/fuzz_strings.c
+++ b/projects/binutils/fuzz_strings.c
@@ -21,6 +21,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
 int
 LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
+  if (size > 16384)
+    return 0;
   char filename[256];
   sprintf(filename, "/tmp/libfuzzer.%d", getpid());
   FILE *fp = fopen(filename, "wb");

--- a/projects/binutils/fuzz_windres.c
+++ b/projects/binutils/fuzz_windres.c
@@ -88,6 +88,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
 int
 LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
+  if (size > 16384)
+    return 0;
   enum res_format input_format;
    input_format = fuzz_format_check_from_mem(data, size);;
 	if (input_format != RES_FORMAT_COFF) {


### PR DESCRIPTION
Limit all the binutils fuzzing inputs to 16384 bytes, and fuzz_as to 1024 which is plenty large enough to wreak havok.  This will fix at least some of the timeouts due to producing large amounts of output from large files.