### PR TITLE
Add HekaDrop — cross-platform Quick Share Rust implementation

### DIFF
--- a/projects/hekadrop/Dockerfile
+++ b/projects/hekadrop/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    pkg-config \
+    libssl-dev \
+    protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 https://github.com/YatogamiRaito/HekaDrop hekadrop
+
+WORKDIR $SRC
+
+COPY build.sh $SRC/

--- a/projects/hekadrop/build.sh
+++ b/projects/hekadrop/build.sh
@@ -22,12 +22,17 @@ cd "$SRC/hekadrop"
 
 cargo fuzz build -O --fuzz-dir fuzz
 
-FUZZ_BIN="fuzz/target/x86_64-unknown-linux-gnu/release"
-
+# Binary path: mimariye göre değişir (x86_64, i686, aarch64 vs.)
+# `find` ile dinamik lokasyon — hardcoded triple yok.
 for f in fuzz/fuzz_targets/*.rs; do
     target=$(basename "${f%.*}")
-    cp "$FUZZ_BIN/$target" "$OUT/$target"
-    if [ -d "fuzz/corpus/$target" ] && [ -n "$(ls -A "fuzz/corpus/$target" 2>/dev/null)" ]; then
+    bin=$(find fuzz/target -name "$target" -type f \
+        ! -name "*.d" ! -path "*/deps/*" | head -1)
+    if [ -n "$bin" ]; then
+        cp "$bin" "$OUT/$target"
+    fi
+    if [ -d "fuzz/corpus/$target" ] && \
+       [ -n "$(ls -A "fuzz/corpus/$target" 2>/dev/null)" ]; then
         zip -j "$OUT/${target}_seed_corpus.zip" "fuzz/corpus/$target"/*
     fi
 done

--- a/projects/hekadrop/build.sh
+++ b/projects/hekadrop/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ "$SANITIZER" = "coverage" ]; then
+    export RUSTFLAGS="$RUSTFLAGS -C debug-assertions=no"
+    export CFLAGS=""
+fi
+
+cd "$SRC/hekadrop"
+
+cargo fuzz build -O --fuzz-dir fuzz
+
+FUZZ_BIN="fuzz/target/x86_64-unknown-linux-gnu/release"
+
+for f in fuzz/fuzz_targets/*.rs; do
+    target=$(basename "${f%.*}")
+    cp "$FUZZ_BIN/$target" "$OUT/$target"
+    if [ -d "fuzz/corpus/$target" ] && [ -n "$(ls -A "fuzz/corpus/$target" 2>/dev/null)" ]; then
+        zip -j "$OUT/${target}_seed_corpus.zip" "fuzz/corpus/$target"/*
+    fi
+done

--- a/projects/hekadrop/project.yaml
+++ b/projects/hekadrop/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/YatogamiRaito/HekaDrop"
+main_repo: "https://github.com/YatogamiRaito/HekaDrop"
+language: rust
+primary_contact: "destek@sourvice.com"
+sanitizers:
+  - address
+  - memory
+  - undefined
+fuzzing_engines:
+  - libfuzzer


### PR DESCRIPTION
## Project description

**HekaDrop** is a cross-platform Rust implementation of Google Quick Share (Nearby Share). It allows Android devices to send files to macOS/Linux/Windows over LAN without installing any app on the phone — the Android side uses the stock Quick Share that ships on all Android devices.

**Language:** Rust  
**Repo:** https://github.com/YatogamiRaito/HekaDrop  
**License:** MIT  

## Security relevance

The project implements a non-trivial cryptographic protocol:

- **UKEY2 handshake** — P-256 ECDH + HKDF-SHA256 key derivation
- **Secure channel** — AES-256-CBC + HMAC-SHA256 (Encrypt-then-MAC)
- **Chunk-HMAC** (RFC-0003) — per-chunk HMAC-SHA256 tags for storage integrity
- **Protobuf parsing** — both Google's Nearby protocol and our extensions

All of these operate on **attacker-controlled input** from the network. A bug in any of these paths is a pre-auth DoS or worse.

## Fuzz targets (10)

| Target | What it tests |
|---|---|
| `fuzz_ukey2_client_init` | `process_client_init` — raw bytes → UKEY2 parse |
| `fuzz_ukey2_client_finish` | `process_client_finish` — ECDH commitment verify |
| `fuzz_frame_decode` | Magic-prefix dispatch + OfflineFrame + HekaDropFrame decode |
| `fuzz_secure_decrypt` | `SecureCtx::decrypt` — AES-256-CBC + HMAC-SHA256 |
| `fuzz_payload_header` | PayloadHeader/Chunk/TransferFrame protobuf decode |
| `fuzz_payload_assembler` | `PayloadAssembler::ingest` state machine |
| `fuzz_chunk_hmac` | `compute_tag` + `verify_tag` + mutated-body rejection |
| `fuzz_resume_meta` | Resume session_id + meta_filename computation |
| `fuzz_protobuf_frames` | All hekadrop_ext types (ChunkIntegrity, ResumeHint, FolderManifest) |
| `fuzz_endpoint_info` | mDNS endpoint_info bitmap + device name parse |

## CI status

All 10 targets compile and run crash-free (verified locally with libFuzzer, 764k+ runs/10s).

## Contact

Primary contact: destek@sourvice.com