### PR TITLE
pjsip: fix build

### DIFF
--- a/projects/pjsip/build.sh
+++ b/projects/pjsip/build.sh
@@ -18,13 +18,6 @@ export CFLAGS="$CFLAGS -DPJMEDIA_HAS_VIDEO=1"
 export CXXFLAGS="$CFLAGS"
 export LDFLAGS="$CFLAGS"
 
-# Temporary workaround for pjproject#4988: the Opus block in fuzz-audio.c has an
-# unterminated /* ... comment right before the stereo-config block, which the
-# preprocessor swallows along with the block's variable declarations and opening
-# brace, breaking the build. Insert the missing */ after the comment's last line.
-# Remove this once the upstream comment is closed.
-sed -i '/registered "opus\/48000\/2" ID)\./a\     */' tests/fuzz/fuzz-audio.c
-
 ./configure \
 --disable-ffmpeg --disable-ssl \
 --disable-speex-aec --disable-g7221-codec \


### PR DESCRIPTION
Removed temporary workaround for pjproject#4988 regarding the Opus block in fuzz-audio.c.