### PR TITLE
Add dnsmasq fuzzers

### DIFF
--- a/projects/dnsmasq/build.sh
+++ b/projects/dnsmasq/build.sh
@@ -47,9 +47,66 @@ rm dnsmasq.o
 $CC $CFLAGS -c dnsmasq.c -o dnsmasq.o -I./ -DVERSION=\'\"UNKNOWN\"\' 
 ar cr libdnsmasq.a *.o
 
+# Build new C fuzzers against libdnsmasq.a.
+# Must be before the sed class/new renaming below (these are C, not C++).
+# CWD is $SRC/dnsmasq/src/ — -I./ picks up dnsmasq.h, -I$SRC/ picks up
+# any headers copied into the oss-fuzz project directory.
+for fuzzer in fuzz_dns fuzz_forward fuzz_dhcp_reply; do
+  $CC $CFLAGS -c $SRC/${fuzzer}.c \
+      -I./ -I$SRC/ \
+      -DVERSION=\'\"UNKNOWN\"\' \
+      -o ${fuzzer}.o
+  $CC $CFLAGS $LIB_FUZZING_ENGINE \
+      ./${fuzzer}.o libdnsmasq.a \
+      -o $OUT/${fuzzer}
+done
+
+# fuzz_dhcp6_reply defines get_client_mac() as a stub to prevent the 500ms
+# nanosleep loop in dhcp6.c's real implementation.  dhcp6.o is extracted from
+# libdnsmasq.a (it provides dhcp6_reply), bringing its own get_client_mac
+# definition along — causing a duplicate symbol.  --allow-multiple-definition
+# resolves this: the linker keeps the first definition (our stub, from
+# fuzz_dhcp6_reply.o, processed before the archive).
+$CC $CFLAGS -c $SRC/fuzz_dhcp6_reply.c \
+    -I./ -I$SRC/ \
+    -DVERSION=\'\"UNKNOWN\"\' \
+    -o fuzz_dhcp6_reply.o
+$CC $CFLAGS $LIB_FUZZING_ENGINE \
+    -Wl,--allow-multiple-definition \
+    ./fuzz_dhcp6_reply.o libdnsmasq.a \
+    -o $OUT/fuzz_dhcp6_reply
+
 sed -i 's/class/class2/g' ./dnsmasq.h
 sed -i 's/new/new2/g' ./dnsmasq.h
 
 # Build the fuzzers
 $CXX $CXXFLAGS -c $SRC/fuzz_util.cc -I./ -I$SRC/ -DVERSION=\'\"UNKNOWN\"\' -g
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE ./fuzz_util.o libdnsmasq.a -o $OUT/fuzz_util
+
+# Seed corpora for new fuzzers
+# fuzz_dns + fuzz_forward share the same DNS wire-format input
+printf '\x12\x34\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00' \
+    > "$WORK/dns_seed.bin"
+printf '\x07\x65\x78\x61\x6d\x70\x6c\x65\x03\x63\x6f\x6d\x00\x00\x01\x00\x01' \
+    >> "$WORK/dns_seed.bin"
+zip -j "$OUT/fuzz_dns_seed_corpus.zip"     "$WORK/dns_seed.bin"
+zip -j "$OUT/fuzz_forward_seed_corpus.zip" "$WORK/dns_seed.bin"
+
+# fuzz_dhcp_reply — minimal DHCPv4 DISCOVER
+{
+  printf '\x01\x01\x06\x00\xde\xad\xbe\xef\x00\x00\x00\x00'
+  printf '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+  printf '\xde\xad\xbe\xef\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+  printf '%0.s\x00' {1..64}
+  printf '%0.s\x00' {1..128}
+  printf '\x63\x82\x53\x63\x35\x01\x01\xff'
+} > "$WORK/dhcp_reply_seed.bin"
+zip -j "$OUT/fuzz_dhcp_reply_seed_corpus.zip" "$WORK/dhcp_reply_seed.bin"
+
+# fuzz_dhcp6_reply — minimal DHCPv6 SOLICIT with DUID-LL
+{
+  printf '\x01\xde\xad\xbe'
+  printf '\x00\x01\x00\x0a'
+  printf '\x00\x03\x00\x01\xde\xad\xbe\xef\x00\x01'
+} > "$WORK/dhcp6_reply_seed.bin"
+zip -j "$OUT/fuzz_dhcp6_reply_seed_corpus.zip" "$WORK/dhcp6_reply_seed.bin"

