### PR TITLE
sound-open-firmware: Update project CCs

### DIFF
--- a/projects/sound-open-firmware/project.yaml
+++ b/projects/sound-open-firmware/project.yaml
@@ -3,13 +3,13 @@ primary_contact: "johnylin@google.com"
 language: c
 auto_ccs:
   - "andyross@google.com"
-  - "ranjani.sridharan@intel.corp-partner.google.com"
   - "lgirdwood@gmail.com"
   - "sathyanarayana.nujella@intel.corp-partner.google.com"
   - "adrian.bonislawski@intel.com"
   - "jyri.sarha@intel.com"
   - "rander.wang@intel.com"
-  - "flavio.ceolin@intel.com"
+  - "tomasz.m.leman@intel.com"
+  - "kai.vehmanen@linux.intel.com"
 fuzzing_engines:
   - libfuzzer
 sanitizers:


### PR DESCRIPTION
Update list of project CCs by removing ex Intel workers and adding 2 active project members.