### PR TITLE
Add ai-plugin-scanner

### DIFF
--- a/projects/ai-plugin-scanner/project.yaml
+++ b/projects/ai-plugin-scanner/project.yaml
@@ -1,0 +1,10 @@
+homepage: https://github.com/hashgraph-online/ai-plugin-scanner
+main_repo: https://github.com/hashgraph-online/ai-plugin-scanner
+language: python
+primary_contact: 6068672+kantorcodes@users.noreply.github.com
+help_url: https://github.com/hashgraph-online/ai-plugin-scanner/issues
+fuzzing_engines:
+- libfuzzer
+sanitizers:
+- address
+- undefined


### PR DESCRIPTION
## Project
Add `ai-plugin-scanner`, a Python security and quality scanner used to lint and verify AI plugin packages and local harness policy before release.

## Why OSS-Fuzz
- The scanner parses and validates untrusted plugin metadata, marketplace manifests, MCP configuration, skills, and related package inputs.
- It already has an Atheris fuzz target in the upstream repository (`fuzzers/manifest_fuzzer.py`).
- The project also runs ClusterFuzzLite in CI today, so there is already an active fuzzing workflow to build on.
- This project sits on the release and security-review path for multi-ecosystem AI plugin packages (Codex, Claude, Gemini, OpenCode), so parser and validation hardening has supply-chain value beyond a single app.

## Upstream repository
- Homepage: https://github.com/hashgraph-online/ai-plugin-scanner
- Main repo: https://github.com/hashgraph-online/ai-plugin-scanner

## Contact
- Primary contact is the established maintainer email from the project commit history. If OSS-Fuzz needs a different Google-account-linked address for dashboard access, we can provide that during review.
