### PR TITLE
Add OSS-Fuzz integration for msgpack-ruby

### DIFF
--- a/projects/msgpack-ruby/Dockerfile
+++ b/projects/msgpack-ruby/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-ruby
+
+RUN git clone --depth 1 --single-branch https://github.com/msgpack/msgpack-ruby.git $SRC/msgpack-ruby
+
+ENV CFLAGS="$CFLAGS -fsanitize=fuzzer-no-link -fno-omit-frame-pointer -fno-common -fPIC -g"
+ENV CXXFLAGS="$CXXFLAGS -fsanitize=fuzzer-no-link -fno-omit-frame-pointer -fno-common -fPIC -g"
+
+COPY build.sh $SRC/build.sh
+COPY fuzz_*.rb fuzz_*.dict fuzz_*.options $SRC/harnesses/
+
+WORKDIR $SRC

--- a/projects/msgpack-ruby/build.sh
+++ b/projects/msgpack-ruby/build.sh
@@ -1,0 +1,71 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cd $SRC/msgpack-ruby
+
+# All C extension files are committed to git — no code generation needed.
+
+# GEM_HOME must be set before any gem install so gems land in $OUT/fuzz-gems,
+# which is the only directory available when OSS-Fuzz copies $OUT to run fuzzers.
+export GEM_HOME=$OUT/fuzz-gems
+
+gem build msgpack.gemspec
+RUZZY_DEBUG=1 gem install --verbose msgpack-*.gem
+rsync -avu /install/ruzzy/* $OUT/fuzz-gems
+
+# ASAN_OPTIONS required for Ruby C extension targets.
+# Ruby GC, signal stack, and VM frame setup conflict with ASan defaults.
+#   allocator_may_return_null=1  — allow malloc to return NULL under memory pressure
+#   detect_leaks=0               — Ruby GC manages its own heap; LSan reports false positives
+#   use_sigaltstack=0            — Ruby installs its own signal stack, conflicts with ASan
+#   detect_stack_use_after_return=0  — Ruby VM frame setup writes into ASan stack redzones
+#   detect_stack_use_after_scope=0   — same issue with inlined C functions + rb_funcall
+ASAN_OPTS="allocator_may_return_null=1:detect_leaks=0:use_sigaltstack=0:detect_stack_use_after_return=0:detect_stack_use_after_scope=0"
+
+for target in fuzz_unpack fuzz_unpack_stream; do
+  cp $SRC/harnesses/${target}.rb $OUT/
+  cat > $OUT/${target} << WRAPPER
+#!/usr/bin/env bash
+# LLVMFuzzerTestOneInput for fuzzer detection.
+this_dir=\$(dirname "\$0")
+export GEM_HOME=\$this_dir/fuzz-gems
+export GEM_PATH=\$this_dir/fuzz-gems
+ASAN_OPTIONS="${ASAN_OPTS}" \
+  LD_PRELOAD=\$(ruby -e 'require "ruzzy"; print Ruzzy::ASAN_PATH') \
+  ruby \$this_dir/${target}.rb "\$@"
+WRAPPER
+  chmod +x $OUT/${target}
+done
+
+# Seed corpus: msgpack binary test fixtures from the project's own spec suite.
+# cases.msg and cases_compact.msg cover all MessagePack types (nil, bool, int,
+# float, string, binary, array, map, ext) in both standard and compact formats.
+zip -j $OUT/fuzz_unpack_seed_corpus.zip \
+    $SRC/msgpack-ruby/spec/cases.msg \
+    $SRC/msgpack-ruby/spec/cases_compact.msg
+cp $OUT/fuzz_unpack_seed_corpus.zip $OUT/fuzz_unpack_stream_seed_corpus.zip
+
+# Dictionaries: MessagePack type byte markers accelerate coverage discovery
+# by helping libFuzzer generate syntactically meaningful byte sequences.
+cp $SRC/harnesses/fuzz_unpack.dict $OUT/
+cp $SRC/harnesses/fuzz_unpack_stream.dict $OUT/
+
+# Options: raise rss_limit_mb to 4096 because the msgpack binary format allows
+# str32/bin32 headers to declare up to 4GB allocations. OSS-Fuzz will report
+# this pre-allocation-without-bounds-check as a DoS finding against msgpack-ruby
+# (unpacker.c:339 rb_str_buf_new(length) with untrusted length). The higher
+# RSS limit lets the fuzzer continue exploring other code paths beyond this known bug.
+cp $SRC/harnesses/fuzz_unpack.options $OUT/
+cp $SRC/harnesses/fuzz_unpack_stream.options $OUT/

--- a/projects/msgpack-ruby/fuzz_unpack.dict
+++ b/projects/msgpack-ruby/fuzz_unpack.dict
@@ -1,0 +1,51 @@
+# MessagePack type markers for libFuzzer guided mutation
+# nil/bool
+"\xc0"
+"\xc2"
+"\xc3"
+# unsigned integers
+"\xcc"
+"\xcd"
+"\xce"
+"\xcf"
+# signed integers
+"\xd0"
+"\xd1"
+"\xd2"
+"\xd3"
+# floats
+"\xca"
+"\xcb"
+# string formats
+"\xd9"
+"\xda"
+"\xdb"
+# binary formats
+"\xc4"
+"\xc5"
+"\xc6"
+# array formats
+"\xdc"
+"\xdd"
+# map formats
+"\xde"
+"\xdf"
+# fixext formats
+"\xd4"
+"\xd5"
+"\xd6"
+"\xd7"
+"\xd8"
+# ext formats
+"\xc7"
+"\xc8"
+"\xc9"
+# fixmap/fixarray/fixstr prefixes
+"\x80"
+"\x90"
+"\xa0"
+# common length suffixes
+"\x00\x00\x00\x00"
+"\xff\xff\xff\xff"
+"\x00\x00"
+"\xff\xff"

--- a/projects/msgpack-ruby/fuzz_unpack.options
+++ b/projects/msgpack-ruby/fuzz_unpack.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+rss_limit_mb = 4096

--- a/projects/msgpack-ruby/fuzz_unpack.rb
+++ b/projects/msgpack-ruby/fuzz_unpack.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'ruzzy'
+require 'msgpack'
+
+# Exercises MessagePack.unpack / MessagePack.load (factory_class.c → unpacker.c)
+# with option variants that exercise distinct C code paths.
+UNPACK_FNS = [
+  # Default path: string → full_unpack via DefaultFactory
+  ->(str) { MessagePack.unpack(str) },
+  # symbolize_keys: rb_str_intern() on every map key (buffer.h: read_top_as_symbol)
+  ->(str) { MessagePack.unpack(str, symbolize_keys: true) },
+  # freeze: rb_obj_freeze() on each deserialized object
+  ->(str) { MessagePack.unpack(str, freeze: true) },
+  # allow_unknown_ext: returns ExtensionValue instead of raising UnknownExtTypeError
+  ->(str) { MessagePack.unpack(str, allow_unknown_ext: true) },
+  # key_cache: exercises rstring_cache_fetch / build_interned_string (buffer.h)
+  # — binary-searches a sorted VALUE array and does MEMMOVE, distinct memory paths
+  ->(str) { MessagePack.unpack(str, symbolize_keys: true, key_cache: true) },
+].freeze
+
+test_one_input = lambda do |data|
+  return 0 if data.empty?
+  str = data.to_s
+  fn = UNPACK_FNS[data.length % UNPACK_FNS.size]
+  begin
+    fn.call(str)
+  rescue NoMemoryError    # rb_str_buf_new(huge_length) returns NULL → Ruby raises this
+  rescue SystemStackError # inherits from Exception, not StandardError — not caught below
+  rescue EOFError
+  rescue MessagePack::UnpackError  # covers Malformed/Stack/UnexpectedType/UnknownExt
+  rescue EncodingError, ArgumentError, TypeError, RangeError
+  rescue StandardError
+  end
+  0
+end
+
+Ruzzy.fuzz(test_one_input)

--- a/projects/msgpack-ruby/fuzz_unpack_stream.dict
+++ b/projects/msgpack-ruby/fuzz_unpack_stream.dict
@@ -1,0 +1,51 @@
+# MessagePack type markers for libFuzzer guided mutation
+# nil/bool
+"\xc0"
+"\xc2"
+"\xc3"
+# unsigned integers
+"\xcc"
+"\xcd"
+"\xce"
+"\xcf"
+# signed integers
+"\xd0"
+"\xd1"
+"\xd2"
+"\xd3"
+# floats
+"\xca"
+"\xcb"
+# string formats
+"\xd9"
+"\xda"
+"\xdb"
+# binary formats
+"\xc4"
+"\xc5"
+"\xc6"
+# array formats
+"\xdc"
+"\xdd"
+# map formats
+"\xde"
+"\xdf"
+# fixext formats
+"\xd4"
+"\xd5"
+"\xd6"
+"\xd7"
+"\xd8"
+# ext formats
+"\xc7"
+"\xc8"
+"\xc9"
+# fixmap/fixarray/fixstr prefixes
+"\x80"
+"\x90"
+"\xa0"
+# common length suffixes
+"\x00\x00\x00\x00"
+"\xff\xff\xff\xff"
+"\x00\x00"
+"\xff\xff"

--- a/projects/msgpack-ruby/fuzz_unpack_stream.options
+++ b/projects/msgpack-ruby/fuzz_unpack_stream.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+rss_limit_mb = 4096

--- a/projects/msgpack-ruby/fuzz_unpack_stream.rb
+++ b/projects/msgpack-ruby/fuzz_unpack_stream.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'ruzzy'
+require 'msgpack'
+
+# Exercises the streaming Unpacker API (unpacker_class.c → unpacker.c):
+#   feed_each, feed+each, feed+read — distinct code paths from MessagePack.unpack.
+STREAM_FNS = [
+  # feed_each: canonical streaming API, calls Unpacker_each_impl internally
+  ->(str) { MessagePack::Unpacker.new.feed_each(str) {} },
+  # feed_each with symbolize_keys
+  ->(str) { MessagePack::Unpacker.new(symbolize_keys: true).feed_each(str) {} },
+  # feed + each: separate feed and iterator (Unpacker_each via Unpacker_each_impl)
+  ->(str) {
+    u = MessagePack::Unpacker.new
+    u.feed(str)
+    u.each {}
+  },
+  # feed + read loop: exercises Unpacker_read directly until EOFError
+  ->(str) {
+    u = MessagePack::Unpacker.new(allow_unknown_ext: true)
+    u.feed(str)
+    loop { u.read }
+  },
+  # key_cache: exercises rstring_cache_fetch / rsymbol_cache_fetch (buffer.h)
+  # — sorted VALUE array binary search + MEMMOVE, distinct from uncached paths
+  ->(str) {
+    u = MessagePack::Unpacker.new(symbolize_keys: true, key_cache: true)
+    u.feed_each(str) {}
+  },
+].freeze
+
+test_one_input = lambda do |data|
+  return 0 if data.empty?
+  str = data.to_s
+  fn = STREAM_FNS[data.length % STREAM_FNS.size]
+  begin
+    fn.call(str)
+  rescue NoMemoryError    # rb_str_buf_new(huge_length) returns NULL → Ruby raises this
+  rescue SystemStackError # inherits from Exception, not StandardError — not caught below
+  rescue EOFError
+  rescue MessagePack::UnpackError  # covers Malformed/Stack/UnexpectedType/UnknownExt
+  rescue EncodingError, ArgumentError, TypeError, RangeError
+  rescue StandardError
+  end
+  0
+end
+
+Ruzzy.fuzz(test_one_input)

--- a/projects/msgpack-ruby/project.yaml
+++ b/projects/msgpack-ruby/project.yaml
@@ -1,0 +1,11 @@
+homepage: "https://github.com/msgpack/msgpack-ruby"
+language: ruby
+primary_contact: "jean.boussier@gmail.com"
+auto_ccs:
+  - "tranquac0312@gmail.com"
+main_repo: "https://github.com/msgpack/msgpack-ruby"
+sanitizers:
+  - address
+  - undefined
+fuzzing_engines:
+  - libfuzzer


### PR DESCRIPTION
## Project

**msgpack-ruby** — the Ruby gem for the MessagePack binary serialization format.

- Repo: https://github.com/msgpack/msgpack-ruby
- Downloads: 468M+ lifetime (~20M/month), used in Rails, Sidekiq, Redis protocol serializers
- C extension: `ext/msgpack/` — 12 source files, ~3,945 LOC
- OSS-Fuzz coverage: `msgpack-c` on OSS-Fuzz covers a C++ header-only library; msgpack-ruby's C extension is completely independent code not covered by any existing project

## Fuzz targets

### `fuzz_unpack` — `MessagePack.unpack` API variants
Exercises `factory_class.c → unpacker_class.c → unpacker.c` with 5 option combinations:
- Default path
- `symbolize_keys: true` — `rb_str_intern()` on every map key
- `freeze: true` — `rb_obj_freeze()` on each object
- `allow_unknown_ext: true` — `ExtensionValue` construction path
- `key_cache: true` — `rstring_cache_fetch` / `build_interned_string` (sorted VALUE array + MEMMOVE in buffer.h)

### `fuzz_unpack_stream` — Streaming `Unpacker` API
Exercises `unpacker_class.c` streaming methods with 5 variants:
- `Unpacker#feed_each` (default)
- `feed_each` with `symbolize_keys: true`
- `feed` + `each` (iterator path)
- `feed` + `loop { read }` (direct `Unpacker_read` path)
- `feed_each` with `key_cache: true`

## Local test results

```
build_image:   SUCCESS
build_fuzzers: SUCCESS (address sanitizer)
check_build:   PASSED

fuzz_unpack:        INITED cov: 41 ft: 42 — coverage growing
fuzz_unpack_stream: INITED cov: 128 ft: 148 — coverage growing (dict active)
```

## Known finding: DoS via unchecked pre-allocation

Both fuzz targets consistently discover a resource exhaustion condition:

```
ERROR: libFuzzer: out-of-memory (malloc(3758149315))
```

**Root cause:** `ext/msgpack/unpacker.c:339` calls `rb_str_buf_new(length)` where `length` comes directly from the msgpack header (str32/bin32 can specify up to 4GB). This allocation happens *before* checking whether that much data is available in the buffer. A 5-byte crafted message can force a 4GB allocation attempt, causing server-side OOM/DoS.

This is an intentional finding — the harnesses are configured with `rss_limit_mb=4096` (via `.options` files) to allow the fuzzer to continue beyond this known condition and discover additional bugs (memory corruption, use-after-free) in the C extension.

## Maintainer acknowledgment

Upstream issue: https://github.com/msgpack/msgpack-ruby/issues/388