### PR TITLE
[opencv] Fix dead filestorage_read_file_fuzzer

### DIFF
--- a/projects/opencv/filestorage_read_file_fuzzer.cc
+++ b/projects/opencv/filestorage_read_file_fuzzer.cc
@@ -14,21 +14,55 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
 
 #include <opencv2/opencv.hpp>
 #include "fuzzer_temp_file.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
-  // Tests reading from a file using cv::FileStorage, which attempts to parse
-  // JSON, XML, and YAML, using the first few bytes of a file to determine which
-  // type to parse it as.
   const FuzzerTemporaryFile temp_file(data, size);
-  cv::FileStorage storage;
+
   try {
-    // TODO: enabling the following crashes right away.
-//    storage.open(temp_file.filename(), cv::FileStorage::READ);
-  } catch (cv::Exception e) {
-    // Do nothing.
+    cv::FileStorage storage;
+    if (!storage.open(temp_file.filename(), cv::FileStorage::READ)) {
+      return 0;
+    }
+
+    cv::FileNode root = storage.root();
+    for (cv::FileNodeIterator it = root.begin(); it != root.end(); ++it) {
+      cv::FileNode node = *it;
+      const std::string node_name = node.name();
+      const int node_type = node.type();
+
+      switch (node_type) {
+        case cv::FileNode::INT:
+          (void)static_cast<int>(node);
+          break;
+        case cv::FileNode::REAL:
+          (void)static_cast<double>(node);
+          break;
+        case cv::FileNode::STRING:
+          (void)static_cast<std::string>(node);
+          break;
+        case cv::FileNode::SEQ:
+        case cv::FileNode::MAP: {
+          for (cv::FileNodeIterator child_it = node.begin();
+               child_it != node.end(); ++child_it) {
+            cv::FileNode child = *child_it;
+            (void)child.name();
+            (void)child.type();
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    }
+
+    storage.release();
+  } catch (const cv::Exception&) {
+  } catch (...) {
   }
+
   return 0;
 }


### PR DESCRIPTION
## Summary

The `filestorage_read_file_fuzzer` harness is a **complete no-op**. Its core API call (`cv::FileStorage::open()`) has been commented out since the fuzzer was added, with a TODO note:

```cpp
// TODO: enabling the following crashes right away.
//    storage.open(temp_file.filename(), cv::FileStorage::READ);
```

Each fuzzing iteration writes fuzz data to a temp file, creates an empty `cv::FileStorage` object, does nothing with it, and returns. **Zero lines of OpenCV's FileStorage parser are ever executed.**

## Context: Four Principles for Fuzz Harness Quality

We are conducting a systematic study of fuzz harness quality across 93 OSS-Fuzz C/C++ projects (813 fuzzers total). We evaluate each harness against four principles:

- **P1**: Harness logic must be correct
- **P2**: Harness must follow target API protocol
- **P3**: Harness must only use security-relevant public APIs
- **P4**: Harness must use correct entry points

This fuzzer violates **P2 (Follow Target API Protocol)** — the target API (`cv::FileStorage::open`) is never called. This is the only OpenCV fuzzer (out of 9) with a principle violation.

## Fix

1. **Enable `storage.open()`** to actually parse fuzz input as XML/YAML/JSON
2. **Iterate over top-level FileStorage nodes** to exercise parser traversal and value-reading code paths (INT, REAL, STRING, SEQ, MAP)
3. **Use proper exception handling** (`const cv::Exception&` instead of catching by value)
4. Return early if `open()` fails (unrecognized format)

## Coverage Evidence (1-minute ASan fuzzing)

| Metric | Original | Fixed | Change |
|--------|----------|-------|--------|
| Edge coverage | 79 | 858 | **+986%** |
| Feature targets | 80 | 1,814 | **+2,168%** |
| Corpus size | 0 inputs / 0B | 355 inputs / 8.6KB | **0 → 355** |

The original fuzzer's 79 edges come entirely from `FuzzerTemporaryFile` I/O overhead — zero edges belong to OpenCV code. The fixed version exercises `cv::FileStorage`'s XML/YAML/JSON parser, producing 858 edges and 355 meaningful corpus entries.

## Test Plan

- [x] Built with OSS-Fuzz infrastructure (`python infra/helper.py build_fuzzers opencv`)
- [x] Verified the fixed fuzzer runs without crashes under ASan for 1 minute
- [x] Confirmed coverage increase from 79 → 858 edges