### PR TITLE
Added a new project to OSS-Fuzz

### DIFF
--- a/projects/fastapi/Dockerfile
+++ b/projects/fastapi/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-fuzz-base/base-builder-python
+
+RUN python3 -m pip install --upgrade pip
+RUN git clone --depth 1 https://github.com/fastapi/fastapi
+
+COPY build.sh $SRC/
+COPY fastapi_fuzz_utils.py fuzz_*.py $SRC/fastapi/
+
+WORKDIR $SRC/fastapi

--- a/projects/fastapi/build.sh
+++ b/projects/fastapi/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -eu
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+python3 -m pip install . 'httpx>=0.23,<1.0.0' 'python-multipart>=0.0.18'
+
+for fuzzer in $(find "$SRC/fastapi" -maxdepth 1 -name 'fuzz_*.py' | sort); do
+  compile_python_fuzzer "$fuzzer"
+done

--- a/projects/fastapi/fastapi_fuzz_utils.py
+++ b/projects/fastapi/fastapi_fuzz_utils.py
@@ -1,0 +1,242 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import base64
+import json
+from typing import Any
+from urllib.parse import urlencode
+
+from starlette.requests import Request
+
+METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
+
+
+def pick(fdp: Any, items: list[Any]) -> Any:
+    return items[fdp.ConsumeIntInRange(0, len(items) - 1)]
+
+
+def text(fdp: Any, max_len: int = 32) -> str:
+    return fdp.ConsumeBytes(max_len).decode("utf-8", "ignore")
+
+
+def token(fdp: Any, max_len: int = 16) -> str:
+    raw = fdp.ConsumeBytes(max_len)
+    if not raw:
+        return "x"
+    out = []
+    for byte in raw:
+        if 48 <= byte <= 57 or 65 <= byte <= 90 or 97 <= byte <= 122:
+            out.append(chr(byte))
+        elif byte in (45, 95):
+            out.append(chr(byte))
+        else:
+            out.append(chr(97 + (byte % 26)))
+    return "".join(out) or "x"
+
+
+def segment(fdp: Any, max_len: int = 12) -> str:
+    value = token(fdp, max_len).strip("-_")
+    return value or "x"
+
+
+def path(fdp: Any, max_segments: int = 3) -> str:
+    count = fdp.ConsumeIntInRange(1, max_segments)
+    return "/".join(segment(fdp) for _ in range(count))
+
+
+def scalar_text(fdp: Any) -> str:
+    choice = fdp.ConsumeIntInRange(0, 4)
+    if choice == 0:
+        return str(fdp.ConsumeIntInRange(-1000, 1000))
+    if choice == 1:
+        return "true" if fdp.ConsumeBool() else "false"
+    if choice == 2:
+        return text(fdp, 24)
+    if choice == 3:
+        return str(round(fdp.ConsumeFloatInRange(-1000.0, 1000.0), 3))
+    return ""
+
+
+def query_items(fdp: Any, max_items: int = 4) -> list[tuple[str, str]]:
+    items = []
+    for _ in range(fdp.ConsumeIntInRange(0, max_items)):
+        items.append((segment(fdp, 8), scalar_text(fdp)))
+    return items
+
+
+def headers(
+    fdp: Any,
+    *,
+    include_auth: bool = False,
+    include_cookie: bool = False,
+) -> dict[str, str]:
+    out = {"host": "testserver"}
+    if fdp.ConsumeBool():
+        out["x-token"] = token(fdp, 20)
+    if fdp.ConsumeBool():
+        out["x-marker"] = token(fdp, 20)
+    if fdp.ConsumeBool():
+        out["x-count"] = str(fdp.ConsumeIntInRange(-100, 100))
+    if fdp.ConsumeBool():
+        out["x-trace-id"] = token(fdp, 20)
+    if fdp.ConsumeBool():
+        out["accept-encoding"] = "gzip"
+    if include_cookie and fdp.ConsumeBool():
+        out["cookie"] = f"session={token(fdp, 16)}"
+    if include_auth and fdp.ConsumeBool():
+        kind = fdp.ConsumeIntInRange(0, 3)
+        if kind == 0:
+            out["authorization"] = f"Bearer {token(fdp, 32)}"
+        elif kind == 1:
+            raw = f"{token(fdp, 12)}:{text(fdp, 12)}".encode("ascii", "ignore")
+            out["authorization"] = "Basic " + base64.b64encode(raw).decode("ascii")
+        elif kind == 2:
+            out["authorization"] = "Basic " + token(fdp, 24)
+        else:
+            out["authorization"] = text(fdp, 40)
+    for _ in range(fdp.ConsumeIntInRange(0, 2)):
+        out[segment(fdp, 8)] = text(fdp, 20)
+    return out
+
+
+def json_value(fdp: Any, depth: int = 0) -> Any:
+    top = 5 if depth >= 2 else 7
+    kind = fdp.ConsumeIntInRange(0, top)
+    if kind == 0:
+        return None
+    if kind == 1:
+        return fdp.ConsumeBool()
+    if kind == 2:
+        return fdp.ConsumeIntInRange(-1000, 1000)
+    if kind == 3:
+        return round(fdp.ConsumeFloatInRange(-1000.0, 1000.0), 3)
+    if kind == 4:
+        return text(fdp, 40)
+    if kind == 5:
+        return [json_value(fdp, depth + 1) for _ in range(fdp.ConsumeIntInRange(0, 3))]
+    if kind == 6:
+        out = {}
+        for _ in range(fdp.ConsumeIntInRange(0, 3)):
+            out[segment(fdp, 8)] = json_value(fdp, depth + 1)
+        return out
+    return [{"value": json_value(fdp, depth + 1)} for _ in range(fdp.ConsumeIntInRange(0, 2))]
+
+
+def body_bytes(value: Any) -> bytes:
+    try:
+        return json.dumps(value).encode("utf-8")
+    except Exception:
+        return str(value).encode("utf-8", "ignore")
+
+
+def build_scope(
+    method: str,
+    path_value: str,
+    *,
+    headers_map: dict[str, str] | None = None,
+    query: list[tuple[str, str]] | None = None,
+    scheme: str = "http",
+) -> dict[str, Any]:
+    raw_headers = []
+    for key, value in (headers_map or {}).items():
+        raw_headers.append(
+            (
+                str(key).lower().encode("latin1", "ignore"),
+                str(value).encode("latin1", "ignore"),
+            )
+        )
+    query_string = urlencode(query or [], doseq=True).encode()
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": method,
+        "scheme": scheme,
+        "path": path_value,
+        "raw_path": path_value.encode("utf-8", "ignore"),
+        "query_string": query_string,
+        "headers": raw_headers,
+        "client": ("127.0.0.1", 1234),
+        "server": ("testserver", 80),
+        "state": {},
+        "root_path": "",
+        "path_params": {},
+    }
+
+
+def build_websocket_scope(
+    path_value: str,
+    *,
+    headers_map: dict[str, str] | None = None,
+    query: list[tuple[str, str]] | None = None,
+) -> dict[str, Any]:
+    raw_headers = []
+    for key, value in (headers_map or {}).items():
+        raw_headers.append(
+            (
+                str(key).lower().encode("latin1", "ignore"),
+                str(value).encode("latin1", "ignore"),
+            )
+        )
+    return {
+        "type": "websocket",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "scheme": "ws",
+        "path": path_value,
+        "raw_path": path_value.encode("utf-8", "ignore"),
+        "query_string": urlencode(query or [], doseq=True).encode(),
+        "headers": raw_headers,
+        "client": ("127.0.0.1", 1234),
+        "server": ("testserver", 80),
+        "subprotocols": [],
+        "state": {},
+        "path_params": {},
+    }
+
+
+def make_receive(body: bytes = b""):
+    sent = False
+
+    async def receive() -> dict[str, Any]:
+        nonlocal sent
+        if sent:
+            return {"type": "http.disconnect"}
+        sent = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return receive
+
+
+def make_send(messages: list[dict[str, Any]]):
+    async def send(message: dict[str, Any]) -> None:
+        messages.append(message)
+
+    return send
+
+
+def make_request(
+    method: str,
+    path_value: str,
+    *,
+    headers_map: dict[str, str] | None = None,
+    query: list[tuple[str, str]] | None = None,
+    body: bytes = b"",
+) -> Request:
+    scope = build_scope(method, path_value, headers_map=headers_map, query=query)
+    return Request(scope, receive=make_receive(body))
+
+
+def run(coro: Any) -> Any:
+    return asyncio.run(coro)

