### PR TITLE
ghidra-decompiler: add new project

### DIFF
--- a/projects/ghidra-decompiler/Dockerfile
+++ b/projects/ghidra-decompiler/Dockerfile
@@ -1,5 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
 # OSS-Fuzz build container for the GayHydra decompiler harnesses.
-# See docs/security/OSS_FUZZ.md.
+# See https://codeberg.org/CryptoJones/GayHydra/src/branch/master/docs/security/OSS_FUZZ.md.
 
 FROM gcr.io/oss-fuzz-base/base-builder
 

--- a/projects/ghidra-decompiler/Dockerfile
+++ b/projects/ghidra-decompiler/Dockerfile
@@ -1,0 +1,14 @@
+# OSS-Fuzz build container for the GayHydra decompiler harnesses.
+# See docs/security/OSS_FUZZ.md.
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN apt-get update && apt-get install -y \
+    bison \
+    flex \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth=1 https://github.com/CryptoJones/GayHydra.git $SRC/ghidra
+WORKDIR $SRC/ghidra
+
+COPY build.sh $SRC/

--- a/projects/ghidra-decompiler/build.sh
+++ b/projects/ghidra-decompiler/build.sh
@@ -1,6 +1,21 @@
 #!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
 # OSS-Fuzz build script for the GayHydra decompiler harnesses.
-# See docs/security/OSS_FUZZ.md.
+# See https://codeberg.org/CryptoJones/GayHydra/src/branch/master/docs/security/OSS_FUZZ.md.
 
 CPP_DIR="$SRC/ghidra/Ghidra/Features/Decompiler/src/decompile/cpp"
 FUZZ_DIR="$CPP_DIR/fuzz"

--- a/projects/ghidra-decompiler/build.sh
+++ b/projects/ghidra-decompiler/build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -eu
+# OSS-Fuzz build script for the GayHydra decompiler harnesses.
+# See docs/security/OSS_FUZZ.md.
+
+CPP_DIR="$SRC/ghidra/Ghidra/Features/Decompiler/src/decompile/cpp"
+FUZZ_DIR="$CPP_DIR/fuzz"
+
+cd "$CPP_DIR"
+
+# Build decompiler object files with the OSS-Fuzz sanitizers.
+# The decompiler's existing Makefile produces objects in-place; we
+# don't link the main binary, only the .o files our harnesses need.
+make OPT_CXXFLAGS="$CXXFLAGS" \
+     OPT_LDFLAGS="" \
+     bare_libdecomp.a 2>/dev/null || \
+make OPT_CXXFLAGS="$CXXFLAGS" \
+     OPT_LDFLAGS="" \
+     xml.o marshal.o address.o space.o
+
+cd "$FUZZ_DIR"
+
+for harness in fuzz_xml fuzz_marshal; do
+    $CXX $CXXFLAGS -std=c++11 -I"$CPP_DIR" -c "$harness.cc" -o "$harness.o"
+    $CXX $CXXFLAGS $LIB_FUZZING_ENGINE "$harness.o" \
+        "$CPP_DIR"/xml.o "$CPP_DIR"/marshal.o \
+        "$CPP_DIR"/address.o "$CPP_DIR"/space.o \
+        -o "$OUT/$harness"
+
+    # Copy seed corpus if it exists.
+    if [ -d "$FUZZ_DIR/seeds/$harness" ]; then
+        ( cd "$FUZZ_DIR/seeds/$harness" && \
+          zip -r "$OUT/${harness}_seed_corpus.zip" . )
+    fi
+done

--- a/projects/ghidra-decompiler/project.yaml
+++ b/projects/ghidra-decompiler/project.yaml
@@ -1,0 +1,27 @@
+# OSS-Fuzz project manifest for GayHydra, a maintained fork of NSA's
+# Ghidra reverse engineering platform. Fuzzes the decompiler's C++
+# parsers (XML + PackedDecode) — first thing user-controlled input
+# hits, historically the source of OOB-read CVEs in Ghidra's
+# decompiler core.
+#
+# See https://codeberg.org/CryptoJones/GayHydra/src/branch/master/docs/security/OSS_FUZZ.md
+# for the in-tree harness sources and rationale.
+
+homepage: "https://codeberg.org/CryptoJones/GayHydra"
+main_repo: "https://codeberg.org/CryptoJones/GayHydra"
+language: c++
+primary_contact: "cryptojones@owasp.org"
+# auto_ccs left empty — single inbox for now (Aaron, 2026-05-26).
+# Add additional maintainer addresses here as the project grows.
+auto_ccs: []
+sanitizers:
+  - address
+  - undefined
+  # - memory   # enable after libc++/dep-build chain is verified
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+architectures:
+  - x86_64
+help_url: "https://codeberg.org/CryptoJones/GayHydra/src/branch/master/docs/security/OSS_FUZZ.md"


