### PR TITLE
minizip: fix build

### DIFF
--- a/projects/minizip/build.sh
+++ b/projects/minizip/build.sh
@@ -22,6 +22,11 @@ if [ "$ARCHITECTURE" = 'i386' ]; then
   rm /usr/lib/i386-linux-gnu/libz.so*
   rm /usr/lib/i386-linux-gnu/libbz2.so*
   rm /usr/lib/i386-linux-gnu/liblzma.so*
+  # Also remove the x86_64 libssl/libcrypto libraries so CMake/ld don't pick
+  # them up for i386 builds (other libs like libz.so.1 must stay since clang
+  # depends on them at runtime).
+  rm -f /usr/lib/x86_64-linux-gnu/libssl.so /usr/lib/x86_64-linux-gnu/libssl.a
+  rm -f /usr/lib/x86_64-linux-gnu/libcrypto.so /usr/lib/x86_64-linux-gnu/libcrypto.a
 fi
 
 # Build project


### PR DESCRIPTION
Remove x86_64 libssl and libcrypto libraries to prevent conflicts during i386 builds.