### PR TITLE
Add subgraph API fuzzer for XNNPACK

### DIFF
--- a/projects/xnnpack/build.sh
+++ b/projects/xnnpack/build.sh
@@ -34,3 +34,11 @@ $CXX $CXXFLAGS $LIB_FUZZING_ENGINE ../fuzz_model.cc \
     ./build/pthreadpool/libpthreadpool.a ./build/cpuinfo/libcpuinfo.a \
     ./build/libxnnpack-microkernels-all.a ./build/libxnnpack-microkernels-prod.a \
     -o $OUT/fuzz_model
+
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE ../fuzz_subgraph.cc \
+    -I/src/xnnpack/src -I/src/xnnpack/build/pthreadpool-source/include \
+    -I/src/xnnpack/build/FXdiv-source/include -I/src/xnnpack/include/ \
+    -I/src/xnnpack/build/FP16-source/include ./build/libXNNPACK.a \
+    ./build/pthreadpool/libpthreadpool.a ./build/cpuinfo/libcpuinfo.a \
+    ./build/libxnnpack-microkernels-all.a ./build/libxnnpack-microkernels-prod.a \
+    -o $OUT/fuzz_subgraph

--- a/projects/xnnpack/fuzz_subgraph.cc
+++ b/projects/xnnpack/fuzz_subgraph.cc
@@ -1,0 +1,123 @@
+/* Copyright 2026 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <cstdint>
+#include <cstddef>
+#include <cstring>
+#include <fuzzer/FuzzedDataProvider.h>
+#include <xnnpack.h>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  FuzzedDataProvider provider(data, size);
+
+  if (xnn_initialize(nullptr) != xnn_status_success) return 0;
+
+  xnn_subgraph_t subgraph = nullptr;
+  if (xnn_create_subgraph(3, 0, &subgraph) != xnn_status_success) return 0;
+
+  // Create input tensor with fuzzed rank (0-8)
+  const size_t num_dims = provider.ConsumeIntegralInRange<size_t>(0, 8);
+  size_t dims[8];
+  for (size_t i = 0; i < num_dims; i++) {
+    dims[i] = provider.ConsumeIntegralInRange<size_t>(1, 8);
+  }
+
+  uint32_t input_id = 0;
+  if (xnn_define_tensor_value(subgraph, xnn_datatype_fp32, num_dims, dims,
+                              nullptr, 0, XNN_VALUE_FLAG_EXTERNAL_INPUT,
+                              &input_id) != xnn_status_success) {
+    xnn_delete_subgraph(subgraph);
+    return 0;
+  }
+
+  uint32_t output_id = 1;
+  if (xnn_define_tensor_value(subgraph, xnn_datatype_fp32, 0, nullptr, nullptr,
+                              1, XNN_VALUE_FLAG_EXTERNAL_OUTPUT,
+                              &output_id) != xnn_status_success) {
+    xnn_delete_subgraph(subgraph);
+    return 0;
+  }
+
+  // Pick which operation to fuzz
+  const int op = provider.ConsumeIntegralInRange<int>(0, 4);
+
+  switch (op) {
+    case 0: {
+      // Fuzz xnn_define_static_reduce_v2: unbounded num_reduction_axes
+      const size_t num_axes = provider.ConsumeIntegralInRange<size_t>(0, 12);
+      int64_t axes[12];
+      for (size_t i = 0; i < num_axes; i++) {
+        axes[i] = provider.ConsumeIntegralInRange<int64_t>(-8, 8);
+      }
+      const int reduce_op = provider.ConsumeIntegralInRange<int>(0, 6);
+      xnn_define_static_reduce_v2(subgraph,
+                                  static_cast<xnn_reduce_operator>(reduce_op),
+                                  num_axes, axes, input_id, output_id, 0);
+      break;
+    }
+    case 1: {
+      // Fuzz xnn_define_static_reduce (v1 wrapper): stack overflow
+      const size_t num_axes = provider.ConsumeIntegralInRange<size_t>(0, 12);
+      size_t axes[12];
+      for (size_t i = 0; i < num_axes; i++) {
+        axes[i] = provider.ConsumeIntegralInRange<size_t>(0, 8);
+      }
+      xnn_define_static_reduce(subgraph, xnn_reduce_mean, num_axes, axes,
+                               input_id, output_id, 0);
+      break;
+    }
+    case 2: {
+      // Fuzz xnn_define_static_slice_v3: unbounded num_dims
+      const size_t slice_dims = provider.ConsumeIntegralInRange<size_t>(0, 12);
+      int64_t begins[12], ends[12];
+      for (size_t i = 0; i < slice_dims; i++) {
+        begins[i] = provider.ConsumeIntegralInRange<int64_t>(0, 4);
+        ends[i] = provider.ConsumeIntegralInRange<int64_t>(1, 8);
+      }
+      xnn_define_static_slice_v3(subgraph, slice_dims, begins, ends, nullptr,
+                                 input_id, output_id, 0);
+      break;
+    }
+    case 3: {
+      // Fuzz xnn_define_even_split: num_outputs=0 guard is assert-only
+      const size_t num_outputs = provider.ConsumeIntegralInRange<size_t>(0, 6);
+      uint32_t outputs[6];
+      for (size_t i = 0; i < num_outputs; i++) {
+        outputs[i] = output_id;
+      }
+      xnn_define_even_split(subgraph, 0, input_id, num_outputs,
+                            num_outputs > 0 ? outputs : nullptr, 0);
+      break;
+    }
+    case 4: {
+      // Fuzz blockwise quantized tensor: block_size=0 missing return
+      const size_t block_size = provider.ConsumeIntegralInRange<size_t>(0, 4);
+      size_t bq_dims[] = {4, 8};
+      uint16_t scales[32] = {};
+      for (auto& s : scales) s = 0x3C00;  // 1.0 in bf16
+      uint8_t tensor_data[16] = {};
+      uint32_t bq_id = XNN_INVALID_VALUE_ID;
+      xnn_define_blockwise_quantized_tensor_value(
+          subgraph, xnn_datatype_qbint4, 0, scales, 2, 0, block_size, bq_dims,
+          tensor_data, XNN_INVALID_VALUE_ID, 0, &bq_id);
+      break;
+    }
+  }
+
+  // Try to create runtime to trigger reshape-time bugs
+  xnn_runtime_t runtime = nullptr;
+  xnn_status status = xnn_create_runtime(subgraph, &runtime);
+  if (runtime) xnn_delete_runtime(runtime);
+
+  xnn_delete_subgraph(subgraph);
+  return 0;
+}


### PR DESCRIPTION
Add a fuzzer targeting XNNPACK subgraph define operations (reduce, slice, blockwise tensor, even-split) with fuzzed dimensions and parameter values.