### PR DESCRIPTION
## Adds new OSS-Fuzz project: ghidra-decompiler

**Project:** [GayHydra](https://codeberg.org/CryptoJones/GayHydra) — a maintained fork of NSA's [Ghidra](https://github.com/NationalSecurityAgency/ghidra) reverse engineering platform.

**Why fuzz this:** Ghidra's C++ decompiler is the first thing user-controlled input hits when an analyst loads a binary (XML address-space / processor specs are parsed before any analysis runs). Historically the OSS-Fuzz history against the upstream Ghidra fork has surfaced OOB-read CVEs in this exact code path. GayHydra inherits the same parser surface; we want continuous fuzz coverage of it on the OSS-Fuzz infrastructure.

## Harnesses

| Harness | Target | Notes |
|---|---|---|
| `fuzz_xml` | The XML parser (`xml.cc` / `xml.hh`) that ingests Ghidra's address-space and processor-spec files. | OSS-Fuzz has reported OOB reads against this surface in the past. |
| `fuzz_marshal` | The `PackedDecode` binary parser (`marshal.cc` / `marshal.hh`) used for decompiler IPC. | Smaller surface than xml, performance-critical, recently RAII-hardened (Rec 31 in our audit). |

Harness sources are in-tree at `Ghidra/Features/Decompiler/src/decompile/cpp/fuzz/{fuzz_xml,fuzz_marshal}.cc`.

## project.yaml

```yaml
homepage:        https://codeberg.org/CryptoJones/GayHydra
main_repo:       https://codeberg.org/CryptoJones/GayHydra
language:        c++
primary_contact: cryptojones@owasp.org
auto_ccs:        []                  # ramp-up phase; single inbox
sanitizers:      [address, undefined]
fuzzing_engines: [libfuzzer, afl, honggfuzz]
architectures:   [x86_64]
```

Memory sanitizer is intentionally out of the initial set — turning it on requires verifying the libc++/dep-build chain across all the transitively-included Ghidra deps; will enable in a follow-up once the AS/UBSan baseline is stable.

## Maintainer commitments

- **Triage cadence:** new crash reports acknowledged within 5 business days. Most will fall on existing GayHydra `bug` / `security` tracking issues.
- **Disclosure:** real security findings get coordinated-disclosure handling via the project's [SECURITY.md](https://codeberg.org/CryptoJones/GayHydra/src/branch/master/SECURITY.md). Non-security parser crashes are public.
- **Build maintenance:** the `Dockerfile` pulls from `github.com/CryptoJones/GayHydra` at HEAD (master); maintained alongside the GitHub release cycle.

## In-tree sources

The three files in this PR live in `.github/oss-fuzz/` in the project tree:
- https://codeberg.org/CryptoJones/GayHydra/src/branch/master/.github/oss-fuzz/project.yaml
- https://codeberg.org/CryptoJones/GayHydra/src/branch/master/.github/oss-fuzz/Dockerfile
- https://codeberg.org/CryptoJones/GayHydra/src/branch/master/.github/oss-fuzz/build.sh

GitHub mirror: https://github.com/CryptoJones/GayHydra

## Known follow-ups (not blockers for this PR)

- `build.sh` compiles harnesses with `-std=c++11`; the GayHydra decompiler itself now builds with `-std=c++20` (Rec 32 in our audit). The flag mismatch is benign for these harness translation units but I'll align them in a follow-up.
- A second project (`ghidra-loader/`, JVM/Jazzer harnesses) is planned but not part of this PR.

Filed in draft so the GayHydra maintainer can eyeball the body before this hits the OSS-Fuzz triage queue.