### PR TITLE
infra: fix local base image listing

### DIFF
--- a/infra/base-images/all.sh
+++ b/infra/base-images/all.sh
@@ -35,6 +35,7 @@ VERSION_TAG=${1:-latest}
 
 # Get the directory where this script is located to find the helper script.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." >/dev/null 2>&1 && pwd)"
 
 # Fetch the official list of images from the Python source of truth.
 # This avoids duplicating the image list and ensures this script is always
@@ -46,7 +47,11 @@ echo "Images to build: ${IMAGE_LIST}"
 
 # Loop through the official list of images and build each one.
 for image_name in ${IMAGE_LIST}; do
-  image_dir="infra/base-images/${image_name}"
+  if [ "${image_name}" == "indexer" ]; then
+    image_dir="${REPO_ROOT}/infra/indexer"
+  else
+    image_dir="${REPO_ROOT}/infra/base-images/${image_name}"
+  fi
   
   if [ "${VERSION_TAG}" == "latest" ]; then
     dockerfile="${image_dir}/Dockerfile"

--- a/infra/base-images/list_images.py
+++ b/infra/base-images/list_images.py
@@ -22,15 +22,24 @@ avoiding logic duplication.
 import os
 import sys
 
-# Add the path to the `functions` directory to import the `base_images` module.
-FUNCTIONS_DIR = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), '..', 'build', 'functions'))
-sys.path.append(FUNCTIONS_DIR)
 
-import base_images
+def get_base_image_defs():
+  """Reads base image definitions without importing Cloud Build dependencies."""
+  functions_dir = os.path.abspath(
+      os.path.join(os.path.dirname(__file__), '..', 'build', 'functions'))
+  sys.path.append(functions_dir)
 
-for image_config in base_images.BASE_IMAGE_DEFS:
-  # Exclude 'base-clang-full' as it is a special case not intended for
-  # the general build script.
-  if image_config.get('name', '') != 'base-clang-full':
-    print(image_config.get('name', ''))
+  from base_image_defs import BASE_IMAGE_DEFS
+  return BASE_IMAGE_DEFS
+
+
+def main():
+  for image_config in get_base_image_defs():
+    # Exclude 'base-clang-full' as it is a special case not intended for
+    # the general build script.
+    if image_config.get('name', '') != 'base-clang-full':
+      print(image_config.get('name', ''))
+
+
+if __name__ == '__main__':
+  main()

--- a/infra/base-images/list_images_test.py
+++ b/infra/base-images/list_images_test.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+"""Tests for list_images."""
+
+import importlib.util
+import os
+import unittest
+
+
+def _load_list_images_module():
+  module_path = os.path.join(os.path.dirname(__file__), 'list_images.py')
+  spec = importlib.util.spec_from_file_location('list_images', module_path)
+  module = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(module)
+  return module
+
+
+class ListImagesTest(unittest.TestCase):
+
+  def test_get_base_image_defs_without_importing_build_dependencies(self):
+    module = _load_list_images_module()
+
+    image_names = [
+        image_config['name'] for image_config in module.get_base_image_defs()
+    ]
+
+    self.assertIn('base-image', image_names)
+    self.assertIn('base-builder', image_names)
+    self.assertIn('base-runner', image_names)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/infra/build/functions/base_image_defs.py
+++ b/infra/build/functions/base_image_defs.py
@@ -1,0 +1,64 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+"""Dependency-light base image definitions."""
+
+# Definitions of the base images to be built.
+BASE_IMAGE_DEFS = [
+    {
+        'name': 'base-image'
+    },
+    {
+        'name': 'base-clang'
+    },
+    {
+        'name': 'base-clang-full',
+        'path': 'infra/base-images/base-clang',
+        'build_args': ('FULL_LLVM_BUILD=1',)
+    },
+    {
+        'name': 'indexer'
+    },
+    {
+        'name': 'base-builder'
+    },
+    {
+        'name': 'base-builder-go'
+    },
+    {
+        'name': 'base-builder-javascript'
+    },
+    {
+        'name': 'base-builder-jvm'
+    },
+    {
+        'name': 'base-builder-python'
+    },
+    {
+        'name': 'base-builder-ruby'
+    },
+    {
+        'name': 'base-builder-rust'
+    },
+    {
+        'name': 'base-builder-swift'
+    },
+    {
+        'name': 'base-runner'
+    },
+    {
+        'name': 'base-runner-debug'
+    },
+]

--- a/infra/build/functions/base_images.py
+++ b/infra/build/functions/base_images.py
@@ -29,6 +29,7 @@ import sys
 
 import google.auth
 
+from base_image_defs import BASE_IMAGE_DEFS
 import build_lib
 
 BASE_PROJECT = 'oss-fuzz-base'
@@ -118,55 +119,6 @@ class ImageConfig:
   def full_image_name_with_tag(self) -> str:
     """Returns the full GCR image name with the final tag."""
     return f'{IMAGE_NAME_PREFIX}{self.name}:{self.final_tag}'
-
-
-# Definitions of the base images to be built.
-BASE_IMAGE_DEFS = [
-    {
-        'name': 'base-image'
-    },
-    {
-        'name': 'base-clang'
-    },
-    {
-        'name': 'base-clang-full',
-        'path': 'infra/base-images/base-clang',
-        'build_args': ('FULL_LLVM_BUILD=1',)
-    },
-    {
-        'name': 'indexer'
-    },
-    {
-        'name': 'base-builder'
-    },
-    {
-        'name': 'base-builder-go'
-    },
-    {
-        'name': 'base-builder-javascript'
-    },
-    {
-        'name': 'base-builder-jvm'
-    },
-    {
-        'name': 'base-builder-python'
-    },
-    {
-        'name': 'base-builder-ruby'
-    },
-    {
-        'name': 'base-builder-rust'
-    },
-    {
-        'name': 'base-builder-swift'
-    },
-    {
-        'name': 'base-runner'
-    },
-    {
-        'name': 'base-runner-debug'
-    },
-]
 
 
 def get_base_image_steps(images: Sequence[ImageConfig]) -> list[dict]:


### PR DESCRIPTION
## Summary
- move base image definitions into a dependency-light module
- make `infra/base-images/list_images.py` work without importing Cloud Build dependencies
- resolve local base image build paths from the repo root, including the `indexer` image

Fixes #14151.

## Validation
- `python3 infra/base-images/list_images.py`
- `python3 -m unittest discover infra/base-images -p '*_test.py'`\n- `bash -n infra/base-images/all.sh`\n- mocked `cd infra/base-images && PATH=... ./all.sh latest` to verify Dockerfile path resolution without building images\n- `python3 -m py_compile infra/base-images/list_images.py infra/base-images/list_images_test.py infra/build/functions/base_image_defs.py infra/build/functions/base_images.py`\n- `git diff --check`