### PR TITLE
zlib: add Deflate64 inflateBack9 fuzzer

### DIFF
--- a/projects/zlib/build.sh
+++ b/projects/zlib/build.sh
@@ -30,7 +30,14 @@ fi
 
 for f in $(find $SRC -name '*_fuzzer.cc'); do
     b=$(basename -s .cc $f)
-    $CXX $CXXFLAGS -std=c++11 -I. $f -o $OUT/$b $LIB_FUZZING_ENGINE ./libz.a
+    if [ "$b" = "infback9_fuzzer" ]; then
+        $CC $CFLAGS -I. -c contrib/infback9/infback9.c -o /tmp/infback9.o
+        $CC $CFLAGS -I. -c contrib/infback9/inftree9.c -o /tmp/inftree9.o
+        $CXX $CXXFLAGS -std=c++11 -I. $f -o $OUT/$b \
+            $LIB_FUZZING_ENGINE /tmp/infback9.o /tmp/inftree9.o ./libz.a
+    else
+        $CXX $CXXFLAGS -std=c++11 -I. $f -o $OUT/$b $LIB_FUZZING_ENGINE ./libz.a
+    fi
 done
 
 zip $OUT/seed_corpus.zip *.*

--- a/projects/zlib/infback9_fuzzer.cc
+++ b/projects/zlib/infback9_fuzzer.cc
@@ -1,0 +1,75 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+extern "C" {
+#include "zlib.h"
+#include "contrib/infback9/infback9.h"
+}
+
+struct Input {
+  const uint8_t *data;
+  size_t size;
+  bool used;
+};
+
+struct Output {
+  size_t size;
+};
+
+static unsigned InputCallback(void *desc, unsigned char **buf) {
+  Input *input = static_cast<Input *>(desc);
+  if (input->used || input->size == 0) {
+    *buf = nullptr;
+    return 0;
+  }
+
+  input->used = true;
+  *buf = const_cast<unsigned char *>(input->data);
+  return static_cast<unsigned>(input->size);
+}
+
+static int OutputCallback(void *desc, unsigned char *, unsigned size) {
+  Output *output = static_cast<Output *>(desc);
+  output->size += size;
+  if (output->size > (1U << 20)) {
+    return 1;
+  }
+  return 0;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  if (size > 1U << 20) {
+    return 0;
+  }
+
+  z_stream strm;
+  unsigned char window[1U << 16];
+  Input input = {data, size, false};
+  Output output = {0};
+
+  memset(&strm, 0, sizeof(strm));
+  if (inflateBack9Init(&strm, window) != Z_OK) {
+    return 0;
+  }
+
+  strm.next_in = Z_NULL;
+  strm.avail_in = 0;
+  (void)inflateBack9(&strm, InputCallback, &input, OutputCallback, &output);
+  (void)inflateBack9End(&strm);
+  return 0;
+}


### PR DESCRIPTION
  This adds OSS-Fuzz coverage for zlib's `contrib/infback9` Deflate64 callback decompressor.

  The existing zlib OSS-Fuzz integration covers the regular zlib APIs, gzio, minigzip, checksum, and example paths, but it does not build a target for `inflateBack9()`. The new target drives the public
  `inflateBack9()` API using fuzzer-controlled bytes through the documented input callback interface and a 64 KiB window, matching the API requirements in `contrib/infback9/infback9.h`.

  The output callback tracks decompressed output and stops after 1 MiB by returning non-zero, which exercises the documented callback failure path while keeping the fuzzer bounded.

  Local validation:

  ```text
  sudo python3 infra/helper.py build_fuzzers --sanitizer address zlib
  sudo python3 infra/helper.py check_build zlib
  sudo python3 infra/helper.py run_fuzzer -e CORPUS_DIR=/tmp/infback9_fuzzer_corpus --corpus-dir=/tmp/infback9-ossfuzz-corpus zlib infback9_fuzzer -- -runs=50000 -max_len=512 -print_final_stats=1
  sudo python3 infra/helper.py build_fuzzers --sanitizer undefined zlib
  sudo python3 infra/helper.py build_fuzzers --sanitizer coverage zlib