### PR TITLE
hiredis: add RESP response reader fuzzer; nettle: add ECDSA/EC-point DER fuzzer

### DIFF
--- a/projects/hiredis/build.sh
+++ b/projects/hiredis/build.sh
@@ -22,3 +22,10 @@ $CC $CFLAGS -std=c99 -pedantic -c -O3 -fPIC -I./ \
 
 $CXX $CXXFLAGS -O3 -fPIC $LIB_FUZZING_ENGINE format_command_fuzzer.o \
 	-o $OUT/format_command_fuzzer libhiredis.a
+
+# Response reader fuzzer - exercises RESP/RESP3 protocol parsing
+$CC $CFLAGS -std=c99 -pedantic -c -O3 -fPIC -I./ \
+	$SRC/response_reader_fuzzer.c -o response_reader_fuzzer.o
+
+$CXX $CXXFLAGS -O3 -fPIC $LIB_FUZZING_ENGINE response_reader_fuzzer.o \
+	-o $OUT/response_reader_fuzzer libhiredis.a

--- a/projects/hiredis/response_reader_fuzzer.c
+++ b/projects/hiredis/response_reader_fuzzer.c
@@ -1,0 +1,84 @@
+// Copyright 2025 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Fuzz the hiredis RESP protocol reader (redisReader) covering:
+ *  - Simple strings (+OK\r\n)
+ *  - Errors (-ERR ...\r\n)
+ *  - Integers (:1234\r\n)
+ *  - Bulk strings ($5\r\nhello\r\n)
+ *  - Arrays (*3\r\n...
+ *  - Inline commands
+ *  - RESP3 aggregate types (%, ~, |, >, =)
+ *  - Partial / fragmented feeds
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "hiredis.h"
+#include "read.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size == 0)
+        return 0;
+
+    /* Use first byte as mode selector */
+    uint8_t mode = data[0] & 0x03;
+    const uint8_t *payload = data + 1;
+    size_t payload_len = size - 1;
+
+    redisReader *reader = redisReaderCreate();
+    if (!reader)
+        return 0;
+
+    if (mode == 0) {
+        /* Feed all at once */
+        redisReaderFeed(reader, (const char *)payload, payload_len);
+    } else if (mode == 1) {
+        /* Feed byte by byte to exercise partial-input paths */
+        for (size_t i = 0; i < payload_len; i++) {
+            if (redisReaderFeed(reader, (const char *)(payload + i), 1) != REDIS_OK)
+                break;
+        }
+    } else if (mode == 2 && payload_len >= 2) {
+        /* Feed in two chunks at a random split point */
+        size_t split = payload[0] % (payload_len - 1) + 1;
+        redisReaderFeed(reader, (const char *)payload, split);
+        redisReaderFeed(reader, (const char *)(payload + split), payload_len - split);
+    } else {
+        /* Feed in 4-byte chunks */
+        for (size_t i = 0; i < payload_len; i += 4) {
+            size_t chunk = payload_len - i < 4 ? payload_len - i : 4;
+            if (redisReaderFeed(reader, (const char *)(payload + i), chunk) != REDIS_OK)
+                break;
+        }
+    }
+
+    /* Drain all available replies */
+    void *reply = NULL;
+    int max_replies = 64;
+    while (max_replies-- > 0) {
+        int ret = redisReaderGetReply(reader, &reply);
+        if (ret != REDIS_OK || reply == NULL)
+            break;
+        freeReplyObject(reply);
+        reply = NULL;
+    }
+
+    redisReaderFree(reader);
+    return 0;
+}

--- a/projects/nettle/build.sh
+++ b/projects/nettle/build.sh
@@ -38,6 +38,7 @@ fuzz_dsa_openssl_private_key_from_der
 fuzz_rsa_keypair_from_sexp
 fuzz_rsa_keypair_from_der
 fuzz_rsa_public_key_from_der
+fuzz_ecdsa_from_der
 "
 
 for fuzzer in $FUZZERS; do

