### PR TITLE
prettier: initial integration

### DIFF
--- a/projects/prettier/Dockerfile
+++ b/projects/prettier/Dockerfile
@@ -1,0 +1,36 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-javascript
+
+COPY build.sh $SRC/
+
+RUN git clone --depth 1 https://github.com/prettier/prettier.git
+
+# Prettier's own package.json sets "type": "module", which makes every .js
+# file inside the repo be loaded as ESM. The fuzz targets are written in
+# CommonJS, so they live in a subdirectory carrying its own package.json
+# with "type": "commonjs" to override the parent setting.
+RUN mkdir -p $SRC/prettier/fuzz_targets
+COPY fuzz_targets/package.json \
+     fuzz_targets/fuzz_format_js.js \
+     fuzz_targets/fuzz_format_ts.js \
+     fuzz_targets/fuzz_format_css.js \
+     fuzz_targets/fuzz_format_json.js \
+     fuzz_targets/fuzz_format_md.js \
+     $SRC/prettier/fuzz_targets/
+
+WORKDIR $SRC/prettier

--- a/projects/prettier/build.sh
+++ b/projects/prettier/build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Install Prettier's own dependencies. Prettier ships its sources runnable
+# as-is from the repo (package.json "main" -> "./src/index.cjs"), so no build
+# step is required for the fuzz targets to require it.
+npm install --ignore-scripts
+
+# Install Jazzer.js. Prettier's `format` API is asynchronous since v3, so the
+# fuzz targets are written as async functions and we do NOT pass --sync.
+# Pinned to 2.1.0 because the 4.0.0 prebuilt native addon requires GLIBC_2.32,
+# which is not available in the current base-builder-javascript image.
+npm install --save-dev @jazzer.js/core@2.1.0
+
+# Build fuzzers.
+compile_javascript_fuzzer prettier fuzz_targets/fuzz_format_js.js
+compile_javascript_fuzzer prettier fuzz_targets/fuzz_format_ts.js
+compile_javascript_fuzzer prettier fuzz_targets/fuzz_format_css.js
+compile_javascript_fuzzer prettier fuzz_targets/fuzz_format_json.js
+compile_javascript_fuzzer prettier fuzz_targets/fuzz_format_md.js

--- a/projects/prettier/fuzz_targets/fuzz_format_css.js
+++ b/projects/prettier/fuzz_targets/fuzz_format_css.js
@@ -1,0 +1,61 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+const { FuzzedDataProvider } = require("@jazzer.js/core");
+const prettier = require("prettier");
+
+const CSS_PARSERS = ["css", "scss", "less"];
+
+module.exports.fuzz = async function (data) {
+  const provider = new FuzzedDataProvider(data);
+  const parser = CSS_PARSERS[provider.consumeIntegralInRange(0, CSS_PARSERS.length - 1)];
+  const options = {
+    parser,
+    printWidth: provider.consumeIntegralInRange(0, 200),
+    tabWidth: provider.consumeIntegralInRange(0, 8),
+    useTabs: provider.consumeBoolean(),
+    singleQuote: provider.consumeBoolean(),
+    endOfLine: ["lf", "crlf", "cr", "auto"][provider.consumeIntegralInRange(0, 3)],
+  };
+  const source = provider.consumeRemainingAsString();
+
+  try {
+    await prettier.format(source, options);
+  } catch (error) {
+    if (!isExpectedError(error)) throw error;
+  }
+};
+
+function isExpectedError(error) {
+  if (error && error.name === "SyntaxError") return true;
+  const msg = (error && error.message) || "";
+  return EXPECTED.some((m) => msg.indexOf(m) !== -1);
+}
+
+const EXPECTED = [
+  "Unknown word",
+  "Unclosed",
+  "Unclosed block",
+  "Unclosed string",
+  "Unclosed bracket",
+  "Unexpected",
+  "Invalid",
+  "Missed semicolon",
+  "Missing whitespace",
+  "Double colon",
+  "Unnecessary curly bracket",
+  "Maximum call stack size exceeded",
+];

