### PR TITLE
Add Undici fuzzing integration

### DIFF
--- a/projects/undici/Dockerfile
+++ b/projects/undici/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-javascript
+
+COPY build.sh $SRC/
+
+RUN apt-get update && apt-get install -y cmake
+
+RUN git clone --depth 1 --branch v6.x https://github.com/nodejs/undici undici
+
+COPY fuzz_headers.js fuzz_request.js fuzz_fetch_formdata.js $SRC/undici/
+
+WORKDIR $SRC/undici

--- a/projects/undici/build.sh
+++ b/projects/undici/build.sh
@@ -1,0 +1,48 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+npm install --ignore-scripts
+npm install --no-save --ignore-scripts @jazzer.js/core
+
+rm -rf "$OUT/undici" "$OUT/fuzz_headers" "$OUT/fuzz_request" "$OUT/fuzz_fetch_formdata"
+
+JAZZER_SRC="$WORK/jazzerjs"
+rm -rf "$JAZZER_SRC"
+JAZZER_VERSION=$(node -p "require('./node_modules/@jazzer.js/core/package.json').version")
+git clone --depth 1 --branch "v${JAZZER_VERSION}" \
+	https://github.com/CodeIntelligenceTesting/jazzer.js "$JAZZER_SRC"
+
+pushd "$JAZZER_SRC/packages/fuzzer"
+npm install --ignore-scripts
+CFLAGS_SAVE="$CFLAGS"
+CXXFLAGS_SAVE="$CXXFLAGS"
+unset CFLAGS
+unset CXXFLAGS
+CC=gcc CXX=g++ npx cmake-js build --out build
+export CFLAGS="$CFLAGS_SAVE"
+export CXXFLAGS="$CXXFLAGS_SAVE"
+mkdir -p prebuilds
+cp build/Release/jazzerjs.node prebuilds/fuzzer-linux-x64.node
+popd
+
+mkdir -p node_modules/@jazzer.js/fuzzer/prebuilds
+cp "$JAZZER_SRC/packages/fuzzer/prebuilds/fuzzer-linux-x64.node" \
+	node_modules/@jazzer.js/fuzzer/prebuilds/
+
+compile_javascript_fuzzer undici fuzz_headers.js -i undici --sync
+compile_javascript_fuzzer undici fuzz_request.js -i undici
+compile_javascript_fuzzer undici fuzz_fetch_formdata.js -i undici

--- a/projects/undici/fuzz_fetch_formdata.js
+++ b/projects/undici/fuzz_fetch_formdata.js
@@ -1,0 +1,70 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+const { FuzzedDataProvider } = require('@jazzer.js/core')
+const { MockAgent, fetch, FormData } = require('undici')
+
+function sanitizeFieldName(value) {
+  const sanitized = value.replace(/[^a-zA-Z0-9_-]/g, '')
+  return sanitized.length === 0 ? 'field' : sanitized
+}
+
+function sanitizeFieldValue(value) {
+  return value.replace(/[\r\n\0]/g, '')
+}
+
+module.exports.fuzz = async function (data) {
+  const provider = new FuzzedDataProvider(data)
+  const form = new FormData()
+  const fieldCount = provider.consumeIntegralInRange(0, 8)
+
+  for (let i = 0; i < fieldCount; i += 1) {
+    const name = sanitizeFieldName(provider.consumeString(provider.consumeIntegralInRange(1, 24)))
+    const value = sanitizeFieldValue(provider.consumeString(provider.consumeIntegralInRange(0, 256)))
+    form.append(name, value)
+  }
+
+  const mockAgent = new MockAgent()
+  mockAgent.disableNetConnect()
+  const mockPool = mockAgent.get('https://example.com')
+
+  const statusCode = provider.consumeIntegralInRange(200, 599)
+  const responseBody = provider.consumeString(provider.consumeIntegralInRange(0, 512))
+  const path = '/fuzz'
+
+  mockPool.intercept({ path, method: 'POST' }).reply(statusCode, responseBody, {
+    headers: {
+      'content-type': 'text/plain'
+    }
+  })
+
+  try {
+    const response = await fetch(`https://example.com${path}`, {
+      method: 'POST',
+      body: form,
+      dispatcher: mockAgent
+    })
+    await response.text()
+  } catch (_err) {
+    // Ignore expected errors from invalid inputs.
+  } finally {
+    try {
+      await mockAgent.close()
+    } catch (_err) {
+      // Ignore cleanup errors.
+    }
+  }
+}

