### PR TITLE
[v8] Support --sandbox-testing

### DIFF
--- a/projects/v8/build.sh
+++ b/projects/v8/build.sh
@@ -33,7 +33,10 @@ ARGS='is_asan = true
  v8_enable_backtrace = true
  v8_enable_slow_dchecks = true
  v8_enable_test_features = true
- v8_enable_fast_mksnapshot = true'
+ v8_enable_fast_mksnapshot = true
+ v8_enable_sandbox = true
+ v8_enable_memory_corruption_api = true'
+
 
 if [[ -n "${INDEXER_BUILD:-}" ]]; then
   ARGS="$ARGS is_debug=true v8_optimized_debug=false v8_enable_slow_dchecks=true clang_base_path=\"/opt/toolchain\""


### PR DESCRIPTION
Updates the v8 build.sh to support --sandbox-testing and --enable_memory_corruption_api

This allows testing different types of bugs using the v8 image