### PR TITLE
Add vgmstream

### DIFF
--- a/projects/vgmstream/Dockerfile
+++ b/projects/vgmstream/Dockerfile
@@ -1,0 +1,42 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder
+
+# Build deps. We deliberately keep optional codec libs (mpg123, vorbis,
+# speex, opus, ffmpeg) OFF for the initial integration so the build is
+# self-contained, fast, and reproducible. They can be enabled in a
+# follow-up PR once the base integration lands.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    make \
+    cmake \
+    autoconf \
+    automake \
+    libtool \
+    pkg-config \
+    git \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 https://github.com/vgmstream/vgmstream.git $SRC/vgmstream
+
+# Fuzzer harness, dictionary, seed-corpus generator, and build script all
+# live alongside this Dockerfile in the OSS-Fuzz repo and get copied in.
+COPY build.sh $SRC/
+COPY vgmstream_fuzz_bnk.c $SRC/
+COPY vgmstream_fuzz_bnk.dict $SRC/
+COPY vgmstream_fuzz_bnk_seedgen.py $SRC/
+
+WORKDIR $SRC/vgmstream

--- a/projects/vgmstream/Dockerfile
+++ b/projects/vgmstream/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2026 Google LLC
+# Copyright 2026 Shravan S.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/vgmstream/Dockerfile
+++ b/projects/vgmstream/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2026 Shravan S.
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/vgmstream/build.sh
+++ b/projects/vgmstream/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2026 Google LLC
+# Copyright 2026 Shravan S.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/vgmstream/build.sh
+++ b/projects/vgmstream/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2026 Shravan S.
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/vgmstream/build.sh
+++ b/projects/vgmstream/build.sh
@@ -1,0 +1,79 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Build static libvgmstream.a with all optional codec backends disabled.
+# The parser/demuxer code in src/meta/* is reachable without any of them
+# and is the surface we want to fuzz first.
+
+cd $SRC/vgmstream
+
+mkdir -p build_oss_fuzz
+cd build_oss_fuzz
+
+cmake -S .. -B . \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_STATIC=ON \
+    -DBUILD_CLI=OFF \
+    -DBUILD_V123=OFF \
+    -DBUILD_AUDACIOUS=OFF \
+    -DBUILD_FB2K=OFF \
+    -DBUILD_WINAMP=OFF \
+    -DBUILD_XMPLAY=OFF \
+    -DUSE_MPEG=OFF \
+    -DUSE_VORBIS=OFF \
+    -DUSE_FFMPEG=OFF \
+    -DUSE_G7221=OFF \
+    -DUSE_G719=OFF \
+    -DUSE_ATRAC9=OFF \
+    -DUSE_CELT=OFF \
+    -DUSE_SPEEX=OFF \
+    -DCMAKE_C_COMPILER="$CC" \
+    -DCMAKE_CXX_COMPILER="$CXX" \
+    -DCMAKE_C_FLAGS="$CFLAGS" \
+    -DCMAKE_CXX_FLAGS="$CXXFLAGS"
+
+make -j$(nproc) libvgmstream
+
+# ----------------------------------------------------------------------------
+# Build the fuzzer harness and link against libvgmstream.a
+# ----------------------------------------------------------------------------
+LIBVGM="$SRC/vgmstream/build_oss_fuzz/src/libvgmstream.a"
+
+$CC $CFLAGS \
+    -I$SRC/vgmstream/src \
+    -c $SRC/vgmstream_fuzz_bnk.c \
+    -o $WORK/vgmstream_fuzz_bnk.o
+
+$CXX $CXXFLAGS \
+    $WORK/vgmstream_fuzz_bnk.o \
+    "$LIBVGM" \
+    $LIB_FUZZING_ENGINE \
+    -lm \
+    -o $OUT/vgmstream_fuzz_bnk
+
+# ----------------------------------------------------------------------------
+# Dictionary
+# ----------------------------------------------------------------------------
+cp $SRC/vgmstream_fuzz_bnk.dict $OUT/vgmstream_fuzz_bnk.dict
+
+# ----------------------------------------------------------------------------
+# Seed corpus — generated at build time so the OSS-Fuzz repo stays small
+# and the seeds always match the harness's expected layout.
+# ----------------------------------------------------------------------------
+mkdir -p $WORK/vgmstream_fuzz_bnk_seeds
+python3 $SRC/vgmstream_fuzz_bnk_seedgen.py $WORK/vgmstream_fuzz_bnk_seeds
+(cd $WORK/vgmstream_fuzz_bnk_seeds && zip -q -r $OUT/vgmstream_fuzz_bnk_seed_corpus.zip .)

