### PR TITLE
Erigon: initial integration

### DIFF
--- a/projects/erigon/Dockerfile
+++ b/projects/erigon/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# base-builder-go carries the OSS-Fuzz Go build tooling (compile_native_go_fuzzer,
+# go-118-fuzz-build, sanitizer/coverage instrumentation). It is required — a plain
+# golang image would lack these and build.sh would fail.
+FROM gcr.io/oss-fuzz-base/base-builder-go
+
+# Go version is NOT pinned here on purpose: erigon's go.mod (`go`/`toolchain`
+# directives) is the single source of truth, and Go's GOTOOLCHAIN=auto fetches
+# the matching toolchain at build time if the base image's bundled Go is older.
+# Bumping Go = editing go.mod in the erigon repo; this Dockerfile stays untouched.
+
+RUN git clone --depth 1 https://github.com/erigontech/erigon erigon
+COPY build.sh $SRC/
+WORKDIR $SRC/erigon

--- a/projects/erigon/build.sh
+++ b/projects/erigon/build.sh
@@ -26,10 +26,9 @@ MOD=github.com/erigontech/erigon
 # which would drop it since no Erigon source imports it).
 go get github.com/AdamKorcz/go-118-fuzz-build/testing
 
-# --- Pure-Go targets (no cgo) ---------------------------------------------
-
-compile_native_go_fuzzer $MOD/common/bitutil           FuzzEncoder              fuzz_bitutil_encoder
-compile_native_go_fuzzer $MOD/common/bitutil           FuzzDecoder              fuzz_bitutil_decoder
+# Enabled targets: native fuzzers verified to compile both under
+# go-118-fuzz-build (libfuzzer/sanitizer builds) and under the CGO-disabled
+# coverage build. New targets are added once their blocker (below) is cleared.
 
 compile_native_go_fuzzer $MOD/db/datastruct/fusefilter FuzzReaderOnBytes        fuzz_fusefilter_reader
 compile_native_go_fuzzer $MOD/db/datastruct/fusefilter FuzzReaderShardedOnBytes fuzz_fusefilter_reader_sharded
@@ -40,30 +39,33 @@ compile_native_go_fuzzer $MOD/db/recsplit/eliasfano16  FuzzDoubleEliasFano      
 compile_native_go_fuzzer $MOD/db/recsplit/eliasfano32  FuzzSingleEliasFano      fuzz_ef32_single
 compile_native_go_fuzzer $MOD/db/recsplit/eliasfano32  FuzzDoubleEliasFano      fuzz_ef32_double
 
-compile_native_go_fuzzer $MOD/db/recsplit              FuzzRecSplit             fuzz_recsplit
-
-compile_native_go_fuzzer $MOD/db/seg                   FuzzCompress             fuzz_seg_compress
-compile_native_go_fuzzer $MOD/db/seg                   FuzzDecompressMatch      fuzz_seg_decompress_match
 compile_native_go_fuzzer $MOD/db/seg/patricia          FuzzPatricia             fuzz_patricia
 compile_native_go_fuzzer $MOD/db/seg/patricia          FuzzLongestMatch         fuzz_patricia_longest_match
 
-compile_native_go_fuzzer $MOD/execution/commitment/nibbles FuzzHexCompactRoundtrip fuzz_nibbles_hexcompact
-
-# --- cgo via secp256k1 only (small C lib; same footprint as go-ethereum) ---
-
 compile_native_go_fuzzer $MOD/execution/abi            FuzzABI                  fuzz_abi
-compile_native_go_fuzzer $MOD/execution/types          FuzzRLP                  fuzz_rlp
-compile_native_go_fuzzer $MOD/execution/vm             FuzzPrecompiledContracts fuzz_precompiles
-compile_native_go_fuzzer $MOD/execution/vm/runtime     FuzzVmRuntime            fuzz_vm_runtime
 
-# --- Deferred: cgo + MDBX (txnprovider/txpool) -----------------------------
+# --- Deferred targets ------------------------------------------------------
+# These build under plain `go test` but not yet under the OSS-Fuzz toolchain.
+# Re-enable each as its blocker is resolved.
 #
