### PR TITLE
pypy3: Only use the `libfuzzer` engine

### DIFF
--- a/projects/pypy3/project.yaml
+++ b/projects/pypy3/project.yaml
@@ -5,5 +5,7 @@ primary_contact: "stanulbrych@gmail.com"
 auto_ccs:
  - "matti.picus@gmail.com"
  - "cfbolz@gmail.com"
+fuzzing_engines:
+ - libfuzzer
 sanitizers:
  - undefined


### PR DESCRIPTION
It's not playing nicely with Centipede: https://oss-fuzz-build-logs.storage.googleapis.com/index.html#pypy3 Something is failing to link. The targets repository only tests libFuzzer, so I think it's best to just limit ourselves to it till we see it running.