### PR TITLE
Add seed corpus for ojph_compress_fuzz_target

### DIFF
--- a/projects/openjph/Dockerfile
+++ b/projects/openjph/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y cmake libtiff-dev zip
 # clone the library
 RUN git clone https://github.com/aous72/OpenJPH.git
 
-# clone the seed corpus
+# import the ojph_expand_fuzz_target seed corpus
 RUN git clone --depth 1 https://github.com/aous72/jp2k_test_codestreams.git
 
 # import the build script

--- a/projects/openjph/build.sh
+++ b/projects/openjph/build.sh
@@ -24,7 +24,9 @@ make -j$(nproc)
 cp fuzzing/ojph_expand_fuzz_target $OUT
 cp fuzzing/ojph_compress_fuzz_target $OUT
 
-# Build the seed corpus
+# Build the seed corpora
 cd $SRC
 rm -f $OUT/ojph_expand_fuzz_target_seed_corpus.zip
 zip -j $OUT/ojph_expand_fuzz_target_seed_corpus.zip jp2k_test_codestreams/openjph/*.j2c
+rm -f $OUT/ojph_compress_fuzz_target_seed_corpus.zip
+zip -j $OUT/ojph_compress_fuzz_target_seed_corpus.zip $SRC/OpenJPH/fuzzing/seed_corpus/ojph_compress_fuzz_target/w128_h128_b2_79_b3_09.bin


### PR DESCRIPTION
It looks like ojph_compress_fuzz_target is blocked. Maybe a seed corpus would help?

https://storage.googleapis.com/oss-fuzz-introspector/openjph/inspector-report/20260510/calltree_view_0.html?scrollToNode=00000