### PR TITLE
base-builder-rust: bump RUSTUP_TOOLCHAIN to nightly-2025-09-05 on ubuntu-24-04

### DIFF
--- a/infra/base-images/base-builder-rust/ubuntu-24-04.Dockerfile
+++ b/infra/base-images/base-builder-rust/ubuntu-24-04.Dockerfile
@@ -26,7 +26,7 @@ ENV OSSFUZZ_RUSTPATH /rust
 # manually specifying what toolchain to use. Note that this environment variable
 # is additionally used by `install_rust.sh` as the toolchain to install.
 # cf https://rust-lang.github.io/rustup/overrides.html
-ENV RUSTUP_TOOLCHAIN nightly-2024-07-12
+ENV RUSTUP_TOOLCHAIN nightly-2025-09-05
 
 # Configure the linker used by default for x86_64 linux to be `clang` instead of
 # rustc's default of `cc` which is able to find custom-built libraries like


### PR DESCRIPTION
Fixes #14220.

The default `base-builder-rust` Dockerfile was bumped to `nightly-2025-09-05` in 625f70d4dee84ca995bb44e6f64cf2ac49448424, but the `ubuntu-24-04` variant was left at `nightly-2024-07-12`. As reported in #14220, this causes build failures / coverage mismatches when projects opt into the `ubuntu-24-04` image (currently 360 projects).

This PR aligns `ubuntu-24-04.Dockerfile` with the default Dockerfile (1-line change).

### Why it's safe to bump now

The original concern raised on #13964 was that `RUSTUP_TOOLCHAIN` couldn't be bumped on the new images while LLVM was at a different revision. As of master, `OUR_LLVM_REVISION=cb2f0d0a5f14` is identical across all three `base-clang` scripts:

```
infra/base-images/base-clang/checkout_build_install_llvm.sh:OUR_LLVM_REVISION=cb2f0d0a5f14
infra/base-images/base-clang/checkout_build_install_llvm_ubuntu_20_04.sh:OUR_LLVM_REVISION=cb2f0d0a5f14
infra/base-images/base-clang/checkout_build_install_llvm_ubuntu_24_04.sh:OUR_LLVM_REVISION=cb2f0d0a5f14
```

So the toolchain/LLVM compatibility concern that delayed this no longer applies — `nightly-2025-09-05` already runs successfully against this LLVM revision in the default image.

### Scope

- Only `ubuntu-24-04.Dockerfile` is touched (the file the issue is about).
- `ubuntu-20-04.Dockerfile` is also at `nightly-2024-07-12` but Ubuntu 20.04 reached EOL in April 2025; whether to bump or remove that file is a separate decision and is intentionally out of scope here.