--- a/projects/prettier/fuzz_targets/fuzz_format_js.js
+++ b/projects/prettier/fuzz_targets/fuzz_format_js.js
@@ -1,0 +1,91 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+const { FuzzedDataProvider } = require("@jazzer.js/core");
+const prettier = require("prettier");
+
+const JS_PARSERS = [
+  "babel",
+  "babel-flow",
+  "acorn",
+  "espree",
+  "meriyah",
+  "flow",
+];
+
+module.exports.fuzz = async function (data) {
+  const provider = new FuzzedDataProvider(data);
+  const parser = JS_PARSERS[provider.consumeIntegralInRange(0, JS_PARSERS.length - 1)];
+  const options = {
+    parser,
+    printWidth: provider.consumeIntegralInRange(0, 200),
+    tabWidth: provider.consumeIntegralInRange(0, 8),
+    useTabs: provider.consumeBoolean(),
+    semi: provider.consumeBoolean(),
+    singleQuote: provider.consumeBoolean(),
+    bracketSpacing: provider.consumeBoolean(),
+    bracketSameLine: provider.consumeBoolean(),
+    arrowParens: provider.consumeBoolean() ? "always" : "avoid",
+    trailingComma: ["all", "es5", "none"][provider.consumeIntegralInRange(0, 2)],
+    quoteProps: ["as-needed", "consistent", "preserve"][
+      provider.consumeIntegralInRange(0, 2)
+    ],
+    endOfLine: ["lf", "crlf", "cr", "auto"][provider.consumeIntegralInRange(0, 3)],
+  };
+  const source = provider.consumeRemainingAsString();
+
+  try {
+    await prettier.format(source, options);
+  } catch (error) {
+    if (!isExpectedError(error)) throw error;
+  }
+};
+
+function isExpectedError(error) {
+  if (error && error.name === "SyntaxError") return true;
+  const msg = (error && error.message) || "";
+  return EXPECTED.some((m) => msg.indexOf(m) !== -1);
+}
+
+const EXPECTED = [
+  "Unexpected token",
+  "Unexpected character",
+  "Unterminated",
+  "Unterminated string",
+  "Unterminated template",
+  "Unterminated comment",
+  "Unterminated regular expression",
+  "Invalid",
+  "Identifier directly after number",
+  "Identifier expected",
+  "Expression expected",
+  "Missing semicolon",
+  "Cannot use import statement",
+  "private name",
+  "is reserved",
+  "decimal escape",
+  "Octal literal in strict mode",
+  "Numeric separator",
+  "Hexadecimal digit expected",
+  "Bigint",
+  "Comma is not permitted",
+  "Trailing comma",
+  "Stage 3",
+  "experimental",
+  "is not enabled",
+  "Decorators",
+  "Maximum call stack size exceeded",
+];

--- a/projects/prettier/fuzz_targets/fuzz_format_json.js
+++ b/projects/prettier/fuzz_targets/fuzz_format_json.js
@@ -1,0 +1,62 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+const { FuzzedDataProvider } = require("@jazzer.js/core");
+const prettier = require("prettier");
+
+const JSON_PARSERS = ["json", "json5", "jsonc", "json-stringify"];
+
+module.exports.fuzz = async function (data) {
+  const provider = new FuzzedDataProvider(data);
+  const parser = JSON_PARSERS[provider.consumeIntegralInRange(0, JSON_PARSERS.length - 1)];
+  const options = {
+    parser,
+    printWidth: provider.consumeIntegralInRange(0, 200),
+    tabWidth: provider.consumeIntegralInRange(0, 8),
+    useTabs: provider.consumeBoolean(),
+    trailingComma: ["all", "es5", "none"][provider.consumeIntegralInRange(0, 2)],
+    endOfLine: ["lf", "crlf", "cr", "auto"][provider.consumeIntegralInRange(0, 3)],
+  };
+  const source = provider.consumeRemainingAsString();
+
+  try {
+    await prettier.format(source, options);
+  } catch (error) {
+    if (!isExpectedError(error)) throw error;
+  }
+};
+
+function isExpectedError(error) {
+  if (error && error.name === "SyntaxError") return true;
+  const msg = (error && error.message) || "";
+  return EXPECTED.some((m) => msg.indexOf(m) !== -1);
+}
+
+const EXPECTED = [
+  "Unexpected token",
+  "Unexpected end of",
+  "Unexpected character",
+  "Unterminated",
+  "Invalid",
+  "JSON5",
+  "Single quote",
+  "Trailing comma",
+  "Expected",
+  "is not allowed",
+  "JSON-stringify",
+  "must be a single",
+  "Maximum call stack size exceeded",
+];

--- a/projects/prettier/fuzz_targets/fuzz_format_md.js
+++ b/projects/prettier/fuzz_targets/fuzz_format_md.js
@@ -1,0 +1,59 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+const { FuzzedDataProvider } = require("@jazzer.js/core");
+const prettier = require("prettier");
+
+const MD_PARSERS = ["markdown", "mdx", "remark"];
+
+module.exports.fuzz = async function (data) {
+  const provider = new FuzzedDataProvider(data);
+  const parser = MD_PARSERS[provider.consumeIntegralInRange(0, MD_PARSERS.length - 1)];
+  const options = {
+    parser,
+    printWidth: provider.consumeIntegralInRange(0, 200),
+    tabWidth: provider.consumeIntegralInRange(0, 8),
+    useTabs: provider.consumeBoolean(),
+    proseWrap: ["always", "never", "preserve"][
+      provider.consumeIntegralInRange(0, 2)
+    ],
+    endOfLine: ["lf", "crlf", "cr", "auto"][provider.consumeIntegralInRange(0, 3)],
+  };
+  const source = provider.consumeRemainingAsString();
+
+  try {
+    await prettier.format(source, options);
+  } catch (error) {
+    if (!isExpectedError(error)) throw error;
+  }
+};
+
+function isExpectedError(error) {
+  if (error && error.name === "SyntaxError") return true;
+  const msg = (error && error.message) || "";
+  return EXPECTED.some((m) => msg.indexOf(m) !== -1);
+}
+
+const EXPECTED = [
+  "Unexpected token",
+  "Unexpected character",
+  "Unterminated",
+  "Invalid",
+  "Expected",
+  "Could not parse",
+  "Unable to parse",
+  "Maximum call stack size exceeded",
+];

