### PR TITLE
structalign: Add structalign Go project

### DIFF
--- a/projects/structalign/Dockerfile
+++ b/projects/structalign/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/peczenyj/structalign structalign
+COPY build.sh $SRC/
+WORKDIR $SRC/structalign

--- a/projects/structalign/build.sh
+++ b/projects/structalign/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Compile FuzzMatchAny and FuzzSplitCSV in internal/match package
+compile_go_fuzzer github.com/peczenyj/structalign/internal/match FuzzMatchAny fuzz_match_any
+compile_go_fuzzer github.com/peczenyj/structalign/internal/match FuzzSplitCSV fuzz_split_csv
+
+# Compile FuzzTruncPad in internal/ui package
+compile_go_fuzzer github.com/peczenyj/structalign/internal/ui FuzzTruncPad fuzz_trunc_pad

--- a/projects/structalign/project.yaml
+++ b/projects/structalign/project.yaml
@@ -1,0 +1,4 @@
+homepage: "https://github.com/peczenyj/structalign"
+language: go
+primary_contact: "tpeczenyj@weborama.com"
+main_repo: "https://github.com/peczenyj/structalign"

--- a/projects/structalign/project.yaml
+++ b/projects/structalign/project.yaml
@@ -1,4 +1,4 @@
 homepage: "https://github.com/peczenyj/structalign"
 language: go
-primary_contact: "tpeczenyj@weborama.com"
+primary_contact: "tiago.peczenyj+structalign@weborama.com"
 main_repo: "https://github.com/peczenyj/structalign"


### PR DESCRIPTION
This pull request registers the `structalign` Go project with OSS-Fuzz's continuous fuzzing infrastructure.

### Project Details:
- **Repository**: https://github.com/peczenyj/structalign
- **Language**: Go
- **Fuzz Targets**:
  - `fuzz_match_any` (wildcard and glob pattern matching)
  - `fuzz_split_csv` (comma-separated parsing)
  - `fuzz_trunc_pad` (CJK character visual truncation and padding alignment)

All fuzz targets have been tested locally and run without issue.