### PR TITLE
e2fsprogs: improve fuzzing coverage

### DIFF
--- a/projects/e2fsprogs/build.sh
+++ b/projects/e2fsprogs/build.sh
@@ -31,3 +31,88 @@ for fuzzer in $(find $SRC/fuzz -name '*_fuzzer.cc'); do
       -L'./lib/et' -lcom_err \
       -o $OUT/$fuzzer_basename
 done
+
+# Build a seed corpus from upstream test images. The e2fsprogs tree carries
+# compressed ext2/3/4 filesystem images under tests/ — these are the
+# regression inputs for e2fsck/debugfs/etc. Reusing them lets the fuzzers
+# start past ext2fs_open's superblock magic check on iteration 1.
+seed_stage=$(mktemp -d)
+# Cap at compressed size 20K (decompressed ~100KB–1MB) to keep each seed
+# under the 1 MiB max_len set below. Bigger ones (e.g. f_large_dir) blow
+# past max_len and would be discarded anyway.
+for img in $(find $SRC/e2fsprogs/tests -name 'image.gz' -size -20k); do
+  tag=$(basename "$(dirname "$img")")
+  gunzip -c "$img" > "$seed_stage/$tag.img"
+  # Trim oversized seeds — libFuzzer would skip files past max_len.
+  if [ $(stat -c%s "$seed_stage/$tag.img") -gt 1048576 ]; then
+    rm "$seed_stage/$tag.img"
+  fi
+done
+for img in $(find $SRC/e2fsprogs/tests -name 'image.bz2' -size -20k); do
+  tag=$(basename "$(dirname "$img")")
+  bunzip2 -c "$img" > "$seed_stage/$tag.img"
+  if [ $(stat -c%s "$seed_stage/$tag.img") -gt 1048576 ]; then
+    rm "$seed_stage/$tag.img"
+  fi
+done
+# Also generate fresh mke2fs images covering feature combinations the upstream
+# test corpus underrepresents (MMP, casefold, encrypt, bigalloc, 64bit) — each
+# unlocks chunks of mmp.c / nls_utf8.c / bitmap64 / etc. that the test images
+# never reach.
+gen_image() {
+  local out="$1"; shift
+  local size_kb="${1:-128}"; shift || true
+  local img="$seed_stage/$out"
+  truncate -s "${size_kb}K" "$img"
+  ./misc/mke2fs -F -q "$@" "$img" 2>/dev/null || rm -f "$img"
+}
+gen_image fresh_ext2.img         512 -t ext2
+gen_image fresh_ext4.img         256 -t ext4
+gen_image fresh_64bit.img        256 -t ext4 -O 64bit,extents,has_journal
+gen_image fresh_journal.img      1024 -t ext4 -O has_journal,extents,64bit -J size=1
+gen_image fresh_mmp.img          512 -t ext4 -O mmp
+gen_image fresh_casefold.img     256 -t ext4 -O casefold,extents
+gen_image fresh_bigalloc.img     1024 -t ext4 -O bigalloc,extents,64bit -C 4096
+gen_image fresh_meta_bg.img      512 -t ext4 -O meta_bg,64bit
+gen_image fresh_inlinedata.img   256 -t ext4 -O inline_data,extents
+gen_image fresh_encrypt.img      256 -t ext4 -O encrypt,extents,64bit
+gen_image fresh_verity.img       256 -t ext4 -O verity,extents,64bit
+gen_image fresh_fastcommit.img   1024 -t ext4 -O fast_commit,extents,has_journal,64bit
+gen_image fresh_project.img      256 -t ext4 -O project,quota,extents,64bit
+gen_image fresh_ea_inode.img     256 -t ext4 -O ea_inode,extents,64bit
+gen_image fresh_extra_isize.img  256 -t ext4 -O extents,64bit -I 256
+gen_image fresh_cf_encrypt.img   256 -t ext4 -O casefold,encrypt,extents,64bit
+gen_image fresh_orphan_file.img  256 -t ext4 -O orphan_file,extents,has_journal,64bit
+gen_image fresh_bs1024.img       512 -t ext4 -O extents,64bit -b 1024
+gen_image fresh_bs2048.img       512 -t ext4 -O extents,64bit -b 2048
+gen_image fresh_no_extents.img   256 -t ext4 -O ^extents,has_journal,64bit
+gen_image fresh_huge_files.img   256 -t ext4 -O huge_file,extents,64bit
+gen_image fresh_metadata_csum.img 256 -t ext4 -O metadata_csum,extents,64bit
+gen_image fresh_quota.img        256 -t ext4 -O quota,extents,has_journal,64bit
+
+# Per-harness seed corpus: run each seed through the harness once and keep
+# only the ones that pass cleanly, so libFuzzer doesn't bail during initial
+# corpus load.
+for fuzzer in $(find $SRC/fuzz -name '*_fuzzer.cc'); do
+  fuzzer_basename=$(basename -s .cc $fuzzer)
+  harness_seeds=$(mktemp -d)
+  cp -r "$seed_stage"/. "$harness_seeds/"
+  for seed in "$harness_seeds"/*; do
+    [ -f "$seed" ] || continue
+    if ! ASAN_OPTIONS=detect_leaks=0:exitcode=77 \
+         timeout 3 "$OUT/$fuzzer_basename" "$seed" >/dev/null 2>&1; then
+      rm "$seed"
+    fi
+  done
+  rm -f "$OUT/${fuzzer_basename}_seed_corpus.zip"
+  (cd "$harness_seeds" && zip -q -r "$OUT/${fuzzer_basename}_seed_corpus.zip" .)
+  rm -rf "$harness_seeds"
+  # Raise max_len above the typical 100KB image size — libFuzzer's default
+  # 4096-byte cap would otherwise discard every seed.
+  cat > "$OUT/${fuzzer_basename}.options" <<EOF
+[libfuzzer]
+max_len = 1048576
+EOF
+done
+
+rm -rf "$seed_stage"

--- a/projects/e2fsprogs/fuzz/ext2fs_iterate_fuzzer.cc
+++ b/projects/e2fsprogs/fuzz/ext2fs_iterate_fuzzer.cc
@@ -1,0 +1,201 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <linux/memfd.h>
+#include <string>
+
+#include "ext2fs/ext2fs.h"
+
+namespace {
+
+int dir_cb(struct ext2_dir_entry *de, int /*offset*/, int /*blocksize*/,
+           char * /*buf*/, void *priv) {
+  ext2_filsys fs = static_cast<ext2_filsys>(priv);
+  if (!fs) return 0;
+  // Touch ext2fs_check_directory, ext2fs_read_inode, and ext2fs_get_pathname
+  // against every directory entry we encounter — exercises namei, inode
+  // reads, and pathname assembly with a stream of attacker-controlled inode
+  // numbers.
+  ext2fs_check_directory(fs, de->inode);
+  struct ext2_inode inode;
+  if (!ext2fs_read_inode(fs, de->inode, &inode)) {
+    char *path = nullptr;
+    if (!ext2fs_get_pathname(fs, EXT2_ROOT_INO, de->inode, &path)) {
+      ext2fs_free_mem(&path);
+    }
+  }
+  // dirhash + lookup against the name we just saw — exercises dirhash.c and
+  // lookup.c (htree walking) for every directory entry in the corpus.
+  int namelen = ext2fs_dirent_name_len(de);
+  if (namelen > 0 && namelen < 256) {
+    ext2_dirhash_t hash, minor_hash;
+    ext2fs_dirhash(EXT2_HASH_HALF_MD4, de->name, namelen, nullptr,
+                   &hash, &minor_hash);
+    ext2_ino_t out_ino;
+    ext2fs_lookup(fs, EXT2_ROOT_INO, de->name, namelen, nullptr, &out_ino);
+  }
+  return 0;
+}
+
+int block_cb(ext2_filsys, blk64_t *, e2_blkcnt_t, blk64_t, int, void *) {
+  return 0;
+}
+
+int xattr_cb(char * /*name*/, char * /*value*/, size_t /*value_len*/,
+             void * /*priv*/) {
+  return 0;
+}
+
+void walk_extents(ext2_filsys fs, ext2_ino_t ino) {
+  ext2_extent_handle_t h;
+  if (ext2fs_extent_open(fs, ino, &h))
+    return;
+  // ext2fs_extent_get_info exercises a path independent of node traversal.
+  struct ext2_extent_info info;
+  ext2fs_extent_get_info(h, &info);
+
+  struct ext2fs_extent extent;
+  int budget = 256;
+  for (int op : {EXT2_EXTENT_ROOT, EXT2_EXTENT_FIRST_SIB,
+                 EXT2_EXTENT_LAST_SIB, EXT2_EXTENT_NEXT_LEAF,
+                 EXT2_EXTENT_PREV_LEAF, EXT2_EXTENT_LAST_LEAF}) {
+    if (budget-- <= 0) break;
+    ext2fs_extent_get(h, op, &extent);
+  }
+  errcode_t e = ext2fs_extent_get(h, EXT2_EXTENT_ROOT, &extent);
+  while (!e && budget-- > 0)
+    e = ext2fs_extent_get(h, EXT2_EXTENT_NEXT, &extent);
+  ext2fs_extent_free(h);
+}
+
+void walk_xattrs(ext2_filsys fs, ext2_ino_t ino) {
+  struct ext2_xattr_handle *xh = nullptr;
+  if (ext2fs_xattrs_open(fs, ino, &xh) || !xh)
+    return;
+  if (!ext2fs_xattrs_read(xh)) {
+    size_t count = 0;
+    ext2fs_xattrs_count(xh, &count);
+    ext2fs_xattrs_iterate(xh, xattr_cb, nullptr);
+  }
+  ext2fs_xattrs_close(&xh);
+}
+
+void walk_bmap(ext2_filsys fs, ext2_ino_t ino, const struct ext2_inode &inode) {
+  // ext2fs_bmap2 exercises the indirect/extent block mapping resolver. Cap at
+  // a handful of logical blocks so we don't dominate fuzzing time on huge
+  // files.
+  blk64_t phys;
+  int budget = 16;
+  for (blk64_t lblk = 0; budget-- > 0; ++lblk) {
+    if (ext2fs_bmap2(fs, ino, (struct ext2_inode *)&inode, nullptr, 0, lblk,
+                     nullptr, &phys))
+      break;
+    if (!phys)
+      break;
+  }
+}
+
+void read_file(ext2_filsys fs, ext2_ino_t ino) {
+  ext2_file_t file;
+  if (ext2fs_file_open(fs, ino, 0, &file))
+    return;
+  char buf[4096];
+  unsigned int got;
+  int budget = 32;  // cap reads per file
+  while (budget-- > 0 && !ext2fs_file_read(file, buf, sizeof(buf), &got) && got)
+    ;
+  ext2fs_file_close(file);
+}
+
+void try_xattr_get(ext2_filsys fs, ext2_ino_t ino) {
+  struct ext2_xattr_handle *xh = nullptr;
+  if (ext2fs_xattrs_open(fs, ino, &xh) || !xh)
+    return;
+  if (!ext2fs_xattrs_read(xh)) {
+    static const char *keys[] = {
+        "user.test", "system.posix_acl_access",
+        "security.selinux", "trusted.foo",
+    };
+    for (const char *k : keys) {
+      void *value = nullptr;
+      size_t value_len = 0;
+      if (!ext2fs_xattr_get(xh, k, &value, &value_len) && value)
+        ext2fs_free_mem(&value);
+    }
+  }
+  ext2fs_xattrs_close(&xh);
+}
+
+}  // namespace
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  if (size < 1024) return 0;
+
+  int fd = syscall(SYS_memfd_create, "ext2_iter_fuzzer", 0);
+  if (fd < 0) return 0;
+  if (write(fd, data, size) != (ssize_t)size) {
+    close(fd);
+    return 0;
+  }
+
+  std::string fspath = "/proc/self/fd/" + std::to_string(fd);
+  ext2_filsys fs;
+  if (ext2fs_open(fspath.c_str(), EXT2_FLAG_IGNORE_CSUM_ERRORS, 0, 0,
+                  unix_io_manager, &fs)) {
+    close(fd);
+    return 0;
+  }
+
+  ext2fs_read_bitmaps(fs);
+  // Block-group descriptor verification — a chunky csum.c / blknum.c path.
+  ext2fs_check_desc(fs);
+
+  // Walk the directory tree from the root once. dir_cb itself dives back into
+  // per-inode APIs (check_directory, read_inode, get_pathname) so this alone
+  // covers a lot of ground beyond inode scan + leaf-block iteration.
+  ext2fs_dir_iterate(fs, EXT2_ROOT_INO, 0, nullptr, dir_cb, fs);
+
+  ext2_inode_scan scan;
+  if (!ext2fs_open_inode_scan(fs, 0, &scan)) {
+    ext2_ino_t ino;
+    struct ext2_inode inode;
+    int budget = 512;
+    while (budget-- > 0 &&
+           !ext2fs_get_next_inode(scan, &ino, &inode) &&
+           ino != 0) {
+      walk_xattrs(fs, ino);
+      try_xattr_get(fs, ino);
+      if (LINUX_S_ISDIR(inode.i_mode)) {
+        ext2fs_dir_iterate(fs, ino, 0, nullptr, dir_cb, fs);
+      } else if (LINUX_S_ISREG(inode.i_mode) || LINUX_S_ISLNK(inode.i_mode)) {
+        if (inode.i_flags & EXT4_EXTENTS_FL) {
+          walk_extents(fs, ino);
+        } else {
+          ext2fs_block_iterate3(fs, ino, 0, nullptr, block_cb, nullptr);
+        }
+        walk_bmap(fs, ino, inode);
+        read_file(fs, ino);
+      }
+    }
+    ext2fs_close_inode_scan(scan);
+  }
+
+  ext2fs_close(fs);
+  close(fd);
+  return 0;
+}

