### PR TITLE
docs: fix local source reproduce command

### DIFF
--- a/docs/advanced-topics/reproducing.md
+++ b/docs/advanced-topics/reproducing.md
@@ -118,11 +118,12 @@ $ python3 infra/helper.py reproduce libxml2 libxml2_xml_read_memory_fuzzer ~/Dow
 
 ## Reproduce using local source checkout
 
-You can also mount local sources into the running container by using these commands:
+You can also build fuzzers from a local source checkout by using these
+commands:
 
 ```bash
 $ python3 infra/helper.py build_fuzzers \
-    --sanitizer <address/memory/undefined> $PROJECT_NAME --mount_path <source_path>
+    --sanitizer <address/memory/undefined> $PROJECT_NAME <source_path>
 $ python3 infra/helper.py reproduce $PROJECT_NAME <fuzz_target_name> <testcase_path>
 ```
 


### PR DESCRIPTION
Fixes #15454.

The local source checkout example on the reproducing crashes page used `--mount_path <source_path>`, but `build_fuzzers` expects the checkout path as the positional `source_path` argument. `--mount_path` is only for overriding where that source is mounted inside the builder container.

This updates the example to pass `<source_path>` after ``.

Validation:
- `git diff --check`