### PR TITLE
projects/miniupnp: add OSS-Fuzz integration for minixml, UPnP reply, IGD desc, and port listing parsers

### DIFF
--- a/projects/miniupnp/Dockerfile
+++ b/projects/miniupnp/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends cmake
+
+RUN git clone --depth 1 https://github.com/miniupnp/miniupnp.git
+
+WORKDIR miniupnp/miniupnpc
+COPY build.sh $SRC/
+COPY *.c $SRC/

--- a/projects/miniupnp/build.sh
+++ b/projects/miniupnp/build.sh
@@ -1,0 +1,45 @@
+#!/bin/bash -eu
+
+cd $SRC/miniupnp/miniupnpc
+
+# Build miniupnpc as a static library
+$CC $CFLAGS -DMINIUPNPC_SET_SOCKET_TIMEOUT \
+    -DMINIUPNPC_GET_SRC_ADDR \
+    -D_BSD_SOURCE -D_DEFAULT_SOURCE \
+    -D_XOPEN_SOURCE=600 \
+    -c src/minixml.c -o minixml.o
+$CC $CFLAGS -c src/upnpreplyparse.c -o upnpreplyparse.o
+$CC $CFLAGS -c src/igd_desc_parse.c -o igd_desc_parse.o
+$CC $CFLAGS -c src/portlistingparse.c -o portlistingparse.o
+$CC $CFLAGS -c src/minisoap.c -o minisoap.o
+
+ar rcs libminiupnpc.a minixml.o upnpreplyparse.o igd_desc_parse.o \
+       portlistingparse.o minisoap.o
+
+# Fuzzer: minixml parser — parses UPnP XML responses from network
+$CC $CFLAGS -Iinclude -c $SRC/fuzz_minixml.c -o fuzz_minixml.o
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz_minixml.o libminiupnpc.a \
+    -o $OUT/fuzz_minixml
+
+# Fuzzer: UPnP reply parser — parses UPnP SOAP/SSDP response key-value pairs
+$CC $CFLAGS -Iinclude -c $SRC/fuzz_upnpreplyparse.c -o fuzz_upnpreplyparse.o
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz_upnpreplyparse.o libminiupnpc.a \
+    -o $OUT/fuzz_upnpreplyparse
+
+# Fuzzer: IGD description parser — parses UPnP IGD XML device descriptions
+$CC $CFLAGS -Iinclude -c $SRC/fuzz_igd_desc_parse.c -o fuzz_igd_desc_parse.o
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz_igd_desc_parse.o libminiupnpc.a \
+    -o $OUT/fuzz_igd_desc_parse
+
+# Fuzzer: port listing parser — parses GetListOfPortMappings XML responses
+$CC $CFLAGS -Iinclude -c $SRC/fuzz_portlistingparse.c -o fuzz_portlistingparse.o
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz_portlistingparse.o libminiupnpc.a \
+    -o $OUT/fuzz_portlistingparse
+
+# Seed corpus from existing test inputs
+zip -j $OUT/fuzz_minixml_seed_corpus.zip \
+    src/testdesc/*.xml 2>/dev/null || true
+zip -j $OUT/fuzz_igd_desc_parse_seed_corpus.zip \
+    src/testdesc/*.xml 2>/dev/null || true
+zip -j $OUT/fuzz_upnpreplyparse_seed_corpus.zip \
+    testreplyparse/*.namevalue 2>/dev/null || true

--- a/projects/miniupnp/fuzz_igd_desc_parse.c
+++ b/projects/miniupnp/fuzz_igd_desc_parse.c
@@ -1,0 +1,54 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include "src/igd_desc_parse.h"
+#include "src/minixml.h"
+
+/*
+ * Fuzz IGD description parser — parses the XML device description returned
+ * by UPnP IGD routers. This is fetched over HTTP from the router and is
+ * fully attacker-controlled in a network-adjacent threat model.
+ */
+int LLVMFuzzerTestOneInput(const uint8_t *in, size_t insize)
+{
+	struct IGDdatas data;
+	struct xmlparser parser;
+
+	char *buf = malloc(insize + 1);
+	if (!buf)
+		return 0;
+	memcpy(buf, in, insize);
+	buf[insize] = '\0';
+
+	memset(&data, 0, sizeof(data));
+	memset(&parser, 0, sizeof(parser));
+
+	parser.xmlstart = buf;
+	parser.xmlsize = (int)insize;
+	parser.data = &data;
+	parser.starteltfunc = IGDstartelt;
+	parser.endeltfunc = IGDendelt;
+	parser.datafunc = IGDdata;
+	parser.attfunc = NULL;
+
+	parsexml(&parser);
+
+	free(buf);
+	return 0;
+}

