### PR TITLE
cifuzz: handle empty frames in get_error_frame to prevent IndexError

### DIFF
--- a/infra/cifuzz/sarif_utils.py
+++ b/infra/cifuzz/sarif_utils.py
@@ -163,7 +163,8 @@ def get_error_frame(crash_info):
     return None
   state = crash_info.crash_state.split('\n')[0]
   logging.info('state: %s frames %s, %s', state, crash_info.frames,
-               [f.function_name for f in crash_info.frames[0]])
+               [f.function_name for f in crash_info.frames[0]]
+               if crash_info.frames else [])
 
   for crash_frames in crash_info.frames:
     for frame in crash_frames:

--- a/infra/cifuzz/sarif_utils_test.py
+++ b/infra/cifuzz/sarif_utils_test.py
@@ -105,6 +105,17 @@ def _get_mock_crash_info():
   return crash_info
 
 
+class GetErrorFrameTest(unittest.TestCase):
+  """Tests for get_error_frame."""
+
+  def test_empty_frames_does_not_raise(self):
+    """Tests that get_error_frame doesn't raise IndexError when frames is empty."""
+    crash_info = mock.MagicMock()
+    crash_info.frames = []
+    crash_info.crash_state = 'some_func\nsome_func1'
+    self.assertIsNone(sarif_utils.get_error_frame(crash_info))
+
+
 class GetErrorSourceInfoTest(unittest.TestCase):
   """Tests for get_error_source_info."""
 


### PR DESCRIPTION
This bug was caused by cifuzz action: https://github.com/Kludex/python-multipart/actions/runs/24344710532/job/71082324098 When the following pr was merged: https://github.com/Kludex/python-multipart/pull/264