### PR TITLE
[bumble] Add new project integration

### DIFF
--- a/projects/bumble/Dockerfile
+++ b/projects/bumble/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-python
+RUN git clone --depth 1 https://github.com/google/bumble $SRC/bumble
+RUN python3 -m pip install --upgrade pip
+WORKDIR $SRC/bumble
+COPY build.sh $SRC/
+COPY fuzz_*.py $SRC/

--- a/projects/bumble/build.sh
+++ b/projects/bumble/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+cd $SRC/bumble
+pip3 install .
+
+# Build fuzzers in \$OUT.
+for fuzzer in \$(find \$SRC -maxdepth 1 -name 'fuzz_*.py'); do
+  compile_python_fuzzer "\$fuzzer"
+done

--- a/projects/bumble/fuzz_att_pdu.py
+++ b/projects/bumble/fuzz_att_pdu.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Atheris harness for bumble.att.ATT_PDU.from_bytes.
+
+ATT PDUs are remote-peer-controlled on every GATT client connection. Prior bugs
+in this parser (e.g. empty-PDU IndexError fixed in PR #912) caused host crashes.
+"""
+import sys
+import atheris
+
+with atheris.instrument_imports():
+    from bumble import att
+
+_BENIGN = (ValueError, IndexError, KeyError, TypeError,
+           NotImplementedError, UnicodeDecodeError, OverflowError,
+           __import__("struct").error)
+
+
+def TestOneInput(data: bytes) -> None:
+    try:
+        att.ATT_PDU.from_bytes(data)
+    except _BENIGN:
+        pass
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/bumble/fuzz_data_types.py
+++ b/projects/bumble/fuzz_data_types.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+"""BT advertising/EIR data-type parser harness.
+
+Covers 20+ data_types classes that share from_bytes() signature. An attacker
+nearby can inject arbitrary bytes into any of these via advertising packets.
+"""
+import sys
+import atheris
+
+with atheris.instrument_imports():
+    from bumble import data_types
+
+_TARGETS = []
+for _name in (
+    "CompleteListOf16BitServiceUUIDs", "CompleteListOf32BitServiceUUIDs",
+    "CompleteListOf128BitServiceUUIDs", "Flags", "ManufacturerSpecificData",
+    "CompleteLocalName", "ShortenedLocalName", "TxPowerLevel", "ClassOfDevice",
+    "PeripheralConnectionIntervalRange", "ServiceData16BitUUID",
+    "ServiceData32BitUUID", "ServiceData128BitUUID",
+    "PublicTargetAddress", "Appearance", "AdvertisingInterval",
+    "LeBluetoothDeviceAddress", "URI", "BroadcastCode",
+):
+    _cls = getattr(data_types, _name, None)
+    if _cls is not None and hasattr(_cls, "from_bytes"):
+        _TARGETS.append(_cls.from_bytes)
+
+_BENIGN = (ValueError, IndexError, KeyError, TypeError,
+           NotImplementedError, UnicodeDecodeError, OverflowError,
+           __import__("struct").error)
+
+
+def TestOneInput(data: bytes) -> None:
+    if len(data) < 1 or not _TARGETS:
+        return
+    target = _TARGETS[data[0] % len(_TARGETS)]
+    try:
+        target(data[1:])
+    except _BENIGN:
+        pass
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/bumble/fuzz_l2cap.py
+++ b/projects/bumble/fuzz_l2cap.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+"""L2CAP PDU + Control Frame parser harness."""
+import sys
+import atheris
+
+with atheris.instrument_imports():
+    from bumble import l2cap
+
+_BENIGN = (ValueError, IndexError, KeyError, TypeError,
+           NotImplementedError, UnicodeDecodeError, OverflowError,
+           __import__("struct").error)
+
+
+def TestOneInput(data: bytes) -> None:
+    if len(data) < 1:
+        return
+    picker = data[0] & 1
+    payload = data[1:]
+    try:
+        if picker == 0:
+            l2cap.L2CAP_PDU.from_bytes(payload)
+        else:
+            l2cap.L2CAP_Control_Frame.from_bytes(payload)
+    except _BENIGN:
+        pass
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/bumble/fuzz_rfcomm.py
+++ b/projects/bumble/fuzz_rfcomm.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+"""RFCOMM frame + MCC field parser harness."""
+import sys
+import atheris
+
+with atheris.instrument_imports():
+    from bumble import rfcomm
+
+_BENIGN = (ValueError, IndexError, KeyError, TypeError,
+           NotImplementedError, UnicodeDecodeError, OverflowError,
+           __import__("struct").error)
+
+
+def TestOneInput(data: bytes) -> None:
+    if len(data) < 1:
+        return
+    picker = data[0] % 3
+    payload = data[1:]
+    try:
+        if picker == 0:
+            rfcomm.RFCOMM_Frame.from_bytes(payload)
+        elif picker == 1:
+            rfcomm.RFCOMM_MCC_PN.from_bytes(payload)
+        else:
+            rfcomm.RFCOMM_MCC_MSC.from_bytes(payload)
+    except _BENIGN:
+        pass
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/bumble/fuzz_sdp.py
+++ b/projects/bumble/fuzz_sdp.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+"""SDP DataElement + SDP_PDU parser harness.
+
+Targets the nested-SEQUENCE recursion class exposed by the depth-limit fix.
+"""
+import sys
+import atheris
+
+with atheris.instrument_imports():
+    from bumble import sdp
+
+_BENIGN = (ValueError, IndexError, KeyError, TypeError,
+           NotImplementedError, UnicodeDecodeError, OverflowError,
+           __import__("struct").error)
+
+
+def TestOneInput(data: bytes) -> None:
+    if len(data) < 1:
+        return
+    picker = data[0] & 1
+    payload = data[1:]
+    try:
+        if picker == 0:
+            sdp.DataElement.from_bytes(payload)
+        else:
+            sdp.SDP_PDU.from_bytes(payload)
+    except _BENIGN:
+        pass
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/bumble/project.yaml
+++ b/projects/bumble/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://github.com/google/bumble"
+language: python
+primary_contact: "bumble-core+oss-fuzz@googlegroups.com"
+main_repo: "https://github.com/google/bumble"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
Bumble (https://github.com/google/bumble) is Google's reference Python Bluetooth stack used for testing, emulation, and research. It parses raw bytes from untrusted remote Bluetooth peers across ATT, L2CAP, SDP, RFCOMM, and advertising-data surfaces - making it a good fit for continuous fuzzing.

Adds 5 libFuzzer-via-atheris harnesses covering the core protocol parsers:
  - fuzz_att_pdu.py       - att.ATT_PDU.from_bytes
  - fuzz_l2cap.py         - L2CAP PDU + Control Frame parsers
  - fuzz_sdp.py           - SDP DataElement + SDP_PDU parsers
  - fuzz_rfcomm.py        - RFCOMM frame + MCC_PN/MSC parsers
  - fuzz_data_types.py    - 20+ advertising/EIR data-type parsers

Local atheris runs against these harnesses have already surfaced real bugs in the Bumble parsers (ATT empty-PDU crash - fixed in google/bumble#912; SDP deep-nesting RecursionError - fix pending in google/bumble#914). OSS-Fuzz integration ensures coverage stays high on future parser changes.