### PR TITLE
libvips: obtain seed corpora from a new Git repository

### DIFF
--- a/projects/libvips/Dockerfile
+++ b/projects/libvips/Dockerfile
@@ -29,11 +29,10 @@ RUN apt-get update && apt-get install -y \
   nasm \
   python3-pip
 RUN pip3 install meson ninja
-RUN mkdir afl-testcases
-RUN curl https://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz | tar xzC afl-testcases
 RUN mkdir pdfium-latest
 RUN curl -L https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-linux-x64.tgz | tar xzC pdfium-latest
 RUN git clone --depth 1 https://github.com/libvips/libvips.git
+RUN git clone --depth 1 https://github.com/libvips/seed-corpora.git
 RUN git clone --depth 1 https://github.com/madler/zlib.git
 RUN git clone --depth 1 https://github.com/libexif/libexif.git
 RUN git clone --depth 1 https://github.com/mm2/Little-CMS.git lcms


### PR DESCRIPTION
This new repo contains the old corpora from https://lcamtuf.coredump.cx, with duplicates removed, and the existing corpora from the main libvips repo.