### PR TITLE
wireshark: Try to fix linker OOMs by limiting concurrent linking

### DIFF
--- a/projects/wireshark/build.sh
+++ b/projects/wireshark/build.sh
@@ -56,6 +56,8 @@ cd "$WIRESHARK_BUILD_PATH"
 cmake -GNinja \
       -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX \
       -DCMAKE_C_FLAGS="-Wno-error=fortify-source -Wno-error=missing-field-initializers $CFLAGS" -DCMAKE_CXX_FLAGS="-Wno-error=fortify-source -Wno-error=missing-field-initializers $CXXFLAGS" \
+      -DCMAKE_JOB_POOL_LINK=limited_link_pool \
+      -DCMAKE_JOBS_POOLS:STRING=limited_link_pool=2 \
       -DENABLE_WERROR=OFF -DOSS_FUZZ=ON $CMAKE_DEFINES \
       -DUSE_STATIC=ON $SRC/wireshark
 


### PR DESCRIPTION
Compiling in parallel seems fine, but all the recent builds have had the linker killed, apparently from OOM. Limit the number of concurrent linker jobs via CMAKE_JOB_POOL_LINK.