### PR TITLE
Libmdbx: initial integration

### DIFF
--- a/projects/libmdbx/Dockerfile
+++ b/projects/libmdbx/Dockerfile
@@ -21,12 +21,13 @@ env MAKE_VERSION 4.4.1
 RUN cd $SRC &&\
   curl -L https://ftp.gnu.org/gnu/make/make-$MAKE_VERSION.tar.gz -o make.tar.gz &&\
   tar xf make.tar.gz &&\
-  mv make-$MAKE_VERSION make &&\
-  cd make &&\
-  ./configure --prefix=$SRC/make &&\
+  cd make-${MAKE_VERSION} &&\
+  ./configure --prefix=$SRC/make-${MAKE_VERSION} &&\
   make -j$(nproc)
 
-RUN git clone --depth 1 https://github.com/erthink/libmdbx
+#RUN git clone --depth 1 https://github.com/erthink/libmdbx
+RUN git clone --depth 1 https://github.com/Segwaz/libmdbx -b fuzz_raw_db_format
+#RUN git clone --depth 1 https://github.com/Segwaz/libmdbx_mirror.git libmdbx
 
 COPY build.sh $SRC/
 

--- a/projects/libmdbx/Dockerfile
+++ b/projects/libmdbx/Dockerfile
@@ -1,0 +1,33 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+env MAKE_VERSION 4.4.1
+
+RUN cd $SRC &&\
+  curl -L https://ftp.gnu.org/gnu/make/make-$MAKE_VERSION.tar.gz -o make.tar.gz &&\
+  tar xf make.tar.gz &&\
+  mv make-$MAKE_VERSION make &&\
+  cd make &&\
+  ./configure --prefix=$SRC/make &&\
+  make -j$(nproc)
+
+RUN git clone --depth 1 https://github.com/erthink/libmdbx
+
+COPY build.sh $SRC/
+
+WORKDIR $SRC

--- a/projects/libmdbx/Dockerfile
+++ b/projects/libmdbx/Dockerfile
@@ -27,7 +27,6 @@ RUN cd $SRC &&\
 
 #RUN git clone --depth 1 https://github.com/erthink/libmdbx
 RUN git clone --depth 1 https://github.com/Segwaz/libmdbx -b fuzz_raw_db_format
-#RUN git clone --depth 1 https://github.com/Segwaz/libmdbx_mirror.git libmdbx
 
 COPY build.sh $SRC/
 

--- a/projects/libmdbx/Dockerfile
+++ b/projects/libmdbx/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/libmdbx/Dockerfile
+++ b/projects/libmdbx/Dockerfile
@@ -18,6 +18,8 @@ FROM gcr.io/oss-fuzz-base/base-builder
 
 env MAKE_VERSION 4.4.1
 
+RUN apt-get update && apt-get install -y ninja-build zlib1g-dev liblzma-dev
+
 RUN cd $SRC &&\
   curl -L https://ftp.gnu.org/gnu/make/make-$MAKE_VERSION.tar.gz -o make.tar.gz &&\
   tar xf make.tar.gz &&\
@@ -25,8 +27,10 @@ RUN cd $SRC &&\
   ./configure --prefix=$SRC/make-${MAKE_VERSION} &&\
   make -j$(nproc)
 
-#RUN git clone --depth 1 https://github.com/erthink/libmdbx
 RUN git clone --recursive https://github.com/Mithril-mine/libmdbx-fuzzing
+
+RUN cd $SRC/libmdbx-fuzzing && \
+ make obj/lpm-build/src/libfuzzer/libprotobuf-mutator-libfuzzer.a
 
 COPY build.sh $SRC/
 

--- a/projects/libmdbx/Dockerfile
+++ b/projects/libmdbx/Dockerfile
@@ -26,7 +26,7 @@ RUN cd $SRC &&\
   make -j$(nproc)
 
 #RUN git clone --depth 1 https://github.com/erthink/libmdbx
-RUN git clone --depth 1 https://github.com/Segwaz/libmdbx -b fuzz_raw_db_format
+RUN git clone --recursive https://github.com/Mithril-mine/libmdbx-fuzzing
 
 COPY build.sh $SRC/
 

--- a/projects/libmdbx/build.sh
+++ b/projects/libmdbx/build.sh
@@ -22,9 +22,9 @@ export MAKE=$SRC/make-"$MAKE_VERSION"/make
 $MAKE clean || true
 $MAKE libmdbx.a CC="$CC" CFLAGS="$CFLAGS"
 
-cp ./fuzz/seed/fuzz_raw_db_format.zip $OUT/fuzz_raw_db_format.zip
+cp ./fuzz/seed/fuzz_raw_db_format_seed_corpus.zip $OUT
 
-$CC $CFLAGS -I./ \
+$CC $CFLAGS -I./ -I./fuzz \
   ./fuzz/fuzz_raw_db_format.c \
   ./libmdbx.a \
   -o $OUT/fuzz_raw_db_format \

--- a/projects/libmdbx/build.sh
+++ b/projects/libmdbx/build.sh
@@ -25,7 +25,8 @@ $MAKE libmdbx.a CC="$CC" CFLAGS="$CFLAGS"
 cp ./fuzz/seed/fuzz_raw_db_format_seed_corpus.zip $OUT
 
 $CC $CFLAGS -I./ -I./fuzz \