--- a/projects/undici/fuzz_headers.js
+++ b/projects/undici/fuzz_headers.js
@@ -1,0 +1,110 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+const { FuzzedDataProvider } = require('@jazzer.js/core')
+const { Headers, Request, Response } = require('undici')
+
+const METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS']
+
+function sanitizeHeaderName(value) {
+  const sanitized = value.toLowerCase().replace(/[^a-z0-9-]/g, '')
+  return sanitized.length === 0 ? 'x-fuzz' : sanitized
+}
+
+function sanitizeHeaderValue(value) {
+  return value.replace(/[\r\n\0]/g, '')
+}
+
+function consumeHeaderPairs(provider, maxPairs) {
+  const pairs = []
+  const count = provider.consumeIntegralInRange(0, maxPairs)
+  for (let i = 0; i < count; i += 1) {
+    const nameSize = provider.consumeIntegralInRange(1, 40)
+    const valueSize = provider.consumeIntegralInRange(0, 128)
+    const name = sanitizeHeaderName(provider.consumeString(nameSize))
+    const value = sanitizeHeaderValue(provider.consumeString(valueSize))
+    pairs.push([name, value])
+  }
+  return pairs
+}
+
+function consumePath(provider) {
+  const segmentCount = provider.consumeIntegralInRange(1, 4)
+  const segments = []
+  for (let i = 0; i < segmentCount; i += 1) {
+    const raw = provider.consumeString(provider.consumeIntegralInRange(0, 24))
+    const segment = encodeURIComponent(raw || 'fuzz')
+    segments.push(segment)
+  }
+  let path = `/${segments.join('/')}`
+  if (provider.consumeBoolean()) {
+    const key = encodeURIComponent(provider.consumeString(provider.consumeIntegralInRange(0, 12)) || 'k')
+    const value = encodeURIComponent(provider.consumeString(provider.consumeIntegralInRange(0, 24)))
+    path += `?${key}=${value}`
+  }
+  return path
+}
+
+module.exports.fuzz = function (data) {
+  const provider = new FuzzedDataProvider(data)
+  const headerPairs = consumeHeaderPairs(provider, 16)
+
+  let headers
+  try {
+    headers = new Headers(headerPairs)
+  } catch (_err) {
+    return
+  }
+
+  const mutationCount = provider.consumeIntegralInRange(0, 8)
+  for (let i = 0; i < mutationCount; i += 1) {
+    const name = sanitizeHeaderName(provider.consumeString(provider.consumeIntegralInRange(1, 32)))
+    const value = sanitizeHeaderValue(provider.consumeString(provider.consumeIntegralInRange(0, 64)))
+    const op = provider.consumeIntegralInRange(0, 2)
+    try {
+      if (op === 0) {
+        headers.append(name, value)
+      } else if (op === 1) {
+        headers.set(name, value)
+      } else {
+        headers.delete(name)
+      }
+    } catch (_err) {
+      // Ignore validation errors to keep fuzzing.
+    }
+  }
+
+  const url = `https://example.com${consumePath(provider)}`
+  const method = METHODS[provider.consumeIntegralInRange(0, METHODS.length - 1)]
+  try {
+    const req = new Request(url, { method, headers })
+    req.headers.get('content-type')
+    for (const _entry of req.headers.entries()) {
+      // Iteration exercises header normalization paths.
+    }
+  } catch (_err) {
+    // Ignore request validation errors.
+  }
+
+  try {
+    const body = provider.consumeString(provider.consumeIntegralInRange(0, 1024))
+    const res = new Response(body, { headers })
+    res.headers.get('content-type')
+    res.headers.forEach(() => {})
+  } catch (_err) {
+    // Ignore response validation errors.
+  }
+}

