### PR TITLE
Add OSS-Fuzz integration for traefik/traefik — HTTP reverse proxy (82/100)

### DIFF
--- a/projects/traefik/Dockerfile
+++ b/projects/traefik/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+
+COPY . $SRC/traefik
+COPY build.sh $SRC/
+WORKDIR $SRC/traefik

--- a/projects/traefik/build.sh
+++ b/projects/traefik/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+go mod download
+compile_go_fuzzer github.com/traefik/traefik/v3 FuzzDomainMatchHostExpression fuzz_domain_match
+compile_go_fuzzer github.com/traefik/traefik/v3 FuzzIsASCII fuzz_is_ascii
+compile_go_fuzzer github.com/traefik/traefik/v3 FuzzRuleParser fuzz_rule_parser

--- a/projects/traefik/project.yaml
+++ b/projects/traefik/project.yaml
@@ -1,0 +1,11 @@
+homepage: "https://github.com/traefik/traefik"
+language: go
+primary_contact: "security@traefik.io"
+auto_ccs:
+  - "security@traefik.io"
+main_repo: "https://github.com/traefik/traefik"
+sanitizers:
+  - address
+  - memory
+fuzzing_engines:
+  - libfuzzer


### PR DESCRIPTION
## Criticality: 82/100 (GHSA-verified)

| Component | Score | Source |
|---|---|---|
| Dependents | 30/30 | GitHub API: 63,636 stars |
| Attack Surface | 25/25 | Pre-auth HTTP proxy + host/path/rule parser |
| CVE History | 20/20 | GitHub Advisory DB: 23 GHSA advisories |
| Supply Chain | 1/15 | Application (plugin SDK available) |
| Security Role | 6/10 | HTTP reverse proxy infrastructure |

### Why Traefik

Traefik is the dominant cloud-native HTTP reverse proxy. It processes every HTTP request at the edge — Host headers, paths, and routing rules are fully attacker-controlled. 23 GitHub Security Advisories confirm the real attack surface.

### Upstream PR

https://github.com/traefik/traefik/pull/13350

### Fuzz targets

1. `FuzzDomainMatchHostExpression` — Host header matching (pre-auth boundary)
2. `FuzzIsASCII` — ASCII validation for HTTP header/URI processing
3. `FuzzRuleParser` — Rule expression parsing (predicate-based routing)

🤖 Generated with [Claude Code](https://claude.com/claude-code) | criticality-scorer v1.0