### PR TITLE
Add libwmf

### DIFF
--- a/projects/libwmf/project.yaml
+++ b/projects/libwmf/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://github.com/caolanm/libwmf"
+language: c++
+primary_contact: "caolanm@gmail.com"
+main_repo: 'https://github.com/caolanm/libwmf.git'
+
+fuzzing_engines:
+  - libfuzzer
+  - honggfuzz
+
+sanitizers:
+  - address
+  - undefined


### PR DESCRIPTION
libwmf is a Windows MetaFile (WMF) library consumed by ImageMagick and GIMP (via plugin)

- ImageMagick/ImageMagick: coders/wmf.c (https://github.com/ImageMagick/ImageMagick/blob/main/coders/wmf.c)
- GNOME/gimp: plug-ins/common/file-wmf.c (https://github.com/GNOME/gimp/blob/master/plug-ins/common/file-wmf.c)