### PR TITLE
project: add casbin fuzzing integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/casbin/casbin casbin
+COPY build.sh $SRC/
+COPY fuzz_*.go $SRC/casbin/
+WORKDIR $SRC/casbin

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+compile_go_fuzzer github.com/casbin/casbin/v3 FuzzEnforce fuzz_enforce
+compile_go_fuzzer github.com/casbin/casbin/v3 FuzzModel fuzz_model

--- a/fuzz_enforce.go
+++ b/fuzz_enforce.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package casbin
+
+func FuzzEnforce(data []byte) int {
+	if len(data) < 4 {
+		return 0
+	}
+
+	e, err := NewEnforcer()
+	if err != nil {
+		return 0
+	}
+
+	sub := string(data[:len(data)/3])
+	obj := string(data[len(data)/3 : len(data)*2/3])
+	act := string(data[len(data)*2/3:])
+
+	_, _ = e.Enforce(sub, obj, act)
+	return 1
+}

--- a/fuzz_model.go
+++ b/fuzz_model.go
@@ -1,0 +1,22 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package casbin
+
+import "github.com/casbin/casbin/v3/model"
+
+func FuzzModel(data []byte) int {
+	_, _ = model.NewModelFromString(string(data))
+	return 1
+}

--- a/projects/casbin/project.yaml
+++ b/projects/casbin/project.yaml
@@ -1,0 +1,23 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+homepage: "https://github.com/casbin/casbin"
+language: go
+primary_contact: "admin@casbin.org"
+main_repo: "https://github.com/casbin/casbin.git"
+file_github_issue: true
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address

--- a/projects/casbin/project.yaml
+++ b/projects/casbin/project.yaml
@@ -16,7 +16,7 @@ homepage: "https://github.com/casbin/casbin"
 language: go
 primary_contact: "admin@casbin.org"
 main_repo: "https://github.com/casbin/casbin.git"
-file_github_issue: true
+file_github_issue: false
 fuzzing_engines:
   - libfuzzer
 sanitizers:


### PR DESCRIPTION
Add OSS-Fuzz integration for casbin, a widely used Go authorization
library supporting ACL, RBAC, and ABAC policy models.

Fuzzers:
- FuzzEnforce: targets policy enforcement engine
- FuzzModel: targets model/policy string parsing

Tested locally:
- build_image: pass
- build_fuzzers --sanitizer address: pass
- check_build: pass