### PR TITLE
vlc: do not try to build the mpcdec contrib

### DIFF
--- a/projects/vlc/build.sh
+++ b/projects/vlc/build.sh
@@ -72,8 +72,7 @@ make V=1 -j$(nproc) \
     .vorbis \
     .speex \
     .speexdsp \
-    .dvbpsi \
-    .mpcdec
+    .dvbpsi
 cd ../../
 
 # Use OSS-Fuzz environment rather than hardcoded setup.
@@ -91,10 +90,6 @@ sed -i 's/..\/..\/lib\/libvlc_internal.h/lib\/libvlc_internal.h/g' ./test/src/in
 # Add extra codec, packetizer, and demux modules for broader fuzzing coverage.
 # See fuzzing-modules.patch for the actual changes.
 patch -p1 < $SRC/fuzzing-modules.patch
-
-# Register the MPC demux module in the static module list (the module is linked
-# via fuzzing-modules.patch but also needs to be in the PLUGINS macro).
-sed -i 's/f(demux_ogg)/f(demux_mpc) \\\n    f(demux_ogg)/' ./test/src/input/demux-run.c
 
 # clang is used to link the binary since there are no cpp sources (but we have
 # cpp modules), force clang++ usage

--- a/projects/vlc/fuzzing-modules.patch
+++ b/projects/vlc/fuzzing-modules.patch
@@ -16,7 +16,6 @@ index 7eb4ab5..cdbd28a 100644
 +	../modules/libvc1_plugin.la \
 +	../modules/libmpgv_plugin.la \
 +	../modules/libdemux_stl_plugin.la \
-+	../modules/libmpc_plugin.la \
 +	../modules/libhx_plugin.la \
 +	../modules/libdmxmus_plugin.la \
  	../modules/libfilesystem_plugin.la \


### PR DESCRIPTION
It was removed [^1] and will fail the build.

[^1]: https://code.videolan.org/videolan/vlc/-/merge_requests/9073