-# The txpool fuzzers (FuzzParseTx, FuzzPooledTransactions66,
-# FuzzGetPooledTransactions66, FuzzOnNewBlocks) transitively link the MDBX C
-# library, which needs validating under the OSS-Fuzz sanitizer toolchain
-# before being enabled. Add in a follow-up once the build is confirmed green:
+# (a) go-118-fuzz-build's testing shim has no testing.B, and these fuzzers
+#     share a file with benchmarks. Fix: move the fuzzer into a benchmark-free
+#     file upstream, then enable here.
+#       $MOD/common/bitutil                FuzzEncoder, FuzzDecoder
+#       $MOD/execution/commitment/nibbles  FuzzHexCompactRoundtrip
 #
-# compile_native_go_fuzzer $MOD/txnprovider/txpool FuzzParseTx                  fuzz_txpool_parsetx
-# compile_native_go_fuzzer $MOD/txnprovider/txpool FuzzPooledTransactions66     fuzz_txpool_pooledtxns66
-# compile_native_go_fuzzer $MOD/txnprovider/txpool FuzzGetPooledTransactions66  fuzz_txpool_getpooledtxns66
-# compile_native_go_fuzzer $MOD/txnprovider/txpool FuzzOnNewBlocks              fuzz_txpool_onnewblocks
+# (b) The shim's testing.T has no Context() method (Go 1.24+), used in these
+#     fuzzer files.
+#       $MOD/db/recsplit                   FuzzRecSplit
+#       $MOD/db/seg                        FuzzCompress, FuzzDecompressMatch
+#
+# (c) Require cgo, but the OSS-Fuzz coverage build runs with CGO disabled
+#     (undefined secp256k1 symbols). Needs the coverage build to allow cgo, or
+#     these excluded from coverage.
+#       $MOD/execution/types               FuzzRLP
+#       $MOD/execution/vm                  FuzzPrecompiledContracts
+#       $MOD/execution/vm/runtime          FuzzVmRuntime
+#
+# (d) cgo + MDBX (large C lib), needs sanitizer-toolchain validation.
+#       $MOD/txnprovider/txpool  FuzzParseTx, FuzzPooledTransactions66,
+#                                FuzzGetPooledTransactions66, FuzzOnNewBlocks

--- a/projects/erigon/build.sh
+++ b/projects/erigon/build.sh
@@ -20,6 +20,12 @@
 
 MOD=github.com/erigontech/erigon
 
+# compile_native_go_fuzzer rewrites each testing.F fuzzer through
+# go-118-fuzz-build, which imports this shim in place of stdlib testing. It must
+# be resolvable in the module graph. Add it here only (not via `go mod tidy`,
+# which would drop it since no Erigon source imports it).
+go get github.com/AdamKorcz/go-118-fuzz-build/testing
+
 # --- Pure-Go targets (no cgo) ---------------------------------------------
 
 compile_native_go_fuzzer $MOD/common/bitutil           FuzzEncoder              fuzz_bitutil_encoder

