### PR TITLE
rabbitmq-c: Fix build for new decode fuzzer

### DIFF
--- a/projects/rabbitmq-c/build.sh
+++ b/projects/rabbitmq-c/build.sh
@@ -32,6 +32,7 @@ fi
 cp fuzz/fuzz_table $OUT/fuzz_table
 cp fuzz/fuzz_server $OUT/fuzz_server
 cp fuzz/fuzz_method_decode $OUT/fuzz_method_decode
+cp fuzz/fuzz_properties_decode $OUT/fuzz_properties_decode
 popd
 
 zip -j ${OUT}/fuzz_url_seed_corpus.zip fuzz/input/fuzz_url.raw


### PR DESCRIPTION
This PR fixes the build for rabbitmq-c to include build of new decode fuzzer.