### PR TITLE
Add OSS-Fuzz integration for openxla/xla

### DIFF
--- a/projects/xla/Dockerfile
+++ b/projects/xla/Dockerfile
@@ -1,0 +1,30 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
+RUN apt-get update && apt-get install -y \
+    python3 \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+# Install OpenJDK 17 via the OSS-Fuzz base-builder helper (Temurin 17).
+# Required by Bazel. Matches the pattern used by other Google ML projects
+# in OSS-Fuzz (e.g. tensorflow).
+RUN install_java.sh
+# Install Bazel via Bazelisk (openxla/xla pins its bazel version via .bazelversion).
+RUN curl -fsSL https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-amd64 \
+    -o /usr/local/bin/bazel && chmod +x /usr/local/bin/bazel
+RUN git clone --depth=1 https://github.com/openxla/xla.git $SRC/xla
+WORKDIR $SRC/xla
+COPY build.sh $SRC/

--- a/projects/xla/build.sh
+++ b/projects/xla/build.sh
@@ -1,0 +1,69 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cd $SRC/xla
+
+# Stage the fuzz harness sources + BUILD into the freshly-cloned xla tree.
+# OSS-Fuzz copies COPY build.sh contents into $SRC/, but other staged files
+# need to be packaged into the project's build context. The harness sources
+# under xla/fuzz/ ship from the openxla/xla upstream once PR-A merges; until
+# then, expect them to be present in the cloned tree at build time.
+test -f xla/fuzz/BUILD || {
+  echo "ERROR: xla/fuzz/BUILD missing — PR-A (upstream harness landing) must merge before this OSS-Fuzz integration builds cleanly."
+  exit 1
+}
+
+# Build flags for libfuzzer + ASAN. base-builder sets $CFLAGS / $CXXFLAGS /
+# $LIB_FUZZING_ENGINE; we pass the fuzzer-link engine via --linkopt and the
+# sanitizer-instrumentation flags via --copt so bazel sees them on every cc_*
+# rule.
+bazel \
+    --host_jvm_args=-Xmx10g \
+    build \
+    -c opt \
+    --copt=-fsanitize=fuzzer-no-link \
+    --copt=-fsanitize=address \
+    --copt=-fno-omit-frame-pointer \
+    --linkopt=-fsanitize=fuzzer \
+    --linkopt=-fsanitize=address \
+    --cxxopt=-stdlib=libc++ \
+    --linkopt=-stdlib=libc++ \
+    --linkopt=-Wl,-rpath,\$ORIGIN \
+    --host_cxxopt=-stdlib=libc++ \
+    --host_linkopt=-stdlib=libc++ \
+    //xla/fuzz:hlo_parser_fuzz \
+    //xla/fuzz:hlo_proto_fuzz
+
+cp bazel-bin/xla/fuzz/hlo_parser_fuzz $OUT/
+cp bazel-bin/xla/fuzz/hlo_proto_fuzz  $OUT/
+
+# xla's hermetic clang toolchain dynamically links libc++/libc++abi/libunwind
+# from external/llvm18_linux_x86_64/lib/. base-runner doesn't ship these, so
+# copy them alongside the fuzzer binaries (base-runner adds $OUT to LD_LIBRARY_PATH).
+for libname in libc++.so.1 libc++abi.so.1 libunwind.so.1; do
+  # Prefer the copy inside the Bazel output tree (deterministic version).
+  src=$(find /root/.cache/bazel/_bazel_root -name "$libname" \
+        2>/dev/null | sort | head -1)
+  # Fall back to full filesystem search if not found in Bazel cache.
+  if [ -z "$src" ]; then
+    src=$(find / -name "$libname" 2>/dev/null | sort | head -1)
+  fi
+  if [ -n "$src" ]; then
+    cp -L "$src" "$OUT/" && echo "staged $libname from $src"
+  else
+    echo "WARN: $libname not found on build container"
+  fi
+done
+

--- a/projects/xla/project.yaml
+++ b/projects/xla/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://openxla.org/xla"
+language: c++
+primary_contact: "xla-team@google.com"
+main_repo: "https://github.com/openxla/xla"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+file_github_issue: True


### PR DESCRIPTION
Add OSS-Fuzz integration for openxla/xla

This PR registers openxla/xla with OSS-Fuzz, adding continuous fuzzing
coverage for XLA's HLO text-format parser and proto deserialization path.
This is the first OSS-Fuzz integration for openxla/xla.

Companion PR in openxla/xla adding the harness sources:
https://github.com/openxla/xla/pull/42055

Note: this integration depends on the companion PR above. The build.sh
guard will exit non-zero until openxla/xla#42055 merges and
xla/fuzz/BUILD is present in the upstream tree. Exact error message:
`ERROR: xla/fuzz/BUILD missing — PR-A (upstream harness landing) must
merge before this OSS-Fuzz integration builds cleanly.`
The OSS-Fuzz CI build will serve as the first end-to-end validation
in the clean pipeline environment.

## Project details

homepage: https://openxla.org/xla
language: C++
sanitizers: address
fuzzing_engines: libfuzzer
primary_contact: xla-team@google.com

## Harnesses

**hlo_parser_fuzz** — exercises `xla::ParseAndReturnUnverifiedModule`
against arbitrary text input bytes. Targets the HLO text-format parser
surface.

**hlo_proto_fuzz** — exercises `xla::HloModule::CreateFromProto` against
arbitrary byte sequences. Includes an explicit size guard against integer
overflow on the `ParseFromArray` size argument.

## Build notes

XLA uses a hermetic LLVM18 toolchain that dynamic-links libc++. The
base-runner image does not ship libc++, so build.sh resolves this by
embedding --linkopt=-Wl,-rpath,$ORIGIN and staging the required libc++
shared objects alongside the fuzzer binaries in $OUT/.

The Dockerfile uses base-builder:ubuntu-24-04 and installs OpenJDK 17
via install_java.sh (matching the pattern used by other Google ML
projects in OSS-Fuzz). Bazel is installed via Bazelisk v1.20.0, which
respects XLA's pinned .bazelversion file.

## Testing

Both harnesses were smoke-tested inside the OSS-Fuzz Docker base image:
- `hlo_parser_fuzz`: 100 runs, zero crashes, 2,371 coverage PCs with
  growth into `xla::HloLexer` and related parser code paths
- `hlo_proto_fuzz`: 100 runs, zero crashes, 819 coverage PCs with
  growth into `xla::HloModuleConfig` and protobuf `TcParser` family
