### PR TITLE
pjsip: install third party libraries

### DIFF
--- a/projects/pjsip/Dockerfile
+++ b/projects/pjsip/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
-RUN apt-get update && apt-get install -y autoconf libtool-bin pkg-config libssl-dev zlib1g-dev
+RUN apt-get update && apt-get install -y autoconf libtool-bin pkg-config libssl-dev zlib1g-dev libopus-dev libvpx-dev
 RUN git clone https://github.com/pjsip/pjproject pjsip
 COPY build.sh $SRC/
 WORKDIR $SRC/pjsip/

--- a/projects/pjsip/build.sh
+++ b/projects/pjsip/build.sh
@@ -23,6 +23,12 @@ export LDFLAGS="$CFLAGS"
 --disable-speex-aec --disable-g7221-codec \
 --disable-resample --disable-libwebrtc --disable-libyuv
 
+# Force static linking of libvpx and libopus so the fuzzers do not depend on
+# .so files that are absent from the OSS-Fuzz runner image. libvpx-dev and
+# libopus-dev both ship .a archives in /usr/lib/x86_64-linux-gnu/.
+sed -i 's|-lvpx|/usr/lib/x86_64-linux-gnu/libvpx.a|g' build.mak
+sed -i 's|-lopus|/usr/lib/x86_64-linux-gnu/libopus.a|g' build.mak
+
 make dep
 make -j$(nproc) --ignore-errors
 make fuzz


### PR DESCRIPTION
In order to enable fuzzing of codec bridges