### PR TITLE
zlib: fix buffer overflow in zlib_uncompress3_fuzzer

### DIFF
--- a/projects/zlib/zlib_uncompress3_fuzzer.cc
+++ b/projects/zlib/zlib_uncompress3_fuzzer.cc
@@ -30,6 +30,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   uLong multiplier1 = size ? (--size, *data++) : 1;
 
   uLongf buffer_length = static_cast<uLongf>(basesz * multiplier0 * multiplier1);
+  if (buffer_length > sizeof(buffer))
+    buffer_length = sizeof(buffer);
   uLong buf_size = static_cast<uLong>(size);
   // Ignore return code.
   uncompress2(buffer, &buffer_length, data, &buf_size);


### PR DESCRIPTION
## Summary

`zlib_uncompress3_fuzzer` has a heap-buffer-overflow: `buffer_length` is computed from three fuzzer-controlled bytes (`basesz * multiplier0 * multiplier1`, up to 255³ = ~16.5MB), but the output buffer is only 256KB. When `uncompress2` writes to `buffer` using the unclamped length, it overflows.

This causes **false positive crash reports** attributed to zlib, when the bug is actually in the harness.

Fixes #15070

## Fix

Clamp `buffer_length` to `sizeof(buffer)` before passing it to `uncompress2`. This prevents overflow while preserving the fuzzer's ability to test different output buffer sizes (unlike setting it to a fixed value, which would reduce coverage of the `buffer_length` parameter space).

## ASan Report (reproducing the overflow)

```
==12==ERROR: AddressSanitizer: heap-buffer-overflow on address ...
WRITE of size 131072 at ...
    #0 uncompress2
    #1 LLVMFuzzerTestOneInput zlib_uncompress3_fuzzer.cc:35
```

## Note

This is similar to #14956, but uses a clamp instead of a fixed value to preserve fuzzer expressiveness.