### PR TITLE
Add agentbridge project (IntelliJ plugin with MCP tools)

### DIFF
--- a/projects/agentbridge/Dockerfile
+++ b/projects/agentbridge/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/agentbridge/Dockerfile
+++ b/projects/agentbridge/Dockerfile
@@ -1,3 +1,19 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 
 RUN git clone --depth 1 https://github.com/catatafishen/agentbridge.git /src/agentbridge

--- a/projects/agentbridge/Dockerfile
+++ b/projects/agentbridge/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm@sha256:d4d8b420a4de8dcde2f2677f38b8ea4ba6f9f3bcb9773859ad3b3ca676351530
 
 RUN git clone --depth 1 https://github.com/catatafishen/agentbridge.git /src/agentbridge
 WORKDIR /src/agentbridge

--- a/projects/agentbridge/Dockerfile
+++ b/projects/agentbridge/Dockerfile
@@ -1,3 +1,19 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 
 RUN git clone --depth 1 https://github.com/catatafishen/agentbridge.git /src/agentbridge

--- a/projects/agentbridge/Dockerfile
+++ b/projects/agentbridge/Dockerfile
@@ -1,20 +1,4 @@
-# Copyright 2026 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-################################################################################
-
-FROM gcr.io/oss-fuzz-base/base-builder-jvm@sha256:d4d8b420a4de8dcde2f2677f38b8ea4ba6f9f3bcb9773859ad3b3ca676351530
+FROM gcr.io/oss-fuzz-base/base-builder-jvm
 
 RUN git clone --depth 1 https://github.com/catatafishen/agentbridge.git /src/agentbridge
 WORKDIR /src/agentbridge

--- a/projects/agentbridge/Dockerfile
+++ b/projects/agentbridge/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/oss-fuzz-base/base-builder-jvm
+
+RUN git clone --depth 1 https://github.com/catatafishen/agentbridge.git /src/agentbridge
+WORKDIR /src/agentbridge
+
+COPY build.sh $SRC/

--- a/projects/agentbridge/build.sh
+++ b/projects/agentbridge/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/agentbridge/build.sh
+++ b/projects/agentbridge/build.sh
@@ -1,4 +1,19 @@
 #!/bin/bash -eu
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
 #
 # OSS-Fuzz build script for AgentBridge (IntelliJ Copilot Plugin).
 # Called inside the Docker container by OSS-Fuzz infrastructure.

--- a/projects/agentbridge/build.sh
+++ b/projects/agentbridge/build.sh
@@ -1,19 +1,4 @@
 #!/bin/bash -eu
-# Copyright 2026 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-################################################################################
 #
 # OSS-Fuzz build script for AgentBridge (IntelliJ Copilot Plugin).
 # Called inside the Docker container by OSS-Fuzz infrastructure.
@@ -21,15 +6,29 @@
 
 cd /src/agentbridge
 
-# Build all test classes (includes fuzz targets)
+# Build all test classes (fuzz targets live in the test source sets).
 ./gradlew :plugin-core:testClasses :mcp-server:testClasses --no-daemon --quiet
 
-# Resolve full test runtime classpath for each module
+# Resolve full test runtime classpaths (includes compiled classes + all dep JARs).
 CP_CORE=$(./gradlew :plugin-core:printFuzzClasspath --no-daemon -q | tail -1)
 CP_MCP=$(./gradlew :mcp-server:printFuzzClasspath --no-daemon -q | tail -1)
-FULL_CP="${CP_CORE}:${CP_MCP}"
 
