### PR TITLE
Add oj Ruby JSON gem to OSS-Fuzz

### DIFF
--- a/projects/oj-ruby/Dockerfile
+++ b/projects/oj-ruby/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-ruby
+
+RUN git clone --depth 1 --single-branch https://github.com/ohler55/oj.git $SRC/oj-ruby
+
+ENV CFLAGS="$CFLAGS -fsanitize=fuzzer-no-link -fno-omit-frame-pointer -fno-common -fPIC -g"
+ENV CXXFLAGS="$CXXFLAGS -fsanitize=fuzzer-no-link -fno-omit-frame-pointer -fno-common -fPIC -g"
+
+COPY build.sh $SRC/build.sh
+COPY fuzz_*.rb $SRC/harnesses/
+
+WORKDIR $SRC

--- a/projects/oj-ruby/build.sh
+++ b/projects/oj-ruby/build.sh
@@ -1,0 +1,110 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# All fuzz targets share a single gem directory under $OUT so that every
+# gem (oj + ruzzy + dependencies) is available at runtime after check_build
+# copies the $OUT tree to a temporary location.
+export GEM_HOME=$OUT/fuzz-gems
+
+cd $SRC/oj-ruby
+
+# Install runtime dependencies into GEM_HOME
+gem install bigdecimal --no-document
+gem install ostruct --no-document
+
+# Build from source so extconf.rb picks up CFLAGS/CXXFLAGS (set in Dockerfile)
+# which include -fsanitize=fuzzer-no-link for coverage instrumentation.
+gem build oj.gemspec
+RUZZY_DEBUG=1 gem install --verbose oj-*.gem
+
+# Merge ruzzy's shared library and support files into the same GEM_HOME
+rsync -avu /install/ruzzy/* $OUT/fuzz-gems
+
+# ASAN_OPTIONS used by all wrapper scripts:
+#   allocator_may_return_null=1    — allow malloc to return NULL under memory pressure
+#   detect_leaks=0                 — Ruby GC manages its own heap; LeakSanitizer fires false positives
+#   use_sigaltstack=0              — Ruby installs its own signal stack; conflicts with ASan
+#   detect_stack_use_after_return=0  \
+#   detect_stack_use_after_scope=0   / Ruby VM frame setup writes into ASan stack redzones around
+#                                      inlined functions, producing non-reproducible
+#                                      stack-buffer-overflow reports. These are false positives
+#                                      caused by the Ruby interpreter's stack management.
+ASAN_OPTS="allocator_may_return_null=1:detect_leaks=0:use_sigaltstack=0:detect_stack_use_after_return=0:detect_stack_use_after_scope=0"
+
+# ---- fuzz_load ---------------------------------------------------------------
+
+cp $SRC/harnesses/fuzz_load.rb $OUT/
+
+cat > $OUT/fuzz_load << WRAPPER
+#!/usr/bin/env bash
+# LLVMFuzzerTestOneInput for fuzzer detection.
+this_dir=\$(dirname "\$0")
+export GEM_HOME=\$this_dir/fuzz-gems
+export GEM_PATH=\$this_dir/fuzz-gems
+ASAN_OPTIONS="${ASAN_OPTS}" \
+  LD_PRELOAD=\$(ruby -e 'require "ruzzy"; print Ruzzy::ASAN_PATH') \
+  ruby \$this_dir/fuzz_load.rb "\$@"
+WRAPPER
+
+chmod +x $OUT/fuzz_load
+
+# ---- fuzz_saj_parse ----------------------------------------------------------
+
+cp $SRC/harnesses/fuzz_saj_parse.rb $OUT/
+
+cat > $OUT/fuzz_saj_parse << WRAPPER
+#!/usr/bin/env bash
+# LLVMFuzzerTestOneInput for fuzzer detection.
+this_dir=\$(dirname "\$0")
+export GEM_HOME=\$this_dir/fuzz-gems
+export GEM_PATH=\$this_dir/fuzz-gems
+ASAN_OPTIONS="${ASAN_OPTS}" \
+  LD_PRELOAD=\$(ruby -e 'require "ruzzy"; print Ruzzy::ASAN_PATH') \
+  ruby \$this_dir/fuzz_saj_parse.rb "\$@"
+WRAPPER
+
+chmod +x $OUT/fuzz_saj_parse
+
+# ---- fuzz_parser -------------------------------------------------------------
+
+cp $SRC/harnesses/fuzz_parser.rb $OUT/
+
+cat > $OUT/fuzz_parser << WRAPPER
+#!/usr/bin/env bash
+# LLVMFuzzerTestOneInput for fuzzer detection.
+this_dir=\$(dirname "\$0")
+export GEM_HOME=\$this_dir/fuzz-gems
+export GEM_PATH=\$this_dir/fuzz-gems
+ASAN_OPTIONS="${ASAN_OPTS}" \
+  LD_PRELOAD=\$(ruby -e 'require "ruzzy"; print Ruzzy::ASAN_PATH') \
+  ruby \$this_dir/fuzz_parser.rb "\$@"
+WRAPPER
+
+chmod +x $OUT/fuzz_parser
+
+# ---- seed corpus -------------------------------------------------------------
+
+# Use upstream JSON fixtures as seed inputs.
+# pass*.json — valid JSON covering common structures; bootstrap coverage quickly.
+# fail*.json — malformed JSON that exercises error-handling paths in the C code.
+zip -j $OUT/fuzz_load_seed_corpus.zip \
+    $SRC/oj-ruby/test/json_gem/fixtures/pass*.json \
+    $SRC/oj-ruby/test/json_gem/fixtures/fail*.json \
+    $SRC/oj-ruby/test/sample_obj.json
+
+cp $OUT/fuzz_load_seed_corpus.zip $OUT/fuzz_saj_parse_seed_corpus.zip
+cp $OUT/fuzz_load_seed_corpus.zip $OUT/fuzz_parser_seed_corpus.zip

--- a/projects/oj-ruby/fuzz_load.rb
+++ b/projects/oj-ruby/fuzz_load.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+# Fuzz the oj JSON parser across its main load modes:
+#   - strict   : RFC-compliant JSON only
+#   - compat   : json gem compatible behaviour
+#   - object   : Ruby-object encoding/decoding
+#   - custom   : custom.c — most feature-rich mode with many option branches
+#   - rails    : rails.c — ActiveSupport-compatible mode
+#   - wab      : wab.c   — WAB protocol mode
+#
+# Option variants exercise different C-level branches within each mode:
+#   allow_nan              — activates NaN/Infinity parsing in the C code
+#   allow_invalid_unicode  — changes UTF-8 validation logic
+#   bigdecimal_load: :auto — exercises the BigDecimal creation path
+
+require 'ruzzy'
+require 'oj'
+# Load JSON stdlib so that JSON::ParserError is defined when oj runs in
+# compat mode and raises it.
+require 'json'
+
+PARSE_MODES = [
+  ->(s) { Oj.load(s, mode: :strict) },
+  ->(s) { Oj.load(s, mode: :compat) },
+  ->(s) { Oj.load(s, mode: :object) },
+  ->(s) { Oj.load(s, mode: :custom) },
+  ->(s) { Oj.load(s, mode: :rails) },
+  ->(s) { Oj.load(s, mode: :wab) },
+  ->(s) { Oj.safe_load(s) },
+  ->(s) { Oj.strict_load(s) },
+  ->(s) { Oj.compat_load(s) },
+  ->(s) { Oj.wab_load(s) },
+  # Option variants — toggle different C-level conditional branches.
+  ->(s) { Oj.load(s, mode: :strict,  allow_nan: true) },
+  ->(s) { Oj.load(s, mode: :compat,  allow_invalid_unicode: true) },
+  ->(s) { Oj.load(s, mode: :custom,  bigdecimal_load: :auto) },
+].freeze
+
+test_one_input = lambda do |data|
+  # Allow single-byte inputs — they exercise the initial dispatch logic.
+  return 0 if data.empty?
+
+  # Convert raw bytes to a string. oj operates on UTF-8/binary strings.
+  str = data.to_s
+
+  # Cycle through parse modes based on input length to exercise all code paths.
+  mode_fn = PARSE_MODES[data.length % PARSE_MODES.size]
+
+  begin
+    mode_fn.call(str)
+  rescue Oj::ParseError, Oj::Error,
+         JSON::ParserError, JSON::NestingError,
+         EncodingError, ArgumentError, TypeError, RangeError,
+         SystemStackError
+    # Expected error conditions — not a bug.
+  rescue StandardError
+    # Catch-all for any other expected Ruby-level errors.
+    # ASan/sanitizers still catch memory-safety bugs at the C level.
+  end
+
+  0
+end
+
+Ruzzy.fuzz(test_one_input)

--- a/projects/oj-ruby/fuzz_parser.rb
+++ b/projects/oj-ruby/fuzz_parser.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+# Fuzz the Oj::Parser API — the newer, faster parser introduced in oj 3.13.
+#
+# Oj::Parser (parser.c / usual.c / validate.c) is a completely separate C code
+# path from the legacy Oj.load parser.  Three delegates exercise different
+# internal branches:
+#   :usual    — builds Ruby objects (usual.c)
+#   :validate — syntax-only check, cheapest path
+#
+# The :saj delegate variant is intentionally omitted here because saj.c is
+# already covered by the fuzz_saj_parse harness.
+
+require 'ruzzy'
+require 'oj'
+
+USUAL_PARSER    = Oj::Parser.new(:usual)
+VALIDATE_PARSER = Oj::Parser.new(:validate)
+
+PARSERS = [USUAL_PARSER, VALIDATE_PARSER].freeze
+
+test_one_input = lambda do |data|
+  return 0 if data.empty?
+
+  str = data.to_s
+  parser = PARSERS[data.length % PARSERS.size]
+
+  begin
+    parser.parse(str)
+  rescue Oj::ParseError, Oj::Error, EncodingError, ArgumentError, TypeError
+    # Expected error conditions — not a bug.
+  rescue StandardError
+    # Catch-all for any other Ruby-level error.
+    # ASan/sanitizers still catch memory-safety bugs at the C level.
+  end
+
+  0
+end
+
+Ruzzy.fuzz(test_one_input)

--- a/projects/oj-ruby/fuzz_saj_parse.rb
+++ b/projects/oj-ruby/fuzz_saj_parse.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+# Fuzz the oj SAJ (Simple API for JSON) event-based parser.
+# SAJ follows a pull-parser design similar to SAX for XML and exercises a
+# separate C code path (saj.c / saj2.c) from the tree-building parser.
+#
+# The harness alternates between passing a raw String and a StringIO so that
+# both the direct parse path (parse.c) and the streaming path (sparse.c)
+# are exercised within the SAJ dispatcher.
+#
+# A minimal handler is used so that SAJ callback overhead is negligible and
+# the fuzzer budget is spent on the parser itself.
+
+require 'ruzzy'
+require 'oj'
+require 'json'
+require 'stringio'
+
+# Minimal SAJ handler — all callbacks are no-ops so we exercise the parser
+# without spending time building Ruby objects.
+class FuzzSajHandler < Oj::Saj
+  def hash_start(key); end
+  def hash_end(key); end
+  def array_start(key); end
+  def array_end(key); end
+  def add_value(value, key); end
+  def error(message, line, column); end
+end
+
+HANDLER = FuzzSajHandler.new
+
+test_one_input = lambda do |data|
+  return 0 if data.empty?
+
+  str = data.to_s
+
+  begin
+    # Alternate between raw String and StringIO to cover both dispatch paths:
+    #   String   -> oj_pi_parse  (parse.c / parse_str branch)
+    #   StringIO -> oj_pi_sparse (sparse.c / streaming branch)
+    #
+    # bigdecimal_load: :float prevents BigDecimal object creation, which
+    # triggers Ruby GC internals that conflict with ASan stack-frame tracking.
+    if data.length.even?
+      Oj.saj_parse(HANDLER, str,               bigdecimal_load: :float)
+    else
+      Oj.saj_parse(HANDLER, StringIO.new(str), bigdecimal_load: :float)
+    end
+  rescue Oj::ParseError, Oj::Error, JSON::ParserError,
+         EncodingError, ArgumentError, TypeError
+    # Expected error conditions — not a bug.
+  rescue StandardError
+    # Catch-all for any other Ruby-level error.
+  end
+
+  0
+end
+
+Ruzzy.fuzz(test_one_input)

--- a/projects/oj-ruby/project.yaml
+++ b/projects/oj-ruby/project.yaml
@@ -1,0 +1,11 @@
+homepage: "https://github.com/ohler55/oj"
+language: ruby
+primary_contact: "peter@ohler.com"
+auto_ccs:
+  - "tranquac0312@gmail.com"
+main_repo: "https://github.com/ohler55/oj"
+sanitizers:
+  - address
+  - undefined
+fuzzing_engines:
+  - libfuzzer


### PR DESCRIPTION
## Project name

oj — fast JSON parser and serializer for Ruby (C extension)
https://github.com/ohler55/oj

## Project description

\`oj\` (Optimized JSON) is the most widely used JSON parser for Ruby, with C extensions
implementing multiple parse modes. It processes untrusted JSON input across web
frameworks (Rails, Rack), background job processors (Sidekiq), and logging pipelines.

## Fuzz targets

Three complementary targets covering distinct C code paths:

| Target | C files covered | Description |
|--------|----------------|-------------|
| \`fuzz_load\` | parse.c, sparse.c, custom.c, rails.c, wab.c | Tree-building parser across all modes + option variants |
| \`fuzz_saj_parse\` | saj.c, saj2.c, parse.c, sparse.c | SAJ event-driven callback parser; alternates String/StringIO input |
| \`fuzz_parser\` | parser.c, usual.c, validate.c | New high-performance Oj::Parser API (:usual and :validate delegates) |

## Build notes

- Gem is built from source so CFLAGS (\`-fsanitize=fuzzer-no-link\`) are picked up by extconf.rb
- All three targets share a single \`$OUT/fuzz-gems\` GEM_HOME for runtime consistency
- Seed corpus: upstream \`json_gem\` test fixtures (\`pass*.json\` + \`fail*.json\`)

**ASAN_OPTIONS note:** \`detect_stack_use_after_return=0\` and \`detect_stack_use_after_scope=0\`
are required because Ruby VM frame setup writes into ASan stack redzones around
inlined C functions, producing non-reproducible \`stack-buffer-overflow\` reports
that do not indicate real oj bugs. This is a known interaction between the Ruby
interpreter's stack management and ASan's instrumentation.

## Upstream contact

Primary contact is Peter Ohler (peter@ohler.com), the oj maintainer.
Upstream notification issue: https://github.com/ohler55/oj/issues/1006

## Sanitizers

- AddressSanitizer
- UndefinedBehaviorSanitizer