### PR TITLE
ruby: disable backtrace

### DIFF
--- a/projects/ruby/build.sh
+++ b/projects/ruby/build.sh
@@ -100,7 +100,8 @@ echo "Configuring target Ruby with static linking..."
     --without-gmp \
     --disable-dtrace \
     --disable-jit-support \
-    --with-baseruby="$BASERUBY"
+    --with-baseruby="$BASERUBY" \
+    ac_cv_func_backtrace=no
 
 # Build Ruby static library
 echo "Building Ruby static library..."


### PR DESCRIPTION
This PR removes backtrace from the ruby build. The reason we want to remove that is to disable [this code block](https://github.com/ruby/ruby/blob/56bdb93b024495bfd544c75a00eaf5d68b15be6c/vm.c#L4108-L4124). From what I can tell, this code block breaks the coverage build; When clang compiles a codebase with coverage instrumentation (-fcoverage-mapping), it can produce a malformed record in the __llvm_covfun ELF section — a ULEB128 value has its continuation bit set but no following byte. Since llvm-cov parses the section sequentially and aborts on the first malformed record, this single bad record (193 bytes out of ~7.4 MB in Rubys case during local testing) causes the entire coverage report to show 0%. This is the case with the Ruby coverage report: The coverage report builds but it incorrectly shows 0% coverage. I don't know why that code block causes that, perhaps it is [the inline include](https://github.com/ruby/ruby/blob/56bdb93b024495bfd544c75a00eaf5d68b15be6c/vm.c#L4109).