--- a/projects/dnsmasq/fuzz_dhcp6_reply.c
+++ b/projects/dnsmasq/fuzz_dhcp6_reply.c
@@ -1,0 +1,378 @@
+/*
+ * dnsmasq_fuzzer_dhcp6.c — libFuzzer harness for DHCPv6 processing.
+ *
+ * Intended for integration into the Google oss-fuzz project.
+ * https://github.com/google/oss-fuzz
+ *
+ * Directly injects fuzz data into daemon->dhcp_packet and calls dhcp6_reply()
+ * from rfc3315.c, bypassing any stdin/loop mechanics in dhcp6.c entirely.
+ * This gives clean single-input semantics and covers:
+ *   - rfc3315.c  dhcp6_reply()       — full DHCPv6 message handling
+ *   - rfc3315.c  relay_upstream6()   — client→server relay forwarding
+ *   - rfc3315.c  relay_reply6()      — server→client relay reply routing
+ *   - dhcp-common.c                  — option_filter(), match_netid(), ...
+ *
+ * Build (oss-fuzz environment — called from build.sh):
+ *   $CC $CFLAGS -DVERSION='"oss-fuzz"' -Isrc \
+ *       -o $OUT/dnsmasq_fuzzer_dhcp6 \
+ *       fuzzing/oss-fuzz/dnsmasq_fuzzer_dhcp6.c \
+ *       <all dnsmasq objects except dnsmasq.o> \
+ *       $LIB_FUZZING_ENGINE
+ *
+ * Local libFuzzer build (for development):
+ *   make CC=clang \
+ *        CFLAGS="-g -O1 -fsanitize=address,fuzzer-no-link" \
+ *        LDFLAGS="-g -fsanitize=address -fsanitize=fuzzer" \
+ *        FUZZER_DRIVER="" \
+ *        mostly_clean oss_fuzz_dhcp6
+ */
+
+#include "dnsmasq.h"
+#include <net/if.h>
+
+/* Fixed timestamp — keeps all time-dependent branches deterministic. */
+#define FUZZ_NOW ((time_t)1000000)
+
+/* dnsmasq.c owns this global; we define it here since we don't link dnsmasq.o */
+struct daemon *daemon;
+
+/* ── Stubs for functions defined in dnsmasq.c ─────────────────────────── */
+void send_event(int fd, int event, int data, char *msg)
+  { (void)fd; (void)event; (void)data; (void)msg; }
+void queue_event(int event)               { (void)event; }
+void send_alarm(time_t event, time_t now) { (void)event; (void)now; }
+int  icmp_ping(struct in_addr addr)       { (void)addr; return 0; }
+int  delay_dhcp(time_t start, int sec, int fd, uint32_t addr, unsigned short id)
+  { (void)start; (void)sec; (void)fd; (void)addr; (void)id; return 0; }
+
+/*
+ * get_client_mac() is defined in dhcp6.c and loops up to 5× with 100ms
+ * nanosleep() per iteration waiting for a neighbour-cache entry, giving
+ * ~500ms per fuzzer execution (~2 exec/s).  Return a fixed fake MAC instead
+ * so the fuzzer runs at full throughput.
+ */
+void get_client_mac(struct in6_addr *client, int iface,
+                    unsigned char *mac, unsigned int *maclenp,
+                    unsigned int *mactypep, time_t now)
+{
+  (void)client; (void)iface; (void)now;
+  memcpy(mac, "\xde\xad\xbe\xef\x00\x02", 6);
+  *maclenp  = 6;
+  *mactypep = ARPHRD_ETHER;
+}
+
+/* Synthetic DUID-LL (type 3, hw_type 1=Ethernet, MAC de:ad:be:ef:00:01) */
+static unsigned char synthetic_duid[] = {
+  0x00, 0x03,               /* DUID type 3 = DUID-LL */
+  0x00, 0x01,               /* hw_type 1 = Ethernet  */
+  0xde, 0xad, 0xbe, 0xef, 0x00, 0x01  /* MAC address */
+};
+
+/* ── Context chain setup ──────────────────────────────────────────────── */
+/*
+ * Replicates the relevant part of the static complete_context6() in dhcp6.c,
+ * without requiring iface_enumerate() or netlink.  Must be called before each
+ * dhcp6_reply() invocation so that context->current is rebuilt from scratch.
+ *
+ * local — the global unicast address we inject for the loopback interface.
+ *         fd00::1 is within --dhcp-range=fd00::100,fd00::200/64.
+ *
+ * Returns the head of the linked context chain (passed to dhcp6_reply() as
+ * the first argument), or NULL if no contexts matched.
+ */
+static struct dhcp_context *build_context6_chain(const struct in6_addr *local)
+{
+  struct dhcp_context *ctx, *chain = NULL;
+
+  /* Reset all contexts to the "unlinked" state (current == self, local6 = 0) */
+  for (ctx = daemon->dhcp6; ctx; ctx = ctx->next)
+    {
+      ctx->current = ctx;
+      memset(&ctx->local6, 0, IN6ADDRSZ);
+    }
+
+  for (ctx = daemon->dhcp6; ctx; ctx = ctx->next)
+    {
+      if (!(ctx->flags & CONTEXT_DHCP))
+        continue;
+      if (ctx->flags & (CONTEXT_TEMPLATE | CONTEXT_OLD))
+        continue;
+      if (ctx->current != ctx)  /* already linked into another chain */
+        continue;
+
+      if (is_same_net6(local, &ctx->start6, ctx->prefix) &&
+          is_same_net6(local, &ctx->end6,   ctx->prefix))
+        {
+          ctx->local6    = *local;
+          ctx->preferred = 0xffffffff;
+          ctx->valid     = 0xffffffff;
+          /* insert at head — ordering by preferred time not critical for fuzzing */
+          ctx->current   = chain;
+          chain          = ctx;
+        }
+    }
+
+  return chain;
+}
+
+/* ── One-time initialization ─────────────────────────────────────────── */
+int LLVMFuzzerInitialize(int *argc, char ***argv)
+{
+  (void)argc; (void)argv;
+
+  static char *fuzz_argv[] = {
+    "fuzz_dhcp6_reply",
+    "--no-daemon",
+    "--no-resolv",
+    "--no-hosts",
+    "--port=0",
+    "--interface=lo",
+    /*
+     * Primary DHCPv6 pool on fd00::/64 (ULA).  The harness injects fd00::1
+     * as the local address, which falls within this prefix, so
+     * build_context6_chain() will link this context.
+     */
+    "--dhcp-range=fd00::100,fd00::200,64,12h",
+    "--dhcp-authoritative",
+    /*
+     * Pre-configured host so find_config() CLID path is reachable.
+     * DUID-LL de:ad:be:ef:00:01 matches the seed lease set up per-input.
+     */
+    "--dhcp-host=id:00:03:00:01:de:ad:be:ef:00:01,fd00::150,testhost6",
+    /*
+     * Relay: local=fd00::1, server=fd00::ffff.
+     * relay->iface_index is patched to lo after dhcp6_init() below.
+     * relay_upstream6() fires for client requests when iface_index matches.
+     * relay_reply6() fires when msg_type==DHCP6RELAYREPL and
+     * link_addr==fd00::1.
+     */
+    "--dhcp-relay=fd00::1,fd00::ffff",
+    /*
+     * OPT_LOG_OPTS → log_options() and all option_bool(OPT_LOG_OPTS) branches
+     * in rfc3315.c.  Absorbed by /dev/null to avoid I/O noise.
+     */
+    "--log-dhcp",
+    /* discard lease file writes to avoid file-I/O non-determinism */
+    "--dhcp-leasefile=/dev/null",
+    "--log-facility=/dev/null",
+  };
+  int fuzz_argc = (int)(sizeof(fuzz_argv) / sizeof(fuzz_argv[0]));
+
+  read_opts(fuzz_argc, fuzz_argv, "");
+
+  /* mirror dnsmasq.c initialisation that read_opts skips */
+  daemon->dumpfd  = -1;
+  daemon->icmp6fd = -1;  /* prevents the 500ms sleep in get_client_mac fallback */
+
+  if (daemon->edns_pktsz < PACKETSZ)
+    daemon->edns_pktsz = PACKETSZ;
+  daemon->packet_buff_sz = daemon->edns_pktsz + MAXDNAME + RRFIXEDSZ;
+  daemon->packet = safe_malloc(daemon->packet_buff_sz);
+
+  /*
+   * dnsmasq.c:main() sets doing_dhcp6 by walking daemon->dhcp6 contexts;
+   * read_opts() populates the contexts but never sets the flag.
+   */
+  {
+    struct dhcp_context *ctx;
+    for (ctx = daemon->dhcp6; ctx; ctx = ctx->next)
+      if (ctx->flags & CONTEXT_DHCP)
+        daemon->doing_dhcp6 = 1;
+  }
+
+  /* Provide a synthetic DUID so lease_init() doesn't die() */
+  daemon->duid     = synthetic_duid;
+  daemon->duid_len = sizeof(synthetic_duid);
+
+  dhcp_common_init();
+  lease_init(FUZZ_NOW);
+  dhcp6_init();   /* binds daemon->dhcp6fd to DHCPV6_SERVER_PORT (547) */
+
+  /*
+   * Rebind daemon->dhcp6fd to port 0 so that multiple parallel harness
+   * instances (e.g. main + ASAN secondary) can coexist on the same host.
+   * The socket is only used by relay_upstream6() for sendto() calls which
+   * fail gracefully when no relay server is reachable.
+   */
+  {
+    struct sockaddr_in6 sa;
+    close(daemon->dhcp6fd);
+    daemon->dhcp6fd = socket(PF_INET6, SOCK_DGRAM, IPPROTO_UDP);
+    if (daemon->dhcp6fd == -1)
+      {
+        perror("harness: socket");
+        return 1;
+      }
+    memset(&sa, 0, sizeof(sa));
+#ifdef HAVE_SOCKADDR_SA_LEN
+    sa.sin6_len = sizeof(sa);
+#endif
+    sa.sin6_family = AF_INET6;
+    sa.sin6_addr   = in6addr_any;
+    sa.sin6_port   = 0;   /* let the OS pick an ephemeral port */
+    if (bind(daemon->dhcp6fd, (struct sockaddr *)&sa, sizeof(sa)) == -1)
+      {
+        perror("harness: bind port 0");
+        return 1;
+      }
+  }
+
+  /*
+   * Enable lease_change_command paths in add_address()
+   * (OPTION6_VENDOR_CLASS, OPTION6_ORO, OPTION6_MUD_URL,
+   *  OPTION6_USER_CLASS parsing + lease_add_extradata).
+   * Must be set AFTER lease_init() — lease_init() calls popen(script+" init")
+   * if the command is set, which would die() on a non-executable path.
+   * daemon->helperfd is -1 so lease_update_file() never sends data to a helper.
+   */
+  daemon->lease_change_command = (char *)"/dev/null";
+
+  /*
+   * Patch relay6 iface_index to the loopback interface.
+   * read_opts() leaves iface_index=0; without this, relay_upstream6()
+   * always returns 0 (no matching relay).
+   */
+  {
+    int lo_idx = (int)if_nametoindex("lo");
+    struct dhcp_relay *r;
+    for (r = daemon->relay6; r; r = r->next)
+      if (r->iface_index == 0)
+        r->iface_index = lo_idx;
+  }
+
+  return 0;
+}
+
+/* ── Per-input processing ────────────────────────────────────────────── */
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+  /* DHCPv6 minimum: msg-type (1 byte) + transaction-id (3 bytes) */
+  if (size < 4)
+    return 0;
+
+  /* Inject fuzz data directly into the shared DHCPv6 packet buffer */
+  if (!expand_buf(&daemon->dhcp_packet, size))
+    return 0;
+  memcpy(daemon->dhcp_packet.iov_base, data, size);
+
+  int iface_index = (int)if_nametoindex("lo");
+  if (iface_index == 0)
+    return 0;
+
+  /*
+   * Synthetic addresses used throughout:
+   *   local6       — global unicast on lo, within fd00::/64 dhcp-range
+   *   ll_addr6     — link-local on lo (fe80::1)
+   *   ula_addr6    — ULA on lo (zeroed: none configured)
+   *   client_addr  — simulated client link-local source address
+   */
+  struct in6_addr local6, ll_addr6, ula_addr6, client_addr;
+  inet_pton(AF_INET6, "fd00::1", &local6);
+  inet_pton(AF_INET6, "fe80::1", &ll_addr6);
+  inet_pton(AF_INET6, "fe80::2", &client_addr);
+  memset(&ula_addr6, 0, sizeof(ula_addr6));
+
+  /*
+   * Pre-create a DHCPv6 NA lease for the known DUID host so that
+   * RENEW/REBIND/RELEASE/CONFIRM paths (which require an existing lease)
+   * are reachable without organically discovering a SOLICIT→REPLY exchange.
+   *
+   * lease6_allocate() returns NULL if a lease already exists (harmless —
+   * lease_prune() cleans up at the end of each input).
+   */
+  {
+    struct in6_addr seed_addr;
+    inet_pton(AF_INET6, "fd00::150", &seed_addr);
+    struct dhcp_lease *seed_lease = lease6_allocate(&seed_addr, LEASE_NA);
+    if (seed_lease)
+      {
+        static const unsigned char seed_clid[] = {
+          0x00, 0x03, 0x00, 0x01,
+          0xde, 0xad, 0xbe, 0xef, 0x00, 0x01
+        };
+        lease_set_hwaddr(seed_lease, NULL, seed_clid, 0, 0,
+                         sizeof(seed_clid), FUZZ_NOW, 0);
+        lease_set_expires(seed_lease, 43200, FUZZ_NOW);
+        lease_set_interface(seed_lease, iface_index, FUZZ_NOW);
+        lease_set_iaid(seed_lease, 1); /* match corpus seeds; RELEASE/DECLINE check iaid */
+      }
+  }
+
+  /* Reset per-iteration relay matchcounts (mirrors dhcp6_packet()) */
+  {
+    struct dhcp_relay *r;
+    for (r = daemon->relay6; r; r = r->next)
+      r->matchcount = 0;
+  }
+
+  /*
+   * relay_reply6() — rfc3315.c
+   *
+   * Returns non-zero when the packet is a DHCP6RELAYREPL (0x13) from an
+   * upstream server to be forwarded back to a client via us as relay.
+   * Guards: sz >= 38 && *inbuff == DHCP6RELAYREPL &&
+   *         link_address (bytes[2..17]) matches relay->local.addr6.
+   *
+   * Mirrors dhcp6_packet() line 213.
+   */
+  {
+    struct sockaddr_in6 peer;
+    memset(&peer, 0, sizeof(peer));
+#ifdef HAVE_SOCKADDR_SA_LEN
+    peer.sin6_len = sizeof(peer);
+#endif
+    peer.sin6_family   = AF_INET6;
+    peer.sin6_addr     = client_addr;
+    peer.sin6_scope_id = (uint32_t)iface_index;
+
+    if (relay_reply6(&peer, (ssize_t)size, "lo") != 0)
+      goto done;
+  }
+
+  /*
+   * relay_upstream6() — rfc3315.c
+   *
+   * Wraps a client request in DHCP6RELAYFORW and forwards it to the upstream
+   * server.  Only acts when a relay6 entry exists with a matching iface_index.
+   * The actual sendto() to fd00::ffff will fail gracefully (no server there).
+   *
+   * Mirrors dhcp6_packet() line 297.
+   */
+  relay_upstream6(iface_index, (ssize_t)size, &client_addr,
+                  (u32)iface_index, FUZZ_NOW);
+
+  /* Build the DHCPv6 context chain for fd00::/64 */
+  {
+    struct dhcp_context *ctx = build_context6_chain(&local6);
+    if (!ctx)
+      goto done;
+
+    /* Prune expired leases before processing */
+    lease_prune(NULL, FUZZ_NOW);
+
+    /*
+     * dhcp6_reply() returns the port to reply on (non-zero on success).
+     * We ignore it — no socket to send on.
+     *
+     * multicast_dest=1 bypasses the early guard at rfc3315.c:85:
+     *   if (msg_type != DHCP6RELAYFORW && !multicast_dest) return 0;
+     * This allows all DHCPv6 message types to be processed.
+     */
+    dhcp6_reply(ctx, /*multicast_dest=*/1, iface_index, "lo",
+                &local6, &ll_addr6, &ula_addr6,
+                size, &client_addr, FUZZ_NOW);
+  }
+
+  /* Sync lease state; no-ops when leasefile=/dev/null */
+  lease_update_file(FUZZ_NOW);
+  lease_update_dns(0);
+
+done:
+  /* Reset leases so every input starts from a clean slate */
+  /* Prune all leases: any lease seeded or created by dhcp*_reply() expires
+   * well before time 2000000 (FUZZ_NOW=1000000, max expiry 1000000+43200).
+   * lease_reset_all() is not in upstream dnsmasq. */
+  lease_prune(NULL, (time_t)2000000);
+
+  return 0;
+}

