### PR TITLE
quic-go: add a service account

### DIFF
--- a/projects/quic-go/project.yaml
+++ b/projects/quic-go/project.yaml
@@ -1,5 +1,7 @@
 homepage: "https://github.com/quic-go/quic-go"
 primary_contact: "martenseemann@gmail.com"
+auto_ccs:
+  - "quic-go-corpus-ci@quic-go-oss-fuzz-ci.iam.gserviceaccount.com"
 language: go
 fuzzing_engines:
 - libfuzzer


### PR DESCRIPTION
I'm working on a CI job that uses the (live) corpus of OSS-Fuzz (see https://github.com/quic-go/quic-go/issues/4036). This requires a service account with access to the storage bucket.