### PR TITLE
Add two version of the Swift flags.

### DIFF
--- a/docs/getting-started/new-project-guide/swift_lang.md
+++ b/docs/getting-started/new-project-guide/swift_lang.md
@@ -58,8 +58,12 @@ instead of using the simple base-builder
 
 ### build.sh
 
-A `precompile_swift` generates an environment variable `SWIFTFLAGS`
-This can then be used in the building command such as `swift build -c release $SWIFTFLAGS`
+A `precompile_swift` generates two environment variables `SWIFTFLAGS` and
+`SWIFT6_2FLAGS`. These can then be used in the building command such as `swift
+build -c release $SWIFTFLAGS`. If your `Package.swift` uses
+`// swift-tools-version:6.2` or higher, then use `SWIFT6_2FLAGS` if us using
+something lower, you'll want to use `SWIFTFLAGS`. If you get errors like
+_undefined symbol '[BINARY\_NAME]\_main'_ then you likely need the 6_2 version.
 
 
 A usage example from swift-protobuf project is

--- a/infra/base-images/base-builder-swift/precompile_swift
+++ b/infra/base-images/base-builder-swift/precompile_swift
@@ -17,17 +17,26 @@
 
 cp /usr/local/bin/llvm-symbolizer-swift $OUT/llvm-symbolizer
 
+# The flags needed depend on the 'swift-tools-version' in the Package.swift, so
+# best we can do it provide two environment variable and let folks use the
+# correct one.
+
 export SWIFTFLAGS="-Xswiftc -parse-as-library -Xswiftc -static-stdlib --static-swift-stdlib"
+export SWIFT6_2FLAGS="-Xswiftc -static-stdlib --static-swift-stdlib"
 if [ "$SANITIZER" = "coverage" ]
 then
     export SWIFTFLAGS="$SWIFTFLAGS -Xswiftc -profile-generate -Xswiftc -profile-coverage-mapping -Xswiftc -sanitize=fuzzer"
+    export SWIFT6_2FLAGS="$SWIFT6_2FLAGS -Xswiftc -profile-generate -Xswiftc -profile-coverage-mapping --sanitize=fuzzer"
 else
     export SWIFTFLAGS="$SWIFTFLAGS -Xswiftc -sanitize=fuzzer,$SANITIZER --sanitize=$SANITIZER"
+    export SWIFT6_2FLAGS="$SWIFT6_2FLAGS --sanitize=fuzzer --sanitize=$SANITIZER"
     for f in $CFLAGS; do
         export SWIFTFLAGS="$SWIFTFLAGS -Xcc=$f"
+        export SWIFT6_2FLAGS="$SWIFT6_2FLAGS -Xcc=$f"
     done
 
     for f in $CXXFLAGS; do
         export SWIFTFLAGS="$SWIFTFLAGS -Xcxx=$f"
+        export SWIFT6_2FLAGS="$SWIFT6_2FLAGS -Xcxx=$f"
     done
 fi

--- a/projects/swift-protobuf/build.sh
+++ b/projects/swift-protobuf/build.sh
@@ -15,42 +15,18 @@
 #
 ################################################################################
 
-
 . precompile_swift
 cd FuzzTesting
 
-
-# Normally one would use `$SWIFTFLAGS` (from `precompile_swift``) on this
-# invocations, but as we found in
-# https://github.com/apple/swift-protobuf/pull/2037, the flags needs depend on
-# *both* the Swift Toolchain version *and& the `swift-tools-version` in the
-# `Package.swift`.
-#
-# So, for now, manually recode `precompile_swift` with the flags needed since
-# swift-protobuf uses a 6.2+ `swift-tools-version`.
-export SWIFTFLAGS="-Xswiftc -static-stdlib --static-swift-stdlib"
-if [ "$SANITIZER" = "coverage" ] ; then
-    export SWIFTFLAGS="$SWIFTFLAGS -Xswiftc -profile-generate -Xswiftc -profile-coverage-mapping --sanitize=fuzzer"
-else
-    export SWIFTFLAGS="$SWIFTFLAGS --sanitize=fuzzer --sanitize=$SANITIZER"
-    for f in $CFLAGS; do
-        export SWIFTFLAGS="$SWIFTFLAGS -Xcc=$f"
-    done
-
-    for f in $CXXFLAGS; do
-        export SWIFTFLAGS="$SWIFTFLAGS -Xcxx=$f"
-    done
-fi
-
 # debug build
-swift build -c debug $SWIFTFLAGS
+swift build -c debug $SWIFT6_2FLAGS
 (
 cd .build/debug/
 find . -maxdepth 1 -type f -name "Fuzz*" -executable | while read i; do cp $i $OUT/"$i"_debug; done
 )
 
 # release build
-swift build -c release $SWIFTFLAGS
+swift build -c release $SWIFT6_2FLAGS
 (
 cd .build/release/
 find . -maxdepth 1 -type f -name "Fuzz*" -executable | while read i; do cp $i $OUT/"$i"_release; done


### PR DESCRIPTION
Depending on how a Swift package is configured (`Package.swift`), different flags may be needed. Provide variables with the two forms. Update the documentation to try and explain things and call out the likely error.

Move swift-protobuf off a hardcoded override to the new values.