### PR TITLE
Add blamejs project

### DIFF
--- a/projects/blamejs/Dockerfile
+++ b/projects/blamejs/Dockerfile
@@ -1,6 +1,18 @@
-# OSS-Fuzz project Dockerfile for blamejs — a Node framework with
-# security-on-by-default posture. See project.yaml for primary
-# contact + upstream homepage.
+# Copyright 2026 The blamejs Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder-javascript
 

--- a/projects/blamejs/Dockerfile
+++ b/projects/blamejs/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2026 The blamejs Authors.
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/blamejs/Dockerfile
+++ b/projects/blamejs/Dockerfile
@@ -1,0 +1,13 @@
+# OSS-Fuzz project Dockerfile for blamejs — a Node framework with
+# security-on-by-default posture. See project.yaml for primary
+# contact + upstream homepage.
+
+FROM gcr.io/oss-fuzz-base/base-builder-javascript
+
+# Clone the framework. ClusterFuzz tracks main on every run; pin a
+# specific tag instead of -b main to freeze the surface.
+RUN git clone --depth 1 -b main https://github.com/blamejs/blamejs $SRC/blamejs
+
+WORKDIR $SRC/blamejs
+
+COPY build.sh $SRC/

--- a/projects/blamejs/build.sh
+++ b/projects/blamejs/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2026 The blamejs Authors.
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/blamejs/build.sh
+++ b/projects/blamejs/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -eu
+#
+# OSS-Fuzz build script for blamejs.
+#
+# Wires every fuzz/<name>.fuzz.js harness into a libFuzzer-shaped
+# runnable via the base-builder-javascript image's
+# compile_javascript_fuzzer helper. The matching
+# fuzz/<name>_seed_corpus/ directory is zipped into the seed corpus
+# the engine bootstraps from.
+
+cd "$SRC/blamejs"
+
+for fuzzer in fuzz/*.fuzz.js; do
+  base=$(basename "$fuzzer" .fuzz.js)
+  echo "[blamejs build] compiling $base"
+  compile_javascript_fuzzer blamejs "$fuzzer" --sync
+
+  seed_dir="fuzz/${base}_seed_corpus"
+  if [ -d "$seed_dir" ]; then
+    echo "[blamejs build] packaging seed corpus for $base"
+    ( cd "$seed_dir" && zip -q -r "$OUT/${base}_seed_corpus.zip" . )
+  fi
+done
+
+echo "[blamejs build] done — $(find "$OUT" -mindepth 1 -maxdepth 1 | wc -l) artifacts in \$OUT"

--- a/projects/blamejs/build.sh
+++ b/projects/blamejs/build.sh
@@ -1,6 +1,19 @@
 #!/bin/bash -eu
+# Copyright 2026 The blamejs Authors.
 #
-# OSS-Fuzz build script for blamejs.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
 #
 # Wires every fuzz/<name>.fuzz.js harness into a libFuzzer-shaped
 # runnable via the base-builder-javascript image's

--- a/projects/blamejs/project.yaml
+++ b/projects/blamejs/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://blamejs.com"
+language: javascript
+primary_contact: "security@blamejs.com"
+auto_ccs:
+  - "security@blamejs.com"
+main_repo: "https://github.com/blamejs/blamejs"
+fuzzing_engines:
+  - libfuzzer


### PR DESCRIPTION
**Project**: blamejs — a Node.js framework with security-on-by-default posture
**Homepage**: https://blamejs.com
**Repo**: https://github.com/blamejs/blamejs
**Primary contact**: security@blamejs.com
**Language**: JavaScript (Node 24 LTS)
**Fuzzing engine**: libFuzzer (via jazzer.js)

## What gets fuzzed

15 coverage-guided fuzz harnesses against the parser / validator primitives most likely to crash on adversarial input:

| Target                              | Surface |
|---|---|
| `b.safeJson.parse`                  | RFC 8259 JSON parser with depth + key-count caps, prototype-pollution refusal |
| `b.safeUrl.parse`                   | URL parser with IDN homograph + mixed-script refusal |
| `b.safeJsonPath.validateExpression` | JSONPath validator refusing filter `?(...)`, deep-scan `$..`, script-shape `(@.x)` |
| `b.guardCsv.validate`               | Formula-injection + bidi + dialect-ambiguity scanner |
| `b.guardHtml.validate`              | XSS / mXSS / DOM-clobbering / dangerous-tag scanner |
| `b.guardJson.parse`                 | Source-level prototype-pollution + JSON5 + dupkey + NaN/Infinity refusal |
| `b.guardYaml.parse`                 | Deserialization-tag RCE + billion-laughs + Norway-problem + multi-doc refusal |
| `b.guardXml.validate`               | XXE / billion-laughs / xi:include / signature-wrapping refusal |
| `b.guardSvg.validate`               | Script / foreignObject / animation href hijack / DOCTYPE refusal |
| `b.guardMarkdown.validate`          | Dangerous URL schemes + CVE-2026-30838 tag bypass + ReDoS emphasis |
| `b.guardEmail.validateMessage`      | SMTP smuggling + CRLF header injection + IDN homograph |
| `b.parsers.{toml,yaml,xml,ini}.parse` | Safe parsers for config / IaC / document-import formats |

## Harness format

Each `fuzz/<name>.fuzz.js` is a jazzer.js libFuzzer entry-point (`module.exports.fuzz = function (data) { ... }`). The build script wires each harness via `compile_javascript_fuzzer` and zips its `fuzz/<name>_seed_corpus/` directory at compile time.

A shared `fuzz/_expected.js` classifies operator-friendly framework throws as expected outcomes; everything else escapes as a finding the engine records + minimizes into a regression-corpus entry.

## Pre-submission verification

End-to-end build verified locally against `gcr.io/oss-fuzz-base/base-builder-javascript`:

```
docker build -t blamejs-test -f projects/blamejs/Dockerfile projects/blamejs/
docker run --rm -e SRC=/src -e OUT=/out -e FUZZING_LANGUAGE=javascript \
  -e SANITIZER=none -e FUZZING_ENGINE=libfuzzer -v /tmp/out:/out \
  blamejs-test bash /src/build.sh
# → [blamejs build] done — 31 artifacts in $OUT
#   (15 fuzzers + 15 seed-corpus zips + 1 jazzer runtime stub)
```

The same harnesses run on every PR + nightly via ClusterFuzzLite at `.github/workflows/cflite_pr.yml` in the project repo; findings reproduce identically between local CFLite and upstream OSS-Fuzz.

## Maintainer commitment

Sole maintainer (security@blamejs.com) commits to triaging crash reports within the standard 90-day disclosure window. The framework has an established security policy (https://github.com/blamejs/blamejs/blob/main/SECURITY.md) including a private disclosure channel.