### PR TITLE
Build OpenEXR by executing the project's oss-fuzz_build.sh from build.sh

### DIFF
--- a/projects/openexr/build.sh
+++ b/projects/openexr/build.sh
@@ -26,12 +26,10 @@
 
 set -x
 
-BUILD_DIR=$WORK/_build.oss-fuzz
+export BUILD_DIR=$WORK/_build.oss-fuzz
 
-cmake -S $SRC/openexr -B $BUILD_DIR --preset oss_fuzz
-cmake --build $BUILD_DIR --target oss_fuzz -j"$(nproc)"
-cmake --install $BUILD_DIR --component oss_fuzz
+./src/test/oss-fuzz/oss-fuzz_build.sh
 
 # Build tests to support replay_tests.sh
 cd $BUILD_DIR
-make OpenEXRTest OpenEXRCoreTest IexTest OpenEXRUtilTest -j$(nproc)
+cmake --build $BUILD_DIR --target OpenEXRTest OpenEXRCoreTest IexTest OpenEXRUtilTest -j$(nproc)


### PR DESCRIPTION
The local build.sh script now invokes OpenEXR's [share/util/oss-fuzz_build.sh](https://github.com/AcademySoftwareFoundation/openexr/blob/main/src/test/oss-fuzz/oss-fuzz_build.sh), the OpenEXR project has direct, local control over the build steps.

The oss-fuzz_build.sh script now vendors in the master branch of OpenJPH prior to building the fuzzer, ensuring that we pick up the recent changes to the dependent library.