### PR TITLE
eslint: initial integration

### DIFF
--- a/projects/eslint/Dockerfile
+++ b/projects/eslint/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-javascript
+
+COPY build.sh $SRC/
+
+RUN git clone --depth 1 https://github.com/eslint/eslint $SRC/eslint
+
+COPY fuzz_linter.js fuzz_verify_and_fix.js fuzz_source_code.js $SRC/eslint/
+
+WORKDIR $SRC/eslint

--- a/projects/eslint/build.sh
+++ b/projects/eslint/build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Install project dependencies. ESLint manages its own dev tooling via npm,
+# but only the runtime dependencies are required to invoke the public API
+# from a fuzz target, so skip optional/scripted prepare steps.
+npm install --ignore-scripts --no-audit --no-fund
+
+# Install Jazzer.js so the fuzz targets can use FuzzedDataProvider and the
+# compile_javascript_fuzzer wrapper script can drive them. Pin to 2.1.0
+# because the prebuilt native fuzzer binary in 4.x requires GLIBC 2.32, which
+# is newer than what the OSS-Fuzz base-runner image (Ubuntu 20.04) provides.
+npm install --save-dev --no-audit --no-fund @jazzer.js/core@2.1.0
+
+# Build Fuzzers.
+compile_javascript_fuzzer eslint fuzz_linter.js --sync
+compile_javascript_fuzzer eslint fuzz_verify_and_fix.js --sync
+compile_javascript_fuzzer eslint fuzz_source_code.js --sync

--- a/projects/eslint/fuzz_linter.js
+++ b/projects/eslint/fuzz_linter.js
@@ -1,0 +1,134 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+"use strict";
+
+const { FuzzedDataProvider } = require("@jazzer.js/core");
+const { Linter } = require("./lib/linter");
+
+const linter = new Linter();
+
+const ECMA_VERSIONS = [3, 5, 2015, 2018, 2020, 2022, 2024, "latest"];
+const SOURCE_TYPES = ["script", "module", "commonjs"];
+
+// A representative cross-section of rules. This mixes parser-touching rules,
+// scope-analysis rules, AST-shape rules, and rules with non-trivial state
+// (control-flow graph, autofix, suggestions) so the fuzzer exercises many
+// different parts of the linter from a single entry point.
+const RULE_POOL = [
+	"no-cond-assign",
+	"no-constant-condition",
+	"no-dupe-args",
+	"no-dupe-keys",
+	"no-empty",
+	"no-extra-boolean-cast",
+	"no-irregular-whitespace",
+	"no-redeclare",
+	"no-undef",
+	"no-unreachable",
+	"no-unused-vars",
+	"no-use-before-define",
+	"complexity",
+	"max-depth",
+	"max-nested-callbacks",
+	"max-params",
+	"prefer-const",
+	"semi",
+	"quotes",
+	"eqeqeq",
+	"curly",
+	"no-var",
+	"no-multi-spaces",
+	"no-trailing-spaces",
+];
+
+/**
+ * Pick a small random subset of rules to enable. Enabling all rules at once
+ * obscures coverage signal because the cheap rules dominate; instead we let
+ * the fuzzer drive which rules are co-enabled.
+ *
+ * @param {FuzzedDataProvider} provider
+ * @returns {Object}
+ */
+function pickRules(provider) {
+	const rules = {};
+	const count = provider.consumeIntegralInRange(0, 8);
+	for (let i = 0; i < count; i++) {
+		const idx = provider.consumeIntegralInRange(0, RULE_POOL.length - 1);
+		rules[RULE_POOL[idx]] = "error";
+	}
+	return rules;
+}
+
+/**
+ * @param { Buffer } data
+ */
+module.exports.fuzz = function (data) {
+	const provider = new FuzzedDataProvider(data);
+
+	const ecmaVersion =
+		ECMA_VERSIONS[provider.consumeIntegralInRange(0, ECMA_VERSIONS.length - 1)];
+	const sourceType =
+		SOURCE_TYPES[provider.consumeIntegralInRange(0, SOURCE_TYPES.length - 1)];
+	const allowInlineConfig = provider.consumeBoolean();
+	const reportUnusedDisableDirectives = provider.consumeBoolean();
+
+	const config = {
+		languageOptions: {
+			ecmaVersion,
+			sourceType,
+			parserOptions: {
+				ecmaFeatures: {
+					jsx: provider.consumeBoolean(),
+					globalReturn: provider.consumeBoolean(),
+				},
+			},
+		},
+		linterOptions: {
+			reportUnusedDisableDirectives,
+		},
+		rules: pickRules(provider),
+	};
+
+	const code = provider.consumeRemainingAsString();
+
+	try {
+		linter.verify(code, config, { allowInlineConfig });
+	} catch (e) {
+		// ESLint surfaces parser errors as lint messages, so any thrown error
+		// is unexpected. A handful of errors are caused by the fuzzer-generated
+		// configuration rather than the source code under test - filter those
+		// out so they don't drown out real bugs.
+		if (isExpectedConfigurationError(e)) {
+			return;
+		}
+		throw e;
+	}
+};
+
+function isExpectedConfigurationError(e) {
+	if (!e || typeof e.message !== "string") {
+		return false;
+	}
+	const msg = e.message;
+	return (
+		msg.includes("Key \"languageOptions\":") ||
+		msg.includes("Key \"linterOptions\":") ||
+		msg.includes("Key \"rules\":") ||
+		msg.includes("ecmaVersion must be") ||
+		msg.includes("sourceType must be")
+	);
+}

