### PR TITLE
`python3-libraries`: Add `zoneinfo` fuzzer

### DIFF
--- a/projects/python3-libraries/build.sh
+++ b/projects/python3-libraries/build.sh
@@ -124,3 +124,7 @@ cp $SRC/library-fuzzers/tomllib.py $OUT/
 cp $SRC/library-fuzzers/fuzzer-plistlib $OUT/
 cp $SRC/library-fuzzers/plist.py $OUT/
 
+cp $SRC/library-fuzzers/fuzzer-zoneinfo $OUT/
+cp $SRC/library-fuzzers/zoneinfo.py $OUT/
+zip -j $OUT/fuzzer-zoneinfo_seed_corpus.zip corp-zoneinfo/*
+


### PR DESCRIPTION
We added it to `library-fuzzers` in https://github.com/python/library-fuzzers/commit/eb273d591de78ec90629d2500fdbc33d47e32033.