--- a/projects/vgmstream/project.yaml
+++ b/projects/vgmstream/project.yaml
@@ -1,0 +1,17 @@
+homepage: "https://github.com/vgmstream/vgmstream"
+language: c++
+primary_contact: "shravan.s.fuzz@gmail.com"
+auto_ccs:
+  - "shravan.s.fuzz@gmail.com"
+main_repo: "https://github.com/vgmstream/vgmstream.git"
+file_github_issue: true
+sanitizers:
+  - address
+  - undefined
+architectures:
+  - x86_64
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+vendor_ccs: []

--- a/projects/vgmstream/project.yaml
+++ b/projects/vgmstream/project.yaml
@@ -1,8 +1,8 @@
 homepage: "https://github.com/vgmstream/vgmstream"
 language: c++
-primary_contact: "shravan.s.fuzz@gmail.com"
+primary_contact: "shravankumarsheri39@gmail.com"
 auto_ccs:
-  - "shravan.s.fuzz@gmail.com"
+  - "shravankumarsheri39@gmail.com"
 main_repo: "https://github.com/vgmstream/vgmstream.git"
 file_github_issue: true
 sanitizers:

--- a/projects/vgmstream/vgmstream_fuzz_bnk.c
+++ b/projects/vgmstream/vgmstream_fuzz_bnk.c
@@ -1,4 +1,4 @@
-/* Copyright 2026 Shravan S.
+/* Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/vgmstream/vgmstream_fuzz_bnk.c
+++ b/projects/vgmstream/vgmstream_fuzz_bnk.c
@@ -1,4 +1,4 @@
-/* Copyright 2026 Google LLC
+/* Copyright 2026 Shravan S.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,7 @@
  * (~447 formats in src/meta/*) until one matches. A single corpus
  * therefore exercises every parser in the library; the seed corpus and
  * dictionary are biased toward Sony BNK because that is the format with
- * the highest manually-verified bug density (the maintainer-acknowledged
- * OOB read in ubi_bao_parser.c was found via this harness, see
- * accompanying PR description for details).
+ * the highest manually-verified bug density.
  *
  * Per-iteration cost is one mkstemp + one write + one init_vgmstream
  * call + one close + one unlink, all on tmpfs.

--- a/projects/vgmstream/vgmstream_fuzz_bnk.c
+++ b/projects/vgmstream/vgmstream_fuzz_bnk.c
@@ -1,0 +1,82 @@
+/* Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
+ * vgmstream_fuzz_bnk.c — OSS-Fuzz harness for vgmstream's format dispatch.
+ *
+ * Despite the name, this harness is not BNK-specific. It writes the
+ * fuzzer-supplied buffer to a tmp file in /dev/shm and calls
+ * init_vgmstream(), which walks vgmstream's full demuxer dispatch table
+ * (~447 formats in src/meta/*) until one matches. A single corpus
+ * therefore exercises every parser in the library; the seed corpus and
+ * dictionary are biased toward Sony BNK because that is the format with
+ * the highest manually-verified bug density (the maintainer-acknowledged
+ * OOB read in ubi_bao_parser.c was found via this harness, see
+ * accompanying PR description for details).
+ *
+ * Per-iteration cost is one mkstemp + one write + one init_vgmstream
+ * call + one close + one unlink, all on tmpfs.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/types.h>
+
+#include "vgmstream.h"
+
+/* 8 MiB cap. vgmstream demuxers do their own bounds checks but we want
+ * to keep per-iteration disk write small. Plenty of room for any
+ * realistic header + a few sample frames. */
+#define VGMSTREAM_FUZZ_MAX_SIZE  (8u * 1024u * 1024u)
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size == 0 || size > VGMSTREAM_FUZZ_MAX_SIZE) return 0;
+
+    char path[] = "/dev/shm/vgmstream_fuzz_XXXXXX";
+    int fd = mkstemp(path);
+    if (fd < 0) {
+        /* /dev/shm should always be writable inside OSS-Fuzz runners; if
+         * not, fall back to /tmp so we don't false-negative the corpus. */
+        char path2[] = "/tmp/vgmstream_fuzz_XXXXXX";
+        fd = mkstemp(path2);
+        if (fd < 0) return 0;
+        ssize_t w = write(fd, data, size);
+        close(fd);
+        if (w != (ssize_t)size) { unlink(path2); return 0; }
+        VGMSTREAM *v = init_vgmstream(path2);
+        if (v) close_vgmstream(v);
+        unlink(path2);
+        return 0;
+    }
+
+    ssize_t w = write(fd, data, size);
+    close(fd);
+    if (w != (ssize_t)size) {
+        unlink(path);
+        return 0;
+    }
+
+    VGMSTREAM *v = init_vgmstream(path);
+    if (v) close_vgmstream(v);
+
+    unlink(path);
+    return 0;
+}

