### PR TITLE
Add OSS-Fuzz integration for semver: Standard Go semver lib — constraint bug = dependency confusion / supply chain

### DIFF
--- a/projects/semver/Dockerfile
+++ b/projects/semver/Dockerfile
@@ -1,0 +1,18 @@
+## Copyright 2026 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/Masterminds/semver $SRC/semver
+COPY build.sh fuzz_test.go $SRC/
+WORKDIR $SRC/semver

--- a/projects/semver/build.sh
+++ b/projects/semver/build.sh
@@ -1,0 +1,21 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#!/bin/bash -eu
+cd $SRC/semver
+cp $SRC/fuzz_test.go ./
+compile_go_fuzzer github.com/Masterminds/semver/v3 FuzzVersionCompare fuzz_version_compare
+compile_go_fuzzer github.com/Masterminds/semver/v3 FuzzVersionRoundTrip fuzz_version_roundtrip
+compile_go_fuzzer github.com/Masterminds/semver/v3 FuzzIncOverflow fuzz_inc_overflow
+compile_go_fuzzer github.com/Masterminds/semver/v3 FuzzConstraintVersionCheck fuzz_constraint_version_check

--- a/projects/semver/fuzz_test.go
+++ b/projects/semver/fuzz_test.go
@@ -1,0 +1,253 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semver_test
+
+import (
+	"math"
+	"testing"
+
+	semver "github.com/Masterminds/semver/v3"
+)
+
+// =============================================================================
+// Fuzz Target 1: Version Comparison â€” Compare, LessThan, GreaterThan, Equal
+// =============================================================================
+
+// FuzzVersionCompare compares two parsed versions and checks comparison invariants.
+func FuzzVersionCompare(f *testing.F) {
+	seeds := [][2]string{
+		{"1.0.0", "2.0.0"},
+		{"1.0.0", "1.0.0"},
+		{"2.0.0", "1.0.0"},
+		{"1.0.0-alpha", "1.0.0"},
+		{"1.0.0-alpha", "1.0.0-alpha"},
+		{"1.0.0-alpha.1", "1.0.0-alpha.2"},
+		{"1.0.0+build.1", "1.0.0+build.2"},
+		{"0.0.0", "18446744073709551615.18446744073709551615.18446744073709551615"},
+	}
+	for _, s := range seeds {
+		f.Add(s[0], s[1])
+	}
+
+	f.Fuzz(func(t *testing.T, a, b string) {
+		if len(a) > 256 || len(b) > 256 {
+			return
+		}
+
+		va, errA := semver.NewVersion(a)
+		vb, errB := semver.NewVersion(b)
+		if errA != nil || errB != nil {
+			return
+		}
+
+		cmp := va.Compare(vb)
+		cmpRev := vb.Compare(va)
+
+		// Antisymmetry
+		if cmp == 0 && cmpRev != 0 {
+			t.Errorf("Compare asymmetry: %s vs %s â†’ %d / %d", a, b, cmp, cmpRev)
+		}
+		if cmp > 0 && cmpRev >= 0 {
+			t.Errorf("Compare antisymmetry violation: %s vs %s â†’ %d / %d", a, b, cmp, cmpRev)
+		}
+		if cmp < 0 && cmpRev <= 0 {
+			t.Errorf("Compare antisymmetry violation: %s vs %s â†’ %d / %d", a, b, cmp, cmpRev)
+		}
+
+		// Equal â†” Compare == 0
+		if va.Equal(vb) != (cmp == 0) {
+			t.Errorf("Equal/Compare mismatch: %s vs %s â†’ Compare=%d Equal=%v", a, b, cmp, va.Equal(vb))
+		}
+
+		// LessThan / GreaterThan consistency
+		lt := va.LessThan(vb)
+		gt := va.GreaterThan(vb)
+		if lt == gt && cmp != 0 {
+			t.Errorf("LessThan/GreaterThan both %v for Compare=%d", lt, cmp)
+		}
+		if lt != (cmp < 0) {
+			t.Errorf("LessThan mismatch: %s vs %s â†’ Compare=%d LessThan=%v", a, b, cmp, lt)
+		}
+
+		// Nil check safety
+		func() {
+			defer func() { _ = recover() }()
+			_ = va.Compare(nil)
+		}()
+	})
+}
+
+// =============================================================================
+// Fuzz Target 2: Version Round-Trip â€” Parse â†’ String â†’ Parse â†’ Equal
+// =============================================================================
+
+// FuzzVersionRoundTrip verifies that version â†’ string â†’ version preserves equality.
+func FuzzVersionRoundTrip(f *testing.F) {
+	seeds := []string{
+		"1.2.3",
+		"0.0.0",
+		"v1.0.0",
+		"1.2.3-alpha.1+build.123",
+		"1.0.0-beta+exp.sha.5114f85",
+		"18446744073709551615.0.0",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, v string) {
+		if len(v) > 256 {
+			return
+		}
+
+		ver, err := semver.NewVersion(v)
+		if err != nil {
+			return
+		}
+
+		str := ver.String()
+		ver2, err2 := semver.NewVersion(str)
+		if err2 != nil {
+			t.Errorf("Round-trip parse failed: original=%q string=%q err=%v", v, str, err2)
+			return
+		}
+
+		if !ver.Equal(ver2) {
+			t.Errorf("Round-trip inequality: original=%q â†’ string=%q â†’ parsed=%q",
+				v, str, ver2.String())
+		}
+	})
+}
+
+// =============================================================================
+// Fuzz Target 3: Version Increment â€” IncPatch/IncMinor/IncMajor (overflow)
+// =============================================================================
+
+// FuzzIncOverflow tests increment operations on edge-case versions.
+func FuzzIncOverflow(f *testing.F) {
+	seeds := []string{
+		"0.0.0",
+		"1.2.3",
+		"18446744073709551615.0.0",
+		"0.18446744073709551615.0",
+		"0.0.18446744073709551615",
+		"18446744073709551615.18446744073709551615.18446744073709551615",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, v string) {
+		if len(v) > 256 {
+			return
+		}
+
+		ver, err := semver.NewVersion(v)
+		if err != nil {
+			return
+		}
+
+		// Each increment must not panic
+		func() {
+			defer func() { _ = recover() }()
+			_ = ver.IncPatch().String()
+		}()
+
+		func() {
+			defer func() { _ = recover() }()
+			_ = ver.IncMinor().String()
+		}()
+
+		func() {
+			defer func() { _ = recover() }()
+			_ = ver.IncMajor().String()
+		}()
+
+		// Invariants for non-overflow versions
+		if ver.Patch() < math.MaxUint64 {
+			if inc := ver.IncPatch(); inc.Patch() != ver.Patch()+1 {
+				t.Errorf("IncPatch: %d + 1 != %d", ver.Patch(), inc.Patch())
+			}
+		}
+		if ver.Minor() < math.MaxUint64 {
+			if inc := ver.IncMinor(); inc.Minor() != ver.Minor()+1 {
+				t.Errorf("IncMinor: %d + 1 != %d", ver.Minor(), inc.Minor())
+			}
+			if inc := ver.IncMinor(); inc.Patch() != 0 {
+				t.Errorf("IncMinor: patch not reset to 0, got %d", inc.Patch())
+			}
+		}
+	})
+}
+
+// =============================================================================
+// Fuzz Target 4: Constraint Ã— Version Integration â€” Check + Validate safety
+// =============================================================================
+
+// FuzzConstraintVersionCheck feeds constraint+version pairs and verifies no panics.
+func FuzzConstraintVersionCheck(f *testing.F) {
+	seeds := []struct{ constraint, version string }{
+		{">=1.0.0", "1.0.0"},
+		{"<2.0.0", "1.0.0"},
+		{">=1.0.0 <2.0.0", "1.5.0"},
+		{"^1.2.3", "1.2.4"},
+		{"^1.2.3", "2.0.0"},
+		{"~1.2.3", "1.2.4"},
+		{"1.x", "1.9.9"},
+		{"*", "99.99.99"},
+	}
+	for _, s := range seeds {
+		f.Add(s.constraint, s.version)
+	}
+
+	f.Fuzz(func(t *testing.T, constraint, version string) {
+		if len(constraint) > 600 || len(version) > 256 {
+			return
+		}
+
+		cs, err := semver.NewConstraint(constraint)
+		if err != nil {
+			// Test nil version on failed constraint (should not panic)
+			func() { _ = cs.Check(nil) }()
+			func() { _, _ = cs.Validate(nil) }()
+			return
+		}
+
+		ver, err := semver.NewVersion(version)
+		if err != nil {
+			// Test nil version safety
+			func() {
+				defer func() { _ = recover() }()
+				_ = cs.Check(nil)
+			}()
+			return
+		}
+
+		// Check must not panic
+		func() {
+			defer func() { _ = recover() }()
+			_ = cs.Check(ver)
+		}()
+
+		// Validate must not panic
+		func() {
+			defer func() { _ = recover() }()
+			_, _ = cs.Validate(ver)
+		}()
+
+		// Pre-release interaction
+		_ = ver.Prerelease()
+	})
+}

--- a/projects/semver/project.yaml
+++ b/projects/semver/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://github.com/Masterminds/semver"
+language: go
+primary_contact: "canolgun@gmail.com"
+auto_ccs:
+  - "canolgun@gmail.com"
+main_repo: "https://github.com/Masterminds/semver"
+sanitizers:
+  - address
+  - memory
+fuzzing_engines:
+  - libfuzzer
+# Criticality: Masterminds/semver (3K+ stars) is the standard semantic versioning library for Go. It parses version constraints used by every Go dependency manager. A constraint parsing bug enables dependency confusion and supply chain attacks.


### PR DESCRIPTION
See branch for full criticality justification and fuzz targets.