### PR TITLE
vscode extension: use SPDX license identfier in package.json

### DIFF
--- a/tools/vscode-extension/package.json
+++ b/tools/vscode-extension/package.json
@@ -9,6 +9,8 @@
     "vscode": "^1.76.0"
   },
   "repository": "https://github.com/google/oss-fuzz",
+  "license": "Apache-2.0",
+  "homepage": "https://google.github.io/oss-fuzz/",
   "categories": [
     "Other"
   ],


### PR DESCRIPTION
fixing package.json according to NPM docs and LICENSE, fixing npm warnings

this will also lead to the correct license [and a homepage URL] be shown in extension marketplaces