### PR TITLE
Add cryptography-rs: Rust cryptography library

### DIFF
--- a/projects/cryptography-rs/Dockerfile
+++ b/projects/cryptography-rs/Dockerfile
@@ -1,0 +1,3 @@
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+RUN git clone --depth 1 https://github.com/darrelllong/cryptography $SRC/cryptography
+COPY build.sh $SRC/

--- a/projects/cryptography-rs/build.sh
+++ b/projects/cryptography-rs/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -eu
+
+cd "$SRC/cryptography"
+cargo fuzz build -O
+
+for f in fuzz/fuzz_targets/*.rs; do
+    FUZZ_TARGET=$(basename "${f%.*}")
+    cp "fuzz/target/x86_64-unknown-linux-gnu/release/$FUZZ_TARGET" "$OUT/"
+done

--- a/projects/cryptography-rs/project.yaml
+++ b/projects/cryptography-rs/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://github.com/darrelllong/cryptography"
+main_repo: "https://github.com/darrelllong/cryptography"
+language: rust
+primary_contact: "darrell.long@gmail.com"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer


### PR DESCRIPTION
## Project

**Homepage:** https://github.com/darrelllong/cryptography
**Language:** Rust
**License:** BSD 2-Clause

A pure-Rust implementation of classical and post-quantum cryptographic
primitives built from specifications, with no third-party crypto
dependencies.

## Fuzz targets (39 total)

**Block ciphers:** AES, Camellia, CAST-128, DES/TDES, Grasshopper, Magma,
PRESENT, SEED, Serpent, Simon, SM4, Speck, Twofish

**Stream ciphers:** ChaCha20, Rabbit, Salsa20, SNOW 3G, ZUC

**Post-quantum (NIST FIPS):** ML-KEM (FIPS 203), ML-DSA (FIPS 204)

**Public-key:** ECDSA, EdDSA, ECDH, Ed25519, DSA, DH, ElGamal, EC-ElGamal,
Edwards-ElGamal, Paillier, Rabin, Cocks, Schmidt-Samoa, ECIES,
RSA-OAEP, RSA-PSS

**Modes:** GCM, EAX, CCM, OCB, ChaCha20-Poly1305, CBC, CTR, AES Key Wrap

**Hash/MAC/KDF:** MD5, SHA-1/2/3 family, HMAC, HKDF

**CSPRNG:** CTR_DRBG-AES-256

## Invariants checked

Each target enforces correctness invariants (encrypt/decrypt roundtrip,
sign/verify roundtrip, Diffie-Hellman property, serialization roundtrip)
in addition to the standard no-panic-on-arbitrary-input guarantee.

## Bugs already found

Initial fuzzing runs found three bugs that have been fixed:
- Two integer overflows in DER parsing (`pos + seq_len` and `pos + len`
  with crafted large-length fields)
- RSA-CRT subtraction underflow when `q > p` (panic in any private-key
  operation triggered by specific ciphertext inputs)