--- a/projects/dnsmasq/fuzz_dhcp6_reply.c
+++ b/projects/dnsmasq/fuzz_dhcp6_reply.c
@@ -1,3 +1,15 @@
+/* Copyright 2026 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 /*
  * dnsmasq_fuzzer_dhcp6.c — libFuzzer harness for DHCPv6 processing.
  *

--- a/projects/dnsmasq/fuzz_dhcp_reply.c
+++ b/projects/dnsmasq/fuzz_dhcp_reply.c
@@ -1,0 +1,326 @@
+/*
+ * dnsmasq_fuzzer_dhcp.c — libFuzzer harness for DHCPv4 processing.
+ *
+ * Intended for integration into the Google oss-fuzz project.
+ * https://github.com/google/oss-fuzz
+ *
+ * Directly injects fuzz data into daemon->dhcp_packet and calls dhcp_reply()
+ * from rfc2131.c, bypassing any stdin/loop mechanics in dhcp.c entirely.
+ * This gives clean single-input semantics and covers:
+ *   - rfc2131.c  dhcp_reply()       — full DHCPv4 message handling
+ *   - rfc2131.c  relay_upstream4()  — client→server relay forwarding
+ *   - rfc2131.c  relay_reply4()     — server→client relay reply routing
+ *   - dhcp-common.c                 — option_filter(), match_netid(),
+ *                                     match_netid_wild(), match_bytes(),
+ *                                     run_tag_if(), config_has_mac(), ...
+ *
+ * Build (oss-fuzz environment — called from build.sh):
+ *   $CC $CFLAGS -DVERSION='"oss-fuzz"' -Isrc \
+ *       -o $OUT/dnsmasq_fuzzer_dhcp \
+ *       fuzzing/oss-fuzz/dnsmasq_fuzzer_dhcp.c \
+ *       <all dnsmasq objects except dnsmasq.o> \
+ *       $LIB_FUZZING_ENGINE
+ *
+ * Local libFuzzer build (for development):
+ *   make CC=clang \
+ *        CFLAGS="-g -O1 -fsanitize=address,fuzzer-no-link" \
+ *        LDFLAGS="-g -fsanitize=address -fsanitize=fuzzer" \
+ *        FUZZER_DRIVER="" \
+ *        mostly_clean oss_fuzz_dhcp
+ */
+
+#include "dnsmasq.h"
+#include <net/if.h>
+
+/* Fixed timestamp — keeps all time-dependent branches deterministic. */
+#define FUZZ_NOW ((time_t)1000000)
+
+/* dnsmasq.c owns this global; we define it here since we don't link dnsmasq.o */
+struct daemon *daemon;
+
+/* ── Stubs for functions defined in dnsmasq.c ─────────────────────────── */
+void send_event(int fd, int event, int data, char *msg)
+  { (void)fd; (void)event; (void)data; (void)msg; }
+void queue_event(int event)               { (void)event; }
+void send_alarm(time_t event, time_t now) { (void)event; (void)now; }
+int  icmp_ping(struct in_addr addr)       { (void)addr; return 0; }
+int  delay_dhcp(time_t start, int sec, int fd, uint32_t addr, unsigned short id)
+  { (void)start; (void)sec; (void)fd; (void)addr; (void)id; return 0; }
+
+/* ── Context chain setup ──────────────────────────────────────────────── */
+/*
+ * Replicates the AFL path inside complete_context() (dhcp.c) without needing
+ * access to that static function.  Must be called before each dhcp_reply()
+ * invocation so that context->current chain is rebuilt from scratch.
+ */
+static struct dhcp_context *build_context_chain(int iface_index)
+{
+  struct in_addr lo, mask, bcast;
+  struct dhcp_context *ctx, *chain = NULL;
+
+  (void)iface_index;
+
+  lo.s_addr    = htonl(0x7f000001); /* 127.0.0.1       */
+  mask.s_addr  = htonl(0xff000000); /* 255.0.0.0       */
+  bcast.s_addr = htonl(0x7fffffff); /* 127.255.255.255 */
+
+  /* reset the "unlinked" marker on every context */
+  for (ctx = daemon->dhcp; ctx; ctx = ctx->next)
+    ctx->current = ctx;
+
+  /* link contexts whose range falls within the loopback subnet */
+  for (ctx = daemon->dhcp; ctx; ctx = ctx->next)
+    {
+      if (!is_same_net(lo, ctx->start, mask) ||
+          !is_same_net(lo, ctx->end,   mask))
+        continue;
+
+      ctx->local  = lo;
+      ctx->router = lo;
+
+      if (!(ctx->flags & CONTEXT_NETMASK))
+        ctx->netmask = mask;
+
+      if (!(ctx->flags & CONTEXT_BRDCAST))
+        ctx->broadcast = bcast;
+
+      ctx->current = chain;
+      chain = ctx;
+    }
+
+  return chain;
+}
+
+/* ── One-time initialization ─────────────────────────────────────────── */
+int LLVMFuzzerInitialize(int *argc, char ***argv)
+{
+  (void)argc; (void)argv;
+
+  static char *fuzz_argv[] = {
+    "fuzz_dhcp_reply",
+    "--no-daemon",
+    "--no-resolv",
+    "--no-hosts",
+    "--port=0",
+    "--interface=lo",
+    "--no-ping",
+    /* set: tag makes context->netid.net non-NULL → option_filter context_tags branch */
+    "--dhcp-range=set:myrange,127.0.0.100,127.0.0.200,12h",
+    "--dhcp-authoritative",
+    "--dhcp-generate-names",
+    "--dhcp-broadcast",
+    "--dhcp-lease-max=150",
+    "--pxe-service=0,boot",
+    /* CONFIG_HWADDR → find_config() MAC path */
+    "--dhcp-host=de:ad:be:ef:00:01,127.0.0.150,testhost",
+    /* CONFIG_CLID → find_config() client-id path */
+    "--dhcp-host=id:ff:00:01:02:03:04:05,127.0.0.152,clid-host",
+    "--dhcp-option=option:router,127.0.0.1",
+    "--dhcp-option=option:dns-server,127.0.0.1",
+    /* negative-tag → match_netid() '!' branch */
+    "--dhcp-option=tag:!pxe,option:ntp-server,127.0.0.1",
+    /* opt60 match → match_bytes() non-RFC3925 path */
+    "--dhcp-vendorclass=set:pxe,PXEClient",
+    /* RFC3925 opt124 match → match_bytes() nested enterprise path */
+    "--dhcp-vendorclass=set:entclass,enterprise:12345,PXEClient",
+    /* run_tag_if() → match_netid_wild() */
+    "--tag-if=set:myclass,tag:pxe",
+    /*
+     * dhcp_match entries — the ONLY way to reach match_bytes() in dhcp-common.c.
+     * --dhcp-vendorclass uses its own memcmp loop and never calls match_bytes().
+     * --dhcp-match populates daemon->dhcp_match which is iterated at rfc2131.c:437.
+     *   non-RFC3925: option_find(opt60) → match_bytes() at line 469
+     *   RFC3925:     option_find(opt124) → match_bytes() at line 457 (nested blocks)
+     */
+    "--dhcp-match=set:opt60match,option:vendor-class,PXEClient",
+    "--dhcp-match=set:opt77match,option:user-class,finance",
+    "--dhcp-match=set:opt124match,vi-encap:12345,PXEClient",
+    /*
+     * --log-dhcp sets OPT_LOG_OPTS → covers log_options() and log_tags() and
+     * all the "if (option_bool(OPT_LOG_OPTS))" branches in dhcp_reply/do_options.
+     * log-facility=/dev/null absorbs the output.
+     */
+    "--log-dhcp",
+    /*
+     * --dhcp-delay triggers apply_delay() at rfc2131.c:1046 and 1361.
+     * Value 0 means no actual delay but the code path is entered.
+     */
+    "--dhcp-reply-delay=0",
+    /*
+     * Normal relay entry.  iface_index is patched to lo after dhcp_init()
+     * since read_opts() leaves it 0.
+     * Triggers: relay_upstream4() line 3087 (!split_mode && iface_index match)
+     *           relay_reply4()     line 3254 (giaddr == relay->local)
+     */
+    "--dhcp-relay=127.0.0.1,127.0.0.254",
+    /*
+     * Split-mode relay entry.
+     *   local  = 127.0.0.1  (client-facing addr, must equal iface_addr)
+     *   server = 127.0.0.254 (upstream)
+     *   iface  = lo          (server-facing interface)
+     * Triggers: relay_upstream4() line 3102 (split_mode && local == iface_addr)
+     *           relay_reply4()     line 3239 (split_mode && giaddr == uplink)
+     */
+    "--dhcp-split-relay=127.0.0.1,127.0.0.254,lo",
+    /*
+     * DHCPLEASEQUERY (RFC 4388): covers lines 1067-1235 in rfc2131.c.
+     * Without this, mess_type==DHCPLEASEQUERY returns 0 at line 1070.
+     */
+    "--leasequery",
+    /*
+     * Rapid-commit: OPT_RAPID_COMMIT → goto rapid_commit at rfc2131.c:1372.
+     */
+    "--dhcp-rapid-commit",
+    /*
+     * CONTEXT_PROXY range.  Enables proxy DHCP path (lines 964-1051) for
+     * PXE DISCOVERs via the PXE proxy loop at line 969.
+     */
+    "--dhcp-range=127.0.0.1,proxy",
+    /*
+     * daemon->override=1: relay server-id override at rfc2131.c:858-870.
+     */
+    "--dhcp-proxy",
+    /*
+     * OPT_FQDN_UPDATE → FQDN flags manipulation at rfc2131.c:713-727.
+     */
+    "--dhcp-client-update",
+    /*
+     * MATCH_CIRCUIT / MATCH_REMOTE in agent-id sub-option loop (rfc2131.c:220).
+     */
+    "--dhcp-circuitid=set:circuit1,mycirc",
+    "--dhcp-remoteid=set:remote1,myremote",
+    /* discard lease file writes to avoid file-I/O non-determinism */
+    "--dhcp-leasefile=/dev/null",
+    "--log-facility=/dev/null",
+  };
+  int fuzz_argc = (int)(sizeof(fuzz_argv) / sizeof(fuzz_argv[0]));
+
+  read_opts(fuzz_argc, fuzz_argv, "");
+
+  /* mirror dnsmasq.c initialisation that read_opts skips */
+  daemon->dumpfd = -1;
+  if (daemon->edns_pktsz < PACKETSZ)
+    daemon->edns_pktsz = PACKETSZ;
+  daemon->packet_buff_sz = daemon->edns_pktsz + MAXDNAME + RRFIXEDSZ;
+  daemon->packet = safe_malloc(daemon->packet_buff_sz);
+
+  dhcp_common_init();
+  lease_init(FUZZ_NOW);
+  dhcp_init();   /* creates daemon->dhcpfd bound to port 0 on lo */
+
+  /*
+   * Patch relay4 iface_index to the loopback interface.
+   * read_opts() leaves iface_index=0; without this, relay_upstream4()'s
+   * !split_mode && iface_index check is always false.
+   */
+  {
+    int lo_idx = (int)if_nametoindex("lo");
+    struct dhcp_relay *r;
+    for (r = daemon->relay4; r; r = r->next)
+      if (!r->split_mode && r->iface_index == 0)
+        r->iface_index = lo_idx;
+  }
+
+  return 0;
+}
+
+/* ── Per-input processing ────────────────────────────────────────────── */
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+  /* Drop inputs too small to be a valid DHCP fixed header */
+  if (size < sizeof(struct dhcp_packet) - sizeof(((struct dhcp_packet *)0)->options))
+    return 0;
+
+  /* Inject fuzz data directly into the shared DHCP packet buffer */
+  if (!expand_buf(&daemon->dhcp_packet, size))
+    return 0;
+  memcpy(daemon->dhcp_packet.iov_base, data, size);
+
+  /* Resolve the loopback interface index; fail fast if lo is absent */
+  int iface_index = (int)if_nametoindex("lo");
+  if (iface_index == 0)
+    return 0;
+
+  struct in_addr lo;
+  lo.s_addr = htonl(0x7f000001); /* server identifier / fallback address */
+
+  struct dhcp_packet *mess = (struct dhcp_packet *)daemon->dhcp_packet.iov_base;
+
+  /*
+   * Pre-create a lease for the known MAC host so that dhcp_reply()'s
+   * "if (lease)" branches (RENEWING/REBINDING/RELEASE/ACK-with-existing-lease)
+   * are reachable without needing to discover a full DISCOVER→ACK exchange.
+   *
+   * lease4_allocate() returns NULL if a lease already exists for that address
+   * (harmless — lease_prune() at the end of each input removes it).
+   */
+  {
+    struct in_addr seed_addr;
+    seed_addr.s_addr = htonl(0x7f000096); /* 127.0.0.150 — matches dhcp-host MAC entry */
+    struct dhcp_lease *seed_lease = lease4_allocate(seed_addr);
+    if (seed_lease)
+      {
+        static const unsigned char seed_mac[] = {0xde, 0xad, 0xbe, 0xef, 0x00, 0x01};
+        lease_set_hwaddr(seed_lease, seed_mac, NULL, 6, ARPHRD_ETHER, 0, FUZZ_NOW, 0);
+        lease_set_expires(seed_lease, 43200, FUZZ_NOW);
+        lease_set_interface(seed_lease, iface_index, FUZZ_NOW);
+      }
+  }
+
+  /* Reset per-iteration relay state (mirrors dhcp_packet() line 383) */
+  {
+    struct dhcp_relay *r;
+    for (r = daemon->relay4; r; r = r->next)
+      r->matchcount = 0;
+  }
+
+  /*
+   * relay_reply4() — rfc2131.c
+   *
+   * Returns non-zero when the packet is a BOOTREPLY (op=2) from an upstream
+   * server to be forwarded back to a DHCP client via us as relay.
+   * Mirrors dhcp_packet() line 350.
+   */
+  if (relay_reply4(mess, size, "lo") != 0)
+    goto done;
+
+  /*
+   * relay_upstream4() — rfc2131.c
+   *
+   * Forwards a BOOTREQUEST from a client upstream toward the DHCP server.
+   * Only acts when mess->op == BOOTREQUEST && mess->hops <= 20 and a
+   * matching relay4 entry exists.  Safe to call unconditionally.
+   * The actual sendto() to 127.0.0.254 will fail gracefully.
+   *
+   * Mirrors dhcp_packet() line 424.
+   */
+  relay_upstream4(lo, iface_index, mess, size, /*unicast=*/1);
+
+  /* Build the dhcp_context chain for 127.0.0.0/8 */
+  {
+    struct dhcp_context *ctx = build_context_chain(iface_index);
+    if (!ctx)
+      goto done;
+
+    /* Prune expired leases before processing */
+    lease_prune(NULL, FUZZ_NOW);
+
+    int is_inform = 0;
+    dhcp_reply(ctx, "lo", iface_index, size, FUZZ_NOW,
+               /*unicast_dest=*/1, /*loopback=*/1,
+               &is_inform, /*pxe=*/0, lo, FUZZ_NOW, lo);
+  }
+
+  /* Sync lease state; no-ops when leasefile=/dev/null */
+  lease_update_file(FUZZ_NOW);
+  lease_update_dns(0);
+
+done:
+  /* Reset leases so every input starts from a clean slate */
+  /* Prune all leases: any lease seeded or created by dhcp*_reply() expires
+   * well before time 2000000 (FUZZ_NOW=1000000, max expiry 1000000+43200).
+   * lease_reset_all() is not in upstream dnsmasq. */
+  lease_prune(NULL, (time_t)2000000);
+
+  return 0;
+}

