### PR TITLE
[jpegxl] Add OSS-Fuzz project for libjxl (JPEG XL reference implementation)

### DIFF
--- a/projects/jpegxl/Dockerfile
+++ b/projects/jpegxl/Dockerfile
@@ -1,0 +1,30 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN apt-get update && apt-get install -y \
+    cmake \
+    ninja-build \
+    nasm \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --recursive https://github.com/libjxl/libjxl.git libjxl
+
+WORKDIR libjxl
+
+COPY build.sh $SRC/

--- a/projects/jpegxl/build.sh
+++ b/projects/jpegxl/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+bash tools/scripts/ossfuzz-build.sh

--- a/projects/jpegxl/project.yaml
+++ b/projects/jpegxl/project.yaml
@@ -1,0 +1,13 @@
+homepage: "https://github.com/libjxl/libjxl"
+language: c++
+primary_contact: "jxl-team@google.com"
+main_repo: "https://github.com/libjxl/libjxl.git"
+sanitizers:
+  - address
+  - undefined
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+auto_ccs:
+  - "jxl-team@google.com"


### PR DESCRIPTION
## Add OSS-Fuzz project for jpegxl / libjxl

This PR adds the OSS-Fuzz integration for [libjxl](https://github.com/libjxl/libjxl), the reference implementation of the JPEG XL image format.

### Why now?

- **jpegxl is a Tier 1 Patch Rewards target** as of January 2025, making continuous fuzz testing directly relevant to Google's Vulnerability Reward Program.
- libjxl processes complex, attacker-controlled image data (a classic high-value fuzzing target), and is shipped in Chrome, Android, and many Linux distros.

### The heavy lifting is already done

The libjxl repository ships 10+ fuzzer source files and a dedicated OSS-Fuzz build script:

- `tools/cjxl_fuzzer.cc` - Encoder fuzzer
- `tools/djxl_fuzzer.cc` - Decoder fuzzer
- `tools/fields_fuzzer.cc` - Bitstream fields fuzzer
- `tools/icc_codec_fuzzer.cc` - ICC profile codec fuzzer
- `tools/rans_fuzzer.cc` - ANS/rANS entropy coder fuzzer
- `tools/color_encoding_fuzzer.cc` - Color encoding fuzzer
- `tools/decode_basic_info_fuzzer.cc` - Basic info decoder fuzzer
- `tools/set_from_bytes_fuzzer.cc` - Bytes parser fuzzer
- `tools/streaming_fuzzer.cc` - Streaming decode fuzzer
- `tools/transforms_fuzzer.cc` - Transform pipeline fuzzer
- `tools/scripts/ossfuzz-build.sh` - OSS-Fuzz build orchestration

### What this PR does

This PR wires the existing fuzzers into OSS-Fuzz infrastructure - nothing more:

- **Dockerfile**: Pulls base-builder, installs cmake, ninja-build, and nasm, clones libjxl with --recursive
- **build.sh**: Delegates entirely to the upstream tools/scripts/ossfuzz-build.sh
- **project.yaml**: Registers the project with address + undefined sanitizers and libfuzzer, afl, honggfuzz engines

### Checklist

- [x] Code coverage: all fuzzers already present upstream
- [x] Build script: tools/scripts/ossfuzz-build.sh already maintained by the libjxl team
- [x] Sanitizers: address, undefined
- [x] Fuzzing engines: libfuzzer, afl, honggfuzz
- [x] Primary contact: jxl-team@google.com
