### PR TITLE
Add a 'disable_remediation_pre_review' configuration field

### DIFF
--- a/docs/getting-started/new_project_guide.md
+++ b/docs/getting-started/new_project_guide.md
@@ -87,6 +87,7 @@ This configuration file stores project metadata. The following attributes are su
 - [builds_per_day](#build_frequency) (optional)
 - [file_github_issue](#file_github_issue) (optional)
 - [disable_remediation](#disable_remediation) (optional)
+- [disable_remediation_pre_review](#disable_remediation_pre_review) (optional)
 
 ### homepage
 You project's homepage.
@@ -217,6 +218,13 @@ is disabled, all disclosure notifications will not include any proposed code
 changes. If enabled (default), proposed code changes and comments to remediate
 bugs may be automatically included in disclosure that is private during the
 embargo of each issue on a case-by-case basis basis.
+
+### disable_remediation_pre_review (optional) {#disable_remediation_pre_review}
+Opt out of human-in-the-loop pre-review for proposed remediation code changes.
+If this is enabled, proposed code changes will be included in disclosure
+notifications without prior manual review by the OSS-Fuzz team. If disabled
+(default), all proposed remediation changes will be reviewed by a human before
+being shared.
 
 ## Dockerfile {#dockerfile}
 

--- a/infra/presubmit.py
+++ b/infra/presubmit.py
@@ -91,6 +91,7 @@ class ProjectYamlChecker:
       'coverage_extra_args',
       'disabled',
       'disable_remediation',
+      'disable_remediation_pre_review',
       'fuzzing_engines',
       'help_url',
       'homepage',


### PR DESCRIPTION
This PR adds an optional field `disable_remediation_pre_review` which allows projects to opt out of human pre-review for proposed code changes when automated remediation is enabled.