### PR TITLE
Add fuzzing support for tree-sitter 

### DIFF
--- a/projects/tree-sitter/Dockerfile
+++ b/projects/tree-sitter/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN apt-get update && apt-get install -y make
+RUN git clone --depth 1 https://github.com/tree-sitter/tree-sitter.git tree-sitter
+RUN git clone --depth 1 https://github.com/tree-sitter/tree-sitter-json.git tree-sitter-json
+WORKDIR $SRC/tree-sitter
+COPY build.sh parse_fuzzer.c $SRC/

--- a/projects/tree-sitter/build.sh
+++ b/projects/tree-sitter/build.sh
@@ -1,0 +1,53 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Build tree-sitter C library (static, amalgamated)
+cd $SRC/tree-sitter
+$CC $CFLAGS -DTREE_SITTER_HIDE_SYMBOLS \
+    -Ilib/include -Ilib/src \
+    -c lib/src/lib.c -o lib.o
+
+# Build tree-sitter-json grammar
+cd $SRC/tree-sitter-json
+$CC $CFLAGS \
+    -I$SRC/tree-sitter/lib/include \
+    -c src/parser.c -o parser.o
+
+# Build and link the fuzzer
+$CC $CFLAGS \
+    -I$SRC/tree-sitter/lib/include \
+    -c $SRC/parse_fuzzer.c -o parse_fuzzer.o
+
+$CXX $CXXFLAGS \
+    parse_fuzzer.o \
+    $SRC/tree-sitter/lib.o \
+    $SRC/tree-sitter-json/parser.o \
+    $LIB_FUZZING_ENGINE \
+    -o $OUT/parse_fuzzer
+
+# Create a minimal seed corpus
+mkdir -p $SRC/seed_corpus
+echo -n '{}' > $SRC/seed_corpus/empty_object.json
+echo -n '[]' > $SRC/seed_corpus/empty_array.json
+echo -n '{"key": "value"}' > $SRC/seed_corpus/simple_object.json
+echo -n '[1, 2, 3]' > $SRC/seed_corpus/simple_array.json
+echo -n '{"a": [1, true, null, "str"]}' > $SRC/seed_corpus/mixed.json
+echo -n 'not json at all {{{' > $SRC/seed_corpus/invalid.json
+echo -n '{"nested": {"a": {"b": [1, {"c": 2}]}}}' > $SRC/seed_corpus/nested.json
+
+cd $SRC/seed_corpus
+zip -j $OUT/parse_fuzzer_seed_corpus.zip *

--- a/projects/tree-sitter/parse_fuzzer.c
+++ b/projects/tree-sitter/parse_fuzzer.c
@@ -1,0 +1,51 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <tree_sitter/api.h>
+
+// Provided by tree-sitter-json
+const TSLanguage *tree_sitter_json(void);
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  // Limit input size to avoid timeouts on pathological inputs
+  if (size > 10000) {
+    return 0;
+  }
+
+  TSParser *parser = ts_parser_new();
+  if (!ts_parser_set_language(parser, tree_sitter_json())) {
+    ts_parser_delete(parser);
+    return 0;
+  }
+
+  // Parse the fuzz input as source text
+  TSTree *tree = ts_parser_parse_string(parser, NULL, (const char *)data, (uint32_t)size);
+  if (tree) {
+    // Exercise tree inspection to catch issues in node/tree APIs
+    TSNode root = ts_tree_root_node(tree);
+    (void)ts_node_child_count(root);
+    (void)ts_node_has_error(root);
+
+    // Exercise s-expression serialization
+    char *sexp = ts_node_string(root);
+    free(sexp);
+
+    ts_tree_delete(tree);
+  }
+
+  ts_parser_delete(parser);
+  return 0;
+}

--- a/projects/tree-sitter/project.yaml
+++ b/projects/tree-sitter/project.yaml
@@ -1,0 +1,13 @@
+homepage: "https://tree-sitter.github.io/"
+language: c
+primary_contact: "maxbrunsfeld@gmail.com"
+auto_ccs:
+  - "amastraea@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+sanitizers:
+  - address
+  - undefined
+main_repo: "https://github.com/tree-sitter/tree-sitter"


### PR DESCRIPTION
Add fuzzing support for tree-sitter an incremental parsing library used by Neovim, VS Code, GitHub, Zed, Helix, and 10,000+ dependents (23.9k stars, 385 contributors).

The integration includes a single fuzz target (parse_fuzzer) that exercises the core C runtime parser via ts_parser_parse_string using the tree-sitter-json grammar, covering parsing, error recovery, tree construction, node inspection, and s-expression serialization.

Files added:
- project.yaml
- Dockerfile
- build.sh
- parse_fuzzer.c (libFuzzer harness)