--- a/projects/erigon/build.sh
+++ b/projects/erigon/build.sh
@@ -1,0 +1,63 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage: compile_native_go_fuzzer <package-import-path> <FuzzFunc> <output-name>
+#
+# Each Erigon fuzz target is a native Go fuzzer (`func FuzzXxx(f *testing.F)`)
+# living in a *_test.go file. The output name must be unique per binary.
+
+MOD=github.com/erigontech/erigon
+
+# --- Pure-Go targets (no cgo) ---------------------------------------------
+
+compile_native_go_fuzzer $MOD/common/bitutil           FuzzEncoder              fuzz_bitutil_encoder
+compile_native_go_fuzzer $MOD/common/bitutil           FuzzDecoder              fuzz_bitutil_decoder
+
+compile_native_go_fuzzer $MOD/db/datastruct/fusefilter FuzzReaderOnBytes        fuzz_fusefilter_reader
+compile_native_go_fuzzer $MOD/db/datastruct/fusefilter FuzzReaderShardedOnBytes fuzz_fusefilter_reader_sharded
+compile_native_go_fuzzer $MOD/db/datastruct/fusefilter FuzzWriterRoundTrip      fuzz_fusefilter_writer_roundtrip
+
+compile_native_go_fuzzer $MOD/db/recsplit/eliasfano16  FuzzSingleEliasFano      fuzz_ef16_single
+compile_native_go_fuzzer $MOD/db/recsplit/eliasfano16  FuzzDoubleEliasFano      fuzz_ef16_double
+compile_native_go_fuzzer $MOD/db/recsplit/eliasfano32  FuzzSingleEliasFano      fuzz_ef32_single
+compile_native_go_fuzzer $MOD/db/recsplit/eliasfano32  FuzzDoubleEliasFano      fuzz_ef32_double
+
+compile_native_go_fuzzer $MOD/db/recsplit              FuzzRecSplit             fuzz_recsplit
+
+compile_native_go_fuzzer $MOD/db/seg                   FuzzCompress             fuzz_seg_compress
+compile_native_go_fuzzer $MOD/db/seg                   FuzzDecompressMatch      fuzz_seg_decompress_match
+compile_native_go_fuzzer $MOD/db/seg/patricia          FuzzPatricia             fuzz_patricia
+compile_native_go_fuzzer $MOD/db/seg/patricia          FuzzLongestMatch         fuzz_patricia_longest_match
+
+compile_native_go_fuzzer $MOD/execution/commitment/nibbles FuzzHexCompactRoundtrip fuzz_nibbles_hexcompact
+
+# --- cgo via secp256k1 only (small C lib; same footprint as go-ethereum) ---
+
+compile_native_go_fuzzer $MOD/execution/abi            FuzzABI                  fuzz_abi
+compile_native_go_fuzzer $MOD/execution/types          FuzzRLP                  fuzz_rlp
+compile_native_go_fuzzer $MOD/execution/vm             FuzzPrecompiledContracts fuzz_precompiles
+compile_native_go_fuzzer $MOD/execution/vm/runtime     FuzzVmRuntime            fuzz_vm_runtime
+
+# --- Deferred: cgo + MDBX (txnprovider/txpool) -----------------------------
+#
+# The txpool fuzzers (FuzzParseTx, FuzzPooledTransactions66,
+# FuzzGetPooledTransactions66, FuzzOnNewBlocks) transitively link the MDBX C
+# library, which needs validating under the OSS-Fuzz sanitizer toolchain
+# before being enabled. Add in a follow-up once the build is confirmed green:
+#
+# compile_native_go_fuzzer $MOD/txnprovider/txpool FuzzParseTx                  fuzz_txpool_parsetx
+# compile_native_go_fuzzer $MOD/txnprovider/txpool FuzzPooledTransactions66     fuzz_txpool_pooledtxns66
+# compile_native_go_fuzzer $MOD/txnprovider/txpool FuzzGetPooledTransactions66  fuzz_txpool_getpooledtxns66
+# compile_native_go_fuzzer $MOD/txnprovider/txpool FuzzOnNewBlocks              fuzz_txpool_onnewblocks

--- a/projects/erigon/project.yaml
+++ b/projects/erigon/project.yaml
@@ -1,0 +1,13 @@
+homepage: "https://erigon.tech/"
+language: go
+primary_contact: "oleksandr.lystopad@erigon.tech"
+auto_ccs:
+  - "andrew.ashikhmin@erigon.tech"
+  - "alex.sharov@erigon.tech"
+main_repo: "https://github.com/erigontech/erigon"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+architectures:
+  - x86_64


### PR DESCRIPTION
## Erigon

[Erigon](https://github.com/erigontech/erigon) is a high-performance Go
implementation of the Ethereum execution layer — one of the major Ethereum
execution clients, widely deployed across Ethereum mainnet, testnets, and L2
infrastructure.

### Fuzz targets

Erigon already ships native Go fuzzers (`func FuzzXxx(f *testing.F)`). This
integration wires up 17 of them via `compile_native_go_fuzzer`, covering the
highest-value untrusted-input boundaries:

- RLP decoding (`execution/types`)
- ABI decoding (`execution/abi`)
- EVM precompiles and interpreter runtime (`execution/vm`, `execution/vm/runtime`)
- Snapshot / index codecs (`db/seg`, `db/recsplit`, elias-fano, patricia, fusefilter)
- bitutil compression and commitment nibbles

The transaction-pool fuzzers are intentionally deferred to a follow-up PR:
they transitively link the MDBX C library, which we want to validate under the
sanitizer toolchain before enabling.

### Contacts

- Primary: oleksandr.lystopad@erigon.tech
- CC: andrew.ashikhmin@erigon.tech, alex.sharov@erigon.tech

All listed contacts are members of the Erigon team.