### PR TITLE
Add new project: opencascade

### DIFF
--- a/projects/opencascade/Dockerfile
+++ b/projects/opencascade/Dockerfile
@@ -1,0 +1,40 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder
+
+# Build deps. OCCT's IGES/STEP parser (TKDEIGES) depends on TKService which
+# requires X11 headers even when Visualization is disabled, so we install
+# libx11-dev, libxext-dev, and libxi-dev.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    make \
+    cmake \
+    git \
+    ca-certificates \
+    libx11-dev \
+    libxext-dev \
+    libxi-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 https://github.com/Open-Cascade-SAS/OCCT.git $SRC/occt
+
+# Fuzzer harness, dictionary, seed-corpus generator, and build script all
+# live alongside this Dockerfile in the OSS-Fuzz repo and get copied in.
+COPY build.sh $SRC/
+COPY occt_fuzz_iges.cpp $SRC/
+COPY occt_fuzz_iges.dict $SRC/
+COPY occt_fuzz_iges_seedgen.py $SRC/
+
+WORKDIR $SRC/occt

--- a/projects/opencascade/build.sh
+++ b/projects/opencascade/build.sh
@@ -1,0 +1,85 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Build OpenCASCADE as a set of static libraries, then link the IGES fuzzer
+# harness against them. We disable as many modules as possible to keep the
+# build fast, but TKDEIGES depends on TKService (which needs X11), so we
+# cannot fully disable the Visualization module.
+
+cd $SRC/occt
+
+mkdir -p build_oss_fuzz
+cd build_oss_fuzz
+
+cmake -S .. -B . \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_MODULE_Visualization=OFF \
+    -DBUILD_MODULE_Draw=OFF \
+    -DBUILD_MODULE_ApplicationFramework=OFF \
+    -DBUILD_LIBRARY_TYPE=Static \
+    -DUSE_FREETYPE=OFF \
+    -DUSE_TK=OFF \
+    -DUSE_TCL=OFF \
+    -DUSE_OPENGL=OFF \
+    -DUSE_GLES2=OFF \
+    -DUSE_VTK=OFF \
+    -DUSE_RAPIDJSON=OFF \
+    -DCMAKE_C_COMPILER="$CC" \
+    -DCMAKE_CXX_COMPILER="$CXX" \
+    -DCMAKE_C_FLAGS="$CFLAGS" \
+    -DCMAKE_CXX_FLAGS="$CXXFLAGS"
+
+make -j$(nproc)
+
+# ----------------------------------------------------------------------------
+# Collect all static libraries produced by the build
+# ----------------------------------------------------------------------------
+LIBDIR="$SRC/occt/build_oss_fuzz/lin64/gcc/lib"
+if [ ! -d "$LIBDIR" ]; then
+    # Fallback: search for the directory containing .a files
+    LIBDIR=$(dirname $(find $SRC/occt/build_oss_fuzz -name "libTKernel.a" -print -quit))
+fi
+
+# ----------------------------------------------------------------------------
+# Build the fuzzer harness and link against all OCCT static libraries
+# ----------------------------------------------------------------------------
+$CXX $CXXFLAGS \
+    -I$SRC/occt/src \
+    -I$SRC/occt/build_oss_fuzz \
+    $(find $SRC/occt/src -maxdepth 1 -type d -printf "-I%p\n") \
+    -c $SRC/occt_fuzz_iges.cpp \
+    -o $WORK/occt_fuzz_iges.o
+
+$CXX $CXXFLAGS \
+    $WORK/occt_fuzz_iges.o \
+    -Wl,--start-group $(ls ${LIBDIR}/*.a) -Wl,--end-group \
+    $LIB_FUZZING_ENGINE \
+    -lpthread -lm -ldl -lX11 \
+    -o $OUT/occt_fuzz_iges
+
+# ----------------------------------------------------------------------------
+# Dictionary
+# ----------------------------------------------------------------------------
+cp $SRC/occt_fuzz_iges.dict $OUT/occt_fuzz_iges.dict
+
+# ----------------------------------------------------------------------------
+# Seed corpus -- generated at build time so the OSS-Fuzz repo stays small
+# and the seeds always match the harness's expected layout.
+# ----------------------------------------------------------------------------
+mkdir -p $WORK/occt_fuzz_iges_seeds
+python3 $SRC/occt_fuzz_iges_seedgen.py $WORK/occt_fuzz_iges_seeds
+(cd $WORK/occt_fuzz_iges_seeds && zip -q -r $OUT/occt_fuzz_iges_seed_corpus.zip .)

--- a/projects/opencascade/occt_fuzz_iges.cpp
+++ b/projects/opencascade/occt_fuzz_iges.cpp
@@ -1,0 +1,59 @@
+/* Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
+ * occt_fuzz_iges.cpp -- libFuzzer harness for OpenCASCADE IGES parser.
+ *
+ * Writes fuzzer-supplied bytes to a tmp file in /dev/shm, then calls
+ * IGESControl_Reader::ReadFile() which dispatches into the IGES parser
+ * (analiges.c, liriges.c, structiges.c). Per-iteration cost is one
+ * mkstemp + write + parse + close + unlink on tmpfs.
+ */
+
+#include <cstdint>
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+#include <unistd.h>
+
+#include <IGESControl_Reader.hxx>
+#include <IGESData_IGESModel.hxx>
+
+#define OCCT_FUZZ_MAX_SIZE (4u * 1024u * 1024u)
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size == 0 || size > OCCT_FUZZ_MAX_SIZE) return 0;
+
+    char path[] = "/dev/shm/occt_iges_XXXXXX";
+    int fd = mkstemp(path);
+    if (fd < 0) return 0;
+
+    ssize_t w = write(fd, data, size);
+    close(fd);
+    if (w != (ssize_t)size) {
+        unlink(path);
+        return 0;
+    }
+
+    try {
+        IGESControl_Reader reader;
+        reader.ReadFile(path);
+    } catch (...) {
+        // Swallow all exceptions -- we only care about ASan/UBSan signals
+    }
+
+    unlink(path);
+    return 0;
+}

