### PR TITLE
[mbedtls] Add PSA Crypto API fuzz target

### DIFF
--- a/projects/mbedtls/build.sh
+++ b/projects/mbedtls/build.sh
@@ -77,3 +77,22 @@ for x in fuzz_*; do
 done
 cd ../..
 cd ..
+
+# ------------------------------------------------------------
+# TF-PSA-Crypto fuzz targets (PSA Crypto API direct fuzzing)
+# ------------------------------------------------------------
+cd $SRC/mbedtls/tf-psa-crypto
+mkdir -p build-fuzz
+cd build-fuzz
+
+cmake .. \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DENABLE_PROGRAMS=ON \
+    -DENABLE_TESTING=OFF \
+    -DCMAKE_C_COMPILER="$CC" \
+    -DCMAKE_CXX_COMPILER="$CXX"
+
+make -j$(nproc) fuzz_psa_crypto
+cp programs/fuzz/fuzz_psa_crypto $OUT/
+cp programs/fuzz/fuzz_psa_crypto.options $OUT/
+cp programs/fuzz/fuzz_psa_crypto_seed_corpus.zip $OUT/


### PR DESCRIPTION
Adds a new fuzz target `fuzz_psa_crypto` that directly exercises the PSA Crypto API: key import, generate, export, sign/verify hash, sign/verify message, and AEAD encrypt/decrypt operations (11 operation types).

The existing fuzz targets cover TLS, X.509, and PK parsing but do not directly fuzz the PSA Crypto API — the cryptographic primitive layer used by all Trusted Firmware components (TF-A, TF-M, OP-TEE) and Mbed TLS 3.x+.

Designed to catch:
- Buffer overflows in key export (cf. CVE-2026-34875)
- Use-after-free in key slot management
- Integer overflows in bignum operations
- Memory leaks in error paths

Files: fuzz_psa_crypto.c (harness), fuzz_psa_crypto.options (max_len=65535), fuzz_psa_crypto_seed_corpus.zip (3 seeds)