### PR TITLE
zstd-seekable-format-go: initial integration

### DIFF
--- a/projects/zstd-seekable-format-go/Dockerfile
+++ b/projects/zstd-seekable-format-go/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+
+RUN git clone --depth 1 https://github.com/SaveTheRbtz/zstd-seekable-format-go $SRC/zstd-seekable-format-go
+RUN cd $SRC/zstd-seekable-format-go/pkg && go mod download
+
+COPY build.sh $SRC/
+WORKDIR $SRC/zstd-seekable-format-go/pkg

--- a/projects/zstd-seekable-format-go/build.sh
+++ b/projects/zstd-seekable-format-go/build.sh
@@ -17,6 +17,10 @@
 
 cd "$SRC/zstd-seekable-format-go/pkg"
 
+# The native Go fuzzer helper rewrites _test.go files into regular Go files.
+# Keep the external-package examples out of that package-local fuzz build.
+rm example_test.go
+
 FUZZERS_PACKAGE=github.com/SaveTheRbtz/zstd-seekable-format-go/pkg
 
 compile_native_go_fuzzer_v2 "$FUZZERS_PACKAGE" FuzzReader FuzzReader
@@ -24,5 +28,5 @@ compile_native_go_fuzzer_v2 "$FUZZERS_PACKAGE" FuzzReaderConst FuzzReaderConst
 compile_native_go_fuzzer_v2 "$FUZZERS_PACKAGE" FuzzRoundTrip FuzzRoundTrip
 compile_native_go_fuzzer_v2 "$FUZZERS_PACKAGE" FuzzCorruptSeekTable FuzzCorruptSeekTable
 
