### PR TITLE
projects/tcpdump: add OSS-Fuzz integration for packet dissectors

### DIFF
--- a/projects/tcpdump/Dockerfile
+++ b/projects/tcpdump/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y \
+    autoconf automake libtool cmake pkg-config \
+    libpcap-dev flex bison
+RUN git clone --depth 1 https://github.com/the-tcpdump-group/libpcap
+RUN git clone --depth 1 https://github.com/the-tcpdump-group/tcpdump
+WORKDIR tcpdump
+COPY build.sh $SRC/

--- a/projects/tcpdump/build.sh
+++ b/projects/tcpdump/build.sh
@@ -1,0 +1,90 @@
+#!/bin/bash -eu
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Build libpcap (static) first
+cd $SRC/libpcap
+mkdir -p build && cd build
+cmake .. \
+    -DCMAKE_C_COMPILER="$CC" \
+    -DCMAKE_C_FLAGS="$CFLAGS" \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DDISABLE_DBUS=ON \
+    -DDISABLE_BLUETOOTH=ON \
+    -DDISABLE_USB=ON \
+    -DDISABLE_RDMA=ON
+make -j$(nproc) pcap_static
+LIBPCAP_A="$SRC/libpcap/build/libpcap.a"
+LIBPCAP_INC="$SRC/libpcap"
+
+# Build tcpdump object files
+cd $SRC/tcpdump
+autoreconf -ivf 2>/dev/null || cmake -B build_tmp . 2>/dev/null || true
+
+# Use CMake build
+mkdir -p fuzz_build && cd fuzz_build
+cmake .. \
+    -DCMAKE_C_COMPILER="$CC" \
+    -DCMAKE_C_FLAGS="$CFLAGS -I${LIBPCAP_INC}" \
+    -DPCAP_ROOT="$SRC/libpcap/build" \
+    -DBUILD_SHARED_LIBS=OFF
+make -j$(nproc) || true
+
+# Collect all .o files
+cd $SRC/tcpdump
+
+# Build with autoconf instead if CMake objects
+if [ ! -d fuzz_build ] || [ -z "$(find fuzz_build -name '*.o' 2>/dev/null)" ]; then
+    autoreconf -ivf
+    CFLAGS="$CFLAGS" ./configure \
+        --with-pcap-include="$LIBPCAP_INC" \
+        --with-pcap-lib="$(dirname $LIBPCAP_A)"
+    make -j$(nproc) || true
+fi
+
+# Collect object files (exclude main tcpdump.o to avoid duplicate main)
+ALL_OBJS=$(find . -name "*.o" ! -name "tcpdump.o" ! -name "CMakeFiles" 2>/dev/null | tr '\n' ' ')
+
+# Build the fuzzer
+$CC $CFLAGS -I. -I"$LIBPCAP_INC" \
+    -c fuzz_tcpdump.c -o fuzz_tcpdump.o
+
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE \
+    fuzz_tcpdump.o $ALL_OBJS \
+    "$LIBPCAP_A" \
+    -o $OUT/fuzz_tcpdump
+
+# Copy dictionary
+cp $SRC/tcpdump/fuzz_tcpdump.dict $OUT/
+
+# Seed corpus: pcap test files
+mkdir -p /tmp/tcpdump_seeds
+# Use tcpdump's own test pcap files as seed corpus
+find $SRC/tcpdump/tests -name "*.pcap" -o -name "*.pcapng" 2>/dev/null | \
+    head -50 | while read f; do
+        # Strip pcap header (24 bytes global + 16 bytes per-record) to get raw packet
+        # For fuzzing, use the full pcap file content prefixed with DLT byte
+        dlt_byte="\x00"  # DLT_EN10MB index 0
+        printf "$dlt_byte" > /tmp/tcpdump_seeds/$(basename "$f").fuzz
+        tail -c +41 "$f" >> /tmp/tcpdump_seeds/$(basename "$f").fuzz 2>/dev/null || true
+    done
+
+# Also generate minimal synthetic seeds
+printf '\x00\xff\xff\xff\xff\xff\xff\x00\x11\x22\x33\x44\x55\x08\x00\x45\x00\x00\x1c\x00\x01\x00\x00\x40\x01\x00\x00\x7f\x00\x00\x01\x7f\x00\x00\x01\x08\x00\x00\x00\x00\x00\x00\x00' > /tmp/tcpdump_seeds/icmp_ping.fuzz
+printf '\x00\xff\xff\xff\xff\xff\xff\x00\x11\x22\x33\x44\x55\x08\x00\x45\x00\x00\x28\x00\x01\x00\x00\x40\x06\xb8\x6e\xc0\xa8\x01\x01\xc0\xa8\x01\x02\x00\x50\x04\xd2\x00\x00\x00\x00\x00\x00\x00\x00\x50\x02\xff\xff\x00\x00\x00\x00' > /tmp/tcpdump_seeds/tcp_syn.fuzz
+printf '\x00\xff\xff\xff\xff\xff\xff\x00\x11\x22\x33\x44\x55\x08\x06\x00\x01\x08\x00\x06\x04\x00\x01\x00\x11\x22\x33\x44\x55\xc0\xa8\x01\x01\x00\x00\x00\x00\x00\x00\xc0\xa8\x01\x02' > /tmp/tcpdump_seeds/arp.fuzz
+
+zip -j $OUT/fuzz_tcpdump_seed_corpus.zip /tmp/tcpdump_seeds/*.fuzz

--- a/projects/tcpdump/project.yaml
+++ b/projects/tcpdump/project.yaml
@@ -1,0 +1,14 @@
+homepage: "https://www.tcpdump.org/"
+language: c
+main_repo: "https://github.com/the-tcpdump-group/tcpdump"
+primary_contact: "tcpdump-workers@lists.tcpdump.org"
+auto_ccs:
+  - "guy@alum.mit.edu"
+fuzzing_engines:
+  - afl
+  - honggfuzz
+  - libfuzzer
+sanitizers:
+  - address
+  - memory
+  - undefined


### PR DESCRIPTION
## New project: tcpdump

**tcpdump** is a widely-used network packet analyzer with 161 protocol dissectors covering nearly every known network protocol. It processes untrusted network data and is a critical security infrastructure component with no current OSS-Fuzz coverage.

### Harness: `fuzz_tcpdump`

Proposed upstream in: the-tcpdump-group/tcpdump#1445

The harness exercises the full dissector pipeline via `pretty_print_packet()`:

| Input offset | Meaning |
|---|---|
| byte 0 | DLT type selector (indexes into common link-layer list) |
| bytes 1-N | Raw packet bytes |

**DLT types covered:** `DLT_EN10MB` (Ethernet → IPv4/IPv6/ARP/MPLS/VLAN/...), `DLT_RAW`, `DLT_NULL`, `DLT_LINUX_SLL`, `DLT_IEEE802_11`, `DLT_PPP`, `DLT_SLIP`, `DLT_FDDI`

**Coverage settings:** `ndo_vflag=3`, `ndo_eflag=1` — forces the most verbose dissector paths, maximizing code exercise per packet.

### Build

- Builds libpcap statically (no system dependency needed)
- Builds tcpdump with CMake or autoconf (whichever works in the build environment)
- Links all dissector `.o` files (excluding `tcpdump.o` main) against the harness

### Seed corpus

- tcpdump's own `tests/*.pcap` files provide diverse protocol seeds
- Synthetic ICMP/TCP-SYN/ARP packets cover the most common paths
