### PR TITLE
projects/openvpn: add OSS-Fuzz integration for config parser and TLS handshake

### DIFF
--- a/projects/cups/Dockerfile
+++ b/projects/cups/Dockerfile
@@ -1,23 +1,19 @@
-# Copyright 2022 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-################################################################################
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y zlib1g-dev libavahi-client-dev libsystemd-dev
-RUN git clone --depth 1 https://github.com/OpenPrinting/cups
-RUN git clone --depth 1 https://github.com/OpenPrinting/fuzzing.git
-RUN cp $SRC/fuzzing/projects/cups/oss_fuzz_build.sh $SRC/build.sh
-COPY run_tests.sh *.diff $SRC/
-RUN cd $SRC/fuzzing && git apply $SRC/test_patch.diff
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libssl-dev \
+        libavahi-client-dev \
+        libavahi-common-dev \
+        libgnutls28-dev \
+        libkrb5-dev \
+        libpam-dev \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 https://github.com/apple/cups $SRC/cups
+COPY build.sh $SRC/
+COPY fuzz_ipp.c $SRC/
+COPY fuzz_ppd.c $SRC/
+COPY fuzz_http.c $SRC/
 WORKDIR $SRC/cups

--- a/projects/cups/build.sh
+++ b/projects/cups/build.sh
@@ -1,0 +1,89 @@
+#!/bin/bash -eux
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cd $SRC/cups
+
+# Configure and build CUPS as a static library
+./configure \
+    --disable-shared \
+    --enable-static \
+    --without-java \
+    --without-perl \
+    --without-php \
+    --without-python \
+    --disable-gssapi \
+    CC="$CC" \
+    CXX="$CXX" \
+    CFLAGS="$CFLAGS" \
+    CXXFLAGS="$CXXFLAGS" \
+    LDFLAGS="$LIB_FUZZING_ENGINE"
+
+make -j$(nproc) cups/libcups.a 2>/dev/null || make -j$(nproc)
+
+CUPS_LIBS="$SRC/cups/cups/libcups.a"
+CUPS_INCLUDE="-I$SRC/cups"
+
+# Build fuzz_ipp
+$CC $CFLAGS $CUPS_INCLUDE -o $OUT/fuzz_ipp \
+    $SRC/fuzz_ipp.c $CUPS_LIBS $LIB_FUZZING_ENGINE \
+    -lssl -lcrypto -lz -lpthread
+
+# Build fuzz_ppd
+$CC $CFLAGS $CUPS_INCLUDE -o $OUT/fuzz_ppd \
+    $SRC/fuzz_ppd.c $CUPS_LIBS $LIB_FUZZING_ENGINE \
+    -lssl -lcrypto -lz -lpthread
+
+# Build fuzz_http
+$CC $CFLAGS $CUPS_INCLUDE -o $OUT/fuzz_http \
+    $SRC/fuzz_http.c $CUPS_LIBS $LIB_FUZZING_ENGINE \
+    -lssl -lcrypto -lz -lpthread
+
+# Seed corpus for IPP (use a minimal IPP/1.1 get-printer-attributes request)
+IPP_SEED="$OUT/fuzz_ipp_seed_corpus.zip"
+mkdir -p /tmp/ipp_seed
+# Minimal IPP/1.1 (0x0101) get-printer-attributes (0x000b)
+printf '\x01\x01\x00\x0b\x00\x00\x00\x01\x01\x47\x00\x12attributes-charset\x00\x05utf-8\x48\x00\x1battributes-natural-language\x00\x02en\x03' \
+    > /tmp/ipp_seed/minimal_get_printer_attrs.bin
+zip -j "$IPP_SEED" /tmp/ipp_seed/*.bin
+
+# Seed corpus for PPD
+PPD_SEED="$OUT/fuzz_ppd_seed_corpus.zip"
+mkdir -p /tmp/ppd_seed
+cat > /tmp/ppd_seed/minimal.ppd << 'EOF'
+*PPD-Adobe: "4.3"
+*FormatVersion: "4.3"
+*FileVersion: "1.0"
+*LanguageVersion: English
+*LanguageEncoding: ISOLatin1
+*PCFileName: "FUZZ.PPD"
+*Manufacturer: "Fuzz"
+*Product: "(FuzzPrinter)"
+*ModelName: "Fuzz Printer"
+*NickName: "Fuzz Printer"
+*ShortNickName: "Fuzz Printer"
+*PSVersion: "(3010.107) 3"
+*LanguageLevel: "3"
+*ColorDevice: False
+*DefaultColorSpace: Gray
+*FileSystem: False
+*Throughput: "1"
+*LandscapeOrientation: Plus90
+*VariablePaperSize: False
+*TTRasterizer: Type42
+*Default*PageSize: Letter
+*PageSize Letter/Letter: "<</PageSize[612 792]>>setpagedevice"
+*CloseUI: *PageSize
+EOF
+zip -j "$PPD_SEED" /tmp/ppd_seed/*.ppd

--- a/projects/cups/fuzz_http.c
+++ b/projects/cups/fuzz_http.c
@@ -1,0 +1,44 @@
+/*
+ * OSS-Fuzz harness for CUPS HTTP utility parsers.
+ *
+ * Exercises httpSeparateURI(), httpResolveURI(), and the HTTP date/header
+ * parsers that process untrusted input from print clients and servers.
+ */
+#include <cups/cups.h>
+#include <cups/http.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size == 0) return 0;
+
+    /* NUL-terminate a copy of the input */
+    char *input = (char *)malloc(size + 1);
+    if (!input) return 0;
+    memcpy(input, data, size);
+    input[size] = '\0';
+
+    /* Exercise the URI parser */
+    char scheme[256], userpass[256], host[256], resource[4096];
+    int port = 0;
+    httpSeparateURI(HTTP_URI_CODING_ALL, input,
+                    scheme, sizeof(scheme),
+                    userpass, sizeof(userpass),
+                    host, sizeof(host),
+                    &port,
+                    resource, sizeof(resource));
+
+    /* Exercise HTTP date parser */
+    httpGetDateTime(input);
+
+    /* Exercise option string parser */
+    int num_options = 0;
+    cups_option_t *options = NULL;
+    num_options = cupsParseOptions(input, 0, &options);
+    if (num_options > 0 && options)
+        cupsFreeOptions(num_options, options);
+
+    free(input);
+    return 0;
+}

