### PR TITLE
Add protobuf-cpp: C++ runtime fuzzer for packed field integer overflow

### DIFF
--- a/projects/protobuf-cpp/Dockerfile
+++ b/projects/protobuf-cpp/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2026 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/protobuf-cpp/Dockerfile
+++ b/projects/protobuf-cpp/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN apt-get update && apt-get install -y cmake ninja-build python3
+
+RUN git clone --depth=1 https://github.com/protocolbuffers/protobuf.git
+
+COPY build.sh fuzz_packed_field_overflow.cc $SRC/

--- a/projects/protobuf-cpp/build.sh
+++ b/projects/protobuf-cpp/build.sh
@@ -53,3 +53,5 @@ echo -ne '\x0a\x04\x01\x02\x03\x04' > \
 
 zip -j $OUT/fuzz_packed_field_overflow_seed_corpus.zip \
   $OUT/fuzz_packed_field_overflow_seed_corpus/seed1
+//
+////////////////////////////////////////////////////////////////////////////////

--- a/projects/protobuf-cpp/build.sh
+++ b/projects/protobuf-cpp/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2026 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/protobuf-cpp/build.sh
+++ b/projects/protobuf-cpp/build.sh
@@ -1,0 +1,55 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC/protobuf
+
+# Build protobuf C++ with cmake + ASan/UBSan as configured by OSS-Fuzz
+cmake -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_C_COMPILER=$CC \
+  -DCMAKE_CXX_COMPILER=$CXX \
+  -DCMAKE_C_FLAGS="$CFLAGS" \
+  -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+  -Dprotobuf_BUILD_TESTS=OFF \
+  -Dprotobuf_BUILD_EXAMPLES=OFF \
+  -DBUILD_SHARED_LIBS=OFF \
+  -S . -B build
+
+cmake --build build --target protobuf --parallel $(nproc)
+
+PROTOBUF_LIB=$SRC/protobuf/build
+PROTOBUF_INC=$SRC/protobuf/src
+
+# Compile the fuzz target
+$CXX $CXXFLAGS \
+  -I$PROTOBUF_INC \
+  -std=c++17 \
+  $SRC/fuzz_packed_field_overflow.cc \
+  -o $OUT/fuzz_packed_field_overflow \
+  $LIB_FUZZING_ENGINE \
+  $PROTOBUF_LIB/libprotobuf.a \
+  -lpthread
+
+# Minimal seed corpus: a valid packed int32 field (field 1, varint-encoded)
+# Wire type 2 (length-delimited) = field 1 << 3 | 2 = 0x0a
+# Length = 4, values = 01 02 03 04
+mkdir -p $OUT/fuzz_packed_field_overflow_seed_corpus
+echo -ne '\x0a\x04\x01\x02\x03\x04' > \
+  $OUT/fuzz_packed_field_overflow_seed_corpus/seed1
+
+zip -j $OUT/fuzz_packed_field_overflow_seed_corpus.zip \
+  $OUT/fuzz_packed_field_overflow_seed_corpus/seed1

--- a/projects/protobuf-cpp/fuzz_packed_field_overflow.cc
+++ b/projects/protobuf-cpp/fuzz_packed_field_overflow.cc
@@ -1,4 +1,4 @@
-// Copyright 2026 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/protobuf-cpp/fuzz_packed_field_overflow.cc
+++ b/projects/protobuf-cpp/fuzz_packed_field_overflow.cc
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
 
 #include <cstdint>
 #include <cstring>

--- a/projects/protobuf-cpp/fuzz_packed_field_overflow.cc
+++ b/projects/protobuf-cpp/fuzz_packed_field_overflow.cc
@@ -1,10 +1,16 @@
 // Copyright 2026 Google LLC
 //
-// Fuzz target for signed integer overflow in ReadPackedFixed /
-// ReadPackedVarintArrayWithField (CVE candidate — parse_context.h).
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Triggers the overflow by feeding a crafted packed repeated field
-// to Message::ParseFromArray via a message that contains a packed int32 field.
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <cstdint>
 #include <cstring>
