### PR TITLE
strongswan: Build custom crypto plugins to fuzz their implementation

### DIFF
--- a/projects/strongswan/build.sh
+++ b/projects/strongswan/build.sh
@@ -23,6 +23,7 @@
 	--enable-libipsec \
 	--enable-eap-radius \
 	--enable-fuzzing \
+	--enable-sha1 --enable-sha2 --enable-sha3 --enable-mgf1 --enable-gmp \
 	--with-libfuzzer=$LIB_FUZZING_ENGINE \
 	--enable-monolithic \
 	--disable-shared \


### PR DESCRIPTION
Since https://github.com/strongswan/strongswan/commit/444a1dc0e3594cbd81a5cc93bef77f367b56151a, the fuzzers are built twice, once loading the default crypto plugin (openssl) and once loading the legacy crypto plugins that were the default before 6.0.0.  If these plugins are not built, the second set of fuzzers are basically no-ops as they won't be able to parse any input.

I kept them on a single line to clarify that they belong together.