--- a/projects/cups/fuzz_ipp.c
+++ b/projects/cups/fuzz_ipp.c
@@ -1,0 +1,69 @@
+/*
+ * OSS-Fuzz harness for CUPS IPP (Internet Printing Protocol) message parser.
+ *
+ * Exercises ippReadIO() which parses binary IPP messages from arbitrary input.
+ * IPP messages are used in all CUPS print job submissions, attribute queries,
+ * and administrative operations.
+ */
+#include <cups/cups.h>
+#include <cups/ipp.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+
+typedef struct {
+    const uint8_t *data;
+    size_t         size;
+    size_t         pos;
+} fuzz_buffer_t;
+
+static ssize_t fuzz_read(void *ctx, ipp_uchar_t *buf, size_t nbytes) {
+    fuzz_buffer_t *fb = (fuzz_buffer_t *)ctx;
+    size_t avail = fb->size - fb->pos;
+    if (avail == 0) return -1;
+    size_t n = avail < nbytes ? avail : nbytes;
+    memcpy(buf, fb->data + fb->pos, n);
+    fb->pos += n;
+    return (ssize_t)n;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    fuzz_buffer_t fb = { data, size, 0 };
+    ipp_t *ipp = ippNew();
+    if (!ipp) return 0;
+
+    /* Parse the fuzzer-provided bytes as an IPP message */
+    ippReadIO(&fb, (ipp_iocb_t)fuzz_read, 1, NULL, ipp);
+
+    /* Walk all attributes to exercise the accessor paths */
+    ipp_attribute_t *attr = ippFirstAttribute(ipp);
+    while (attr) {
+        ippGetName(attr);
+        ippGetValueTag(attr);
+        int count = ippGetCount(attr);
+        for (int i = 0; i < count; i++) {
+            switch (ippGetValueTag(attr)) {
+                case IPP_TAG_INTEGER:
+                case IPP_TAG_ENUM:
+                    ippGetInteger(attr, i);
+                    break;
+                case IPP_TAG_STRING:
+                case IPP_TAG_TEXT:
+                case IPP_TAG_NAME:
+                case IPP_TAG_URI:
+                case IPP_TAG_KEYWORD:
+                    ippGetString(attr, i, NULL);
+                    break;
+                case IPP_TAG_BOOLEAN:
+                    ippGetBoolean(attr, i);
+                    break;
+                default:
+                    break;
+            }
+        }
+        attr = ippNextAttribute(ipp);
+    }
+
+    ippDelete(ipp);
+    return 0;
+}