--- a/projects/miniupnp/fuzz_minixml.c
+++ b/projects/miniupnp/fuzz_minixml.c
@@ -1,0 +1,63 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include "src/minixml.h"
+
+/* Callback that collects element names and values */
+static void xml_start_elt(void *data, const char *name, int namelen)
+{
+	(void)data; (void)name; (void)namelen;
+}
+
+static void xml_end_elt(void *data, const char *name, int namelen)
+{
+	(void)data; (void)name; (void)namelen;
+}
+
+static void xml_data(void *data, const char *d, int len)
+{
+	(void)data; (void)d; (void)len;
+}
+
+/* Fuzz the minixml SAX parser with arbitrary XML input. */
+int LLVMFuzzerTestOneInput(const uint8_t *in, size_t insize)
+{
+	struct xmlparser parser;
+
+	/* parsexml expects a null-terminated string */
+	char *buf = malloc(insize + 1);
+	if (!buf)
+		return 0;
+	memcpy(buf, in, insize);
+	buf[insize] = '\0';
+
+	memset(&parser, 0, sizeof(parser));
+	parser.xmlstart = buf;
+	parser.xmlsize = (int)insize;
+	parser.data = NULL;
+	parser.starteltfunc = xml_start_elt;
+	parser.endeltfunc = xml_end_elt;
+	parser.datafunc = xml_data;
+	parser.attfunc = NULL;
+
+	parsexml(&parser);
+
+	free(buf);
+	return 0;
+}

--- a/projects/miniupnp/fuzz_portlistingparse.c
+++ b/projects/miniupnp/fuzz_portlistingparse.c
@@ -1,0 +1,42 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include "src/portlistingparse.h"
+
+/*
+ * Fuzz GetListOfPortMappings response parser.
+ * Response XML comes from the router and is network-attacker-controllable.
+ */
+int LLVMFuzzerTestOneInput(const uint8_t *in, size_t insize)
+{
+	struct PortMappingParserData data;
+
+	char *buf = malloc(insize + 1);
+	if (!buf)
+		return 0;
+	memcpy(buf, in, insize);
+	buf[insize] = '\0';
+
+	memset(&data, 0, sizeof(data));
+	ParsePortListing(buf, (int)insize, &data);
+	FreePortListing(&data);
+
+	free(buf);
+	return 0;
+}

--- a/projects/miniupnp/fuzz_upnpreplyparse.c
+++ b/projects/miniupnp/fuzz_upnpreplyparse.c
@@ -1,0 +1,43 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include "src/upnpreplyparse.h"
+
+/*
+ * Fuzz UPnP SOAP reply parsing.
+ * UPnP SOAP responses from IGD routers are attacker-controlled in a
+ * network-adjacent threat model — a rogue router can send crafted replies.
+ */
+int LLVMFuzzerTestOneInput(const uint8_t *in, size_t insize)
+{
+	struct NameValueParserData data;
+
+	/* Parser needs null-terminated input */
+	char *buf = malloc(insize + 1);
+	if (!buf)
+		return 0;
+	memcpy(buf, in, insize);
+	buf[insize] = '\0';
+
+	ParseNameValue(buf, (int)insize, &data);
+	ClearNameValueList(&data);
+
+	free(buf);
+	return 0;
+}

--- a/projects/miniupnp/project.yaml
+++ b/projects/miniupnp/project.yaml
@@ -1,0 +1,13 @@
+main_repo: "https://github.com/miniupnp/miniupnp"
+homepage: "https://github.com/miniupnp/miniupnp"
+language: c
+primary_contact: "miniupnp@free.fr"
+auto_ccs:
+  - "miniupnp@free.fr"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+sanitizers:
+  - address
+  - undefined


### PR DESCRIPTION
## Summary

[miniupnp/miniupnpc](https://github.com/miniupnp/miniupnp) is the most widely-deployed open-source UPnP NAT traversal client library. It is used by BitTorrent clients (Transmission, qBittorrent, libtorrent), VPN tools, and is included in many Linux distributions. It currently has **no OSS-Fuzz coverage**.

## Attack surface

All four parsers process data from UPnP-capable routers over HTTP/SSDP. In a **network-adjacent threat model** (same subnet as a rogue or compromised router), an attacker controls the full content of responses these parsers handle:

1. **minixml** (`fuzz_minixml`) — SAX XML parser used for all UPnP XML responses
2. **upnpreplyparse** (`fuzz_upnpreplyparse`) — SOAP reply key-value parser for UPnP action responses
3. **igd_desc_parse** (`fuzz_igd_desc_parse`) — IGD device description XML parser (fetched over HTTP at startup)
4. **portlistingparse** (`fuzz_portlistingparse`) — GetListOfPortMappings XML response parser

## Seed corpus

Test XML/namevalue files shipped in the repository (`testreplyparse/`, `testdesc/`) are bundled as seed corpora.

I have read the CLA Document and I hereby sign the CLA