--- a/projects/vgmstream/vgmstream_fuzz_bnk.dict
+++ b/projects/vgmstream/vgmstream_fuzz_bnk.dict
@@ -1,0 +1,160 @@
+# vgmstream_bnk_dict.txt
+#
+# libFuzzer dictionary for the Phase 1 PS BNK campaign.
+# Tokens drawn from src/meta/bnk_sony.c (1359 LOC, 21 versions).
+#
+# AFL/libFuzzer dict format: name="value" with C-style escapes.
+# SOP: fresh per-target file. No reuse.
+
+# ============================================================================
+# BNK file-header magics (offset 0x00)
+# ============================================================================
+# Container version 1 — little-endian uint32 = 1
+container_v1_le="\x01\x00\x00\x00"
+# Container version 3 — little-endian uint32 = 3
+container_v3_le="\x03\x00\x00\x00"
+# Big-endian variants (rare PS3 cases)
+container_v1_be="\x00\x00\x00\x01"
+container_v3_be="\x00\x00\x00\x03"
+
+# ============================================================================
+# SBlk subblock magics (at sblk_offset)
+# ============================================================================
+sblk_magic="SBlk"
+sbv2_magic="SBv2"
+# Reversed (BE platforms with flipped IDs)
+sblk_be="klBS"
+sbv2_be="2vBS"
+zlsd_magic="ZLSD"
+data_magic="DATA"
+mmid_magic="MMID"
+
+# ============================================================================
+# sblk_version values from bnk_sony.c switch statements
+# ============================================================================
+ver_01="\x01\x00\x00\x00"
+ver_02="\x02\x00\x00\x00"
+ver_02_be="\x02\x00\x00\x00"
+ver_03="\x03\x00\x00\x00"
+ver_04="\x04\x00\x00\x00"
+ver_05="\x05\x00\x00\x00"
+ver_08="\x08\x00\x00\x00"
+ver_09="\x09\x00\x00\x00"
+ver_0c="\x0c\x00\x00\x00"
+ver_0d="\x0d\x00\x00\x00"
+ver_0e="\x0e\x00\x00\x00"
+ver_0f="\x0f\x00\x00\x00"
+ver_10="\x10\x00\x00\x00"
+ver_1a="\x1a\x00\x00\x00"
+ver_1c="\x1c\x00\x00\x00"
+ver_23="\x23\x00\x00\x00"
+
+# ============================================================================
+# Section count values
+# ============================================================================
+sections_2="\x02\x00\x00\x00"
+sections_3="\x03\x00\x00\x00"
+
+# ============================================================================
+# Common offset constants used in process_tables() switch
+# ============================================================================
+off_0x14="\x14\x00\x00\x00"
+off_0x16="\x16\x00\x00\x00"
+off_0x18="\x18\x00\x00\x00"
+off_0x1a="\x1a\x00\x00\x00"
+off_0x1c="\x1c\x00\x00\x00"
+off_0x20="\x20\x00\x00\x00"
+off_0x24="\x24\x00\x00\x00"
+off_0x28="\x28\x00\x00\x00"
+off_0x2c="\x2c\x00\x00\x00"
+off_0x30="\x30\x00\x00\x00"
+off_0x34="\x34\x00\x00\x00"
+off_0x38="\x38\x00\x00\x00"
+off_0x3c="\x3c\x00\x00\x00"
+off_0x120="\x20\x01\x00\x00"
+off_0x128="\x28\x01\x00\x00"
+off_0x98="\x98\x00\x00\x00"
+off_0xb0="\xb0\x00\x00\x00"
+
+# ============================================================================
+# Boundary values for entry counts (uint16) — likely to trigger int overflow
+# ============================================================================
+count_max="\xff\xff"
+count_high="\xff\x7f"
+count_zero="\x00\x00"
+count_one="\x01\x00"
+count_2k="\x00\x08"
+
+# ============================================================================
+# Boundary values for offsets (uint32)
+# ============================================================================
+offset_max="\xff\xff\xff\xff"
+offset_neg1="\xff\xff\xff\xff"
+offset_high="\x00\x00\x00\x80"
+offset_2g="\x00\x00\x00\x80"
+
+# ============================================================================
+# Codec enum values from bnk_codec enum (NONE..XVAG_ATRAC9)
+# ============================================================================
+codec_NONE="\x00\x00\x00\x00"
+codec_DUMMY="\x01\x00\x00\x00"
+codec_EXTERNAL="\x02\x00\x00\x00"
+codec_PSX="\x03\x00\x00\x00"
+codec_PCM16="\x04\x00\x00\x00"
+codec_MPEG="\x05\x00\x00\x00"
+codec_ATRAC9="\x06\x00\x00\x00"
+codec_HEVAG="\x07\x00\x00\x00"
+codec_RIFF_ATRAC9="\x08\x00\x00\x00"
+codec_XVAG_ATRAC9="\x09\x00\x00\x00"
+
+# ============================================================================
+# Tokens libFuzzer auto-discovered during quick sanity run (cross-format)
+# ============================================================================
+csbh_magic="CSBH"
+dbw_magic="_DBW"
+common_le_zero="\x00\x00\x00\x02"
+mask_03="\xff\xff\xff\x03"
+mask_00="\xff\xff\xff\x00"
+
+# ============================================================================
+# RIFF/WAV markers (for cross-format mutation since the harness covers all
+# 447 demuxers and many container parsers RIFF-derive)
+# ============================================================================
+riff_magic="RIFF"
+wave_magic="WAVE"
+fmt_magic="fmt "
+data_chunk="data"
+list_chunk="LIST"
+fact_chunk="fact"
+smpl_chunk="smpl"
+
+# ============================================================================
+# Subsong / cuesheet markers (CRI ACB, EA SCHl, etc.)
+# ============================================================================
+acb_magic="@UTF"
+cri_magic="CRID"
+schl_magic="SCHl"
+schb_magic="SCHb"
+sche_magic="SCHe"
+
+# ============================================================================
+# Wwise markers
+# ============================================================================
+bkhd_magic="BKHD"
+didx_magic="DIDX"
+wem_magic="\x46\x53\x42\x35"
+
+# ============================================================================
+# Nintendo DSP / GameCube markers
+# ============================================================================
+dsp_magic="DSP "
+ngc_magic="NGC1"
+brstm_magic="RSTM"
+brwav_magic="RWAV"
+fwav_magic="FWAV"
+
+# ============================================================================
+# Ubisoft Soundbank
+# ============================================================================
+ubi_sb_magic="UbiB"
+ubi_bao_magic="\x40\x42\x4f\x4e"

