### PR TITLE
varnish: fix broken build

### DIFF
--- a/projects/varnish/build.sh
+++ b/projects/varnish/build.sh
@@ -20,8 +20,8 @@
 ./autogen.sh
 ./configure --enable-oss-fuzz PCRE2_LIBS=-l:libpcre2-8.a
 make -j2 -C include/
-make -j2 -C lib/libvarnish/
+make -j2 -C lib/libvinyl/
 make -j2 -C lib/libvgz/
 make -j2 -C lib/libvsc/
-make -j2 -C bin/varnishd/ esi_parse_fuzzer
-cp bin/varnishd/*_fuzzer $OUT/
+make -j2 -C bin/vinyld/ esi_parse_fuzzer
+cp bin/vinyld/*_fuzzer $OUT/


### PR DESCRIPTION
---

## Disclaimer
Investigation and work on this PR was primarily done by AI. I (Timothée Chauvin):

* verified that the improvement is real (see the automatically run [fuzzing coverage report](#fuzzing-coverage-report))
* briefly reviewed the full diff and commit/PR descriptions, but can't vouch for every detail.

Please let me know if you'd like a different level of verbosity or confidence in future PRs.

---

The build has been broken since 2026-03-08 (last successful build: 2026-03-07). See the [build status dashboard][build-status].

The upstream project repository was renamed from `varnish-cache` to `vinyl-cache`, which involved renaming several directories within the source tree:

- `lib/libvarnish/` → `lib/libvinyl/`
- `bin/varnishd/` → `bin/vinyld/`

[#14985][pr-14985] ([commit `2692c26`][commit-2692c26]) updated the Dockerfile to clone from `code.vinyl-cache.org/vinyl-cache/vinyl-cache`, but did not update `build.sh`, which still references the old directory names and fails with:

```
make: *** lib/libvarnish/: No such file or directory.  Stop.
```

This patch updates `build.sh` to use the new directory names.

[build-status]: https://oss-fuzz-build-logs.storage.googleapis.com/index.html#varnish
[pr-14985]: https://github.com/google/oss-fuzz/pull/14985
[commit-2692c26]: https://github.com/google/oss-fuzz/commit/2692c26113cc8e632caf2c02e3f8961e59e53b3b

---

<!-- fuzz-coverage-report -->

## Fuzzing Coverage Report

**Tested:** project `varnish` · base `c4ba43b` → head `e09153f` · 300s total fuzz budget · updated 2026-05-28 05:55 UTC · [workflow run](https://github.com/tc-agent/oss-fuzz/actions/runs/26557175342)

| Metric | Before | After | Delta |
|---|---|---|---|
| Static reachability | 2.2% (99/4425) | 60.2% (68/113) | **+57.9%** |
| Line coverage | 0% | 33.6% (780/2321) | **new** |
| Branch coverage | 0% | 30.0% (449/1496) | **new** |
| Function coverage | 0% | 35.1% (47/134) | **new** |

### Per-harness

| Harness | Lines before | Lines after | Δ |
|---|---|---|---|
| `esi_parse_fuzzer` | 0% | 33.6% (780/2321) | **new** |

<sub>Δ = (after − before) / before, to accommodate that denominators may change. "new" when before is 0; "deleted" when after is 0.</sub>
