### PR TITLE
projects/libpcap: add fuzz_rclient and fuzz_rserver RPCAP protocol fuzzers

### DIFF
--- a/projects/libpcap/build.sh
+++ b/projects/libpcap/build.sh
@@ -16,27 +16,48 @@
 ################################################################################
 
 cd libpcap
-# build project
+
+# build project (with rpcapd enabled so daemon.h / daemon.c are available)
 mkdir build
 cd build
-cmake ..
+cmake .. -DENABLE_REMOTE=ON
 make
+cd ..
 
-
-# build fuzz targets
+# build existing fuzz targets
 for target in pcap filter both
 do
-    $CC $CFLAGS -I.. -c ../testprogs/fuzz/fuzz_$target.c -o fuzz_$target.o
-    $CXX $CXXFLAGS fuzz_$target.o -o $OUT/fuzz_$target libpcap.a $LIB_FUZZING_ENGINE
+    $CC $CFLAGS -I. -c testprogs/fuzz/fuzz_$target.c -o fuzz_$target.o
+    $CXX $CXXFLAGS fuzz_$target.o -o $OUT/fuzz_$target build/libpcap.a $LIB_FUZZING_ENGINE
 done
 
-# export other associated stuff
-cd ..
-cp testprogs/fuzz/fuzz_*.options $OUT/
-# builds corpus
+# build rpcap client/server fuzz targets (previously missing from OSS-Fuzz)
+# fuzz_rclient: exercises the RPCAP client-side network protocol parser
+# fuzz_rserver: exercises rpcapd daemon_serviceloop() server-side protocol handling
+for target in rclient rserver
+do
+    $CC $CFLAGS -I. -Irpcapd -c testprogs/fuzz/fuzz_$target.c -o fuzz_$target.o
+    if [ "$target" = "rserver" ]; then
+        # rserver needs daemon.c and log.c from rpcapd
+        $CC $CFLAGS -I. -Irpcapd -c rpcapd/daemon.c  -o daemon.o
+        $CC $CFLAGS -I. -Irpcapd -c rpcapd/log.c     -o log.o
+        $CXX $CXXFLAGS fuzz_$target.o daemon.o log.o \
+            -o $OUT/fuzz_$target build/libpcap.a $LIB_FUZZING_ENGINE
+    else
+        $CXX $CXXFLAGS fuzz_$target.o \
+            -o $OUT/fuzz_$target build/libpcap.a $LIB_FUZZING_ENGINE
+    fi
+done
+
+# export options files
+cp testprogs/fuzz/fuzz_*.options $OUT/ 2>/dev/null || true
+
+# seed corpora
 cd $SRC/tcpdump/
 zip -r fuzz_pcap_seed_corpus.zip tests/
 cp fuzz_pcap_seed_corpus.zip $OUT/
+cp fuzz_pcap_seed_corpus.zip $OUT/fuzz_rclient_seed_corpus.zip
+
 cd $SRC/libpcap/testprogs/BPF
 mkdir corpus
 ls *.txt | while read i; do tail -1 $i > corpus/$i; done


### PR DESCRIPTION
## Summary

The libpcap repo already contains two fuzzing harnesses for the RPCAP remote-capture protocol that are **not currently compiled or run by OSS-Fuzz**:

- `testprogs/fuzz/fuzz_rclient.c` — fuzzes the RPCAP **client-side** protocol parser (`pcap_open` → `pcap_next_ex` over a fuzzed socket)
- `testprogs/fuzz/fuzz_rserver.c` — fuzzes the **rpcapd daemon** `daemon_serviceloop()` server-side protocol handling

Both harnesses use `sock_initfuzz()` to inject fuzz data into the socket layer, exercising the full network protocol parsing stack without requiring a real network connection.

## Why This Matters

The RPCAP protocol implementation (`rpcap/`) parses untrusted network data. Memory-safety bugs here are directly reachable from the network:
- Integer overflows in packet length fields
- OOB reads/writes in authentication message parsing
- State-machine confusion in the multi-step RPCAP handshake

These paths were **completely uncovered** by existing OSS-Fuzz harnesses (`fuzz_pcap`, `fuzz_filter`, `fuzz_both`).

## Changes

- Enable `-DENABLE_REMOTE=ON` in cmake so rpcapd headers/objects are available
- Compile `fuzz_rclient` and `fuzz_rserver` alongside existing targets
- Reuse tcpdump test corpus as seed for `fuzz_rclient`

## Testing

Verified harnesses compile cleanly against libpcap master with ASAN enabled.