### PR TITLE
tz: add OSS-Fuzz integration for TZif binary format parser

### DIFF
--- a/projects/tz/Dockerfile
+++ b/projects/tz/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends make
+
+RUN git clone --depth=1 https://github.com/eggert/tz.git tz
+
+WORKDIR tz
+COPY build.sh fuzz_tzif.c $SRC/

--- a/projects/tz/build.sh
+++ b/projects/tz/build.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -eu
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cd $SRC/tz
+
+# Build the TZif binary format parser fuzz target
+$CC $CFLAGS $LIB_FUZZING_ENGINE \
+    $SRC/fuzz_tzif.c \
+    localtime.c asctime.c difftime.c \
+    -I. \
+    -DTZDIR=\"/usr/share/zoneinfo\" \
+    -o $OUT/fuzz_tzif
+
+# Seed corpus: use real timezone files
+mkdir -p $OUT/fuzz_tzif_seed_corpus
+for f in /usr/share/zoneinfo/America/New_York \
+          /usr/share/zoneinfo/Europe/London \
+          /usr/share/zoneinfo/Asia/Tokyo \
+          /usr/share/zoneinfo/UTC \
+          /usr/share/zoneinfo/Pacific/Auckland; do
+    [ -f "$f" ] && cp "$f" "$OUT/fuzz_tzif_seed_corpus/$(basename $f)" || true
+done
+zip -j $OUT/fuzz_tzif_seed_corpus.zip $OUT/fuzz_tzif_seed_corpus/* 2>/dev/null || true

--- a/projects/tz/fuzz_tzif.c
+++ b/projects/tz/fuzz_tzif.c
@@ -1,0 +1,79 @@
+/*
+ * Fuzz harness for the tz (tzdata) TZif binary format parser.
+ *
+ * Target: tzloadbody() in localtime.c, which parses TZif version 1/2/3
+ * binary timezone data files.
+ *
+ * Attack surface:
+ *   - Any process calling tzset(3) with a crafted TZ environment variable
+ *     pointing to an attacker-controlled file (e.g. "TZ=:./evil.tzif")
+ *   - Container environments sharing a mounted /usr/share/zoneinfo
+ *   - Applications that call tzalloc(3) with untrusted timezone names
+ *
+ * TZif format bugs that this harness can find:
+ *   - Integer overflow in detzcode()/detzcode64() result usage
+ *   - OOB read in ttis[], leaps[], chars[] array accesses
+ *   - Sign extension issues in transition time handling
+ *   - Incorrect bounds checks on ttisstdcnt/ttisutcnt/leapcnt/timecnt/typecnt/charcnt
+ *   - Version-2/3 header parsing inconsistencies
+ *
+ * Build:
+ *   clang -fsanitize=fuzzer,address -DDONT_USE_TZDB fuzz/fuzz_tzif.c \
+ *         localtime.c asctime.c difftime.c strftime.c \
+ *         -o fuzz_tzif
+ *
+ * OSS-Fuzz:
+ *   $CC $CFLAGS $LIB_FUZZING_ENGINE fuzz/fuzz_tzif.c localtime.c \
+ *       asctime.c difftime.c strftime.c -o $OUT/fuzz_tzif
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+/*
+ * Write fuzz data to a temp file, set TZ to point to it,
+ * then call tzset() to trigger tzloadbody().
+ * This exercises the exact production code path.
+ */
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    /* Write fuzz data to a temporary file */
+    char tmppath[] = "/tmp/fuzz_tz_XXXXXX";
+    int fd = mkstemp(tmppath);
+    if (fd < 0)
+        return 0;
+
+    if (write(fd, data, size) != (ssize_t)size) {
+        close(fd);
+        unlink(tmppath);
+        return 0;
+    }
+    close(fd);
+
+    /* Set TZ env var to point to our file (colon prefix = absolute path) */
+    char tz_env[256];
+    snprintf(tz_env, sizeof(tz_env), ":%s", tmppath);
+    setenv("TZ", tz_env, 1);
+
+    /*
+     * tzset() calls tzloadbody() which parses the TZif binary format.
+     * With ASan/MSan, any OOB read/write or use-after-free will be caught.
+     */
+    tzset();
+
+    /*
+     * Also call localtime() which uses the loaded timezone state
+     * to do transition lookups (exercises the binary search in transtime()).
+     */
+    time_t t = 0;
+    localtime(&t);
+    t = (time_t)1700000000; /* Nov 2023 */
+    localtime(&t);
+
+    unlink(tmppath);
+    return 0;
+}

--- a/projects/tz/fuzz_tzif.c
+++ b/projects/tz/fuzz_tzif.c
@@ -1,3 +1,17 @@
+/* Copyright 2025 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 /*
  * Fuzz harness for the tz (tzdata) TZif binary format parser.
  *

--- a/projects/tz/project.yaml
+++ b/projects/tz/project.yaml
@@ -1,0 +1,14 @@
+homepage: "https://www.iana.org/time-zones"
+language: c
+primary_contact: "tz@iana.org"
+main_repo: "https://github.com/eggert/tz"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+sanitizers:
+  - address
+  - memory
+  - undefined
+auto_ccs:
+  - "tz@iana.org"


### PR DESCRIPTION
## Summary

Adds [tz (IANA timezone database)](https://github.com/eggert/tz) to OSS-Fuzz, with a fuzz harness targeting `tzloadbody()` in `localtime.c` — the parser for TZif version 1/2/3 binary timezone data files.

## Project

| Field | Value |
|-------|-------|
| Homepage | https://www.iana.org/time-zones |
| Repo | https://github.com/eggert/tz |
| Language | C |
| Contact | tz@iana.org |

## Fuzz Target: `fuzz_tzif`

**How it works:**
1. Writes fuzz input to a temp file via `mkstemp()`
2. Sets `TZ=:<tmppath>` — the standard POSIX mechanism for loading arbitrary TZif files
3. Calls `tzset()` → triggers `tzloadbody()` on the fuzz data
4. Calls `localtime()` with two timestamps → exercises `transtime()` binary search

**Coverage:**
- `detzcode()` / `detzcode64()` — big-endian 4/8-byte integer decoding from file bytes
- Header field bounds: `ttisstdcnt`, `ttisutcnt`, `leapcnt`, `timecnt`, `typecnt`, `charcnt`
- Array accesses: `ttis[]`, `leaps[]`, `chars[]`
- TZif version 1 vs version 2/3 branching and 64-bit transition table parsing
- POSIX TZ rule string parser (`tzparse()`) invoked at end of v2/v3 files

**Seed corpus:** Real TZif files from `/usr/share/zoneinfo/` are copied as seeds.

## Security Relevance

`tzloadbody()` processes binary data that can be attacker-influenced in:
- Container environments where `/usr/share/zoneinfo` is a shared bind-mount
- Applications calling `tzalloc()` with user-controlled timezone names
- Programs reading TZ from the environment without sanitization

A bug in the TZif binary parser (OOB read in `ttis[]`/`leaps[]`/`chars[]`, integer overflow in field usage) would affect every timezone-aware C program linked against this library — including most POSIX-compliant software.