--- a/projects/opencascade/occt_fuzz_iges.dict
+++ b/projects/opencascade/occt_fuzz_iges.dict
@@ -1,0 +1,90 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# IGES format dictionary for fuzzing OpenCASCADE IGES parser
+# Section identifiers (column 73 of 80-col lines)
+section_start="S"
+section_global="G"
+section_directory="D"
+section_parameter="P"
+section_terminate="T"
+
+# Field delimiters
+delim_param=","
+delim_record=";"
+
+# Common IGES entity types (directory entry field 1)
+ent_circular_arc="100"
+ent_composite="102"
+ent_conic_arc="104"
+ent_copious="106"
+ent_line="110"
+ent_parametric_spline="112"
+ent_point="116"
+ent_ruled_surface="118"
+ent_surface_rev="120"
+ent_tabulated_cyl="122"
+ent_transform="124"
+ent_rational_bspline="126"
+ent_rational_bspline_surf="128"
+ent_offset_curve="130"
+ent_connect_point="132"
+ent_trimmed_surface="144"
+ent_bounded_surface="143"
+ent_plane="190"
+ent_right_circ_cyl="192"
+ent_color="314"
+ent_subfigure="308"
+ent_singular_subfig="408"
+ent_view="410"
+ent_drawing="404"
+ent_property="406"
+ent_assoc="402"
+
+# Hollerith string prefix (nH = n chars follow)
+hollerith_1="1H"
+hollerith_2="2H"
+hollerith_3="3H"
+hollerith_4="4H"
+hollerith_8="8H"
+hollerith_16="16H"
+hollerith_80="80H"
+hollerith_200="200H"
+
+# Common global section values
+global_comma="1H,"
+global_semi="1H;"
+global_product="7Hproduct"
+global_file="4Hfile"
+global_system="6Hsystem"
+global_version="4H5.3"
+
+# Integer values common in directory entries
+int_0="0"
+int_1="1"
+int_2="2"
+int_3="3"
+int_4="4"
+int_8="8"
+
+# Overflow triggers
+big_hollerith="99999H"
+big_int="999999999"
+neg_int="-1"
+zero="0"
+many_params=",,,,,,,,,,,,,,,,"
+
+# Line padding (spaces to fill 72-col data area)
+spaces8="        "
+spaces16="                "

