### PR TITLE
Add NanoMQ fuzzing integration

### DIFF
--- a/projects/nanomq/Dockerfile
+++ b/projects/nanomq/Dockerfile
@@ -1,0 +1,28 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN apt-get update && apt-get install -y \
+    cmake ninja-build pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 https://github.com/nanomq/nanomq.git $SRC/nanomq && \
+    cd $SRC/nanomq && \
+    git submodule update --init --recursive
+
+WORKDIR $SRC/nanomq
+COPY build.sh $SRC/

--- a/projects/nanomq/build.sh
+++ b/projects/nanomq/build.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC/nanomq
+
+mkdir -p build && cd build
+
+cmake \
+  -G Ninja \
+  -DENABLE_FUZZING=ON \
+  -DCMAKE_C_COMPILER="$CC" \
+  -DCMAKE_CXX_COMPILER="$CXX" \
+  -DCMAKE_C_FLAGS="$CFLAGS" \
+  -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+  -DLIB_FUZZING_ENGINE="$LIB_FUZZING_ENGINE" \
+  ..
+
+ninja pub_decode_fuzzer
+
+# Copy fuzzer binary
+cp nanomq/tests/fuzz/pub_decode_fuzzer $OUT/
+
+# Copy dictionary (named <binary>.dict for automatic pickup)
+cp $SRC/nanomq/nanomq/tests/fuzz/mqtt.dict $OUT/pub_decode_fuzzer.dict
+
+# Package seed corpus (named <binary>_seed_corpus.zip)
+zip -j $OUT/pub_decode_fuzzer_seed_corpus.zip \
+    $SRC/nanomq/nanomq/tests/fuzz/corpus/*

--- a/projects/nanomq/project.yaml
+++ b/projects/nanomq/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://nanomq.io"
+language: c
+primary_contact: "jaylin@emqx.io"
+auto_ccs:
+  - "lihj@emqx.io"
+  - "saberrg@gmail.com"
+main_repo: "https://github.com/nanomq/nanomq"
+sanitizers:
+  - address
+  - undefined
+architectures:
+  - x86_64


### PR DESCRIPTION
## Project

**NanoMQ** — an ultra-lightweight MQTT broker for IoT and edge computing.

- Homepage: https://nanomq.io
- Repository: https://github.com/nanomq/nanomq
- Language: C
- License: MIT

## Fuzzer

`pub_decode_fuzzer` targets `decode_pub_message()`, the MQTT PUBLISH packet decoder. This is a critical network-facing code path that processes every PUBLISH packet received by the broker.

The fuzzer:
- Tests both MQTT v3.1.1 and v5.0 PUBLISH decoding
- Uses a seed corpus of 3 files (v3/v5 PUBLISH packets + a known leak reproducer)
- Uses an MQTT-specific dictionary (38 entries covering packet types and v5 property IDs)

## Sanitizers

- AddressSanitizer (`address`)
- UndefinedBehaviorSanitizer (`undefined`)

## Existing Bug Findings

This fuzzer has already found and led to fixes for real memory safety issues:

1. **nanomq/nanomq#2238** — Initial fuzzer integration (heap buffer overflow + memory leak in `free_pub_packet`)
2. **nanomq/nanomq#2289** — Memory leaks in MQTT v5 property decode error paths across `pub_handler.c`, `sub_handler.c`, and `unsub_handler.c`

The LeakSanitizer output from the reproducer:
```
SUMMARY: AddressSanitizer: 192 byte(s) leaked in 3 allocation(s).
```

## Build

Uses CMake + Ninja. The `ENABLE_FUZZING=ON` flag automatically enables static library builds and wires up `$LIB_FUZZING_ENGINE`. NNG (the networking dependency) is a git submodule cloned via `--recurse-submodules`.

## Checklist

- [x] `project.yaml` with `primary_contact`, `auto_ccs`, `main_repo`, sanitizers
- [x] `Dockerfile` that clones the repo with submodules
- [x] `build.sh` that builds and copies fuzzer binary, dictionary, and seed corpus to `$OUT`
- [x] Fuzzer binary naming follows OSS-Fuzz conventions (no extension, alphanumeric)
- [x] Seed corpus packaged as `pub_decode_fuzzer_seed_corpus.zip`
- [x] Dictionary named `pub_decode_fuzzer.dict` for automatic pickup