### PR TITLE
zephyr: initial integration

### DIFF
--- a/projects/zephyr/Dockerfile
+++ b/projects/zephyr/Dockerfile
@@ -1,0 +1,74 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+# Host build dependencies for the Zephyr / native_sim toolchain.
+# (cmake and a recent clang are already provided by the base image.)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ninja-build \
+        gperf \
+        device-tree-compiler \
+        xz-utils \
+        file \
+        libmagic1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Zephyr's CMake (zephyr/cmake/modules/python.cmake) requires Python >= 3.12,
+# but base-builder ships Python 3.11. Build 3.12 from source and front it
+# ahead of the base image's interpreter on PATH. Same pattern base-builder
+# uses for 3.11 (infra/base-images/base-builder/Dockerfile).
+ENV ZEPHYR_PYTHON_VERSION=3.12.10
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev \
+        libsqlite3-dev libreadline-dev libffi-dev libbz2-dev liblzma-dev \
+ && unset CFLAGS CXXFLAGS \
+ && cd /tmp \
+ && curl -fsSLO https://www.python.org/ftp/python/$ZEPHYR_PYTHON_VERSION/Python-$ZEPHYR_PYTHON_VERSION.tar.xz \
+ && tar -xf Python-$ZEPHYR_PYTHON_VERSION.tar.xz \
+ && cd Python-$ZEPHYR_PYTHON_VERSION \
+ && ./configure --prefix=/opt/python-3.12 --enable-shared --with-ensurepip=install \
+ && make -j$(nproc) \
+ && make install \
+ && echo /opt/python-3.12/lib > /etc/ld.so.conf.d/python-3.12.conf \
+ && ldconfig \
+ && cd /tmp && rm -rf Python-$ZEPHYR_PYTHON_VERSION* \
+ && rm -rf /var/lib/apt/lists/* \
+ && ln -sf /opt/python-3.12/bin/python3.12 /usr/local/bin/python3 \
+ && ln -sf /opt/python-3.12/bin/python3.12 /usr/local/bin/python \
+ && ln -sf /opt/python-3.12/bin/pip3.12   /usr/local/bin/pip3 \
+ && ln -sf /opt/python-3.12/bin/pip3.12   /usr/local/bin/pip
+ENV PATH=/opt/python-3.12/bin:$PATH
+
+# Install west under Python 3.12 so its shebang and Zephyr's WEST_PYTHON
+# both point at the 3.12 interpreter.
+RUN /opt/python-3.12/bin/pip3.12 install --no-cache-dir west
+
+# Initialize a Zephyr workspace and pull the modules pinned by the
+# upstream west manifest. --narrow + --depth=1 keeps the checkout small
+# while still giving us everything CMake needs to configure native_sim.
+WORKDIR $SRC
+RUN west init -m https://github.com/zephyrproject-rtos/zephyr.git \
+        --mr main zephyrproject \
+ && cd zephyrproject \
+ && west update --narrow -o=--depth=1 \
+ && west zephyr-export
+
+RUN /opt/python-3.12/bin/pip3.12 install --no-cache-dir \
+        -r $SRC/zephyrproject/zephyr/scripts/requirements-base.txt
+
+WORKDIR $SRC/zephyrproject/zephyr
+COPY build.sh $SRC/

--- a/projects/zephyr/build.sh
+++ b/projects/zephyr/build.sh
@@ -1,0 +1,65 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+set -euo pipefail
+
+# Zephyr's upstream fuzzing path is `native_sim/native/64` driven by
+# CONFIG_ARCH_POSIX_LIBFUZZER, which hard-codes `-fsanitize=fuzzer` into
+# the link. That makes libFuzzer the only currently supported engine.
+if [ "${FUZZING_ENGINE:-libfuzzer}" != "libfuzzer" ]; then
+    echo "Skipping unsupported FUZZING_ENGINE=$FUZZING_ENGINE (Zephyr only" \
+         "supports libFuzzer for now)."
+    exit 0
+fi
+
+export ZEPHYR_BASE="$SRC/zephyrproject/zephyr"
+export ZEPHYR_TOOLCHAIN_VARIANT="host/llvm"
+
+# Map OSS-Fuzz's $SANITIZER onto Zephyr's Kconfig sanitizer options.
+# Zephyr's arch/posix/CMakeLists.txt builds the `-fsanitize=...` arg from
+# these CONFIG_* values, so we drive the sanitizer choice through Kconfig
+# instead of CFLAGS/CXXFLAGS to avoid double-instrumentation.
+SANITIZER_CONF="-DCONFIG_ARCH_POSIX_LIBFUZZER=y"
+case "${SANITIZER:-address}" in
+    address)   SANITIZER_CONF="$SANITIZER_CONF -DCONFIG_ASAN=y" ;;
+    undefined) SANITIZER_CONF="$SANITIZER_CONF -DCONFIG_UBSAN=y" ;;
+    memory)    SANITIZER_CONF="$SANITIZER_CONF -DCONFIG_MSAN=y" ;;
+    coverage)  ;;
+    *) echo "Unsupported SANITIZER=$SANITIZER"; exit 1 ;;
+esac
+
+# Zephyr drives sanitizer/fuzzer flags from Kconfig and supplies its own
+# toolchain config files via clang's `--config`. Letting OSS-Fuzz's pre-set
+# CFLAGS/CXXFLAGS leak through causes duplicate `-fsanitize=` flags and
+# `--config` clashes, so we clear them here.
+unset CFLAGS CXXFLAGS
+
+build_fuzzer() {
+    local sample_path="$1"   # e.g. samples/subsys/debug/fuzz
+    local fuzzer_name="$2"   # output binary name in $OUT
+    local build_dir="$WORK/build-$fuzzer_name"
+    rm -rf "$build_dir"
+
+    cd "$ZEPHYR_BASE"
+    west build -d "$build_dir" -b native_sim/native/64 "$sample_path" \
+        -- $SANITIZER_CONF
+
+    cp "$build_dir/zephyr/zephyr.exe" "$OUT/$fuzzer_name"
+}
+
+# Upstream fuzz harness: drives the OS through an interrupt and exercises
+# kernel scheduling, IRQ dispatch and printk on every input.
+build_fuzzer "samples/subsys/debug/fuzz" "zephyr_fuzz_sample"

--- a/projects/zephyr/project.yaml
+++ b/projects/zephyr/project.yaml
@@ -1,0 +1,14 @@
+homepage: "https://www.zephyrproject.org/"
+language: c
+main_repo: "https://github.com/zephyrproject-rtos/zephyr.git"
+primary_contact: "vulnerabilities@zephyrproject.org"
+
+fuzzing_engines:
+  - libfuzzer
+
+sanitizers:
+  - address
+  - undefined
+
+architectures:
+  - x86_64


### PR DESCRIPTION
Initial OSS-Fuzz integration for the Zephyr RTOS
(https://github.com/zephyrproject-rtos/zephyr).

Build path: native_sim/native/64 with `CONFIG_ARCH_POSIX_LIBFUZZER=y`,
which is Zephyr's upstream-supported libFuzzer entry point. No patches
to Zephyr are required.

- Dockerfile: pulls a Zephyr workspace via `west init` + `west update`,
  and builds Python 3.12 from source (Zephyr's CMake requires >= 3.12,
  base-builder ships 3.11).
- build.sh: maps OSS-Fuzz's $SANITIZER onto Zephyr's `CONFIG_ASAN`,
  `CONFIG_UBSAN`, `CONFIG_MSAN` Kconfigs and drives
  `west build -b native_sim/native/64 samples/subsys/debug/fuzz`.
- One initial fuzz target (`zephyr_fuzz_sample`, the in-tree fuzz
  harness). More targets can be added by extending build.sh.

Tested locally with Docker:
- `build_fuzzers` succeeds for SANITIZER=address and SANITIZER=undefined.
- `check_build` (test_all.py) passes for both sanitizers.
- `run_fuzzer` exercises the binary at ~22k exec/s and grows coverage as
  expected (cov 211 / ft 222 in 16s).

The Zephyr security team has been notified upstream and the primary
contact in project.yaml will be confirmed there before merge.
