### PR TITLE
bleach: disable

### DIFF
--- a/projects/bleach/project.yaml
+++ b/projects/bleach/project.yaml
@@ -10,3 +10,4 @@ fuzzing_engines:
 sanitizers:
   - address
   - undefined
+disabled: true


### PR DESCRIPTION
Project is no longer maintained, including for security issues: https://github.com/mozilla/bleach/pull/787