### PR TITLE
strongswan: Enable radius / vici

### DIFF
--- a/projects/strongswan/build.sh
+++ b/projects/strongswan/build.sh
@@ -15,12 +15,17 @@
 #
 ################################################################################
 
+# Temporary fix to break circular dependency issue
+sed -i '/libcharon\/\.libs\/libcharon\.a.*\\$/a\	$(top_builddir)/src/libradius/.libs/libradius.a \\' $SRC/strongswan/fuzz/Makefile.am
+
 ./autogen.sh
 
 ./configure CFLAGS="$CFLAGS -DNO_CHECK_MEMWIPE -DDEBUG_LEVEL=-1" \
 	--enable-imc-test \
 	--enable-tnccs-20 \
 	--enable-libipsec \
+	--enable-vici \
+	--enable-eap-radius \
 	--enable-fuzzing \
 	--with-libfuzzer=$LIB_FUZZING_ENGINE \
 	--enable-monolithic \


### PR DESCRIPTION
This PR fixes the build for strongswan project to enable radius/vici for fuzzing. It also contains a temporary fixes of the Makefile in upstream to avoid a circular dependency issue.