--- a/projects/e2fsprogs/fuzz/ext2fs_write_fuzzer.cc
+++ b/projects/e2fsprogs/fuzz/ext2fs_write_fuzzer.cc
@@ -1,0 +1,219 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <linux/memfd.h>
+#include <string>
+
+#include "ext2fs/ext2fs.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  if (size < 1024) return 0;
+
+  int fd = syscall(SYS_memfd_create, "ext2_write_fuzzer", 0);
+  if (fd < 0) return 0;
+  if (write(fd, data, size) != (ssize_t)size) {
+    close(fd);
+    return 0;
+  }
+
+  std::string fspath = "/proc/self/fd/" + std::to_string(fd);
+  ext2_filsys fs;
+  if (ext2fs_open(fspath.c_str(),
+                  EXT2_FLAG_RW | EXT2_FLAG_IGNORE_CSUM_ERRORS, 0, 0,
+                  unix_io_manager, &fs)) {
+    close(fd);
+    return 0;
+  }
+
+  if (ext2fs_read_bitmaps(fs)) {
+    ext2fs_close(fs);
+    close(fd);
+    return 0;
+  }
+
+  // ---- Block allocation / freeing ----
+  blk64_t alloc_blk = 0;
+  if (!ext2fs_new_block2(fs, 0, nullptr, &alloc_blk)) {
+    ext2fs_block_alloc_stats2(fs, alloc_blk, +1);
+    ext2fs_block_alloc_stats2(fs, alloc_blk, -1);
+  }
+
+  // ---- Inode allocation + write_inode ----
+  ext2_ino_t new_ino = 0;
+  if (!ext2fs_new_inode(fs, EXT2_ROOT_INO, LINUX_S_IFREG | 0644, nullptr,
+                        &new_ino) && new_ino) {
+    ext2fs_inode_alloc_stats2(fs, new_ino, +1, 0);
+    struct ext2_inode inode = {};
+    inode.i_mode = LINUX_S_IFREG | 0644;
+    inode.i_links_count = 1;
+    ext2fs_write_new_inode(fs, new_ino, &inode);
+    ext2fs_write_inode(fs, new_ino, &inode);
+
+    // Try to attach the new inode under root with a fresh name.
+    if (!ext2fs_link(fs, EXT2_ROOT_INO, "fuzzlnk", new_ino,
+                     EXT2_FT_REG_FILE)) {
+      ext2fs_unlink(fs, EXT2_ROOT_INO, "fuzzlnk", new_ino, 0);
+    }
+
+    struct ext2_xattr_handle *xh = nullptr;
+    if (!ext2fs_xattrs_open(fs, new_ino, &xh) && xh) {
+      const char *val = "v";
+      if (!ext2fs_xattr_set(xh, "user.fuzz", val, 1)) {
+        ext2fs_xattrs_write(xh);
+        ext2fs_xattr_remove(xh, "user.fuzz");
+        ext2fs_xattrs_write(xh);
+      }
+      ext2fs_xattrs_close(&xh);
+    }
+
+    ext2fs_inode_alloc_stats2(fs, new_ino, -1, 0);
+  }
+
+  // ---- mkdir + bulk-link many entries to push htree split paths ----
+  if (!ext2fs_new_inode(fs, EXT2_ROOT_INO, LINUX_S_IFDIR | 0755, nullptr,
+                        &new_ino) && new_ino) {
+    if (!ext2fs_mkdir(fs, EXT2_ROOT_INO, new_ino, "fdir")) {
+      for (int i = 0; i < 32; ++i) {
+        char name[32];
+        snprintf(name, sizeof(name), "ent_%08x", i);
+        ext2fs_link(fs, new_ino, name, EXT2_ROOT_INO, EXT2_FT_REG_FILE);
+      }
+      ext2fs_expand_dir(fs, new_ino);
+    }
+  }
+
+  // ---- bmap2 with BMAP_ALLOC on the root inode forces block allocation
+  // through alloc.c / bmap.c / extent.c. ----
+  {
+    struct ext2_inode root_ino_for_bmap;
+    if (!ext2fs_read_inode(fs, EXT2_ROOT_INO, &root_ino_for_bmap)) {
+      blk64_t phys;
+      ext2fs_bmap2(fs, EXT2_ROOT_INO, &root_ino_for_bmap, nullptr,
+                   BMAP_ALLOC, 0, nullptr, &phys);
+    }
+  }
+
+  // ---- dblist: collect directory blocks and replay them ----
+  ext2_dblist dblist = nullptr;
+  if (!ext2fs_init_dblist(fs, &dblist)) {
+    ext2fs_add_dir_block2(dblist, EXT2_ROOT_INO, 0, 0);
+    ext2fs_dblist_sort(dblist, nullptr);
+    ext2fs_dblist_iterate(dblist, [](ext2_filsys, struct ext2_db_entry *,
+                                     void *) { return 0; }, nullptr);
+    ext2fs_free_dblist(dblist);
+  }
+
+  // ---- punch (free a range of blocks) on the root inode ----
+  struct ext2_inode root_inode;
+  if (!ext2fs_read_inode(fs, EXT2_ROOT_INO, &root_inode)) {
+    ext2fs_punch(fs, EXT2_ROOT_INO, &root_inode, nullptr, 0, 1);
+  }
+
+  // ---- Walk every inode; for files with extents, exercise extent_set_bmap
+  // and extent_replace; for inodes with xattrs, set + remove a key. Caps the
+  // scan at 64 inodes to keep wall-time per exec manageable. ----
+  ext2_inode_scan scan;
+  if (!ext2fs_open_inode_scan(fs, 0, &scan)) {
+    ext2_ino_t ino;
+    struct ext2_inode inode;
+    int budget = 64;
+    while (budget-- > 0 &&
+           !ext2fs_get_next_inode(scan, &ino, &inode) &&
+           ino != 0) {
+      if ((inode.i_flags & EXT4_EXTENTS_FL) && LINUX_S_ISREG(inode.i_mode)) {
+        ext2_extent_handle_t h;
+        if (!ext2fs_extent_open(fs, ino, &h)) {
+          ext2fs_extent_set_bmap(h, 0, 0, 0);
+          // Walk to a leaf and try a few mutating operations.
+          struct ext2fs_extent extent;
+          if (!ext2fs_extent_get(h, EXT2_EXTENT_ROOT, &extent)) {
+            ext2fs_extent_fix_parents(h);
+            ext2fs_extent_node_split(h);
+            // Delete and re-walk — exercises rebalance paths.
+            ext2fs_extent_delete(h, 0);
+          }
+          ext2fs_extent_free(h);
+        }
+        // ext2fs_punch on the same inode hits the extent-aware free path.
+        ext2fs_punch(fs, ino, &inode, nullptr, 0, ~0ULL);
+      }
+      struct ext2_xattr_handle *xh = nullptr;
+      if (!ext2fs_xattrs_open(fs, ino, &xh) && xh) {
+        const char *val = "x";
+        if (!ext2fs_xattr_set(xh, "user.fz", val, 1))
+          ext2fs_xattr_remove(xh, "user.fz");
+        ext2fs_xattrs_close(&xh);
+      }
+    }
+    ext2fs_close_inode_scan(scan);
+  }
+
+  // ---- icount: build an in-memory inode-link-count table and exercise it
+  // against the on-disk inode scan ----
+  ext2_icount_t icount = nullptr;
+  if (!ext2fs_create_icount2(fs, 0, 0, nullptr, &icount) && icount) {
+    ext2_inode_scan ic_scan;
+    if (!ext2fs_open_inode_scan(fs, 0, &ic_scan)) {
+      ext2_ino_t ino;
+      struct ext2_inode inode;
+      int budget = 64;
+      while (budget-- > 0 &&
+             !ext2fs_get_next_inode(ic_scan, &ino, &inode) &&
+             ino != 0) {
+        __u16 ret;
+        ext2fs_icount_store(icount, ino, inode.i_links_count);
+        ext2fs_icount_increment(icount, ino, &ret);
+        ext2fs_icount_decrement(icount, ino, &ret);
+        ext2fs_icount_fetch(icount, ino, &ret);
+      }
+      ext2fs_close_inode_scan(ic_scan);
+    }
+    ext2fs_icount_validate(icount, stderr);
+    ext2fs_free_icount(icount);
+  }
+
+  // ---- Inline data create/set on a fresh inode ----
+  if (!ext2fs_new_inode(fs, EXT2_ROOT_INO, LINUX_S_IFREG | 0644, nullptr,
+                        &new_ino) && new_ino) {
+    struct ext2_inode inline_inode = {};
+    inline_inode.i_mode = LINUX_S_IFREG | 0644;
+    inline_inode.i_links_count = 1;
+    if (!ext2fs_write_new_inode(fs, new_ino, &inline_inode) &&
+        !ext2fs_inline_data_init(fs, new_ino)) {
+      char small_buf[40] = {};
+      ext2fs_inline_data_set(fs, new_ino, &inline_inode,
+                             small_buf, sizeof(small_buf));
+      size_t got = 0;
+      ext2fs_inline_data_size(fs, new_ino, &got);
+    }
+  }
+
+  // ---- Journal inode creation — drags in mkjournal.c writeback paths. ----
+  ext2fs_add_journal_inode2(fs, 8, 0, 0);
+
+  // ---- Misc write-side paths that don't need a specific inode. ----
+  ext2fs_create_orphan_file(fs, 4);
+  ext2fs_set_gdt_csum(fs);
+
+  // ---- Flush dirty bitmaps + superblock — drives close/csum write paths ----
+  ext2fs_flush(fs);
+
+  ext2fs_close(fs);
+  close(fd);
+  return 0;
+}


