### PR TITLE
gdk-pixbuf: fix pixbuf leak and API misuse in pixbuf_file_fuzzer

### DIFF
--- a/projects/gdk-pixbuf/targets/pixbuf_file_fuzzer.c
+++ b/projects/gdk-pixbuf/targets/pixbuf_file_fuzzer.c
@@ -21,7 +21,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     if (size < 1) {
         return 0;
     }
-    GdkPixbuf *pixbuf;
+    GdkPixbuf *pixbuf, *rotated, *scaled;
     GError *error = NULL;
 
     char *tmpfile = fuzzer_get_tmpfile(data, size);
@@ -39,14 +39,18 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     gdk_pixbuf_get_width(pixbuf);
     gdk_pixbuf_get_height(pixbuf);
     gdk_pixbuf_get_bits_per_sample(pixbuf);
-    gdk_pixbuf_scale(pixbuf, pixbuf,
-            0, 0, 
-            gdk_pixbuf_get_width(pixbuf) / 4, 
+
+    scaled = gdk_pixbuf_scale_simple(pixbuf,
+            gdk_pixbuf_get_width(pixbuf) / 4,
             gdk_pixbuf_get_height(pixbuf) / 4,
-            0, 0, 0.5, 0.5,
             GDK_INTERP_NEAREST);
+    if (scaled) g_object_unref(scaled);
+
     unsigned int rot_amount = ((unsigned int) data[0]) % 4;
-    pixbuf = gdk_pixbuf_rotate_simple(pixbuf, rot_amount * 90);
+    rotated = gdk_pixbuf_rotate_simple(pixbuf, rot_amount * 90);
+    g_object_unref(pixbuf);
+    pixbuf = rotated;
+
     gdk_pixbuf_set_option(pixbuf, buf, buf);
     gdk_pixbuf_get_option(pixbuf, buf);
 


### PR DESCRIPTION
## Summary

This is **not** a bug in gdk-pixbuf. It is a bug in the fuzz harness `pixbuf_file_fuzzer` that causes a **memory leak** (104 bytes in 2 allocations per iteration) detectable by LeakSanitizer, and an **API contract violation** (`gdk_pixbuf_scale` with same src and dest).

### False Positive Impact

If left unfixed, any leak report from this fuzzer will be a **false positive** — the leak originates in the harness, not in gdk-pixbuf. This can lead to:

- **Wasted developer time**: Maintainers investigating leak reports that are not real gdk-pixbuf bugs
- **Noise in OSS-Fuzz dashboards**: Persistent unfixed "bugs" that are actually harness defects
- **Amplified impact in the AI era**: AI-assisted fuzzing tools increasingly reference existing OSS-Fuzz harnesses as ground truth. A buggy harness pattern can be copied and propagated by LLM-based harness generators, multiplying false positives across downstream projects

### Bugs Fixed

**P1 (Harness Logic)**: The original pixbuf from `gdk_pixbuf_new_from_file()` is leaked when overwritten by `gdk_pixbuf_rotate_simple()`:

```c
pixbuf = gdk_pixbuf_new_from_file(tmpfile, &error);   // original pixbuf
...
pixbuf = gdk_pixbuf_rotate_simple(pixbuf, rot_amount * 90);  // overwrites — original leaked
```

**P2 (API Protocol)**: `gdk_pixbuf_scale(pixbuf, pixbuf, ...)` uses the same pixbuf as both source and destination. The [API documentation](https://docs.gtk.org/gdk-pixbuf/method.Pixbuf.scale.html) requires they be different.

### LSan Report

```
==14==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 104 byte(s) in 2 object(s) allocated from:
    #0 calloc (asan_malloc_linux.cpp:74)
    #1 gdk_pixbuf_new (gdk-pixbuf.c:638)
    #2 gdk_pixbuf__png_image_load (io-png.c)
    #3 LLVMFuzzerTestOneInput (pixbuf_file_fuzzer.c)

SUMMARY: AddressSanitizer: 104 byte(s) leaked in 2 allocation(s).
```

### Fix

1. Save original pixbuf before `gdk_pixbuf_rotate_simple()` and unref it after
2. Replace `gdk_pixbuf_scale(src==dest)` with `gdk_pixbuf_scale_simple()`