### PR TITLE
Add OSS-Fuzz project for libpng (read + write + progressive fuzz harnesses)

### DIFF
--- a/projects/libpng/build.sh
+++ b/projects/libpng/build.sh
@@ -1,0 +1,70 @@
+#!/bin/bash -eu
+#
+# OSS-Fuzz build script for libpng.
+#
+# Environment variables injected by OSS-Fuzz:
+#   $CC, $CXX           – compiler (clang / clang++)
+#   $CFLAGS, $CXXFLAGS  – sanitizer + coverage flags
+#   $LIB_FUZZING_ENGINE – fuzzing engine link flag (-fsanitize=fuzzer etc.)
+#   $OUT                – output directory for fuzzer binaries
+#   $SRC                – source root (set in Dockerfile)
+
+# ---------------------------------------------------------------------------
+# 1. Build zlib (static)
+# ---------------------------------------------------------------------------
+echo "==> Building zlib"
+cd "$SRC/zlib"
+# Use the configure wrapper so we get a plain static archive.
+CFLAGS="$CFLAGS" ./configure \
+    --prefix="$WORK" \
+    --static
+make -j"$(nproc)" clean
+make -j"$(nproc)"
+make install
+
+# ---------------------------------------------------------------------------
+# 2. Build libpng (static, cmake)
+# ---------------------------------------------------------------------------
+echo "==> Building libpng"
+mkdir -p "$WORK/libpng-build"
+cd "$WORK/libpng-build"
+
+cmake "$SRC/libpng" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER="$CC" \
+    -DCMAKE_C_FLAGS="$CFLAGS" \
+    -DCMAKE_INSTALL_PREFIX="$WORK" \
+    -DPNG_SHARED=OFF \
+    -DPNG_STATIC=ON \
+    -DPNG_TESTS=OFF \
+    -DZLIB_ROOT="$WORK" \
+    -DZLIB_LIBRARY="$WORK/lib/libz.a" \
+    -DZLIB_INCLUDE_DIR="$WORK/include"
+
+make -j"$(nproc)"
+make install
+
+# ---------------------------------------------------------------------------
+# 3. Compile fuzzer binaries
+# ---------------------------------------------------------------------------
+echo "==> Compiling fuzzers"
+
+INCLUDES="-I$WORK/include"
+LIBS="$WORK/lib/libpng.a $WORK/lib/libz.a"
+
+# png_read_fuzzer
+$CXX $CXXFLAGS $INCLUDES \
+    "$SRC/png_read_fuzzer.cc" \
+    $LIB_FUZZING_ENGINE \
+    $LIBS \
+    -o "$OUT/png_read_fuzzer"
+
+# png_write_fuzzer
+$CXX $CXXFLAGS $INCLUDES \
+    "$SRC/png_write_fuzzer.cc" \
+    $LIB_FUZZING_ENGINE \
+    $LIBS \
+    -o "$OUT/png_write_fuzzer"
+
+echo "==> Build complete. Fuzzers written to $OUT/"
+ls -lh "$OUT/"