@@ -13,10 +19,6 @@
 #include "google/protobuf/descriptor.h"
 #include "google/protobuf/dynamic_message.h"
 #include "google/protobuf/descriptor.pb.h"
-
-// We use a FileDescriptorProto to dynamically define a message with a
-// packed repeated int32 field, then parse fuzzer input as that message.
-// This exercises ReadPackedFixed / ReadPackedVarintArrayWithField directly.
 
 static google::protobuf::DescriptorPool* pool = nullptr;
 static google::protobuf::DynamicMessageFactory* factory = nullptr;
@@ -30,33 +32,26 @@ static void Init() {
   auto* msg = file.add_message_type();
   msg->set_name("FuzzMsg");
 
-  // packed repeated int32 — exercises ReadPackedVarintArrayWithField
   auto* f1 = msg->add_field();
   f1->set_name("packed_int32");
   f1->set_number(1);
   f1->set_type(google::protobuf::FieldDescriptorProto::TYPE_INT32);
   f1->set_label(google::protobuf::FieldDescriptorProto::LABEL_REPEATED);
-  f1->set_options_json_name("packed_int32");
-  auto* opts = f1->mutable_options();
-  opts->set_packed(true);
+  f1->mutable_options()->set_packed(true);
 
-  // packed repeated fixed32 — exercises ReadPackedFixed<uint32_t>
   auto* f2 = msg->add_field();
   f2->set_name("packed_fixed32");
   f2->set_number(2);
   f2->set_type(google::protobuf::FieldDescriptorProto::TYPE_FIXED32);
   f2->set_label(google::protobuf::FieldDescriptorProto::LABEL_REPEATED);
-  auto* opts2 = f2->mutable_options();
-  opts2->set_packed(true);
+  f2->mutable_options()->set_packed(true);
 
-  // packed repeated bool — exercises ReadPackedVarintArrayWithField<bool>
   auto* f3 = msg->add_field();
   f3->set_name("packed_bool");
   f3->set_number(3);
   f3->set_type(google::protobuf::FieldDescriptorProto::TYPE_BOOL);
   f3->set_label(google::protobuf::FieldDescriptorProto::LABEL_REPEATED);
-  auto* opts3 = f3->mutable_options();
-  opts3->set_packed(true);
+  f3->mutable_options()->set_packed(true);
 
   pool = new google::protobuf::DescriptorPool();
   pool->BuildFile(file);
@@ -70,17 +65,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     Init();
     initialized = true;
   }
-
   if (msg_desc == nullptr) return 0;
-
   const google::protobuf::Message* prototype = factory->GetPrototype(msg_desc);
   if (!prototype) return 0;
-
   google::protobuf::Message* msg = prototype->New();
-  // ParseFromArray calls EpsCopyInputStream which routes through
-  // ReadPackedFixed / ReadPackedVarintArrayWithField — the vulnerable paths.
   msg->ParseFromArray(data, static_cast<int>(size));
   delete msg;
-
   return 0;
 }

