### PR TITLE
wireshark: reduce parallel jobs to fix build

### DIFF
--- a/projects/wireshark/build.sh
+++ b/projects/wireshark/build.sh
@@ -59,6 +59,6 @@ cmake -GNinja \
       -DENABLE_WERROR=OFF -DOSS_FUZZ=ON $CMAKE_DEFINES \
       -DUSE_STATIC=ON $SRC/wireshark
 
-ninja all-fuzzers -j$(expr $(nproc) / 2)
+ninja all-fuzzers -j$(expr $(nproc) / 4)
 
 $SRC/wireshark/tools/oss-fuzzshark/build.sh all


### PR DESCRIPTION
The current build is failing with processes being killed: https://oss-fuzz-build-logs.storage.googleapis.com/log-3bd3ff93-fd29-47a9-addc-b8bb9af720cb.txt

```
[2108/2116] Linking CXX executable run/fuzzshark_udp_port-dhcp[K
[2108/2116] Linking CXX executable run/fuzzshark_media_type-json[K
[2109/2116] Linking CXX executable run/fuzzshark_media_type-json[K
Step #21 - "compile-libfuzzer-address-x86_64": [31mFAILED: [0mrun/fuzzshark_media_type-json 
Step #21 - "compile-libfuzzer-address-x86_64": : && /usr/local/bin/clang++ -Wall -Wextra -Wformat -Wformat=2 -Wpointer-arith -Wformat-security -fexcess-precision=fast -Wvla -Wattributes -Wpragmas -Wheader-guard -Wcomma -Wshorten-64-to-32 -Wredundant-decls -Wunreachable-code -Wdocumentation -Wextra-semi -fstrict-flex-arrays=3 -fstack-clash-protection -fcf-protection=full -D_GLIBCXX_ASSERTIONS -fstack-protector-strong -fno-delete-null-pointer-checks -fno-strict-aliasing -fexceptions -Qunused-arguments -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -fno-strict-overflow -Wframe-larger-than=32768 -Wno-format-nonliteral -fcolor-diagnostics -Wno-error=fortify-source -Wno-error=missing-field-initializers -O1   -fno-omit-frame-pointer   -gline-tables-only   -Wno-error=incompatible-function-pointer-types   -Wno-error=int-conversion   -Wno-error=deprecated-declarations   -Wno-error=implicit-function-declaration   -Wno-error=implicit-int   -Wno-error=unknown-warning-option   -Wno-error=vla-cxx-extension   -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=address -fsanitize-address-use-after-scope -fsanitize=fuzzer-no-link -stdlib=libc++ -fmacro-prefix-map="/src/wireshark/"= -fmacro-prefix-map="/work/build/"= -O2 -g -DNDEBUG -Wl,--as-needed -no-pie fuzz/CMakeFiles/fuzzshark_media_type-json.dir/fuzzshark.c.o fuzz/CMakeFiles/fuzzshark_media_type-json.dir/__/app/wireshark_flavor.c.o -o run/fuzzshark_media_type-json  run/libui.a  run/libwiretap.a  run/libwireshark.a  run/libwsutil.a  -fsanitize=fuzzer  run/libwiretap.a  run/libwsutil.a  /usr/lib/x86_64-linux-gnu/libgmodule-2.0.a  -ldl  /usr/lib/x86_64-linux-gnu/libpcre2-8.a  /usr/lib/x86_64-linux-gnu/libglib-2.0.a  /usr/lib/x86_64-linux-gnu/libpcre.a  -pthread  /usr/lib/x86_64-linux-gnu/libcares.a  /usr/local/lib/libxml2.a  -lxml2  /usr/lib/x86_64-linux-gnu/libgcrypt.a  /usr/lib/x86_64-linux-gnu/libgpg-error.a  -lm  /usr/lib/x86_64-linux-gnu/libz.a && :
Step #21 - "compile-libfuzzer-address-x86_64": clang++: [0;1;31merror: [0m[1munable to execute command: Killed[0m
Step #21 - "compile-libfuzzer-address-x86_64": clang++: [0;1;31merror: [0m[1mlinker command failed due to signal (use -v to see invocation)[0m
Step #21 - "compile-libfuzzer-address-x86_64": 
[2110/2116] Linking CXX executable run/fuzzshark_ip[K
[2111/2116] Linking CXX executable run/fuzzshark_udp_port-dhcp[K
[2112/2116] Linking CXX executable run/fuzzshark_tcp_port-bgp[K
[2113/2116] Linking CXX executable run/fuzzshark_ip_proto-ospf[K
[2114/2116] Linking CXX executable run/fuzzshark_ip_proto-udp[K
[2115/2116] Linking CXX executable run/fuzzshark_udp_port-dns[K
[2116/2116] Linking CXX executable run/fuzzshark[K
Step #21 - "compile-libfuzzer-address-x86_64": ninja: build stopped: subcommand failed.
```

This is an effort to reduce the resource usage to make the build pass each time.