--- a/projects/nettle/fuzz_ecdsa_from_der.c
+++ b/projects/nettle/fuzz_ecdsa_from_der.c
@@ -1,0 +1,124 @@
+// Copyright 2025 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Fuzz nettle's ECDSA keypair DER parsing paths covering:
+ *  - SEC1 ECC private key DER decoding (rsa-like via bignum)
+ *  - ASN.1 DER iterator on SEQUENCE/BIT STRING wrapping EC keys
+ *  - ecc_point_set with values parsed from DER (invalid curves, OOB coords)
+ *  - PKCS#8 PrivateKeyInfo wrapper containing ECPrivateKey
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <nettle/ecc.h>
+#include <nettle/ecdsa.h>
+#include <nettle/bignum.h>
+#include <nettle/asn1.h>
+
+/*
+ * Try to decode an ASN.1 DER SEQUENCE containing:
+ *   version INTEGER,
+ *   privateKey OCTET STRING,
+ *   [0] OID OPTIONAL,
+ *   [1] BIT STRING OPTIONAL  <-- public key point
+ *
+ * as an EC private key and validate the public key point on P-256.
+ */
+static void fuzz_ec_private_key_der(const uint8_t *data, size_t size)
+{
+    struct asn1_der_iterator i, inner;
+
+    if (asn1_der_iterator_first(&i, size, data) != ASN1_ITERATOR_CONSTRUCTED)
+        return;
+    if (i.type != ASN1_SEQUENCE)
+        return;
+    if (asn1_der_decode_constructed_last(&i) != ASN1_ITERATOR_PRIMITIVE)
+        return;
+
+    /* version */
+    if (i.type != ASN1_INTEGER)
+        return;
+    if (asn1_der_iterator_next(&i) != ASN1_ITERATOR_PRIMITIVE)
+        return;
+
+    /* privateKey OCTET STRING */
+    if (i.type != ASN1_OCTET_STRING)
+        return;
+
+    size_t priv_len = i.length;
+    const uint8_t *priv_data = i.data;
+
+    /* Attempt to parse as a scalar on P-256 */
+    const struct ecc_curve *curve = nettle_get_secp_256r1();
+    struct ecc_scalar priv_scalar;
+    ecc_scalar_init(&priv_scalar, curve);
+
+    mpz_t z;
+    mpz_init(z);
+    nettle_mpz_set_str_256_u(z, priv_len, priv_data);
+
+    /* ecc_scalar_set returns 1 on success, 0 if out-of-range */
+    (void)ecc_scalar_set(&priv_scalar, z);
+
+    mpz_clear(z);
+    ecc_scalar_clear(&priv_scalar);
+}
+
+/*
+ * Try to parse an EC point (uncompressed 04 || X || Y, 65 bytes for P-256)
+ * directly from the fuzz input and test ecc_point_set validation.
+ */
+static void fuzz_ec_point_set(const uint8_t *data, size_t size)
+{
+    if (size < 64)
+        return;
+
+    const struct ecc_curve *curve = nettle_get_secp_256r1();
+    struct ecc_point pub;
+    ecc_point_init(&pub, curve);
+
+    mpz_t x, y;
+    mpz_init(x);
+    mpz_init(y);
+
+    nettle_mpz_set_str_256_u(x, 32, data);
+    nettle_mpz_set_str_256_u(y, 32, data + 32);
+
+    /* ecc_point_set validates that (x,y) is on the curve */
+    (void)ecc_point_set(&pub, x, y);
+
+    mpz_clear(x);
+    mpz_clear(y);
+    ecc_point_clear(&pub);
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    if (size < 2)
+        return 0;
+
+    uint8_t mode = data[0] & 0x01;
+    data++;
+    size--;
+
+    if (mode == 0)
+        fuzz_ec_private_key_der(data, size);
+    else
+        fuzz_ec_point_set(data, size);
+
+    return 0;
+}


### PR DESCRIPTION
## hiredis: `response_reader_fuzzer`

The existing `format_command_fuzzer` only tests command *formatting* (`redisFormatCommand`). This PR adds a fuzzer for the *response parsing* path — `redisReaderFeed` + `redisReaderGetReply` — which is the higher-risk side since it processes untrusted server responses.

**Coverage added:**
- Simple strings, errors, integers, bulk strings, arrays
- RESP3 aggregate types (maps, sets, push, attributes, big numbers)
- Fragmented input: byte-at-a-time, random-split, 4-byte-chunk feeds
- Drains multiple replies from a single stream

## nettle: `fuzz_ecdsa_from_der`

The existing nettle fuzzers cover RSA/DSA DER and S-expression parsing but **no ECC paths**. This adds a fuzzer covering:

1. **ASN.1 DER ECPrivateKey parsing → `ecc_scalar_set`** on P-256: exercises `der-iterator.c` + `bignum.c` parsing with out-of-range scalars, truncated DER, and malformed tag/length encodings.

2. **Direct `ecc_point_set` with arbitrary (x,y) coordinates** on P-256: exercises the on-curve validation in `ecc-a-to-j.c` / `ecc-dup-jj.c` with crafted points that lie off the curve or have coordinates ≥ p.

These paths are security-critical (key loading from external DER/PEM data) and were previously uncovered.