### PR TITLE
Add contents: read to base-OS and ubuntu-sync check workflows

### DIFF
--- a/.github/workflows/check_base_os.yml
+++ b/.github/workflows/check_base_os.yml
@@ -21,6 +21,9 @@ on:
     paths:
       - 'projects/**'
 
+permissions:
+  contents: read
+
 jobs:
   check-consistency:
     runs-on: ubuntu-latest

--- a/.github/workflows/ubuntu_version_sync.yml
+++ b/.github/workflows/ubuntu_version_sync.yml
@@ -20,6 +20,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   check-sync:
     name: Ubuntu File Synchronization Check


### PR DESCRIPTION
Two pre-existing pull_request validators (`check_base_os.yml` and `ubuntu_version_sync.yml`) currently leave their `GITHUB_TOKEN` scope at the repository default. Both just:

1. Check out the repo (`actions/checkout`)
2. Diff changed files against the base/head SHAs
3. Run a Python/shell consistency check and `exit 1` on mismatch

Neither posts a comment, pushes a commit, or calls any GitHub write endpoint. Declaring `contents: read` makes the minimum scope explicit and matches what other workflows in this repo do.

YAML parses cleanly.