--- a/projects/undici/fuzz_request.js
+++ b/projects/undici/fuzz_request.js
@@ -1,0 +1,108 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+const { FuzzedDataProvider } = require('@jazzer.js/core')
+const { MockAgent, request } = require('undici')
+
+const METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS']
+
+function sanitizeHeaderName(value) {
+  const sanitized = value.toLowerCase().replace(/[^a-z0-9-]/g, '')
+  return sanitized.length === 0 ? 'x-fuzz' : sanitized
+}
+
+function sanitizeHeaderValue(value) {
+  return value.replace(/[\r\n\0]/g, '')
+}
+
+function buildHeaders(provider, maxHeaders) {
+  const headers = {}
+  const count = provider.consumeIntegralInRange(0, maxHeaders)
+  for (let i = 0; i < count; i += 1) {
+    const name = sanitizeHeaderName(provider.consumeString(provider.consumeIntegralInRange(1, 32)))
+    const value = sanitizeHeaderValue(provider.consumeString(provider.consumeIntegralInRange(0, 128)))
+    headers[name] = value
+  }
+  return headers
+}
+
+function buildPath(provider) {
+  const segmentCount = provider.consumeIntegralInRange(1, 4)
+  const segments = []
+  for (let i = 0; i < segmentCount; i += 1) {
+    const raw = provider.consumeString(provider.consumeIntegralInRange(0, 24))
+    const segment = encodeURIComponent(raw || 'fuzz')
+    segments.push(segment)
+  }
+  let path = `/${segments.join('/')}`
+  if (provider.consumeBoolean()) {
+    const key = encodeURIComponent(provider.consumeString(provider.consumeIntegralInRange(0, 12)) || 'k')
+    const value = encodeURIComponent(provider.consumeString(provider.consumeIntegralInRange(0, 24)))
+    path += `?${key}=${value}`
+  }
+  return path
+}
+
+module.exports.fuzz = async function (data) {
+  const provider = new FuzzedDataProvider(data)
+  const method = METHODS[provider.consumeIntegralInRange(0, METHODS.length - 1)]
+  const path = buildPath(provider)
+  const headers = buildHeaders(provider, 12)
+
+  let body
+  if (method !== 'GET' && method !== 'HEAD' && provider.consumeBoolean()) {
+    body = provider.consumeString(provider.consumeIntegralInRange(0, 2048))
+    if (headers['content-type'] === undefined) {
+      headers['content-type'] = 'text/plain'
+    }
+  }
+
+  const mockAgent = new MockAgent()
+  mockAgent.disableNetConnect()
+  const mockPool = mockAgent.get('https://example.com')
+
+  const statusCode = provider.consumeIntegralInRange(100, 599)
+  const responseBody = provider.consumeString(provider.consumeIntegralInRange(0, 1024))
+  mockPool.intercept({ path, method }).reply(statusCode, responseBody, {
+    headers: {
+      'content-type': 'text/plain'
+    }
+  })
+
+  try {
+    const result = await request(`https://example.com${path}`, {
+      method,
+      headers,
+      body,
+      dispatcher: mockAgent
+    })
+    try {
+      await result.body.text()
+    } catch (_err) {
+      if (result.body && typeof result.body.dump === 'function') {
+        await result.body.dump()
+      }
+    }
+  } catch (_err) {
+    // Ignore expected errors from invalid inputs.
+  } finally {
+    try {
+      await mockAgent.close()
+    } catch (_err) {
+      // Ignore cleanup errors.
+    }
+  }
+}

--- a/projects/undici/project.yaml
+++ b/projects/undici/project.yaml
@@ -1,0 +1,8 @@
+homepage: https://undici.nodejs.org
+language: javascript
+main_repo: https://github.com/nodejs/undici.git
+primary_contact: "security@nodejs.org"
+fuzzing_engines:
+- libfuzzer
+sanitizers:
+- none

--- a/projects/undici/project.yaml
+++ b/projects/undici/project.yaml
@@ -1,7 +1,7 @@
 homepage: https://undici.nodejs.org
 language: javascript
 main_repo: https://github.com/nodejs/undici.git
-primary_contact: "security@nodejs.org"
+primary_contact: "undici@iojs.org"
 fuzzing_engines:
 - libfuzzer
 sanitizers:


### PR DESCRIPTION
This adds an initial OSS-Fuzz integration for Undici, the HTTP client used by Node.js.

The integration uses the JavaScript/Jazzer.js OSS-Fuzz setup and adds three fuzz targets covering:

- `Headers`, `Request`, and `Response` construction and header mutation
- `undici.request` with a `MockAgent`, so fuzzing does not make network calls
- `fetch` with `FormData` and a mocked response path

A couple of notes about the setup:

- The project is pinned to Undici's `v6.x` branch for now. Current Undici releases require a newer Node.js runtime than the OSS-Fuzz JavaScript base image provides.
- Jazzer.js is rebuilt inside the image because the published Linux prebuild currently requires a newer glibc than the OSS-Fuzz base image has. The rebuild is pinned to the same Jazzer.js version installed by npm.
- `primary_contact` is set to `security@nodejs.org`, matching the existing Node.js OSS-Fuzz project contact.

I verified this locally with:

```bash
DOCKER_DEFAULT_PLATFORM=linux/amd64 python3 infra/helper.py build_image --no-pull undici
DOCKER_DEFAULT_PLATFORM=linux/amd64 python3 infra/helper.py build_fuzzers --clean --engine libfuzzer --sanitizer none undici
DOCKER_DEFAULT_PLATFORM=linux/amd64 python3 infra/helper.py check_build --engine libfuzzer --sanitizer none undici
DOCKER_DEFAULT_PLATFORM=linux/amd64 python3 infra/helper.py run_fuzzer --engine libfuzzer --sanitizer none undici fuzz_headers -- -runs=25
DOCKER_DEFAULT_PLATFORM=linux/amd64 python3 infra/helper.py run_fuzzer --engine libfuzzer --sanitizer none undici fuzz_request -- -runs=25
DOCKER_DEFAULT_PLATFORM=linux/amd64 python3 infra/helper.py run_fuzzer --engine libfuzzer --sanitizer none undici fuzz_fetch_formdata -- -runs=25
```
