### PR TITLE
projects/ldns: add OSS-Fuzz integration for DNS wire and RR parsers

### DIFF
--- a/projects/ldns/Dockerfile
+++ b/projects/ldns/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y \
+    autoconf automake libtool pkg-config \
+    libssl-dev libpcap-dev
+RUN git clone --depth 1 https://github.com/NLnetLabs/ldns
+WORKDIR ldns
+COPY build.sh fuzz_ldns_wire.c fuzz_ldns_rr.c $SRC/

--- a/projects/ldns/build.sh
+++ b/projects/ldns/build.sh
@@ -1,0 +1,75 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC/ldns
+
+# Build ldns as a static library
+autoreconf -ivf
+./configure \
+    CC="$CC" \
+    CFLAGS="$CFLAGS" \
+    --disable-shared \
+    --enable-static \
+    --with-ssl \
+    --disable-dane-verify \
+    --disable-examples \
+    --disable-drill \
+    --without-pyldns
+make -j$(nproc) || make
+
+LDNS_A=$(find . -name "libldns.a" | head -1)
+
+# Build wire format fuzzer
+$CC $CFLAGS -I. -I./include \
+    $SRC/fuzz_ldns_wire.c \
+    "$LDNS_A" -lssl -lcrypto \
+    $LIB_FUZZING_ENGINE \
+    -o $OUT/fuzz_ldns_wire
+
+# Build RR text parser fuzzer
+$CC $CFLAGS -I. -I./include \
+    $SRC/fuzz_ldns_rr.c \
+    "$LDNS_A" -lssl -lcrypto \
+    $LIB_FUZZING_ENGINE \
+    -o $OUT/fuzz_ldns_rr
+
+# Seed corpus: well-formed DNS messages
+mkdir -p /tmp/ldns_seeds
+
+# Minimal valid A-record response (www.example.com -> 93.184.216.34)
+printf '\x00\x01\x81\x80\x00\x01\x00\x01\x00\x00\x00\x00'  > /tmp/ldns_seeds/a_response.dns
+printf '\x03www\x07example\x03com\x00\x00\x01\x00\x01'     >> /tmp/ldns_seeds/a_response.dns
+printf '\xc0\x0c\x00\x01\x00\x01\x00\x00\x01\x2c\x00\x04\x5d\xb8\xd8\x22' >> /tmp/ldns_seeds/a_response.dns
+
+# Minimal valid query (A record for example.com)
+printf '\x12\x34\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00'  > /tmp/ldns_seeds/a_query.dns
+printf '\x07example\x03com\x00\x00\x01\x00\x01'             >> /tmp/ldns_seeds/a_query.dns
+
+# AAAA query
+printf '\xab\xcd\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00'  > /tmp/ldns_seeds/aaaa_query.dns
+printf '\x07example\x03com\x00\x00\x1c\x00\x01'             >> /tmp/ldns_seeds/aaaa_query.dns
+
+zip -j $OUT/fuzz_ldns_wire_seed_corpus.zip /tmp/ldns_seeds/*.dns
+
+# Seed for RR text parser
+mkdir -p /tmp/ldns_rr_seeds
+echo 'www.example.com. 3600 IN A 93.184.216.34' > /tmp/ldns_rr_seeds/a_record.txt
+echo 'mail.example.com. 3600 IN MX 10 mail.example.com.' > /tmp/ldns_rr_seeds/mx_record.txt
+echo 'example.com. 3600 IN NS ns1.example.com.' > /tmp/ldns_rr_seeds/ns_record.txt
+echo 'example.com. 3600 IN SOA ns1.example.com. admin.example.com. 2024010101 3600 900 604800 300' > /tmp/ldns_rr_seeds/soa_record.txt
+echo 'example.com. 3600 IN TXT "v=spf1 include:example.com ~all"' > /tmp/ldns_rr_seeds/txt_record.txt
+zip -j $OUT/fuzz_ldns_rr_seed_corpus.zip /tmp/ldns_rr_seeds/*.txt

--- a/projects/ldns/fuzz_ldns_rr.c
+++ b/projects/ldns/fuzz_ldns_rr.c
@@ -1,0 +1,53 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+/*
+ * OSS-Fuzz harness for ldns DNS RR text parser.
+ * Exercises ldns_rr_new_frm_str() — the text-format resource record parser.
+ */
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include "ldns/ldns.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    if (size == 0)
+        return 0;
+
+    /* Null-terminate for string parsing */
+    char *str = malloc(size + 1);
+    if (!str)
+        return 0;
+    memcpy(str, data, size);
+    str[size] = '\0';
+
+    ldns_rr *rr = NULL;
+    ldns_rdf *origin = NULL;
+    ldns_rdf *prev = NULL;
+    uint32_t default_ttl = 3600;
+
+    ldns_status status = ldns_rr_new_frm_str(&rr, str, default_ttl, origin, &prev);
+    if (status == LDNS_STATUS_OK && rr != NULL) {
+        ldns_rr_free(rr);
+    }
+    if (prev != NULL) {
+        ldns_rdf_free(prev);
+    }
+
+    free(str);
+    return 0;
+}

