### PR TITLE
capnproto: add packed, JSON, text and schema-parser fuzz harnesses

### DIFF
--- a/projects/capnproto/Dockerfile
+++ b/projects/capnproto/Dockerfile
@@ -18,4 +18,6 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y autoconf automake libtool zlib1g-dev
 RUN git clone --depth 1 https://github.com/capnproto/capnproto
 WORKDIR $SRC/capnproto
-COPY build.sh $SRC/
+COPY build.sh capnp-packed-fuzzer.c++ capnp-json-fuzzer.c++ \
+     capnp-schema-parser-fuzzer.c++ capnp-text-fuzzer.c++ $SRC/
+COPY seeds $SRC/seeds

--- a/projects/capnproto/build.sh
+++ b/projects/capnproto/build.sh
@@ -22,3 +22,45 @@ autoreconf -i
 make -j$(nproc)
 make -j$(nproc) capnp-llvm-fuzzer-testcase
 cp *fuzzer* $OUT/
+
+# Build extra harnesses for code paths the default
+# capnp-llvm-fuzzer-testcase does not exercise.
+EXTRA_LIBS="libcapnp-test.a \
+            .libs/libcapnpc.a \
+            .libs/libcapnp-json.a \
+            .libs/libcapnp-rpc.a \
+            .libs/libcapnp.a \
+            .libs/libkj-async.a \
+            .libs/libkj.a"
+
+for harness in "$SRC"/capnp-packed-fuzzer.c++ \
+               "$SRC"/capnp-json-fuzzer.c++ \
+               "$SRC"/capnp-schema-parser-fuzzer.c++ \
+               "$SRC"/capnp-text-fuzzer.c++; do
+    name=$(basename "$harness" .c++)
+    $CXX $CXXFLAGS -std=gnu++23 -stdlib=libc++ \
+        -I src \
+        "$harness" \
+        $EXTRA_LIBS \
+        $LIB_FUZZING_ENGINE \
+        -lpthread -ldl -lz \
+        -o "$OUT/$name"
+done
+
+# Build seed corpora directly from the upstream test-data tree so we don't
+# need to vendor binary fixtures into the oss-fuzz repo.
+TD="$SRC/capnproto/c++/src/capnp/testdata"
+zip -j "$OUT/capnp-packed-fuzzer_seed_corpus.zip" \
+    "$TD/packed" "$TD/packedflat" "$TD/segmented-packed"
+zip -j "$OUT/capnp-json-fuzzer_seed_corpus.zip" \
+    "$TD/short.json" "$TD/pretty.json" "$TD/annotated.json"
+zip -j "$OUT/capnp-text-fuzzer_seed_corpus.zip" \
+    "$TD/short.txt" "$TD/pretty.txt"
+# Schema-parser seeds: real upstream .capnp source files plus our tiny one.
+zip -j "$OUT/capnp-schema-parser-fuzzer_seed_corpus.zip" \
+    "$SRC/capnproto/c++/src/capnp/c++.capnp" \
+    "$SRC/capnproto/c++/src/capnp/persistent.capnp" \
+    "$SRC/capnproto/c++/src/capnp/stream.capnp" \
+    "$SRC/capnproto/c++/src/capnp/compiler/grammar.capnp" \
+    "$SRC/capnproto/c++/src/capnp/compiler/lexer.capnp" \
+    "$SRC/seeds/capnp-schema-parser-fuzzer/tiny.capnp"

--- a/projects/capnproto/capnp-json-fuzzer.c++
+++ b/projects/capnproto/capnp-json-fuzzer.c++
@@ -1,0 +1,51 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <capnp/test-util.h>
+#include <capnp/compat/json.h>
+#include <capnp/message.h>
+#include <capnp/test.capnp.h>
+#include <kj/exception.h>
+#include <kj/string.h>
+
+// Fuzzes the JSON parser/decoder in capnp::JsonCodec. Two complementary
+// entry points are exercised:
+//   1. decodeRaw -> writes into a json::Value tree; pure parser path.
+//   2. decode    -> parser plus the binding logic that maps JSON onto a
+//                   typed schema (TestAllTypes) and re-encodes the result.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
+  kj::ArrayPtr<const char> input(reinterpret_cast<const char*>(Data), Size);
+
+  capnp::JsonCodec codec;
+
+  (void)kj::runCatchingExceptions([&]() {
+    capnp::MallocMessageBuilder rawMessage;
+    auto rawRoot = rawMessage.initRoot<capnp::JsonValue>();
+    codec.decodeRaw(input, rawRoot);
+    // Round-trip the parsed JsonValue to also exercise the encoder.
+    kj::String reencoded = codec.encodeRaw(rawRoot.asReader());
+    (void)reencoded;
+  });
+
+  (void)kj::runCatchingExceptions([&]() {
+    capnp::MallocMessageBuilder typedMessage;
+    auto root = typedMessage.initRoot<capnp::_::TestAllTypes>();
+    codec.decode(input, root);
+    codec.setHasMode(capnp::HasMode::NON_DEFAULT);
+    kj::String encoded = codec.encode(root.asReader());
+    (void)encoded;
+  });
+
+  return 0;
+}

