### PR TITLE
upx: fix build

### DIFF
--- a/projects/upx/build.sh
+++ b/projects/upx/build.sh
@@ -23,8 +23,8 @@ git apply   --ignore-space-change --ignore-whitespace  $SRC/upx/fuzzers/build.pa
 # e.g.
 mkdir -p build/debug
 cd build/debug
-+# Disable UBSan for the compiler sanity check that intentionally tests overflow
-+cmake ../.. -DCMAKE_CXX_FLAGS="${CXXFLAGS} -fno-sanitize=signed-integer-overflow" -DCMAKE_C_FLAGS="${CFLAGS} -fno-sanitize=signed-integer-overflow"
+# Disable UBSan for the compiler sanity check that intentionally tests overflow
+cmake ../.. -DCMAKE_CXX_FLAGS="${CXXFLAGS} -fno-sanitize=signed-integer-overflow" -DCMAKE_C_FLAGS="${CFLAGS} -fno-sanitize=signed-integer-overflow"
 
 for fuzzer in $(find $SRC -name '*_fuzzer.cpp'); do
     fuzz_basename=$(basename -s .cpp $fuzzer)


### PR DESCRIPTION
Disable UBSan for compiler sanity check to avoid overflow issues.