### PR DESCRIPTION
---

## Disclaimer
Investigation and work on this PR was primarily done by AI. I (Timothée Chauvin):

* verified that the improvement is real (see the automatically run [fuzzing coverage report](#fuzzing-coverage-report))
* briefly reviewed the full diff and commit/PR descriptions, but can't vouch for every detail.

Please let me know if you'd like a different level of verbosity or confidence in future PRs.

---

## Summary

This change improves coverage of the three existing libFuzzer harnesses and adds two new ones: a filesystem walker (read side) and a write-side harness exercising allocation, write-back, journal-inode creation, and metadata mutation.

According to [Fuzz Introspector](https://introspector.oss-fuzz.com/project-profile?project=e2fsprogs) the project currently sits at **10.99% line coverage (1,814 lines)**, with \`ext2fs_check_directory_fuzzer\` reported at 0%. The three existing harnesses ship without seed corpora, so libFuzzer starts from a zero-byte input and never gets past the superblock magic check in [\`ext2fs_open\`](https://github.com/tytso/e2fsprogs/blob/master/lib/ext2fs/openfs.c) within a typical CI run.

## What changes

### \`build.sh\` — bundle a per-harness seed corpus

Two seed sources, generated at build time so no binaries are checked in:

1. Decompress every [test image](https://github.com/tytso/e2fsprogs/tree/master/tests) with compressed size under 20 KB (yielding ~100 valid/corrupt filesystem images of 100 KB–1 MB). These are the regression inputs for e2fsck.
2. Generate fresh \`mke2fs\` images covering feature combinations the upstream test corpus underrepresents: \`64bit\`, \`mmp\`, \`casefold\`, \`bigalloc\`, \`encrypt\`, \`verity\`, \`fast_commit\`, \`project,quota\`, \`ea_inode\`, \`inline_data\`, \`orphan_file\`, \`metadata_csum\`, alternative block sizes, \`extra_isize\`, \`huge_file\`, etc.

Each candidate seed is replayed once through its target harness (3-second timeout) and only kept if the replay exits cleanly. A \`<harness>.options\` file is emitted alongside each fuzzer — including the three pre-existing ones — setting \`max_len = 1048576\`. libFuzzer's default 4 KB cap would otherwise discard every seed.

### \`fuzz/ext2fs_iterate_fuzzer.cc\` — new read-side walker

Mirrors the maintainer-authored [\`misc/check_fuzzer.c\`](https://github.com/tytso/e2fsprogs/blob/master/misc/check_fuzzer.c) approach but broadens it. After \`ext2fs_open\` + \`ext2fs_read_bitmaps\` + \`ext2fs_check_desc\`, it walks the root directory recursively, then the inode scan. For each entry: \`check_directory\`, \`read_inode\`, \`get_pathname\`, \`dirhash\`, \`lookup\`. For each inode: \`xattrs_open\`/\`xattrs_read\`/\`xattrs_iterate\`/\`xattr_get\`, then directory iteration, extent walking (\`extent_open\` + \`extent_get\` with multiple traversal ops), or \`block_iterate3\`, plus \`bmap2\` and \`file_read\`.

### \`fuzz/ext2fs_write_fuzzer.cc\` — new write-side harness

Opens the image \`EXT2_FLAG_RW\` and exercises allocation/write paths: \`new_block2\`/\`block_alloc_stats2\`, \`new_inode\`/\`write_new_inode\`/\`write_inode\`, \`link\`/\`unlink\`, \`mkdir\` + bulk link of 32 entries (htree split paths), \`xattr_set\`/\`xattrs_write\`/\`xattr_remove\`, \`punch\` (bounded and \`~0ULL\`), per-inode \`extent_set_bmap\`/\`extent_fix_parents\`/\`extent_node_split\`/\`extent_delete\`, \`bmap2\` with \`BMAP_ALLOC\`, \`expand_dir\`, \`init_dblist\` + \`add_dir_block2\` + \`dblist_iterate\`, \`create_icount2\` + \`icount_store\`/\`increment\`/\`decrement\`/\`fetch\`/\`validate\`, \`inline_data_init\` + \`inline_data_set\`, \`add_journal_inode2\`, \`create_orphan_file\`, \`set_gdt_csum\`, then \`ext2fs_flush\` + \`ext2fs_close\` to drive close-time superblock/bitmap/csum write paths in \`closefs.c\`, \`csum.c\`, \`rw_bitmaps.c\`.

---

<!-- fuzz-coverage-report -->

## Fuzzing Coverage Report

**Tested:** project `e2fsprogs` · base `d6faa1f` → head `87de67f` · 300s total fuzz budget · updated 2026-05-28 00:29 UTC · [workflow run](https://github.com/tc-agent/oss-fuzz/actions/runs/26546627238)

| Metric | Before | After | Delta |
|---|---|---|---|
| Static reachability | 19.8% (159/805) | 55.5% (548/987) | **+35.8%** |
| Line coverage | 2.8% (470/16510) | 40.8% (8295/20342) | **+1664.9%** |
| Branch coverage | 1.6% (123/7908) | 34.0% (3312/9739) | **+2592.7%** |
| Function coverage | 3.8% (31/811) | 43.8% (435/994) | **+1303.2%** |

### Per-harness

| Harness | Lines before | Lines after | Δ |
|---|---|---|---|
| `ext2fs_check_directory_fuzzer` | 0.0% (0/16124) | 6.6% (1069/16124) | **new** |
| `ext2fs_image_read_write_fuzzer` | 2.7% (446/16471) | 10.6% (1739/16471) | **+289.9%** |
| `ext2fs_iterate_fuzzer` | 0% | 24.5% (4025/16406) | **new** |
| `ext2fs_read_bitmap_fuzzer` | 2.7% (442/16146) | 9.8% (1577/16146) | **+256.8%** |
| `ext2fs_write_fuzzer` | 0% | 36.5% (7156/19623) | **new** |

<sub>Δ = (after − before) / before, to accommodate that denominators may change. "new" when before is 0; "deleted" when after is 0.</sub>
