### PR TITLE
projects/urllib3: fix fuzz_requests harness to bound fuzzer input con…

### DIFF
--- a/projects/urllib3/fuzz_requests.py
+++ b/projects/urllib3/fuzz_requests.py
@@ -57,9 +57,11 @@ def TestOneInput(data):
     fdp = atheris.FuzzedDataProvider(data)
 
     global GLOBAL_RESPONSE_BODY, GLOBAL_RESPONSE_CODE, GLOBAL_CONTENT_TYPE
-    GLOBAL_RESPONSE_BODY = fdp.ConsumeBytes(sys.maxsize)
+    body_len = fdp.ConsumeIntInRange(0, 65536)
+    GLOBAL_RESPONSE_BODY = fdp.ConsumeBytes(body_len)
     GLOBAL_RESPONSE_CODE = fdp.ConsumeIntInRange(200, 599)
-    GLOBAL_CONTENT_TYPE = fdp.ConsumeBytes(sys.maxsize)
+    content_type_len = fdp.ConsumeIntInRange(0, 256)
+    GLOBAL_CONTENT_TYPE = fdp.ConsumeBytes(content_type_len)
 
     requestType = fdp.PickValueInList(REQUEST_METHODS)
 
@@ -67,14 +69,14 @@ def TestOneInput(data):
     requestHeaders = urllib3._collections.HTTPHeaderDict({})
     for i in range(0, fdp.ConsumeIntInRange(0, 10)):
         requestHeaders.add(
-            fdp.ConsumeString(sys.maxsize), fdp.ConsumeString(sys.maxsize)
+            fdp.ConsumeString(64), fdp.ConsumeString(64)
         )
     requestHeaders = None if fdp.ConsumeBool() else requestHeaders
 
     # Optionally generate form data
     formData = {}
     for i in range(0, fdp.ConsumeIntInRange(0, 100)):
-        formData[fdp.ConsumeString(sys.maxsize)] = fdp.ConsumeString(sys.maxsize)
+        formData[fdp.ConsumeString(64)] = fdp.ConsumeString(64)
     formData = None if fdp.ConsumeBool() else formData
 
     timeout = urllib3.util.Timeout(connect=0.1, read=0.1)


### PR DESCRIPTION
# Summary
Fix the fuzz_requests.py harness so it no longer consumes the entire fuzzer input in the first ConsumeBytes call.

# Root cause
The harness used fdp.ConsumeBytes(sys.maxsize) for GLOBAL_RESPONSE_BODY and GLOBAL_CONTENT_TYPE, which drains the entire fuzzer input on larger inputs. That left downstream fdp calls with no bytes, so response code, content type, request method, headers, and form data were not actually fuzzed.

# Fix
Fixes #15451

- Bound response body size with fdp.ConsumeIntInRange(0, 65536)
- Bound content type size with fdp.ConsumeIntInRange(0, 256)
- Bound header and form-data string lengths to 64 bytes to prevent unbounded string growth while still allowing meaningful variation across request headers and form fields.

This keeps the harness responsive and ensures later fuzz parameters receive input.

# Testing
```
bhaskar@debian:/home/debian/oss-fuzz$  cd /home/debian/oss-fuzz && .venv/bin/python - <<'PY'
import os, sys
sys.path.insert(0, os.getcwd())
from projects.urllib3.fuzz_requests import TestOneInput
for data in [b'hello', b'A'*1000, b'A'*200000]:
    print('Testing input size', len(data))
    try:
        TestOneInput(data)
    except Exception as e:
        print('FAILED with exception:', type(e).__name__, e)
        raise
    else:
        print('PASS')
PY
Testing input size 5
PASS
Testing input size 1000
PASS
Testing input size 200000
PASS
```

```
bhaskar@debian:/home/debian/oss-fuzz$  cd /home/debian/oss-fuzz && .venv/bin/python - <<'PY'
import os
path = 'tmp_poc_16mb.bin'
with open(path, 'wb') as f:
    f.write(b'A' * 16 * 1024 * 1024)
print('Created', path, 'size', os.path.getsize(path))

from projects.urllib3.fuzz_requests import TestOneInput
with open(path, 'rb') as f:
    data = f.read()
try:
    TestOneInput(data)
    print('PASS: POC input executed without exception')
PY  raise('FAIL: raised', type(e).__name__, e)
Created tmp_poc_16mb.bin size 16777216
PASS: POC input executed without exception
```