### PR TITLE
Add Hancock to OSS-Fuzz

### DIFF
--- a/projects/hancock/Dockerfile
+++ b/projects/hancock/Dockerfile
@@ -16,6 +16,6 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-python
 RUN apt-get update && apt-get install -y python3-dev
-RUN git clone --depth 1 https://github.com/0ai-Cyberviser/Hancock.git $SRC/hancock
+RUN git clone --depth 1 https://github.com/cyberviser/Hancock.git $SRC/hancock
 WORKDIR $SRC/hancock
 COPY build.sh $SRC/

--- a/projects/hancock/Dockerfile
+++ b/projects/hancock/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-python
+RUN apt-get update && apt-get install -y python3-dev
+RUN git clone --depth 1 https://github.com/0ai-Cyberviser/Hancock.git $SRC/hancock
+WORKDIR $SRC/hancock
+COPY build.sh $SRC/

--- a/projects/hancock/build.sh
+++ b/projects/hancock/build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+pip3 install -r "$SRC/hancock/requirements.txt"
+
+FUZZ_DIR="$SRC/hancock/fuzz"
+
+shopt -s nullglob
+for fuzzer in "$FUZZ_DIR"/fuzz_*.py; do
+  fuzzer_basename=$(basename "$fuzzer" .py)
+  compile_python_fuzzer "$fuzzer"
+  corpus_name="${fuzzer_basename#fuzz_}"
+  corpus_dir="$FUZZ_DIR/corpus/$corpus_name"
+  if [ -d "$corpus_dir" ]; then
+    zip -j "$OUT/${fuzzer_basename}_seed_corpus.zip" "$corpus_dir"/* 2>/dev/null || true
+  fi
+done

--- a/projects/hancock/project.yaml
+++ b/projects/hancock/project.yaml
@@ -1,0 +1,11 @@
+homepage: "https://github.com/0ai-Cyberviser/Hancock"
+language: python
+primary_contact: "cyberviser@proton.me"
+auto_ccs:
+  - "security@cyberviser.ai"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+  - undefined
+main_repo: "https://github.com/0ai-Cyberviser/Hancock"

--- a/projects/hancock/project.yaml
+++ b/projects/hancock/project.yaml
@@ -1,11 +1,11 @@
-homepage: "https://github.com/0ai-Cyberviser/Hancock"
+homepage: "https://github.com/cyberviser/Hancock"
 language: python
-primary_contact: "cyberviser@proton.me"
+primary_contact: "0ai@cyberviserai.com"
 auto_ccs:
-  - "security@cyberviser.ai"
+  - "cyberviser@proton.me"
 fuzzing_engines:
   - libfuzzer
 sanitizers:
   - address
   - undefined
-main_repo: "https://github.com/0ai-Cyberviser/Hancock"
+main_repo: "https://github.com/cyberviser/Hancock"


### PR DESCRIPTION
Adds [Hancock](https://github.com/cyberviser/Hancock) (AI-powered cybersecurity agent) to OSS-Fuzz with 8 Atheris-based Python fuzz targets and seed corpora.

This supersedes #15315 from the older `0ai-Cyberviser` fork and continues the same integration from a writable `cyberviser/oss-fuzz` fork. The code change in this refresh is narrow: it updates the project metadata and source clone URL to the current upstream repository location.

## Fuzz targets
- `fuzz_nvd_parser`: NVD JSON/feed parsing
- `fuzz_mitre_parser`: MITRE ATT&CK data parsing
- `fuzz_formatter`: advisory output formatting
- `fuzz_formatter_v3`: CVSSv3 formatter paths
- `fuzz_api_inputs`: API endpoint input validation
- `fuzz_webhook_signature`: webhook HMAC signature verification
- `fuzz_ghsa_parser`: GitHub Security Advisory parsing
- `fuzz_xml_parsing`: XML/defusedxml parsing

## Integration details
- Language: Python
- Engine: libFuzzer via Atheris
- Sanitizers: address, undefined
- Upstream fuzz targets and corpora: https://github.com/cyberviser/Hancock/tree/main/fuzz
- CIFuzz and continuous fuzz workflows are enabled upstream

## Validation
- `python3 infra/helper.py build_image hancock`
