### PR TITLE
Add fbthrift to OSS-Fuzz

### DIFF
--- a/projects/fbthrift/Dockerfile
+++ b/projects/fbthrift/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
+
+RUN apt-get update && apt-get install -y \
+    git \
+    cmake \
+    ninja-build \
+    libfmt-dev
+
+RUN git clone --depth 1 https://github.com/facebook/fbthrift.git
+
+COPY build.sh $SRC/

--- a/projects/fbthrift/build.sh
+++ b/projects/fbthrift/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -eu
+
+SRC_DIR="$SRC/fbthrift"
+BUILD_DIR="$WORK/build"
+
+cmake -S "$SRC_DIR/thrift/lib/cpp/protocol" -B "$BUILD_DIR" -G Ninja \
+  -DCMAKE_C_COMPILER="$CC" \
+  -DCMAKE_CXX_COMPILER="$CXX" \
+  -DCMAKE_C_FLAGS="$CFLAGS" \
+  -DCMAKE_CXX_FLAGS="$CXXFLAGS"
+
+cmake --build "$BUILD_DIR" --target fuzz_thrift -j"$(nproc)"
+
+cp "$BUILD_DIR/fuzz_thrift" "$OUT/"

--- a/projects/fbthrift/project.yaml
+++ b/projects/fbthrift/project.yaml
@@ -1,0 +1,12 @@
+base_os_version: ubuntu-24-04
+homepage: "https://github.com/facebook/fbthrift"
+language: c++
+primary_contact: "juchem@gmail.com"
+vendor_ccs:
+  - "juchem@gmail.com"
+main_repo: "https://github.com/facebook/fbthrift.git"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+  - undefined


### PR DESCRIPTION
This adds OSS-Fuzz integration for fbthrift.

The setup builds a minimal fuzz target focused on protocol deserialization (Binary and Compact protocols). The build stays lightweight and avoids pulling in the full dependency graph.

The fuzzer has been tested locally with helper.py using both address and undefined sanitizers.

Upstream PR: https://github.com/facebook/fbthrift/pull/695