### PR TITLE
wazuh: fix build

### DIFF
--- a/projects/wazuh/build.sh
+++ b/projects/wazuh/build.sh
@@ -19,7 +19,7 @@ cd src
 export LDFLAGS="$CFLAGS"
 sed -i 's/CC=gcc/CC=clang/g' Makefile
 
-make deps
+make deps TARGET=agent
 mkdir -p build && cd build
 cmake .. -DTARGET=agent
 make wazuh -j$(nproc)


### PR DESCRIPTION
Updated build script to specify target as 'agent' for dependencies and build.