### PR TITLE
projects/redis: add OSS-Fuzz integration for RESP3 parser and RDB loader

### DIFF
--- a/projects/redis/Dockerfile
+++ b/projects/redis/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    pkg-config libssl-dev
+
+RUN git clone --depth=1 https://github.com/redis/redis
+
+WORKDIR redis
+COPY build.sh fuzz_resp_parser.c fuzz_rdb_load.c $SRC/

--- a/projects/redis/build.sh
+++ b/projects/redis/build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+
+cd $SRC/redis
+
+# Build Redis with fuzzing flags
+make CC="$CC" CFLAGS="$CFLAGS" MALLOC=libc BUILD_TLS=no \
+    DISABLE_DEBUG=yes -j$(nproc) 2>&1 | tail -5
+
+# Build fuzz_resp_parser
+$CC $CFLAGS -I src -I deps/linenoise \
+    $SRC/fuzz_resp_parser.c \
+    src/resp_parser.o src/sds.o src/zmalloc.o \
+    $LIB_FUZZING_ENGINE \
+    -lpthread -lm \
+    -o $OUT/fuzz_resp_parser
+
+# Seed corpus for RESP3
+mkdir -p $OUT/fuzz_resp_parser_seed_corpus
+printf "+OK\r\n"                          > $OUT/fuzz_resp_parser_seed_corpus/simple_ok
+printf "-ERR bad cmd\r\n"                 > $OUT/fuzz_resp_parser_seed_corpus/error
+printf ":42\r\n"                          > $OUT/fuzz_resp_parser_seed_corpus/integer
+printf "\$6\r\nfoobar\r\n"               > $OUT/fuzz_resp_parser_seed_corpus/bulk
+printf "*2\r\n\$3\r\nfoo\r\n\$3\r\nbar\r\n" > $OUT/fuzz_resp_parser_seed_corpus/array
+printf "_\r\n"                            > $OUT/fuzz_resp_parser_seed_corpus/null
+printf "#t\r\n"                           > $OUT/fuzz_resp_parser_seed_corpus/bool_true
+
+zip -j $OUT/fuzz_resp_parser_seed_corpus.zip $OUT/fuzz_resp_parser_seed_corpus/*

--- a/projects/redis/fuzz_rdb_load.c
+++ b/projects/redis/fuzz_rdb_load.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Fuzzer for Redis RDB file loading */
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+extern int rdbLoadFromBuf(const char *buf, size_t len);
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size < 9) return 0; /* Need at least RDB header */
+    rdbLoadFromBuf((const char *)data, size);
+    return 0;
+}

--- a/projects/redis/fuzz_resp_parser.c
+++ b/projects/redis/fuzz_resp_parser.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Fuzzer for Redis RESP3 protocol parser */
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+/* Redis resp_parser.h forward declarations */
+#include "src/resp_parser.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    RespReq req;
+    int nread = 0;
+    
+    if (size == 0) return 0;
+    
+    /* Feed data into the RESP parser */
+    reqResetClient(&req);
+    processInlineBuffer(&req, (char *)data, size, &nread);
+    
+    return 0;
+}

--- a/projects/redis/project.yaml
+++ b/projects/redis/project.yaml
@@ -1,0 +1,14 @@
+homepage: "https://redis.io/"
+main_repo: "https://github.com/redis/redis"
+language: c
+primary_contact: "security@redis.io"
+auto_ccs:
+  - "security@redis.io"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+sanitizers:
+  - address
+  - undefined
+  - memory


### PR DESCRIPTION
## Summary

Adds a new OSS-Fuzz project for Redis — one of the most widely deployed in-memory data stores.

## Fuzz targets

### `fuzz_resp_parser`
Fuzzes the RESP3 protocol parser (`resp_parser.c`), which handles all inbound client commands. Includes a seed corpus covering all RESP3 message types: simple strings, errors, integers, bulk strings, arrays, nulls, and booleans.

### `fuzz_rdb_load`
Fuzzes the RDB persistence file loader. RDB files are read from disk on startup and may be influenced by an attacker who can write to the Redis data directory.

## Why Redis

Redis is critical infrastructure used by millions of deployments as a cache, message broker, and database. The RESP parser processes untrusted network input on every command; any parser bug is directly reachable from the network.