### PR TITLE
projects/libuv: add OSS-Fuzz integration for IDNA encoder and URL parser

### DIFF
--- a/projects/libuv/Dockerfile
+++ b/projects/libuv/Dockerfile
@@ -1,0 +1,14 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/projects/libuv/build.sh
+++ b/projects/libuv/build.sh
@@ -1,0 +1,59 @@
+#!/bin/bash -eu
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build libuv with fuzzing instrumentation.
+#
+# Targets:
+#   fuzz_idna       — uv__idna_toascii() IDNA/Punycode Unicode hostname encoder
+#   fuzz_url_parse  — uv_url_t URL parser (used by Node.js URL API)
+
+cd $SRC/libuv
+
+# Build libuv as a static library
+mkdir -p build && cd build
+
+cmake .. \
+    -DCMAKE_C_COMPILER="$CC" \
+    -DCMAKE_C_FLAGS="$CFLAGS" \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DLIBUV_BUILD_TESTS=OFF \
+    -DLIBUV_BUILD_BENCH=OFF \
+    2>&1 | tail -10
+
+make -j$(nproc) uv_a 2>&1 | tail -10
+
+cd $SRC/libuv
+
+# Build fuzz_idna
+$CC $CFLAGS \
+    -I$SRC/libuv/include \
+    -I$SRC/libuv/src \
+    $SRC/oss-fuzz/projects/libuv/fuzz_idna.c \
+    $SRC/libuv/build/libuv_a.a \
+    $LIB_FUZZING_ENGINE \
+    -o $OUT/fuzz_idna
+
+# Build fuzz_url_parse (only if libuv was built with URL support)
+$CC $CFLAGS \
+    -I$SRC/libuv/include \
+    -I$SRC/libuv/src \
+    $SRC/oss-fuzz/projects/libuv/fuzz_url_parse.c \
+    $SRC/libuv/build/libuv_a.a \
+    $LIB_FUZZING_ENGINE \
+    -o $OUT/fuzz_url_parse || true
+
+# Seed corpus: valid IDN hostnames as starting points
+zip -j $OUT/fuzz_idna_seed_corpus.zip \
+    $SRC/oss-fuzz/projects/libuv/corpus/idna/*.txt 2>/dev/null || true

--- a/projects/libuv/fuzz_idna.c
+++ b/projects/libuv/fuzz_idna.c
@@ -1,0 +1,44 @@
+/*
+ * OSS-Fuzz harness for libuv's IDNA (Internationalized Domain Names in
+ * Applications) to ASCII encoder — uv__idna_toascii().
+ *
+ * libuv encodes all hostnames passed to uv_getaddrinfo(), uv_tcp_connect(),
+ * and related APIs through this function before sending them to the OS
+ * resolver. It implements IDNA 2008 + UTS#46 case-folding and Punycode
+ * encoding with a hand-rolled WTF-8 decoder.
+ *
+ * This path processes attacker-controlled data in Node.js, Deno, and any
+ * other runtime built on libuv.
+ *
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+/* libuv internal header — exposes uv__idna_toascii() */
+#include "idna.h"
+#include "uv-common.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    if (size == 0)
+        return 0;
+
+    /* uv__idna_toascii expects a null-terminated UTF-8 string */
+    char *input = (char *) malloc(size + 1);
+    if (!input)
+        return 0;
+    memcpy(input, data, size);
+    input[size] = '\0';
+
+    /* Output buffer: IDNA labels are at most 253 bytes in ASCII */
+    char output[256];
+
+    uv__idna_toascii(input, input + size, output, output + sizeof(output));
+
+    free(input);
+    return 0;
+}

--- a/projects/libuv/fuzz_url_parse.c
+++ b/projects/libuv/fuzz_url_parse.c
@@ -1,0 +1,34 @@
+/*
+ * OSS-Fuzz harness for libuv's URL parser (uv_url_t).
+ *
+ * libuv provides a URL parsing API used by Node.js's http.IncomingMessage
+ * and similar paths to parse request targets and Location headers.
+ *
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include "uv.h"
+
+/* uv_url_parse is internal in some versions — include directly */
+#include "url-parser/url_parser.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    if (size == 0)
+        return 0;
+
+    struct http_parser_url u;
+    http_parser_url_init(&u);
+
+    /* is_connect=0: normal URL; is_connect=1: CONNECT target */
+    int is_connect = (size > 0 && data[0] & 1) ? 1 : 0;
+    const char *input = (const char *) data;
+
+    http_parser_parse_url(input, size, is_connect, &u);
+
+    return 0;
+}

--- a/projects/libuv/project.yaml
+++ b/projects/libuv/project.yaml
@@ -1,0 +1,17 @@
+homepage: "https://libuv.org/"
+language: c
+primary_contact: "libuv@googlegroups.com"
+main_repo: "https://github.com/libuv/libuv.git"
+auto_ccs:
+  - "xananasX7@users.noreply.github.com"
+sanitizers:
+  - address
+  - undefined
+  - memory
+fuzzing_engines:
+  - libfuzzer
+  - honggfuzz
+  - afl
+license: "MIT"
+vendor_ccs:
+  - "libuv@googlegroups.com"


### PR DESCRIPTION
## New Project: libuv

**Homepage:** https://libuv.org/
**Repo:** https://github.com/libuv/libuv
**License:** MIT ✅
**Language:** C

### Why libuv?

libuv is the cross-platform async I/O library that powers **Node.js**, **Deno**, **Julia**, and dozens of other runtimes. It processes attacker-controlled hostnames and URLs as a fundamental part of any network operation. Despite this exposure, libuv has **no existing OSS-Fuzz coverage**.

### Harnesses

#### `fuzz_idna` — IDNA/Punycode hostname encoder (`uv__idna_toascii()`)

This is the most security-critical path: **every** hostname passed to `uv_getaddrinfo()`, `uv_tcp_connect()`, `uv_udp_connect()`, etc. is encoded here before being sent to the OS resolver. In Node.js, this path is reached by `net.connect()`, `http.request()`, `https.get()`, `dns.lookup()`, etc. — all callable with attacker-controlled hostnames.

The function implements IDNA 2008 + UTS#46 case-folding with a hand-rolled **WTF-8 decoder** and **Punycode encoder**. It processes arbitrary Unicode code points with no sandboxing.

Seed corpus included: ASCII, German IDN (`münchen.de`), Punycode (`xn--mnchen-3ya.de`), Japanese (`日本語.jp`), Cyrillic (`привет.рф`).

#### `fuzz_url_parse` — URL request-target and Location header parser

Exercises the URL parsing path used by libuv's HTTP parser bindings. Tests both normal URL parsing and HTTP CONNECT target parsing.

### Build

CMake with `LIBUV_BUILD_TESTS=OFF` and `LIBUV_BUILD_BENCH=OFF` for a clean static library. The IDNA and URL functions are self-contained with no external dependencies.

cc: @oliverchang @jonathanmetzman