### PR TITLE
Add prism to OSS-Fuzz

### DIFF
--- a/projects/prism/Dockerfile
+++ b/projects/prism/Dockerfile
@@ -1,0 +1,28 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+# Ruby is needed only to generate templated C source files (templates/template.rb).
+# No Ruzzy or Ruby runtime is required for the fuzz targets themselves.
+RUN apt-get update && apt-get install -y ruby make
+
+RUN git clone --depth 1 --single-branch https://github.com/ruby/prism.git $SRC/prism
+
+COPY build.sh $SRC/build.sh
+COPY fuzz_lex.c $SRC/
+
+WORKDIR $SRC

--- a/projects/prism/build.sh
+++ b/projects/prism/build.sh
@@ -1,0 +1,48 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cd $SRC/prism
+
+# Generate templated C source files (ext/prism/api_node.c, include/prism/ast.h,
+# src/diagnostic.c, etc.) that are not committed to git.
+ruby templates/template.rb
+
+# Build libprism.a with OSS-Fuzz sanitizer flags injected via $CC/$CFLAGS.
+make static CC="$CC" CFLAGS="$CFLAGS"
+
+# Copy our lex harness alongside the existing fuzz/parse.c from the project.
+cp $SRC/fuzz_lex.c fuzz/lex.c
+
+# Compile and link fuzz targets.
+# fuzz/fuzz.c provides: LLVMFuzzerTestOneInput(data, size) -> harness(data, size)
+# fuzz/parse.c and fuzz/lex.c each implement: harness(input, size)
+for target in parse lex; do
+  $CC $CFLAGS   -c fuzz/fuzz.c      -Iinclude -o /tmp/fuzz_driver.o
+  $CC $CFLAGS   -c fuzz/${target}.c -Iinclude -o /tmp/fuzz_${target}.o
+  $CXX $CXXFLAGS /tmp/fuzz_driver.o /tmp/fuzz_${target}.o \
+      build/libprism.a $LIB_FUZZING_ENGINE \
+      -o $OUT/fuzz_${target}
+done
+
+# Dictionary: use prism's own fuzz/dict (Ruby keywords, operators, magic tokens).
+cp fuzz/dict $OUT/fuzz_parse.dict
+cp fuzz/dict $OUT/fuzz_lex.dict
+
+# Seed corpus: all Ruby fixture files from the test suite.
+# find (not glob) to include all subdirectories (~986 files vs ~107 at top level).
+# Relative paths without -j to avoid basename collisions across subdirs.
+find test/prism/fixtures -name '*.txt' | \
+    xargs zip $OUT/fuzz_parse_seed_corpus.zip
+cp $OUT/fuzz_parse_seed_corpus.zip $OUT/fuzz_lex_seed_corpus.zip

--- a/projects/prism/fuzz_lex.c
+++ b/projects/prism/fuzz_lex.c
@@ -1,0 +1,24 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Exercises the prism lexer via pm_serialize_lex.
+// Paired with fuzz/fuzz.c which provides LLVMFuzzerTestOneInput -> harness().
+
+#include <prism.h>
+
+void harness(const uint8_t *input, size_t size) {
+    pm_buffer_t *buffer = pm_buffer_new();
+    pm_serialize_lex(buffer, input, size, NULL);
+    pm_buffer_free(buffer);
+}

--- a/projects/prism/project.yaml
+++ b/projects/prism/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://github.com/ruby/prism"
+language: c
+primary_contact: "kddnewton@gmail.com"
+auto_ccs:
+  - "tranquac0312@gmail.com"
+main_repo: "https://github.com/ruby/prism"
+sanitizers:
+  - address
+  - memory
+  - undefined
+fuzzing_engines:
+  - libfuzzer


### PR DESCRIPTION
## New Project: prism (C library)

Adds continuous fuzzing for https://github.com/ruby/prism by fuzzing **libprism directly as a standalone C library**, not through the Ruby extension.

> This revision addresses feedback from @Earlopain in ruby/prism#4073 who correctly pointed out that prism is also a C library and should be fuzzed at that level.

### Fuzz targets

| Target | Entry point | Coverage |
|---|---|---|
| `fuzz_parse` | `pm_serialize_parse()` | Full AST parse path — uses upstream `fuzz/parse.c` |
| `fuzz_lex` | `pm_serialize_lex()` | Lexer-only path — `fuzz_lex.c` |

### Build

```
ruby templates/template.rb   # generate templated C sources
make static CC=$CC CFLAGS=$CFLAGS   # build libprism.a with sanitizer flags
$CC/$CXX + $LIB_FUZZING_ENGINE      # link harnesses against library
```

### Sanitizers

`address`, `memory` (msan — not possible with Ruby extension), `undefined`

### Corpus & dictionary

- **Seed corpus**: ~986 Ruby fixture files from `test/prism/fixtures/` (all subdirs)
- **Dictionary**: `fuzz/dict` from the project (Ruby keywords, operators, magic tokens)

### Build verification

- `build_image` ✓
- `build_fuzzers --sanitizer address` ✓
- `check_build --sanitizer address` ✓
- Smoke tests: both targets run clean, no crashes

Project maintainer: @kddnewton (Kevin Newton, `kddnewton@gmail.com`)