### PR TITLE
evalbox: initial integration

### DIFF
--- a/projects/evalbox/Dockerfile
+++ b/projects/evalbox/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/evalbox/Dockerfile
+++ b/projects/evalbox/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+
+RUN git clone --depth 1 https://github.com/fullzer4/evalbox evalbox
+WORKDIR $SRC/evalbox
+
+COPY build.sh $SRC/

--- a/projects/evalbox/build.sh
+++ b/projects/evalbox/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/evalbox/build.sh
+++ b/projects/evalbox/build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -eu
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC/evalbox
+
+if [ "$SANITIZER" = "coverage" ]; then
+    export RUSTFLAGS="$RUSTFLAGS -C debug-assertions=no"
+    export CFLAGS=""
+fi
+
+cargo fuzz build -O --debug-assertions
+
+FUZZ_TARGET_OUTPUT_DIR=fuzz/target/x86_64-unknown-linux-gnu/release
+for f in fuzz/fuzz_targets/*.rs; do
+    FUZZ_TARGET_NAME=$(basename ${f%.*})
+    cp $FUZZ_TARGET_OUTPUT_DIR/$FUZZ_TARGET_NAME $OUT/
+done

--- a/projects/evalbox/project.yaml
+++ b/projects/evalbox/project.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/evalbox/project.yaml
+++ b/projects/evalbox/project.yaml
@@ -1,0 +1,22 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+homepage: "https://github.com/fullzer4/evalbox"
+main_repo: "https://github.com/fullzer4/evalbox"
+primary_contact: "gabrielpelizzaro@gmail.com"
+language: rust
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer


### PR DESCRIPTION
evalbox is a secure sandbox library for executing untrusted code (Python, Go, Shell) using Landlock v5, seccomp-BPF, and rlimits no containers, no VMs, no root required.

Fuzz target covers BPF filter generation for the seccomp syscall whitelist.