### PR TITLE
Migrate zeek to Ubuntu 24.04

### DIFF
--- a/projects/zeek/Dockerfile
+++ b/projects/zeek/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bison \

--- a/projects/zeek/build.sh
+++ b/projects/zeek/build.sh
@@ -56,6 +56,10 @@ for f in ${fuzzers}; do
         done
 
         copy_lib ${f} libpcap
+        copy_lib ${f} libibverbs
+        copy_lib ${f} libdbus
+        copy_lib ${f} libnl-3
+        copy_lib ${f} libnl-route-3
         copy_lib ${f} libssl
         copy_lib ${f} libcrypto
         copy_lib ${f} libz
@@ -72,6 +76,12 @@ for f in ${fuzzers}; do
         # Make libzmq search for dependencies in $ORIGIN so it
         # has them available at runtime.
         patchelf --set-rpath '$ORIGIN' ${OUT}/lib/libzmq.so*
+
+        # Do the same for libpcap and libibverbs. libpcap depends
+        # on the latter and that one depends on libnl-3 and
+        # libnl-route-3.
+        patchelf --set-rpath '$ORIGIN' ${OUT}/lib/libpcap.so*
+        patchelf --set-rpath '$ORIGIN' ${OUT}/lib/libibverbs.so*
     fi
 
     patchelf --set-rpath '$ORIGIN/lib' ${OUT}/${fuzzer_exe}

--- a/projects/zeek/project.yaml
+++ b/projects/zeek/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://www.zeek.org"
 language: c++
 primary_contact: "security@zeek.org"


### PR DESCRIPTION
The latest version in the master branch requires OpenSSL 3.0 or later which Ubuntu 20.04 doesn't contain. Bump the base_os_image to 24.04 and adapt the Dockerfile.