--- a/projects/fastapi/fuzz_applications.py
+++ b/projects/fastapi/fuzz_applications.py
@@ -1,0 +1,142 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Targets:
+# - fastapi/applications.py
+# Delta:
+# - fastapi/applications.py >= 60%
+
+import sys
+from contextlib import asynccontextmanager
+
+import atheris
+
+with atheris.instrument_imports():
+    import fastapi.applications as applications_mod
+    from fastapi import Depends, HTTPException, Query
+    from fastapi.exceptions import RequestValidationError, ResponseValidationError
+    from fastapi.middleware.gzip import GZipMiddleware
+    from fastapi.middleware.httpsredirect import HTTPSRedirectMiddleware
+    from fastapi.middleware.trustedhost import TrustedHostMiddleware
+    from fastapi.testclient import TestClient
+    from pydantic import ValidationError
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse, PlainTextResponse
+    from starlette.exceptions import HTTPException as StarletteHTTPException
+
+    import fastapi_fuzz_utils as fuzz
+
+
+def build_app(fdp: atheris.FuzzedDataProvider) -> applications_mod.FastAPI:
+    title = "FastAPI " + fuzz.segment(fdp, 10)
+    version = f"{fdp.ConsumeIntInRange(0, 9)}.{fdp.ConsumeIntInRange(0, 9)}.{fdp.ConsumeIntInRange(0, 9)}"
+    openapi_url = "/openapi.json" if fdp.ConsumeBool() else None
+    docs_url = "/docs" if fdp.ConsumeBool() else None
+    redoc_url = "/redoc" if fdp.ConsumeBool() else None
+    events: list[str] = []
+
+    @asynccontextmanager
+    async def lifespan(app):
+        events.append("startup")
+        yield {"events": events}
+        events.append("shutdown")
+
+    app = applications_mod.FastAPI(
+        title=title,
+        version=version,
+        summary=fuzz.text(fdp, 24) or None,
+        description=fuzz.text(fdp, 48),
+        openapi_url=openapi_url,
+        docs_url=docs_url,
+        redoc_url=redoc_url,
+        swagger_ui_parameters={"deepLinking": fdp.ConsumeBool(), "displayRequestDuration": fdp.ConsumeBool()},
+        lifespan=lifespan,
+        generate_unique_id_function=lambda route: "app-" + (route.name or "route"),
+    )
+
+    if fdp.ConsumeBool():
+        app.add_middleware(GZipMiddleware, minimum_size=1)
+    if fdp.ConsumeBool():
+        app.add_middleware(HTTPSRedirectMiddleware)
+    if fdp.ConsumeBool():
+        app.add_middleware(TrustedHostMiddleware, allowed_hosts=["testserver", "*.example.com"])
+
+    def dep(flag: bool = Query(default=False)) -> bool:
+        return flag
+
+    @app.get("/ping")
+    async def ping(flag: bool = Depends(dep)) -> dict[str, object]:
+        return {"ok": True, "flag": flag}
+
+    @app.get("/text")
+    async def text_route() -> PlainTextResponse:
+        return PlainTextResponse("ok")
+
+    @app.get("/http-error")
+    async def http_error() -> None:
+        raise HTTPException(status_code=418, detail="boom")
+
+    @app.get("/value-error")
+    async def value_error() -> None:
+        raise ValueError("bad")
+
+    async def value_error_handler(request: Request, exc: ValueError) -> JSONResponse:
+        return JSONResponse({"detail": str(exc), "path": request.url.path}, status_code=499)
+
+    app.add_exception_handler(ValueError, value_error_handler)
+    app.add_exception_handler(404, value_error_handler)
+    app.setup()
+    return app
+
+
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+
+    try:
+        app = build_app(fdp)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            client.get("/ping", params={"flag": "true" if fdp.ConsumeBool() else "false"}, headers={"host": "testserver"})
+            client.get("/text", headers={"host": "testserver"})
+            client.get("/http-error", headers={"host": "testserver"})
+            client.get("/value-error", headers={"host": "testserver"})
+            client.get("/missing", headers={"host": "testserver"})
+
+            if app.openapi_url:
+                client.get(app.openapi_url, headers={"host": "testserver"})
+            if app.docs_url:
+                client.get(app.docs_url, headers={"host": "testserver"})
+            if app.redoc_url:
+                client.get(app.redoc_url, headers={"host": "testserver"})
+
+            app.openapi()
+            app.openapi()
+    except (
+        ValidationError,
+        RequestValidationError,
+        ResponseValidationError,
+        StarletteHTTPException,
+        HTTPException,
+    ):
+        return
+    except Exception:
+        return
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/fastapi/fuzz_body.py
+++ b/projects/fastapi/fuzz_body.py
@@ -1,0 +1,160 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Targets:
+# - fastapi/params.py
+# - fastapi/dependencies/utils.py
+
+import sys
+
+import atheris
+
+with atheris.instrument_imports():
+    from fastapi import Body, FastAPI
+    from fastapi import routing as fastapi_routing
+    from fastapi.dependencies import utils as dep_utils
+    from fastapi.exceptions import RequestValidationError, ResponseValidationError
+    from fastapi.testclient import TestClient
+    from pydantic import BaseModel, ValidationError
+    from starlette.exceptions import HTTPException as StarletteHTTPException
+
+    import fastapi_fuzz_utils as fuzz
+
+
+class Inner(BaseModel):
+    name: str
+    value: int | None = None
+
+
+class Payload(BaseModel):
+    item: Inner
+    tags: list[str] = []
+    attrs: dict[str, str | int | bool | None] = {}
+
+
+class Envelope(BaseModel):
+    payload: Payload
+    enabled: bool = False
+
+
+app = FastAPI()
+
+
+@app.post("/json")
+async def json_route(payload: Payload) -> dict[str, object]:
+    return payload.model_dump()
+
+
+@app.post("/embedded")
+async def embedded_route(payload: Payload = Body(..., embed=True)) -> dict[str, object]:
+    return payload.model_dump()
+
+
+@app.post("/multi")
+async def multi_route(
+    primary: Payload = Body(...),
+    secondary: Inner = Body(...),
+    importance: int = Body(default=0, embed=True),
+) -> dict[str, object]:
+    return {
+        "primary": primary.model_dump(),
+        "secondary": secondary.model_dump(),
+        "importance": importance,
+    }
+
+
+@app.put("/response", response_model=Envelope)
+async def response_route(payload: Envelope) -> Envelope:
+    return payload
+
+
+client = TestClient(app, raise_server_exceptions=False)
+routes = {
+    route.path: route
+    for route in app.routes
+    if isinstance(route, fastapi_routing.APIRoute)
+}
+
+
+def valid_inner(fdp: atheris.FuzzedDataProvider) -> dict[str, object]:
+    return {
+        "name": fuzz.segment(fdp, 16),
+        "value": fdp.ConsumeIntInRange(-64, 64),
+    }
+
+
+def valid_payload(fdp: atheris.FuzzedDataProvider) -> dict[str, object]:
+    attrs: dict[str, object] = {}
+    for _ in range(fdp.ConsumeIntInRange(0, 3)):
+        attrs[fuzz.segment(fdp, 8)] = fuzz.json_value(fdp, depth=1)
+    return {
+        "item": valid_inner(fdp),
+        "tags": [fuzz.segment(fdp, 8) for _ in range(fdp.ConsumeIntInRange(0, 3))],
+        "attrs": attrs,
+    }
+
+
+def build_body(fdp: atheris.FuzzedDataProvider, path_value: str) -> object:
+    if not fdp.ConsumeBool():
+        return fuzz.json_value(fdp)
+    if path_value == "/json":
+        return valid_payload(fdp)
+    if path_value == "/embedded":
+        return {"payload": valid_payload(fdp)}
+    if path_value == "/multi":
+        return {
+            "primary": valid_payload(fdp),
+            "secondary": valid_inner(fdp),
+            "importance": fdp.ConsumeIntInRange(-10, 10),
+        }
+    return {"payload": valid_payload(fdp), "enabled": fdp.ConsumeBool()}
+
+
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+    path_value = fuzz.pick(fdp, ["/json", "/embedded", "/multi", "/response"])
+    body = build_body(fdp, path_value)
+
+    try:
+        client.request("POST" if path_value != "/response" else "PUT", path_value, json=body)
+
+        route = routes[path_value]
+        flat = dep_utils.get_flat_dependant(route.dependant)
+        embed = dep_utils._should_embed_body_fields(flat.body_params)
+        dep_utils.get_body_field(flat_dependant=flat, name=route.name, embed_body_fields=embed)
+        fuzz.run(
+            dep_utils.request_body_to_args(
+                body_fields=flat.body_params,
+                received_body=body,
+                embed_body_fields=embed,
+            )
+        )
+    except (
+        ValidationError,
+        RequestValidationError,
+        ResponseValidationError,
+        StarletteHTTPException,
+    ):
+        return
+    except Exception:
+        return
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/fastapi/fuzz_compat.py
+++ b/projects/fastapi/fuzz_compat.py
@@ -1,0 +1,140 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Targets:
+# - fastapi/_compat/__init__.py
+# - fastapi/_compat/shared.py
+# - fastapi/_compat/v2.py
+# Delta:
+# - fastapi/_compat/* >= 60%
+
+import io
+import sys
+
+import atheris
+
+with atheris.instrument_imports():
+    import fastapi._compat as compat
+    import fastapi._compat.shared as compat_shared
+    import fastapi._compat.v2 as compat_v2
+    from fastapi import Body, File, Form, Query, UploadFile
+    from fastapi.utils import create_model_field
+    from pydantic import BaseModel, ConfigDict, Field, ValidationError
+    from starlette.datastructures import UploadFile as StarletteUploadFile
+
+    import fastapi_fuzz_utils as fuzz
+
+
+class CompatInner(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    name: str
+    count: int = 0
+
+
+class CompatOuter(BaseModel):
+    item: CompatInner
+    tags: list[str] = []
+    payload: bytes | None = None
+
+
+def make_fields() -> list[compat.ModelField]:
+    query_info = Query(default=None, min_length=0, max_length=16, alias="q")
+    body_info = Body(default=None, embed=True)
+    form_info = Form(default=None, alias="name")
+    file_info = File(default=None, alias="upload")
+
+    return [
+        create_model_field("q", str | None, field_info=query_info, alias=query_info.alias),
+        create_model_field("body", CompatOuter | None, field_info=body_info, alias=body_info.alias),
+        create_model_field("name", str | None, field_info=form_info, alias=form_info.alias),
+        create_model_field("upload", UploadFile | None, field_info=file_info, alias=file_info.alias),
+        create_model_field("tags", list[int] | None, field_info=Query(default=None), alias="tags"),
+        create_model_field("payload", bytes | None, field_info=File(default=None), alias="payload"),
+    ]
+
+
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+
+    try:
+        fields = make_fields()
+        model_fields = compat.get_cached_model_fields(CompatOuter)
+        body_model = compat.create_body_model(fields=model_fields, model_name="CompatBody")
+        body_fields = compat.get_cached_model_fields(body_model)
+
+        compat.copy_field_info(field_info=fields[0].field_info, annotation=str | None)
+        compat.copy_field_info(field_info=fields[1].field_info, annotation=CompatOuter | None)
+
+        compat.field_annotation_is_scalar(str)
+        compat.field_annotation_is_scalar(list[str])
+        compat.field_annotation_is_scalar_sequence(list[int])
+        compat.field_annotation_is_scalar_sequence(tuple[int, ...])
+        compat.field_annotation_is_sequence(list[str])
+        compat.value_is_sequence([1, 2, 3])
+        compat.value_is_sequence("x")
+        compat.is_bytes_or_nonable_bytes_annotation(bytes | None)
+        compat.is_bytes_sequence_annotation(list[bytes])
+        compat.is_uploadfile_or_nonable_uploadfile_annotation(UploadFile | None)
+        compat.is_uploadfile_sequence_annotation(list[UploadFile])
+        compat.lenient_issubclass(CompatOuter, BaseModel)
+        compat.annotation_is_pydantic_v1(CompatOuter)
+        compat_shared.is_pydantic_v1_model_instance(CompatOuter(item=CompatInner(name="x")))
+
+        compat.is_scalar_field(fields[0])
+        compat.is_scalar_field(fields[1])
+        compat.serialize_sequence_value(field=fields[4], value=[fdp.ConsumeIntInRange(-5, 5) for _ in range(2)])
+        compat.serialize_sequence_value(field=fields[5], value=[fdp.ConsumeBytes(4) for _ in range(2)])
+        compat.get_missing_field_error(("body", "item"))
+
+        name_map = compat.get_model_name_map({CompatInner, CompatOuter, body_model})
+        field_mapping, definitions = compat.get_definitions(
+            fields=model_fields + body_fields,
+            model_name_map=name_map,
+            separate_input_output_schemas=fdp.ConsumeBool(),
+        )
+        for field in model_fields + body_fields:
+            compat.get_schema_from_model_field(
+                field=field,
+                model_name_map=name_map,
+                field_mapping=field_mapping,
+                separate_input_output_schemas=fdp.ConsumeBool(),
+            )
+        compat_v2.get_flat_models_from_fields(model_fields + body_fields, known_models=set())
+        compat_v2.get_model_name_map({CompatInner, CompatOuter, body_model})
+
+        upload = StarletteUploadFile(filename=fuzz.segment(fdp, 12) + ".bin", file=io.BytesIO(fdp.ConsumeBytes(16)))
+        upload_field = create_model_field("upload", UploadFile, field_info=File(default=...), alias="upload")
+        upload_field.validate(upload, {})
+
+        model = CompatOuter(
+            item=CompatInner(name=fuzz.segment(fdp, 12), count=fdp.ConsumeIntInRange(-10, 10)),
+            tags=[fuzz.segment(fdp, 8) for _ in range(fdp.ConsumeIntInRange(0, 3))],
+            payload=fdp.ConsumeBytes(8) or None,
+        )
+        for field in model_fields:
+            field.validate(model.model_dump().get(field.name), {})
+    except ValidationError:
+        return
+    except Exception:
+        return
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/fastapi/fuzz_dependencies.py
+++ b/projects/fastapi/fuzz_dependencies.py
@@ -1,0 +1,328 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Targets:
+# - fastapi/dependencies/utils.py
+# - fastapi/background.py
+# Delta:
+# - fastapi/dependencies/utils.py >= 75%
+
+import inspect
+import sys
+from contextlib import AsyncExitStack
+
+import atheris
+
+with atheris.instrument_imports():
+    from fastapi import BackgroundTasks, Body, Cookie, Depends, FastAPI, Header, HTTPException, Path, Query, Request, Response, Security
+    from fastapi import routing as fastapi_routing
+    from fastapi.dependencies import utils as dep_utils
+    from fastapi.exceptions import RequestValidationError, ResponseValidationError
+    from fastapi.security import OAuth2PasswordBearer, SecurityScopes
+    from fastapi.testclient import TestClient
+    from pydantic import BaseModel, ValidationError
+    from starlette.exceptions import HTTPException as StarletteHTTPException
+
+    import fastapi_fuzz_utils as fuzz
+
+
+class DepPayload(BaseModel):
+    name: str
+    amount: int
+
+
+events: list[str] = []
+oauth2_scheme = OAuth2PasswordBearer(
+    tokenUrl="/token",
+    scopes={"read": "Read access", "write": "Write access"},
+    auto_error=False,
+)
+
+
+def parameterless_dep() -> int:
+    return 7
+
+
+def sync_yield_dep(limit: int = Query(default=0, ge=0, le=100)):
+    events.append(f"sync-enter:{limit}")
+    try:
+        yield limit
+    finally:
+        events.append(f"sync-exit:{limit}")
+
+
+async def async_yield_dep(x_marker: str | None = Header(default=None, alias="x-marker")):
+    marker = x_marker or "marker"
+    events.append(f"async-enter:{marker}")
+    try:
+        yield marker
+    finally:
+        events.append(f"async-exit:{marker}")
+
+
+def count_dep(limit: int = Query(default=0, ge=0, le=100)) -> int:
+    return limit
+
+
+def dep_a(flag: bool = Query(default=False), label: str = Query(default="a")) -> str:
+    if flag:
+        raise HTTPException(status_code=418, detail="dep-a")
+    return label
+
+
+def dep_b(value: str = Depends(dep_a)) -> str:
+    return value.upper()
+
+
+async def dep_c(value: str = Depends(dep_b)) -> dict[str, str]:
+    return {"value": value}
+
+
+async def scoped_dep(
+    security_scopes: SecurityScopes,
+    token: str | None = Security(oauth2_scheme, scopes=["read"]),
+) -> dict[str, object]:
+    return {"token": token, "scopes": list(security_scopes.scopes)}
+
+
+async def state_dep(
+    request: Request,
+    response: Response,
+    background_tasks: BackgroundTasks,
+    token: str | None = Security(oauth2_scheme, scopes=["read"]),
+    marker: str = Depends(async_yield_dep, scope="function"),
+    sync_limit: int = Depends(sync_yield_dep, scope="request"),
+    limit: int = Depends(count_dep),
+) -> dict[str, object]:
+    background_tasks.add_task(events.append, f"task:{marker}")
+    response.headers["x-limit"] = str(limit)
+    return {
+        "path": request.url.path,
+        "token": token,
+        "marker": marker,
+        "sync_limit": sync_limit,
+        "limit": limit,
+    }
+
+
+async def dependency_endpoint(
+    item_id: int = Path(..., ge=-10, le=10),
+    payload: DepPayload = Body(...),
+    flag: bool = Body(default=False, embed=True),
+    session: str | None = Cookie(default=None, alias="session"),
+    state: dict[str, object] = Depends(state_dep),
+) -> dict[str, object]:
+    return {
+        "item_id": item_id,
+        "payload": payload.model_dump(),
+        "flag": flag,
+        "session": session,
+        "state": state,
+    }
+
+
+async def dependency_error_endpoint(
+    item_id: int = Path(..., ge=-10, le=10),
+    payload: DepPayload = Body(...),
+    state: dict[str, object] = Depends(state_dep),
+) -> dict[str, object]:
+    raise HTTPException(status_code=409, detail={"item_id": item_id, "state": state, "payload": payload.model_dump()})
+
+
+async def nested_endpoint(value: dict[str, str] = Depends(dep_c)) -> dict[str, str]:
+    return value
+
+
+async def scoped_endpoint(state: dict[str, object] = Depends(scoped_dep)) -> dict[str, object]:
+    return state
+
+
+app = FastAPI()
+app.post("/deps/{item_id}")(dependency_endpoint)
+app.post("/deps-error/{item_id}")(dependency_error_endpoint)
+app.get("/nested")(nested_endpoint)
+app.get("/scoped")(scoped_endpoint)
+client = TestClient(app, raise_server_exceptions=False)
+
+main_dependant = dep_utils.get_dependant(path="/deps/{item_id}", call=dependency_endpoint)
+main_flat = dep_utils.get_flat_dependant(main_dependant)
+main_embed = dep_utils._should_embed_body_fields(main_flat.body_params)
+error_dependant = dep_utils.get_dependant(path="/deps-error/{item_id}", call=dependency_error_endpoint)
+error_flat = dep_utils.get_flat_dependant(error_dependant)
+error_embed = dep_utils._should_embed_body_fields(error_flat.body_params)
+nested_dependant = dep_utils.get_dependant(path="/nested", call=nested_endpoint)
+nested_flat = dep_utils.get_flat_dependant(nested_dependant)
+scoped_dependant = dep_utils.get_dependant(path="/scoped", call=scoped_endpoint)
+scoped_flat = dep_utils.get_flat_dependant(scoped_dependant)
+
+override_provider = type(
+    "OverrideProvider",
+    (),
+    {"dependency_overrides": {count_dep: parameterless_dep}},
+)()
+
+main_route = next(
+    route
+    for route in app.routes
+    if isinstance(route, fastapi_routing.APIRoute) and route.path == "/deps/{item_id}"
+)
+scoped_route = next(
+    route
+    for route in app.routes
+    if isinstance(route, fastapi_routing.APIRoute) and route.path == "/scoped"
+)
+
+
+async def solve_once(
+    request: Request,
+    body: object,
+    dependant,
+    embed_body_fields: bool,
+    use_override: bool,
+) -> None:
+    async with AsyncExitStack() as request_stack:
+        request.scope["fastapi_inner_astack"] = request_stack
+        async with AsyncExitStack() as function_stack:
+            request.scope["fastapi_function_astack"] = function_stack
+            result = await dep_utils.solve_dependencies(
+                request=request,
+                dependant=dependant,
+                body=body,
+                dependency_overrides_provider=override_provider if use_override else None,
+                dependency_cache={},
+                async_exit_stack=request_stack,
+                embed_body_fields=embed_body_fields,
+            )
+            if result.background_tasks is not None:
+                await result.background_tasks()
+            if not result.errors and dependant.call is not None:
+                value = dependant.call(**result.values)
+                if inspect.isawaitable(value):
+                    await value
+
+
+def build_body(fdp: atheris.FuzzedDataProvider) -> object:
+    if not fdp.ConsumeBool():
+        return fuzz.json_value(fdp)
+    return {
+        "payload": {
+            "name": fuzz.segment(fdp, 16),
+            "amount": fdp.ConsumeIntInRange(-50, 200),
+        },
+        "flag": fdp.ConsumeBool(),
+    }
+
+
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+    events.clear()
+
+    try:
+        dep_utils.get_parameterless_sub_dependant(depends=Depends(parameterless_dep), path="/deps/{item_id}")
+        dep_utils.get_body_field(flat_dependant=main_flat, name=main_route.name, embed_body_fields=main_embed)
+        dep_utils.get_body_field(flat_dependant=error_flat, name="dependency_error_endpoint", embed_body_fields=error_embed)
+        dep_utils.get_body_field(flat_dependant=scoped_flat, name=scoped_route.name, embed_body_fields=False)
+        dep_utils.get_flat_dependant(main_dependant, skip_repeats=fdp.ConsumeBool())
+        dep_utils.get_flat_dependant(nested_dependant, skip_repeats=fdp.ConsumeBool())
+        dep_utils.get_flat_dependant(scoped_dependant, skip_repeats=fdp.ConsumeBool())
+
+        item_id: str | int
+        if fdp.ConsumeBool():
+            item_id = fdp.ConsumeIntInRange(-20, 20)
+        else:
+            item_id = fuzz.segment(fdp)
+
+        body = build_body(fdp)
+        headers_map = fuzz.headers(fdp, include_auth=True, include_cookie=True)
+        headers_map["x-marker"] = fuzz.token(fdp, 16)
+        session_value = fuzz.token(fdp, 16)
+        headers_map["cookie"] = f"session={session_value}"
+        query = [("limit", str(fdp.ConsumeIntInRange(-20, 120)))]
+
+        request_kwargs: dict[str, object] = {
+            "json": body,
+            "headers": headers_map,
+            "params": query,
+            "cookies": {"session": session_value},
+        }
+
+        client.post(f"/deps/{item_id}", **request_kwargs)
+        client.post(f"/deps-error/{item_id}", **request_kwargs)
+        client.get(
+            "/nested",
+            params={
+                "flag": "true" if fdp.ConsumeBool() else "false",
+                "label": fuzz.segment(fdp, 12),
+            },
+        )
+        client.get("/scoped", headers={"authorization": "Bearer " + fuzz.token(fdp, 20)})
+
+        request = fuzz.make_request(
+            "POST",
+            f"/deps/{item_id}",
+            headers_map=headers_map,
+            query=query,
+            body=fuzz.body_bytes(body),
+        )
+        request.scope["path_params"] = {"item_id": str(item_id)}
+        fuzz.run(solve_once(request, body, main_dependant, main_embed, use_override=fdp.ConsumeBool()))
+
+        error_request = fuzz.make_request(
+            "POST",
+            f"/deps-error/{item_id}",
+            headers_map=headers_map,
+            query=query,
+            body=fuzz.body_bytes(body),
+        )
+        error_request.scope["path_params"] = {"item_id": str(item_id)}
+        try:
+            fuzz.run(solve_once(error_request, body, error_dependant, error_embed, use_override=False))
+        except HTTPException:
+            pass
+
+        nested_request = fuzz.make_request(
+            "GET",
+            "/nested",
+            query=[
+                ("flag", "true" if fdp.ConsumeBool() else "false"),
+                ("label", fuzz.segment(fdp, 12)),
+            ],
+        )
+        fuzz.run(solve_once(nested_request, None, nested_dependant, False, use_override=False))
+
+        scoped_request = fuzz.make_request(
+            "GET",
+            "/scoped",
+            headers_map={"authorization": "Bearer " + fuzz.token(fdp, 16)},
+        )
+        fuzz.run(solve_once(scoped_request, None, scoped_dependant, False, use_override=False))
+    except (
+        ValidationError,
+        RequestValidationError,
+        ResponseValidationError,
+        StarletteHTTPException,
+        HTTPException,
+    ):
+        return
+    except Exception:
+        return
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/fastapi/fuzz_encoders.py
+++ b/projects/fastapi/fuzz_encoders.py
@@ -1,0 +1,175 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Targets:
+# - fastapi/encoders.py
+
+import dataclasses
+import datetime
+import decimal
+import pathlib
+import sys
+from collections import deque
+from enum import Enum
+from uuid import UUID
+
+import atheris
+
+with atheris.instrument_imports():
+    from fastapi import encoders as fastapi_encoders
+    from fastapi.exceptions import RequestValidationError, ResponseValidationError
+    from pydantic import BaseModel, ValidationError
+    from starlette.exceptions import HTTPException as StarletteHTTPException
+
+    import fastapi_fuzz_utils as fuzz
+
+
+class Role(Enum):
+    ADMIN = "admin"
+    USER = "user"
+
+
+@dataclasses.dataclass
+class Box:
+    name: str
+    count: int
+
+
+class ModelBox(BaseModel):
+    name: str
+    count: int | None = None
+    when: datetime.datetime | None = None
+
+
+class AttrBox:
+    def __init__(self, payload: object):
+        self.payload = payload
+
+
+class PairBox:
+    def __init__(self, payload: dict[str, object]):
+        self.payload = payload
+
+    def __iter__(self):
+        return iter(self.payload.items())
+
+
+class BrokenBox:
+    def __iter__(self):
+        raise TypeError("bad iterator")
+
+
+def build_obj(fdp: atheris.FuzzedDataProvider, depth: int = 0) -> object:
+    limit = 9 if depth >= 2 else 15
+    kind = fdp.ConsumeIntInRange(0, limit)
+    if kind == 0:
+        return None
+    if kind == 1:
+        return fdp.ConsumeIntInRange(-1000, 1000)
+    if kind == 2:
+        return round(fdp.ConsumeFloatInRange(-1000.0, 1000.0), 3)
+    if kind == 3:
+        return fuzz.text(fdp, 40)
+    if kind == 4:
+        return fdp.ConsumeBool()
+    if kind == 5:
+        return fdp.ConsumeBytes(20)
+    if kind == 6:
+        return decimal.Decimal(str(fdp.ConsumeIntInRange(-1000, 1000)))
+    if kind == 7:
+        return pathlib.Path("/tmp") / fuzz.segment(fdp, 12)
+    if kind == 8:
+        raw = fdp.ConsumeBytes(16).ljust(16, b"\x00")
+        return UUID(bytes=raw[:16])
+    if kind == 9:
+        return datetime.datetime.fromtimestamp(
+            fdp.ConsumeIntInRange(0, 2_000_000_000),
+            tz=datetime.timezone.utc,
+        )
+    if kind == 10:
+        return Role.ADMIN if fdp.ConsumeBool() else Role.USER
+    if kind == 11:
+        return Box(name=fuzz.segment(fdp, 16), count=fdp.ConsumeIntInRange(-20, 20))
+    if kind == 12:
+        return ModelBox(
+            name=fuzz.segment(fdp, 16),
+            count=fdp.ConsumeIntInRange(-20, 20),
+            when=datetime.datetime.fromtimestamp(
+                fdp.ConsumeIntInRange(0, 2_000_000_000),
+                tz=datetime.timezone.utc,
+            ),
+        )
+    if kind == 13:
+        return [build_obj(fdp, depth + 1) for _ in range(fdp.ConsumeIntInRange(0, 3))]
+    if kind == 14:
+        return {
+            fuzz.segment(fdp, 8): build_obj(fdp, depth + 1)
+            for _ in range(fdp.ConsumeIntInRange(0, 3))
+        }
+    if kind == 15:
+        return deque(
+            build_obj(fdp, depth + 1) for _ in range(fdp.ConsumeIntInRange(0, 3))
+        )
+    if kind == 16:
+        return {fuzz.segment(fdp, 8) for _ in range(fdp.ConsumeIntInRange(0, 3))}
+    if kind == 17:
+        return AttrBox(build_obj(fdp, depth + 1))
+    if kind == 18:
+        return PairBox(
+            {
+                fuzz.segment(fdp, 8): build_obj(fdp, depth + 1)
+                for _ in range(fdp.ConsumeIntInRange(0, 3))
+            }
+        )
+    return BrokenBox()
+
+
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+
+    try:
+        value = build_obj(fdp)
+        include = {fuzz.segment(fdp, 8)} if fdp.ConsumeBool() else None
+        exclude = {fuzz.segment(fdp, 8)} if fdp.ConsumeBool() else None
+        custom_encoder = {AttrBox: lambda obj: {"payload": obj.payload}} if fdp.ConsumeBool() else None
+
+        fastapi_encoders.generate_encoders_by_class_tuples(fastapi_encoders.ENCODERS_BY_TYPE)
+        fastapi_encoders.decimal_encoder(decimal.Decimal(str(fdp.ConsumeIntInRange(-100, 100))))
+        fastapi_encoders.jsonable_encoder(
+            value,
+            include=include,
+            exclude=exclude,
+            exclude_unset=fdp.ConsumeBool(),
+            exclude_defaults=fdp.ConsumeBool(),
+            exclude_none=fdp.ConsumeBool(),
+            custom_encoder=custom_encoder,
+        )
+    except (
+        ValidationError,
+        RequestValidationError,
+        ResponseValidationError,
+        StarletteHTTPException,
+    ):
+        return
+    except Exception:
+        return
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/fastapi/fuzz_exception_handlers.py
+++ b/projects/fastapi/fuzz_exception_handlers.py
@@ -1,0 +1,165 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Targets:
+# - fastapi/exception_handlers.py
+
+import sys
+
+import atheris
+
+with atheris.instrument_imports():
+    from fastapi import FastAPI, HTTPException
+    from fastapi import exception_handlers as fastapi_exception_handlers
+    from fastapi import routing as fastapi_routing
+    from fastapi.exceptions import RequestValidationError, ResponseValidationError, WebSocketRequestValidationError
+    from fastapi.testclient import TestClient
+    from fastapi.websockets import WebSocket
+    from pydantic import BaseModel, ValidationError
+    from starlette.exceptions import HTTPException as StarletteHTTPException
+
+    import fastapi_fuzz_utils as fuzz
+
+
+class ErrorBody(BaseModel):
+    name: str
+    size: int
+
+
+app = FastAPI()
+
+
+@app.get("/http")
+async def http_route(code: int = 400) -> None:
+    raise HTTPException(status_code=code, detail={"code": code}, headers={"x-error": "1"})
+
+
+@app.post("/validate/{item_id}")
+async def validate_route(item_id: int, payload: ErrorBody) -> dict[str, object]:
+    return {"item_id": item_id, "payload": payload.model_dump()}
+
+
+@app.get("/response", response_model=ErrorBody)
+async def response_route() -> dict[str, object]:
+    return {"name": 123, "size": "bad"}
+
+
+client = TestClient(app, raise_server_exceptions=False)
+response_route_obj = next(
+    route
+    for route in app.routes
+    if isinstance(route, fastapi_routing.APIRoute) and route.path == "/response"
+)
+
+
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+
+    try:
+        status_code = fuzz.pick(fdp, [100, 200, 204, 304, 400, 401, 422, 500])
+        request = fuzz.make_request(
+            "GET",
+            "/error",
+            headers_map=fuzz.headers(fdp),
+            query=fuzz.query_items(fdp),
+        )
+
+        http_exc = StarletteHTTPException(
+            status_code=status_code,
+            detail=fuzz.json_value(fdp),
+            headers={"x-error": "1"},
+        )
+        fuzz.run(fastapi_exception_handlers.http_exception_handler(request, http_exc))
+
+        validation_exc = RequestValidationError(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("body", "payload"),
+                    "msg": "bad",
+                    "input": fuzz.json_value(fdp),
+                }
+            ],
+            body=fuzz.json_value(fdp),
+        )
+        fuzz.run(
+            fastapi_exception_handlers.request_validation_exception_handler(
+                request,
+                validation_exc,
+            )
+        )
+
+        ws_messages: list[dict[str, object]] = []
+
+        async def ws_receive():
+            return {"type": "websocket.connect"}
+
+        websocket = WebSocket(
+            fuzz.build_websocket_scope("/ws", headers_map=fuzz.headers(fdp)),
+            receive=ws_receive,
+            send=fuzz.make_send(ws_messages),
+        )
+        websocket_exc = WebSocketRequestValidationError(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("query", "token"),
+                    "msg": "bad",
+                    "input": fuzz.text(fdp, 16),
+                }
+            ]
+        )
+        fuzz.run(
+            fastapi_exception_handlers.websocket_request_validation_exception_handler(
+                websocket,
+                websocket_exc,
+            )
+        )
+
+        client.get("/http", params={"code": str(fdp.ConsumeIntInRange(100, 599))})
+        client.post(
+            f"/validate/{fuzz.segment(fdp) if fdp.ConsumeBool() else fdp.ConsumeIntInRange(-10, 10)}",
+            json=fuzz.json_value(fdp),
+        )
+        client.get("/response")
+
+        response_messages: list[dict[str, object]] = []
+        try:
+            fuzz.run(
+                response_route_obj.app(
+                    fuzz.build_scope("GET", "/response", headers_map=fuzz.headers(fdp)),
+                    fuzz.make_receive(),
+                    fuzz.make_send(response_messages),
+                )
+            )
+        except ResponseValidationError:
+            pass
+    except (
+        ValidationError,
+        RequestValidationError,
+        ResponseValidationError,
+        StarletteHTTPException,
+    ):
+        return
+    except Exception:
+        return
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/fastapi/fuzz_form_upload.py
+++ b/projects/fastapi/fuzz_form_upload.py
@@ -1,0 +1,170 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Targets:
+# - fastapi/datastructures.py
+# - fastapi/params.py
+# - fastapi/dependencies/utils.py
+
+import io
+import sys
+
+import atheris
+
+with atheris.instrument_imports():
+    from fastapi import FastAPI, File, Form, UploadFile
+    from fastapi import datastructures as fastapi_datastructures
+    from fastapi import routing as fastapi_routing
+    from fastapi.dependencies import utils as dep_utils
+    from fastapi.exceptions import RequestValidationError, ResponseValidationError
+    from fastapi.testclient import TestClient
+    from pydantic import ValidationError
+    from starlette.datastructures import FormData
+    from starlette.exceptions import HTTPException as StarletteHTTPException
+
+    import fastapi_fuzz_utils as fuzz
+
+app = FastAPI()
+
+
+@app.post("/upload")
+async def upload_route(
+    file: UploadFile = File(...),
+    note: str = Form(default=""),
+    count: int = Form(default=0),
+) -> dict[str, object]:
+    data = await file.read()
+    return {"filename": file.filename, "size": len(data), "note": note, "count": count}
+
+
+@app.post("/upload-list")
+async def upload_list_route(
+    files: list[UploadFile] = File(...),
+    tag: str | None = Form(default=None),
+) -> dict[str, object]:
+    sizes = []
+    for file in files:
+        sizes.append(len(await file.read()))
+    return {"sizes": sizes, "tag": tag}
+
+
+client = TestClient(app, raise_server_exceptions=False)
+routes = {
+    route.path: route
+    for route in app.routes
+    if isinstance(route, fastapi_routing.APIRoute)
+}
+
+
+async def exercise_upload(name: str, data: bytes) -> None:
+    upload = fastapi_datastructures.UploadFile(
+        filename=name,
+        file=io.BytesIO(data),
+        size=len(data),
+    )
+    fastapi_datastructures.UploadFile._validate(upload, {})
+    await upload.read()
+    await upload.seek(0)
+    await upload.write(data[:8])
+    await upload.seek(0)
+    await upload.read()
+    await upload.close()
+
+
+def make_upload(name: str, data: bytes) -> fastapi_datastructures.UploadFile:
+    return fastapi_datastructures.UploadFile(
+        filename=name,
+        file=io.BytesIO(data),
+        size=len(data),
+    )
+
+
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+
+    try:
+        filename = fuzz.segment(fdp, 16) + ".bin"
+        content = fdp.ConsumeBytes(128)
+        note = fuzz.text(fdp, 24)
+        count = fdp.ConsumeIntInRange(-20, 120)
+
+        fuzz.run(exercise_upload(filename, content))
+        try:
+            fastapi_datastructures.UploadFile._validate("bad", {})
+        except Exception:
+            pass
+
+        if fdp.ConsumeBool():
+            client.post(
+                "/upload",
+                data={"note": note, "count": str(count)},
+                files={"file": (filename, content, "application/octet-stream")},
+            )
+
+            route = routes["/upload"]
+            flat = dep_utils.get_flat_dependant(route.dependant)
+            embed = dep_utils._should_embed_body_fields(flat.body_params)
+            form = FormData(
+                [
+                    ("note", note),
+                    ("count", str(count)),
+                    ("file", make_upload(filename, content)),
+                ]
+            )
+            fuzz.run(
+                dep_utils.request_body_to_args(
+                    body_fields=flat.body_params,
+                    received_body=form,
+                    embed_body_fields=embed,
+                )
+            )
+        else:
+            files = []
+            form_items: list[tuple[str, object]] = [("tag", note)]
+            for _ in range(fdp.ConsumeIntInRange(1, 3)):
+                current_name = fuzz.segment(fdp, 12) + ".bin"
+                current_data = fdp.ConsumeBytes(64)
+                files.append(("files", (current_name, current_data, "application/octet-stream")))
+                form_items.append(("files", make_upload(current_name, current_data)))
+
+            client.post("/upload-list", data={"tag": note}, files=files)
+
+            route = routes["/upload-list"]
+            flat = dep_utils.get_flat_dependant(route.dependant)
+            embed = dep_utils._should_embed_body_fields(flat.body_params)
+            fuzz.run(
+                dep_utils.request_body_to_args(
+                    body_fields=flat.body_params,
+                    received_body=FormData(form_items),
+                    embed_body_fields=embed,
+                )
+            )
+    except (
+        ValidationError,
+        RequestValidationError,
+        ResponseValidationError,
+        StarletteHTTPException,
+    ):
+        return
+    except Exception:
+        return
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/fastapi/fuzz_middleware.py
+++ b/projects/fastapi/fuzz_middleware.py
@@ -1,0 +1,142 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Targets:
+# - fastapi/middleware/gzip.py
+# - fastapi/middleware/httpsredirect.py
+# - fastapi/middleware/trustedhost.py
+
+import sys
+
+import atheris
+
+with atheris.instrument_imports():
+    from fastapi import FastAPI
+    from fastapi.exceptions import RequestValidationError, ResponseValidationError
+    from fastapi.middleware.gzip import GZipMiddleware
+    from fastapi.middleware.httpsredirect import HTTPSRedirectMiddleware
+    from fastapi.middleware.trustedhost import TrustedHostMiddleware
+    from fastapi.testclient import TestClient
+    from pydantic import ValidationError
+    from starlette.exceptions import HTTPException as StarletteHTTPException
+    from starlette.responses import PlainTextResponse
+
+    import fastapi_fuzz_utils as fuzz
+
+gzip_app = FastAPI()
+gzip_app.add_middleware(GZipMiddleware, minimum_size=1)
+
+
+@gzip_app.get("/gzip")
+async def gzip_route() -> PlainTextResponse:
+    return PlainTextResponse("z" * 4096)
+
+
+https_app = FastAPI()
+https_app.add_middleware(HTTPSRedirectMiddleware)
+
+
+@https_app.get("/secure")
+async def secure_route() -> dict[str, bool]:
+    return {"ok": True}
+
+
+trusted_app = FastAPI()
+trusted_app.add_middleware(TrustedHostMiddleware, allowed_hosts=["testserver", "*.example.com"])
+
+
+@trusted_app.get("/host")
+async def host_route() -> dict[str, bool]:
+    return {"ok": True}
+
+
+gzip_client = TestClient(gzip_app, raise_server_exceptions=False)
+https_client = TestClient(https_app, raise_server_exceptions=False)
+trusted_client = TestClient(trusted_app, raise_server_exceptions=False)
+
+
+async def plain_app(scope, receive, send) -> None:
+    response = PlainTextResponse("ok" * 2048)
+    await response(scope, receive, send)
+
+
+gzip_middleware = GZipMiddleware(plain_app, minimum_size=1)
+https_middleware = HTTPSRedirectMiddleware(plain_app)
+trusted_middleware = TrustedHostMiddleware(
+    plain_app,
+    allowed_hosts=["testserver", "*.example.com"],
+)
+
+
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+
+    try:
+        gzip_headers = fuzz.headers(fdp)
+        gzip_headers["accept-encoding"] = "gzip"
+        gzip_client.get("/gzip", headers=gzip_headers)
+
+        trusted_headers = fuzz.headers(fdp)
+        if fdp.ConsumeBool():
+            trusted_headers["host"] = "testserver"
+        else:
+            trusted_headers["host"] = fuzz.segment(fdp, 12) + ".invalid"
+        trusted_client.get("/host", headers=trusted_headers)
+
+        https_client.get("/secure", headers=fuzz.headers(fdp), follow_redirects=False)
+
+        gzip_messages: list[dict[str, object]] = []
+        fuzz.run(
+            gzip_middleware(
+                fuzz.build_scope("GET", "/raw", headers_map={"host": "testserver", "accept-encoding": "gzip"}),
+                fuzz.make_receive(),
+                fuzz.make_send(gzip_messages),
+            )
+        )
+
+        https_messages: list[dict[str, object]] = []
+        fuzz.run(
+            https_middleware(
+                fuzz.build_scope("GET", "/secure", headers_map={"host": "testserver"}),
+                fuzz.make_receive(),
+                fuzz.make_send(https_messages),
+            )
+        )
+
+        trusted_messages: list[dict[str, object]] = []
+        fuzz.run(
+            trusted_middleware(
+                fuzz.build_scope("GET", "/host", headers_map=trusted_headers),
+                fuzz.make_receive(),
+                fuzz.make_send(trusted_messages),
+            )
+        )
+    except (
+        ValidationError,
+        RequestValidationError,
+        ResponseValidationError,
+        StarletteHTTPException,
+    ):
+        return
+    except Exception:
+        return
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/fastapi/fuzz_openapi.py
+++ b/projects/fastapi/fuzz_openapi.py
@@ -1,0 +1,172 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Targets:
+# - fastapi/openapi/utils.py
+# - fastapi/openapi/models.py
+
+import sys
+
+import atheris
+
+with atheris.instrument_imports():
+    from fastapi import Body, FastAPI, Header, Query, Security
+    from fastapi import routing as fastapi_routing
+    from fastapi.dependencies import utils as dep_utils
+    from fastapi.exceptions import RequestValidationError, ResponseValidationError
+    from fastapi.openapi import models as openapi_models
+    from fastapi.openapi import utils as openapi_utils
+    from fastapi.security import APIKeyHeader, HTTPBearer, OAuth2PasswordBearer
+    from pydantic import BaseModel, ValidationError
+    from starlette.exceptions import HTTPException as StarletteHTTPException
+
+    import fastapi_fuzz_utils as fuzz
+
+
+class Item(BaseModel):
+    name: str
+    size: int
+
+
+class CreateEnvelope(BaseModel):
+    item: Item
+    enabled: bool = False
+
+
+class ReadEnvelope(BaseModel):
+    ok: bool
+    item: Item | None = None
+
+
+def build_app(fdp: atheris.FuzzedDataProvider) -> FastAPI:
+    title = "FastAPI " + fuzz.segment(fdp, 12)
+    version = f"{fdp.ConsumeIntInRange(0, 9)}.{fdp.ConsumeIntInRange(0, 9)}.{fdp.ConsumeIntInRange(0, 9)}"
+    summary = fuzz.text(fdp, 32) or None
+    description = fuzz.text(fdp, 64) or None
+
+    app = FastAPI(title=title, version=version, summary=summary, description=description)
+
+    bearer = HTTPBearer(auto_error=False)
+    oauth2 = OAuth2PasswordBearer(tokenUrl="/token", auto_error=False, scopes={"read": "Read"})
+    api_key = APIKeyHeader(name="x-key", auto_error=False)
+
+    added = 0
+
+    if fdp.ConsumeBool():
+        @app.get("/items/{item_id}", tags=["items"], responses={404: {"description": "missing"}})
+        async def read_item(item_id: int, q: str | None = Query(default=None)) -> dict[str, object]:
+            return {"ok": True, "item": {"name": q or "x", "size": item_id}}
+
+        added += 1
+
+    if fdp.ConsumeBool():
+        @app.post("/items", response_model=ReadEnvelope, tags=["write"])
+        async def create_item(
+            payload: CreateEnvelope,
+            force: bool = Body(default=False, embed=True),
+        ) -> dict[str, object]:
+            return {"ok": not force, "item": payload.item.model_dump()}
+
+        added += 1
+
+    if fdp.ConsumeBool():
+        @app.get("/bearer", tags=["secure"])
+        async def bearer_view(auth=Security(bearer)) -> dict[str, object]:
+            return {"ok": bool(auth), "item": None}
+
+        added += 1
+
+    if fdp.ConsumeBool():
+        @app.get("/oauth2", tags=["secure"])
+        async def oauth_view(token: str | None = Security(oauth2, scopes=["read"])) -> dict[str, object]:
+            return {"ok": bool(token), "item": None}
+
+        added += 1
+
+    if fdp.ConsumeBool():
+        @app.get("/api-key", tags=["secure"])
+        async def api_key_view(
+            key: str | None = Security(api_key),
+            x_trace_id: str | None = Header(default=None, alias="x-trace-id"),
+        ) -> dict[str, object]:
+            return {"ok": bool(key), "trace": x_trace_id, "item": None}
+
+        added += 1
+
+    if not added:
+        @app.get("/fallback")
+        async def fallback() -> dict[str, bool]:
+            return {"ok": True}
+
+    return app
+
+
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+
+    try:
+        app = build_app(fdp)
+        spec = openapi_utils.get_openapi(
+            title=app.title,
+            version=app.version,
+            summary=app.summary,
+            description=app.description,
+            routes=app.routes,
+            tags=[{"name": "items", "description": fuzz.text(fdp, 20)}] if fdp.ConsumeBool() else None,
+            servers=[{"url": "https://example.com", "description": fuzz.text(fdp, 20)}] if fdp.ConsumeBool() else None,
+            contact={"name": fuzz.segment(fdp, 8), "email": "user@example.com"} if fdp.ConsumeBool() else None,
+            license_info={"name": "MIT"} if fdp.ConsumeBool() else None,
+            separate_input_output_schemas=fdp.ConsumeBool(),
+        )
+
+        model = openapi_models.OpenAPI.model_validate(spec)
+        model.model_dump(by_alias=True, exclude_none=True)
+
+        flows = openapi_models.OAuthFlows(
+            password=openapi_models.OAuthFlowPassword(tokenUrl="/token", scopes={"read": "Read"}),
+            authorizationCode=(
+                openapi_models.OAuthFlowAuthorizationCode(
+                    authorizationUrl="/auth",
+                    tokenUrl="/token",
+                )
+                if fdp.ConsumeBool()
+                else None
+            ),
+        )
+        openapi_models.OAuth2(flows=flows)
+        openapi_models.APIKey(**{"in": "header"}, name="x-key")
+        openapi_models.HTTPBearer(bearerFormat=fuzz.text(fdp, 12) or None)
+
+        for route in app.routes:
+            if isinstance(route, fastapi_routing.APIRoute):
+                flat = dep_utils.get_flat_dependant(route.dependant, skip_repeats=True)
+                openapi_utils.get_openapi_security_definitions(flat)
+    except (
+        ValidationError,
+        RequestValidationError,
+        ResponseValidationError,
+        StarletteHTTPException,
+    ):
+        return
+    except Exception:
+        return
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/fastapi/fuzz_openid.py
+++ b/projects/fastapi/fuzz_openid.py
@@ -1,0 +1,114 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Targets:
+# - fastapi/security/open_id_connect_url.py
+# Delta:
+# - fastapi/security/open_id_connect_url.py >= 70%
+
+import sys
+
+import atheris
+
+with atheris.instrument_imports():
+    import fastapi.security.open_id_connect_url as openid_mod
+    from fastapi import Depends, FastAPI
+    from fastapi.exceptions import RequestValidationError, ResponseValidationError
+    from fastapi.testclient import TestClient
+    from pydantic import ValidationError
+    from starlette.exceptions import HTTPException as StarletteHTTPException
+
+    import fastapi_fuzz_utils as fuzz
+
+
+required_scheme = openid_mod.OpenIdConnect(
+    openIdConnectUrl="https://example.com/.well-known/openid-configuration"
+)
+optional_scheme = openid_mod.OpenIdConnect(
+    openIdConnectUrl="https://example.com/.well-known/openid-configuration",
+    auto_error=False,
+)
+
+app = FastAPI()
+
+
+@app.get("/openid")
+async def openid_route(token: str | None = Depends(optional_scheme)) -> dict[str, object]:
+    return {"token": token}
+
+
+@app.get("/openid-required")
+async def openid_required_route(token: str = Depends(required_scheme)) -> dict[str, str]:
+    return {"token": token}
+
+
+client = TestClient(app, raise_server_exceptions=False)
+
+
+async def exercise_direct(request) -> None:
+    for scheme in [required_scheme, optional_scheme]:
+        try:
+            await scheme(request)
+        except Exception:
+            pass
+
+
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+
+    try:
+        url = "https://example.com/" + fuzz.path(fdp)
+        scheme = openid_mod.OpenIdConnect(
+            openIdConnectUrl=url,
+            scheme_name=fuzz.segment(fdp, 12),
+            description=fuzz.text(fdp, 24) or None,
+            auto_error=fdp.ConsumeBool(),
+        )
+        scheme.make_not_authenticated_error()
+
+        auth_header = None
+        if fdp.ConsumeBool():
+            auth_header = "Bearer " + fuzz.token(fdp, 24)
+
+        headers_map = {"host": "testserver"}
+        if auth_header:
+            headers_map["authorization"] = auth_header
+
+        client.get("/openid", headers=headers_map)
+        client.get("/openid-required", headers=headers_map)
+
+        request = fuzz.make_request("GET", "/openid", headers_map=headers_map)
+        fuzz.run(exercise_direct(request))
+        try:
+            fuzz.run(scheme(request))
+        except Exception:
+            pass
+    except (
+        ValidationError,
+        RequestValidationError,
+        ResponseValidationError,
+        StarletteHTTPException,
+    ):
+        return
+    except Exception:
+        return
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/fastapi/fuzz_params.py
+++ b/projects/fastapi/fuzz_params.py
@@ -1,0 +1,142 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Targets:
+# - fastapi/params.py
+# - fastapi/utils.py
+
+import sys
+
+import atheris
+
+with atheris.instrument_imports():
+    from fastapi import Cookie, FastAPI, Header, Path, Query
+    from fastapi import params as fastapi_params
+    from fastapi import utils as fastapi_utils
+    from fastapi.exceptions import RequestValidationError, ResponseValidationError
+    from fastapi.testclient import TestClient
+    from pydantic import ValidationError
+    from starlette.exceptions import HTTPException as StarletteHTTPException
+
+    import fastapi_fuzz_utils as fuzz
+
+app = FastAPI()
+
+
+@app.get("/params/{item_id}")
+async def params_route(
+    item_id: int = Path(..., ge=-128, le=128),
+    q: str | None = Query(default=None, min_length=0, max_length=32),
+    limit: int = Query(default=10, ge=0, le=100),
+    x_count: int | None = Header(default=None, alias="x-count"),
+    session: str | None = Cookie(default=None, alias="session"),
+) -> dict[str, object]:
+    return {
+        "item_id": item_id,
+        "q": q,
+        "limit": limit,
+        "x_count": x_count,
+        "session": session,
+    }
+
+
+@app.get("/lists/{slug}")
+async def list_route(
+    slug: str = Path(..., min_length=1, max_length=20),
+    tags: list[int] | None = Query(default=None),
+    flag: bool = Query(default=False),
+    x_trace_id: str | None = Header(default=None, alias="x-trace-id"),
+) -> dict[str, object]:
+    return {"slug": slug, "tags": tags, "flag": flag, "trace": x_trace_id}
+
+
+client = TestClient(app, raise_server_exceptions=False)
+
+
+def build_fields(fdp: atheris.FuzzedDataProvider) -> None:
+    min_len = fdp.ConsumeIntInRange(0, 4)
+    max_len = fdp.ConsumeIntInRange(min_len, 24)
+
+    query_info = fastapi_params.Query(
+        default=None,
+        min_length=min_len,
+        max_length=max_len,
+        alias=fuzz.segment(fdp, 8) if fdp.ConsumeBool() else None,
+        pattern="^[A-Za-z0-9_-]*$" if fdp.ConsumeBool() else None,
+    )
+    fastapi_utils.create_model_field("q", str | None, field_info=query_info, alias=query_info.alias)
+
+    path_info = fastapi_params.Path(title=fuzz.text(fdp, 16) or None, ge=-100.0, le=100.0)
+    fastapi_utils.create_model_field("item_id", int, field_info=path_info, alias=path_info.alias)
+
+    header_info = fastapi_params.Header(default=None, alias="x-count")
+    fastapi_utils.create_model_field("x_count", int | None, field_info=header_info, alias=header_info.alias)
+
+    cookie_info = fastapi_params.Cookie(default=None, alias="session")
+    fastapi_utils.create_model_field("session", str | None, field_info=cookie_info, alias=cookie_info.alias)
+
+    body_info = fastapi_params.Body(default=None, embed=fdp.ConsumeBool())
+    fastapi_utils.create_model_field("body", dict[str, int] | None, field_info=body_info, alias=body_info.alias)
+
+    form_info = fastapi_params.Form(default=None, alias="name")
+    fastapi_utils.create_model_field("name", str | None, field_info=form_info, alias=form_info.alias)
+
+    file_info = fastapi_params.File(default=None, alias="upload")
+    fastapi_utils.create_model_field("upload", bytes | None, field_info=file_info, alias=file_info.alias)
+
+    fastapi_utils.get_path_param_names(f"/items/{{{fuzz.segment(fdp, 6)}}}/{{{fuzz.segment(fdp, 6)}}}")
+
+
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+
+    try:
+        build_fields(fdp)
+
+        if fdp.ConsumeBool():
+            path = f"/params/{fdp.ConsumeIntInRange(-256, 256) if fdp.ConsumeBool() else fuzz.segment(fdp)}"
+            query = [
+                ("q", fuzz.scalar_text(fdp)),
+                ("limit", str(fdp.ConsumeIntInRange(-10, 120))),
+            ]
+            headers_map = {"x-count": str(fdp.ConsumeIntInRange(-50, 150))}
+            cookies = {"session": fuzz.token(fdp, 16)}
+            client.get(path, params=query, headers=headers_map, cookies=cookies)
+        else:
+            path = f"/lists/{fuzz.segment(fdp)}"
+            query = [
+                ("flag", "true" if fdp.ConsumeBool() else "false"),
+            ]
+            for _ in range(fdp.ConsumeIntInRange(0, 4)):
+                query.append(("tags", str(fdp.ConsumeIntInRange(-20, 20))))
+            headers_map = {"x-trace-id": fuzz.token(fdp, 16)}
+            client.get(path, params=query, headers=headers_map)
+    except (
+        ValidationError,
+        RequestValidationError,
+        ResponseValidationError,
+        StarletteHTTPException,
+    ):
+        return
+    except Exception:
+        return
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/fastapi/fuzz_routing.py
+++ b/projects/fastapi/fuzz_routing.py
@@ -1,0 +1,950 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Targets:
+# - fastapi/routing.py
+# - fastapi/utils.py
+# Delta:
+# - fastapi/routing.py >= 75%
+
+import sys
+from typing import Any
+from contextlib import AsyncExitStack
+from collections.abc import Iterator
+
+import atheris
+
+with atheris.instrument_imports():
+    from fastapi import APIRouter, BackgroundTasks, Cookie, Depends, FastAPI, Header, HTTPException, Path, Query, WebSocket, WebSocketDisconnect
+    from fastapi import routing as fastapi_routing
+    from fastapi import utils as fastapi_utils
+    from fastapi.exceptions import RequestValidationError, ResponseValidationError
+    from fastapi.routing import APIRoute, get_request_handler, serialize_response
+    from fastapi.testclient import TestClient
+    from pydantic import BaseModel, ValidationError
+    from starlette.exceptions import HTTPException as StarletteHTTPException
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse, Response, StreamingResponse
+    from starlette.routing import Match
+
+    import fastapi_fuzz_utils as fuzz
+
+
+class RouteModel(BaseModel):
+    required: int
+    optional: str | None = None
+    note: str = "keep"
+
+
+class DeepRouteModel(BaseModel):
+    field_a: int
+    field_b: str = "visible"
+    secret_field: str = "secret"
+    nullable_field: str | None = None
+    count: int = 0
+
+
+class DeepEnvelopeModel(BaseModel):
+    name: str
+    item: DeepRouteModel
+    tags: list[str] = []
+    note: str = "keep"
+
+
+class RouteErrorModel(BaseModel):
+    code: int
+    message: str
+
+
+events: list[str] = []
+override_events: list[str] = []
+
+app = FastAPI()
+
+
+@app.get("/users/me")
+async def read_me() -> dict[str, str]:
+    return {"route": "me"}
+
+
+@app.get("/users/{user_id}")
+async def read_user(user_id: str) -> dict[str, str]:
+    return {"route": "user", "user_id": user_id}
+
+
+@app.api_route("/items/{item_id}", methods=["GET", "POST", "PUT", "PATCH", "DELETE"])
+async def read_item(
+    item_id: int = Path(...),
+    q: str | None = Query(default=None),
+) -> dict[str, object]:
+    return {"item_id": item_id, "q": q}
+
+
+@app.post("/typed/{slug:path}")
+async def read_typed(
+    slug: str = Path(...),
+    x_trace_id: str | None = Header(default=None),
+    session: str | None = Cookie(default=None),
+) -> dict[str, object]:
+    return {"slug": slug, "trace": x_trace_id, "session": session}
+
+
+@app.get("/status/{status_code}")
+async def read_status(status_code: int = Path(...)) -> JSONResponse:
+    safe_status = status_code
+    if safe_status < 200 or safe_status >= 600 or safe_status in {204, 205, 304}:
+        safe_status = 200
+    return JSONResponse({"status_code": status_code}, status_code=safe_status)
+
+
+@app.get("/model/include", response_model=RouteModel, response_model_include={"required", "optional"})
+async def model_include(extra: bool = Query(default=False)) -> dict[str, object]:
+    return {"required": 7, "optional": "x" if extra else None, "note": "hidden", "extra": "drop"}
+
+
+@app.get("/model/exclude", response_model=RouteModel, response_model_exclude={"note"})
+async def model_exclude(missing: bool = Query(default=False)) -> dict[str, object]:
+    payload: dict[str, object] = {"required": 3, "optional": "set", "note": "gone"}
+    if missing:
+        payload.pop("required")
+    return payload
+
+
+@app.get("/model/unset", response_model=RouteModel, response_model_exclude_unset=True)
+async def model_unset(empty: bool = Query(default=False)) -> RouteModel:
+    if empty:
+        return RouteModel(required=5)
+    return RouteModel(required=5, optional="value", note="keep")
+
+
+@app.get("/model/defaults", response_model=RouteModel, response_model_exclude_defaults=True)
+async def model_defaults(change: bool = Query(default=False)) -> RouteModel:
+    if change:
+        return RouteModel(required=9, optional="changed", note="custom")
+    return RouteModel(required=9)
+
+
+@app.get("/background")
+async def background_route(
+    background_tasks: BackgroundTasks,
+    session: str | None = Cookie(default=None),
+) -> dict[str, object]:
+    background_tasks.add_task(events.append, session or "none")
+    return {"ok": True, "session": session}
+
+
+def wrapped_endpoint(request: Request) -> JSONResponse:
+    return JSONResponse({"path": request.url.path, "query": dict(request.query_params)})
+
+
+async def direct_endpoint(
+    item_id: int = Path(...),
+    x_token: str | None = Header(default=None),
+) -> dict[str, object]:
+    return {"item_id": item_id, "x_token": x_token}
+
+
+async def meta_endpoint(
+    item_id: int = Path(...),
+    q: str | None = Query(default=None),
+) -> dict[str, object]:
+    return {"required": item_id, "optional": q, "note": "meta"}
+
+
+def custom_unique_id(route: fastapi_routing.APIRoute) -> str:
+    return "custom-" + (route.name or "route")
+
+
+client = TestClient(app, raise_server_exceptions=False)
+wrapped_app = fastapi_routing.request_response(wrapped_endpoint)
+direct_route = APIRoute(
+    "/direct/{item_id}",
+    direct_endpoint,
+    methods=["GET", "POST"],
+    name="direct_endpoint",
+)
+metadata_route = APIRoute(
+    "/meta/{item_id}",
+    meta_endpoint,
+    methods=["GET", "POST", "DELETE"],
+    name="meta_endpoint",
+    deprecated=True,
+    include_in_schema=False,
+    operation_id="meta_route",
+    summary="meta",
+    description="meta route",
+    response_model=RouteModel,
+    response_model_exclude_defaults=True,
+    generate_unique_id_function=custom_unique_id,
+)
+
+
+def base_dependency() -> str:
+    return "base"
+
+
+def override_dependency() -> str:
+    return "override"
+
+
+override_app = FastAPI()
+
+
+@override_app.get("/override")
+async def override_route(value: str = Depends(base_dependency)) -> dict[str, str]:
+    override_events.append(value)
+    return {"value": value}
+
+
+override_client = TestClient(override_app, raise_server_exceptions=False)
+
+ws_app = FastAPI()
+
+
+async def ws_endpoint(websocket: WebSocket, room: str = Path(...), token: str | None = Query(default=None)) -> None:
+    await websocket.accept()
+    message = await websocket.receive_text()
+    if message == "boom":
+        await websocket.close(code=1008)
+        return
+    await websocket.send_json({"room": room, "token": token, "message": message})
+    await websocket.close()
+
+
+ws_app.add_api_websocket_route("/ws/{room}", ws_endpoint, name="ws_endpoint")
+ws_client = TestClient(ws_app, raise_server_exceptions=False)
+
+
+def router_dep() -> str:
+    return "dep"
+
+
+def choose_fields(
+    fdp: atheris.FuzzedDataProvider,
+    names: list[str],
+    minimum: int = 1,
+) -> set[str]:
+    chosen = {name for name in names if fdp.ConsumeBool()}
+    for name in names:
+        if len(chosen) >= minimum:
+            break
+        chosen.add(name)
+    return chosen
+
+
+def make_deep_model(
+    fdp: atheris.FuzzedDataProvider,
+    *,
+    unset: bool = False,
+    defaults: bool = False,
+    nullable: bool = False,
+) -> DeepRouteModel:
+    if unset:
+        return DeepRouteModel(field_a=fdp.ConsumeIntInRange(-20, 20))
+    if defaults:
+        return DeepRouteModel(
+            field_a=fdp.ConsumeIntInRange(-20, 20),
+            field_b="visible",
+            secret_field="secret",
+            nullable_field=None,
+            count=0,
+        )
+    return DeepRouteModel(
+        field_a=fdp.ConsumeIntInRange(-20, 20),
+        field_b=fuzz.segment(fdp, 10),
+        secret_field=fuzz.text(fdp, 12) or "secret",
+        nullable_field=None if nullable else (fuzz.text(fdp, 10) or None),
+        count=fdp.ConsumeIntInRange(-5, 20),
+    )
+
+
+def make_envelopes(fdp: atheris.FuzzedDataProvider) -> list[DeepEnvelopeModel]:
+    items = []
+    for _ in range(fdp.ConsumeIntInRange(1, 3)):
+        items.append(
+            DeepEnvelopeModel(
+                name=fuzz.segment(fdp, 10),
+                item=make_deep_model(fdp),
+                tags=[fuzz.segment(fdp, 8) for _ in range(fdp.ConsumeIntInRange(0, 2))],
+                note=fuzz.segment(fdp, 10),
+            )
+        )
+    return items
+
+
+async def call_route_handler(
+    route: APIRoute,
+    method: str,
+    path_value: str,
+    *,
+    headers_map: dict[str, str] | None = None,
+    query: list[tuple[str, str]] | None = None,
+    path_params: dict[str, str] | None = None,
+    body: bytes = b"",
+) -> None:
+    handler = get_request_handler(
+        dependant=route.dependant,
+        body_field=route.body_field,
+        status_code=route.status_code,
+        response_class=route.response_class,
+        response_field=route.response_field,
+        response_model_include=route.response_model_include,
+        response_model_exclude=route.response_model_exclude,
+        response_model_by_alias=route.response_model_by_alias,
+        response_model_exclude_unset=route.response_model_exclude_unset,
+        response_model_exclude_defaults=route.response_model_exclude_defaults,
+        response_model_exclude_none=route.response_model_exclude_none,
+        dependency_overrides_provider=route.dependency_overrides_provider,
+        embed_body_fields=route._embed_body_fields,
+        strict_content_type=route.strict_content_type,
+        stream_item_field=route.stream_item_field,
+        is_json_stream=route.is_json_stream,
+    )
+    request = fuzz.make_request(
+        method,
+        path_value,
+        headers_map=headers_map,
+        query=query,
+        body=body,
+    )
+    request.scope["path_params"] = path_params or {}
+
+    async with AsyncExitStack() as middleware_stack:
+        request.scope["fastapi_middleware_astack"] = middleware_stack
+        async with AsyncExitStack() as inner_stack:
+            request.scope["fastapi_inner_astack"] = inner_stack
+            async with AsyncExitStack() as function_stack:
+                request.scope["fastapi_function_astack"] = function_stack
+                response = await handler(request)
+                await response(request.scope, fuzz.make_receive(), fuzz.make_send([]))
+
+
+async def serialize_for_route(
+    route: APIRoute,
+    response_content: Any,
+    *,
+    is_coroutine: bool,
+) -> Any:
+    return await serialize_response(
+        field=route.response_field,
+        response_content=response_content,
+        include=route.response_model_include,
+        exclude=route.response_model_exclude,
+        by_alias=route.response_model_by_alias,
+        exclude_unset=route.response_model_exclude_unset,
+        exclude_defaults=route.response_model_exclude_defaults,
+        exclude_none=route.response_model_exclude_none,
+        is_coroutine=is_coroutine,
+        endpoint_ctx={"path": route.path, "function": route.name},
+    )
+
+
+def build_edge_app(
+    fdp: atheris.FuzzedDataProvider,
+) -> tuple[FastAPI, dict[str, str], dict[str, APIRoute]]:
+    include_fields = choose_fields(
+        fdp,
+        ["field_a", "field_b", "count", "nullable_field"],
+        minimum=2,
+    )
+    exclude_fields = choose_fields(
+        fdp,
+        ["field_b", "secret_field", "nullable_field", "count"],
+        minimum=1,
+    )
+    exclude_fields.add("secret_field")
+    picked_response_kind = fuzz.pick(fdp, ["response", "json", "stream", "dict"])
+    base_prefix = ""
+    if fdp.ConsumeBool():
+        base_prefix = "/" + fuzz.segment(fdp, 8)
+    tags = [fuzz.segment(fdp, 8) for _ in range(fdp.ConsumeIntInRange(0, 2))]
+    dependency_overrides_enabled = fdp.ConsumeBool()
+    include_dependencies = [Depends(router_dep)] if fdp.ConsumeBool() else []
+    nested_flat_toggle = fdp.ConsumeBool()
+
+    plain_text = fuzz.text(fdp, 18) or "plain"
+    json_value = fuzz.segment(fdp, 10)
+    stream_chunks = [
+        (fuzz.text(fdp, 8) or "chunk1").encode("utf-8", "ignore"),
+        (fuzz.text(fdp, 8) or "chunk2").encode("utf-8", "ignore"),
+    ]
+
+    def original_dep() -> str:
+        return "original"
+
+    def override_dep_local() -> str:
+        return "override"
+
+    def make_uid(label: str):
+        def uid(route: APIRoute) -> str:
+            return f"{label}-{route.name or 'route'}-{route.path_format.strip('/').replace('/', '-')}"
+
+        return uid
+
+    app = FastAPI(generate_unique_id_function=make_uid("app"))
+
+    if dependency_overrides_enabled:
+        app.dependency_overrides[original_dep] = override_dep_local
+
+    router_a = APIRouter(
+        prefix="/edge",
+        dependencies=[Depends(original_dep)],
+        generate_unique_id_function=make_uid("router-a"),
+    )
+    router_b = APIRouter(
+        prefix="/edge",
+        generate_unique_id_function=make_uid("router-b"),
+    )
+    router_nested = APIRouter(
+        prefix="/nested",
+        generate_unique_id_function=make_uid("nested"),
+    )
+
+    @router_a.get(
+        "/items/{item_id}",
+        responses={404: {"model": RouteErrorModel}, 422: {"model": RouteErrorModel}},
+        tags=["primary"],
+        summary="primary item",
+        description="primary overlap route",
+    )
+    def edge_item_primary(
+        item_id: int = Path(...),
+        dep: str = Depends(original_dep),
+    ) -> dict[str, object]:
+        return {"item_id": item_id, "dep": dep, "route": "primary"}
+
+    @router_b.get("/items/{item_id}", tags=["secondary"])
+    async def edge_item_secondary(item_id: int = Path(...)) -> dict[str, object]:
+        return {"item_id": item_id, "route": "secondary"}
+
+    @router_a.get("/sync/{item_id}", response_model=DeepRouteModel, tags=["workers"])
+    def sync_worker(
+        item_id: int = Path(...),
+        q: str | None = Query(default=None),
+        dep: str = Depends(original_dep),
+    ) -> dict[str, object]:
+        total = sum(range(100))
+        return {
+            "field_a": item_id + total,
+            "field_b": q or dep,
+            "secret_field": dep,
+            "nullable_field": None,
+            "count": total,
+        }
+
+    @router_a.get("/async/{item_id}", response_model=DeepRouteModel, tags=["workers"])
+    async def async_worker(
+        item_id: int = Path(...),
+        q: str | None = Query(default=None),
+        dep: str = Depends(original_dep),
+    ) -> dict[str, object]:
+        return {
+            "field_a": item_id,
+            "field_b": q or dep,
+            "secret_field": dep,
+            "nullable_field": None,
+            "count": 1,
+        }
+
+    @router_a.get(
+        "/serialize/include",
+        response_model=DeepRouteModel,
+        response_model_include=include_fields,
+    )
+    async def serialize_include() -> DeepRouteModel:
+        return make_deep_model(fdp)
+
+    @router_a.get(
+        "/serialize/exclude",
+        response_model=DeepRouteModel,
+        response_model_exclude=exclude_fields,
+    )
+    async def serialize_exclude() -> DeepRouteModel:
+        return make_deep_model(fdp)
+
+    @router_a.get(
+        "/serialize/unset",
+        response_model=DeepRouteModel,
+        response_model_exclude_unset=True,
+    )
+    async def serialize_unset() -> DeepRouteModel:
+        return make_deep_model(fdp, unset=True)
+
+    @router_a.get(
+        "/serialize/defaults",
+        response_model=DeepRouteModel,
+        response_model_exclude_defaults=True,
+    )
+    async def serialize_defaults() -> DeepRouteModel:
+        return make_deep_model(fdp, defaults=True)
+
+    @router_a.get(
+        "/serialize/none",
+        response_model=DeepRouteModel,
+        response_model_exclude_none=True,
+    )
+    async def serialize_none() -> DeepRouteModel:
+        return make_deep_model(fdp, nullable=True)
+
+    @router_a.get("/serialize/list", response_model=list[DeepEnvelopeModel])
+    async def serialize_list() -> list[DeepEnvelopeModel]:
+        return make_envelopes(fdp)
+
+    @router_a.get("/serialize/invalid", response_model=DeepRouteModel)
+    async def serialize_invalid() -> dict[str, object]:
+        return {"field_b": fuzz.segment(fdp, 10), "secret_field": "broken"}
+
+    @router_a.get("/direct/plain")
+    def direct_plain(background_tasks: BackgroundTasks) -> Response:
+        background_tasks.add_task(events.append, "plain")
+        return Response(content=plain_text, media_type="text/plain")
+
+    @router_a.get("/direct/json")
+    async def direct_json(background_tasks: BackgroundTasks) -> JSONResponse:
+        background_tasks.add_task(events.append, "json")
+        return JSONResponse({"kind": "json", "value": json_value})
+
+    @router_a.get("/direct/stream")
+    def direct_stream(background_tasks: BackgroundTasks) -> StreamingResponse:
+        background_tasks.add_task(events.append, "stream")
+        return StreamingResponse(iter(stream_chunks), media_type="text/plain")
+
+    @router_a.get("/direct/pick", response_model=None)
+    def direct_pick(background_tasks: BackgroundTasks) -> Response | JSONResponse | StreamingResponse | dict[str, str]:
+        background_tasks.add_task(events.append, "pick")
+        if picked_response_kind == "response":
+            return Response(content=plain_text, media_type="text/plain")
+        if picked_response_kind == "json":
+            return JSONResponse({"kind": "json", "value": json_value})
+        if picked_response_kind == "stream":
+            return StreamingResponse(iter(stream_chunks), media_type="text/plain")
+        return {"kind": "dict", "value": json_value}
+
+    @router_a.get("/generated/stream", response_class=StreamingResponse)
+    def generated_stream() -> Iterator[bytes]:
+        def chunks() -> Iterator[bytes]:
+            for chunk in stream_chunks:
+                yield chunk
+
+        return chunks()
+
+    @router_nested.get("/leaf/{item_id}", tags=["nested"])
+    async def nested_leaf(item_id: int = Path(...)) -> DeepEnvelopeModel:
+        return DeepEnvelopeModel(
+            name="nested",
+            item=DeepRouteModel(field_a=item_id, field_b="leaf"),
+            tags=["nested"],
+        )
+
+    router_a.include_router(
+        router_nested,
+        tags=["nested"],
+        responses={409: {"model": RouteErrorModel}},
+        generate_unique_id_function=make_uid("router-nested-include"),
+    )
+
+    app.include_router(
+        router_a,
+        prefix=base_prefix,
+        tags=tags or None,
+        dependencies=include_dependencies or None,
+        responses={401: {"model": RouteErrorModel}},
+        generate_unique_id_function=make_uid("app-include-a"),
+    )
+    app.include_router(
+        router_b,
+        prefix=base_prefix,
+        tags=["secondary"],
+        responses={403: {"model": RouteErrorModel}},
+        generate_unique_id_function=make_uid("app-include-b"),
+    )
+
+    if nested_flat_toggle:
+        app.include_router(
+            router_nested,
+            prefix=base_prefix + "/flat",
+            generate_unique_id_function=make_uid("app-flat-nested"),
+        )
+
+    route_map = {
+        route.name: route
+        for route in app.routes
+        if isinstance(route, APIRoute)
+    }
+    base_edge = base_prefix + "/edge"
+    paths = {
+        "overlap": base_edge + "/items/1",
+        "sync": base_edge + "/sync/1",
+        "async": base_edge + "/async/1",
+        "include": base_edge + "/serialize/include",
+        "exclude": base_edge + "/serialize/exclude",
+        "unset": base_edge + "/serialize/unset",
+        "defaults": base_edge + "/serialize/defaults",
+        "none": base_edge + "/serialize/none",
+        "list": base_edge + "/serialize/list",
+        "invalid": base_edge + "/serialize/invalid",
+        "plain": base_edge + "/direct/plain",
+        "json": base_edge + "/direct/json",
+        "stream": base_edge + "/direct/stream",
+        "pick": base_edge + "/direct/pick",
+        "generated": base_edge + "/generated/stream",
+        "nested": base_edge + "/nested/leaf/1",
+    }
+    if nested_flat_toggle:
+        paths["flat_nested"] = base_prefix + "/flat/nested/leaf/1"
+    return app, paths, route_map
+
+
+def exercise_edge_routing(fdp: atheris.FuzzedDataProvider) -> None:
+    edge_app, edge_paths, edge_routes = build_edge_app(fdp)
+    edge_client = TestClient(edge_app, raise_server_exceptions=False)
+    worker_order = ["sync", "async"] if fdp.ConsumeBool() else ["async", "sync"]
+    worker_query = [("q", fuzz.segment(fdp, 8))]
+
+    edge_client.get(edge_paths["overlap"])
+    edge_client.get(edge_paths["nested"])
+    if "flat_nested" in edge_paths:
+        edge_client.get(edge_paths["flat_nested"])
+
+    for name in worker_order:
+        edge_client.get(edge_paths[name], params={"q": fuzz.segment(fdp, 8)})
+
+    for name in ["include", "exclude", "unset", "defaults", "none", "list", "invalid"]:
+        edge_client.get(edge_paths[name])
+
+    for name in ["plain", "json", "stream", "pick"]:
+        edge_client.get(edge_paths[name])
+    edge_client.get(edge_paths["generated"])
+
+    edge_app.openapi()
+
+    sync_route = edge_routes["sync_worker"]
+    async_route = edge_routes["async_worker"]
+    plain_route = edge_routes["direct_plain"]
+    json_route = edge_routes["direct_json"]
+
+    fuzz.run(
+        call_route_handler(
+            sync_route,
+            "GET",
+            edge_paths["sync"],
+            query=worker_query,
+            path_params={"item_id": "1"},
+        )
+    )
+    fuzz.run(
+        call_route_handler(
+            async_route,
+            "GET",
+            edge_paths["async"],
+            query=worker_query,
+            path_params={"item_id": "1"},
+        )
+    )
+    fuzz.run(call_route_handler(plain_route, "GET", edge_paths["plain"]))
+    fuzz.run(call_route_handler(json_route, "GET", edge_paths["json"]))
+
+    include_route = edge_routes["serialize_include"]
+    exclude_route = edge_routes["serialize_exclude"]
+    unset_route = edge_routes["serialize_unset"]
+    defaults_route = edge_routes["serialize_defaults"]
+    none_route = edge_routes["serialize_none"]
+    list_route = edge_routes["serialize_list"]
+    invalid_route = edge_routes["serialize_invalid"]
+
+    fuzz.run(serialize_for_route(include_route, make_deep_model(fdp), is_coroutine=True))
+    fuzz.run(serialize_for_route(exclude_route, make_deep_model(fdp), is_coroutine=True))
+    fuzz.run(serialize_for_route(unset_route, make_deep_model(fdp, unset=True), is_coroutine=True))
+    fuzz.run(serialize_for_route(defaults_route, make_deep_model(fdp, defaults=True), is_coroutine=True))
+    fuzz.run(serialize_for_route(none_route, make_deep_model(fdp, nullable=True), is_coroutine=True))
+    fuzz.run(serialize_for_route(list_route, make_envelopes(fdp), is_coroutine=True))
+    fuzz.run(serialize_for_route(sync_route, make_deep_model(fdp), is_coroutine=False))
+    try:
+        fuzz.run(
+            serialize_for_route(
+                invalid_route,
+                {"field_b": fuzz.segment(fdp, 8)},
+                is_coroutine=True,
+            )
+        )
+    except ResponseValidationError:
+        pass
+
+
+def exercise_router_variants() -> None:
+    async def async_lifespan(_: Any):
+        yield
+
+    def startup_handler() -> None:
+        events.append("variant-startup")
+
+    def shutdown_handler() -> None:
+        events.append("variant-shutdown")
+
+    def extra_dep() -> str:
+        return "extra"
+
+    app = FastAPI()
+    router = APIRouter(
+        prefix="/variant",
+        on_startup=[startup_handler],
+        on_shutdown=[shutdown_handler],
+        lifespan=async_lifespan,
+    )
+
+    @router.route("/plain", methods=["GET"])
+    def plain_route(_: Request) -> Response:
+        return Response(content="plain", media_type="text/plain")
+
+    @router.get("/no-body", status_code=204)
+    async def no_body_route() -> dict[str, str]:
+        return {"ignored": "body"}
+
+    @router.get("/typed/{item_id}")
+    async def typed_route(item_id: int = Path(...)) -> dict[str, int]:
+        return {"item_id": item_id}
+
+    @router.websocket("/ws-api/{room}")
+    async def api_ws(
+        websocket: WebSocket,
+        room: str,
+        dep: str = Depends(extra_dep),
+    ) -> None:
+        await websocket.accept()
+        message = await websocket.receive_text()
+        await websocket.send_json({"room": room, "dep": dep, "message": message})
+        await websocket.close()
+
+    @router.websocket_route("/ws-raw")
+    async def raw_ws(websocket: WebSocket) -> None:
+        await websocket.accept()
+        await websocket.send_text("raw")
+        await websocket.close()
+
+    app.include_router(router)
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        client.get("/variant/plain")
+        client.get("/variant/no-body")
+        client.get("/variant/typed/1")
+        client.get("/variant/typed/bad")
+        with client.websocket_connect("/variant/ws-api/room") as websocket:
+            websocket.send_text("hello")
+            websocket.receive_json()
+        with client.websocket_connect("/variant/ws-raw") as websocket:
+            websocket.receive_text()
+
+
+def build_included_app(fdp: atheris.FuzzedDataProvider) -> tuple[FastAPI, str, str]:
+    app = FastAPI(generate_unique_id_function=custom_unique_id)
+    router = APIRouter()
+    prefix = ""
+    if fdp.ConsumeBool():
+        prefix = "/" + fuzz.segment(fdp, 10)
+    tags = [fuzz.segment(fdp, 8) for _ in range(fdp.ConsumeIntInRange(0, 2))]
+    dependencies = [Depends(router_dep)] if fdp.ConsumeBool() else []
+    route_path = "/child/{item_id}"
+
+    @router.api_route(
+        route_path,
+        methods=["GET", "POST"],
+        deprecated=fdp.ConsumeBool(),
+        include_in_schema=fdp.ConsumeBool(),
+        operation_id=fuzz.segment(fdp, 12),
+        summary=fuzz.text(fdp, 18) or None,
+        description=fuzz.text(fdp, 24) or None,
+        response_model=RouteModel,
+        response_model_exclude_unset=fdp.ConsumeBool(),
+        response_model_exclude_defaults=fdp.ConsumeBool(),
+    )
+    async def child_route(
+        item_id: int = Path(...),
+        q: str | None = Query(default=None),
+        dep: str = Depends(router_dep),
+    ) -> dict[str, object]:
+        return {"required": item_id, "optional": q or dep, "note": dep}
+
+    app.include_router(
+        router,
+        prefix=prefix,
+        tags=tags or None,
+        dependencies=dependencies or None,
+        responses={404: {"description": "missing"}},
+    )
+    return app, prefix + route_path.replace("{item_id}", "1"), prefix
+
+
+async def run_asgi(app_obj, scope: dict[str, object], body: bytes = b"") -> None:
+    async with AsyncExitStack() as stack:
+        active_scope = dict(scope)
+        active_scope["fastapi_middleware_astack"] = stack
+        await app_obj(active_scope, fuzz.make_receive(body), fuzz.make_send([]))
+
+
+def pick_path(fdp: atheris.FuzzedDataProvider) -> str:
+    choice = fdp.ConsumeIntInRange(0, 10)
+    if choice == 0:
+        return "/users/me"
+    if choice == 1:
+        return f"/users/{fuzz.segment(fdp)}"
+    if choice == 2:
+        return f"/items/{fdp.ConsumeIntInRange(-50, 50)}"
+    if choice == 3:
+        return f"/typed/{fuzz.path(fdp)}"
+    if choice == 4:
+        return f"/status/{fdp.ConsumeIntInRange(100, 599)}"
+    if choice == 5:
+        return "/model/include"
+    if choice == 6:
+        return "/model/exclude"
+    if choice == 7:
+        return "/model/unset"
+    if choice == 8:
+        return "/model/defaults"
+    if choice == 9:
+        return "/background"
+    return "/" + fuzz.path(fdp)
+
+
+def exercise_websocket(fdp: atheris.FuzzedDataProvider) -> None:
+    room = fuzz.segment(fdp, 8)
+    token = fuzz.token(fdp, 10)
+    with ws_client.websocket_connect(f"/ws/{room}?token={token}") as websocket:
+        websocket.send_text(fuzz.text(fdp, 24) or "hello")
+        try:
+            websocket.receive_json()
+        except WebSocketDisconnect:
+            pass
+
+    try:
+        with ws_client.websocket_connect(f"/ws/{room}") as websocket:
+            websocket.send_text("boom")
+            websocket.receive_text()
+    except WebSocketDisconnect:
+        pass
+
+
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+    method = fuzz.pick(fdp, fuzz.METHODS)
+    headers_map = fuzz.headers(fdp, include_cookie=True)
+    query = fuzz.query_items(fdp)
+    body_value = fuzz.json_value(fdp)
+    body = fuzz.body_bytes(body_value)
+
+    try:
+        path = pick_path(fdp)
+        if path == "/model/include":
+            query.append(("extra", "true" if fdp.ConsumeBool() else "false"))
+        elif path == "/model/exclude":
+            query.append(("missing", "true" if fdp.ConsumeBool() else "false"))
+        elif path == "/model/unset":
+            query.append(("empty", "true" if fdp.ConsumeBool() else "false"))
+        elif path == "/model/defaults":
+            query.append(("change", "true" if fdp.ConsumeBool() else "false"))
+
+        request_kwargs: dict[str, object] = {"params": query, "headers": headers_map}
+        if path == "/background":
+            request_kwargs["cookies"] = {"session": fuzz.token(fdp, 12)}
+        if method in {"POST", "PUT", "PATCH", "DELETE"} and fdp.ConsumeBool():
+            request_kwargs["json"] = body_value
+        client.request(method, path, **request_kwargs)
+
+        fastapi_utils.generate_unique_id(direct_route)
+        fastapi_utils.generate_unique_id(metadata_route)
+        custom_unique_id(metadata_route)
+        try:
+            exercise_edge_routing(fdp)
+        except (
+            ValidationError,
+            RequestValidationError,
+            ResponseValidationError,
+            HTTPException,
+            StarletteHTTPException,
+            WebSocketDisconnect,
+            Exception,
+        ):
+            pass
+        try:
+            exercise_router_variants()
+        except (
+            ValidationError,
+            RequestValidationError,
+            ResponseValidationError,
+            HTTPException,
+            StarletteHTTPException,
+            WebSocketDisconnect,
+            Exception,
+        ):
+            pass
+
+        direct_value = fdp.ConsumeIntInRange(-50, 50)
+        direct_scope = fuzz.build_scope(method, f"/direct/{direct_value}", headers_map=headers_map, query=query)
+        match, child_scope = direct_route.matches(direct_scope)
+        if match != Match.NONE:
+            merged_scope = dict(direct_scope)
+            merged_scope.update(child_scope)
+            fuzz.run(run_asgi(direct_route.app, merged_scope, body))
+
+        wrapped_scope = fuzz.build_scope(method, "/wrapped/" + fuzz.path(fdp), headers_map=headers_map, query=query)
+        fuzz.run(run_asgi(wrapped_app, wrapped_scope, body))
+
+        meta_scope = fuzz.build_scope("GET", f"/meta/{fdp.ConsumeIntInRange(-10, 10)}", headers_map=headers_map, query=query)
+        meta_match, meta_child = metadata_route.matches(meta_scope)
+        if meta_match != Match.NONE:
+            merged_meta_scope = dict(meta_scope)
+            merged_meta_scope.update(meta_child)
+            fuzz.run(run_asgi(metadata_route.app, merged_meta_scope, body))
+
+        included_app, included_path, prefix = build_included_app(fdp)
+        included_client = TestClient(included_app, raise_server_exceptions=False)
+        included_client.request(
+            "POST" if fdp.ConsumeBool() else "GET",
+            included_path,
+            params={"q": fuzz.segment(fdp, 8)},
+            headers={"x-token": fuzz.token(fdp, 12)},
+        )
+        if fdp.ConsumeBool():
+            included_app.openapi()
+        if prefix:
+            fastapi_utils.get_path_param_names(prefix + "/child/{item_id}")
+
+        if fdp.ConsumeBool():
+            override_app.dependency_overrides[base_dependency] = override_dependency
+        else:
+            override_app.dependency_overrides.clear()
+        override_client.get("/override")
+        override_app.dependency_overrides.clear()
+
+        exercise_websocket(fdp)
+    except (
+        ValidationError,
+        RequestValidationError,
+        ResponseValidationError,
+        HTTPException,
+        StarletteHTTPException,
+        WebSocketDisconnect,
+    ):
+        return
+    except Exception:
+        return
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/fastapi/fuzz_security.py
+++ b/projects/fastapi/fuzz_security.py
@@ -1,0 +1,322 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Targets:
+# - fastapi/security/api_key.py
+# - fastapi/security/http.py
+# - fastapi/security/oauth2.py
+# - fastapi/security/utils.py
+# Delta:
+# - fastapi/security/http.py >= 75%
+
+import base64
+import sys
+
+import atheris
+
+with atheris.instrument_imports():
+    import fastapi.security.api_key as api_key_mod
+    import fastapi.security.http as http_mod
+    import fastapi.security.oauth2 as oauth2_mod
+    import fastapi.security.utils as security_utils
+    from fastapi import Depends, FastAPI, Security
+    from fastapi.exceptions import RequestValidationError, ResponseValidationError
+    from fastapi.security import (
+        APIKeyCookie,
+        APIKeyHeader,
+        APIKeyQuery,
+        HTTPBasic,
+        HTTPBearer,
+        HTTPDigest,
+        OAuth2,
+        OAuth2AuthorizationCodeBearer,
+        OAuth2PasswordBearer,
+        OAuth2PasswordRequestFormStrict,
+    )
+    from fastapi.testclient import TestClient
+    from pydantic import ValidationError
+    from starlette.exceptions import HTTPException as StarletteHTTPException
+
+    import fastapi_fuzz_utils as fuzz
+
+
+query_scheme = APIKeyQuery(name="key", auto_error=False)
+header_scheme = APIKeyHeader(name="x-key", auto_error=False)
+cookie_scheme = APIKeyCookie(name="session", auto_error=False)
+
+basic_optional = HTTPBasic(auto_error=False)
+basic_required = HTTPBasic()
+bearer_optional = HTTPBearer(auto_error=False)
+bearer_required = HTTPBearer()
+digest_optional = HTTPDigest(auto_error=False)
+digest_required = HTTPDigest()
+
+oauth2_password = OAuth2PasswordBearer(tokenUrl="/token", auto_error=False, scopes={"read": "Read"})
+oauth2_code = OAuth2AuthorizationCodeBearer(
+    authorizationUrl="/auth",
+    tokenUrl="/token",
+    auto_error=False,
+    scopes={"write": "Write"},
+)
+oauth2_base = OAuth2(
+    flows={"password": {"tokenUrl": "/token", "scopes": {"read": "Read"}}},
+    auto_error=False,
+)
+
+app = FastAPI()
+
+
+@app.get("/query")
+async def query_route(key: str | None = Depends(query_scheme)) -> dict[str, object]:
+    return {"key": key}
+
+
+@app.get("/header")
+async def header_route(key: str | None = Depends(header_scheme)) -> dict[str, object]:
+    return {"key": key}
+
+
+@app.get("/cookie")
+async def cookie_route(session: str | None = Depends(cookie_scheme)) -> dict[str, object]:
+    return {"session": session}
+
+
+@app.get("/basic")
+async def basic_route(credentials: http_mod.HTTPBasicCredentials | None = Depends(basic_optional)) -> dict[str, object]:
+    return {
+        "username": credentials.username if credentials else None,
+        "password": credentials.password if credentials else None,
+    }
+
+
+@app.get("/basic-required")
+async def basic_required_route(credentials: http_mod.HTTPBasicCredentials = Depends(basic_required)) -> dict[str, object]:
+    return {"username": credentials.username, "password": credentials.password}
+
+
+@app.get("/bearer")
+async def bearer_route(credentials: http_mod.HTTPAuthorizationCredentials | None = Depends(bearer_optional)) -> dict[str, object]:
+    return {
+        "scheme": credentials.scheme if credentials else None,
+        "credentials": credentials.credentials if credentials else None,
+    }
+
+
+@app.get("/bearer-required")
+async def bearer_required_route(
+    credentials: http_mod.HTTPAuthorizationCredentials = Depends(bearer_required),
+) -> dict[str, object]:
+    return {"scheme": credentials.scheme, "credentials": credentials.credentials}
+
+
+@app.get("/digest")
+async def digest_route(credentials: http_mod.HTTPAuthorizationCredentials | None = Depends(digest_optional)) -> dict[str, object]:
+    return {
+        "scheme": credentials.scheme if credentials else None,
+        "credentials": credentials.credentials if credentials else None,
+    }
+
+
+@app.get("/digest-required")
+async def digest_required_route(
+    credentials: http_mod.HTTPAuthorizationCredentials = Depends(digest_required),
+) -> dict[str, object]:
+    return {"scheme": credentials.scheme, "credentials": credentials.credentials}
+
+
+@app.get("/oauth2/password")
+async def oauth2_password_route(token: str | None = Security(oauth2_password, scopes=["read"])) -> dict[str, object]:
+    return {"token": token}
+
+
+@app.get("/oauth2/code")
+async def oauth2_code_route(token: str | None = Security(oauth2_code, scopes=["write"])) -> dict[str, object]:
+    return {"token": token}
+
+
+@app.get("/oauth2/base")
+async def oauth2_base_route(token: str | None = Depends(oauth2_base)) -> dict[str, object]:
+    return {"token": token}
+
+
+@app.post("/login")
+async def login_route(form: OAuth2PasswordRequestFormStrict = Depends()) -> dict[str, object]:
+    return {
+        "username": form.username,
+        "password": form.password,
+        "scopes": form.scopes,
+        "client_id": form.client_id,
+        "client_secret": form.client_secret,
+    }
+
+
+client = TestClient(app, raise_server_exceptions=False)
+
+
+def make_basic_header(username: str, password: str) -> str:
+    raw = f"{username}:{password}".encode("ascii", "ignore")
+    return "Basic " + base64.b64encode(raw).decode("ascii")
+
+
+def pick_auth_header(fdp: atheris.FuzzedDataProvider) -> str | None:
+    choice = fdp.ConsumeIntInRange(0, 7)
+    if choice == 0:
+        return None
+    if choice == 1:
+        return "Bearer " + fuzz.token(fdp, 24)
+    if choice == 2:
+        return make_basic_header(fuzz.segment(fdp, 12), fuzz.text(fdp, 12))
+    if choice == 3:
+        return "Basic " + fuzz.token(fdp, 24)
+    if choice == 4:
+        raw = base64.b64encode(fuzz.segment(fdp, 12).encode("ascii", "ignore")).decode("ascii")
+        return "Basic " + raw
+    if choice == 5:
+        return "Digest " + fuzz.text(fdp, 40)
+    if choice == 6:
+        return "Digest username=\"alice\", realm=\"realm\", nonce=\"n\", uri=\"/\", response=\"r\""
+    return fuzz.text(fdp, 40)
+
+
+async def exercise_direct(request) -> None:
+    for scheme in [
+        query_scheme,
+        header_scheme,
+        cookie_scheme,
+        basic_optional,
+        basic_required,
+        bearer_optional,
+        bearer_required,
+        digest_optional,
+        digest_required,
+        oauth2_password,
+        oauth2_code,
+        oauth2_base,
+    ]:
+        try:
+            await scheme(request)
+        except Exception:
+            pass
+
+
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+
+    try:
+        query_key = fuzz.token(fdp, 16)
+        header_key = fuzz.token(fdp, 16)
+        session_value = fuzz.token(fdp, 16)
+        auth_header = pick_auth_header(fdp)
+
+        headers_map = fuzz.headers(fdp)
+        headers_map["x-key"] = header_key
+        headers_map["cookie"] = f"session={session_value}"
+        if auth_header:
+            headers_map["authorization"] = auth_header
+
+        query = [("key", query_key)]
+
+        path_value = fuzz.pick(
+            fdp,
+            [
+                "/query",
+                "/header",
+                "/cookie",
+                "/basic",
+                "/basic-required",
+                "/bearer",
+                "/bearer-required",
+                "/digest",
+                "/digest-required",
+                "/oauth2/password",
+                "/oauth2/code",
+                "/oauth2/base",
+                "/login",
+            ],
+        )
+
+        if path_value == "/login":
+            client.post(
+                path_value,
+                data={
+                    "grant_type": "password",
+                    "username": fuzz.segment(fdp, 16),
+                    "password": fuzz.text(fdp, 16),
+                    "scope": " ".join(fuzz.segment(fdp, 8) for _ in range(fdp.ConsumeIntInRange(0, 3))),
+                    "client_id": fuzz.segment(fdp, 8),
+                    "client_secret": fuzz.text(fdp, 12),
+                },
+                headers=headers_map,
+            )
+        else:
+            client.get(
+                path_value,
+                params=query,
+                headers=headers_map,
+                cookies={"session": session_value},
+            )
+
+        client.get("/basic", headers={"authorization": "Bearer " + fuzz.token(fdp, 16)})
+        client.get("/basic-required", headers={"authorization": "Bearer " + fuzz.token(fdp, 16)})
+        client.get("/bearer", headers={"authorization": make_basic_header("alice", "secret")})
+        client.get("/bearer-required", headers={"authorization": make_basic_header("alice", "secret")})
+        client.get("/digest", headers={"authorization": "Bearer " + fuzz.token(fdp, 16)})
+        client.get("/digest-required", headers={"authorization": make_basic_header("alice", "secret")})
+        client.get("/digest-required")
+        client.get("/basic-required", headers={"authorization": "Basic " + fuzz.token(fdp, 24)})
+
+        security_utils.get_authorization_scheme_param(headers_map.get("authorization"))
+        security_utils.get_authorization_scheme_param("Basic bad")
+        security_utils.get_authorization_scheme_param("Digest token")
+        security_utils.get_authorization_scheme_param(None)
+
+        http_mod.HTTPBasicCredentials(username=fuzz.segment(fdp, 12), password=fuzz.text(fdp, 12))
+        http_mod.HTTPAuthorizationCredentials(
+            scheme=fuzz.segment(fdp, 8),
+            credentials=fuzz.token(fdp, 24),
+        )
+        api_key_mod.APIKeyQuery(name=fuzz.segment(fdp, 8), auto_error=fdp.ConsumeBool())
+        oauth2_mod.OAuth2(
+            flows={"password": {"tokenUrl": "/token", "scopes": {"read": "Read"}}},
+            auto_error=False,
+        )
+        OAuth2PasswordRequestFormStrict(
+            grant_type="password",
+            username=fuzz.segment(fdp, 12),
+            password=fuzz.text(fdp, 12),
+            scope="read write",
+            client_id=fuzz.segment(fdp, 8),
+            client_secret=fuzz.text(fdp, 8),
+        )
+
+        request = fuzz.make_request("GET", "/security", headers_map=headers_map, query=query)
+        fuzz.run(exercise_direct(request))
+    except (
+        ValidationError,
+        RequestValidationError,
+        ResponseValidationError,
+        StarletteHTTPException,
+    ):
+        return
+    except Exception:
+        return
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/fastapi/project.yaml
+++ b/projects/fastapi/project.yaml
@@ -1,0 +1,23 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+fuzzing_engines:
+- libfuzzer
+homepage: https://github.com/fastapi/fastapi
+language: python
+main_repo: https://github.com/fastapi/fastapi
+primary_contact: shemtorga@gmail.com
+sanitizers:
+- address
+- undefined


### PR DESCRIPTION
What changed

Add a new OSS-Fuzz project for FastAPI under projects/fastapi.

This includes:

project metadata and Docker/build setup
shared Python fuzz helpers
subsystem fuzzers for routing, params, body parsing, dependencies, encoders, security, OpenAPI, form uploads, exception handlers, middleware, applications, compat, and OpenID

Reason

FastAPI has a lot of logic below the top-level app entrypoint. This adds shaped, module-aware fuzz targets that exercise the main internal subsystems directly instead of relying only on shallow HTTP request fuzzing.

Impact

This gives FastAPI an OSS-Fuzz integration that is ready for review and local reproduction with the normal OSS-Fuzz Python workflow.

Validation

python3 infra/helper.py build_fuzzers fastapi
targeted local run_fuzzer smoke runs during development
custom local coverage driver run from the FastAPI builder image