### PR TITLE
elfutils: add fuzz-dwarf-expressions harness for DWARF location/srcline parsing

### DIFF
--- a/projects/elfutils/build.sh
+++ b/projects/elfutils/build.sh
@@ -155,3 +155,11 @@ $CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz-libdwfl.o \
 	./libasm/libasm.a ./libebl/libebl.a ./backends/libebl_backends.a ./libcpu/libcpu.a \
   ./libdw/libdw.a ./libelf/libelf.a ./lib/libeu.a "$zlib" \
 	-o "$OUT/fuzz-libdwfl"
+
+$CC $CFLAGS \
+  -D_GNU_SOURCE -DHAVE_CONFIG_H \
+  -I. -I./lib -I./libelf -I./libebl -I./libdw -I./libdwelf -I./libdwfl -I./libasm \
+  -c "$SRC/fuzz-dwarf-expressions.c" -o fuzz-dwarf-expressions.o
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz-dwarf-expressions.o \
+	./libdw/libdw.a ./libelf/libelf.a ./lib/libeu.a "$zlib" \
+	-o "$OUT/fuzz-dwarf-expressions"

--- a/projects/elfutils/fuzz-dwarf-expressions.c
+++ b/projects/elfutils/fuzz-dwarf-expressions.c
@@ -1,0 +1,156 @@
+/* Copyright 2024 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/* Fuzz harness for DWARF expression/location and source-line parsing in libdw.
+ *
+ * Coverage targets not reached by existing fuzzers:
+ *   - dwarf_getlocation() / dwarf_getlocations()
+ *                              (DW_AT_location / DW_AT_frame_base expressions)
+ *   - dwarf_getsrclines()      (source-line information table)
+ *   - dwarf_getabbrev() /
+ *     dwarf_getabbrevattr_data() (abbreviation table traversal)
+ *
+ * fuzz-libelf.c covers ELF structure; fuzz-libdwfl.c covers coredump /
+ * module-level DWARF via Dwfl; fuzz-dwfl-core.c covers core-file attachment.
+ * None of them walk CU DIEs and exercise the above libdw APIs directly.
+ */
+
+#include <assert.h>
+#include <dwarf.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "elfutils/libdw.h"
+#include "system.h"
+
+
+/* Walk the abbreviation table entries for the given DIE. */
+static void
+fuzz_abbrev (Dwarf_Die *die)
+{
+  Dwarf_Abbrev *abbrev = dwarf_getabbrev (die, 0, NULL);
+  if (abbrev == NULL || abbrev == DWARF_END_ABBREV)
+    return;
+
+  for (size_t idx = 0; ; idx++)
+    {
+      unsigned int attr_name = 0;
+      unsigned int form = 0;
+      Dwarf_Sword impl = 0;
+      if (dwarf_getabbrevattr_data (abbrev, idx, &attr_name, &form,
+                                   &impl, NULL) != 0)
+        break;
+    }
+}
+
+
+/* Probe location-expression attributes on a single DIE. */
+static void
+fuzz_locations (Dwarf_Die *die)
+{
+  static const unsigned int loc_attrs[] = {
+    DW_AT_location,
+    DW_AT_frame_base,
+    DW_AT_data_member_location,
+    DW_AT_vtable_elem_location,
+    DW_AT_use_location,
+    DW_AT_string_length,
+    DW_AT_return_addr,
+    DW_AT_static_link,
+  };
+
+  for (size_t i = 0; i < sizeof (loc_attrs) / sizeof (loc_attrs[0]); i++)
+    {
+      Dwarf_Attribute attr;
+      if (dwarf_attr (die, loc_attrs[i], &attr) == NULL)
+        continue;
+
+      /* Single-expression form. */
+      Dwarf_Op *ops = NULL;
+      size_t nops = 0;
+      dwarf_getlocation (&attr, &ops, &nops);
+
+      /* Location-list form (range list of expressions). */
+      ptrdiff_t offset = 0;
+      Dwarf_Addr base = 0, start = 0, end = 0;
+      Dwarf_Op *rl_ops = NULL;
+      size_t rl_nops = 0;
+      while ((offset = dwarf_getlocations (&attr, offset, &base,
+                                           &start, &end,
+                                           &rl_ops, &rl_nops)) > 0)
+        ;
+    }
+}
+
+
+/* Exercise all target APIs on a CU root DIE. */
+static void
+fuzz_die (Dwarf_Die *die)
+{
+  fuzz_abbrev (die);
+  fuzz_locations (die);
+
+  /* Source-line table. */
+  Dwarf_Lines *lines = NULL;
+  size_t nlines = 0;
+  dwarf_getsrclines (die, &lines, &nlines);
+}
+
+
+int
+LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
+{
+  if (size < 4)
+    return 0;
+
+  char filename[] = "/tmp/fuzz-dwarf-expressions.XXXXXX";
+  int fd = mkstemp (filename);
+  assert (fd >= 0);
+
+  ssize_t n = write_retry (fd, data, size);
+  assert (n == (ssize_t) size);
+
+  /* dwarf_begin reads via the fd; rewind so it starts at byte 0. */
+  lseek (fd, 0, SEEK_SET);
+
+  Dwarf *dbg = dwarf_begin (fd, DWARF_C_READ);
+  if (dbg == NULL)
+    goto cleanup;
+
+  Dwarf_Off off = 0;
+  Dwarf_Off next_off = 0;
+  size_t hdr_size = 0;
+
+  while (dwarf_nextcu (dbg, off, &next_off, &hdr_size,
+                       NULL, NULL, NULL) == 0)
+    {
+      Dwarf_Die die;
+      if (dwarf_offdie (dbg, off + hdr_size, &die) != NULL)
+        fuzz_die (&die);
+
+      if (next_off == 0)
+        break;
+      off = next_off;
+    }
+
+  dwarf_end (dbg);
+
+cleanup:
+  close (fd);
+  unlink (filename);
+  return 0;
+}


