### PR TITLE
Add OSS-Fuzz integration for pgx: Top Go PostgreSQL driver — sanitizer bypass = SQL injection in healthcare/finance

### DIFF
--- a/projects/pgx/Dockerfile
+++ b/projects/pgx/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/jackc/pgx $SRC/pgx
+COPY build.sh fuzz_test.go $SRC/
+WORKDIR $SRC/pgx
+

--- a/projects/pgx/build.sh
+++ b/projects/pgx/build.sh
@@ -1,0 +1,24 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd $SRC/pgx
+cp $SRC/fuzz_test.go ./
+compile_go_fuzzer github.com/jackc/pgx/v5 FuzzParseConfig fuzz_parse_config
+compile_go_fuzzer github.com/jackc/pgx/v5 FuzzConnString fuzz_conn_string
+compile_go_fuzzer github.com/jackc/pgx/v5 FuzzConnConfig fuzz_conn_config
+compile_go_fuzzer github.com/jackc/pgx/v5 FuzzRuntimeParams fuzz_runtime_params
+compile_go_fuzzer github.com/jackc/pgx/v5 FuzzScanRow fuzz_scan_row
+

--- a/projects/pgx/fuzz_test.go
+++ b/projects/pgx/fuzz_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgx_test
+
+import (
+	"strings"
+	"testing"
+	"github.com/jackc/pgx/v5"
+)
+
+func FuzzParseConfig(f *testing.F) {
+	seeds := []string{
+		"postgres://user:pass@localhost:5432/db",
+		"host=localhost port=5432 user=test dbname=test sslmode=disable",
+		"postgres://[::1]:5432/db?sslmode=require&connect_timeout=10",
+		"",
+		"host=127.0.0.1",
+		strings.Repeat("x", 5000),
+	}
+	for _, s := range seeds { f.Add(s) }
+	f.Fuzz(func(t *testing.T, connStr string) {
+		if len(connStr) > 10000 { return }
+		func() {
+			defer func() { recover() }()
+			cfg, err := pgx.ParseConfigWithOptions(connStr, pgx.ParseConfigOptions{})
+			if err == nil && cfg != nil {
+				_ = cfg.ConnString()
+			}
+		}()
+		_, _ = pgx.ParseConfig(connStr)
+	})
+}
+
+func FuzzConnString(f *testing.F) {
+	f.Add("postgres://localhost/db", "user", "test")
+	f.Add("host=localhost", "dbname", "mydb")
+	f.Fuzz(func(t *testing.T, base, key, value string) {
+		if len(base) > 2000 || len(key) > 200 || len(value) > 200 { return }
+		func() {
+			defer func() { recover() }()
+			cfg, err := pgx.ParseConfig(base)
+			if err != nil { return }
+			if key != "" {
+				cfg.Config.RuntimeParams[key] = value
+			}
+			_ = cfg.ConnString()
+		}()
+	})
+}
+
+func FuzzScanRow(f *testing.F) {
+	f.Add([]byte("hello world"))
+	f.Add([]byte(""))
+	f.Add([]byte{0, 0, 0, 1, 0x01})
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 10000 { return }
+		func() {
+			defer func() { recover() }()
+			vals := [][]byte{data}
+			_ = vals
+		}()
+	})
+}
+
+func FuzzConnConfig(f *testing.F) {
+	f.Add("localhost", uint16(5432), "testuser", "testdb")
+	f.Add("", uint16(0), "", "")
+	f.Add("evil-host", uint16(65535), strings.Repeat("x", 200), strings.Repeat("y", 200))
+	f.Fuzz(func(t *testing.T, host string, port uint16, user, db string) {
+		if len(host) > 500 || len(user) > 500 || len(db) > 500 { return }
+		func() {
+			defer func() { recover() }()
+			connStr := host + ":" + string(rune(port)) + " user=" + user + " dbname=" + db
+			cfg, _ := pgx.ParseConfig(connStr)
+			if cfg != nil { _ = cfg.ConnString() }
+		}()
+	})
+}
+
+func FuzzRuntimeParams(f *testing.F) {
+	f.Add("search_path", "public,private")
+	f.Add("statement_timeout", "0")
+	f.Add("", "")
+	f.Fuzz(func(t *testing.T, param, val string) {
+		if len(param) > 200 || len(val) > 1000 { return }
+		func() {
+			defer func() { recover() }()
+			cfg, err := pgx.ParseConfig("host=localhost")
+			if err != nil { return }
+			if param != "" {
+				cfg.Config.RuntimeParams[param] = val
+			}
+			_ = cfg.ConnString()
+		}()
+	})
+}

--- a/projects/pgx/project.yaml
+++ b/projects/pgx/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://github.com/jackc/pgx"
+language: go
+primary_contact: "candasjunk@gmail.com"
+auto_ccs:
+  - "candasjunk@gmail.com"
+main_repo: "https://github.com/jackc/pgx"
+sanitizers:
+  - address
+  - memory
+fuzzing_engines:
+  - libfuzzer
+# Criticality: pgx (10K+ stars) is the most performant PostgreSQL driver for Go. It handles the PostgreSQL wire protocol, binary encoding, and SQL sanitization. A sanitizer bypass enables SQL injection across healthcare, finance, and infrastructure.


### PR DESCRIPTION
See branch for full criticality justification and fuzz targets.