--- a/projects/eslint/fuzz_source_code.js
+++ b/projects/eslint/fuzz_source_code.js
@@ -1,0 +1,103 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+"use strict";
+
+const { FuzzedDataProvider } = require("@jazzer.js/core");
+const { Linter } = require("./lib/linter");
+
+const linter = new Linter();
+
+// Drives SourceCode-side APIs through the linter. Linter.verify() parses the
+// source and stashes the resulting SourceCode on the linter; we then exercise
+// the read-only inspection helpers that rules call into. Bugs in token/comment
+// indexing or location lookups tend to surface here rather than in verify().
+module.exports.fuzz = function (data) {
+	const provider = new FuzzedDataProvider(data);
+
+	const ecmaVersion = provider.consumeIntegralInRange(2015, 2024);
+	const sourceType = provider.consumeBoolean() ? "module" : "script";
+
+	const config = {
+		languageOptions: {
+			ecmaVersion,
+			sourceType,
+		},
+	};
+
+	const code = provider.consumeRemainingAsString();
+
+	try {
+		linter.verify(code, config);
+	} catch (e) {
+		if (isExpectedConfigurationError(e)) {
+			return;
+		}
+		throw e;
+	}
+
+	const sourceCode = linter.getSourceCode();
+	if (!sourceCode || !sourceCode.ast) {
+		// Parsing failed - the parser error is surfaced as a lint message and
+		// no SourceCode is produced. Nothing more to fuzz on this input.
+		return;
+	}
+
+	try {
+		// Token APIs.
+		const tokens = sourceCode.ast.tokens || [];
+		if (tokens.length > 0) {
+			const t = tokens[0];
+			sourceCode.getTokenByRangeStart(t.range[0]);
+			sourceCode.getTokenBefore(t);
+			sourceCode.getTokenAfter(t);
+			sourceCode.getFirstToken(sourceCode.ast);
+			sourceCode.getLastToken(sourceCode.ast);
+		}
+
+		// Comment APIs.
+		sourceCode.getAllComments();
+
+		// Text/location APIs.
+		sourceCode.getText();
+		sourceCode.getLines();
+		const totalLength = sourceCode.getText().length;
+		if (totalLength > 0) {
+			const offset = provider.consumeIntegralInRange(0, totalLength - 1);
+			sourceCode.getLocFromIndex(offset);
+		}
+
+		// Scope and ancestor APIs (driven through the AST root).
+		sourceCode.getScope(sourceCode.ast);
+		sourceCode.getAncestors(sourceCode.ast);
+	} catch (e) {
+		// The above are documented public APIs and should not throw on any
+		// successfully-parsed input - re-raise so the fuzzer reports it.
+		throw e;
+	}
+};
+
+function isExpectedConfigurationError(e) {
+	if (!e || typeof e.message !== "string") {
+		return false;
+	}
+	const msg = e.message;
+	return (
+		msg.includes("Key \"languageOptions\":") ||
+		msg.includes("ecmaVersion must be") ||
+		msg.includes("sourceType must be")
+	);
+}

