### PR TITLE
strongswan: Enable more plugins for simaka

### DIFF
--- a/projects/strongswan/build.sh
+++ b/projects/strongswan/build.sh
@@ -21,7 +21,16 @@
 	--enable-imc-test \
 	--enable-tnccs-20 \
 	--enable-libipsec \
+	--enable-dnscert \
+	--enable-ipseckey \
 	--enable-eap-radius \
+	--enable-eap-aka \
+	--enable-eap-sim \
+	--enable-eap-md5 \
+	--enable-eap-mschapv2 \
+	--enable-eap-identity \
+	--enable-md4 \
+	--enable-md5 \
 	--enable-pkcs12 \
 	--enable-hmac \
 	--enable-acert \


### PR DESCRIPTION
This PR enables simaka related plugins for the new fuzz-simaka introducing in https://github.com/strongswan/strongswan/pull/3081.

This PR requires https://github.com/strongswan/strongswan/pull/3081 to merged in to enable the simaka build from strongswan side.