### PR TITLE
lua: enable quiet mode for zip

### DIFF
--- a/projects/lua/build.sh
+++ b/projects/lua/build.sh
@@ -139,7 +139,7 @@ do
   corpus_dir="corpus_dir/$module"
   echo "Copying for $module";
   cp $f $OUT/
-  [[ -e $corpus_dir ]] && find "$corpus_dir" -mindepth 1 -maxdepth 1 | zip -@ -j $OUT/"$name"_seed_corpus.zip
+  [[ -e $corpus_dir ]] && find "$corpus_dir" -mindepth 1 -maxdepth 1 | zip --quiet -@ -j $OUT/"$name"_seed_corpus.zip
 done
 
 # Finish execution if libFuzzer is not used, because luzer
@@ -177,7 +177,7 @@ for fuzzer in $(find $SRC -name '*_test.lua'); do
   test_name_we="${test_file%.*}";
   module_name=$(echo $test_name_we | sed 's/_test//' )
   corpus_dir="corpus_dir/$module_name"
-  [[ -e $corpus_dir ]] && find "$corpus_dir" -mindepth 1 -maxdepth 1 | zip -@ -j $OUT/"$test_name_we"_seed_corpus.zip
+  [[ -e $corpus_dir ]] && find "$corpus_dir" -mindepth 1 -maxdepth 1 | zip --quiet -@ -j $OUT/"$test_name_we"_seed_corpus.zip
 done
 cp $SRC/testdir/tests/lapi/lib*.lua "$OUT/"
 

--- a/projects/tarantool/build.sh
+++ b/projects/tarantool/build.sh
@@ -170,7 +170,7 @@ do
   cp "$test_path" "$OUT/"
   corpus_dir="test/static/corpus/$module_name"
   if [ -e "$corpus_dir" ]; then
-    zip -j $OUT/"$test_name_we"_seed_corpus.zip $corpus_dir/*
+    zip --quiet -j $OUT/"$test_name_we"_seed_corpus.zip $corpus_dir/*
     echo "Build corpus '$OUT/"$test_name_we"_seed_corpus.zip' for the test '$test_name_we'"
   fi
 done


### PR DESCRIPTION
There are a lot of files in the seed corpuses, and when zip prints which files it added to the archives, this greatly increases the size of the logs. The patch suppresses this output.