### PR TITLE
Add OSS-Fuzz integration for testify: Most-used Go test toolkit — mock/assert bug = supply chain compromise at build

### DIFF
--- a/projects/testify/Dockerfile
+++ b/projects/testify/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/stretchr/testify $SRC/testify
+COPY build.sh fuzz_test.go $SRC/
+WORKDIR $SRC/testify
+

--- a/projects/testify/build.sh
+++ b/projects/testify/build.sh
@@ -1,0 +1,24 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC/testify
+cp $SRC/fuzz_test.go ./
+compile_go_fuzzer github.com/stretchr/testify FuzzAssertEqual fuzz_assert_equal
+compile_go_fuzzer github.com/stretchr/testify FuzzAssertJSON fuzz_assert_json
+compile_go_fuzzer github.com/stretchr/testify FuzzAssertYAML fuzz_assert_yaml
+compile_go_fuzzer github.com/stretchr/testify FuzzRequireInt fuzz_require_int
+compile_go_fuzzer github.com/stretchr/testify FuzzElementsMatch fuzz_elements_match
+

--- a/projects/testify/fuzz_test.go
+++ b/projects/testify/fuzz_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testify_test
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzAssertEqual(f *testing.F) {
+	f.Add("hello", "hello")
+	f.Add("", "")
+	f.Add("hello", "world")
+	f.Fuzz(func(t *testing.T, expected, actual string) {
+		if len(expected) > 10000 || len(actual) > 10000 { return }
+		func() {
+			defer func() { recover() }()
+			mockT := new(testing.T)
+			assert.Equal(mockT, expected, actual)
+			assert.NotEqual(mockT, expected, "different-"+expected)
+			assert.Contains(mockT, expected+actual, expected)
+		}()
+	})
+}
+
+func FuzzAssertJSON(f *testing.F) {
+	f.Add(`{"a":1}`, `{"a":1}`)
+	f.Add(`{"a":1}`, `{"a":2}`)
+	f.Add(`[1,2,3]`, `[1,2,3]`)
+	f.Add(`null`, `null`)
+	f.Add(`"hello"`, `"hello"`)
+	f.Fuzz(func(t *testing.T, expectedJSON, actualJSON string) {
+		if len(expectedJSON) > 1<<16 || len(actualJSON) > 1<<16 { return }
+		func() {
+			defer func() { recover() }()
+			mockT := new(testing.T)
+			assert.JSONEq(mockT, expectedJSON, actualJSON)
+		}()
+	})
+}
+
+func FuzzAssertYAML(f *testing.F) {
+	f.Add("key: value", "key: value")
+	f.Add("list:\n  - a\n  - b", "list:\n  - a\n  - b")
+	f.Add("", "")
+	f.Fuzz(func(t *testing.T, expectedYAML, actualYAML string) {
+		if len(expectedYAML) > 1<<16 || len(actualYAML) > 1<<16 { return }
+		func() {
+			defer func() { recover() }()
+			mockT := new(testing.T)
+			assert.YAMLEq(mockT, expectedYAML, actualYAML)
+		}()
+	})
+}
+
+func FuzzRequireInt(f *testing.F) {
+	f.Add(42, 42)
+	f.Add(-1, 0)
+	f.Fuzz(func(t *testing.T, val, compare int) {
+		func() {
+			defer func() { recover() }()
+			mockT := new(testing.T)
+			require.NotNil(mockT, &val)
+			require.GreaterOrEqual(mockT, val, compare-1)
+			require.LessOrEqual(mockT, val, compare+100)
+		}()
+	})
+}
+
+func FuzzElementsMatch(f *testing.F) {
+	f.Add("a", "b", "c")
+	f.Add("", "", "")
+	f.Fuzz(func(t *testing.T, a, b, c string) {
+		if len(a) > 1000 || len(b) > 1000 || len(c) > 1000 { return }
+		func() {
+			defer func() { recover() }()
+			mockT := new(testing.T)
+			assert.ElementsMatch(mockT, []string{a, b, c}, []string{c, b, a})
+		}()
+	})
+}

--- a/projects/testify/project.yaml
+++ b/projects/testify/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://github.com/stretchr/testify"
+language: go
+primary_contact: "candasjunk@gmail.com"
+auto_ccs:
+  - "candasjunk@gmail.com"
+main_repo: "https://github.com/stretchr/testify"
+sanitizers:
+  - address
+  - memory
+fuzzing_engines:
+  - libfuzzer
+# Criticality: Testify (22K+ stars) is the most-used Go testing toolkit. Every Go project's CI/CD depends on it. A malicious input that exploits testify's assertion or mock handling would compromise the software supply chain at build time.


### PR DESCRIPTION
See branch for full criticality justification and fuzz targets.