### PR TITLE
lua: build corpus for Lua API tests

### DIFF
--- a/projects/lua/build.sh
+++ b/projects/lua/build.sh
@@ -173,6 +173,11 @@ LUA_RUNTIME_NAME=lua
 for fuzzer in $(find $SRC -name '*_test.lua'); do
   $SRC/compile_lua_fuzzer $LUA_RUNTIME_NAME $(basename $fuzzer)
   cp $fuzzer "$OUT/"
+  test_file=$(basename $fuzzer);
+  test_name_we="${test_file%.*}";
+  module_name=$(echo $test_name_we | sed 's/_test//' )
+  corpus_dir="corpus_dir/$module_name"
+  [[ -e $corpus_dir ]] && find "$corpus_dir" -mindepth 1 -maxdepth 1 | zip -@ -j $OUT/"$test_name_we"_seed_corpus.zip
 done
 cp $SRC/testdir/tests/lapi/lib.lua "$OUT/"
 


### PR DESCRIPTION
Follows up the commit 8361dd0b6fd5c4c6598d02a436bf5dd8b7d027ce ("lua: support luzer-based testing (#14610)")

Follows up #14610