### PR TITLE
quic-go: run oss-fuzz.sh from the checkout

### DIFF
--- a/projects/quic-go/Dockerfile
+++ b/projects/quic-go/Dockerfile
@@ -21,11 +21,5 @@ RUN go install github.com/AdamKorcz/go-118-fuzz-build@latest
 RUN git clone --depth 1 https://github.com/quic-go/qpack/ $GOPATH/src/github.com/quic-go/qpack
 RUN git clone --depth 1 https://github.com/quic-go/quic-go/ $GOPATH/src/github.com/quic-go/quic-go
 
-RUN cp $GOPATH/src/github.com/quic-go/quic-go/oss-fuzz.sh $SRC/build.sh
-# Local testing:
-# 1. copy oss-fuzz.sh from quic-go repo to projects/quic-go
-# 2. uncomment this line
-# 3. run infra/helper.py build_image quic-go
-# COPY oss-fuzz.sh $SRC/build.sh
-
+COPY build.sh $SRC/build.sh
 RUN chmod +x $SRC/build.sh

--- a/projects/quic-go/build.sh
+++ b/projects/quic-go/build.sh
@@ -1,4 +1,20 @@
 #!/bin/bash
+#
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
 
 set -euo pipefail
 

--- a/projects/quic-go/build.sh
+++ b/projects/quic-go/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euo pipefail
+
+exec bash "$GOPATH/src/github.com/quic-go/quic-go/oss-fuzz.sh" "$@"


### PR DESCRIPTION
Use a small OSS-Fuzz build wrapper so quic-go local builds with a mounted checkout execute that checkout's oss-fuzz.sh instead of a copy baked into the image.