--- a/projects/libpng/png_read_fuzzer.cc
+++ b/projects/libpng/png_read_fuzzer.cc
@@ -1,0 +1,210 @@
+// OSS-Fuzz fuzzing harness for libpng read paths.
+// Covers:
+//   1. png_read_png()  - high-level one-shot read
+//   2. png_read_image() - row-by-row read after png_read_info()
+//   3. Progressive read via png_process_data()
+//
+// Build with: clang++ -g -fsanitize=address,undefined -lpng -lz png_read_fuzzer.cc -o png_read_fuzzer
+
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdlib.h>
+#include <setjmp.h>
+
+#include "png.h"
+
+// ---------------------------------------------------------------------------
+// Memory-backed I/O helpers
+// ---------------------------------------------------------------------------
+
+struct MemReader {
+  const uint8_t *data;
+  size_t         size;
+  size_t         pos;
+};
+
+static void mem_read_fn(png_structp png_ptr, png_bytep out, png_size_t len) {
+  MemReader *r = reinterpret_cast<MemReader *>(png_get_io_ptr(png_ptr));
+  if (r->pos + len > r->size) {
+    // Signal error – libpng will longjmp out.
+    png_error(png_ptr, "read beyond end of buffer");
+    return;
+  }
+  memcpy(out, r->data + r->pos, len);
+  r->pos += len;
+}
+
+// ---------------------------------------------------------------------------
+// Path 1 – png_read_png() (high-level, all transforms)
+// ---------------------------------------------------------------------------
+
+static void fuzz_read_png(const uint8_t *data, size_t size) {
+  MemReader reader = {data, size, 0};
+
+  png_structp png_ptr = png_create_read_struct(
+      PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+  if (!png_ptr) return;
+
+  png_infop info_ptr = png_create_info_struct(png_ptr);
+  if (!info_ptr) {
+    png_destroy_read_struct(&png_ptr, nullptr, nullptr);
+    return;
+  }
+
+  if (setjmp(png_jmpbuf(png_ptr))) {
+    png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
+    return;
+  }
+
+  png_set_read_fn(png_ptr, &reader, mem_read_fn);
+
+  // Exercise a wide set of transforms to maximise code coverage.
+  int transforms = PNG_TRANSFORM_STRIP_16   |
+                   PNG_TRANSFORM_PACKING    |
+                   PNG_TRANSFORM_EXPAND     |
+                   PNG_TRANSFORM_BGR        |
+                   PNG_TRANSFORM_GRAY_TO_RGB;
+
+  png_read_png(png_ptr, info_ptr, transforms, nullptr);
+
+  png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// Path 2 – png_read_info() + png_read_image() + png_read_end()
+// ---------------------------------------------------------------------------
+
+static void fuzz_read_image(const uint8_t *data, size_t size) {
+  MemReader reader = {data, size, 0};
+
+  png_structp png_ptr = png_create_read_struct(
+      PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+  if (!png_ptr) return;
+
+  png_infop info_ptr  = png_create_info_struct(png_ptr);
+  png_infop end_info  = png_create_info_struct(png_ptr);
+  if (!info_ptr || !end_info) {
+    png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
+    return;
+  }
+
+  if (setjmp(png_jmpbuf(png_ptr))) {
+    png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
+    return;
+  }
+
+  png_set_read_fn(png_ptr, &reader, mem_read_fn);
+
+  png_read_info(png_ptr, info_ptr);
+
+  png_uint_32 width  = png_get_image_width(png_ptr, info_ptr);
+  png_uint_32 height = png_get_image_height(png_ptr, info_ptr);
+
+  // Guard against absurdly large dimensions to keep run-time sane.
+  if (width == 0 || height == 0 || width > 4096 || height > 4096) {
+    png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
+    return;
+  }
+
+  size_t row_bytes = png_get_rowbytes(png_ptr, info_ptr);
+  if (row_bytes == 0 || row_bytes > 4096 * 8) {
+    png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
+    return;
+  }
+
+  // Allocate row pointers.
+  png_bytepp rows = reinterpret_cast<png_bytepp>(
+      malloc(height * sizeof(png_bytep)));
+  if (!rows) {
+    png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
+    return;
+  }
+  for (png_uint_32 i = 0; i < height; ++i) {
+    rows[i] = reinterpret_cast<png_bytep>(malloc(row_bytes));
+    if (!rows[i]) {
+      // Free what we've allocated so far, then bail.
+      for (png_uint_32 j = 0; j < i; ++j) free(rows[j]);
+      free(rows);
+      png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
+      return;
+    }
+  }
+
+  png_read_image(png_ptr, rows);
+  png_read_end(png_ptr, end_info);
+
+  for (png_uint_32 i = 0; i < height; ++i) free(rows[i]);
+  free(rows);
+  png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
+}
+
+// ---------------------------------------------------------------------------
+// Path 3 – Progressive read via png_process_data()
+// ---------------------------------------------------------------------------
+
+// We don't do anything with the decoded rows; we just exercise the path.
+static void info_callback(png_structp /*png_ptr*/, png_infop /*info_ptr*/) {}
+static void row_callback(png_structp /*png_ptr*/, png_bytep /*row*/,
+                         png_uint_32 /*row_num*/, int /*pass*/) {}
+static void end_callback(png_structp /*png_ptr*/, png_infop /*info_ptr*/) {}
+
+static void fuzz_progressive(const uint8_t *data, size_t size) {
+  png_structp png_ptr = png_create_read_struct(
+      PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+  if (!png_ptr) return;
+
+  png_infop info_ptr = png_create_info_struct(png_ptr);
+  if (!info_ptr) {
+    png_destroy_read_struct(&png_ptr, nullptr, nullptr);
+    return;
+  }
+
+  if (setjmp(png_jmpbuf(png_ptr))) {
+    png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
+    return;
+  }
+
+  png_set_progressive_read_fn(png_ptr, nullptr,
+                               info_callback, row_callback, end_callback);
+
+  // Feed data in variable-sized chunks (powers of 2) to stress the
+  // progressive decoder's internal state machine.
+  const size_t chunk_sizes[] = {1, 4, 16, 64, 256, 1024};
+  const size_t n_chunks = sizeof(chunk_sizes) / sizeof(chunk_sizes[0]);
+
+  size_t pos = 0;
+  size_t chunk_idx = 0;
+  while (pos < size) {
+    size_t chunk = chunk_sizes[chunk_idx % n_chunks];
+    if (chunk > size - pos) chunk = size - pos;
+    png_process_data(png_ptr, info_ptr,
+                     const_cast<png_bytep>(data + pos), chunk);
+    pos += chunk;
+    ++chunk_idx;
+  }
+
+  png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// Fuzzer entry point
+// ---------------------------------------------------------------------------
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  // Need at least a byte to dispatch and a minimal header (8 bytes).
+  if (size < 9) return 0;
+
+  // Use the first byte as a path selector so all three paths get exercised.
+  uint8_t selector = data[0] % 3;
+  const uint8_t *payload = data + 1;
+  size_t         payload_size = size - 1;
+
+  switch (selector) {
+    case 0: fuzz_read_png(payload, payload_size);   break;
+    case 1: fuzz_read_image(payload, payload_size); break;
+    case 2: fuzz_progressive(payload, payload_size); break;
+  }
+
+  return 0;
+}

--- a/projects/libpng/png_write_fuzzer.cc
+++ b/projects/libpng/png_write_fuzzer.cc
@@ -1,0 +1,233 @@
+// OSS-Fuzz fuzzing harness for libpng write path.
+// Strategy: treat raw fuzz bytes as pixel data, write them as a PNG into an
+// in-memory buffer via png_write_png(), then read that buffer back with
+// png_read_png() to exercise the full encode→decode roundtrip.
+//
+// Build with: clang++ -g -fsanitize=address,undefined -lpng -lz png_write_fuzzer.cc -o png_write_fuzzer
+
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdlib.h>
+#include <setjmp.h>
+#include <vector>
+#include <algorithm>
+
+#include "png.h"
+
+// ---------------------------------------------------------------------------
+// Memory-backed write I/O
+// ---------------------------------------------------------------------------
+
+struct MemWriter {
+  std::vector<uint8_t> buf;
+};
+
+static void mem_write_fn(png_structp png_ptr, png_bytep data, png_size_t len) {
+  MemWriter *w = reinterpret_cast<MemWriter *>(png_get_io_ptr(png_ptr));
+  w->buf.insert(w->buf.end(), data, data + len);
+}
+
+static void mem_flush_fn(png_structp /*png_ptr*/) {
+  // Nothing to flush for in-memory I/O.
+}
+
+// ---------------------------------------------------------------------------
+// Memory-backed read I/O (for the decode side)
+// ---------------------------------------------------------------------------
+
+struct MemReader {
+  const uint8_t *data;
+  size_t         size;
+  size_t         pos;
+};
+
+static void mem_read_fn(png_structp png_ptr, png_bytep out, png_size_t len) {
+  MemReader *r = reinterpret_cast<MemReader *>(png_get_io_ptr(png_ptr));
+  if (r->pos + len > r->size) {
+    png_error(png_ptr, "read beyond end of buffer");
+    return;
+  }
+  memcpy(out, r->data + r->pos, len);
+  r->pos += len;
+}
+
+// ---------------------------------------------------------------------------
+// Write path: encode arbitrary bytes as a grayscale PNG
+// ---------------------------------------------------------------------------
+
+static bool write_png(const uint8_t *data, size_t size,
+                      MemWriter &writer,
+                      png_uint_32 &out_width, png_uint_32 &out_height) {
+  if (size == 0) return false;
+
+  // Treat the input as rows of 8-bit grayscale pixels.
+  // Width is fixed at up to 64; height is derived from size.
+  const png_uint_32 width  = std::min<png_uint_32>(64, (png_uint_32)size);
+  const png_uint_32 height = (png_uint_32)((size + width - 1) / width);
+
+  // Guard against degenerate dimensions.
+  if (width == 0 || height == 0 || height > 4096) return false;
+
+  out_width  = width;
+  out_height = height;
+
+  png_structp png_ptr = png_create_write_struct(
+      PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+  if (!png_ptr) return false;
+
+  png_infop info_ptr = png_create_info_struct(png_ptr);
+  if (!info_ptr) {
+    png_destroy_write_struct(&png_ptr, nullptr);
+    return false;
+  }
+
+  if (setjmp(png_jmpbuf(png_ptr))) {
+    png_destroy_write_struct(&png_ptr, &info_ptr);
+    return false;
+  }
+
+  png_set_write_fn(png_ptr, &writer, mem_write_fn, mem_flush_fn);
+
+  // Use compression level from the first byte so the fuzzer can vary it.
+  int clevel = (int)(data[0] % 10);
+  png_set_compression_level(png_ptr, clevel);
+
+  png_set_IHDR(png_ptr, info_ptr,
+               width, height,
+               8,                      // bit depth
+               PNG_COLOR_TYPE_GRAY,    // color type
+               PNG_INTERLACE_NONE,
+               PNG_COMPRESSION_TYPE_DEFAULT,
+               PNG_FILTER_TYPE_DEFAULT);
+
+  // Build row pointer array, padding the last row with zeros if needed.
+  size_t row_bytes = (size_t)width;
+  std::vector<uint8_t> padded(height * row_bytes, 0);
+  memcpy(padded.data(), data, std::min(size, padded.size()));
+
+  std::vector<png_bytep> rows(height);
+  for (png_uint_32 i = 0; i < height; ++i)
+    rows[i] = padded.data() + i * row_bytes;
+
+  png_set_rows(png_ptr, info_ptr, rows.data());
+  png_write_png(png_ptr, info_ptr, PNG_TRANSFORM_IDENTITY, nullptr);
+
+  png_destroy_write_struct(&png_ptr, &info_ptr);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Read path: decode the PNG we just wrote back into memory
+// ---------------------------------------------------------------------------
+
+static void read_back_png(const MemWriter &writer) {
+  if (writer.buf.empty()) return;
+
+  MemReader reader = {writer.buf.data(), writer.buf.size(), 0};
+
+  png_structp png_ptr = png_create_read_struct(
+      PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+  if (!png_ptr) return;
+
+  png_infop info_ptr = png_create_info_struct(png_ptr);
+  if (!info_ptr) {
+    png_destroy_read_struct(&png_ptr, nullptr, nullptr);
+    return;
+  }
+
+  if (setjmp(png_jmpbuf(png_ptr))) {
+    png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
+    return;
+  }
+
+  png_set_read_fn(png_ptr, &reader, mem_read_fn);
+  png_read_png(png_ptr, info_ptr, PNG_TRANSFORM_IDENTITY, nullptr);
+  png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// Auxiliary path: exercise png_write_row() individually
+// ---------------------------------------------------------------------------
+
+static void fuzz_write_row(const uint8_t *data, size_t size) {
+  if (size < 2) return;
+
+  const png_uint_32 width  = std::min<png_uint_32>(64, (png_uint_32)size);
+  const png_uint_32 height = (png_uint_32)((size + width - 1) / width);
+  if (height == 0 || height > 4096) return;
+
+  MemWriter writer;
+
+  png_structp png_ptr = png_create_write_struct(
+      PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+  if (!png_ptr) return;
+
+  png_infop info_ptr = png_create_info_struct(png_ptr);
+  if (!info_ptr) {
+    png_destroy_write_struct(&png_ptr, nullptr);
+    return;
+  }
+
+  if (setjmp(png_jmpbuf(png_ptr))) {
+    png_destroy_write_struct(&png_ptr, &info_ptr);
+    return;
+  }
+
+  png_set_write_fn(png_ptr, &writer, mem_write_fn, mem_flush_fn);
+  png_set_IHDR(png_ptr, info_ptr,
+               width, height, 8,
+               PNG_COLOR_TYPE_GRAY,
+               PNG_INTERLACE_NONE,
+               PNG_COMPRESSION_TYPE_DEFAULT,
+               PNG_FILTER_TYPE_DEFAULT);
+  png_write_info(png_ptr, info_ptr);
+
+  size_t row_bytes = (size_t)width;
+  std::vector<uint8_t> row_buf(row_bytes, 0);
+  for (png_uint_32 i = 0; i < height; ++i) {
+    size_t src_offset = (size_t)i * row_bytes;
+    if (src_offset < size) {
+      size_t avail = std::min(row_bytes, size - src_offset);
+      memcpy(row_buf.data(), data + src_offset, avail);
+    } else {
+      memset(row_buf.data(), 0, row_bytes);
+    }
+    png_write_row(png_ptr, row_buf.data());
+  }
+
+  png_write_end(png_ptr, info_ptr);
+  png_destroy_write_struct(&png_ptr, &info_ptr);
+}
+
+// ---------------------------------------------------------------------------
+// Fuzzer entry point
+// ---------------------------------------------------------------------------
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  if (size < 2) return 0;
+
+  // Use the first byte to select between write-path variants.
+  uint8_t selector = data[0] % 2;
+  const uint8_t *payload = data + 1;
+  size_t         payload_size = size - 1;
+
+  switch (selector) {
+    case 0: {
+      // Full roundtrip: write → read-back.
+      MemWriter writer;
+      png_uint_32 w = 0, h = 0;
+      if (write_png(payload, payload_size, writer, w, h)) {
+        read_back_png(writer);
+      }
+      break;
+    }
+    case 1: {
+      // Row-by-row write path.
+      fuzz_write_row(payload, payload_size);
+      break;
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Add OSS-Fuzz project for libpng

### What this PR does

This PR integrates **libpng** ([pnggroup/libpng](https://github.com/pnggroup/libpng)) into OSS-Fuzz with two purpose-built fuzzing harnesses and a complete build infrastructure.

---

### Background & gap being filled

libpng is one of the most widely deployed C libraries in existence — it underpins image decoding in browsers, operating systems, graphics toolkits, and embedded firmware. Despite its critical role and its long history of memory-safety vulnerabilities (CVE-2014-9495, CVE-2015-8126, CVE-2016-10087, CVE-2017-12652, and others), libpng has **no existing OSS-Fuzz project** and no dedicated fuzz directory in its upstream repository.

The absence of continuous fuzzing leaves several high-value attack surfaces unmonitored:

- **PNG read path** — header parsing, chunk dispatch, filter reconstruction, gamma/iCCP/sPLT metadata handling, interlacing (Adam7), and all libpng transforms.
- **Progressive read path** — the `png_process_data()` state machine, which handles streaming network delivery and is exercised differently from the non-progressive decoder.
- **Write path** — `png_write_png()` / `png_write_row()` and the deflate compression layer, which are exercised far less than the read path in real-world usage.

---

### Fuzzers

#### `png_read_fuzzer.cc`

Exercises three distinct read paths selected by the first byte of each input:

- **Selector 0**: `png_read_png()` with a broad set of transforms (STRIP_16, PACKING, EXPAND, BGR, GRAY_TO_RGB)
- **Selector 1**: `png_read_info()` then `png_read_image()` then `png_read_end()` with heap-allocated row buffers
- **Selector 2**: `png_set_progressive_read_fn()` + `png_process_data()` fed in variable chunk sizes (1, 4, 16, 64, 256, 1024 bytes) to stress the progressive state machine

All paths use a custom `png_set_read_fn()` callback backed by an in-memory MemReader struct (no temporary files), and rely on setjmp/longjmp for error handling exactly as the libpng documentation requires.

#### `png_write_fuzzer.cc`

Exercises two write-path variants selected by the first byte of each input:

- **Selector 0**: Encodes raw fuzz bytes as 8-bit grayscale rows via `png_write_png()`, writes to an in-memory MemWriter buffer, then decodes the output with `png_read_png()` — a full encode->decode roundtrip
- **Selector 1**: Encodes row-by-row via `png_write_info()` + `png_write_row()` + `png_write_end()`, exercising the row-level write API independently

The compression level is derived from the first payload byte so the fuzzer automatically varies `png_set_compression_level()` across the 0-9 range.

---

### Build infrastructure

- **Dockerfile**: Clones pnggroup/libpng and madler/zlib from HEAD; installs cmake/make/autoconf
- **build.sh**: Builds zlib static, then builds libpng static via cmake, then links both fuzzers with $LIB_FUZZING_ENGINE
- **project.yaml**: Declares c++, sanitizers address+undefined, engines libfuzzer+afl+honggfuzz, main_repo pointing at the canonical upstream

zlib is built from source (rather than the system package) so that OSS-Fuzz can apply its own -fsanitize flags to the entire dependency chain, avoiding false negatives from sanitizer boundary crossings.

---

### Testing notes

- Both fuzzers were compiled locally against libpng 1.6.43 + zlib 1.3.1 with -fsanitize=address,undefined and run against a small corpus of valid PNGs and malformed inputs without crashes or sanitizer errors in the harness infrastructure itself.
- Dimension guards (width/height <= 4096) prevent OOM-class timeouts while still covering the decoder logic for realistic image sizes.
- The progressive fuzzer feeds data in multiple chunk sizes in a single LLVMFuzzerTestOneInput call to maximise coverage of the internal state machine without requiring the fuzzer to coordinate multiple calls.

---

### References
- https://github.com/pnggroup/libpng
- http://www.libpng.org/pub/png/libpng.html
- https://google.github.io/oss-fuzz/getting-started/new-project-guide/
