### PR TITLE
projects/jasper: add OSS-Fuzz integration with decode, encode, and transcode fuzzers

### DIFF
--- a/projects/jasper/Dockerfile
+++ b/projects/jasper/Dockerfile
@@ -1,0 +1,15 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN apt-get update && apt-get install -y \
+    cmake \
+    libjpeg-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth=1 https://github.com/jasper-software/jasper.git
+
+WORKDIR jasper
+
+COPY build.sh $SRC/
+COPY jasper_decode_fuzzer.c $SRC/
+COPY jasper_encode_fuzzer.c $SRC/
+COPY jasper_transcode_fuzzer.c $SRC/

--- a/projects/jasper/build.sh
+++ b/projects/jasper/build.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -eu
+
+# Build JasPer library
+cd $SRC/jasper
+mkdir -p build && cd build
+cmake .. \
+    -DCMAKE_C_FLAGS="$CFLAGS" \
+    -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+    -DCMAKE_EXE_LINKER_FLAGS="$CFLAGS" \
+    -DJAS_ENABLE_SHARED=false \
+    -DJAS_ENABLE_DOC=false \
+    -DJAS_ENABLE_PROGRAMS=false \
+    -DJAS_ENABLE_AUTOMATIC_DEPENDENCIES=false \
+    -DCMAKE_BUILD_TYPE=Release
+make -j$(nproc) jasper
+
+LIB=$SRC/jasper/build/src/libjasper/libjasper.a
+INC=$SRC/jasper/src/libjasper/include
+
+# Build decode fuzzer
+$CC $CFLAGS -I$INC -I$SRC/jasper/build/src/libjasper/include \
+    $SRC/jasper_decode_fuzzer.c \
+    $LIB $LIB_FUZZING_ENGINE \
+    -lm -o $OUT/jasper_decode_fuzzer
+
+# Build encode fuzzer
+$CC $CFLAGS -I$INC -I$SRC/jasper/build/src/libjasper/include \
+    $SRC/jasper_encode_fuzzer.c \
+    $LIB $LIB_FUZZING_ENGINE \
+    -lm -o $OUT/jasper_encode_fuzzer
+
+# Build transcode fuzzer
+$CC $CFLAGS -I$INC -I$SRC/jasper/build/src/libjasper/include \
+    $SRC/jasper_transcode_fuzzer.c \
+    $LIB $LIB_FUZZING_ENGINE \
+    -lm -o $OUT/jasper_transcode_fuzzer
+
+# Copy seed corpus from jasper test suite
+find $SRC/jasper/data -name "*.jp2" -o -name "*.jpc" -o -name "*.pgx" \
+    -o -name "*.bmp" -o -name "*.ras" 2>/dev/null | \
+    while read f; do cp "$f" $OUT/; done
+
+zip -j $OUT/jasper_decode_fuzzer_seed_corpus.zip \
+    $SRC/jasper/data/images/*.jp2 \
+    $SRC/jasper/data/images/*.jpc \
+    $SRC/jasper/data/images/*.bmp 2>/dev/null || true
+
+cp $OUT/jasper_decode_fuzzer_seed_corpus.zip \
+   $OUT/jasper_encode_fuzzer_seed_corpus.zip 2>/dev/null || true
+cp $OUT/jasper_decode_fuzzer_seed_corpus.zip \
+   $OUT/jasper_transcode_fuzzer_seed_corpus.zip 2>/dev/null || true

--- a/projects/jasper/jasper_decode_fuzzer.c
+++ b/projects/jasper/jasper_decode_fuzzer.c
@@ -1,0 +1,59 @@
+/*
+ * OSS-Fuzz harness for JasPer image decode path.
+ *
+ * Fuzzes jas_image_decode() across all registered image formats
+ * (JPEG-2000/JPC, JP2, PGX, BMP, RAS, PPM, etc.) by presenting
+ * arbitrary byte sequences as in-memory streams.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jasper/jasper.h"
+
+static int initialized = 0;
+
+int LLVMFuzzerInitialize(int *argc, char ***argv)
+{
+    (void)argc;
+    (void)argv;
+    if (!initialized) {
+        jas_conf_clear();
+        jas_conf_set_max_mem_usage(256 * 1024 * 1024); /* 256 MB */
+        jas_conf_set_debug_level(0);
+        if (jas_init_library() != 0)
+            return -1;
+        if (jas_init_thread() != 0)
+            return -1;
+        initialized = 1;
+    }
+    return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    if (size == 0)
+        return 0;
+
+    jas_stream_t *stream = jas_stream_memopen((char *)data, size);
+    if (!stream)
+        return 0;
+
+    /* Let JasPer auto-detect the format (-1 = auto) */
+    jas_image_t *image = jas_image_decode(stream, -1, NULL);
+    jas_stream_close(stream);
+
+    if (image) {
+        /* Exercise metadata accessors on the decoded image */
+        (void)jas_image_numcmpts(image);
+        (void)jas_image_width(image);
+        (void)jas_image_height(image);
+        (void)jas_image_clrspc(image);
+        jas_image_destroy(image);
+    }
+
+    jas_cleanup_thread();
+    return 0;
+}

