### PR TITLE
nodejs: fix bootstrap to expose require

### DIFF
--- a/projects/nodejs/fuzz_sources/fuzz_common.cc
+++ b/projects/nodejs/fuzz_sources/fuzz_common.cc
@@ -195,8 +195,14 @@ static void InitializePersistentEnvOnce() {
 
     g_env = node::CreateEnvironment(g_iso_data, ctx, args, exec_args, flags);
 
-    // Bootstrap Node (no entry script).
-    node::LoadEnvironment(g_env, const_cast<char*>(""));
+    // Bootstrap Node, should initialize some builtins.
+    node::LoadEnvironment(g_env, const_cast<char*>(
+      "globalThis.require = require;"
+      "globalThis.module = module;"
+      "globalThis.exports = exports;"
+      "globalThis.__filename = __filename;"
+      "globalThis.__dirname = __dirname;"
+    ));
 
     // Build and cache the comparator function.
     BuildBufCmpOnce();


### PR DESCRIPTION
I have been testing Node.js and found suspicious behavior. My harness don't get any coverage in target modules. I start investigate it, make abort at V8 exceptions and found, that code under `InitializePersistentEnvOnce` can't use Node.js global service builtins like `require`. And on harness start up I can see:

```console
FATAL: Unhandled JavaScript exception
Exception: ReferenceError: require is not defined
Message: Uncaught ReferenceError: require is not defined
Location: undefined:1
Stack:
ReferenceError: require is not defined
    at <anonymous>:1:26
```

After investigation I found that we should modify bootstrap script to expected behavior of `require` calls, like this:
```c++
node::LoadEnvironment(g_env, const_cast<char*>(
      "globalThis.require = require;"
      "globalThis.module = module;"
      "globalThis.exports = exports;"
      "globalThis.__filename = __filename;"
      "globalThis.__dirname = __dirname;"
    ));
```

Tested on Node.js v24.


It's hard to check for current fuzz-tests, cause they not strongly correlate with C++ code. Maybe checking coverage for `crypto` model can say, that current harnesses fails on require and not testing code - https://storage.googleapis.com/oss-fuzz-coverage/nodejs/reports/20260121/linux/src/node/src/crypto/report.html . I have better example, but I found Node.js bug from this harness and cant disclose this for now (when it will be fixed, I should add new harnesses to this repository)

<details><summary>Expose exceptions for testing</summary>

```c++
inline void CallNoThrow(v8::Isolate* iso,
                        v8::Local<v8::Context> ctx,
                        v8::Local<v8::Function> fn,
                        int argc,
                        v8::Local<v8::Value>* argv) {
  v8::TryCatch tc(iso);
  (void)fn->Call(ctx, v8::Undefined(iso), argc, argv);
  
  if (tc.HasCaught()) {
    v8::Local<v8::Value> exception = tc.Exception();
    v8::Local<v8::Message> message = tc.Message();
    
    fprintf(stderr, "FATAL: Unhandled JavaScript exception\n");
    
    if (!message.IsEmpty()) {
      v8::String::Utf8Value exception_str(iso, exception);
      v8::String::Utf8Value message_str(iso, message->Get());
      v8::String::Utf8Value filename(iso, message->GetScriptResourceName());
      int line = message->GetLineNumber(ctx).FromMaybe(-1);
      
      fprintf(stderr, "Exception: %s\n", *exception_str);
      fprintf(stderr, "Message: %s\n", *message_str);
      fprintf(stderr, "Location: %s:%d\n", *filename, line);
      
      if (exception->IsObject()) {
        auto maybe_stack = v8::Local<v8::Object>::Cast(exception)->Get(
          ctx, v8::String::NewFromUtf8(iso, "stack").ToLocalChecked());
        if (!maybe_stack.IsEmpty()) {
          v8::Local<v8::Value> stack = maybe_stack.ToLocalChecked();
          if (stack->IsString()) {
            v8::String::Utf8Value stack_str(iso, v8::Local<v8::String>::Cast(stack));
            fprintf(stderr, "Stack:\n%s\n", *stack_str);
          }
        }
      }
    } else {
      v8::String::Utf8Value exception_str(iso, exception);
      fprintf(stderr, "Exception: %s\n", *exception_str);
    }
    
    std::abort();
  }
}
```
</details> 

@AdamKorcz 