### PR TITLE
tensorflow: register TFLite, GraphDef, and checkpoint fuzz targets

### DIFF
--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -209,7 +209,9 @@ export FUZZTEST_DO_SYNC="no"
 
 # Set fuzz targets. Exclude cc/ops and core/kernels/fuzzing as they depend on
 # ops::Placeholder which was removed from TF's C++ ops API.
-export FUZZTEST_TARGET_FOLDER="//tensorflow/security/fuzzing/cc:all+//tensorflow/cc/saved_model/...+//tensorflow/cc/framework/fuzzing/...+//tensorflow/core/common_runtime/...+//tensorflow/core/framework/..."
+# Includes //tensorflow/security/fuzzing/cc/{lite,graph,checkpoint}:all for the
+# TFLite interpreter, ImportGraphDef, and V2 checkpoint loader fuzz targets.
+export FUZZTEST_TARGET_FOLDER="//tensorflow/security/fuzzing/cc:all+//tensorflow/security/fuzzing/cc/lite:all+//tensorflow/security/fuzzing/cc/graph:all+//tensorflow/security/fuzzing/cc/checkpoint:all+//tensorflow/cc/saved_model/...+//tensorflow/cc/framework/fuzzing/...+//tensorflow/core/common_runtime/...+//tensorflow/core/framework/..."
 
 # Remove the cc/ops BUILD file - those fuzzers use removed Placeholder API
 rm -f $SRC/tensorflow/tensorflow/security/fuzzing/cc/ops/BUILD


### PR DESCRIPTION
# PR for `google/oss-fuzz`

**Title:** `tensorflow: register TFLite, GraphDef, and checkpoint fuzz targets`

## Summary

Appends three new target folders to `projects/tensorflow/build.sh`'s `FUZZTEST_TARGET_FOLDER` so the raw-bytes fuzz targets added upstream in tensorflow/tensorflow#116009 are picked up by the OSS-Fuzz TF build:

- `//tensorflow/security/fuzzing/cc/lite:all` — TFLite Interpreter fuzzer
- `//tensorflow/security/fuzzing/cc/graph:all` — `ImportGraphDef` raw-bytes fuzzer
- `//tensorflow/security/fuzzing/cc/checkpoint:all` — V2 checkpoint loader fuzzer

**Depends on:** tensorflow/tensorflow#116009 (must merge first, since `build.sh` does a fresh `git clone` of the TF master branch at Docker build time).

## Why

TFLite, raw-bytes `ImportGraphDef`, and the checkpoint loader currently have **zero coverage** in the OSS-Fuzz TF build set. See the upstream PR for the coverage-gap rationale per target.

## Changes

```
projects/tensorflow/build.sh   | 4 +++-
1 file changed, 3 insertions(+), 1 deletion(-)
```

One line extended (the `FUZZTEST_TARGET_FOLDER` export) plus a two-line comment. No changes to `Dockerfile`, `project.yaml`, or anything else.

## Test plan

After the upstream PR lands:

```bash
python3 infra/helper.py build_image tensorflow
python3 infra/helper.py build_fuzzers --sanitizer address tensorflow
ls build/out/tensorflow/ | grep -E 'tflite_interpreter_fuzz|import_graph_def_fuzz|load_checkpoint_fuzz'
python3 infra/helper.py check_build tensorflow
```

CI already restricts presubmit builds to `//tensorflow/security/fuzzing/cc:base64_fuzz` via the `OSS_FUZZ_CI` override, so adding these targets does not change presubmit latency.

## No seed corpora shipped

`_seed_corpus.zip` inputs for fuzztest targets are silently dropped by the libFuzzer compatibility adapter unless they carry a `FUZZTESTv1` magic header (`fuzztest/internal/serialization.cc::ParseIRObject` + `compatibility_mode.cc::RunOneInputData`). Shipping raw `.tflite`/`.pb`/`.index` bytes would give the appearance of seeded discovery while the bytes were actually being ignored. If seeding is needed, the upstream harnesses can grow `.WithSeeds(...)` calls in a follow-up; that path bypasses the IRObject parser.
