### PR TITLE
[apache-httpd] fix fuzz_preq build: add standalone libapreq2

### DIFF
--- a/projects/apache-httpd/Dockerfile
+++ b/projects/apache-httpd/Dockerfile
@@ -17,7 +17,8 @@
 FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y make autoconf automake libtool wget \
                                          uuid-dev pkg-config libtool-bin \
-                                         libbsd-dev
+                                         libbsd-dev perl cpanminus
+RUN cpanm --notest ExtUtils::XSBuilder
 
 RUN git clone https://github.com/PCRE2Project/pcre2 pcre2 && \
     cd pcre2 && \
@@ -34,6 +35,8 @@ RUN wget https://github.com/libexpat/libexpat/releases/download/R_2_4_1/expat-2.
     ./configure && \
     make && \
     make install
+
+RUN git clone --depth=1 https://github.com/apache/apreq
 
 RUN git clone --depth=1 https://github.com/apache/httpd
 WORKDIR httpd

--- a/projects/apache-httpd/build.sh
+++ b/projects/apache-httpd/build.sh
@@ -30,11 +30,37 @@ make -j$( nproc )
 
 static_pcre=($(find /src/pcre2 -name "libpcre2-8.a"))
 
+# Build libapreq2 against the apr we just built.
+# APR 2.x merged apr-util, so apu-config no longer exists.
+# Provide a shim that delegates to apr-2-config but returns empty for
+# --apu-la-file, which apr-2-config does not support.
+cat > $SRC/httpd/srclib/apr/apu-2-config <<'EOF'
+#!/bin/sh
+if [ "$1" = "--apu-la-file" ]; then
+  echo ""
+else
+  exec "$(dirname "$0")/apr-2-config" "$@"
+fi
+EOF
+chmod +x $SRC/httpd/srclib/apr/apu-2-config
+
+cd $SRC/apreq
+./buildconf
+./configure --with-apache2-src=$SRC/httpd \
+            --with-apr-config=$SRC/httpd/srclib/apr/apr-2-config \
+            --with-apu-config=$SRC/httpd/srclib/apr/apu-2-config \
+            --disable-perl-glue \
+            --disable-dependency-tracking \
+            APR_MAJOR_VERSION=2
+make -C library -j$(nproc)
+cd $SRC/httpd
+
 # Build the fuzzers
 for fuzzname in utils parse tokenize addr_parse uri request preq; do
   $CC $CFLAGS -c \
     -I$SRC/fuzz-headers/lang/c -I./include -I./os/unix \
     -I./srclib/apr/include -I./srclib/apr-util/include/ \
+    -I$SRC/apreq/include \
     $SRC/fuzz_${fuzzname}.c
 
   $INITIAL_CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz_${fuzzname}.o -o $OUT/fuzz_${fuzzname} \
@@ -45,5 +71,6 @@ for fuzzname in utils parse tokenize addr_parse uri request preq; do
                       ./server/mpm/event/.libs/libevent.a \
                       ./os/unix/.libs/libos.a \
                       ./srclib/apr/.libs/libapr-2.a \
+                      $SRC/apreq/library/.libs/libapreq2.a \
     -Wl,--end-group -luuid -lcrypt -lexpat -l:libbsd.a ${static_pcre}
 done


### PR DESCRIPTION
## Summary

The apache-httpd OSS-Fuzz build has been failing since April 25, 2026 at 03:15 AM (Washington DC time / EDT).

Build logs: https://oss-fuzz-build-logs.storage.googleapis.com/index.html#apache-httpd

## Root Cause

The failure is caused by the following upstream commit in the Apache httpd repository:

https://github.com/apache/httpd/commit/48e9e82540902966e953abb2fa07e7babaecc369

This commit removed apreq from the httpd trunk per a PMC vote, which means `include/apreq_parser.h` and the related source files no longer exist in the httpd repository. Since the Dockerfile clones the latest httpd trunk on every build, `fuzz_preq.c` has been failing to compile due to the missing header.

## Fix

This PR adds a build step that clones and builds the standalone [libapreq2](https://github.com/apache/apreq) library before compiling the fuzzers. The changes are:

- **Dockerfile**: clone `https://github.com/apache/apreq` and install `perl`, `cpanminus`, and `ExtUtils::XSBuilder` (required by apreq's `buildconf`)
- **build.sh**: build `libapreq2` against the apr already built as part of httpd, then add `-I$SRC/apreq/include` to the compiler flags and link `libapreq2.a` into the fuzzer binaries

Note: APR 2.x merged apr-util, so `apu-config` no longer exists as a separate script. A small shim wrapping `apr-2-config` is generated at build time to satisfy apreq's configure script, which was written against APR 1.x.

## Testing

Verified locally that all fuzz targets including `fuzz_preq` build and run successfully with this fix.

Thank you for your time and consideration in reviewing this pull request.