### PR TITLE
arrow: Add per-fuzzer timeouts

### DIFF
--- a/projects/arrow/arrow-csv-fuzz.options
+++ b/projects/arrow/arrow-csv-fuzz.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+timeout = 30

--- a/projects/arrow/arrow-ipc-file-fuzz.options
+++ b/projects/arrow/arrow-ipc-file-fuzz.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+timeout = 10

--- a/projects/arrow/arrow-ipc-stream-fuzz.options
+++ b/projects/arrow/arrow-ipc-stream-fuzz.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+timeout = 10

--- a/projects/arrow/arrow-ipc-tensor-stream-fuzz.options
+++ b/projects/arrow/arrow-ipc-tensor-stream-fuzz.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+timeout = 10

--- a/projects/arrow/parquet-arrow-fuzz.options
+++ b/projects/arrow/parquet-arrow-fuzz.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+timeout = 30

--- a/projects/arrow/parquet-encoding-fuzz.options
+++ b/projects/arrow/parquet-encoding-fuzz.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+timeout = 5


### PR DESCRIPTION
Since some payloads can be legitimate time bombs (e.g. due to compression), we want to waste less time before OOM.