### PR TITLE
projects: add unjs/md4x

### DIFF
--- a/projects/md4x/Dockerfile
+++ b/projects/md4x/Dockerfile
@@ -1,0 +1,36 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y autoconf automake libtool
+RUN git clone --depth 1 --branch 0.2.5 https://github.com/yaml/libyaml
+RUN git clone https://github.com/unjs/md4x
+
+# Dictionaries:
+RUN git clone --depth 1 https://github.com/google/fuzzing && \
+    mv fuzzing/dictionaries/markdown.dict $SRC/fuzz-mdhtml.dict && \
+    cp $SRC/fuzz-mdhtml.dict $SRC/fuzz-mdast.dict && \
+    cp $SRC/fuzz-mdhtml.dict $SRC/fuzz-mdansi.dict && \
+    cp $SRC/fuzz-mdhtml.dict $SRC/fuzz-mdtext.dict && \
+    cp $SRC/fuzz-mdhtml.dict $SRC/fuzz-mdmeta.dict && \
+    cp $SRC/fuzz-mdhtml.dict $SRC/fuzz-mdheal.dict && \
+    rm -rf fuzzing
+
+# Seed corpus (shared across all fuzzers):
+RUN zip -j $SRC/seed_corpus.zip $SRC/md4x/test/fuzzers/seed-corpus/*.md
+
+WORKDIR $SRC/md4x
+COPY build.sh $SRC/

--- a/projects/md4x/build.sh
+++ b/projects/md4x/build.sh
@@ -1,0 +1,68 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Build libyaml as a static library
+cd $SRC/libyaml
+./bootstrap
+./configure --disable-shared --prefix=$SRC/libyaml-install
+make -j$(nproc)
+make install
+cd $SRC/md4x
+
+LIBYAML_DIR=$SRC/libyaml-install
+SRC_DIR=$SRC/md4x/src
+RENDERERS=$SRC_DIR/renderers
+FUZZERS=$SRC/md4x/test/fuzzers
+INCLUDES="-I$SRC_DIR -I$RENDERERS -I$LIBYAML_DIR/include -DMD4X_USE_UTF8"
+
+# Compile shared source files
+$CC $CFLAGS $INCLUDES -c $SRC_DIR/md4x.c -o md4x.o
+$CC $CFLAGS $INCLUDES -c $SRC_DIR/entity.c -o entity.o
+$CC $CFLAGS $INCLUDES -c $RENDERERS/md4x-heal.c -o md4x-heal.o
+
+# Compile renderer source files
+$CC $CFLAGS $INCLUDES -c $RENDERERS/md4x-html.c -o md4x-html.o
+$CC $CFLAGS $INCLUDES -c $RENDERERS/md4x-ast.c -o md4x-ast.o
+$CC $CFLAGS $INCLUDES -c $RENDERERS/md4x-ansi.c -o md4x-ansi.o
+$CC $CFLAGS $INCLUDES -c $RENDERERS/md4x-text.c -o md4x-text.o
+$CC $CFLAGS $INCLUDES -c $RENDERERS/md4x-meta.c -o md4x-meta.o
+
+# Compile fuzzer harnesses
+$CC $CFLAGS $INCLUDES -c $FUZZERS/fuzz-mdhtml.c -o fuzz-mdhtml.o
+$CC $CFLAGS $INCLUDES -c $FUZZERS/fuzz-mdast.c -o fuzz-mdast.o
+$CC $CFLAGS $INCLUDES -c $FUZZERS/fuzz-mdansi.c -o fuzz-mdansi.o
+$CC $CFLAGS $INCLUDES -c $FUZZERS/fuzz-mdtext.c -o fuzz-mdtext.o
+$CC $CFLAGS $INCLUDES -c $FUZZERS/fuzz-mdmeta.c -o fuzz-mdmeta.o
+$CC $CFLAGS $INCLUDES -c $FUZZERS/fuzz-mdheal.c -o fuzz-mdheal.o
+
+COMMON="md4x.o entity.o md4x-heal.o"
+
+# Link fuzzers
+LIBYAML_A=$LIBYAML_DIR/lib/libyaml.a
+
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz-mdhtml.o md4x-html.o $COMMON $LIBYAML_A -o $OUT/fuzz-mdhtml
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz-mdast.o md4x-ast.o $COMMON $LIBYAML_A -o $OUT/fuzz-mdast
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz-mdansi.o md4x-ansi.o $COMMON -o $OUT/fuzz-mdansi
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz-mdtext.o md4x-text.o $COMMON -o $OUT/fuzz-mdtext
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz-mdmeta.o md4x-meta.o $COMMON $LIBYAML_A -o $OUT/fuzz-mdmeta
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz-mdheal.o md4x-heal.o -o $OUT/fuzz-mdheal
+
+# Copy seed corpus and dictionaries
+for fuzzer in fuzz-mdhtml fuzz-mdast fuzz-mdansi fuzz-mdtext fuzz-mdmeta fuzz-mdheal; do
+    cp $SRC/seed_corpus.zip $OUT/${fuzzer}_seed_corpus.zip
+    mv $SRC/${fuzzer}.dict $OUT/ 2>/dev/null || true
+done

--- a/projects/md4x/project.yaml
+++ b/projects/md4x/project.yaml
@@ -1,0 +1,5 @@
+homepage: "https://github.com/unjs/md4x"
+main_repo: "https://github.com/unjs/md4x"
+primary_contact: "pooya+unjs@pi0.io"
+language: c
+file_github_issue: true


### PR DESCRIPTION
Hi!

This PR adds [unjs/md4x](https://github.com/unjs/md4x). This library is a major rewrite and modernized version of [md4c](https://github.com/mity/md4c) (already [in here](https://github.com/google/oss-fuzz/tree/master/projects/md4c)) with additions of JSON AST renderers and MDC/Comark syntax. 

JSON AST renderers especially need more care as trees are built in memory with dynamic heap allocations.

The importance of this project is that this library is likely to go into production runtime critical paths. At unjs, we have high-traffic libraries such as [jiti](https://github.com/unjs/jiti) with 300+M monthly downloads.

----

Fuzzers: https://github.com/unjs/md4x/tree/main/test/fuzzers

Locally verified with:

```
python infra/helper.py build_image md4x
python infra/helper.py build_fuzzers md4x
python infra/helper.py run_fuzzer md4x fuzz-mdhtml -- -max_total_time=60
```