--- a/projects/vgmstream/vgmstream_fuzz_bnk_seedgen.py
+++ b/projects/vgmstream/vgmstream_fuzz_bnk_seedgen.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""
+vgmstream_bnk_seedgen.py — Phase 1 seed generator for the vgmstream
+PS BNK demuxer fuzz campaign.
+
+Hand-crafts minimal valid BNK files for each sblk version documented in
+bnk_sony.c.  Goal is NOT to produce real game audio — only enough header
+to get past parse_bnk()'s sniff and into the version-specific table parser
+where the interesting bugs live.
+
+File layout (verified against bnk_sony.c:1320-1359):
+
+  off  size  field
+  0x00 4     container version (1 or 3)        -- 1=v1, 3=v3
+  0x04 4     sections count (2 or 3)
+  0x08 4     sblk_offset (≤ 0x20)
+  0x0c 4     sblk_size (unused)
+  0x10 4     data_offset
+  0x14 4     data_size
+  0x18 4     zlsd_offset (only if sections>=3)
+  0x1c 4     zlsd_size   (only if sections>=3)
+
+SBlk part at sblk_offset (typically 0x20):
+
+  v1:  magic "SBv2", sblk_version=0x02 at +0x04
+  v3:  magic "SBlk", sblk_version (0x03..0x23) at +0x04
+
+Then version-specific tables follow.  See bnk_sony.c:process_tables() for
+field offsets per version.
+
+Output:
+    snippingtool_corpus_jxr/  (no, that's the other project — see below)
+    vgmstream_bnk_seeds/
+
+SOP: every file fresh, prefixed vgmstream_*.  No reuse.
+"""
+
+import os
+import struct
+import sys
+
+OUT_DIR = sys.argv[1] if len(sys.argv) > 1 else "vgmstream_bnk_seeds"
+os.makedirs(OUT_DIR, exist_ok=True)
+
+def le32(v): return struct.pack("<I", v & 0xFFFFFFFF)
+def le16(v): return struct.pack("<H", v & 0xFFFF)
+def be32(v): return struct.pack(">I", v & 0xFFFFFFFF)
+def be16(v): return struct.pack(">H", v & 0xFFFF)
+
+def write_seed(name, data, size=512):
+    """Pad/truncate to `size` bytes and write."""
+    if len(data) > size:
+        size = len(data) + 64
+    pad = size - len(data)
+    if pad > 0:
+        data = data + bytes(pad)
+    path = os.path.join(OUT_DIR, name)
+    with open(path, "wb") as f:
+        f.write(data)
+    print(f"  {len(data):4d}B  {name}")
+
+def make_file_header(container_ver, sections, sblk_offset=0x20,
+                     data_offset=0x200, data_size=0x100,
+                     zlsd_offset=0x300, zlsd_size=0x10):
+    """Build the 0x00-0x1f file header."""
+    h  = le32(container_ver)        # 0x00 container version
+    h += le32(sections)              # 0x04 sections
+    h += le32(sblk_offset)           # 0x08 sblk_offset
+    h += le32(0x100)                 # 0x0c sblk_size (unused)
+    h += le32(data_offset)           # 0x10 data_offset
+    h += le32(data_size)             # 0x14 data_size
+    if sections >= 3:
+        h += le32(zlsd_offset)       # 0x18 zlsd_offset
+        h += le32(zlsd_size)         # 0x1c zlsd_size
+    else:
+        h += b"\x00" * 8             # pad
+    return h
+
+def make_v1_seed():
+    """Container version 1 → SBv2 magic, sblk_version=0x02"""
+    fhdr = make_file_header(container_ver=1, sections=2)
+    sblk  = b"SBv2"                  # magic at sblk_offset+0x00
+    sblk += le32(0x02)               # sblk_version at +0x04
+    # v1/v2 process_tables uses sblk_offset+0x14..0x1a for entry counts,
+    # then +0x1c..0x20 for table offsets
+    sblk += b"\x00" * 0x0c           # 0x08..0x13 padding
+    sblk += le16(2)                  # 0x14 sounds_entries (case 0x02)
+    sblk += le16(2)                  # 0x16 grains_entries
+    sblk += le16(0)                  # 0x18 (unused/waves)
+    sblk += le16(1)                  # 0x1a stream_entries
+    sblk += le32(0x40)               # 0x1c table1_offset (rel to sblk)
+    sblk += le32(0x60)               # 0x20 table2_offset (rel to sblk)
+    sblk += le32(0x80)               # 0x24 table3_offset
+    return fhdr + sblk
+
+def make_v3_seed(sblk_version, table_layout="early"):
+    """
+    Container version 3 → SBlk magic, sblk_version varies.
+
+    table_layout:
+      "early"  → versions 0x03..0x09  (counts at +0x16/+0x18/+0x1a, offsets at +0x1c..)
+      "mid"    → versions 0x0c..0x10  (offsets at +0x18..+0x30, counts at +0x38..)
+      "late"   → versions 0x1a/0x1c/0x23 (different layout entirely)
+    """
+    fhdr = make_file_header(container_ver=3, sections=2)
+    sblk  = b"SBlk"                  # magic
+    sblk += le32(sblk_version)       # sblk_version
+
+    if table_layout == "early":
+        sblk += b"\x00" * 0x0e       # pad to 0x16
+        sblk += le16(2)              # 0x16 sounds_entries
+        sblk += le16(2)              # 0x18 grains_entries
+        sblk += le16(1)              # 0x1a stream_entries
+        sblk += le32(0x40)           # 0x1c table1_offset
+        sblk += le32(0x60)           # 0x20 table2_offset
+        sblk += le32(0x80)           # 0x24 (vag addr)
+        sblk += le32(0x90)           # 0x28 (data size)
+        sblk += le32(0xa0)           # 0x2c (ram size)
+        sblk += le32(0xb0)           # 0x30 (next block offset)
+        sblk += le32(0xc0)           # 0x34 table3_offset
+        sblk += le32(0xd0)           # 0x38 table4_offset
+
+    elif table_layout == "mid":
+        sblk += b"\x00" * 0x10       # pad to 0x18
+        sblk += le32(0x40)           # 0x18 table1_offset
+        sblk += le32(0x60)           # 0x1c table2_offset
+        sblk += b"\x00" * 0x0c       # pad
+        sblk += le32(0x80)           # 0x2c table3_offset
+        sblk += le32(0xa0)           # 0x30 table4_offset
+        sblk += b"\x00" * 0x04       # pad
+        sblk += le16(2)              # 0x38 sounds_entries
+        sblk += le16(2)              # 0x3a grains_entries
+        sblk += le16(1)              # 0x3c stream_entries
+
+    elif table_layout == "late":
+        # versions 0x1a/0x1c/0x23 — bank_name + tables_offset structures
+        sblk += b"\x00" * 0x14       # pad
+        # bank_name area (0x1c or 0x20)
+        sblk += b"vgmstream_bnk\x00\x00\x00"  # bank name
+        sblk += b"\x00" * 0x100       # name continues
+        # tables_offset is at sblk+0x120 or sblk+0x128
+        # counts_offset = tables_offset + 0x98 or +0xb0
+        sblk += le32(0x40)            # tables_offset+0x00
+        sblk += le32(0x60)            # +0x04
+        sblk += le32(0x80)            # +0x08 table3_offset
+        sblk += b"\x00" * 0x100        # pad to counts area
+        sblk += le16(2)               # sounds
+        sblk += le16(2)               # grains
+        sblk += le16(0)               # waves
+        sblk += le16(1)               # stream_entries
+
+    return fhdr + sblk
+
+def make_zlsd_seed():
+    """Sections=3 → triggers ZLSD parsing path"""
+    fhdr = make_file_header(container_ver=3, sections=3,
+                            zlsd_offset=0x300, zlsd_size=0x40)
+    sblk  = b"SBlk" + le32(0x09) + b"\x00" * 0xf8
+    return fhdr + sblk
+
+def make_be_seed():
+    """Big-endian variant — guess_endian32 picks BE if v=01000000"""
+    h  = be32(1)                 # version 1 in BE
+    h += be32(2)                 # sections
+    h += be32(0x20)              # sblk_offset
+    h += be32(0x100)             # sblk_size
+    h += be32(0x200)             # data_offset
+    h += be32(0x100)             # data_size
+    h += b"\x00" * 8
+    sblk  = b"2vBS"              # SBv2 reversed (BE)
+    sblk += be32(0x02)
+    return h + sblk
+
+# ---------- generate ----------
+print(f"writing seeds to {OUT_DIR}/")
+
+write_seed("vgmstream_bnk_seed_v1.bin", make_v1_seed())
+write_seed("vgmstream_bnk_seed_v3_03.bin", make_v3_seed(0x03, "early"))
+write_seed("vgmstream_bnk_seed_v3_04.bin", make_v3_seed(0x04, "early"))
+write_seed("vgmstream_bnk_seed_v3_05.bin", make_v3_seed(0x05, "early"))
+write_seed("vgmstream_bnk_seed_v3_08.bin", make_v3_seed(0x08, "early"))
+write_seed("vgmstream_bnk_seed_v3_09.bin", make_v3_seed(0x09, "early"))
+write_seed("vgmstream_bnk_seed_v3_0c.bin", make_v3_seed(0x0c, "mid"))
+write_seed("vgmstream_bnk_seed_v3_0d.bin", make_v3_seed(0x0d, "mid"))
+write_seed("vgmstream_bnk_seed_v3_0e.bin", make_v3_seed(0x0e, "mid"))
+write_seed("vgmstream_bnk_seed_v3_0f.bin", make_v3_seed(0x0f, "mid"))
+write_seed("vgmstream_bnk_seed_v3_10.bin", make_v3_seed(0x10, "mid"))
+write_seed("vgmstream_bnk_seed_v3_1a.bin", make_v3_seed(0x1a, "late"), size=1024)
+write_seed("vgmstream_bnk_seed_v3_1c.bin", make_v3_seed(0x1c, "late"), size=1024)
+write_seed("vgmstream_bnk_seed_v3_23.bin", make_v3_seed(0x23, "late"), size=1024)
+write_seed("vgmstream_bnk_seed_zlsd.bin", make_zlsd_seed(), size=1024)
+write_seed("vgmstream_bnk_seed_be.bin",   make_be_seed())
+
+# Edge case: maximum entry counts (likely to trigger int overflow)
+def make_overflow_seed():
+    fhdr = make_file_header(container_ver=3, sections=2)
+    sblk  = b"SBlk" + le32(0x05)
+    sblk += b"\x00" * 0x0e
+    sblk += le16(0xFFFF)         # max sounds_entries
+    sblk += le16(0xFFFF)         # max grains_entries
+    sblk += le16(0xFFFF)         # max stream_entries
+    sblk += le32(0xFFFFFFFF)     # huge table1_offset
+    sblk += le32(0xFFFFFFFF)     # huge table2_offset
+    return fhdr + sblk
+
+def make_underflow_seed():
+    fhdr = make_file_header(container_ver=3, sections=2,
+                            sblk_offset=0x20, data_offset=0,
+                            data_size=0xFFFFFFFF)
+    sblk  = b"SBlk" + le32(0x09)
+    sblk += b"\x00" * 0x0e
+    sblk += le16(0)              # zero counts
+    sblk += le16(0)
+    sblk += le16(0)
+    sblk += le32(0)              # zero offsets
+    return fhdr + sblk
+
+write_seed("vgmstream_bnk_seed_overflow.bin", make_overflow_seed())
+write_seed("vgmstream_bnk_seed_underflow.bin", make_underflow_seed())
+
+print(f"\ntotal seeds: {len(os.listdir(OUT_DIR))}")

--- a/projects/vgmstream/vgmstream_fuzz_bnk_seedgen.py
+++ b/projects/vgmstream/vgmstream_fuzz_bnk_seedgen.py
@@ -1,6 +1,19 @@
 #!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
-vgmstream_bnk_seedgen.py — Phase 1 seed generator for the vgmstream
+vgmstream_bnk_seedgen.py -- seed generator for the vgmstream
 PS BNK demuxer fuzz campaign.
 
 Hand-crafts minimal valid BNK files for each sblk version documented in


### PR DESCRIPTION
## What is vgmstream

[vgmstream](https://github.com/vgmstream/vgmstream) is a C/C++ library for decoding ~447 streamed audio formats used in video games. It is the back end for the foobar2000 vgmstream component, the audacious plugin, the XMPlay plugin, and the standalone `vgmstream-cli` and `vgmstream123` tools. Each demuxer in `src/meta/*` is an independent format parser that consumes untrusted bytes from a file.

## Why fuzz vgmstream

- **447 independent demuxers**, all reachable through a single dispatch entry point (`init_vgmstream`).
- **All input is untrusted**: every demuxer reads bytes straight from a file the user provides (e.g. via foobar2000 / audacious / XMPlay).
- **No prior fuzzing coverage**: vgmstream is not currently in OSS-Fuzz and has no published CVEs.
- **Active upstream maintainer** with GHSA enabled and a `SECURITY.md` that invites private vulnerability reports.
- **Cross-platform C/C++**, builds cleanly on Ubuntu with CMake. No GPU, no kernel, no exotic toolchain.

## Coverage

Measured with `llvm-cov` (clang-18, ASan + libFuzzer instrumentation, 320-file mutated corpus from a 60-minute campaign):

| Scope | Functions | Lines | Branches |
|---|---|---|---|
| **Whole library** | 25.33% | 7.83% | 4.47% |
| **`src/meta/` (parser surface)** | **50.55%** | 11.00% | 5.56% |

The harness enters **50% of all parser functions** in `src/meta/` from a single dispatch call. Line coverage is moderate because each parser bails early on unrecognized magic bytes. Sustained fuzzing on OSS-Fuzz infrastructure will drive depth significantly as the corpus evolves to bypass those initial checks.

## What this PR adds

```
projects/vgmstream/
├── Dockerfile                       # base-builder + cmake deps
├── build.sh                         # static libvgmstream.a + harness link
├── project.yaml                     # ASan + UBSan, libFuzzer/AFL/honggfuzz
├── vgmstream_fuzz_bnk.c             # libFuzzer harness (format-agnostic dispatch)
├── vgmstream_fuzz_bnk.dict          # 160-entry dictionary (BNK magics, codec enums, format tokens)
└── vgmstream_fuzz_bnk_seedgen.py    # build-time seed corpus generator
```

### Harness design

`vgmstream_fuzz_bnk.c` writes the fuzzer-supplied buffer to a tmp file in `/dev/shm`, calls `init_vgmstream()`, and frees. `init_vgmstream()` walks the full demuxer dispatch table internally, so a single harness exercises every parser in the library. Per-iteration cost is one mkstemp + one tmpfs write + one dispatch + one close + one unlink. No real disk I/O.

The `_bnk` suffix reflects the seed corpus and dictionary bias toward Sony PS BNK headers (the format family with the highest manually-verified bug density). The harness itself is format-agnostic.

### Sanitizer config

Initial PR ships with **ASan + UBSan**. MSan is held back because vgmstream depends on uninstrumented libc calls (`fread`, `memcpy`, `iconv`). Happy to add it in a follow-up if preferred.

### Optional codec backends

The build deliberately disables libmpg123 / libvorbis / FFmpeg / libg7221 / libg719 / libcelt / libspeex / libatrac9. The parser surface in `src/meta/*` is fully reachable without them. Re-enabling them is a one-line `build.sh` change for a follow-up PR.

## Author

- **Shravan Kumar Sheri**
- **GitHub:** [@Sheri98](https://github.com/Sheri98)
- **Contact:** `shravankumarsheri39@gmail.com`