--- a/projects/eslint/fuzz_verify_and_fix.js
+++ b/projects/eslint/fuzz_verify_and_fix.js
@@ -1,0 +1,114 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+"use strict";
+
+const { FuzzedDataProvider } = require("@jazzer.js/core");
+const { Linter } = require("./lib/linter");
+
+const linter = new Linter();
+
+// Restrict to rules that ship with autofixers. The verifyAndFix path runs the
+// fixer in a loop until convergence, so it stresses fixer composition and the
+// "fixes that touch overlapping ranges" path that pure verify() misses.
+const FIXABLE_RULE_POOL = [
+	"semi",
+	"quotes",
+	"no-extra-semi",
+	"no-extra-boolean-cast",
+	"no-trailing-spaces",
+	"no-multi-spaces",
+	"prefer-const",
+	"no-var",
+	"eqeqeq",
+	"curly",
+	"dot-notation",
+	"object-shorthand",
+	"prefer-arrow-callback",
+	"prefer-template",
+	"arrow-parens",
+	"arrow-spacing",
+	"comma-dangle",
+	"comma-spacing",
+	"indent",
+	"key-spacing",
+	"keyword-spacing",
+	"no-extra-parens",
+	"no-useless-rename",
+	"no-useless-return",
+	"yoda",
+];
+
+const ECMA_VERSIONS = [5, 2015, 2018, 2020, 2022, 2024, "latest"];
+const SOURCE_TYPES = ["script", "module", "commonjs"];
+
+function pickRules(provider) {
+	const rules = {};
+	const count = provider.consumeIntegralInRange(1, 6);
+	for (let i = 0; i < count; i++) {
+		const idx = provider.consumeIntegralInRange(
+			0,
+			FIXABLE_RULE_POOL.length - 1,
+		);
+		rules[FIXABLE_RULE_POOL[idx]] = "error";
+	}
+	return rules;
+}
+
+/**
+ * @param { Buffer } data
+ */
+module.exports.fuzz = function (data) {
+	const provider = new FuzzedDataProvider(data);
+
+	const ecmaVersion =
+		ECMA_VERSIONS[provider.consumeIntegralInRange(0, ECMA_VERSIONS.length - 1)];
+	const sourceType =
+		SOURCE_TYPES[provider.consumeIntegralInRange(0, SOURCE_TYPES.length - 1)];
+	const fix = provider.consumeBoolean();
+
+	const config = {
+		languageOptions: {
+			ecmaVersion,
+			sourceType,
+		},
+		rules: pickRules(provider),
+	};
+
+	const code = provider.consumeRemainingAsString();
+
+	try {
+		linter.verifyAndFix(code, config, { fix });
+	} catch (e) {
+		if (isExpectedConfigurationError(e)) {
+			return;
+		}
+		throw e;
+	}
+};
+
+function isExpectedConfigurationError(e) {
+	if (!e || typeof e.message !== "string") {
+		return false;
+	}
+	const msg = e.message;
+	return (
+		msg.includes("Key \"languageOptions\":") ||
+		msg.includes("Key \"rules\":") ||
+		msg.includes("ecmaVersion must be") ||
+		msg.includes("sourceType must be")
+	);
+}

--- a/projects/eslint/project.yaml
+++ b/projects/eslint/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://eslint.org/"
+language: javascript
+main_repo: "https://github.com/eslint/eslint"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - none
+primary_contact: "milos.djermanovic@gmail.com"

--- a/projects/eslint/project.yaml
+++ b/projects/eslint/project.yaml
@@ -5,4 +5,4 @@ fuzzing_engines:
   - libfuzzer
 sanitizers:
   - none
-primary_contact: "milos.djermanovic@gmail.com"
+primary_contact: "contact@eslint.org"


### PR DESCRIPTION
Adds an OSS-Fuzz integration for [ESLint](https://github.com/eslint/eslint) (https://eslint.org/), the AST-based pattern checker for JavaScript.

Three fuzz targets cover the public API surface that the project itself documents:

- `fuzz_linter` — `Linter.verify` with varied ECMA versions, source types, parser feature flags, and a randomised subset of rules so the fuzzer drives which rules get co-enabled rather than running them all every iteration.
- `fuzz_verify_and_fix` — `Linter.verifyAndFix` restricted to fixable rules, to exercise the autofix loop and overlapping-fix path.
- `fuzz_source_code` — post-parse `SourceCode` helpers (tokens, comments, `getLocFromIndex`, `getScope`, `getAncestors`).

`@jazzer.js/core` is pinned to `2.1.0` — the prebuilt native fuzzer in `4.x` requires GLIBC 2.32, which the Ubuntu 20.04 base-runner doesn't provide. There's a comment in `build.sh` next to the pin.

Upstream tracking issue (asking ESLint maintainers to confirm the primary contact and to LGTM here): _filed alongside this PR_.

## Test plan
Tested locally against the cloned upstream `master` of `eslint/eslint`:

- [x] `python3 infra/helper.py build_image eslint`
- [x] `python3 infra/helper.py build_fuzzers eslint`
- [x] `python3 infra/helper.py check_build eslint` — passes for all three targets
- [x] `python3 infra/helper.py run_fuzzer eslint fuzz_linter` — coverage growth, no crashes
- [x] `python3 infra/helper.py run_fuzzer eslint fuzz_verify_and_fix` — coverage growth, no crashes
- [x] `python3 infra/helper.py run_fuzzer eslint fuzz_source_code` — coverage growth, no crashes
- [x] `python3 infra/presubmit.py format` and `license` pass