### PR TITLE
ClusterFuzzLite: fix execution for non-external projects

### DIFF
--- a/infra/cifuzz/continuous_integration.py
+++ b/infra/cifuzz/continuous_integration.py
@@ -156,11 +156,14 @@ def get_replace_repo_and_build_command(host_repo_path, image_repo_path):
   """Returns the command to replace the repo located at |image_repo_path| with
   |host_repo_path| and build the project inside the project builder
   container."""
-  rm_path = os.path.join(image_repo_path, '*')
-  image_src_path = os.path.dirname(image_repo_path)
   build_command = get_build_command()
-  command = (f'cd / && rm -rf {rm_path} && cp -r {host_repo_path} '
-             f'{image_src_path} && cd - && {build_command}')
+  if host_repo_path is None:
+    command = f'{build_command}'
+  else:
+    rm_path = os.path.join(image_repo_path, '*')
+    image_src_path = os.path.dirname(image_repo_path)
+    command = (f'cd / && rm -rf {rm_path} && cp -r {host_repo_path} '
+               f'{image_src_path} && cd - && {build_command}')
   return command
 
 

--- a/infra/helper.py
+++ b/infra/helper.py
@@ -832,6 +832,8 @@ def run_clusterfuzzlite(args):
           f'{filestore_path}:{filestore_path}',
           '-v',
           f'{workspace}:{workspace}',
+          '-v',
+          f'{common_utils.OSS_FUZZ_DIR}:/opt/oss-fuzz',
           '-e',
           f'FILESTORE_ROOT_DIR={filestore_path}',
           '-e',


### PR DESCRIPTION
See the individual commits for more details.

Tested using:
```console
$ python3 infra/helper.py run_clusterfuzzlite --branch master libvips
```

And:
```console
$ git clone https://github.com/libvips/libvips.git $HOME/libvips
$ mkdir $HOME/libvips/.clusterfuzzlite
$ cp projects/libvips/{build.sh,Dockerfile,project.yaml} $HOME/libvips/.clusterfuzzlite/
$ sed -i "/^COPY /s/build.sh/.clusterfuzzlite\/&/" $HOME/libvips/.clusterfuzzlite/Dockerfile
$ python3 infra/helper.py run_clusterfuzzlite --branch master --external $HOME/libvips
````

See also: #9087.