### PR TITLE
Add go-seccure project

### DIFF
--- a/projects/go-seccure/Dockerfile
+++ b/projects/go-seccure/Dockerfile
@@ -1,0 +1,9 @@
+# OSS-Fuzz build container for go-seccure. Lives here for review/onboarding;
+# the active copy is in google/oss-fuzz's projects/go-seccure/ directory.
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+
+RUN git clone --depth 1 https://github.com/invenity-labs/go-seccure $SRC/go-seccure
+WORKDIR $SRC/go-seccure
+
+COPY build.sh $SRC/

--- a/projects/go-seccure/Dockerfile
+++ b/projects/go-seccure/Dockerfile
@@ -1,5 +1,22 @@
-# OSS-Fuzz build container for go-seccure. Lives here for review/onboarding;
-# the active copy is in google/oss-fuzz's projects/go-seccure/ directory.
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+# OSS-Fuzz build container for go-seccure. Lives here in the upstream
+# project repo for review/onboarding; the active copy is in
+# google/oss-fuzz's projects/go-seccure/ directory.
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
 

--- a/projects/go-seccure/Dockerfile
+++ b/projects/go-seccure/Dockerfile
@@ -14,9 +14,7 @@
 #
 ################################################################################
 #
-# OSS-Fuzz build container for go-seccure. Lives here in the upstream
-# project repo for review/onboarding; the active copy is in
-# google/oss-fuzz's projects/go-seccure/ directory.
+# OSS-Fuzz build container for go-seccure.
 
 FROM gcr.io/oss-fuzz-base/base-builder-go
 

--- a/projects/go-seccure/build.sh
+++ b/projects/go-seccure/build.sh
@@ -1,5 +1,19 @@
 #!/bin/bash -eu
-# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
 #
 # OSS-Fuzz build script. Compiles each of go-seccure's native Go fuzz
 # targets (defined in fuzz_test.go) into a libFuzzer-compatible binary

--- a/projects/go-seccure/build.sh
+++ b/projects/go-seccure/build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -eu
+# SPDX-License-Identifier: LGPL-3.0-or-later
+#
+# OSS-Fuzz build script. Compiles each of go-seccure's native Go fuzz
+# targets (defined in fuzz_test.go) into a libFuzzer-compatible binary
+# using compile_native_go_fuzzer, then OSS-Fuzz harnesses run them
+# continuously on Google's infrastructure.
+
+cd "${SRC}/go-seccure"
+
+# `compile_native_go_fuzzer` generates a shim file that imports
+# github.com/AdamKorcz/go-118-fuzz-build/testing — the standard
+# adapter from Go's native fuzzing API to libFuzzer. The library's
+# canonical go.mod doesn't include that dependency (we keep it
+# zero-deps for the production library), so add it here inside the
+# OSS-Fuzz build container. This `go get` only modifies the
+# container's transient go.mod, not the upstream repo's.
+go get github.com/AdamKorcz/go-118-fuzz-build/testing
+
+# Each target gets its own libFuzzer binary. Seed corpora are pulled
+# from each f.Add() entry automatically by the wrapper.
+for target in \
+    FuzzDecodeCompactNeverPanics \
+    FuzzEncodeDecodeCompactRoundTrip \
+    FuzzPassphraseToPubkeyNeverPanics \
+    FuzzDecryptNeverPanics \
+    FuzzVerifyBinaryNeverPanics \
+    FuzzCurveByNameNeverPanics
+do
+    compile_native_go_fuzzer github.com/invenity-labs/go-seccure "${target}" "${target}"
+done

--- a/projects/go-seccure/project.yaml
+++ b/projects/go-seccure/project.yaml
@@ -1,16 +1,8 @@
 # OSS-Fuzz project descriptor for go-seccure.
-#
-# This file isn't consumed from this repo at runtime — it lives here for
-# convenience and is copied verbatim into google/oss-fuzz's
-# projects/go-seccure/ directory when onboarding. See
-# https://google.github.io/oss-fuzz/getting-started/new-project-guide/go-lang/
-# for the canonical onboarding flow.
 
 homepage: "https://github.com/invenity-labs/go-seccure"
 language: go
 primary_contact: "imdaveb@gmail.com"
-auto_ccs:
-  - "imdaveb@gmail.com"
 sanitizers:
   - address
 fuzzing_engines:

--- a/projects/go-seccure/project.yaml
+++ b/projects/go-seccure/project.yaml
@@ -1,0 +1,19 @@
+# OSS-Fuzz project descriptor for go-seccure.
+#
+# This file isn't consumed from this repo at runtime — it lives here for
+# convenience and is copied verbatim into google/oss-fuzz's
+# projects/go-seccure/ directory when onboarding. See
+# https://google.github.io/oss-fuzz/getting-started/new-project-guide/go-lang/
+# for the canonical onboarding flow.
+
+homepage: "https://github.com/invenity-labs/go-seccure"
+language: go
+primary_contact: "imdaveb@gmail.com"
+auto_ccs:
+  - "imdaveb@gmail.com"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer
+main_repo: "https://github.com/invenity-labs/go-seccure"
+file_github_issue: true


### PR DESCRIPTION
Pure-Go port of SECCURE (https://github.com/invenity-labs/go-seccure).
  Six native Go fuzz targets in fuzz_test.go cover the base-90 codec,
  public-key derivation, decryption, signature verification, and
  curve-name lookup. Smoke-tested locally via build_fuzzers and
  check_build, both pass.