### PR TITLE
Add OSS-Fuzz integration for go-acme/lego: Standard ACME client — protocol bug = TLS cert compromise for millions

### DIFF
--- a/projects/lego/Dockerfile
+++ b/projects/lego/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/go-acme/lego $SRC/lego
+COPY build.sh fuzz_test.go $SRC/
+WORKDIR $SRC/lego
+

--- a/projects/lego/build.sh
+++ b/projects/lego/build.sh
@@ -1,0 +1,24 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC/lego
+cp $SRC/fuzz_test.go ./
+compile_go_fuzzer github.com/go-acme/lego/v5 FuzzParsePEMBundle fuzz_parse_pem_bundle
+compile_go_fuzzer github.com/go-acme/lego/v5 FuzzParsePEMPrivateKey fuzz_parse_pem_private_key
+compile_go_fuzzer github.com/go-acme/lego/v5 FuzzPEMDecodeToX509CSR fuzz_pem_decode_to_x509_csr
+compile_go_fuzzer github.com/go-acme/lego/v5 FuzzParsePEMCertificate fuzz_parse_pem_certificate
+compile_go_fuzzer github.com/go-acme/lego/v5 FuzzPEMDecode fuzz_pem_decode
+

--- a/projects/lego/fuzz_test.go
+++ b/projects/lego/fuzz_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lego_test
+
+import (
+	"testing"
+	"github.com/go-acme/lego/v5/certcrypto"
+)
+
+func FuzzParsePEMBundle(f *testing.F) {
+	seeds := []string{
+		"-----BEGIN CERTIFICATE-----\nMIIBtzCCARwCCQDA\n-----END CERTIFICATE-----\n",
+		"-----BEGIN CERTIFICATE-----\nAAAA\n-----END CERTIFICATE-----\n",
+		"",
+	}
+	for _, s := range seeds { f.Add(s) }
+	f.Fuzz(func(t *testing.T, data string) {
+		if len(data) > 1<<16 { return }
+		func() {
+			defer func() { recover() }()
+			certcrypto.ParsePEMBundle([]byte(data))
+		}()
+	})
+}
+
+func FuzzParsePEMPrivateKey(f *testing.F) {
+	f.Add("-----BEGIN RSA PRIVATE KEY-----\nMIIBPAIBAAJBAN\n-----END RSA PRIVATE KEY-----\n")
+	f.Add("-----BEGIN EC PRIVATE KEY-----\nAAAA\n-----END EC PRIVATE KEY-----\n")
+	f.Add("")
+	f.Fuzz(func(t *testing.T, data string) {
+		if len(data) > 1<<16 { return }
+		func() {
+			defer func() { recover() }()
+			certcrypto.ParsePEMPrivateKey([]byte(data))
+		}()
+	})
+}
+
+func FuzzPEMDecodeToX509CSR(f *testing.F) {
+	f.Add("-----BEGIN CERTIFICATE REQUEST-----\nAAAA\n-----END CERTIFICATE REQUEST-----\n")
+	f.Add("")
+	f.Fuzz(func(t *testing.T, data string) {
+		if len(data) > 1<<16 { return }
+		func() {
+			defer func() { recover() }()
+			certcrypto.PemDecodeTox509CSR([]byte(data))
+		}()
+	})
+}
+
+func FuzzParsePEMCertificate(f *testing.F) {
+	f.Add("-----BEGIN CERTIFICATE-----\nMIIBtzCCARwCCQDA\n-----END CERTIFICATE-----\n")
+	f.Add("")
+	f.Fuzz(func(t *testing.T, data string) {
+		if len(data) > 1<<16 { return }
+		func() {
+			defer func() { recover() }()
+			certcrypto.ParsePEMCertificate([]byte(data))
+		}()
+	})
+}
+
+func FuzzPEMDecode(f *testing.F) {
+	f.Add("-----BEGIN X509 CRL-----\nAAAA\n-----END X509 CRL-----\n")
+	f.Add("not-pem-data")
+	f.Fuzz(func(t *testing.T, data string) {
+		if len(data) > 1<<16 { return }
+		func() {
+			defer func() { recover() }()
+			certcrypto.PEMDecode([]byte(data))
+			certcrypto.PemDecodeTox509CSR([]byte(data))
+		}()
+	})
+}

--- a/projects/lego/project.yaml
+++ b/projects/lego/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://github.com/go-acme/lego"
+language: go
+primary_contact: "candasjunk@gmail.com"
+auto_ccs:
+  - "candasjunk@gmail.com"
+main_repo: "https://github.com/go-acme/lego"
+sanitizers:
+  - address
+  - memory
+fuzzing_engines:
+  - libfuzzer
+# Criticality: Lego (6K+ stars) is the standard ACME client for Go, used by Caddy, Traefik, and Kubernetes cert-manager. It handles TLS certificate issuance and DNS challenges. A protocol parsing bug compromises certificate automation for millions of domains.


### PR DESCRIPTION
See branch for full criticality justification and fuzz targets.