### PR TITLE
projects/libexpat: add OSS-Fuzz integration for XML parse and parsebuffer fuzz targets

### DIFF
--- a/projects/libexpat/Dockerfile
+++ b/projects/libexpat/Dockerfile
@@ -1,0 +1,10 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends cmake && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 https://github.com/libexpat/libexpat.git
+
+WORKDIR $SRC/libexpat/expat
+COPY build.sh $SRC/

--- a/projects/libexpat/build.sh
+++ b/projects/libexpat/build.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -eu
+
+cd "$SRC/libexpat/expat"
+cmake . \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DEXPAT_BUILD_DOCS=OFF \
+    -DEXPAT_BUILD_EXAMPLES=OFF \
+    -DEXPAT_BUILD_TESTS=OFF \
+    -DEXPAT_BUILD_TOOLS=OFF \
+    -DEXPAT_SHARED_LIBS=OFF \
+    -DCMAKE_C_FLAGS="$CFLAGS" \
+    -DCMAKE_CXX_FLAGS="$CXXFLAGS"
+make -j$(nproc)
+
+# Build the parse fuzzer
+$CC $CFLAGS -I./lib \
+    -c fuzz/xml_parse_fuzzer.c \
+    -o xml_parse_fuzzer.o
+
+$CC $CFLAGS $LIB_FUZZING_ENGINE \
+    xml_parse_fuzzer.o \
+    ./libexpat.a \
+    -o "$OUT/xml_parse_fuzzer"
+
+# Build the parsebuffer fuzzer
+$CC $CFLAGS -I./lib \
+    -c fuzz/xml_parsebuffer_fuzzer.c \
+    -o xml_parsebuffer_fuzzer.o
+
+$CC $CFLAGS $LIB_FUZZING_ENGINE \
+    xml_parsebuffer_fuzzer.o \
+    ./libexpat.a \
+    -o "$OUT/xml_parsebuffer_fuzzer"
+
+# Seed corpus: use existing XML test cases
+find "$SRC/libexpat/expat/tests" -name "*.xml" 2>/dev/null | head -50 | \
+    xargs -I{} cp {} "$OUT/xml_parse_fuzzer_seed_corpus/" 2>/dev/null || true
+mkdir -p "$OUT/xml_parse_fuzzer_seed_corpus"
+echo "<root/>" > "$OUT/xml_parse_fuzzer_seed_corpus/minimal.xml"
+echo "<?xml version='1.0'?><root attr='val'>text</root>" > "$OUT/xml_parse_fuzzer_seed_corpus/attrs.xml"
+zip -j "$OUT/xml_parse_fuzzer_seed_corpus.zip" "$OUT/xml_parse_fuzzer_seed_corpus/"*
+cp "$OUT/xml_parse_fuzzer_seed_corpus.zip" "$OUT/xml_parsebuffer_fuzzer_seed_corpus.zip"

--- a/projects/libexpat/project.yaml
+++ b/projects/libexpat/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://libexpat.github.io/"
+language: c
+primary_contact: "libexpat-users@lists.sourceforge.net"
+main_repo: "https://github.com/libexpat/libexpat"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+sanitizers:
+  - address
+  - undefined
+  - memory


### PR DESCRIPTION
## libexpat OSS-Fuzz Integration

**libexpat** is a widely deployed C XML parser (Expat library) used in Python's standard library (`xml.parsers.expat`), Firefox, Chrome, Apache httpd, OpenSSH, Perl, PHP, and hundreds of other projects. It handles untrusted XML input across the ecosystem.

Despite being a Tier 1 security-critical library with known CVE history (CVE-2021-45960, CVE-2022-25235, CVE-2022-40674, etc.), libexpat currently has **no OSS-Fuzz project**.

### Fuzz targets

| Target | Coverage |
|--------|----------|
| `xml_parse_fuzzer` | `XML_Parse()` — streaming byte-chunk input parser |
| `xml_parsebuffer_fuzzer` | `XML_ParseBuffer()` — buffer-based parser (different code path) |

The fuzz harnesses are the existing ones from libexpat's own `expat/fuzz/` directory — no new harness code is needed.

### Build

Uses CMake with static library build. Seed corpus includes representative XML files from libexpat's own test suite.

### Why this matters

libexpat's parser handles recursive XML, namespace expansion, attribute enumeration, and doctype declarations — all historically high-bug-density areas. Continuous fuzzing will catch regressions before they ship.