### PR TITLE
openssh: add sshconfig_fuzz support and authkeys_fuzz seed corpus

### DIFF
--- a/projects/openssh/build.sh
+++ b/projects/openssh/build.sh
@@ -61,3 +61,38 @@ CASES="$SRC/openssh-fuzz-cases"
 (set -e ; cd ${CASES}/sshsigopt ; zip -r $OUT/sshsigopt_fuzz_seed_corpus.zip .)
 (set -e ; cd ${CASES}/kex ; zip -r $OUT/kex_fuzz_seed_corpus.zip .)
 (set -e ; cd ${CASES}/agent ; zip -r $OUT/agent_fuzz_seed_corpus.zip .)
+
+# authkeys seed corpus: sample authorized_keys lines (keys embedded in harness)
+mkdir -p /tmp/authkeys_corpus
+cp regress/misc/fuzz-harness/testdata/id_ed25519.pub /tmp/authkeys_corpus/ 2>/dev/null || true
+cp regress/misc/fuzz-harness/testdata/id_ecdsa.pub /tmp/authkeys_corpus/ 2>/dev/null || true
+printf 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDPQXmEVMVLmeFRyafKMVWgPDkv8/uRBTwmcEDatZzMD user@host\n' > /tmp/authkeys_corpus/plain.pub
+printf 'from="192.168.1.*",command="/bin/sh" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDPQXmEVMVLmeFRyafKMVWgPDkv8/uRBTwmcEDatZzMD restricted\n' > /tmp/authkeys_corpus/restricted.pub
+printf 'no-pty,no-x11-forwarding,no-agent-forwarding ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA3I user@host\n' > /tmp/authkeys_corpus/no-opts.pub
+(cd /tmp/authkeys_corpus && zip -r $OUT/authkeys_fuzz_seed_corpus.zip .)
+
+# sshconfig seed corpus: sample ssh_config snippets
+mkdir -p /tmp/sshconfig_corpus
+cat > /tmp/sshconfig_corpus/basic.conf << 'CONF'
+Host example.com
+    User admin
+    Port 2222
+    IdentityFile ~/.ssh/id_ed25519
+    StrictHostKeyChecking yes
+CONF
+cat > /tmp/sshconfig_corpus/match.conf << 'CONF'
+Match Host *.internal exec "test -f /etc/flag"
+    ProxyJump bastion.example.com
+    IdentityFile ~/.ssh/internal_key
+    ServerAliveInterval 60
+CONF
+cat > /tmp/sshconfig_corpus/wildcard.conf << 'CONF'
+Host *
+    AddKeysToAgent yes
+    ForwardAgent no
+    Compression yes
+    ConnectTimeout 30
+    ServerAliveCountMax 3
+CONF
+cp $SRC/openssh/ssh_config /tmp/sshconfig_corpus/system.conf 2>/dev/null || true
+(cd /tmp/sshconfig_corpus && zip -r $OUT/sshconfig_fuzz_seed_corpus.zip .)


### PR DESCRIPTION
## Summary

Two improvements to the openssh OSS-Fuzz project:

### 1. Wire in `sshconfig_fuzz` (SSH client config parser)

A new harness `sshconfig_fuzz.cc` has been added upstream (openssh/openssh-portable#680) covering `readconf.c` — the SSH client configuration file parser. This file is 3957 lines and handles complex, security-sensitive directives:

- `Match` blocks with multi-criteria evaluation
- `ProxyCommand` / `ProxyJump` argument parsing  
- `IdentityFile` / `CertificateFile` path expansion
- Hostname canonicalization rules
- Per-host option inheritance and merging

This parser is exercised every time `ssh` reads `~/.ssh/config` but has had **no OSS-Fuzz coverage** until now.

The build.sh already auto-discovers all `*_fuzz.cc` harnesses via:
```bash
FUZZER_TARGETS=$(cd regress/misc/fuzz-harness && ls *_fuzz.cc | grep -v sntrup761 | ...)
```
This PR adds the seed corpus generation for `sshconfig_fuzz`.

### 2. Add missing `authkeys_fuzz` seed corpus

`authkeys_fuzz.cc` exists in the openssh repo and is listed in the upstream Makefile's `TARGETS`, but the build.sh had no seed corpus setup for it. This PR adds inline seed generation:
- Plain `authorized_keys` entry
- Entry with `from=`, `command=` restrictions  
- Entry with `no-pty,no-x11-forwarding,no-agent-forwarding` options
- Testdata keys when present in the source tree

## Testing

Seed corpus generation uses only `mkdir`, `printf`, `cat`, and `zip` — same pattern as other seed sections in this build.sh.
