### PR TITLE
intentproof: initial integration

### DIFF
--- a/projects/intentproof/Dockerfile
+++ b/projects/intentproof/Dockerfile
@@ -1,0 +1,35 @@
+# Copyright 2026 IntentProof contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+
+RUN apt-get update && apt-get install -y git zip
+
+ENV TOOLS_REF=912952e4f9fcaf568b6ecc747f296d3413055ddf
+ENV SPEC_REF=808cf98781f65580b8027a0eddd3a017f2bc1ebb
+ENV CORE_REF=93f7625e7f97ec9bf74691bbc99322f8bbd70586
+
+RUN git clone https://github.com/IntentProof/intentproof-tools.git "$SRC/intentproof-tools" && \
+    cd "$SRC/intentproof-tools" && git checkout "$TOOLS_REF"
+
+RUN git clone https://github.com/IntentProof/intentproof-spec.git "$SRC/intentproof-spec" && \
+    cd "$SRC/intentproof-spec" && git checkout "$SPEC_REF"
+
+RUN git clone https://github.com/IntentProof/intentproof-core.git "$SRC/intentproof-core" && \
+    cd "$SRC/intentproof-core" && git checkout "$CORE_REF"
+
+WORKDIR $SRC/intentproof-tools
+COPY build.sh $SRC/

--- a/projects/intentproof/Dockerfile
+++ b/projects/intentproof/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2026 IntentProof contributors
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/intentproof/build.sh
+++ b/projects/intentproof/build.sh
@@ -1,0 +1,68 @@
+#!/bin/bash -eu
+# Copyright 2026 IntentProof contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+TOOLS_SRC="${SRC}/intentproof-tools"
+SPEC_SRC="${SRC}/intentproof-spec"
+CORE_SRC="${SRC}/intentproof-core"
+
+export INTENTPROOF_SPEC_DIR="${SPEC_SRC}"
+
+go get github.com/AdamKorcz/go-118-fuzz-build/testing
+
+pack_seed_corpus() {
+  local fuzzer_name="$1"
+  local corpus_dir="$2"
+  if [[ ! -d "${corpus_dir}" ]]; then
+    return 0
+  fi
+  shopt -s nullglob
+  local files=("${corpus_dir}"/*)
+  shopt -u nullglob
+  if (( ${#files[@]} == 0 )); then
+    return 0
+  fi
+  (cd "${corpus_dir}" && zip -j "${OUT}/${fuzzer_name}_seed_corpus.zip" ./*)
+}
+
+cd "${TOOLS_SRC}"
+export GOWORK=off
+
+compile_native_go_fuzzer github.com/intentproof/intentproof-tools/pkg/canon FuzzMarshalRaw fuzz_marshal_raw
+pack_seed_corpus fuzz_marshal_raw "${SPEC_SRC}/golden/fuzz-corpora/canon"
+
+compile_native_go_fuzzer github.com/intentproof/intentproof-tools/pkg/verifier FuzzVerify fuzz_verify
+
+compile_native_go_fuzzer github.com/intentproof/intentproof-tools/pkg/bundle FuzzBundleVerify fuzz_bundle_verify
+pack_seed_corpus fuzz_bundle_verify "${SPEC_SRC}/golden/fuzz-corpora/bundle"
+
+compile_native_go_fuzzer github.com/intentproof/intentproof-tools/pkg/policy FuzzCompile fuzz_compile
+pack_seed_corpus fuzz_compile "${SPEC_SRC}/golden/fuzz-corpora/policy"
+
+cat > "${SRC}/go.work" <<EOF
+go 1.25.10
+
+use (
+	./intentproof-tools
+	./intentproof-core
+)
+EOF
+
+cd "${CORE_SRC}"
+export GOWORK="${SRC}/go.work"
+
+compile_native_go_fuzzer github.com/intentproof/intentproof-core/pkg/ingest FuzzParseExecutionEvent fuzz_parse_execution_event
+pack_seed_corpus fuzz_parse_execution_event "${SPEC_SRC}/golden/fuzz-corpora/ingest"

--- a/projects/intentproof/build.sh
+++ b/projects/intentproof/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2026 IntentProof contributors
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/intentproof/project.yaml
+++ b/projects/intentproof/project.yaml
@@ -1,0 +1,11 @@
+homepage: "https://github.com/IntentProof/intentproof-tools"
+language: go
+primary_contact: "security@intentproof.io"
+auto_ccs:
+  - "security@intentproof.io"
+main_repo: "https://github.com/IntentProof/intentproof-tools.git"
+file_github_issue: true
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
Initial OSS-Fuzz integration for [IntentProof](https://github.com/IntentProof/intentproof-tools),
an Apache-2.0 platform for verifiable execution proofs (bundle verification,
policy evaluation, JCS canonicalization, and HTTP ingest parsing).
## Project details
- **Language:** Go
- **Main repo:** https://github.com/IntentProof/intentproof-tools.git
- **Primary contact:** security@intentproof.io
- **Sanitizers:** address
- **Fuzzing engine:** libfuzzer
## What this adds
Three files under `projects/intentproof/`:
- `project.yaml` — project metadata and contacts
- `Dockerfile` — `base-builder-go`; clones `intentproof-tools`,
  `intentproof-spec`, and `intentproof-core` at pinned merge SHAs
- `build.sh` — native Go fuzz targets via `compile_native_go_fuzzer`;
  packs seed corpora from `intentproof-spec/golden/fuzz-corpora/` into
  `*_seed_corpus.zip` for OSS-Fuzz
## Fuzz targets
| Binary | Package | Seed corpus |
|--------|---------|-------------|
| `fuzz_marshal_raw` | `intentproof-tools/pkg/canon` | `canon/` |
| `fuzz_verify` | `intentproof-tools/pkg/verifier` | inline seeds only |
| `fuzz_bundle_verify` | `intentproof-tools/pkg/bundle` | `bundle/` |
| `fuzz_compile` | `intentproof-tools/pkg/policy` | `policy/` |
| `fuzz_parse_execution_event` | `intentproof-core/pkg/ingest` | `ingest/` |
The core ingest target uses a generated `go.work` so `intentproof-core` can
import shared helpers from `intentproof-tools` during the OSS-Fuzz build.
## Local verification
- [ ] `python3 infra/helper.py build_image intentproof` — pass
- [ ] `python3 infra/helper.py build_fuzzers --sanitizer address intentproof` — pass
- [ ] `python3 infra/helper.py check_build --sanitizer address intentproof` — pass
## Notes
- Fuzz targets and golden corpora are maintained in the IntentProof repos;
  Dockerfile pins are updated when fuzz surfaces change.
- IntentProof also runs the same targets in CI via
  `intentproof-tools/scripts/run-fuzz-gate.sh`; OSS-Fuzz provides continuous
  cluster fuzzing on these library/parser surfaces.