### PR TITLE
Add djvu-rs project

### DIFF
--- a/projects/djvu-rs/Dockerfile
+++ b/projects/djvu-rs/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 FROM gcr.io/oss-fuzz-base/base-builder-rust
 
-RUN git clone https://github.com/matyushkin/djvu-rs
+RUN git clone --depth 1 https://github.com/matyushkin/djvu-rs.git $SRC/djvu-rs
 WORKDIR $SRC/djvu-rs
 
 COPY build.sh $SRC/

--- a/projects/djvu-rs/Dockerfile
+++ b/projects/djvu-rs/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+
+RUN git clone https://github.com/matyushkin/djvu-rs
+WORKDIR $SRC/djvu-rs
+
+COPY build.sh $SRC/

--- a/projects/djvu-rs/build.sh
+++ b/projects/djvu-rs/build.sh
@@ -15,13 +15,13 @@
 #
 ################################################################################
 
-# Build seed corpus from test fixtures
-zip -r -j "$OUT/fuzz_full_seed_corpus.zip" tests/fixtures/*.djvu
-
-# Build all fuzz targets
 cargo fuzz build -O
 
-# Copy fuzz binaries to $OUT
-cargo fuzz list | while read target; do
-    cp "fuzz/target/x86_64-unknown-linux-gnu/release/$target" "$OUT/"
+# Copy fuzz binaries and seed corpora to $OUT.
+fuzz_out=fuzz/target/x86_64-unknown-linux-gnu/release
+for target in fuzz_full fuzz_iff fuzz_jb2 fuzz_bzz fuzz_iw44; do
+    cp "$fuzz_out/$target" "$OUT/$target"
+    if [ -d "fuzz/corpus/$target" ] && [ -n "$(ls -A fuzz/corpus/$target 2>/dev/null)" ]; then
+        (cd "fuzz/corpus/$target" && zip -qr "$OUT/${target}_seed_corpus.zip" .)
+    fi
 done

--- a/projects/djvu-rs/build.sh
+++ b/projects/djvu-rs/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Build seed corpus from test fixtures
+zip -r -j "$OUT/fuzz_full_seed_corpus.zip" tests/fixtures/*.djvu
+
+# Build all fuzz targets
+cargo fuzz build -O
+
+# Copy fuzz binaries to $OUT
+cargo fuzz list | while read target; do
+    cp "fuzz/target/x86_64-unknown-linux-gnu/release/$target" "$OUT/"
+done

--- a/projects/djvu-rs/project.yaml
+++ b/projects/djvu-rs/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://github.com/matyushkin/djvu-rs"
+main_repo: "https://github.com/matyushkin/djvu-rs"
+primary_contact: "matyushkin@gmail.com"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+language: rust


### PR DESCRIPTION
## New project: djvu-rs

**Website:** https://github.com/matyushkin/djvu-rs
**Language:** Rust
**Contact:** matyushkin@gmail.com

### Description

djvu-rs is a pure-Rust DjVu document parser and renderer (no C dependencies). It decodes IFF containers, BZZ compression, JB2 bitonal images, IW44 wavelets, and renders full pages.

### Fuzz targets (5)

| Target | What it fuzzes |
|--------|---------------|
| `fuzz_iff` | IFF container format parser |
| `fuzz_bzz` | BZZ decompression codec |
| `fuzz_jb2` | JB2 bitonal image decoder |
| `fuzz_iw44` | IW44 wavelet image decoder |
| `fuzz_full` | Full document: parse → render → text extract → thumbnails |

### Seed corpus

Test fixtures (`.djvu` files) are bundled as seed corpus for `fuzz_full`.