### PR TITLE
[quickjs] add module_export, json, regexp_compile, and bytecode fuzzers

### DIFF
--- a/projects/quickjs/build.sh
+++ b/projects/quickjs/build.sh
@@ -23,6 +23,11 @@ CONFIG_CLANG=y make libquickjs.fuzz.a .obj/fuzz_common.o .obj/libregexp.fuzz.o .
 zip -r $OUT/fuzz_eval_seed_corpus.zip $SRC/quickjs-corpus/js/*.js
 zip -r $OUT/fuzz_compile_seed_corpus.zip $SRC/quickjs-corpus/js/*.js
 
+zip -r $OUT/fuzz_module_export_seed_corpus.zip $SRC/quickjs-corpus/js/*.js
+zip -r $OUT/fuzz_json_seed_corpus.zip $SRC/quickjs-corpus/js/*.js
+zip -r $OUT/fuzz_regexp_compile_seed_corpus.zip $SRC/quickjs-corpus/js/*.js
+zip -r $OUT/fuzz_bytecode_seed_corpus.zip $SRC/quickjs-corpus/js/*.js
+
 build_fuzz_target () {
     local target=$1
     shift
@@ -33,6 +38,14 @@ build_fuzz_target () {
 build_fuzz_target fuzz_eval .obj/fuzz_common.o libquickjs.fuzz.a
 build_fuzz_target fuzz_compile .obj/fuzz_common.o libquickjs.fuzz.a
 build_fuzz_target fuzz_regexp .obj/libregexp.fuzz.o .obj/cutils.fuzz.o .obj/libunicode.fuzz.o
+build_fuzz_target fuzz_module_export .obj/fuzz_common.o libquickjs.fuzz.a
+build_fuzz_target fuzz_json .obj/fuzz_common.o libquickjs.fuzz.a
+build_fuzz_target fuzz_regexp_compile .obj/libregexp.fuzz.o .obj/cutils.fuzz.o .obj/libunicode.fuzz.o
+build_fuzz_target fuzz_bytecode .obj/fuzz_common.o libquickjs.fuzz.a
 
 cp fuzz/fuzz.dict $OUT/fuzz_eval.dict
 cp fuzz/fuzz.dict $OUT/fuzz_compile.dict
+cp fuzz/fuzz.dict $OUT/fuzz_module_export.dict
+cp fuzz/fuzz.dict $OUT/fuzz_json.dict
+cp fuzz/fuzz.dict $OUT/fuzz_regexp_compile.dict
+cp fuzz/fuzz.dict $OUT/fuzz_bytecode.dict

--- a/projects/quickjs/run_tests_patch.diff
+++ b/projects/quickjs/run_tests_patch.diff
@@ -1,8 +1,8 @@
 diff --git a/Makefile b/Makefile
-index 3b1c745..e0a1b97 100644
+index e10cd42..12efc24 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -449,7 +449,6 @@ test: qjs$(EXE)
+@@ -454,7 +454,6 @@ test: qjs$(EXE)
  	$(WINE) ./qjs$(EXE) tests/test_loop.js
  	$(WINE) ./qjs$(EXE) tests/test_bigint.js
  	$(WINE) ./qjs$(EXE) tests/test_cyclic_import.js


### PR DESCRIPTION
This PR updates the QuickJS OSS-Fuzz project build script to add support for the new fuzzers:\n\n- fuzz_module_export\n- fuzz_json\n- fuzz_regexp_compile\n- fuzz_bytecode\n\nIt also adds seed corpus zips and dictionaries for each new target.