-# Fuzz target classes — each has a fuzzerTestOneInput(FuzzedDataProvider) entry point
+# Copy every JAR from the classpath into $OUT/ and every class directory into
+# $OUT/classes/.  The jazzer_driver wrapper uses "$this_dir/*" (Java wildcard
+# classpath) and "$this_dir/classes" at fuzzing runtime.
+mkdir -p "$OUT/classes"
+for cp in "$CP_CORE" "$CP_MCP"; do
+  IFS=':' read -ra entries <<< "$cp"
+  for entry in "${entries[@]}"; do
+    if [[ -f "$entry" && "$entry" == *.jar ]]; then
+      cp -n "$entry" "$OUT/" 2>/dev/null || true
+    elif [[ -d "$entry" ]]; then
+      cp -rn "$entry/." "$OUT/classes/" 2>/dev/null || true
+    fi
+  done
+done
+
+# Fuzz target classes — each exposes fuzzerTestOneInput(FuzzedDataProvider).
 TARGETS=(
   com.github.catatafishen.agentbridge.fuzz.AgentIdMapperFuzz
   com.github.catatafishen.agentbridge.fuzz.MarkdownRendererFuzz
@@ -43,6 +42,23 @@ TARGETS=(
 for target in "${TARGETS[@]}"; do
   short_name="${target##*.}"
 
-  # compile_java_fuzzer is provided by the base-builder-jvm image
-  compile_java_fuzzer "/src/agentbridge" "$target" "$OUT/${short_name}" "$FULL_CP"
+  # Create the execution wrapper (the file OSS-Fuzz treats as the fuzzer binary).
+  cat > "$OUT/${short_name}" << EOF
+#!/bin/bash
+# LLVMFuzzerTestOneInput for fuzzer detection.
+this_dir=\$(dirname "\$0")
+if [[ "\$@" =~ (^| )-runs=[0-9]+(\$| ) ]]; then
+  mem_settings='-Xmx1900m:-Xss900k'
+else
+  mem_settings='-Xmx2048m:-Xss1024k'
+fi
+LD_LIBRARY_PATH="${JVM_LD_LIBRARY_PATH}:\$this_dir" \\
+ASAN_OPTIONS=\$ASAN_OPTIONS:symbolize=1:external_symbolizer_path=\$this_dir/llvm-symbolizer:detect_leaks=0 \\
+\$this_dir/jazzer_driver --agent_path=\$this_dir/jazzer_agent_deploy.jar \\
+--cp=\$this_dir/classes:\$this_dir/* \\
+--target_class=${target} \\
+--jvm_args="\$mem_settings" \\
+"\$@"
+EOF
+  chmod +x "$OUT/${short_name}"
 done

--- a/projects/agentbridge/build.sh
+++ b/projects/agentbridge/build.sh
@@ -1,4 +1,19 @@
 #!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
 #
 # OSS-Fuzz build script for AgentBridge (IntelliJ Copilot Plugin).
 # Called inside the Docker container by OSS-Fuzz infrastructure.

--- a/projects/agentbridge/build.sh
+++ b/projects/agentbridge/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -eu
+#
+# OSS-Fuzz build script for AgentBridge (IntelliJ Copilot Plugin).
+# Called inside the Docker container by OSS-Fuzz infrastructure.
+# $SRC, $OUT, and $JAVA_HOME are set by the base image.
+
+cd /src/agentbridge
+
+# Build all test classes (includes fuzz targets)
+./gradlew :plugin-core:testClasses :mcp-server:testClasses --no-daemon --quiet
+
+# Resolve full test runtime classpath for each module
+CP_CORE=$(./gradlew :plugin-core:printFuzzClasspath --no-daemon -q | tail -1)
+CP_MCP=$(./gradlew :mcp-server:printFuzzClasspath --no-daemon -q | tail -1)
+FULL_CP="${CP_CORE}:${CP_MCP}"
+
+# Fuzz target classes — each has a fuzzerTestOneInput(FuzzedDataProvider) entry point
+TARGETS=(
+  com.github.catatafishen.agentbridge.fuzz.AgentIdMapperFuzz
+  com.github.catatafishen.agentbridge.fuzz.MarkdownRendererFuzz
+  com.github.catatafishen.agentbridge.fuzz.TimeArgParserFuzz
+  com.github.catatafishen.agentbridge.fuzz.AbuseDetectorFuzz
+  com.github.catatafishen.agentbridge.fuzz.NewSessionResponseFuzz
+  com.github.catatafishen.agentbridge.fuzz.JunitXmlParserFuzz
+  com.github.copilot.mcp.McpStdioProxyFuzz
+)
+
+for target in "${TARGETS[@]}"; do
+  short_name="${target##*.}"
+
+  # compile_java_fuzzer is provided by the base-builder-jvm image
+  compile_java_fuzzer "/src/agentbridge" "$target" "$OUT/${short_name}" "$FULL_CP"
+done

--- a/projects/agentbridge/project.yaml
+++ b/projects/agentbridge/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/catatafishen/agentbridge"
+language: jvm
+primary_contact: "catatafishen@users.noreply.github.com"
+main_repo: "https://github.com/catatafishen/agentbridge.git"
+fuzzing_engines:
+  - jazzer
+sanitizers:
+  - address
+vendor_ccs:
+  - "catatafishen@users.noreply.github.com"

--- a/projects/agentbridge/project.yaml
+++ b/projects/agentbridge/project.yaml
@@ -1,10 +1,10 @@
 homepage: "https://github.com/catatafishen/agentbridge"
 language: jvm
-primary_contact: "catatafishen@users.noreply.github.com"
+primary_contact: "henrik@westergard.org"
 main_repo: "https://github.com/catatafishen/agentbridge.git"
 fuzzing_engines:
   - jazzer
 sanitizers:
   - address
 vendor_ccs:
-  - "catatafishen@users.noreply.github.com"
+  - "henrik@westergard.org"


### PR DESCRIPTION
## New Project: agentbridge

**Website:** https://github.com/catatafishen/agentbridge
**Language:** JVM (Java 21)
**Fuzzing Engine:** Jazzer

### Project Description

AgentBridge is an IntelliJ platform plugin that exposes IDE code intelligence as MCP (Model Context Protocol) tools to AI coding agents. It runs across all JetBrains IDEs (IntelliJ IDEA, WebStorm, PyCharm, Rider, etc.) and processes untrusted input from external AI agents via JSON-RPC/MCP protocol messages.

### Fuzz Targets (7)

| Target | What it fuzzes |
|--------|----------------|
| `McpStdioProxyFuzz` | Hand-rolled JSON parser for JSON-RPC id extraction — every MCP message flows through this |
| `AbuseDetectorFuzz` | Security-critical command injection detection in tool arguments |
| `TimeArgParserFuzz` | Multi-format date/time parser (7+ formats, waterfall parsing) |
| `NewSessionResponseFuzz` | Polymorphic JSON normalization for ACP session responses |
| `JunitXmlParserFuzz` | XML test report parsing with XXE protection |
| `AgentIdMapperFuzz` | Agent identifier mapping and normalization |
| `MarkdownRendererFuzz` | Markdown→HTML state machine conversion |

### Why This Project Benefits from Fuzzing

- Processes **untrusted input from external AI agents** (JSON-RPC messages, tool arguments)
- Contains **hand-rolled JSON parsers** on the critical path (no library — lightweight by design)
- **Security-critical validators** (AbuseDetector) that must not be bypassable
- Multiple **format-polymorphic deserializers** that handle 3+ wire formats
- **XML parsing** with XXE protection that needs adversarial testing

### Build & Test

The project uses Gradle with Jazzer. Existing CI already runs these targets weekly:
https://github.com/catatafishen/agentbridge/blob/master/.github/workflows/fuzz.yml