-  ./fuzz/fuzz_raw_db_format.c \
-  ./libmdbx.a \
-  -o $OUT/fuzz_raw_db_format \
-  $LIB_FUZZING_ENGINE
+    ./fuzz/fuzz_raw_db_format.c \
+    ./fuzz/mode_desc.c \
+    ./libmdbx.a \
+    -o $OUT/fuzz_raw_db_format \
+    $LIB_FUZZING_ENGINE

--- a/projects/libmdbx/build.sh
+++ b/projects/libmdbx/build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -eu
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC/libmdbx
+
+export MAKE=$SRC/make-"$MAKE_VERSION"/make
+
+$MAKE clean || true
+$MAKE libmdbx.a CC="$CC" CFLAGS="$CFLAGS"
+
+cp ./fuzz/seed/fuzz_raw_db_format.zip $OUT/fuzz_raw_db_format.zip
+
+$CC $CFLAGS -I./ \
+  ./fuzz/fuzz_raw_db_format.c \
+  ./libmdbx.a \
+  -o $OUT/fuzz_raw_db_format \
+  $LIB_FUZZING_ENGINE

--- a/projects/libmdbx/build.sh
+++ b/projects/libmdbx/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2016 Google Inc.
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/libmdbx/build.sh
+++ b/projects/libmdbx/build.sh
@@ -23,5 +23,6 @@ $MAKE clean || true
 $MAKE fuzz_raw_db_format fuzz_api
 
 cp ./seed/fuzz_raw_db_format_seed_corpus.zip $OUT
+cp ./seed/fuzz_api_seed_corpus.zip $OUT
 cp ./fuzz_raw_db_format $OUT
 cp ./fuzz_api $OUT

--- a/projects/libmdbx/build.sh
+++ b/projects/libmdbx/build.sh
@@ -15,18 +15,12 @@
 #
 ################################################################################
 
-cd $SRC/libmdbx
+cd $SRC/libmdbx-fuzzing
 
 export MAKE=$SRC/make-"$MAKE_VERSION"/make
 
 $MAKE clean || true
-$MAKE libmdbx.a CC="$CC" CFLAGS="$CFLAGS"
+$MAKE fuzz_raw_db_format
 
-cp ./fuzz/seed/fuzz_raw_db_format_seed_corpus.zip $OUT
-
-$CC $CFLAGS -I./ -I./fuzz \
-    ./fuzz/fuzz_raw_db_format.c \
-    ./fuzz/mode_desc.c \
-    ./libmdbx.a \
-    -o $OUT/fuzz_raw_db_format \
-    $LIB_FUZZING_ENGINE
+cp ./seed/fuzz_raw_db_format_seed_corpus.zip $OUT
+cp ./fuzz_raw_db_format $OUT

--- a/projects/libmdbx/build.sh
+++ b/projects/libmdbx/build.sh
@@ -20,7 +20,8 @@ cd $SRC/libmdbx-fuzzing
 export MAKE=$SRC/make-"$MAKE_VERSION"/make
 
 $MAKE clean || true
-$MAKE fuzz_raw_db_format
+$MAKE fuzz_raw_db_format fuzz_api
 
 cp ./seed/fuzz_raw_db_format_seed_corpus.zip $OUT
 cp ./fuzz_raw_db_format $OUT
+cp ./fuzz_api $OUT

--- a/projects/libmdbx/project.yaml
+++ b/projects/libmdbx/project.yaml
@@ -1,0 +1,11 @@
+homepage: "https://github.com/libmdbx/libmdbx"
+language: c++
+primary_contact: "leo@yuriev.ru"
+auto_ccs:
+  - "chloe.cano@protonmail.com"
+sanitizers:
+  - address
+  - memory:
+     experimental: True
+  - undefined
+main_repo: 'https://github.com/erthink/libmdbx'

--- a/projects/libmdbx/project.yaml
+++ b/projects/libmdbx/project.yaml
@@ -5,7 +5,5 @@ auto_ccs:
   - "chloe.cano@protonmail.com"
 sanitizers:
   - address
-  - memory:
-     experimental: True
   - undefined
 main_repo: 'https://github.com/erthink/libmdbx'


### PR DESCRIPTION
**About**
Libmdbx is the successor / alternative to LMDB, an embedded key-value store with a strong focus on correctness and performance. It is used by Ethereum clients such as Erigon, Silkworm, Reth and Akula as well as other performance-critical systems. Bugs on such a shared storage engine can propagate across independent implementations and impact system/data integrity or consensus.

**Work done**
- Protobuf fuzz target for core DB operations (put/get/cursor/txn lifecycle)
- Raw database format fuzzing
- Associated seed corporas and generation utilities
- OSS-fuzz build
- 2 bugs corrected during the integration effort

**Notes**
- I am not a maintainer but they are aware and want this integration (see https://github.com/Mithril-mine/libmdbx-fuzzing/issues/1#issuecomment-4153629413)
- it was decided to put fuzzing related components in a separate repository to keep the main one from distributing unnecessary dependencies. It is part of libmdbx Github organization (Mithril-mine).
- the main repository used to not live primarily on Github until very recently (a week or so).