### PR TITLE
cairo: fix raster_fuzzer — remove PDF API calls that prevent acquire callback

### DIFF
--- a/projects/cairo/targets/raster_fuzzer.c
+++ b/projects/cairo/targets/raster_fuzzer.c
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <cairo.h>
-#include <cairo-pdf.h>
 #include "fuzzer_temp_file.h"
 
 static cairo_surface_t *
@@ -58,8 +57,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     pattern = cairo_pattern_create_raster_source(buf, content, w, h);
     cairo_raster_source_pattern_set_acquire (pattern, acquire, release);
     cairo_set_source(cr, pattern);
-    cairo_pdf_surface_set_page_label(surface, buf);
-    cairo_pdf_surface_set_metadata(surface, CAIRO_PDF_METADATA_KEYWORDS, buf);
     cairo_paint(cr);
 
     cairo_destroy(cr);


### PR DESCRIPTION
## Summary

The `raster_fuzzer` harness is intended to test cairo's raster source pattern mechanism (the `acquire`/`release` callbacks). However, two misplaced calls to PDF-surface-specific APIs on an image surface **contaminate the surface's error state**, causing `cairo_paint()` to short-circuit. As a result, **the `acquire` callback is never triggered, and the harness's core testing target is completely dead code.**

## Root Cause

In `raster_fuzzer.c`, lines 61–62:

```c
cairo_pdf_surface_set_page_label(surface, buf);
cairo_pdf_surface_set_metadata(surface, CAIRO_PDF_METADATA_KEYWORDS, buf);
```

Here, `surface` is an image surface created by `cairo_image_surface_create_from_png()`. These two functions are designed exclusively for PDF surfaces. Internally, they call `_extract_pdf_surface()`, which checks whether the surface is paginated. When it is not, it sets the surface's error status to `CAIRO_STATUS_SURFACE_TYPE_MISMATCH`:

```c
// cairo-pdf-surface.c: _extract_pdf_surface()
if (! _cairo_surface_is_paginated (surface)) {
    status_ignored = _cairo_surface_set_error (surface,
                       _cairo_error (CAIRO_STATUS_SURFACE_TYPE_MISMATCH));
    return FALSE;
}
```

Once the surface enters this error state, `cairo_paint()` checks the target surface status and **short-circuits without performing any drawing** — so the raster source `acquire` callback is never invoked.

## Verification

I wrote a standalone test program that isolates the issue:

**Without PDF calls:**
```
Surface status before paint: no error has occurred
ACQUIRE CALLBACK TRIGGERED (call #1)
RELEASE CALLBACK TRIGGERED
acquire_called after paint: 1
```

**With PDF calls on image surface:**
```
Surface status AFTER pdf_set_page_label: the surface type is not appropriate for the operation
acquire_called after paint: 0
```

The acquire callback fires normally without the PDF calls, but is **never triggered** when the PDF calls are present.

## Coverage Comparison (600s each)

| Metric | Original | Fixed | Diff |
|--------|----------|-------|------|
| Line coverage | 0.57% | 0.65% | +0.08 |
| Function coverage | 1.12% | 1.28% | +0.16 |
| Branch coverage | 0.27% | 0.30% | +0.03 |

## Fix

Remove the two PDF-specific calls and the unnecessary `#include <cairo-pdf.h>`. This allows `cairo_paint()` to proceed normally, triggering the acquire/release callbacks as intended.