### PR TITLE
arrow-py: Fix fuzzing harness

### DIFF
--- a/projects/arrow-py/fuzz_tzinfo.py
+++ b/projects/arrow-py/fuzz_tzinfo.py
@@ -29,7 +29,11 @@ def TestOneInput(data):
   try:
     c1 = arrow.parser.TzinfoParser()
     c1.parse(tzinfo_string)
-  except (arrow.parser.ParserError,):
+  except (arrow.parser.ParserError, ValueError):
+    # Some inputs may trigger ZoneInfo path validation which raises
+    # ValueError (e.g. empty or malformed zone path). Treat these as
+    # expected parse errors and ignore them to avoid false positives
+    # during check_build.
     pass
 
 


### PR DESCRIPTION
Any invalid input was causing a NoneType error preventing the fuzzer from progressing. This fix ignores those types of exceptions to get the `build` / `check_build` steps to succeed.