--- a/projects/capnproto/capnp-packed-fuzzer.c++
+++ b/projects/capnproto/capnp-packed-fuzzer.c++
@@ -1,0 +1,52 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <capnp/dynamic.h>
+#include <capnp/serialize-packed.h>
+#include <capnp/test.capnp.h>
+#include <kj/exception.h>
+#include <kj/io.h>
+#include <kj/string.h>
+
+namespace c = capnproto_test::capnp::test;
+
+// Fuzzes the packed-message decoder path
+// (capnp::PackedMessageReader / serialize-packed.c++), which is independent
+// from the unpacked path exercised by capnp-llvm-fuzzer-testcase. The
+// stringify of both the typed and dynamic root walks every field, exercising
+// the reader-side accessors without the noisy KJ_LOG output that the
+// gtest-style EXPECT_EQ-laden checkTestMessage helpers produce on
+// non-matching input.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
+  kj::ArrayPtr<const uint8_t> array(Data, Size);
+  kj::ArrayInputStream ais(array);
+
+  (void)kj::runCatchingExceptions([&]() {
+    capnp::PackedMessageReader reader(ais);
+    auto root = reader.getRoot<c::TestAllTypes>();
+    // Touch a handful of primitive and pointer fields. Each access walks
+    // the packed-segment cursor to the corresponding offset, exercising
+    // the unpacker without the unbounded recursion that a full stringify
+    // can hit on a maliciously-shaped message.
+    (void)root.getInt32Field();
+    (void)root.getUInt64Field();
+    (void)root.getFloat64Field();
+    (void)root.getTextField();
+    (void)root.getDataField();
+    (void)root.getStructField().getInt32Field();
+    (void)root.getStructList().size();
+    (void)root.getEnumList().size();
+  });
+  return 0;
+}

--- a/projects/capnproto/capnp-schema-parser-fuzzer.c++
+++ b/projects/capnproto/capnp-schema-parser-fuzzer.c++
@@ -1,0 +1,103 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <capnp/schema-parser.h>
+#include <capnp/schema.h>
+#include <kj/array.h>
+#include <kj/exception.h>
+#include <kj/string.h>
+
+// Fuzzes the capnp schema-language compiler: lexer, parser, grammar, node
+// translator, and SchemaParser glue. The input bytes are wrapped in a
+// minimal in-memory SchemaFile so no filesystem (real or virtual) is
+// involved — avoiding the lifetime quirks of kj::newInMemoryDirectory().
+// After a successful parse, the root types are walked so the schema graph
+// is also exercised.
+namespace {
+
+class MemSchemaFile final: public capnp::SchemaFile {
+public:
+  MemSchemaFile(kj::ArrayPtr<const kj::byte> data): data(data) {}
+
+  kj::StringPtr getDisplayName() const override { return "input.capnp"_kj; }
+
+  kj::Array<const char> readContent() const override {
+    auto out = kj::heapArray<char>(data.size());
+    memcpy(out.begin(), data.begin(), data.size());
+    return out.releaseAsBytes().releaseAsChars();
+  }
+
+  kj::Maybe<kj::Own<SchemaFile>> import(kj::StringPtr) const override {
+    return kj::none;  // no imports
+  }
+
+  bool operator==(const SchemaFile& other) const override {
+    return this == &other;
+  }
+  size_t hashCode() const override {
+    return reinterpret_cast<size_t>(this);
+  }
+
+  void reportError(SourcePos, SourcePos, kj::StringPtr) const override {}
+
+private:
+  kj::ArrayPtr<const kj::byte> data;
+};
+
+void walk(capnp::Schema schema, int depth) {
+  if (depth > 4) return;
+  auto proto = schema.getProto();
+  (void)proto.getDisplayName();
+  if (proto.isStruct()) {
+    auto s = schema.asStruct();
+    for (auto field : s.getFields()) {
+      (void)field.getProto().getName();
+      auto type = field.getType();
+      if (type.isStruct()) walk(type.asStruct(), depth + 1);
+      else if (type.isList()) (void)type.asList().getElementType();
+      else if (type.isEnum()) (void)type.asEnum().getEnumerants().size();
+      else if (type.isInterface()) walk(type.asInterface(), depth + 1);
+    }
+  } else if (proto.isInterface()) {
+    auto i = schema.asInterface();
+    for (auto method : i.getMethods()) {
+      (void)method.getProto().getName();
+      walk(method.getParamType(), depth + 1);
+      walk(method.getResultType(), depth + 1);
+    }
+  }
+}
+
+// parseFile returns a ParsedSchema for a *file* node, not a struct or
+// interface. To exercise the schema graph we have to descend into its
+// nested declarations.
+void walkFile(capnp::ParsedSchema parsed, int depth) {
+  if (depth > 4) return;
+  for (auto nested : parsed.getAllNested()) {
+    walk(nested, depth);
+    walkFile(nested, depth + 1);
+  }
+}
+
+}  // namespace
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
+  (void)kj::runCatchingExceptions([&]() {
+    capnp::SchemaParser parser;
+    capnp::ParsedSchema parsed = parser.parseFile(
+        kj::heap<MemSchemaFile>(kj::ArrayPtr<const kj::byte>(Data, Size)));
+    walkFile(parsed, 0);
+  });
+  return 0;
+}

