### PR TITLE
add lneto

### DIFF
--- a/projects/lneto/Dockerfile
+++ b/projects/lneto/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/soypat/lneto.git
+RUN go install github.com/AdamKorcz/go-118-fuzz-build@latest
+COPY build.sh $SRC/
+WORKDIR $SRC/lneto

--- a/projects/lneto/build.sh
+++ b/projects/lneto/build.sh
@@ -17,6 +17,7 @@
 
 go get github.com/AdamKorcz/go-118-fuzz-build/testing
 
-compile_native_go_fuzzer github.com/soypat/lneto/x/xnet    FuzzStackAsyncHTTP    fuzz_AsyncHTTP
+compile_native_go_fuzzer github.com/soypat/lneto/x/xnet    FuzzStackPacketHTTP   fuzz_StackPacketHTTP
+compile_native_go_fuzzer github.com/soypat/lneto/x/xnet    FuzzStackSeeded       fuzz_StackSeeded
 compile_native_go_fuzzer github.com/soypat/lneto/tcp       FuzzTCBActions        fuzz_TCBActions
 compile_native_go_fuzzer github.com/soypat/lneto/tcp       FuzzTCPControlBlock   fuzz_TCB

--- a/projects/lneto/build.sh
+++ b/projects/lneto/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+go get github.com/AdamKorcz/go-118-fuzz-build/testing
+
+compile_native_go_fuzzer github.com/soypat/lneto/x/xnet    FuzzStackAsyncHTTP    fuzz_AsyncHTTP
+compile_native_go_fuzzer github.com/soypat/lneto/tcp       FuzzTCBActions        fuzz_TCBActions
+compile_native_go_fuzzer github.com/soypat/lneto/tcp       FuzzTCPControlBlock   fuzz_TCB

--- a/projects/lneto/project.yaml
+++ b/projects/lneto/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/soypat/lneto"
+language: go
+primary_contact: "graded.sp@gmail.com"
+auto_ccs:
+  - "ron@hybridgroup.com"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+main_repo: "https://github.com/soypat/lneto.git"


### PR DESCRIPTION
Lneto is like a lighter, simpler gvisor.

https://github.com/soypat/lneto


### Major users
Major users are those who write firmware in Go on wifi boards like the Raspberry Pi Pico W and ESP32. lneto will soon be integrated into TamaGo. It is also being evaluated by netbird.io to replace gvisor for lighter webassembly binaries and better performance.


### Criticality
It is a networking stack. Hard to think of something more critical in a software other than crypto libraries or operating system primitives. This is also being used on no-operating system/baremetal targets and thus a crash/panic is equivalent to taking down the entire computer system in most cases.

### Project maintainer agrees to integrate to OSS-Fuzz?
I am the project maintainer. I agree to integrate into OSS-Fuzz.
 