-zip "$OUT/FuzzReader_seed_corpus.zip" testdata/fuzz/FuzzReader/*
-zip "$OUT/FuzzRoundTrip_seed_corpus.zip" testdata/fuzz/FuzzRoundTrip/*
+zip -j "$OUT/FuzzReader_seed_corpus.zip" testdata/fuzz/FuzzReader/*
+zip -j "$OUT/FuzzRoundTrip_seed_corpus.zip" testdata/fuzz/FuzzRoundTrip/*

--- a/projects/zstd-seekable-format-go/build.sh
+++ b/projects/zstd-seekable-format-go/build.sh
@@ -18,15 +18,19 @@
 cd "$SRC/zstd-seekable-format-go/pkg"
 
 # The native Go fuzzer helper rewrites _test.go files into regular Go files.
-# Keep the external-package examples out of that package-local fuzz build.
+# Keep external-package examples out of package-local fuzz builds.
 rm example_test.go
+rm framecache/example_test.go
 
 FUZZERS_PACKAGE=github.com/SaveTheRbtz/zstd-seekable-format-go/pkg
+FRAMECACHE_FUZZERS_PACKAGE="$FUZZERS_PACKAGE/framecache"
 
 compile_native_go_fuzzer_v2 "$FUZZERS_PACKAGE" FuzzReader FuzzReader
 compile_native_go_fuzzer_v2 "$FUZZERS_PACKAGE" FuzzReaderConst FuzzReaderConst
 compile_native_go_fuzzer_v2 "$FUZZERS_PACKAGE" FuzzRoundTrip FuzzRoundTrip
 compile_native_go_fuzzer_v2 "$FUZZERS_PACKAGE" FuzzCorruptSeekTable FuzzCorruptSeekTable
+compile_native_go_fuzzer_v2 "$FUZZERS_PACKAGE" FuzzReaderFrameCacheConcurrentReadAt FuzzReaderFrameCacheConcurrentReadAt
+compile_native_go_fuzzer_v2 "$FRAMECACHE_FUZZERS_PACKAGE" FuzzFrameCacheAccessPatterns FuzzFrameCacheAccessPatterns
 
 zip -j "$OUT/FuzzReader_seed_corpus.zip" testdata/fuzz/FuzzReader/*
 zip -j "$OUT/FuzzRoundTrip_seed_corpus.zip" testdata/fuzz/FuzzRoundTrip/*

--- a/projects/zstd-seekable-format-go/build.sh
+++ b/projects/zstd-seekable-format-go/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd "$SRC/zstd-seekable-format-go/pkg"
+
+FUZZERS_PACKAGE=github.com/SaveTheRbtz/zstd-seekable-format-go/pkg
+
+compile_native_go_fuzzer_v2 "$FUZZERS_PACKAGE" FuzzReader FuzzReader
+compile_native_go_fuzzer_v2 "$FUZZERS_PACKAGE" FuzzReaderConst FuzzReaderConst
+compile_native_go_fuzzer_v2 "$FUZZERS_PACKAGE" FuzzRoundTrip FuzzRoundTrip
+compile_native_go_fuzzer_v2 "$FUZZERS_PACKAGE" FuzzCorruptSeekTable FuzzCorruptSeekTable
+
+zip "$OUT/FuzzReader_seed_corpus.zip" testdata/fuzz/FuzzReader/*
+zip "$OUT/FuzzRoundTrip_seed_corpus.zip" testdata/fuzz/FuzzRoundTrip/*

--- a/projects/zstd-seekable-format-go/project.yaml
+++ b/projects/zstd-seekable-format-go/project.yaml
@@ -1,0 +1,24 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+homepage: "https://github.com/SaveTheRbtz/zstd-seekable-format-go"
+language: go
+primary_contact: "rbtz@ph34r.me"
+main_repo: "https://github.com/SaveTheRbtz/zstd-seekable-format-go"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
Initial OSS-Fuzz integration for [zstd-seekable-format-go](https://github.com/SaveTheRbtz/zstd-seekable-format-go), a Go library for random-access reads of Zstandard seekable-format streams.

## Project details

- **Language:** Go
- **Main repo:** https://github.com/SaveTheRbtz/zstd-seekable-format-go
- **Fuzzing engine:** libFuzzer
- **Sanitizer:** address
- **Primary contact:** rbtz@ph34r.me

## What this adds

New files under `projects/zstd-seekable-format-go/`:

- `project.yaml` - project metadata and contact
- `Dockerfile` - uses `base-builder-go`, clones the upstream repository, and downloads Go module dependencies
- `build.sh` - builds native Go fuzz targets with `compile_native_go_fuzzer_v2`

## Fuzz targets

| Binary | Upstream fuzz target | Coverage |
|--------|----------------------|----------|
| `FuzzReader` | `FuzzReader` | Reader construction, `Seek`, `Read`, and `ReadAt` on arbitrary seekable Zstandard input |
| `FuzzReaderConst` | `FuzzReaderConst` | Reader seeking and random-access reads over a known valid seekable stream |
| `FuzzRoundTrip` | `FuzzRoundTrip` | Writer/reader round trips across randomized frame layouts and seek operations |
| `FuzzCorruptSeekTable` | `FuzzCorruptSeekTable` | Seek table parsing and reader behavior with mutated seek table data |
| `FuzzReaderFrameCacheConcurrentReadAt` | `FuzzReaderFrameCacheConcurrentReadAt` | Concurrent `ReadAt` behavior with pluggable reader frame caches |
| `FuzzFrameCacheAccessPatterns` | `FuzzFrameCacheAccessPatterns` | Frame cache replacement strategies and cache invariants under generated access patterns |

## Seed corpus

The checked-in native Go fuzz corpus for `FuzzReader` and `FuzzRoundTrip` is packaged as OSS-Fuzz seed corpus archives.

## Local verification

- `python3 infra/presubmit.py` - pass
- `python3 infra/presubmit.py license` - pass
- `python3 infra/helper.py build_image --no-pull zstd-seekable-format-go` - pass
- `python3 infra/helper.py build_fuzzers --sanitizer address --clean zstd-seekable-format-go` - pass
- `python3 infra/helper.py check_build --sanitizer address zstd-seekable-format-go` - pass
- `go test ./...` in the upstream package - pass
- Native Go OSS-Fuzz build/check smoke coverage for all six fuzz targets - pass
