### PR TITLE
projects/libsndfile: add sndfile_write_fuzzer for encode/transcode path

### DIFF
--- a/projects/libsndfile/build.sh
+++ b/projects/libsndfile/build.sh
@@ -20,7 +20,7 @@ apt-get update
 ./ossfuzz/ossfuzz.sh
 
 # To make CIFuzz fast, see here for details: https://github.com/libsndfile/libsndfile/pull/796
-for fuzzer in sndfile_alt_fuzzer sndfile_fuzzer; do
+for fuzzer in sndfile_alt_fuzzer sndfile_fuzzer sndfile_write_fuzzer; do
   echo "[libfuzzer]" > ${OUT}/${fuzzer}.options
   echo "close_fd_mask = 3" >> ${OUT}/${fuzzer}.options
 done


### PR DESCRIPTION
## Summary

Extends the existing libsndfile OSS-Fuzz integration to include **`sndfile_write_fuzzer`**, a new harness targeting the encode/transcode path.

### What's new

The existing integration copies two fuzzers — `sndfile_fuzzer` and `sndfile_alt_fuzzer` — both of which exercise only the **read/decode** path. The write/encode path (format-specific encoders, sample-rate conversion, `SF_VIRTUAL_IO` write callbacks) has no continuous coverage.

`sndfile_write_fuzzer`:
1. Opens fuzz input as a virtual in-memory read file
2. Transcodes valid audio to WAV or AU in an expandable in-memory buffer
3. Targets: `sf_writef_float()`, `sf_writef_short()`, all format encoder code paths

### Upstream PR

The fuzzer harness lives in the libsndfile source repo and is built by `ossfuzz.sh`:
👉 libsndfile/libsndfile#1126

This oss-fuzz PR simply adds `sndfile_write_fuzzer` to the `build.sh` options loop.

## Test

I have read the CLA Document and I hereby sign the CLA

Signed-off-by: XananasX7 <mehdiananas007@gmail.com>