--- a/projects/protobuf-cpp/fuzz_packed_field_overflow.cc
+++ b/projects/protobuf-cpp/fuzz_packed_field_overflow.cc
@@ -1,0 +1,86 @@
+// Copyright 2026 Google LLC
+//
+// Fuzz target for signed integer overflow in ReadPackedFixed /
+// ReadPackedVarintArrayWithField (CVE candidate — parse_context.h).
+//
+// Triggers the overflow by feeding a crafted packed repeated field
+// to Message::ParseFromArray via a message that contains a packed int32 field.
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+#include "google/protobuf/descriptor.h"
+#include "google/protobuf/dynamic_message.h"
+#include "google/protobuf/descriptor.pb.h"
+
+// We use a FileDescriptorProto to dynamically define a message with a
+// packed repeated int32 field, then parse fuzzer input as that message.
+// This exercises ReadPackedFixed / ReadPackedVarintArrayWithField directly.
+
+static google::protobuf::DescriptorPool* pool = nullptr;
+static google::protobuf::DynamicMessageFactory* factory = nullptr;
+static const google::protobuf::Descriptor* msg_desc = nullptr;
+
+static void Init() {
+  google::protobuf::FileDescriptorProto file;
+  file.set_name("fuzz.proto");
+  file.set_syntax("proto2");
+
+  auto* msg = file.add_message_type();
+  msg->set_name("FuzzMsg");
+
+  // packed repeated int32 — exercises ReadPackedVarintArrayWithField
+  auto* f1 = msg->add_field();
+  f1->set_name("packed_int32");
+  f1->set_number(1);
+  f1->set_type(google::protobuf::FieldDescriptorProto::TYPE_INT32);
+  f1->set_label(google::protobuf::FieldDescriptorProto::LABEL_REPEATED);
+  f1->set_options_json_name("packed_int32");
+  auto* opts = f1->mutable_options();
+  opts->set_packed(true);
+
+  // packed repeated fixed32 — exercises ReadPackedFixed<uint32_t>
+  auto* f2 = msg->add_field();
+  f2->set_name("packed_fixed32");
+  f2->set_number(2);
+  f2->set_type(google::protobuf::FieldDescriptorProto::TYPE_FIXED32);
+  f2->set_label(google::protobuf::FieldDescriptorProto::LABEL_REPEATED);
+  auto* opts2 = f2->mutable_options();
+  opts2->set_packed(true);
+
+  // packed repeated bool — exercises ReadPackedVarintArrayWithField<bool>
+  auto* f3 = msg->add_field();
+  f3->set_name("packed_bool");
+  f3->set_number(3);
+  f3->set_type(google::protobuf::FieldDescriptorProto::TYPE_BOOL);
+  f3->set_label(google::protobuf::FieldDescriptorProto::LABEL_REPEATED);
+  auto* opts3 = f3->mutable_options();
+  opts3->set_packed(true);
+
+  pool = new google::protobuf::DescriptorPool();
+  pool->BuildFile(file);
+  msg_desc = pool->FindMessageTypeByName("FuzzMsg");
+  factory = new google::protobuf::DynamicMessageFactory(pool);
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  static bool initialized = false;
+  if (!initialized) {
+    Init();
+    initialized = true;
+  }
+
+  if (msg_desc == nullptr) return 0;
+
+  const google::protobuf::Message* prototype = factory->GetPrototype(msg_desc);
+  if (!prototype) return 0;
+
+  google::protobuf::Message* msg = prototype->New();
+  // ParseFromArray calls EpsCopyInputStream which routes through
+  // ReadPackedFixed / ReadPackedVarintArrayWithField — the vulnerable paths.
+  msg->ParseFromArray(data, static_cast<int>(size));
+  delete msg;
+
+  return 0;
+}

--- a/projects/protobuf-cpp/project.yaml
+++ b/projects/protobuf-cpp/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://github.com/protocolbuffers/protobuf"
+language: c++
+primary_contact: "cloudflare.ddos21@gmail.com"
+sanitizers:
+  - address
+  - undefined
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+auto_ccs:
+  - "cloudflare.ddos21@gmail.com"

--- a/projects/protobuf-cpp/project.yaml
+++ b/projects/protobuf-cpp/project.yaml
@@ -1,4 +1,5 @@
 homepage: "https://github.com/protocolbuffers/protobuf"
+main_repo: "https://github.com/protocolbuffers/protobuf"
 language: c++
 primary_contact: "cloudflare.ddos21@gmail.com"
 sanitizers:


### PR DESCRIPTION
## Summary

Adds a new OSS-Fuzz project `protobuf-cpp` targeting the C++ runtime of
[Protocol Buffers](https://github.com/protocolbuffers/protobuf).

## Fuzz target

`fuzz_packed_field_overflow` exercises `ReadPackedFixed` and
`ReadPackedVarintArrayWithField` in `src/google/protobuf/parse_context.h`
via `Message::ParseFromArray` with packed repeated fields (int32, fixed32, bool).

These functions contain signed integer overflow vulnerabilities where
`old_entries + num` / `out.size() + count` can wrap to a negative value,
causing `ReserveWithArena` to skip `Grow()` and `AddNAlreadyReserved` to
write beyond the allocated buffer.

## Related

- Fix PR (open): https://github.com/protocolbuffers/protobuf/pull/27611
- Security report: https://issuetracker.google.com/issues/518018345