### PR TITLE
quic-go: replace service account with separate Google account

### DIFF
--- a/projects/quic-go/project.yaml
+++ b/projects/quic-go/project.yaml
@@ -1,7 +1,7 @@
 homepage: "https://github.com/quic-go/quic-go"
 primary_contact: "martenseemann@gmail.com"
 auto_ccs:
-  - "quic-go-corpus-ci@quic-go-oss-fuzz-ci.iam.gserviceaccount.com"
+  - "quicgo.ossfuzz@gmail.com"
 language: go
 fuzzing_engines:
 - libfuzzer


### PR DESCRIPTION
I'm working on a CI job that uses the corpus of OSS-Fuzz (see https://github.com/quic-go/quic-go/issues/4036) to track fuzz coverage in Codecov.

In #15481, I added a service account, however this didn't work and I am still not able to access the corpora from CI. I opened #15489, but I haven't heard anything back yet. I assume this is a more involved issue and to be able to make progress I created a Google account. With this PR I'm adding this Google account to `auto_ccs`.

Since this new Google account will exclusively be used to access OSS-Fuzz, it is less risky to store GCP credentials for that account on CI (as compared to using my primary Google account).