### PR TITLE
Update OTS build

### DIFF
--- a/projects/ots/Dockerfile
+++ b/projects/ots/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y python3-pip && \
-    pip3 install meson==0.55.2 ninja
+    pip3 install meson==1.2.0 ninja
 RUN git clone --depth 1 https://github.com/khaledhosny/ots.git
 WORKDIR ots
 COPY run_tests.sh build.sh ots-fuzzer.* $SRC/


### PR DESCRIPTION
Use a modern meson version. We pin meson to avoid unexpected breakage in meson, but we don’t really need such old version. Update to 1.2.0 so that we don’t have to update it in a while.

Upstream is going to require 0.58.0, so this unblocks it, too.