--- a/projects/dnsmasq/fuzz_dhcp_reply.c
+++ b/projects/dnsmasq/fuzz_dhcp_reply.c
@@ -1,3 +1,15 @@
+/* Copyright 2026 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 /*
  * dnsmasq_fuzzer_dhcp.c — libFuzzer harness for DHCPv4 processing.
  *

--- a/projects/dnsmasq/fuzz_dns.c
+++ b/projects/dnsmasq/fuzz_dns.c
@@ -1,0 +1,322 @@
+/*
+ * dnsmasq_fuzzer_dns.c — libFuzzer harness for DNS packet processing.
+ *
+ * Intended for integration into the Google oss-fuzz project.
+ * https://github.com/google/oss-fuzz
+ *
+ * Exercises the full rfc1035.c function suite plus edns0.c and rrfilter.c
+ * with fuzz data treated as raw DNS wire-format packets.  Coverage:
+ *   extract_request, extract_name (all 4 modes), skip_name/questions/section
+ *   answer_request (with/without AD+DO), extract_addresses (with/without
+ *   rebind check), setup_reply, do_doctor, check_for_bogus_wildcard,
+ *   check_for_ignored_address, check_for_local_domain, in_arpa_name_2_addr,
+ *   private_net / private_net6, resize_packet, find_pseudoheader,
+ *   add_pseudoheader, add_resource_record, rrfilter (EDNS0+DNSSEC modes).
+ *
+ * Build (oss-fuzz environment — called from build.sh):
+ *   $CC $CFLAGS -DVERSION='"oss-fuzz"' -Isrc \
+ *       -o $OUT/dnsmasq_fuzzer_dns \
+ *       fuzzing/oss-fuzz/dnsmasq_fuzzer_dns.c \
+ *       <all dnsmasq objects except dnsmasq.o> \
+ *       $LIB_FUZZING_ENGINE
+ *
+ * Local libFuzzer build (for development):
+ *   make CC=clang \
+ *        CFLAGS="-g -O1 -fsanitize=address,fuzzer-no-link" \
+ *        LDFLAGS="-g -fsanitize=address -fsanitize=fuzzer" \
+ *        FUZZER_DRIVER="" \
+ *        mostly_clean oss_fuzz_dns
+ */
+
+#include "dnsmasq.h"
+#include <time.h>
+
+/* Fixed timestamp — keeps all time-dependent branches deterministic.
+ * Using time(NULL) causes TTL comparisons and negative-cache checks to flip
+ * between the fuzzer's two stability-measurement runs, tanking stability. */
+#define FUZZ_NOW ((time_t)1000000)
+
+/* dnsmasq.c owns this global; we define it here since we don't link dnsmasq.o */
+struct daemon *daemon;
+
+/* ── Stubs for functions defined in dnsmasq.c ─────────────────────────── */
+void send_event(int fd, int event, int data, char *msg)
+  { (void)fd; (void)event; (void)data; (void)msg; }
+void queue_event(int event)               { (void)event; }
+void send_alarm(time_t event, time_t now) { (void)event; (void)now; }
+int  icmp_ping(struct in_addr addr)       { (void)addr; return 0; }
+int  delay_dhcp(time_t start, int sec, int fd, uint32_t addr, unsigned short id)
+  { (void)start; (void)sec; (void)fd; (void)addr; (void)id; return 0; }
+
+/* ── One-time initialization ─────────────────────────────────────────── */
+int LLVMFuzzerInitialize(int *argc, char ***argv)
+{
+  (void)argc; (void)argv;
+
+  /*
+   * Do NOT redirect stdout/stderr here.  In LLVM 18+, LLVMFuzzerInitialize
+   * is called BEFORE libfuzzer prints its own INFO lines, so redirecting
+   * here would silence all fuzzer output.  Suppress dnsmasq log output via
+   * --log-facility=/dev/null and log_start(NULL, -1) instead.
+   */
+
+  static char *fuzz_argv[] = {
+    "fuzz_dns",
+    "--keep-in-foreground",
+    "--no-resolv",
+    "--no-hosts",
+    "--port=0",
+    "--cache-size=512",
+    /* Records that answer_request() can serve */
+    "--host-record=host.fuzz.test,192.0.2.1,2001:db8::1",
+    "--mx-host=fuzz.test,mail.fuzz.test,10",
+    "--txt-record=fuzz.test,v=spf1 ~all",
+    "--cname=alias.fuzz.test,host.fuzz.test",
+    "--srv-host=_http._tcp.fuzz.test,host.fuzz.test,80",
+    /* address= populates F_CONFIG A answers */
+    "--address=/fuzz.test/192.0.2.1",
+    /* Bogus-wildcard detection: marks 198.105.254.11 as a lie */
+    "--bogus-nxdomain=198.105.254.11",
+    /* Rebind check for extract_addresses */
+    "--stop-dns-rebind",
+    /* NAT-alias / do_doctor path */
+    "--alias=10.0.0.1,192.0.2.1",
+    "--log-facility=/dev/null",
+  };
+  int fuzz_argc = (int)(sizeof(fuzz_argv) / sizeof(fuzz_argv[0]));
+
+  read_opts(fuzz_argc, fuzz_argv, "");
+
+  /* Route all my_syslog() calls to /dev/null instead of falling back to vsyslog() */
+  log_start(NULL, -1);
+
+  /* Post-read_opts initialisation, matching dnsmasq.c */
+  daemon->dumpfd = -1;
+
+  if (daemon->edns_pktsz < PACKETSZ)
+    daemon->edns_pktsz = PACKETSZ;
+  daemon->packet_buff_sz = daemon->edns_pktsz + MAXDNAME + RRFIXEDSZ;
+  daemon->packet = safe_malloc(daemon->packet_buff_sz);
+
+  cache_init();
+  blockdata_init();
+
+  return 0;
+}
+
+/* ── Per-input processing ────────────────────────────────────────────── */
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+  /* Need at least a DNS header (12 bytes). */
+  if (size < sizeof(struct dns_header))
+    return 0;
+
+  /*
+   * Expire all dynamic cache entries so every iteration starts from a clean
+   * slate.  Setting ttd=0 on each non-immortal entry makes cache_find_by_name/
+   * addr skip them (both call is_expired() which returns 1 when ttd < now).
+   * Immortal entries (F_IMMORTAL) from --host-record / --address / etc. are
+   * unaffected because is_expired() returns 0 for them regardless of ttd.
+   *
+   * We do NOT call cache_init() here: that function safe_malloc's a fresh
+   * crec array without freeing the previous one, so repeated calls grow the
+   * LRU list unboundedly and corrupt eviction order.
+   */
+  {
+    struct crec *crec;
+    cache_enumerate(1);
+    while ((crec = cache_enumerate(0)))
+      crec->ttd = 0;
+  }
+
+  /* Working copy — many callers write back into the buffer. */
+  static unsigned char buf[65536];
+  size_t capped = size < sizeof(buf) ? size : sizeof(buf);
+  memcpy(buf, data, capped);
+
+  struct dns_header *header = (struct dns_header *)buf;
+  time_t now = FUZZ_NOW;
+
+  /* ── 1. extract_request ─────────────────────────────────────────────────── */
+  char name[MAXDNAME*2+1];
+  unsigned short qtype = 0, qclass = 0;
+  extract_request(header, capped, name, &qtype, &qclass);
+
+  /* ── 2. extract_name (all four modes) ──────────────────────────────────── */
+  {
+    char name2[MAXDNAME*2+1];
+    unsigned char *pp;
+
+    pp = (unsigned char *)(header + 1);
+    extract_name(header, capped, &pp, name2, EXTR_NAME_EXTRACT, 0);
+
+    pp = (unsigned char *)(header + 1);
+    extract_name(header, capped, &pp, name2, EXTR_NAME_COMPARE, 0);
+
+    pp = (unsigned char *)(header + 1);
+    extract_name(header, capped, &pp, name2, EXTR_NAME_NOCASE, 0);
+
+    pp = (unsigned char *)(header + 1);
+    extract_name(header, capped, &pp, name2, EXTR_NAME_FLIP, 0);
+  }
+
+  /* ── 3. skip_* pointer traversal ───────────────────────────────────────── */
+  {
+    unsigned char *p = skip_questions(header, capped);
+    if (p)
+      {
+        skip_name(p, header, capped, 0);
+        skip_section(p, (int)ntohs(header->ancount), header, capped);
+      }
+  }
+
+  /* ── 4. answer_request: serve from configured local records / cache ─────── */
+  {
+    static unsigned char abuf[65536];
+    size_t alen = capped;
+    memcpy(abuf, data, alen);
+    struct dns_header *ah = (struct dns_header *)abuf;
+    char *alimit = (char *)abuf + sizeof(abuf);
+    struct in_addr local  = { .s_addr = htonl(0xc0000201) }; /* 192.0.2.1 */
+    struct in_addr mask   = { .s_addr = htonl(0xffffff00) }; /* /24 */
+    int stale = 0, filtered = 0;
+
+    /* plain query (no AD/DO) */
+    answer_request(ah, alimit, alen, local, mask, now, 0, 0, 0, &stale, &filtered);
+
+    /* with AD and DO bits requested */
+    memcpy(abuf, data, alen);
+    ah->hb4 |= HB4_AD;
+    answer_request(ah, alimit, alen, local, mask, now, 1, 1, 0, &stale, &filtered);
+  }
+
+  /* ── 5. extract_addresses: parse fuzz data as upstream response ─────────── */
+  {
+    static unsigned char ebuf[65536];
+    memcpy(ebuf, data, capped);
+    struct dns_header *eh = (struct dns_header *)ebuf;
+    char ename[MAXDNAME*2+1];
+
+    /* Mark as a DNS response (QR=1) */
+    eh->hb3 |= HB3_QR;
+
+    /* Without rebind check */
+    extract_addresses(eh, capped, ename, now, NULL, NULL, 0, 0, 0);
+
+    /* With rebind check (exercises OPT_NO_REBIND path) */
+    memcpy(ebuf, data, capped);
+    eh->hb3 |= HB3_QR;
+    extract_addresses(eh, capped, ename, now, NULL, NULL, 1, 0, 0);
+  }
+
+  /* ── 6. setup_reply with several flag combinations ──────────────────────── */
+  {
+    static unsigned char sbuf[sizeof(struct dns_header)];
+    memcpy(sbuf, buf, sizeof(sbuf));
+    struct dns_header *sh = (struct dns_header *)sbuf;
+
+    setup_reply(sh, F_NOERR,    EDE_UNSET);
+    setup_reply(sh, F_NXDOMAIN, EDE_UNSET);
+    setup_reply(sh, F_NEG,      EDE_OTHER);
+    setup_reply(sh, 0,          EDE_FILTERED);
+  }
+
+  /* ── 7. do_doctor: NAT address rewriting in responses ───────────────────── */
+  {
+    static unsigned char dbuf[65536];
+    memcpy(dbuf, data, capped);
+    struct dns_header *dh = (struct dns_header *)dbuf;
+    dh->hb3 |= HB3_QR; /* responses only */
+    do_doctor(dh, capped, daemon->namebuff);
+  }
+
+  /* ── 8. check_for_bogus_wildcard ────────────────────────────────────────── */
+  check_for_bogus_wildcard(header, capped, daemon->namebuff, now);
+
+  /* ── 9. check_for_ignored_address ───────────────────────────────────────── */
+  check_for_ignored_address(header, capped);
+
+  /* ── 10. check_for_local_domain ─────────────────────────────────────────── */
+  if (name[0])
+    check_for_local_domain(name, now);
+
+  /* ── 11. in_arpa_name_2_addr ────────────────────────────────────────────── */
+  if (name[0])
+    {
+      union all_addr arpa;
+      in_arpa_name_2_addr(name, &arpa);
+    }
+
+  /* ── 12. private_net / private_net6 ─────────────────────────────────────── */
+  {
+    struct in_addr a4;
+    memset(&a4, 0, sizeof(a4));
+    if (capped >= sizeof(a4))
+      memcpy(&a4, data, sizeof(a4));
+
+    struct in6_addr a6;
+    memset(&a6, 0, sizeof(a6));
+    if (capped >= sizeof(a6))
+      memcpy(&a6, data, sizeof(a6));
+
+    private_net(a4, 0);
+    private_net(a4, 1);
+    private_net6(&a6, 0);
+    private_net6(&a6, 1);
+  }
+
+  /* ── 13. find_pseudoheader + resize_packet ──────────────────────────────── */
+  {
+    static unsigned char pbuf[65536];
+    memcpy(pbuf, data, capped);
+    struct dns_header *ph = (struct dns_header *)pbuf;
+
+    size_t        optsz    = 0;
+    unsigned char *optp    = NULL;
+    int           is_sign  = 0, is_last = 0;
+    unsigned char *opt_start =
+      find_pseudoheader(ph, capped, &optsz, &optp, &is_sign, &is_last);
+
+    if (opt_start)
+      resize_packet(ph, capped, opt_start, optsz);
+  }
+
+  /* ── 14. add_pseudoheader (add EDE option) ──────────────────────────────── */
+  {
+    static unsigned char pbuf2[65536];
+    memcpy(pbuf2, data, capped);
+    struct dns_header *ph2 = (struct dns_header *)pbuf2;
+    add_pseudoheader(ph2, capped, pbuf2 + sizeof(pbuf2),
+                     EDNS0_OPTION_EDE, NULL, 0, 0, 0);
+  }
+
+  /* ── 15. add_resource_record (fixed A record into a scratch header) ──────── */
+  {
+    static unsigned char rbuf[65536];
+    memset(rbuf, 0, sizeof(struct dns_header));
+    struct dns_header *rh  = (struct dns_header *)rbuf;
+    unsigned char     *rp  = rbuf + sizeof(struct dns_header);
+    int truncated = 0;
+    struct in_addr addr4   = { .s_addr = htonl(0xc0000201) }; /* 192.0.2.1 */
+
+    add_resource_record(rh, (char *)rbuf + sizeof(rbuf), &truncated,
+                        sizeof(struct dns_header), &rp,
+                        300, NULL, T_A, C_IN, "4", &addr4);
+  }
+
+  /* ── 16. rrfilter: strip EDNS0 then DNSSEC ──────────────────────────────── */
+  {
+    static unsigned char fbuf[65536];
+    size_t flen;
+
+    memcpy(fbuf, data, capped);
+    flen = capped;
+    rrfilter((struct dns_header *)fbuf, &flen, RRFILTER_EDNS0);
+
+    memcpy(fbuf, data, capped);
+    flen = capped;
+    rrfilter((struct dns_header *)fbuf, &flen, RRFILTER_DNSSEC);
+  }
+
+  return 0;
+}