### PR DESCRIPTION
## Summary

This PR adds a new fuzz target, `fuzz-dwarf-expressions`, to the `projects/elfutils` directory of OSS-Fuzz. It exercises libdw APIs that are not covered by any of the three existing elfutils fuzz targets.

## Coverage gap

| Existing fuzzer | What it covers |
|---|---|
| `fuzz-libelf` | ELF structure (sections, symbols, compression via `elf_begin` / `gelf_getshdr`) |
| `fuzz-libdwfl` | Module-level DWARF loading via `Dwfl` (`dwfl_report_offline` / `dwfl_module_getdwarf`) |
| `fuzz-dwfl-core` | Core-file coredump attachment via `Dwfl` |

None of them walk CU DIEs and call the raw libdw expression/line APIs directly:

- **`dwarf_getlocation()` / `dwarf_getlocations()`** – decode `DW_AT_location`, `DW_AT_frame_base`, and other location-expression attributes, including range-list forms that iterate over multiple address ranges.
- **`dwarf_getsrclines()`** – parse the `.debug_line` source-line table for each compilation unit.
- **`dwarf_getabbrev()` / `dwarf_getabbrevattr_data()`** – traverse the `.debug_abbrev` abbreviation table entries and their attributes.

These are complex parsers that consume attacker-controlled byte streams from DWARF sections and are good fuzzing targets for memory-safety bugs.

## Harness design

The harness follows the existing elfutils conventions exactly:

- `mkstemp` + `write_retry` (from `system.h`) to materialise fuzz input as a file
- `dwarf_begin(fd, DWARF_C_READ)` to open the file as a DWARF object
- `dwarf_nextcu` loop to walk all compilation units
- For each CU root DIE: call `fuzz_abbrev`, `fuzz_locations`, and `dwarf_getsrclines`
- Compiles with `-D_GNU_SOURCE -DHAVE_CONFIG_H` and the standard elfutils `-I` include paths
- Links against `libdw`, `libelf`, and `libeu` (same minimal set as `fuzz-dwfl-core`)
- Clean compile under `-Werror -Wall -Wextra`

## Files changed

- `projects/elfutils/fuzz-dwarf-expressions.c` – new fuzz harness
- `projects/elfutils/build.sh` – add compilation and linking step for the new target