### PR TITLE
tinyusb: remove duplicate key from project.yaml

### DIFF
--- a/projects/tinyusb/project.yaml
+++ b/projects/tinyusb/project.yaml
@@ -1,6 +1,5 @@
 homepage: "https://docs.tinyusb.org/en/latest/"
 language: c++
-primary_contact: "Ha Thach"
 main_repo: "https://github.com/hathach/tinyusb.git"
 primary_contact: "thach@tinyusb.org"
 auto_ccs:


### PR DESCRIPTION
Duplicate keys in yaml files are invalid: https://yaml.org/spec/1.2.2/#mapping

Having duplicate keys causes some yaml parsers to fail. In this case I think the "primary_contact" should be the email address rather than the name of the contact. 