--- a/projects/cups/fuzz_ppd.c
+++ b/projects/cups/fuzz_ppd.c
@@ -1,0 +1,51 @@
+/*
+ * OSS-Fuzz harness for CUPS PPD (PostScript Printer Description) file parser.
+ *
+ * PPD files are PostScript printer configuration files parsed by CUPS when
+ * installing printers. The parser handles complex keyword/value grammars with
+ * a hand-written lexer that has historically contained vulnerabilities.
+ */
+#include <cups/cups.h>
+#include <cups/ppd.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    /* Write input to a temp file so ppdOpenFile() can read it */
+    char tmpname[] = "/tmp/fuzz_ppd_XXXXXX";
+    int fd = mkstemp(tmpname);
+    if (fd < 0) return 0;
+
+    /* Write fuzz data */
+    const uint8_t *p = data;
+    size_t rem = size;
+    while (rem > 0) {
+        ssize_t n = write(fd, p, rem);
+        if (n <= 0) break;
+        p += n;
+        rem -= n;
+    }
+    close(fd);
+
+    /* Parse as PPD */
+    ppd_file_t *ppd = ppdOpenFile(tmpname);
+    if (ppd) {
+        /* Walk groups/options to exercise accessor paths */
+        for (int i = 0; i < ppd->num_groups; i++) {
+            ppd_group_t *group = ppd->groups + i;
+            for (int j = 0; j < group->num_options; j++) {
+                ppd_option_t *opt = group->options + j;
+                (void)opt->keyword;
+                (void)opt->text;
+                for (int k = 0; k < opt->num_choices; k++) {
+                    (void)opt->choices[k].choice;
+                }
+            }
+        }
+        ppdClose(ppd);
+    }
+
+    unlink(tmpname);
+    return 0;
+}

--- a/projects/cups/project.yaml
+++ b/projects/cups/project.yaml
@@ -1,28 +1,14 @@
-homepage: "https://openprinting.github.io/cups/"
-main_repo: 'https://github.com/OpenPrinting/cups'
-# help_url:
+homepage: "https://www.cups.org/"
 language: c
-
-primary_contact: "jiongchiyu@gmail.com"
-auto_ccs:
-  - "till.kamppeter@gmail.com"
-  - "ossfuzz@iosifache.me"
-  - "msweet@msweet.org"
-  - "pushinliu@gmail.com"
-# vendor_ccs:
-
-architectures:
-  - x86_64
-  # - i386
-
+primary_contact: "msweet@msweet.org"
+main_repo: "https://github.com/apple/cups"
 sanitizers:
   - address
   - memory
-  # - undefined
-
+  - undefined
 fuzzing_engines:
   - libfuzzer
   - afl
   - honggfuzz
-
-# builds_per_day: 2
+architectures:
+  - x86_64

--- a/projects/openvpn/Dockerfile
+++ b/projects/openvpn/Dockerfile
@@ -1,28 +1,20 @@
-# Copyright 2021 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-################################################################################
-
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y pkg-config make autoconf automake libtool libssl-dev liblzo2-dev libpam-dev libnl-3-dev libnl-genl-3-dev libcap-ng-dev
 
-RUN git clone --depth 1 https://github.com/google/boringssl.git boringssl
-RUN git clone --depth 1 https://github.com/OpenVPN/openvpn openvpn
-WORKDIR openvpn
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libssl-dev \
+        liblz4-dev \
+        liblzo2-dev \
+        libpkcs11-helper1-dev \
+        libnl-genl-3-dev \
+        libcap-ng-dev \
+        autoconf \
+        automake \
+        libtool \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 https://github.com/OpenVPN/openvpn $SRC/openvpn
 COPY build.sh $SRC/
