### PR TITLE
Add provii-crypto project

### DIFF
--- a/projects/provii-crypto/Dockerfile
+++ b/projects/provii-crypto/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+
+# Clone the provii-crypto repository
+RUN git clone --depth 1 https://github.com/provii/provii-crypto provii-crypto
+
+WORKDIR $SRC/provii-crypto
+
+# Copy the build script
+COPY build.sh $SRC/

--- a/projects/provii-crypto/build.sh
+++ b/projects/provii-crypto/build.sh
@@ -1,0 +1,40 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd "$SRC/provii-crypto/fuzz"
+
+# Build every fuzz target defined in fuzz/Cargo.toml.
+cargo fuzz build -O
+
+FUZZ_TARGET_DIR="$SRC/provii-crypto/fuzz/target/x86_64-unknown-linux-gnu/release"
+
+# Enumerate targets directly from Cargo.toml via `cargo fuzz list` so this
+# script can never drift out of sync with the [[bin]] entries. Each target is
+# copied to $OUT, along with a seed corpus when one is committed under
+# fuzz/corpus/<target>/.
+for target in $(cargo fuzz list); do
+    if [ ! -f "$FUZZ_TARGET_DIR/$target" ]; then
+        echo "Error: $target not found in $FUZZ_TARGET_DIR" >&2
+        exit 1
+    fi
+    cp "$FUZZ_TARGET_DIR/$target" "$OUT/"
+
+    corpus_dir="corpus/$target"
+    if [ -d "$corpus_dir" ] && [ -n "$(ls -A "$corpus_dir" 2>/dev/null)" ]; then
+        zip -j "$OUT/${target}_seed_corpus.zip" "$corpus_dir"/*
+    fi
+done

--- a/projects/provii-crypto/project.yaml
+++ b/projects/provii-crypto/project.yaml
@@ -1,0 +1,22 @@
+# OSS-Fuzz integration configuration for provii-crypto.
+# Schema: https://google.github.io/oss-fuzz/getting-started/new-project-guide/
+#
+# Note: primary_contact and auto_ccs must be Google-account email addresses to
+# receive ClusterFuzz access, crash reports, and fuzzer statistics.
+
+homepage: "https://github.com/provii/provii-crypto"
+main_repo: "https://github.com/provii/provii-crypto"
+language: rust
+primary_contact: "tom@maelstrom.au"
+auto_ccs:
+  - "tom@maelstrom.au"
+
+# cargo-fuzz / libfuzzer-sys harnesses build only against libFuzzer.
+fuzzing_engines:
+  - libfuzzer
+
+# AddressSanitizer catches memory errors; UBSan catches undefined behaviour in
+# the native dependencies (jubjub, blake2s_simd, bellman, etc.).
+sanitizers:
+  - address
+  - undefined


### PR DESCRIPTION
Initial OSS-Fuzz integration for **provii-crypto**.

### What it is
[provii-crypto](https://github.com/provii/provii-crypto) is the zero-knowledge age-verification cryptography library behind Provii (Apache-2.0, Rust). Its public surface parses untrusted input, which makes it a good fuzzing candidate:

- RedJubjub / ed25519 signature and key parsing + verification
- Groth16 proof verification and verification-key loading
- Pedersen commitments and nullifiers
- Attestation JSON (de)serialisation
- Protocol message parsing (challenges, origin hashes, replay tags, length-prefixed reads)

### Integration
- `fuzz/` provides **23 libFuzzer targets** built with `cargo-fuzz`; `build.sh` enumerates them via `cargo fuzz list` so the set can't drift.
- Engine: libFuzzer. Sanitizers: address + undefined.
- All 23 targets build under `cargo +nightly fuzz build -O`.

### Contacts
`primary_contact` / `auto_ccs` use a Google-account address (`tom@maelstrom.au`). I maintain provii-crypto and am authorising this integration.

I'll sign the CLA when prompted.