### PR TITLE
libcoap: Support fuzzing pushed branches

### DIFF
--- a/projects/libcoap/Dockerfile
+++ b/projects/libcoap/Dockerfile
@@ -17,6 +17,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
     pkg-config libcunit1 libcunit1-doc libcunit1-dev
-RUN git clone --depth 1 https://github.com/obgm/libcoap.git libcoap
+RUN git clone https://github.com/obgm/libcoap.git libcoap
 WORKDIR libcoap
 COPY *.sh $SRC/


### PR DESCRIPTION
This PR removes the `--depth 1` git clone option, so that oss-fuzz can checkout the branch that has just been pushed and hence run oss-fuzz on that branch.