### PR TITLE
Add OSS-Fuzz project for protobuf (protocolbuffers/protobuf)

### DIFF
--- a/projects/protobuf/Dockerfile
+++ b/projects/protobuf/Dockerfile
@@ -1,0 +1,38 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        cmake \
+        ninja-build \
+        python3 \
+        curl \
+        unzip \
+        openjdk-11-jdk-headless && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Bazel (needed by some protobuf build paths)
+RUN curl -fsSL https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-amd64 \
+        -o /usr/local/bin/bazel && \
+    chmod +x /usr/local/bin/bazel
+
+RUN git clone --depth 1 https://github.com/protocolbuffers/protobuf.git $SRC/protobuf
+
+WORKDIR $SRC/protobuf
+
+COPY build.sh proto_decode_fuzzer.cc proto_json_fuzzer.cc $SRC/

--- a/projects/protobuf/build.sh
+++ b/projects/protobuf/build.sh
@@ -1,0 +1,75 @@
+#!/bin/bash -eu
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+cd $SRC/protobuf
+
+# Update submodules (third-party deps)
+git submodule update --init --recursive
+
+# Configure with CMake
+mkdir -p build && cd build
+cmake .. \
+    -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER="${CC}" \
+    -DCMAKE_CXX_COMPILER="${CXX}" \
+    -DCMAKE_C_FLAGS="${CFLAGS}" \
+    -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
+    -DCMAKE_EXE_LINKER_FLAGS="${LIB_FUZZING_ENGINE}" \
+    -Dprotobuf_BUILD_TESTS=OFF \
+    -Dprotobuf_BUILD_FUZZ_TESTS=ON \
+    -Dprotobuf_BUILD_SHARED_LIBS=OFF \
+    -Dprotobuf_ABSL_PROVIDER=package \
+    -DABSL_PROPAGATE_CXX_STD=ON
+
+ninja -j$(nproc) protobuf
+
+# Path to built static libraries
+LIBDIR="$SRC/protobuf/build"
+
+# Include dirs
+INCLUDES="-I$SRC/protobuf/src"
+
+# Compile proto_decode_fuzzer
+$CXX $CXXFLAGS $INCLUDES \
+    $SRC/proto_decode_fuzzer.cc \
+    -o $OUT/proto_decode_fuzzer \
+    $LIB_FUZZING_ENGINE \
+    "$LIBDIR/libprotobuf.a" \
+    "$LIBDIR/libprotobuf-lite.a" 2>/dev/null || \
+$CXX $CXXFLAGS $INCLUDES \
+    $SRC/proto_decode_fuzzer.cc \
+    -o $OUT/proto_decode_fuzzer \
+    $LIB_FUZZING_ENGINE \
+    $(find "$LIBDIR" -name "libprotobuf*.a" | tr '\n' ' ')
+
+# Compile proto_json_fuzzer
+$CXX $CXXFLAGS $INCLUDES \
+    $SRC/proto_json_fuzzer.cc \
+    -o $OUT/proto_json_fuzzer \
+    $LIB_FUZZING_ENGINE \
+    "$LIBDIR/libprotobuf.a" \
+    "$LIBDIR/libprotobuf-lite.a" 2>/dev/null || \
+$CXX $CXXFLAGS $INCLUDES \
+    $SRC/proto_json_fuzzer.cc \
+    -o $OUT/proto_json_fuzzer \
+    $LIB_FUZZING_ENGINE \
+    $(find "$LIBDIR" -name "libprotobuf*.a" | tr '\n' ' ')

--- a/projects/protobuf/project.yaml
+++ b/projects/protobuf/project.yaml
@@ -1,0 +1,14 @@
+homepage: "https://github.com/protocolbuffers/protobuf"
+language: c++
+primary_contact: "protobuf-oss-fuzz@google.com"
+auto_ccs:
+  - "protobuf-team@google.com"
+sanitizers:
+  - address
+  - undefined
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+architectures:
+  - x86_64

--- a/projects/protobuf/proto_decode_fuzzer.cc
+++ b/projects/protobuf/proto_decode_fuzzer.cc
@@ -1,0 +1,17 @@
+#include <stddef.h>
+#include <stdint.h>
+#include "google/protobuf/message.h"
+#include "google/protobuf/descriptor.pb.h"
+
+// Fuzz ParseFromString on a FileDescriptorProto (self-describing protobuf)
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    google::protobuf::FileDescriptorProto proto;
+    std::string input(reinterpret_cast<const char*>(data), size);
+    proto.ParseFromString(input);
+    // Also test SerializeToString roundtrip
+    std::string output;
+    proto.SerializeToString(&output);
+    google::protobuf::FileDescriptorProto proto2;
+    proto2.ParseFromString(output);
+    return 0;
+}

--- a/projects/protobuf/proto_json_fuzzer.cc
+++ b/projects/protobuf/proto_json_fuzzer.cc
@@ -1,0 +1,9 @@
+#include "google/protobuf/util/json_util.h"
+#include "google/protobuf/descriptor.pb.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    std::string input(reinterpret_cast<const char*>(data), size);
+    google::protobuf::FileDescriptorProto proto;
+    google::protobuf::util::JsonStringToMessage(input, &proto);
+    return 0;
+}


### PR DESCRIPTION
## New Project: protobuf

This PR adds OSS-Fuzz integration for [protocolbuffers/protobuf](https://github.com/protocolbuffers/protobuf), the Protocol Buffers library maintained by Google.

### Fuzzers added

1. **`proto_decode_fuzzer`** — Fuzzes binary wire-format parsing via `ParseFromString` on a `FileDescriptorProto`, including a serialize→re-parse round-trip to catch consistency bugs.
2. **`proto_json_fuzzer`** — Fuzzes JSON→proto conversion via `util::JsonStringToMessage` on a `FileDescriptorProto`.

### Build system

- CMake with `-Dprotobuf_BUILD_FUZZ_TESTS=ON`
- Fuzzers linked against `libprotobuf.a`
- Sanitizers: AddressSanitizer + UndefinedBehaviorSanitizer
- Engines: libFuzzer, AFL, Honggfuzz

### Files

```
projects/protobuf/
  Dockerfile
  build.sh
  project.yaml
  proto_decode_fuzzer.cc
  proto_json_fuzzer.cc
```