--- a/projects/ldns/fuzz_ldns_wire.c
+++ b/projects/ldns/fuzz_ldns_wire.c
@@ -1,0 +1,48 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+/*
+ * OSS-Fuzz harness for ldns DNS wire format parser.
+ * Exercises ldns_wire2pkt() — the primary entry point for parsing
+ * raw DNS message bytes received from the network.
+ */
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include "ldns/ldns.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    ldns_pkt *pkt = NULL;
+    ldns_status status;
+
+    if (size == 0)
+        return 0;
+
+    /* Parse raw DNS wire message */
+    status = ldns_wire2pkt(&pkt, data, size);
+    if (status == LDNS_STATUS_OK && pkt != NULL) {
+        /* Exercise the printing path to cover more code */
+        ldns_buffer *buf = ldns_buffer_new(4096);
+        if (buf) {
+            ldns_pkt2buffer_str(buf, pkt);
+            ldns_buffer_free(buf);
+        }
+        ldns_pkt_free(pkt);
+    }
+
+    return 0;
+}

--- a/projects/ldns/project.yaml
+++ b/projects/ldns/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://www.nlnetlabs.nl/projects/ldns/"
+language: c
+main_repo: "https://github.com/NLnetLabs/ldns"
+primary_contact: "dns-team@nlnetlabs.nl"
+fuzzing_engines:
+  - afl
+  - honggfuzz
+  - libfuzzer
+sanitizers:
+  - address
+  - memory
+  - undefined


### PR DESCRIPTION
## New project: ldns

**ldns** is a DNS library from NLnet Labs, used by NSD (authoritative DNS server), Unbound (DNS resolver), and many other security-critical DNS tools and validators. It parses untrusted DNS responses from the network and zone file text, but has no current OSS-Fuzz coverage.

### Harnesses

#### `fuzz_ldns_wire` — DNS wire format parser
- Entry point: `ldns_wire2pkt()` — parses raw DNS message bytes (UDP/TCP)
- Also exercises `ldns_pkt2buffer_str()` to maximize dissector coverage
- Seed corpus: minimal A-record response, A-record query, AAAA query

#### `fuzz_ldns_rr` — DNS RR text format parser
- Entry point: `ldns_rr_new_frm_str()` — parses text-format resource records (zone files, config)
- Seed corpus: A, MX, NS, SOA, TXT record examples

### Build

- Builds ldns as a static library (`--disable-shared --enable-static`)
- Links with OpenSSL for DNSSEC support
- Both harnesses are self-contained; no network or file access

### Coverage

ldns processes DNS data at security boundaries (resolver responses, authoritative zone files). Bugs in its parser can affect any tool that uses it, including Unbound and NSD — which handle millions of DNS queries per day.