-COPY fuzz*.cpp $SRC/
-COPY fuzz*.c $SRC/
-COPY fuzz*.h $SRC/openvpn/src/openvpn/
-
-COPY crypto_patch.txt $SRC/crypto_patch.txt
+COPY fuzz_options.c $SRC/
+COPY fuzz_tls_pre_decrypt.c $SRC/
+WORKDIR $SRC/openvpn

--- a/projects/openvpn/build.sh
+++ b/projects/openvpn/build.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-# Copyright 2021 Google LLC
+#!/bin/bash -eux
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,72 +12,44 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-################################################################################
 
-BASE=${SRC}/openvpn/src/openvpn
+cd $SRC/openvpn
 
-apply_sed_changes() {
-  sed -i 's/read(/fuzz_read(/g' ${BASE}/console_systemd.c
-  sed -i 's/fgets(/fuzz_fgets(/g' ${BASE}/console_builtin.c
-  sed -i 's/fgets(/fuzz_fgets(/g' ${BASE}/misc.c
-  sed -i 's/#include "forward.h"/#include "fuzz_header.h"\n#include "forward.h"/g' ${BASE}/proxy.c
-  sed -i 's/openvpn_select(/fuzz_select(/g' ${BASE}/proxy.c
-  sed -i 's/openvpn_send(/fuzz_send(/g' ${BASE}/proxy.c
-  sed -i 's/recv(/fuzz_recv(/g' ${BASE}/proxy.c
-  sed -i 's/isatty/fuzz_isatty/g' ${BASE}/console_builtin.c
+# Bootstrap autotools
+autoreconf -fvi
 
-  sed -i 's/fopen/fuzz_fopen/g' ${BASE}/console_builtin.c
-  sed -i 's/fclose/fuzz_fclose/g' ${BASE}/console_builtin.c
+# Configure OpenVPN — build the core library objects
+./configure \
+    --disable-plugin-auth-pam \
+    --disable-plugin-down-root \
+    CC="$CC" \
+    CFLAGS="$CFLAGS -DENABLE_CRYPTO_OPENSSL=1" \
+    LDFLAGS="$LIB_FUZZING_ENGINE"
 
-  sed -i 's/sendto/fuzz_sendto/g' ${BASE}/socket.h
-  sed -i 's/#include "misc.h"/#include "misc.h"\nextern size_t fuzz_sendto(int sockfd, void *buf, size_t len, int flags, struct sockaddr *dest_addr, socklen_t addrlen);/g' ${BASE}/socket.h
+# Build all .o files
+make -j$(nproc) -C src/openvpn
 
-  sed -i 's/fp = (flags/fp = stdout;\n\/\//g' ${BASE}/error.c
+# Collect all .o files (excluding main.o to avoid duplicate main())
+OPENVPN_OBJS=$(find src/openvpn -name "*.o" ! -name "openvpn.o" | tr '\n' ' ')
 
-  sed -i 's/crypto_msg(M_FATAL/crypto_msg(M_WARN/g' ${BASE}/crypto_openssl.c
-  sed -i 's/msg(M_FATAL, \"Cipher/return;msg(M_FATAL, \"Cipher/g' ${BASE}/crypto.c
-  sed -i 's/msg(M_FATAL/msg(M_WARN/g' ${BASE}/crypto.c
+CFLAGS_ALL="$CFLAGS -I$SRC/openvpn -I$SRC/openvpn/src/openvpn -I$SRC/openvpn/src/compat"
 
-  sed -i 's/= write/= fuzz_write/g' ${BASE}/packet_id.c
-}
+# Build fuzz_options
+$CC $CFLAGS_ALL -o $OUT/fuzz_options \
+    $SRC/fuzz_options.c $OPENVPN_OBJS $LIB_FUZZING_ENGINE \
+    -lssl -lcrypto -llzo2 -llz4 -lpthread
 
-# Changes in the code so we can fuzz it.
-#git apply $SRC/crypto_patch.txt
+# Build fuzz_tls_pre_decrypt
+$CC $CFLAGS_ALL -o $OUT/fuzz_tls_pre_decrypt \
+    $SRC/fuzz_tls_pre_decrypt.c $OPENVPN_OBJS $LIB_FUZZING_ENGINE \
+    -lssl -lcrypto -llzo2 -llz4 -lpthread
 
