### PR TITLE
fix(nginx): fix leaks in http_request_fuzzer

### DIFF
--- a/projects/nginx/fuzz/http_request_fuzzer.cc
+++ b/projects/nginx/fuzz/http_request_fuzzer.cc
@@ -231,9 +231,6 @@ extern "C" int InitializeNginx(void) {
   ngx_event_actions.init = init_event;
   ngx_io.send_chain = send_chain;
   ngx_event_flags = 1;
-  ngx_queue_init(&ngx_posted_accept_events);
-  ngx_queue_init(&ngx_posted_next_events);
-  ngx_queue_init(&ngx_posted_events);
   ngx_event_timer_init(cycle->log);
   return 0;
 }
@@ -246,6 +243,10 @@ extern "C" long int invalid_call(ngx_connection_s *a, ngx_chain_s *b,
 DEFINE_PROTO_FUZZER(const HttpProto &input) {
   static int init = InitializeNginx();
   assert(init == 0);
+
+  ngx_queue_init(&ngx_posted_accept_events);
+  ngx_queue_init(&ngx_posted_next_events);
+  ngx_queue_init(&ngx_posted_events);
 
   // have two free connections, one for client, one for upstream
   ngx_event_t read_event1 = {};
@@ -322,9 +323,20 @@ DEFINE_PROTO_FUZZER(const HttpProto &input) {
   if (c->destroyed != 1) {
     if (c->read->data != NULL) {
       ngx_connection_t *c2 = (ngx_connection_t*)c->read->data;
-        ngx_http_request_t *req_tmp = (ngx_http_request_t*)c2->data;
-        req_tmp->cleanup = NULL;
-        ngx_http_finalize_request(req_tmp, NGX_DONE);
+      ngx_http_request_t *req_tmp = (ngx_http_request_t*)c2->data;
+      req_tmp->cleanup = NULL;
+      ngx_http_upstream_t *u = req_tmp->upstream;
+      if (u) {
+        ngx_peer_connection_t pc = u->peer;
+        if (pc.connection) {
+          ngx_close_socket(pc.connection->fd);
+          ngx_destroy_pool(pc.connection->pool);
+
+          if (pc.connection->write->timer.left)
+            ngx_del_timer(pc.connection->write);
+        }
+      }
+      ngx_http_finalize_request(req_tmp, NGX_DONE);
     }
     ngx_close_connection(c);
   }


### PR DESCRIPTION
### Description
This PR fixes several resource leaks in the `http_request_fuzzer.cc` for the Nginx project:
1. **File descriptor leak**: Some paths were not closing FDs, leading to resource exhaustion.
2. **Memory leaks**: Multiple buffers were not freed correctly after the fuzzing iteration.

### How to check
* Prepare
```bash
echo "cmVxdWVzdDogIkROIC8gICAgSFRUUC8xLjBcbnJcblxuIgpyZXBseTogIiIK" | base64 -d > 46ce8a6b9a5889abf6fadf2cd74f0730cf4d51ca

echo "cmVxdWVzdDogIkdFVCAvXG4iCnJlcGx5OiAiKSIK" | base64 -d > leak-90b0adf9fbedf1d8bc887cd5b4b42edab78c9ff5

echo "cmVxdWVzdDogIk4gLyBIVFRQLzEuMFxuQ29udGVudC1MZW5ndGg6MFxuXG4iCnJlcGx5OiAiXDM1NiIK" | base64 -d > b892acd0421f56f2335af5f853992d5df38e08d8

echo "cmVxdWVzdDogIk4gLy13IEhUVFAvMS4wXG5TXG5Ib3N0OltESG0pZ1wnQVwnXG5IIgpyZXBseTogIiIK" | base64 -d > crash-e2d1d2fb658f8cd0ee00312b4bda39d39683381c

echo "cmVxdWVzdDogIk1OIC8gICAgSFRUUC8xLjBcbnJcbk1LVFAvSUNUSVZJcmVxdWVzdDogXCJETiAg
L1JldHJ5LUFJZi1Vbm1vZGlmaWVkLVNpbmNlXG5NS0FDUElWTFRJQ1RJVklyZXF1ZXN0OiApRE4w
XG5yXG5NQWNjZXNzLUNvbnRyb2wtQWxsb3ctT3JpZ2luQ29udGVudC1MYW5ndWFnZVRQU3RhdHVz
XG5NS0FDVElWSVRJOlRJVklyZXFldHJ5LUFmdEtUQUNQSVZMVElDVElWSXJlcXVlc3Q6MS4wXG5y
XG5NS0FDZXRyeS1BZnRlcjBvbGljeTBcbnJcbk1LQUNQSVZMVElDdWVzdDogKUROMFxuclxuTUtU
UC8xLjBcbnJcbk1LQUNUSVZJVElWSXJlcXVlc3Q6UmVmZXJlclJldHJ5LUFmdGVyMCpcbk4wXG5y
XG5NS1RQU3RhdHVzXG5NS0FDVElWSVRJQ1RJVklyZUNLWC15LUFmdFxuTUtBQ1BJVkxUSUNlc3Q6
IClETjBcbnJcbk1LZXN0Om5zc04gIC9SZSAgSFRUUC8xLjBcblZpeS1BZnRPcmlnaW5cbk1LVFAv
MS4wXG5yXG5NS0FDUElWTFRJQ1RJVklyZXF1ZXN0OiApRE4wQ09QWUtUUC8xLjAgKUROMFxuclxu
TUtUUFN0YXR1c1xuTUtBQ1RJVklUSTpUSVZJcmVxZXRyeS1BZnRLVFAvMS4wXG5yXG5NS1R1ZXN0
OlJlZmVyZXJSZXRyeS1BZnRlcjAqXG5OMFxuclxuTUtUUFN0Q29udGVudC1TZWNWSVRJQ1RJVkly
ZXF1ZXN0OlB1YmxpYy1LZXktUHVlc3Q6IClETjBDT1BZS1RQLzEuMCApRE4wXG5yXG5NS1RQU3Rh
dHVzXG5NS0FDVElWSVRJOlRJVklyZXFldHJ5LUFmdEtUUC8xLjBcbnJcbk1LVHVlc3Q6UnktQWZ0
ZXIwb2xpY3kwXG5yXG5NS0FDUElWTFRJQ3Vlc3Q6IClETjBcbnJcbk1LVFAvMS4wXG5yXG5NS0FD
VElWSVRJVklyZXF1ZXN0OlJlZmVyZXJSZXRyeS1BZnRlcjAqXG5OMFxuclxuTUtUUFN0YXR1c1xu
TUtBQ1RJVklUSUNUSVZJcmVDS1gteS1BZnRcbk1LQUNQSVZMVElDZXN0OiApRE4wXG5yXG5NS2Vz
dDpuc3NOICAvUmUgIEhUVFAvMS4wXG5WaXktQWZ0T3JpZ2luXG5NS1RQLzEuMFxuclxuTUtBQ1BJ
VkFmdFxuTUtBQ1BJVkxUSUNlc3Q6IClETjBcbnJcbk1Lcm94eV9jYWNoZVxuclxuTUtUUC8xLjBc
bnJcbk1LQUNQSVZMVElyXG5NS1RQLzEuMFxuclxuTUtBQ1BJZXRyeS1BZnRPcmlnaW5cbk1LVFAv
MS4wXG5yXG5NS0FDUElWTFRJQ1RJVklyZXF1ZXN0OjEuMFxuclxuTUtBQ2V0cnktQWZ0ZXIwb2xp
Y3kwXG5yXG5NS0FDUElWTFRJQ3Vlc3Q6IClETjBcbnJcbk1LVFAvMS4wXG5yXG5NS0FDVElWSVRJ
VklyZXF1ZXN0OlJlZmVyZXJSZXRyeS1BZnRlcjAqXG5OMFxuclxuTUtUUFN0YXR1c1xuTUtBQ1RJ
VklUSUNUSVZJcmVDS1gteS1BZnRcbk1LQUNQSVZMVElDZXNjdXJpdHktUG9saWN5MFxuclxuTUtB
Q1BJVkxUSUNUSVZJcmVxdWVzdDogKUROMFxuclxuTUtUUC8wLjBcbnJcblRQLzEuMFxuclxuTVgt
Q29udGVudC1TZWN1cml0eS1Qb2xpY3kwXG5yXG5NS0FDUFZJcmVxZXRyeS1BZnRcbk1LQUNQSVZM
VElDZXN0OlZJVElWSXJlcXVlc3Q6UmVmZXJlclJldHJ5LUFmdGVyMCpcbk4wXG5yXG5NS1RQU3Rh
dHVzXG5NS0FDVElWSVRJQ1RJVklyZXFldHJ5LUFmdFxuTUtBQ1BJVkxUSUNlc3Q6IClETjBcbnJc
bk1Lcm94eV9jYWNoZVxuclxuTUtUUC8xLjBcbnJcbk1LQUNQSVZMVElyXG5NS1RQLzEuMFxuclxu
TUtBQ1BJZXRyeS1BZnRPcmlnaW5cbk1LVFAvMS4wXG5yXG5NS0FDUElWTFRJQ1RJVklyZXF1ZXN0
OjEuMFxuclxuTUtBQ2V0cnktQWZ0ZXIwb2xpY3kwXG5yXG5NS0FDUElWTFRJQ3Vlc3Q6IClETjBc
bnJcbk1LVFAvMS4wXG5yXG5NS0FDVElWSVRJVklyZXF1ZXN0OlJlZmVyZXJSZXRyeS1BZnRlcjAq
XG5OMFxuclxuTUtUUFN0YXR1c1xuTUtBQ1RJVklUSUNUSVZJcmVDS1gteS1BZnRcbk1LQUNQSVZM
VElDZXN0OiApRE4wXG5yXG5NS2VzdDpuc3NOICAvUmUgIEhUVFAvMS4wXG5WaXktQWZ0T3JpZ2lu
XG5NS1RQLzEuMFxuclxuTUtBQ1BJVkFmdFxuTUtBQ1BJVkxUSUNlc3Q6IClETjBcbnJcbk1Lcm94
eV9jYWNoZVxuclxuTUtUUC8xLjBcbnJcbk1LQUNQSVZMVElyXG5NS1RQLzEuMFxuclxuTUtBQ1BJ
ZXRyeS1BZnRPcmlnaW5cbk1LVFAvMS4wXG5yXG5NS0FDUElWTFRJQ1RJVklyZXF1ZXN0OjEuMFxu
clxuTUtBQ2V0cnktQWZ0ZXIwb2xpY3kwXG5yXG5NS0FDUElWTFRJQ3Vlc3Q6IClETjBcbnJcbk1L
VFAvMS4wXG5yXG5NS0FDVElWSVRJVklyZXF1ZXN0OlJlZmVyZXJSZXRyeS1BZnRlcjAqXG5OMFxu
clxuTUtUUFN0YXR1c1xuTUtBQ1RJVklUSUNUSVZJcmVDS1gteS1BZnRcbk1LQUNQSVZMVElDZXN0
OiApRE4wXG5yXG5NS2VzdDpuc3NOICAvUmUgIEhUVFAvMS4wXG5WaXktQWZ0T3JpZ2luXG5NS1RQ
LzEuMFxuclxuTUtBQ1BJVkxUSUNUSVZJcmVxdWVzdDogKUROMENPUFlLVFAvMS4wIClETjBcbnJc
bk1LVFBTdGF0dXNcbk1LQUNUSVZJVEk6VElWSXJlcWV0cnktQWZ0S1RQLzEuMFxuclxuTUtUdWVz
dDpSeS1BZnRlcjBvbGljeTBcbnJcbk1LQUNQSVZMVElDdWVzdDogKUROMFxuclxuTUtUUC8xLjBc
bnJcbk1LQUNUSVZJVElWSXJlcXVlc3Q6UmVmZXJlclJldHJ5LUFmdGVyMCpcbk4wXG5yXG5NS1RQ
U3RhdHVzXG5NS0FDVElWSVRJQ1RJVklyZUNLWC15LUFmdFxuTUtBQ1BJVkxUSUNlc3Q6IClETjBc
bnJcbk1LZXN0Om5zc04gIC9SZSAgSFRUUC8xLjBcblZpeS1BZnRPcmlnaW5cbi8xLjBcbnJcbk1L
QUNQSVZMVElDVElWSXJlcXVlc3Q6IClETjBDT1BZS1RQLzEuMCApRE4wXG5yXG5NS1RQU3RhdHVz
XG5NS0FDVElWSVRJOlRJVklyZXFldHJ5LUFmdEtUUC8xLjBcbnJcbk1LVHVlc3Q6UnktQWZ0ZXIw
b2xpY3kwXG5yXG5NS0FDUElWTFRJQ3Vlc3Q6IClETjBcbnJcbk1LVFAvMS4wXG5yXG5NS0FDVElW
SVRJVklyZXF1ZXN0OlJlZmVyZXJSZXRyeS1BZnRlcjAqXG5OMFxuclxuTUtUUFN0YXR1c1xuTUtB
Q1RJVklUSUNUSVZJcmVDS1gteS1BZnRcbk1LQUNQSVZMVElDZXN0OiApRE4wXG5yXG5NS2VzdDpu
c3NOICAvUmUgIEhUVFAvMS4wXG5WaXktQWZ0T3JpZ2luXG5NS1RQLzEuMFxuclxuTUtBQ1BJVkFm
dFxuTUtBQ1BJVkxUSUNlc3Q6IClETjBcbnJcbk1Lcm94eV9jYWNoZVxuclxuVXNlci1BZ2VudFxu
TUtBQ1BJVkxUSXJcbk1LVFAvMS4wXG5yXG5NS0FDUElldHJ5LUFmdE9yaWdpblxuTUtUUC8xLjBc
bnJcbk1LQUNQSVZMVElDVElWSXJlcXVlc3Q6MS4wXG5yXG5NS0FDZXRyeS1BZnRlcjBvbGljeTBc
bnJcbk1LQUNQSVZMVElDdWVzdDogKUROMFxuclxuTUtUUC8xLjBcbnJcbk1LQUNUSVZJVElWSXJl
cXVlc3Q6UmVmZXJlclJldHJ5LUFmdGVyMCpcbk4wXG5yXG5NS1RQU3RhdHVzXG5NS0FDVElWSVRJ
Q1RJVklyZUNLWC15LUFmdFxuTUtBQ1BJVkxUSUNlc3Q6IClETjBcbnJcbk1LZXN0Om5zc04gIC9S
ZSAgSFRUUC8xLjBcblZpeS1BZnRPcmlnaW5cbk1LVFAvMS4wXG5yXG5NS0FDUElWTFRJQ1RJVkly
ZXF1ZXN0OiApRE4wQ09QWUtUUC8xLjAgKUROMFxuclxuTUtUUFN0YXR1c1xuTUtBQ1RJVklUSTpU
SVZJcmVxZXRyeS1BZnRLVFAvMS4wXG5yXG5NeS1BZnRlcjBcXFxuXG5yTUtUUC8xLkZvcndhcmRl
ZCQkJCQkJCQlJCQkQUNUSVZJVElWXCJJVElDXG4iCnJlcGx5OiAiIgo=" | base64 -d > 75d00dda771aff71cf4f8e3c78a082405c27c6d4
```

* Test descriptor leaks
```bash
mkdir in out
cp 46ce8a6b9a5889abf6fadf2cd74f0730cf4d51ca in/
./http_request_fuzzer ./out ./in
```

* Test memory leaks
```bash
mkdir in out
cp 46ce8a6b9a5889abf6fadf2cd74f0730cf4d51ca in/
cp 75d00dda771aff71cf4f8e3c78a082405c27c6d4 in/
cp b892acd0421f56f2335af5f853992d5df38e08d8 in/
cp crash-e2d1d2fb658f8cd0ee00312b4bda39d39683381c in/
cp leak-90b0adf9fbedf1d8bc887cd5b4b42edab78c9ff5 in/
./http_request_fuzzer ./out ./in
```