--- a/projects/capnproto/capnp-text-fuzzer.c++
+++ b/projects/capnproto/capnp-text-fuzzer.c++
@@ -1,0 +1,46 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <capnp/test-util.h>
+#include <capnp/dynamic.h>
+#include <capnp/message.h>
+#include <capnp/serialize-text.h>
+#include <capnp/test.capnp.h>
+#include <kj/exception.h>
+#include <kj/string.h>
+
+// Fuzzes the text-format codec (capnp::TextCodec, backed by
+// serialize-text.c++ and the same lexer/parser used by SchemaParser).
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) {
+  // TextCodec::decode takes a kj::StringPtr — must be NUL-terminated.
+  kj::String input = kj::heapString(
+      reinterpret_cast<const char*>(Data), Size);
+
+  capnp::TextCodec codec;
+
+  (void)kj::runCatchingExceptions([&]() {
+    capnp::MallocMessageBuilder message;
+    auto root = message.initRoot<capnp::_::TestAllTypes>();
+    codec.decode(input, root);
+
+    // Round-trip: encode the decoded value back to text and stringify the
+    // dynamic view to exercise stringify.c++ paths too.
+    kj::String reencoded = codec.encode(root.asReader());
+    (void)reencoded;
+    kj::String stringified = kj::str(root.asReader());
+    (void)stringified;
+  });
+
+  return 0;
+}

--- a/projects/capnproto/seeds/capnp-schema-parser-fuzzer/tiny.capnp
+++ b/projects/capnproto/seeds/capnp-schema-parser-fuzzer/tiny.capnp
@@ -1,0 +1,14 @@
+@0x123456789abcdef0;
+struct Foo {
+  bar @0 :Text;
+  baz @1 :Int32 = 42;
+  list @2 :List(UInt8);
+  union {
+    a @3 :Bool;
+    b @4 :Float64;
+  }
+}
+enum Color { red @0; green @1; blue @2; }
+interface Iface {
+  method @0 (x :Foo) -> (y :Color);
+}


### PR DESCRIPTION
---

## Disclaimer
Investigation and work on this PR was primarily done by AI. I (Timothée Chauvin):