--- a/projects/dnsmasq/fuzz_dns.c
+++ b/projects/dnsmasq/fuzz_dns.c
@@ -1,3 +1,15 @@
+/* Copyright 2026 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 /*
  * dnsmasq_fuzzer_dns.c — libFuzzer harness for DNS packet processing.
  *

--- a/projects/dnsmasq/fuzz_forward.c
+++ b/projects/dnsmasq/fuzz_forward.c
@@ -1,0 +1,334 @@
+/*
+ * dnsmasq_fuzzer_forward.c — libFuzzer harness for the dnsmasq forwarding
+ *                            pipeline.
+ *
+ * Intended for integration into the Google oss-fuzz project.
+ * https://github.com/google/oss-fuzz
+ *
+ * Exercises the upstream-reply processing path unique to forward.c:
+ *
+ *   return_reply()
+ *     → process_reply()
+ *         → find_pseudoheader()         (EDNS0 opt parsing)
+ *         → check_for_bogus_wildcard()  (spoofed-NXDOMAIN detection)
+ *         → check_for_ignored_address() (--bogus-nxdomain filter)
+ *         → do_doctor()                 (NAT-alias address rewriting)
+ *         → extract_addresses()         (cache insertion from reply RRs)
+ *         → rrfilter()                  (strip EDNS0 / DNSSEC RRs)
+ *         → add_pseudoheader()          (EDE option injection)
+ *     → flip_queryname()                (case-scramble reversal, multi-client)
+ *     → truncation path                 (reply > one client's UDP size limit)
+ *     → free_frec()                     (forwarding-record lifecycle)
+ *
+ * Three flag combinations are tested per input so different branches of
+ * process_reply() and return_reply() are reached:
+ *
+ *   (a) flags=0, two frec_src clients
+ *       → flip_queryname() exercised; second client's small udp_pkt_size
+ *         triggers the truncation loop
+ *   (b) FREC_NOREBIND | FREC_DO_QUESTION | FREC_HAS_PHEADER, one client
+ *       → rebind check skipped for this forward; EDNS0 pseudo-header kept
+ *   (c) FREC_CHECKING_DISABLED | FREC_AD_QUESTION, one client
+ *       → CD bit preserved in reply; AD bit handling
+ *
+ * Build (oss-fuzz environment — called from build.sh):
+ *   $CC $CFLAGS -DVERSION='"oss-fuzz"' -Isrc \
+ *       -o $OUT/dnsmasq_fuzzer_forward \
+ *       fuzzing/oss-fuzz/dnsmasq_fuzzer_forward.c \
+ *       <all dnsmasq objects except dnsmasq.o> \
+ *       $LIB_FUZZING_ENGINE
+ *
+ * Local libFuzzer build (for development):
+ *   make CC=clang \
+ *        CFLAGS="-g -O1 -fsanitize=address,fuzzer-no-link" \
+ *        LDFLAGS="-g -fsanitize=address -fsanitize=fuzzer" \
+ *        FUZZER_DRIVER="" \
+ *        mostly_clean oss_fuzz_forward
+ */
+
+#include "dnsmasq.h"
+#include <time.h>
+
+/* Fixed timestamp — keeps all time-dependent branches deterministic.
+ * Using time(NULL) causes TTL comparisons and log-timestamp branches to flip
+ * between the fuzzer's two stability-measurement runs, tanking stability. */
+#define FUZZ_NOW ((time_t)1000000)
+
+/* dnsmasq.c owns this global; we redefine it here since dnsmasq.o is excluded. */
+struct daemon *daemon;
+
+/* ── Stubs for dnsmasq.c-defined symbols ─────────────────────────────────── */
+void send_event(int fd, int event, int data, char *msg)
+  { (void)fd; (void)event; (void)data; (void)msg; }
+void queue_event(int event) { (void)event; }
+void send_alarm(time_t event, time_t now) { (void)event; (void)now; }
+int  icmp_ping(struct in_addr addr) { (void)addr; return 0; }
+int  delay_dhcp(time_t start, int sec, int fd, uint32_t addr, unsigned short id)
+  { (void)start; (void)sec; (void)fd; (void)addr; (void)id; return 0; }
+
+/* ── Objects reused across iterations ────────────────────────────────────── */
+
+/* A single frec is pre-allocated and linked into daemon->frec_list.
+   free_frec() (called at the end of return_reply()) zeroes sentto, flags,
+   frec_src.next, stash, and rfds but does NOT free the frec struct itself,
+   so we can safely re-populate and reuse it every iteration. */
+static struct frec *fuzz_frec;
+
+/* A minimal fake upstream server.  process_reply() references server->flags
+   and prettyprint_addr(&server->addr, ...) but nothing requiring a live
+   socket.  return_reply() only uses forward->sentto, not serverarray[]. */
+static struct server fake_server;
+
+/* ── One-time setup ──────────────────────────────────────────────────────── */
+
+int LLVMFuzzerInitialize(int *argc, char ***argv)
+{
+  (void)argc; (void)argv;
+
+  /*
+   * Do NOT redirect stdout/stderr here.  In LLVM 18+, LLVMFuzzerInitialize
+   * is called BEFORE libfuzzer prints its own INFO lines, so redirecting
+   * here would silence all fuzzer output.  Suppress dnsmasq log output via
+   * --log-facility=/dev/null and log_start(NULL, -1) instead.
+   */
+
+  static char *fuzz_argv[] = {
+    "fuzz_forward",
+    "--keep-in-foreground",
+    "--no-resolv",
+    "--no-hosts",
+    "--port=0",
+    "--cache-size=512",
+    /* Exercises the rebind-check path in process_reply() */
+    "--stop-dns-rebind",
+    "--rebind-domain-ok=fuzz.test",
+    /* Exercises check_for_bogus_wildcard() / check_for_ignored_address() */
+    "--bogus-nxdomain=198.105.254.11",
+    /* Exercises do_doctor() NAT-alias rewriting in process_reply() */
+    "--alias=10.0.0.1,192.0.2.1",
+    /* Upstream server: read_opts() builds serverarray with one entry */
+    "--server=127.0.0.1#5553",
+    "--log-facility=/dev/null",
+  };
+  int fuzz_argc = (int)(sizeof(fuzz_argv) / sizeof(fuzz_argv[0]));
+
+  read_opts(fuzz_argc, fuzz_argv, "");
+
+  /* Route my_syslog() to /dev/null so it doesn't fall back to vsyslog(). */
+  log_start(NULL, -1);
+
+  /* Post-read_opts initialisation matching dnsmasq.c */
+  daemon->dumpfd         = -1;
+  daemon->pipe_to_parent = -1;
+  daemon->srv_save       = NULL;
+
+  if (daemon->edns_pktsz < PACKETSZ)
+    daemon->edns_pktsz = PACKETSZ;
+  daemon->packet_buff_sz = daemon->edns_pktsz + MAXDNAME + RRFIXEDSZ;
+  daemon->packet = safe_malloc(daemon->packet_buff_sz);
+
+  cache_init();
+  blockdata_init();
+
+  /* Pre-populate the frec_src free pool so free_frec() can return extra
+     frec_src records to it and we can pull them back for the next call. */
+  daemon->ftabsize       = 100;
+  daemon->frec_src_count = 0;
+  daemon->free_frec_src  = NULL;
+  for (int i = 0; i < 16; i++)
+    {
+      struct frec_src *s = safe_malloc(sizeof(struct frec_src));
+      memset(s, 0, sizeof(*s));
+      s->next = daemon->free_frec_src;
+      daemon->free_frec_src = s;
+      daemon->frec_src_count++;
+    }
+
+  /* Pre-allocate the frec and link it into daemon->frec_list so that
+     free_frec() won't try to free or allocate around it. */
+  fuzz_frec = safe_malloc(sizeof(struct frec));
+  memset(fuzz_frec, 0, sizeof(*fuzz_frec));
+  fuzz_frec->next   = daemon->frec_list;
+  daemon->frec_list = fuzz_frec;
+
+  /* Minimal fake upstream server (used as forward->sentto). */
+  memset(&fake_server, 0, sizeof(fake_server));
+  fake_server.addr.sa.sa_family       = AF_INET;
+  fake_server.addr.in.sin_addr.s_addr = htonl(0x7f000001); /* 127.0.0.1 */
+  fake_server.addr.in.sin_port        = htons(5553);
+  fake_server.last_server             = -1;
+
+  return 0;
+}
+
+/* ── Per-input helper ────────────────────────────────────────────────────── */
+
+/*
+ * Build a frec with the given flags and call return_reply().
+ *
+ * If add_second_client is non-zero, a second frec_src is pulled from the
+ * daemon free pool and linked as frec_src.next.  The second client has a
+ * smaller udp_pkt_size (512 bytes) and a non-zero encode_bitmap, which
+ * exercises both the truncation loop and flip_queryname() inside
+ * return_reply().
+ *
+ * On return, free_frec() (called inside return_reply()) has:
+ *   - set fuzz_frec->sentto = NULL, ->flags = 0, ->frec_src.next = NULL
+ *   - returned the second frec_src (if any) to daemon->free_frec_src
+ *   - left fuzz_frec->next intact (the frec stays in daemon->frec_list)
+ *
+ * Callers must re-populate fuzz_frec before the next call.
+ */
+static void call_return_reply(time_t now,
+                               const uint8_t *data, size_t capped,
+                               unsigned int frec_flags, int add_second_client)
+{
+  /* Copy fuzz data into daemon->packet so process_reply() can work on it
+     in-place (it may shrink/expand the packet within the buffer). */
+  memcpy(daemon->packet, data, capped);
+  memset(daemon->packet + capped, 0, daemon->packet_buff_sz - capped);
+
+  struct dns_header *hdr = (struct dns_header *)daemon->packet;
+
+  /* process_reply() expects a DNS response (QR=1) with at least one
+     question.  Set the minimum required bits without disturbing the rest of
+     the fuzz-supplied header so we still reach deep parsing paths. */
+  hdr->hb3 |= HB3_QR;
+  if (ntohs(hdr->qdcount) == 0)
+    hdr->qdcount = htons(1);
+
+  /* ── Rebuild fuzz_frec (zeroed by free_frec() in the previous call) ───── */
+  struct frec *fwd  = fuzz_frec;
+  fwd->sentto       = &fake_server;
+  fwd->flags        = frec_flags;
+  fwd->new_id       = hdr->id;
+  fwd->stash        = NULL;
+  fwd->rfds         = NULL;
+  fwd->forwardall   = 0;
+
+  /* Primary client (embedded frec_src).  fd=-1 → return_reply() skips the
+     actual send_from() call, so no real socket is required. */
+  fwd->frec_src.fd                        = -1;
+  fwd->frec_src.source.sa.sa_family       = AF_INET;
+  fwd->frec_src.source.in.sin_addr.s_addr = htonl(0x7f000001); /* 127.0.0.1 */
+  fwd->frec_src.source.in.sin_port        = htons(5353);
+  fwd->frec_src.dest.addr4.s_addr         = htonl(0x7f000001);
+  fwd->frec_src.orig_id                   = ntohs(hdr->id);
+  fwd->frec_src.udp_pkt_size              = PACKETSZ; /* full-size allowed */
+  fwd->frec_src.log_id                    = 1;
+  fwd->frec_src.encode_bitmap             = 0;
+  fwd->frec_src.encode_bigmap             = NULL;
+  fwd->frec_src.next                      = NULL;
+
+  /* Optional second client (exercises flip_queryname + truncation path). */
+  if (add_second_client && daemon->free_frec_src)
+    {
+      struct frec_src *s2    = daemon->free_frec_src;
+      daemon->free_frec_src  = s2->next;
+
+      memset(s2, 0, sizeof(*s2));
+      s2->fd                        = -1;
+      s2->source.sa.sa_family       = AF_INET;
+      s2->source.in.sin_addr.s_addr = htonl(0xc0000201); /* 192.0.2.1 */
+      s2->source.in.sin_port        = htons(9999);
+      s2->dest.addr4.s_addr         = htonl(0xc0000202);
+      s2->udp_pkt_size              = 512;        /* smaller → truncation */
+      s2->orig_id                   = ntohs(hdr->id) ^ 0x4242;
+      s2->encode_bitmap             = 0xdeadbeef; /* non-zero → case flip */
+      s2->encode_bigmap             = NULL;
+      s2->log_id                    = 2;
+
+      fwd->frec_src.next = s2;
+    }
+
+  /*
+   * return_reply() → process_reply() → extract_addresses() / do_doctor() /
+   * check_for_bogus_wildcard() / check_for_ignored_address() / rrfilter() /
+   * add_pseudoheader() → per-frec_src delivery loop → flip_queryname() →
+   * free_frec()
+   *
+   * STAT_OK == 0x70000; in non-DNSSEC builds `status' is immediately
+   * voided so any value is fine.
+   */
+  return_reply(now, fwd, hdr, (ssize_t)capped, STAT_OK);
+
+  /* free_frec() has now cleared fwd->sentto/flags/frec_src.next/stash/rfds.
+     The frec struct memory is still valid (free_frec never calls free(f)).
+     Callers may immediately re-populate and reuse fuzz_frec. */
+}
+
+/* ── Per-input entry point ───────────────────────────────────────────────── */
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+  /* Need at least a DNS header. */
+  if (size < sizeof(struct dns_header))
+    return 0;
+
+  /* Cap at the packet buffer size; daemon->packet is the working area. */
+  size_t capped = size < daemon->packet_buff_sz ? size : daemon->packet_buff_sz;
+  time_t now    = FUZZ_NOW;
+
+  /*
+   * Expire all dynamic cache entries so every iteration starts from the same
+   * state.  ttd=0 < FUZZ_NOW=1000000, so is_expired() returns 1 for them and
+   * cache_find_by_name/addr skip them.  Immortal config entries are unaffected.
+   *
+   * We do NOT call cache_init() — it safe_malloc's without freeing the old crec
+   * array, growing the LRU list unboundedly across persistent-mode iterations.
+   */
+  {
+    struct crec *crec;
+    cache_enumerate(1);
+    while ((crec = cache_enumerate(0)))
+      crec->ttd = 0;
+  }
+
+  /*
+   * Reset fake_server mutable state.
+   *
+   * process_reply() sets server->flags |= SERV_WARNED_RECURSIVE the first time
+   * it sees a reply without the RA bit.  Without a reset, iteration 1 sets the
+   * flag and iterations 2-N skip the warning branch entirely — different coverage.
+   *
+   * server->nxdomain_replies is incremented on every NXDOMAIN reply; not a
+   * branch itself, but domain-match.c uses it as a quality metric.
+   */
+  fake_server.flags            = 0;
+  fake_server.nxdomain_replies = 0;
+  daemon->srv_save             = NULL;
+
+  /* ── 1. Plain reply — two clients ───────────────────────────────────────
+   *
+   * The second client has udp_pkt_size=512 and a non-zero encode_bitmap,
+   * so if the processed reply is > 512 bytes both the truncation loop and
+   * flip_queryname() are exercised.  If process_reply() shrinks the reply
+   * to ≤ 512 bytes, flip_queryname() is still called for the second src.
+   */
+  call_return_reply(now, data, capped, /*flags=*/0, /*two_clients=*/1);
+
+  /* ── 2. Rebind-exempt + EDNS0 passthrough + DO bit ─────────────────────
+   *
+   * FREC_NOREBIND:    skips the rebind check for this forward record
+   * FREC_HAS_PHEADER: client sent EDNS0 → process_reply() keeps the
+   *                   pseudo-header instead of stripping it
+   * FREC_DO_QUESTION: client set DO bit → process_reply() advertises our
+   *                   edns_pktsz back to the client
+   */
+  call_return_reply(now, data, capped,
+                    FREC_NOREBIND | FREC_HAS_PHEADER | FREC_DO_QUESTION,
+                    /*two_clients=*/0);
+
+  /* ── 3. Checking-disabled + AD question ────────────────────────────────
+   *
+   * FREC_CHECKING_DISABLED: CD bit is preserved in the reply (no DNSSEC
+   *                         validation was requested by the client)
+   * FREC_AD_QUESTION:       client set AD bit → process_reply() may set
+   *                         AD in the reply if the answer is secure
+   */
+  call_return_reply(now, data, capped,
+                    FREC_CHECKING_DISABLED | FREC_AD_QUESTION,
+                    /*two_clients=*/0);
+
+  return 0;
+}

