### PR TITLE
Fixing use of undefined variable

### DIFF
--- a/infra/base-images/base-runner/profraw_update.py
+++ b/infra/base-images/base-runner/profraw_update.py
@@ -121,7 +121,7 @@ def upgrade(data, sect_prf_cnts, sect_prf_data):
     # We need this because of CountersDelta -= sizeof(*SrcData);
     # seen in __llvm_profile_merge_from_buffer.
     dataref += 44 + 2 * (v9_header.ValueKindLast + 1)
-    if was8:
+    if base_version <= 8:
       #profraw9 added RelativeBitmapPtr and NumBitmapBytes (8+4 rounded up to 16)
       dataref -= 16
     # This is the size of one ProfrawData structure.


### PR DESCRIPTION
While working on #12365 , the author pushed commit 695666b631278f10b33d284aeace982dcd89862e to help simplify this script by removing variable `was8` but forgot to refactor this one last reference. I just noticed it and replaced with what seems to be the most sensible clause.