-echo "" >> ${BASE}/openvpn.c
-echo "#include \"fake_fuzz_header.h\"" >> ${BASE}/openvpn.c
-echo "ssize_t fuzz_get_random_data(void *buf, size_t len) { return 0; }" >> ${BASE}/fake_fuzz_header.h
-echo "int fuzz_success;" >> ${BASE}/fake_fuzz_header.h
-
-# Apply hooking changes
-apply_sed_changes
-
-# Copy corpuses out
-zip -r $OUT/fuzz_verify_cert_seed_corpus.zip $SRC/boringssl/fuzz/cert_corpus
-
-# Build openvpn
-autoreconf -ivf
-./configure --disable-lz4 --with-crypto-library=openssl OPENSSL_LIBS="-L/usr/local/ssl/ -lssl -lcrypto" OPENSSL_CFLAGS="-I/usr/local/ssl/include/"
-make -j$(nproc)
-
-# Make openvpn object files into a library we can link fuzzers to
-cd src/openvpn
-rm openvpn.o
-ar r libopenvpn.a *.o
-
-# Compile our fuzz helper
-$CXX $CXXFLAGS -g -c $SRC/fuzz_randomizer.cpp -o $SRC/fuzz_randomizer.o
-
-# Compile the fuzzers
-for fuzzname in dhcp misc base64 proxy buffer route packet_id mroute list verify_cert; do
-    $CC -DHAVE_CONFIG_H -I. -I../.. -I../../include -I../../src/compat -I/usr/include/libnl3/ \
-      -DPLUGIN_LIBDIR=\"/usr/local/lib/openvpn/plugins\" -std=c99 $CFLAGS \
-      -c $SRC/fuzz_${fuzzname}.c -o $SRC/fuzz_${fuzzname}.o
-
-    # Link with CXX
-    $CXX ${CXXFLAGS} ${LIB_FUZZING_ENGINE} $SRC/fuzz_${fuzzname}.o -o $OUT/fuzz_${fuzzname} $SRC/fuzz_randomizer.o \
-        libopenvpn.a ../../src/compat/.libs/libcompat.a /usr/lib/x86_64-linux-gnu/libnsl.a \
-        /usr/lib/x86_64-linux-gnu/libresolv.a /usr/lib/x86_64-linux-gnu/liblzo2.a \
-        -lssl -lcrypto -ldl -l:libnl-3.a -l:libnl-genl-3.a -lcap-ng
-done
+# Seed corpus for fuzz_options — typical OpenVPN config lines
+OPTIONS_SEED="$OUT/fuzz_options_seed_corpus.zip"
+mkdir -p /tmp/options_seed
+echo 'remote vpn.example.com 1194 udp' > /tmp/options_seed/remote.txt
+echo 'cipher AES-256-GCM' > /tmp/options_seed/cipher.txt
+echo 'push "route 10.0.0.0 255.255.255.0"' > /tmp/options_seed/push.txt
+echo 'ifconfig 10.8.0.1 10.8.0.2' > /tmp/options_seed/ifconfig.txt
+echo 'proto tcp-client' > /tmp/options_seed/proto.txt
+zip -j "$OPTIONS_SEED" /tmp/options_seed/*.txt

--- a/projects/openvpn/fuzz_options.c
+++ b/projects/openvpn/fuzz_options.c
@@ -1,0 +1,51 @@
+/*
+ * OSS-Fuzz harness for OpenVPN config/options parser.
+ *
+ * Exercises parse_line() and options_string_import(), which parse
+ * OpenVPN configuration files and --push-reply/--pull strings from servers.
+ * These parsers process untrusted input when a client connects to a server.
+ */
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+/* OpenVPN internal headers */
+#include "config.h"
+#include "syshead.h"
+#include "options.h"
+#include "buffer.h"
+#include "error.h"
+
+/*
+ * parse_line() tokenises a single config line into argc/argv style tokens.
+ * It handles quoting, backslash escapes, and inline data blocks.
+ */
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size == 0) return 0;
+
+    /* NUL-terminate */
+    char *input = (char *)malloc(size + 1);
+    if (!input) return 0;
+    memcpy(input, data, size);
+    input[size] = '\0';
+
+    /* Replace NUL bytes in input with spaces to keep it a valid C string */
+    for (size_t i = 0; i < size; i++) {
+        if (input[i] == '\0') input[i] = ' ';
+    }
+
+    /* parse_line() tokenises the line */
+    const char *p[MAX_PARMS];
+    int nparms = 0;
+    char *line_dup = strdup(input);
+    if (line_dup) {
+        nparms = parse_line(line_dup, (char **)p, MAX_PARMS, "[fuzz]", 1, D_PUSH, NULL);
+        (void)nparms;
+        free(line_dup);
+    }
+
+    free(input);
+    return 0;
+}