--- a/projects/dnsmasq/fuzz_forward.c
+++ b/projects/dnsmasq/fuzz_forward.c
@@ -1,3 +1,15 @@
+/* Copyright 2026 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 /*
  * dnsmasq_fuzzer_forward.c — libFuzzer harness for the dnsmasq forwarding
  *                            pipeline.


### PR DESCRIPTION
## Summary

Adds four new libFuzzer harnesses for dnsmasq, all linked against the existing
`libdnsmasq.a` produced by `projects/dnsmasq/build.sh`:

- **`fuzz_dns`** — exercises the DNS message parsing path (`answer_request` and
  related helpers in `rfc1035.c`) with raw DNS wire-format input.
- **`fuzz_forward`** — drives the DNS forwarding pipeline
  (`receive_query` / `reply_query`), covering query/response handling between
  the client and upstream paths.
- **`fuzz_dhcp_reply`** — targets DHCPv4 reply construction (`dhcp_reply`)
  with DHCPv4 packet input.
- **`fuzz_dhcp6_reply`** — targets DHCPv6 reply construction (`dhcp6_reply`)
  with DHCPv6 packet input.

## Implementation notes

- All four harnesses are pure C and built before the `sed 's/class/class2/g'` /
  `sed 's/new/new2/g'` rename in `build.sh`, since they include `dnsmasq.h`
  directly and don't need the C++ keyword workaround that `fuzz_util.cc`
  requires.
- `fuzz_dhcp6_reply.c` stubs `get_client_mac()` to avoid the real
  implementation's 500 ms `nanosleep` loop, which would otherwise dominate
  every fuzzing iteration. Because `dhcp6.o` (pulled from `libdnsmasq.a` to
  provide `dhcp6_reply`) carries its own definition, the harness is linked
  with `-Wl,--allow-multiple-definition` so the stub from the harness object
  (processed first) wins.
- Each harness ships a minimal seed corpus (`fuzz_*_seed_corpus.zip`) built
  inline in `build.sh`: a small DNS query for the DNS/forward harnesses, a
  DHCPv4 DISCOVER for `fuzz_dhcp_reply`, and a DHCPv6 SOLICIT with DUID-LL for
  `fuzz_dhcp6_reply`.

## Test plan

- [x] `python3 infra/helper.py build_image dnsmasq`
- [x] `python3 infra/helper.py build_fuzzers --sanitizer address dnsmasq`
- [x] `python3 infra/helper.py build_fuzzers --sanitizer undefined dnsmasq`
- [x] `python3 infra/helper.py run_fuzzer dnsmasq fuzz_dns -- -runs=100000`
- [x] `python3 infra/helper.py run_fuzzer dnsmasq fuzz_forward -- -runs=100000`
- [x] `python3 infra/helper.py run_fuzzer dnsmasq fuzz_dhcp_reply -- -runs=100000`
- [x] `python3 infra/helper.py run_fuzzer dnsmasq fuzz_dhcp6_reply -- -runs=100000`
- [x] `python3 infra/presubmit.py` — passes format/lint/license.