### PR TITLE
Monero: fix build

### DIFF
--- a/projects/monero/build.sh
+++ b/projects/monero/build.sh
@@ -25,7 +25,12 @@ git submodule update
 mkdir -p build
 cd build
 export CXXFLAGS="${CXXFLAGS} -fPIC -DBOOST_NO_INCLASS_MEMBER_INITIALIZATION"
-cmake -D OSSFUZZ=ON -D STATIC=ON -D BUILD_TESTS=ON -D USE_LTO=OFF -D ARCH="default" ..
+# Upstream monero (commit 65c15857, "cmake: use boost provided module") switched
+# to find_package(Boost ... CONFIG) and dropped its internal
+# `set(Boost_USE_STATIC_RUNTIME ON)`. The OSS-Fuzz image builds Boost with
+# `runtime-link=static`, so config-mode find_package rejects that variant unless
+# Boost_USE_STATIC_RUNTIME is ON. Re-supply it here to match the image's Boost.
+cmake -D OSSFUZZ=ON -D STATIC=ON -D BUILD_TESTS=ON -D USE_LTO=OFF -D ARCH="default" -D Boost_USE_STATIC_RUNTIME=ON ..
 
 TESTS="\
   base58_fuzz_tests \


### PR DESCRIPTION
Added Boost_USE_STATIC_RUNTIME flag to cmake command for compatibility with OSS-Fuzz image.