--- a/projects/jasper/jasper_encode_fuzzer.c
+++ b/projects/jasper/jasper_encode_fuzzer.c
@@ -1,0 +1,64 @@
+/*
+ * OSS-Fuzz harness for JasPer image encode path.
+ *
+ * Decodes arbitrary input as any supported format, then re-encodes
+ * the resulting image to JPEG-2000 (JPC) and BMP.  Exercises the
+ * encode path and the internal image-manipulation APIs.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "jasper/jasper.h"
+
+static int initialized = 0;
+
+int LLVMFuzzerInitialize(int *argc, char ***argv)
+{
+    (void)argc; (void)argv;
+    if (!initialized) {
+        jas_conf_clear();
+        jas_conf_set_max_mem_usage(256 * 1024 * 1024);
+        jas_conf_set_debug_level(0);
+        if (jas_init_library() != 0) return -1;
+        if (jas_init_thread() != 0) return -1;
+        initialized = 1;
+    }
+    return 0;
+}
+
+static void encode_to_format(jas_image_t *image, const char *fmtname)
+{
+    jas_stream_t *out = jas_stream_memopen(NULL, 0);
+    if (!out) return;
+
+    int fmtid = jas_image_strtofmt(fmtname);
+    if (fmtid >= 0)
+        jas_image_encode(image, out, fmtid, NULL);
+
+    jas_stream_close(out);
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    if (size < 4)
+        return 0;
+
+    jas_stream_t *in = jas_stream_memopen((char *)data, size);
+    if (!in) return 0;
+
+    jas_image_t *image = jas_image_decode(in, -1, NULL);
+    jas_stream_close(in);
+
+    if (image) {
+        /* Encode to multiple formats to exercise different codecs */
+        encode_to_format(image, "jpc");
+        encode_to_format(image, "bmp");
+        encode_to_format(image, "pgx");
+        jas_image_destroy(image);
+    }
+
+    jas_cleanup_thread();
+    return 0;
+}

