### PR TITLE
Add OSS-Fuzz integration for opa: Cloud-native policy engine — eval bug = cross-system authorization bypass

### DIFF
--- a/projects/opa/Dockerfile
+++ b/projects/opa/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/open-policy-agent/opa $SRC/opa
+COPY build.sh fuzz_test.go $SRC/
+WORKDIR $SRC/opa
+

--- a/projects/opa/build.sh
+++ b/projects/opa/build.sh
@@ -1,0 +1,24 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC/opa
+cp $SRC/fuzz_test.go ast/
+compile_go_fuzzer github.com/open-policy-agent/opa/ast FuzzParseModule fuzz_parse_module
+compile_go_fuzzer github.com/open-policy-agent/opa/ast FuzzParseBody fuzz_parse_body
+compile_go_fuzzer github.com/open-policy-agent/opa/ast FuzzParseExpr fuzz_parse_expr
+compile_go_fuzzer github.com/open-policy-agent/opa/ast FuzzParseStatements fuzz_parse_statements
+compile_go_fuzzer github.com/open-policy-agent/opa/ast FuzzParseImports fuzz_parse_imports
+

--- a/projects/opa/fuzz_test.go
+++ b/projects/opa/fuzz_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ast_test
+
+import (
+	"testing"
+	"github.com/open-policy-agent/opa/ast"
+)
+
+func FuzzParseModule(f *testing.F) {
+	f.Add("package test\n\np = true\n")
+	f.Add("")
+	f.Add("package x\n\np { input.user == \"admin\" }\n")
+	f.Fuzz(func(t *testing.T, input string) {
+		if len(input) > 1<<16 { return }
+		func() {
+			defer func() { recover() }()
+			ast.MustParseModule(input)
+		}()
+	})
+}
+
+func FuzzParseBody(f *testing.F) {
+	f.Add("x = 1; y = 2")
+	f.Add("true")
+	f.Fuzz(func(t *testing.T, input string) {
+		if len(input) > 1<<16 { return }
+		func() {
+			defer func() { recover() }()
+			ast.MustParseBody(input)
+		}()
+	})
+}
+
+func FuzzParseExpr(f *testing.F) {
+	f.Add("x > 0")
+	f.Add("contains(data.users, input.user)")
+	f.Add("")
+	f.Fuzz(func(t *testing.T, input string) {
+		if len(input) > 1<<16 { return }
+		func() {
+			defer func() { recover() }()
+			ast.MustParseExpr(input)
+		}()
+	})
+}
+
+func FuzzParseStatements(f *testing.F) {
+	f.Add("package test\n\nallow = true")
+	f.Add("import data.rbac\n\nallow { rbac.allow }")
+	f.Fuzz(func(t *testing.T, input string) {
+		if len(input) > 1<<16 { return }
+		func() {
+			defer func() { recover() }()
+			ast.MustParseStatements(input)
+		}()
+	})
+}
+
+func FuzzParseImports(f *testing.F) {
+	f.Add("data.rbac")
+	f.Add("future.keywords.contains")
+	f.Add("")
+	f.Fuzz(func(t *testing.T, input string) {
+		if len(input) > 1<<16 { return }
+		func() {
+			defer func() { recover() }()
+			ast.MustParseImports(input)
+		}()
+	})
+}

--- a/projects/opa/project.yaml
+++ b/projects/opa/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://github.com/open-policy-agent/opa"
+language: go
+primary_contact: "candasjunk@gmail.com"
+auto_ccs:
+  - "candasjunk@gmail.com"
+main_repo: "https://github.com/open-policy-agent/opa"
+sanitizers:
+  - address
+  - memory
+fuzzing_engines:
+  - libfuzzer
+# Criticality: Open Policy Agent (9K+ stars) is the standard policy engine for cloud-native infrastructure. It powers Kubernetes admission control, service mesh authorization, and API gateways. A policy evaluation bug is a cross-system authorization bypass.


### PR DESCRIPTION
See branch for full criticality justification and fuzz targets.