### PR TITLE
nccl: fix build

### DIFF
--- a/projects/nccl/build.sh
+++ b/projects/nccl/build.sh
@@ -18,17 +18,20 @@
 # CUDA does not support clang versions above 10.0. This should not affect the
 # target of the fuzzers, however, during build we still need to allow it to
 # compile with the OSS-Fuzz clang version.
-sed -i 's/-std=c++11 --expt-extended-lambda/-allow-unsupported-compiler -std=c++11 --expt-extended-lambda/g' ./makefiles/common.mk
+sed -i 's/--expt-extended-lambda/-allow-unsupported-compiler --expt-extended-lambda/g' ./makefiles/common.mk
+sed -i 's/--expt-extended-lambda/-allow-unsupported-compiler --expt-extended-lambda/g' ./src/device/Makefile
 export CXXFLAGS="$CXXFLAGS -stdlib=libstdc++"
 make clean
 # Watch out for exhausting memory
 make -j3 src.build
 
 $CXX $LIB_FUZZING_ENGINE $CXXFLAGS $SRC/fuzz_xml.cpp -o $OUT/fuzz_xml \
-    -I./src/graph/ -I./src/include -I./build/include/ \
+    -DNCCL_OS_LINUX \
+    -I./src/graph/ -I./src/include -I./src/include/plugin -I./build/include/ \
     -I/usr/local/cuda-12.9/targets/x86_64-linux/include/ \
     ./build/lib/libnccl_static.a \
-    /usr/local/cuda-12.9/targets/x86_64-linux/lib/libcudart.so
+    /usr/local/cuda-12.9/targets/x86_64-linux/lib/libcudart.so \
+    -latomic
 
 cp /usr/local/cuda-12.9/targets/x86_64-linux/lib/libcudart.so.12 $OUT/libcudart.so.12
 cp /usr/local/cuda-12.9/targets/x86_64-linux/lib/libcudart.so $OUT/libcudart.so


### PR DESCRIPTION
Updated build script to allow unsupported compiler and include additional plugin directory.