### PR TITLE
gstreamer: Fix Dockerfile and build.sh

### DIFF
--- a/projects/gstreamer/Dockerfile
+++ b/projects/gstreamer/Dockerfile
@@ -16,7 +16,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN apt-get update && \
-   apt-get install -y make autoconf automake libtool build-essential pkg-config bison flex patchelf
+   apt-get install -y make autoconf automake libtool build-essential pkg-config bison flex patchelf nasm
 
 RUN pip3 install --disable-pip-version-check --no-cache-dir \
         pip==25.1.1
@@ -24,10 +24,6 @@ RUN pip3 install --disable-pip-version-check --no-cache-dir \
         corpus-replicator \
         meson==1.8.2 \
         ninja==1.11.1.4
-
-RUN git clone --depth 1 https://gitlab.xiph.org/xiph/vorbis.git vorbis
-RUN git clone --depth 1 https://gitlab.xiph.org/xiph/ogg.git ogg
-RUN git clone --depth 1 https://gitlab.xiph.org/xiph/theora.git theora
 
 # Checkout repository
 RUN git clone --depth 1 --recursive https://gitlab.freedesktop.org/gstreamer/gstreamer.git gstreamer

--- a/projects/gstreamer/build.sh
+++ b/projects/gstreamer/build.sh
@@ -18,17 +18,14 @@
 # gstreamer requires autoconf 2.71 minimum which is not available in the Ubuntu 20 base image
 # Skip this step if a newer base image is used
 if grep -q -F "20.04" /etc/os-release ; then
-    cd /tmp
+    pushd /tmp
     wget https://archive.ubuntu.com/ubuntu/pool/main/a/autoconf/autoconf_2.71-2_all.deb
     # Ensure file is not modified or corrupted before install
     if echo "96b528889794c4134015a63c75050f93d8aecdf5e3f2a20993c1433f4c61b80e autoconf_2.71-2_all.deb" | sha256sum --check --status ; then
         # Install but use G option to prevent downgrade in case this is
         dpkg -i -G /tmp/autoconf_2.71-2_all.deb
     fi
+    popd
 fi
-
-
-# Fix Meson dependency error in ci/fuzzing/meson.build
-sed -i 's/extra_deps = dependency(target.get(2))/foreach d : target.get(2)\n      extra_deps += dependency(d)\n    endforeach/' $SRC/gstreamer/ci/fuzzing/meson.build
 
 $SRC/gstreamer/ci/fuzzing/build-oss-fuzz.sh


### PR DESCRIPTION
This PR fixes the Dockerfile and build.sh to accommodate some changes from the gstreamer meson build system.

1) The 3 dependency libraries is removed since the gstreamer is able to build them automatically with meson wrap file upstream.
2) Install nasm prepare for more vpx format fuzzing.
3) Address a directory mismatch problem.
3) Remove the temp fix for meson.build which has been addressed upstream.