### PR TITLE
Add cpace project

### DIFF
--- a/projects/cpace/Dockerfile
+++ b/projects/cpace/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+
+RUN git clone --depth 1 https://github.com/the-sarge/cpace.git
+WORKDIR /src/cpace
+
+COPY build.sh $SRC/

--- a/projects/cpace/build.sh
+++ b/projects/cpace/build.sh
@@ -1,0 +1,39 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+src_dir="$SRC/cpace"
+build_dir="$WORK/cpace-build"
+rm -rf "$build_dir"
+mkdir -p "$build_dir"
+cp -a "$src_dir"/. "$build_dir"/
+cd "$build_dir"
+
+go install github.com/AdamKorcz/go-118-fuzz-build@latest
+go get github.com/AdamKorcz/go-118-fuzz-build/testing
+
+compile_native_go_fuzzer github.com/the-sarge/cpace FuzzDecodeMessageA fuzz_decode_message_a
+compile_native_go_fuzzer github.com/the-sarge/cpace FuzzDecodeMessageB fuzz_decode_message_b
+compile_native_go_fuzzer github.com/the-sarge/cpace FuzzDecodeMessageC fuzz_decode_message_c
+compile_native_go_fuzzer github.com/the-sarge/cpace FuzzDraftVectorJSONLoader fuzz_draft_vector_json_loader
+compile_native_go_fuzzer github.com/the-sarge/cpace FuzzDraftInvalidVectorJSONLoader fuzz_draft_invalid_vector_json_loader
+compile_native_go_fuzzer github.com/the-sarge/cpace FuzzProtocolConsistency fuzz_protocol_consistency
+compile_native_go_fuzzer github.com/the-sarge/cpace FuzzProtocolMismatch fuzz_protocol_mismatch
+compile_native_go_fuzzer github.com/the-sarge/cpace FuzzRespondWithFuzzedMessageA fuzz_respond_with_fuzzed_message_a
+compile_native_go_fuzzer github.com/the-sarge/cpace FuzzInitiatorFinishWithFuzzedMessageB fuzz_initiator_finish_with_fuzzed_message_b
+compile_native_go_fuzzer github.com/the-sarge/cpace FuzzResponderFinishWithFuzzedMessageC fuzz_responder_finish_with_fuzzed_message_c
+compile_native_go_fuzzer github.com/the-sarge/cpace FuzzScalarMultVFY fuzz_scalar_mult_vfy
+compile_native_go_fuzzer github.com/the-sarge/cpace FuzzMessageARoundTrip fuzz_message_a_round_trip
+compile_native_go_fuzzer github.com/the-sarge/cpace FuzzMessageBRoundTrip fuzz_message_b_round_trip
+compile_native_go_fuzzer github.com/the-sarge/cpace FuzzMessageCRoundTrip fuzz_message_c_round_trip

--- a/projects/cpace/project.yaml
+++ b/projects/cpace/project.yaml
@@ -1,0 +1,23 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+homepage: "https://github.com/the-sarge/cpace"
+language: go
+primary_contact: "the-sarge@the-sarge.com"
+main_repo: "https://github.com/the-sarge/cpace.git"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+help_url: "https://github.com/the-sarge/cpace/blob/main/SECURITY.md"


### PR DESCRIPTION
Add OSS-Fuzz coverage for CPace, a Go implementation of the CPace PAKE draft.

This project entry builds the existing Go fuzz harness with `compile_native_go_fuzzer` and exposes 14 fuzz targets covering message decoding, draft vector loading, protocol consistency/mismatch paths, transcript-message round trips, and scalar multiplication input handling.

Validation run locally from this OSS-Fuzz checkout:

```
DOCKER_DEFAULT_PLATFORM=linux/amd64 python3 infra/helper.py build_fuzzers --architecture x86_64 --sanitizer address --clean cpace
DOCKER_DEFAULT_PLATFORM=linux/amd64 python3 infra/helper.py check_build cpace
```

Both commands passed. The Docker image was cache-busted before validation and confirmed to clone CPace commit `955855b58424a8868d318096149be615bb3989da` from the project main branch.