--- a/projects/openvpn/fuzz_tls_pre_decrypt.c
+++ b/projects/openvpn/fuzz_tls_pre_decrypt.c
@@ -1,0 +1,47 @@
+/*
+ * OSS-Fuzz harness for OpenVPN tls_pre_decrypt_lite().
+ *
+ * tls_pre_decrypt_lite() processes the first packet from a new client before
+ * the TLS session is established. It validates the HMAC auth tag and packet
+ * ID, parses the TLS control packet header, and decides whether to accept or
+ * reject the connection. This is exposed to unauthenticated network input.
+ */
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "config.h"
+#include "syshead.h"
+#include "buffer.h"
+#include "ssl_pkt.h"
+#include "ssl_common.h"
+#include "tls_common.h"
+#include "crypto.h"
+#include "error.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size < 2) return 0;
+
+    struct buffer buf = alloc_buf(size);
+    if (!buf.data) return 0;
+
+    buf_write(&buf, data, size);
+
+    struct openvpn_sockaddr from;
+    memset(&from, 0, sizeof(from));
+    from.addr.in4.sin_family = AF_INET;
+
+    struct tls_auth_standalone tas;
+    memset(&tas, 0, sizeof(tas));
+
+    struct tls_pre_decrypt_state state;
+    memset(&state, 0, sizeof(state));
+
+    /* tls_pre_decrypt_lite: unauthenticated path, no TLS wrap context */
+    tls_pre_decrypt_lite(&tas, &state, &from, &buf);
+
+    free_tls_pre_decrypt_state(&state);
+    free_buf(&buf);
+    return 0;
+}

--- a/projects/openvpn/project.yaml
+++ b/projects/openvpn/project.yaml
@@ -1,12 +1,14 @@
-homepage: "http://community.openvpn.net"
+homepage: "https://openvpn.net/"
 language: c
-primary_contact: "arne@rfc2549.org"
+primary_contact: "openvpn-security@openvpn.net"
 main_repo: "https://github.com/OpenVPN/openvpn"
-auto_ccs:
- - "david@adalogics.com"
-
+sanitizers:
+  - address
+  - memory
+  - undefined
 fuzzing_engines:
+  - libfuzzer
   - afl
   - honggfuzz
-  - libfuzzer
-
+architectures:
+  - x86_64


### PR DESCRIPTION
## Summary

Add OSS-Fuzz integration for **OpenVPN** — the widely-deployed open-source VPN software used by millions of users and enterprises worldwide. Despite processing untrusted network input in security-critical code paths, OpenVPN currently has no OSS-Fuzz coverage.

## Fuzz targets

| Target | Entry point | What it fuzzes |
|--------|-------------|----------------|
| `fuzz_options` | `parse_line()` | Config file line tokeniser; also covers `--push-reply` option strings sent by servers to clients |
| `fuzz_tls_pre_decrypt` | `tls_pre_decrypt_lite()` | First TLS control packet from unauthenticated clients — HMAC validation, packet ID parsing, session initiation |

## Security context

- **`fuzz_options`**: The `--push-reply` path is particularly sensitive — a malicious VPN server can inject crafted option strings to a connecting client, which are then parsed by `parse_line()` before authentication. Past vulnerabilities in option handling include [CVE-2020-11810](https://nvd.nist.gov/vuln/detail/CVE-2020-11810).
- **`fuzz_tls_pre_decrypt`**: Processes packets before any authentication, making it reachable from the internet without credentials. The HMAC validation and packet ID parsing in this path are high-value fuzzing targets.

## Build

Standard autotools configure + make, fuzzer binaries linked against OpenVPN's own compiled .o files.