--- a/projects/prettier/fuzz_targets/fuzz_format_ts.js
+++ b/projects/prettier/fuzz_targets/fuzz_format_ts.js
@@ -1,0 +1,70 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+const { FuzzedDataProvider } = require("@jazzer.js/core");
+const prettier = require("prettier");
+
+const TS_PARSERS = ["typescript", "babel-ts"];
+
+module.exports.fuzz = async function (data) {
+  const provider = new FuzzedDataProvider(data);
+  const parser = TS_PARSERS[provider.consumeIntegralInRange(0, TS_PARSERS.length - 1)];
+  const options = {
+    parser,
+    printWidth: provider.consumeIntegralInRange(0, 200),
+    tabWidth: provider.consumeIntegralInRange(0, 8),
+    useTabs: provider.consumeBoolean(),
+    semi: provider.consumeBoolean(),
+    singleQuote: provider.consumeBoolean(),
+    bracketSpacing: provider.consumeBoolean(),
+    bracketSameLine: provider.consumeBoolean(),
+    arrowParens: provider.consumeBoolean() ? "always" : "avoid",
+    trailingComma: ["all", "es5", "none"][provider.consumeIntegralInRange(0, 2)],
+    endOfLine: ["lf", "crlf", "cr", "auto"][provider.consumeIntegralInRange(0, 3)],
+  };
+  const source = provider.consumeRemainingAsString();
+
+  try {
+    await prettier.format(source, options);
+  } catch (error) {
+    if (!isExpectedError(error)) throw error;
+  }
+};
+
+function isExpectedError(error) {
+  if (error && error.name === "SyntaxError") return true;
+  const msg = (error && error.message) || "";
+  return EXPECTED.some((m) => msg.indexOf(m) !== -1);
+}
+
+const EXPECTED = [
+  "Unexpected token",
+  "Unexpected character",
+  "Unterminated",
+  "Invalid",
+  "Identifier expected",
+  "Expression expected",
+  "Missing semicolon",
+  "Type expected",
+  "Declaration expected",
+  "Argument expression expected",
+  "private name",
+  "Decorators",
+  "is reserved",
+  "Cannot use",
+  "is not enabled",
+  "Maximum call stack size exceeded",
+];

--- a/projects/prettier/fuzz_targets/package.json
+++ b/projects/prettier/fuzz_targets/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "prettier-fuzz-targets",
+  "private": true,
+  "type": "commonjs"
+}

--- a/projects/prettier/project.yaml
+++ b/projects/prettier/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://prettier.io/"
+language: javascript
+main_repo: "https://github.com/prettier/prettier"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - none
+primary_contact: "lionkay@gmail.com"


### PR DESCRIPTION
Adds an initial OSS-Fuzz integration for [Prettier](https://github.com/prettier/prettier), the opinionated code formatter used across a huge slice of the JS/TS/CSS/Markdown/JSON/YAML ecosystem.

The setup follows the Jazzer.js pattern used by the existing JavaScript projects in this repo (`typescript`, `js-yaml`, `fast-xml-parser`, etc.).

### Fuzz targets

Five targets, each one wrapped around `prettier.format()` for a parser family, with formatting options pulled from `FuzzedDataProvider`:

- `fuzz_format_js`   — `babel`, `babel-flow`, `acorn`, `espree`, `meriyah`, `flow`
- `fuzz_format_ts`   — `typescript`, `babel-ts`
- `fuzz_format_css`  — `css`, `scss`, `less`
- `fuzz_format_json` — `json`, `json5`, `jsonc`, `json-stringify`
- `fuzz_format_md`   — `markdown`, `mdx`, `remark`

Expected parse failures (`SyntaxError`, "Unexpected token", "Unterminated …", etc.) are filtered out so the fuzzers only surface unexpected exceptions and crashes.

### A couple of things worth flagging

- The fuzz targets live in a `fuzz_targets/` subdirectory with its own tiny `package.json` declaring `"type": "commonjs"`. Prettier's own `package.json` sets `"type": "module"`, which would otherwise make Node load every `.js` file in the repo as ESM and break the CommonJS `require()` calls in the fuzzers.
- `@jazzer.js/core` is pinned to `2.1.0`. The freshly released `4.0.0` ships a prebuilt native addon that needs `GLIBC_2.32`, which isn't available yet in `base-builder-javascript` (Ubuntu 20.04, glibc 2.31). Once the base image is bumped this pin can go away.
- Since Prettier v3 `format()` is async, the targets are written as `async function` and `--sync` is not passed to `compile_javascript_fuzzer`.

### Test plan

- [x] `docker build` of the project image succeeds
- [x] All five fuzzers compile under `base-builder-javascript`
- [x] Each fuzzer starts and runs cleanly; `fuzz_format_js` and `fuzz_format_json` produce non-trivial coverage in a short local run