--- a/projects/opencascade/occt_fuzz_iges_seedgen.py
+++ b/projects/opencascade/occt_fuzz_iges_seedgen.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Seed generator for fuzzing OpenCASCADE's IGES parser.
+
+IGES files are 80-column fixed-format ASCII. Each line has:
+  - Columns 1-72: data
+  - Column 73: section letter (S/G/D/P/T)
+  - Columns 74-80: sequence number within that section
+
+Sections: Start, Global, Directory Entry, Parameter Data, Terminate.
+"""
+
+import os
+import sys
+
+OUT_DIR = sys.argv[1] if len(sys.argv) > 1 else "occt_iges_seeds"
+
+
+def iges_line(data, section, seq):
+    """Format one 80-column IGES line."""
+    d = data[:72].ljust(72)
+    return f"{d}{section}{seq:7d}\n"
+
+
+def make_minimal_iges():
+    """Minimal valid IGES: start + global + terminate, no entities."""
+    lines = []
+    lines.append(iges_line("Minimal IGES file for fuzzing", "S", 1))
+    # Global section: param delim, record delim, product ID, file name,
+    # system ID, preprocessor version, int bits, max power of 10 float,
+    # sig digits float, max power of 10 double, sig digits double,
+    # product ID (receiving), scale, unit flag, unit name, max line weight,
+    # max line weight width, date, resolution, max coordinate, author,
+    # org, IGES version, drafting standard
+    g = "1H,,1H;,7Hproduct,4Hfile,6Hsystem,5Hv1.0,32,75,6,75,15,,1.0,2,2HMM,1,0.01,15H20260410.120000,0.001,100.0,5Hfuzzy,3Horg,11,0;"
+    lines.append(iges_line(g, "G", 1))
+    lines.append(iges_line(f"S{1:7d}G{1:7d}D{0:7d}P{0:7d}", "T", 1))
+    return "".join(lines)
+
+
+def make_line_entity():
+    """IGES with one Line entity (type 110)."""
+    lines = []
+    lines.append(iges_line("Line entity seed", "S", 1))
+    g = "1H,,1H;,7Hproduct,4Hfile,6Hsystem,5Hv1.0,32,75,6,75,15,,1.0,2,2HMM,1,0.01,15H20260410.120000,0.001,100.0,5Hfuzzy,3Horg,11,0;"
+    lines.append(iges_line(g, "G", 1))
+    # Directory entry for line (type 110): 2 lines, 20 fields of 8 chars
+    # Fields: type, param_ptr, structure, line_font, level, view, xform,
+    #         label_assoc, status, seq
+    de1 = "     110       1       0       0       0       0       0       000000000"
+    de2 = "     110       0       0       1       0       0       0       0       0"
+    lines.append(iges_line(de1, "D", 1))
+    lines.append(iges_line(de2, "D", 2))
+    # Parameter data: entity type, x1, y1, z1, x2, y2, z2
+    p = "110,0.0,0.0,0.0,10.0,10.0,0.0;"
+    lines.append(iges_line(f"{p:72s}", "P", 1))
+    lines.append(iges_line(f"S{1:7d}G{1:7d}D{2:7d}P{1:7d}", "T", 1))
+    return "".join(lines)
+
+
+def make_long_param():
+    """IGES with a parameter line containing a very long field (>80 chars)
+    to trigger the char param[80] overflow in analiges.c."""
+    lines = []
+    lines.append(iges_line("Long param overflow seed", "S", 1))
+    g = "1H,,1H;,7Hproduct,4Hfile,6Hsystem,5Hv1.0,32,75,6,75,15,,1.0,2,2HMM,1,0.01,15H20260410.120000,0.001,100.0,5Hfuzzy,3Horg,11,0;"
+    lines.append(iges_line(g, "G", 1))
+    de1 = "     110       1       0       0       0       0       0       000000000"
+    de2 = "     110       0       0       1       0       0       0       0       0"
+    lines.append(iges_line(de1, "D", 1))
+    lines.append(iges_line(de2, "D", 2))
+    # Long parameter without delimiter -- 90 chars of digits with no comma
+    p = "110," + "1" * 90 + ",0.0,0.0,10.0,10.0,0.0;"
+    # This will span multiple lines in the 72-col format
+    lines.append(iges_line(p[:72], "P", 1))
+    if len(p) > 72:
+        lines.append(iges_line(p[72:144] if len(p) > 144 else p[72:], "P", 2))
+    lines.append(iges_line(f"S{1:7d}G{1:7d}D{2:7d}P{2:7d}", "T", 1))
+    return "".join(lines)
+
+
+def make_hollerith_overflow():
+    """IGES with a Hollerith string claiming more chars than available."""
+    lines = []
+    lines.append(iges_line("Hollerith overflow seed", "S", 1))
+    g = "1H,,1H;,7Hproduct,4Hfile,6Hsystem,5Hv1.0,32,75,6,75,15,,1.0,2,2HMM,1,0.01,15H20260410.120000,0.001,100.0,5Hfuzzy,3Horg,11,0;"
+    lines.append(iges_line(g, "G", 1))
+    de1 = "     110       1       0       0       0       0       0       000000000"
+    de2 = "     110       0       0       1       0       0       0       0       0"
+    lines.append(iges_line(de1, "D", 1))
+    lines.append(iges_line(de2, "D", 2))
+    # Hollerith: 9999H followed by short data -- nbcarH will be huge
+    p = "110,9999Hshort,0.0,0.0,10.0,10.0,0.0;"
+    lines.append(iges_line(p[:72], "P", 1))
+    lines.append(iges_line(f"S{1:7d}G{1:7d}D{2:7d}P{1:7d}", "T", 1))
+    return "".join(lines)
+
+
+def make_many_entities():
+    """IGES with 5 line entities to exercise iteration paths."""
+    lines = []
+    lines.append(iges_line("Multi entity seed", "S", 1))
+    g = "1H,,1H;,7Hproduct,4Hfile,6Hsystem,5Hv1.0,32,75,6,75,15,,1.0,2,2HMM,1,0.01,15H20260410.120000,0.001,100.0,5Hfuzzy,3Horg,11,0;"
+    lines.append(iges_line(g, "G", 1))
+    d_seq = 1
+    p_seq = 1
+    for i in range(5):
+        de1 = f"     110{p_seq:8d}       0       0       0       0       0       000000000"
+        de2 = f"     110       0       0       1       0       0       0       0       0"
+        lines.append(iges_line(de1, "D", d_seq))
+        lines.append(iges_line(de2, "D", d_seq + 1))
+        d_seq += 2
+        p = f"110,{i*10}.0,0.0,0.0,{i*10+10}.0,10.0,0.0;"
+        lines.append(iges_line(p[:72], "P", p_seq))
+        p_seq += 1
+    lines.append(iges_line(f"S{1:7d}G{1:7d}D{d_seq-1:7d}P{p_seq-1:7d}", "T", 1))
+    return "".join(lines)
+
+
+def make_transform_entity():
+    """IGES with a transformation matrix entity (type 124)."""
+    lines = []
+    lines.append(iges_line("Transform matrix seed", "S", 1))
+    g = "1H,,1H;,7Hproduct,4Hfile,6Hsystem,5Hv1.0,32,75,6,75,15,,1.0,2,2HMM,1,0.01,15H20260410.120000,0.001,100.0,5Hfuzzy,3Horg,11,0;"
+    lines.append(iges_line(g, "G", 1))
+    de1 = "     124       1       0       0       0       0       0       000000000"
+    de2 = "     124       0       0       1       0       0       0       0       0"
+    lines.append(iges_line(de1, "D", 1))
+    lines.append(iges_line(de2, "D", 2))
+    # 3x4 matrix (R11,R12,R13,T1, R21,R22,R23,T2, R31,R32,R33,T3)
+    p = "124,1.0,0.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,0.0,1.0,0.0;"
+    lines.append(iges_line(p[:72], "P", 1))
+    if len(p) > 72:
+        lines.append(iges_line(p[72:], "P", 2))
+    lines.append(iges_line(f"S{1:7d}G{1:7d}D{2:7d}P{1:7d}", "T", 1))
+    return "".join(lines)
+
+
+def main():
+    os.makedirs(OUT_DIR, exist_ok=True)
+    seeds = {
+        "minimal.igs": make_minimal_iges(),
+        "line_entity.igs": make_line_entity(),
+        "long_param.igs": make_long_param(),
+        "hollerith_overflow.igs": make_hollerith_overflow(),
+        "many_entities.igs": make_many_entities(),
+        "transform.igs": make_transform_entity(),
+    }
+    for name, content in seeds.items():
+        path = os.path.join(OUT_DIR, name)
+        with open(path, "w") as f:
+            f.write(content)
+        print(f"  {len(content):5d}B  {name}")
+    print(f"\ntotal seeds: {len(seeds)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/opencascade/project.yaml
+++ b/projects/opencascade/project.yaml
@@ -1,0 +1,17 @@
+homepage: "https://github.com/Open-Cascade-SAS/OCCT"
+language: c++
+primary_contact: "shravankumarsheri39@gmail.com"
+auto_ccs:
+  - "shravankumarsheri39@gmail.com"
+main_repo: "https://github.com/Open-Cascade-SAS/OCCT.git"
+file_github_issue: true
+sanitizers:
+  - address
+  - undefined
+architectures:
+  - x86_64
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+vendor_ccs: []


### PR DESCRIPTION
# Add OpenCASCADE (OCCT) IGES parser fuzzing

## Summary

- Add libFuzzer harness for OpenCASCADE Technology (OCCT) IGES file parser
- Targets `IGESControl_Reader::ReadFile()` which dispatches into the core IGES
  parsing routines (analiges.c, liriges.c, structiges.c)
- Includes fuzzing dictionary with IGES section identifiers, entity types,
  Hollerith string prefixes, and overflow triggers
- Includes seed corpus generator that produces 6 structurally valid IGES files
  covering minimal files, line entities, transformation matrices, multi-entity
  files, long parameter fields, and Hollerith length mismatches
- Sanitizers: AddressSanitizer + UndefinedBehaviorSanitizer
- Engines: libFuzzer, AFL, honggfuzz

## Motivation

OpenCASCADE is a widely used open-source CAD kernel. Its IGES parser processes
untrusted input in many CAD/CAM workflows. The 80-column fixed-format IGES
specification has complex parsing logic involving Hollerith strings, section
interleaving, and fixed-width numeric fields -- all of which are historically
prone to buffer overflows and out-of-bounds reads.

## Build notes

OCCT is built as static libraries with most optional modules disabled. The IGES
parser lives in TKDEIGES, which depends on TKService (requiring X11 headers).
The harness writes fuzzer input to a tmpfs file and passes the path to
`IGESControl_Reader::ReadFile()`.

## Test plan

- [ ] `python3 infra/helper.py build_image opencascade`
- [ ] `python3 infra/helper.py build_fuzzers --sanitizer address opencascade`
- [ ] `python3 infra/helper.py run_fuzzer opencascade occt_fuzz_iges -- -max_total_time=60`
- [ ] `python3 infra/helper.py build_fuzzers --sanitizer undefined opencascade`
- [ ] `python3 infra/helper.py check_build opencascade`
