### PR TITLE
configure gas fuzzer with --enable-leak-check

### DIFF
--- a/projects/binutils/build.sh
+++ b/projects/binutils/build.sh
@@ -157,7 +157,7 @@ done
 if [ "$FUZZING_ENGINE" != "afl" ]
 then
   cd ../gas
-  ./configure
+  ./configure --enable-leak-check
   make -j$(nproc)
   sed 's/main (int argc/old_main32 (int argc, char **argv);\nint old_main32 (int argc/' as.c > fuzz_as.h
   rm as.o || true


### PR DESCRIPTION
Needed to enable the code that frees memory and reinitialises. https://issues.oss-fuzz.com/issues/490291763