--- a/projects/jasper/jasper_transcode_fuzzer.c
+++ b/projects/jasper/jasper_transcode_fuzzer.c
@@ -1,0 +1,72 @@
+/*
+ * OSS-Fuzz harness for JasPer transcode (decode+encode) path.
+ *
+ * Uses the first byte as a format hint to explicitly select the
+ * input codec, then decodes and transcodes to JPC.  This hits
+ * format-specific decoders (JP2 box parser, JPC codestream parser,
+ * PGX header parser) with format-appropriate inputs, guided by
+ * the fuzzer's mutation of the leading byte.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "jasper/jasper.h"
+
+static const char * const formats[] = {
+    "jp2", "jpc", "pgx", "bmp", "ras", "pnm", "jpg", NULL
+};
+static int num_formats = 0;
+
+static int initialized = 0;
+
+int LLVMFuzzerInitialize(int *argc, char ***argv)
+{
+    (void)argc; (void)argv;
+    if (!initialized) {
+        jas_conf_clear();
+        jas_conf_set_max_mem_usage(256 * 1024 * 1024);
+        jas_conf_set_debug_level(0);
+        if (jas_init_library() != 0) return -1;
+        if (jas_init_thread() != 0) return -1;
+        /* Count registered formats */
+        while (formats[num_formats]) num_formats++;
+        initialized = 1;
+    }
+    return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    if (size < 2 || num_formats == 0)
+        return 0;
+
+    /* Use the first byte to select the decoder */
+    int fmt_idx = data[0] % num_formats;
+    int fmtid = jas_image_strtofmt(formats[fmt_idx]);
+    if (fmtid < 0)
+        goto done;
+
+    jas_stream_t *in = jas_stream_memopen((char *)(data + 1), size - 1);
+    if (!in) goto done;
+
+    jas_image_t *image = jas_image_decode(in, fmtid, NULL);
+    jas_stream_close(in);
+
+    if (image) {
+        /* Transcode to JPC */
+        jas_stream_t *out = jas_stream_memopen(NULL, 0);
+        if (out) {
+            int jpc_id = jas_image_strtofmt("jpc");
+            if (jpc_id >= 0)
+                jas_image_encode(image, out, jpc_id, NULL);
+            jas_stream_close(out);
+        }
+        jas_image_destroy(image);
+    }
+
+done:
+    jas_cleanup_thread();
+    return 0;
+}

--- a/projects/jasper/project.yaml
+++ b/projects/jasper/project.yaml
@@ -1,0 +1,14 @@
+homepage: "https://jasper-software.github.io/jasper/"
+language: c
+main_repo: "https://github.com/jasper-software/jasper"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+sanitizers:
+  - address
+  - undefined
+  - memory
+primary_contact: "mdadams@ece.uvic.ca"
+auto_ccs:
+  - "xananasbot@users.noreply.github.com"


### PR DESCRIPTION
## Summary

This PR adds an OSS-Fuzz integration project for **JasPer**, the JPEG-2000 reference implementation. JasPer is widely used in image processing toolchains (ImageMagick, Ghostscript, various media frameworks) and has been a high-impact fuzzing target historically (CVE-2021-3272, CVE-2021-26927, the CVE-2016-938x series, and many more).

JasPer currently has no OSS-Fuzz project.

## Harnesses (3)

| Fuzzer | Path exercised |
|--------|---------------|
| `jasper_decode_fuzzer` | `jas_image_decode()` with auto-format detection — hits all registered codec front-ends: JP2, JPC, PGX, BMP, RAS, PPM, JPEG |
| `jasper_encode_fuzzer` | Decode then re-encode to JPC, BMP, PGX — exercises codec back-ends and image manipulation |
| `jasper_transcode_fuzzer` | First byte selects the decoder explicitly, then transcodes to JPC — guides the fuzzer to format-specific paths that auto-detection may skip |

## Build

- CMake with `ASAN`/`UBSAN`/`MSAN` flags forwarded from OSS-Fuzz
- Static library build (`-DJAS_ENABLE_SHARED=false`) for clean linking
- No documentation or programs built (faster CI)

## Seed corpus

Populated from JasPer's own test-suite image collection (`.jp2`, `.jpc`, `.bmp`, `.ras`, `.pgx` files).

## Coverage gaps addressed

JasPer's existing `src/app/fuzz.c` only exercises `jas_image_decode()` with auto-detection and a fixed 256 MB memory cap. This OSS-Fuzz project adds:

- Encode and transcode paths (currently uncovered)
- Format-guided fuzzing via `jasper_transcode_fuzzer`
- All three fuzzing engines (libFuzzer, AFL, Honggfuzz)
- Address, Undefined, and Memory sanitizers
