### PR TITLE
binutils fuzz_strings timeout

### DIFF
--- a/projects/binutils/fuzz_strings.c
+++ b/projects/binutils/fuzz_strings.c
@@ -34,6 +34,11 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
   program_name = "fuzz_strings";
 
+  string_min = 4;
+  encoding = 's';
+  encoding_bytes = 1;
+  datasection_only = true;
+
   // Main fuzz entrypoint in strings.c
   strings_object_file(filename);
 


### PR DESCRIPTION
fuzz_strings needs some globals to be initialised.  Without this nothing is read from the file and blank lines are printed until the fuzzer times out.