* verified that the improvement is real (see the automatically run [fuzzing coverage report](#fuzzing-coverage-report))
* briefly reviewed the full diff and commit/PR descriptions, but can't vouch for every detail.

Please let me know if you'd like a different level of verbosity or confidence in future PRs.

---

## Motivation

`capnproto` currently ships a single fuzz harness (`capnp-llvm-fuzzer-testcase`) that exercises only the unpacked binary message reader. Per the [Fuzz Introspector profile](https://introspector.oss-fuzz.com/project-profile?project=capnproto), reported line coverage sits at **6.51 % (2 451 / 37 649 lines)**. The packed-message decoder, JSON codec, text codec and schema-language compiler are unfuzzed.

## Changes

Four new harnesses are added alongside the existing one. All take attacker-controlled bytes as input:

- **`capnp-packed-fuzzer`** drives `capnp::PackedMessageReader` (the packed-encoding decoder in [`serialize-packed.c++`](https://github.com/capnproto/capnproto/blob/master/c%2B%2B/src/capnp/serialize-packed.c%2B%2B)).
- **`capnp-json-fuzzer`** drives `capnp::JsonCodec::decodeRaw` (parser-only) and `capnp::JsonCodec::decode` against `TestAllTypes` (parser + schema-bound binding logic in [`compat/json.c++`](https://github.com/capnproto/capnproto/blob/master/c%2B%2B/src/capnp/compat/json.c%2B%2B)), then re-encodes to also exercise the encoder.
- **`capnp-text-fuzzer`** drives `capnp::TextCodec::decode` against `TestAllTypes`, exercising [`serialize-text.c++`](https://github.com/capnproto/capnproto/blob/master/c%2B%2B/src/capnp/serialize-text.c%2B%2B) and the lexer it shares with the schema language.
- **`capnp-schema-parser-fuzzer`** drives `capnp::SchemaParser::parseFile` via a tiny in-memory `SchemaFile` subclass (no kj filesystem allocation, avoiding a known cleanup-order leak), hitting the full schema-language pipeline: [`compiler/lexer.c++`](https://github.com/capnproto/capnproto/blob/master/c%2B%2B/src/capnp/compiler/lexer.c%2B%2B), [`compiler/parser.c++`](https://github.com/capnproto/capnproto/blob/master/c%2B%2B/src/capnp/compiler/parser.c%2B%2B), [`compiler/node-translator.c++`](https://github.com/capnproto/capnproto/blob/master/c%2B%2B/src/capnp/compiler/node-translator.c%2B%2B), [`compiler/compiler.c++`](https://github.com/capnproto/capnproto/blob/master/c%2B%2B/src/capnp/compiler/compiler.c%2B%2B), and [`schema-parser.c++`](https://github.com/capnproto/capnproto/blob/master/c%2B%2B/src/capnp/schema-parser.c%2B%2B).

`build.sh` is extended to compile the new harnesses against the `.la`-built `libcapnp*` / `libcapnpc.a` / `libkj*` archives produced by the existing `make` step. The `Dockerfile` `COPY`s the new sources and the (small) `seeds/` directory.

## Seed corpora

`build.sh` builds each seed corpus directly from the upstream tree at [`c++/src/capnp/testdata/`](https://github.com/capnproto/capnproto/tree/master/c%2B%2B/src/capnp/testdata) so no binary fixtures are vendored:

- `capnp-packed-fuzzer`: `packed`, `packedflat`, `segmented-packed` — packed-encoded `TestAllTypes` messages produced upstream by `capnp encode`.
- `capnp-json-fuzzer`: `short.json`, `pretty.json`, `annotated.json`.
- `capnp-text-fuzzer`: `short.txt`, `pretty.txt`.
- `capnp-schema-parser-fuzzer`: real upstream `.capnp` source files (`c++.capnp`, `persistent.capnp`, `stream.capnp`, `compiler/grammar.capnp`, `compiler/lexer.capnp`) plus one tiny hand-written schema (`seeds/capnp-schema-parser-fuzzer/tiny.capnp`, 14 lines, the only file under `seeds/` in the diff) covering structs, unions, lists, enums and interfaces.

---

<!-- fuzz-coverage-report -->

## Fuzzing Coverage Report

**Tested:** project `capnproto` · base `26deef8` → head `83bf809` · 300s total fuzz budget · updated 2026-05-27 19:03 UTC · [workflow run](https://github.com/tc-agent/oss-fuzz/actions/runs/26525252613)

| Metric | Before | After | Delta |
|---|---|---|---|
| Static reachability | [>45m](https://github.com/tc-agent/oss-fuzz/actions/runs/26525252613) | [>45m](https://github.com/tc-agent/oss-fuzz/actions/runs/26525252613) | — |
| Line coverage | 5.9% (2213/37653) | 25.8% (14295/55514) | **+546.0%** |
| Branch coverage | 8.4% (613/7330) | 32.0% (4099/12820) | **+568.7%** |
| Function coverage | 5.4% (507/9465) | 19.4% (2358/12174) | **+365.1%** |

### Per-harness

| Harness | Lines before | Lines after | Δ |
|---|---|---|---|
| `capnp-json-fuzzer` | 0% | 10.9% (4116/37916) | **new** |
| `capnp-llvm-fuzzer-testcase` | 5.9% (2213/37653) | 5.6% (2106/37653) | **-4.8%** |
| `capnp-packed-fuzzer` | 0% | 21.5% (1987/9258) | **new** |
| `capnp-schema-parser-fuzzer` | 0% | 34.8% (11556/33164) | **new** |
| `capnp-text-fuzzer` | 0% | 12.6% (5763/45806) | **new** |

<sub>Δ = (after − before) / before, to accommodate that denominators may change. "new" when before is 0; "deleted" when after is 0.</sub>
