### PR TITLE
[umbrella-protocol] Initial integration

### DIFF
--- a/projects/umbrella-protocol/Dockerfile
+++ b/projects/umbrella-protocol/Dockerfile
@@ -1,0 +1,62 @@
+# Dockerfile для Google OSS-Fuzz интеграции Umbrella Protocol.
+# Dockerfile for Google OSS-Fuzz integration of Umbrella Protocol.
+#
+# Этап 9 Hardening, блок 9.6 — OSS-Fuzz onboarding.
+# Stage 9 Hardening, block 9.6 — OSS-Fuzz onboarding.
+#
+# Этот файл — локальный stub в нашем репозитории. Submission в Google OSS-Fuzz
+# выполняется через PR в `google/oss-fuzz` repo, где этот Dockerfile помещается
+# в `projects/umbrella-protocol/Dockerfile`. Backend coordination + status
+# tracking — через Google OSS-Fuzz issue tracker.
+#
+# This file is a local stub in our repository. Submission to Google OSS-Fuzz
+# is via PR to the `google/oss-fuzz` repo, where this Dockerfile is placed at
+# `projects/umbrella-protocol/Dockerfile`. Backend coordination and status
+# tracking are via the Google OSS-Fuzz issue tracker.
+
+# Базовый образ Google OSS-Fuzz Rust builder. Содержит pre-installed nightly
+# Rust toolchain + cargo-fuzz binary, что нужно для libfuzzer-sys 0.4 build.
+# См. <https://google.github.io/oss-fuzz/getting-started/new-project-guide/rust-lang/>
+# § "Project files".
+#
+# Base image: Google OSS-Fuzz Rust builder. Provides a pre-installed nightly
+# Rust toolchain plus the `cargo-fuzz` binary required by `libfuzzer-sys` 0.4.
+# See <https://google.github.io/oss-fuzz/getting-started/new-project-guide/rust-lang/>
+# section "Project files".
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+
+# Maintainer хука для OSS-Fuzz issue notifications. Адрес фигурирует в
+# project.yaml `primary_contact` — см. SPEC-13-PQ-HYBRID и memory.
+# Maintainer hook for OSS-Fuzz issue notifications. The address also appears
+# in project.yaml `primary_contact` — see SPEC-13-PQ-HYBRID and memory.
+LABEL maintainer="UmbrellaX Security <samuel.vens18@gmail.com>"
+
+# Установить системные deps. На base-builder-rust большинство уже presell;
+# git нужен явно для clone.
+# Install system deps. Most are present on base-builder-rust; git is pulled in
+# explicitly for the clone.
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y git ca-certificates && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Clone репо в OSS-Fuzz workspace (`$SRC` — стандартная переменная окружения
+# OSS-Fuzz, указывает на `/src/`). Используется master branch как канонический
+# источник; OSS-Fuzz CI re-pull'ит upstream при каждом build цикле для свежей
+# версии (24-часовой кадeнс per Google docs).
+#
+# Clone the repo into the OSS-Fuzz workspace (`$SRC` — standard OSS-Fuzz env
+# variable that points to `/src/`). The master branch is used as the canonical
+# source; OSS-Fuzz CI re-pulls upstream on every build cycle to pick up the
+# latest revision (24-hour cadence per Google docs).
+RUN git clone --depth 1 https://github.com/umbrellax/umbrella-protocol $SRC/umbrella-protocol
+
+# Скопировать build script в workspace location, ожидаемый OSS-Fuzz harness.
+# Copy the build script into the workspace location expected by the OSS-Fuzz harness.
+COPY build.sh $SRC/
+
+# Workdir для удобства debug — все subsequent команды OSS-Fuzz относительно
+# репо. Реальный build path определяется внутри build.sh ($WORK / $OUT).
+# Workdir for debug convenience — all subsequent OSS-Fuzz commands are relative
+# to the repo. The actual build path is set inside build.sh ($WORK / $OUT).
+WORKDIR $SRC/umbrella-protocol

--- a/projects/umbrella-protocol/build.sh
+++ b/projects/umbrella-protocol/build.sh
@@ -1,0 +1,69 @@
+#!/bin/bash -eu
+# Build script для Google OSS-Fuzz интеграции Umbrella Protocol.
+# Build script for the Google OSS-Fuzz integration of Umbrella Protocol.
+#
+# Этап 9 Hardening, блок 9.6 — OSS-Fuzz onboarding.
+# Stage 9 Hardening, block 9.6 — OSS-Fuzz onboarding.
+#
+# Запускается из Google OSS-Fuzz CI после Dockerfile build phase. Переменные
+# окружения OSS-Fuzz: $SRC = /src, $WORK = /work, $OUT = /out (выходная
+# директория для libFuzzer binaries). См.
+# <https://google.github.io/oss-fuzz/getting-started/new-project-guide/rust-lang/>
+# раздел "build.sh".
+#
+# Invoked by Google OSS-Fuzz CI after the Dockerfile build phase. OSS-Fuzz
+# environment: $SRC = /src, $WORK = /work, $OUT = /out (output directory for
+# libFuzzer binaries). See
+# <https://google.github.io/oss-fuzz/getting-started/new-project-guide/rust-lang/>
+# section "build.sh".
+
+# Перейти в sub-workspace umbrella-fuzz-targets — отдельный Cargo workspace
+# для libfuzzer-sys (требует nightly Rust + isolation от main stable workspace
+# MSRV 1.87 per crates/umbrella-fuzz/fuzz/Cargo.toml).
+#
+# Switch to the umbrella-fuzz-targets sub-workspace — a separate Cargo
+# workspace for libfuzzer-sys (requires nightly Rust + isolation from the main
+# stable workspace MSRV 1.87 per crates/umbrella-fuzz/fuzz/Cargo.toml).
+cd "$SRC/umbrella-protocol/crates/umbrella-fuzz/fuzz"
+
+# Build все 23 fuzz target'а одной командой. Флаг `-O` включает release
+# оптимизации; --debug-assertions полезен для catch'инга debug-only invariants.
+# Feature `pq` активируется автоматически через umbrella-fuzz dep declaration
+# (crates/umbrella-fuzz/fuzz/Cargo.toml: `features = ["pq"]`).
+#
+# Build all 23 fuzz targets in one pass. The `-O` flag enables release
+# optimisations; `--debug-assertions` is helpful for catching debug-only
+# invariants. The `pq` feature is activated automatically through the
+# umbrella-fuzz dep declaration (crates/umbrella-fuzz/fuzz/Cargo.toml:
+# `features = ["pq"]`).
+cargo fuzz build -O --debug-assertions
+
+# Скопировать сборные libFuzzer binary targets в $OUT. Шаблон автоматически
+# обнаруживает все `fuzz_targets/*.rs` и копирует соответствующий compiled
+# binary. Совместимо с future targets без изменения скрипта.
+#
+# Copy the built libFuzzer binary targets into $OUT. The pattern auto-discovers
+# all `fuzz_targets/*.rs` and copies the corresponding compiled binary,
+# remaining compatible with future targets without script changes.
+FUZZ_TARGET_OUTPUT_DIR="target/x86_64-unknown-linux-gnu/release"
+for f in fuzz_targets/*.rs; do
+    FUZZ_TARGET_NAME=$(basename "${f%.*}")
+    cp "$FUZZ_TARGET_OUTPUT_DIR/$FUZZ_TARGET_NAME" "$OUT/"
+done
+
+# Опциональная корпус-инициализация. Initial corpus seeds — KAT vectors из
+# crates/umbrella-vectors/data/ для xwing / hybrid-sig / KT entries — могут
+# быть подгружены через `cp -r ../../umbrella-vectors/data $OUT/<target>_seed_corpus.zip`
+# при необходимости. На день block 9.6 corpus deferred — Google OSS-Fuzz
+# самостоятельно генерирует initial corpus из coverage feedback после первых
+# 1-2 циклов запуска. Detailed corpus seeding fix-on-sight для post-block 9.6
+# revision (TODO.md).
+#
+# Optional corpus initialisation. Initial corpus seeds — KAT vectors from
+# crates/umbrella-vectors/data/ for xwing / hybrid-sig / KT entries — can be
+# loaded via
+# `cp -r ../../umbrella-vectors/data $OUT/<target>_seed_corpus.zip`
+# if needed. At block 9.6 the corpus seeding is deferred — Google OSS-Fuzz
+# generates an initial corpus from coverage feedback after the first 1-2
+# fuzzing cycles. Detailed corpus seeding is a fix-on-sight item for a
+# post-block 9.6 revision (TODO.md).

--- a/projects/umbrella-protocol/project.yaml
+++ b/projects/umbrella-protocol/project.yaml
@@ -1,0 +1,91 @@
+# Google OSS-Fuzz project configuration для Umbrella Protocol.
+# Google OSS-Fuzz project configuration for Umbrella Protocol.
+#
+# Этап 9 Hardening, блок 9.6 — OSS-Fuzz onboarding.
+# Stage 9 Hardening, block 9.6 — OSS-Fuzz onboarding.
+#
+# Submission flow:
+#   1. Открыть PR в google/oss-fuzz repo с тремя файлами в
+#      `projects/umbrella-protocol/`: Dockerfile + build.sh + project.yaml
+#      (содержимое идентично нашим локальным `oss-fuzz/*` файлам).
+#   2. После merge — Google CI автоматически запускает 24-часовые fuzz циклы
+#      per target (23 binary entries — 16 classical + 7 PQ).
+#   3. Findings reported в `bugs.chromium.org/p/oss-fuzz` issue tracker;
+#      automatic email notifications на primary_contact.
+#
+# Submission flow:
+#   1. Open a PR in the google/oss-fuzz repo with three files in
+#      `projects/umbrella-protocol/`: Dockerfile + build.sh + project.yaml
+#      (content identical to our local `oss-fuzz/*` files).
+#   2. After merge, Google CI automatically runs 24-hour fuzz cycles per
+#      target (23 binary entries — 16 classical + 7 PQ).
+#   3. Findings are reported in the `bugs.chromium.org/p/oss-fuzz` issue
+#      tracker; automatic email notifications go to primary_contact.
+
+# Язык проекта. На блок 9.6 supported sanitizers для Rust — только `address`
+# (per Google OSS-Fuzz Rust integration guide); fuzzing engine — только
+# `libfuzzer`.
+#
+# Project language. As of block 9.6, the supported sanitizers for Rust are
+# only `address` (per the Google OSS-Fuzz Rust integration guide); the
+# fuzzing engine is only `libfuzzer`.
+language: rust
+
+# Single supported fuzzing engine для Rust crates per Google docs.
+# Single supported fuzzing engine for Rust crates per Google docs.
+fuzzing_engines:
+  - libfuzzer
+
+# Только address sanitizer supported для Rust per Google docs.
+# undefined / memory sanitizers НЕ supported (postulate 1: документы =
+# источник правды; не активируем неподдерживаемые опции).
+#
+# Only address sanitizer is supported for Rust per Google docs.
+# undefined / memory sanitizers are NOT supported (postulate 1: documents =
+# source of truth; we do not activate unsupported options).
+sanitizers:
+  - address
+
+# Primary contact — Daniel (UmbrellaX security lead). Получает email
+# notifications о новых findings, build failures, корнelованных corpus
+# changes.
+#
+# Primary contact — Daniel (UmbrellaX security lead). Receives email
+# notifications about new findings, build failures, and corpus changes.
+primary_contact: samuel.vens18@gmail.com
+
+# Auto-CCs — пустой на блок 9.6. Backend team coordination per ADR-014
+# (rust_1mlrd cross-references) проходит через separate workflow; OSS-Fuzz
+# notifications направляются только к primary_contact на этой фазе. Список
+# может расширяться post-9.6 при onboarding additional security engineers.
+#
+# Auto-CCs are empty at block 9.6. Backend team coordination per ADR-014
+# (rust_1mlrd cross-references) goes via a separate workflow; OSS-Fuzz
+# notifications are routed only to primary_contact at this phase. The list
+# may grow post-9.6 as additional security engineers are onboarded.
+auto_ccs: []
+
+# Каноническая ссылка на upstream repo. Используется Google OSS-Fuzz CI для
+# git clone (соответствует Dockerfile RUN git clone выше).
+#
+# Canonical link to the upstream repo. Used by Google OSS-Fuzz CI for the
+# git clone (matches the Dockerfile RUN git clone above).
+main_repo: 'https://github.com/umbrellax/umbrella-protocol'
+
+# Homepage — публичный сайт UmbrellaX (referenced в Cargo.toml `homepage`).
+# Homepage — UmbrellaX public site (referenced in Cargo.toml `homepage`).
+homepage: 'https://umbrellax.io'
+
+# Vendor CCs — пустой. Сторонние audit firms (Cure53 + NCC Group per ADR-012
+# Решение 4 + memory project_stage_9_hardening.md) НЕ получают autom OSS-Fuzz
+# notifications; reports им поступают через separate audit deliverables
+# workflow в block 9.Z (closing milestone). Этот список может быть extended
+# при формальном onboarding'е audit teams в OSS-Fuzz access tier.
+#
+# Vendor CCs are empty. Third-party audit firms (Cure53 + NCC Group per
+# ADR-012 Decision 4 + memory project_stage_9_hardening.md) do NOT receive
+# automatic OSS-Fuzz notifications; reports reach them through the separate
+# audit deliverables workflow in block 9.Z (closing milestone). This list may
+# be extended once audit teams are formally onboarded into the OSS-Fuzz
+# access tier.
+vendor_ccs: []


### PR DESCRIPTION
## Project

- **Name**: umbrella-protocol
- **Repo**: https://github.com/umbrellax/umbrella-protocol
- **Language**: Rust (workspace, nightly required for libfuzzer-sys 0.4)
- **Primary contact**: samuel.vens18@gmail.com

## Description

Umbrella Protocol is the cryptographic core of the UmbrellaX end-to-end-encrypted messenger (target scale 1B users). The project is fully implemented in Rust (`forbid(unsafe_code)` on every crate; allowed `unsafe` only on libcrux-* / fips205 backends with formal verification or NCC audit).

Stage 8 of the project added hybrid post-quantum primitives (X-Wing combiner KEM `draft-connolly-cfrg-xwing-kem-06`, Ed25519+ML-DSA-65 hybrid signature per NIST SP 800-227, SLH-DSA-128f backup per FIPS 205, MLS ciphersuite `0x004D` `MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519`). Stage 9 hardening (in progress) adds formal verification (Tamarin/ProVerif) and OSS-Fuzz integration — this PR.

## Coverage

23 libfuzzer targets covering all wire-format parser surfaces:

**Classical (16)**: `parse_mls_envelope`, `strip_padding`, `verify_inclusion`, `oprf_parse_blinded_request`, `oprf_parse_server_evaluation`, `oprf_threshold_combine`, `wrapped_key_parse`, `unwrap_share_parse`, `qr_payload_parse`, `noise_responder_msg1`, `noise_initiator_msg2`, `authorization_request_parse`, `authorization_approval_parse`, `authorization_revocation_parse`, `identity_rotation_parse`, `fuzz_sframe_header_parse`, `fuzz_sframe_frame_parse`.

**Post-quantum wire-format (7)**: `xwing_pubkey_parser`, `xwing_ciphertext_parser`, `hybrid_signature_parser`, `kt_entry_v2_parser`, `sealed_sender_v2_parser`, `wrapped_key_v2_parser`, `mls_keypackage_parser`.

Each target lives at `crates/umbrella-fuzz/fuzz/fuzz_targets/<name>.rs` in the upstream repo and is compiled via `cargo +nightly fuzz build -O --debug-assertions`.

## Files in this PR

- `projects/umbrella-protocol/Dockerfile` — base `gcr.io/oss-fuzz-base/base-builder-rust`, clones `umbrellax/umbrella-protocol` master, copies build.sh.
- `projects/umbrella-protocol/build.sh` — `cd $SRC/umbrella-protocol/crates/umbrella-fuzz/fuzz && cargo fuzz build -O --debug-assertions` + auto-discover loop copying every `fuzz_targets/*.rs` binary to `$OUT/`.
- `projects/umbrella-protocol/project.yaml` — `language: rust`, `fuzzing_engines: [libfuzzer]`, `sanitizers: [address]`, `primary_contact`, `auto_ccs: []`, `vendor_ccs: []`.

## Configuration choices

- **Single sanitizer (`address`)** — only sanitizer supported for Rust per OSS-Fuzz Rust integration guide.
- **Single fuzzing engine (`libfuzzer`)** — only engine supported for Rust per OSS-Fuzz Rust integration guide.
- **`auto_ccs: []` / `vendor_ccs: []`** — third-party audit firms (Cure53, NCC Group) coordinate via separate audit deliverables workflow, not OSS-Fuzz issue tracker. May be extended once those teams are formally onboarded.

## Local verification

The project also runs the same 23 targets locally and via GitHub Actions weekly cron (alternative pipeline while OSS-Fuzz onboarding lands). Targets compile cleanly with `cargo +nightly fuzz build -O` and pass smoke + property tests on stable Rust.

Happy to address any review feedback.