### PR TITLE
update libtorrent to the 2.1 branch

### DIFF
--- a/projects/libtorrent/Dockerfile
+++ b/projects/libtorrent/Dockerfile
@@ -14,10 +14,10 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y wget libssl-dev libboost-tools-dev libboost-dev libboost-system-dev
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
+RUN apt-get update && apt-get install -y wget libssl-dev libboost-tools-dev libboost-dev libboost-system-dev libboost-json-dev
 
-RUN git clone --depth 1 --single-branch --branch RC_2_0 --recurse-submodules https://github.com/arvidn/libtorrent.git
+RUN git clone --depth 1 --single-branch --branch RC_2_1 --recurse-submodules https://github.com/arvidn/libtorrent.git
 WORKDIR libtorrent
 COPY build.sh $SRC/
 

--- a/projects/libtorrent/build.sh
+++ b/projects/libtorrent/build.sh
@@ -22,10 +22,10 @@ echo "using clang : ossfuzz : $CXX : <compileflags>\"$CXXFLAGS\" <linkflags>\"$C
 cat project-config.jam
 cd fuzzers
 # we don't want sanitizers enabled on b2 itself
-ASAN_OPTIONS=detect_leaks=0 b2 clang-ossfuzz -j$(nproc) crypto=openssl fuzz=external sanitize=off stage-large logging=off
+ASAN_OPTIONS=detect_leaks=0 b2 clang-ossfuzz fuzz=external sanitize=off stage-large logging=off webtorrent=on
 cp fuzzers/* $OUT
 
-wget --no-verbose https://github.com/arvidn/libtorrent/releases/download/2.0/corpus.zip
+wget --no-verbose https://github.com/arvidn/libtorrent/releases/download/v2.1.0-rc1/corpus.zip
 unzip -q corpus.zip
 cd corpus
 for f in *; do

--- a/projects/libtorrent/project.yaml
+++ b/projects/libtorrent/project.yaml
@@ -5,6 +5,7 @@ auto_ccs:
  - "oss-fuzz-libtorrent@pauldreik.se"
  - "arvid.norberg@gmail.com"
 main_repo: 'https://github.com/arvidn/libtorrent.git'
+base_os_version: ubuntu-24-04
 fuzzing_engines:
   - afl
   - honggfuzz


### PR DESCRIPTION
* bump libtorrent to new 2.1 RC branch
* enable new webtorrent support
* bump image to Ubuntu 24.04 to get access to boost-json

`b2` uses all cores by default, so `-j$(nproc)` is not necessary. `openssl` build feature is on by default now, so it's not necessary.