### PR TITLE
Add OSS-Fuzz integration for gin-gonic/gin — Go HTTP web framework (88K stars)

### DIFF
--- a/projects/gin/Dockerfile
+++ b/projects/gin/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+COPY . $SRC/gin
+COPY build.sh $SRC/
+WORKDIR $SRC/gin

--- a/projects/gin/build.sh
+++ b/projects/gin/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+go mod download
+compile_go_fuzzer github.com/gin-gonic/gin FuzzJSONBinding fuzz_json_binding
+compile_go_fuzzer github.com/gin-gonic/gin FuzzGinPathMatch fuzz_gin_path_match
+compile_go_fuzzer github.com/gin-gonic/gin FuzzFormBinding fuzz_form_binding

--- a/projects/gin/project.yaml
+++ b/projects/gin/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/gin-gonic/gin"
+language: go
+primary_contact: "security@gin-gonic.com"
+main_repo: "https://github.com/gin-gonic/gin"
+sanitizers: [address, memory]
+fuzzing_engines: [libfuzzer]


### PR DESCRIPTION
## gin-gonic/gin — Most popular Go web framework

| Metric | Value |
|---|---|
| Stars | 88,664 |
| GHSA Advisories | 5 |
| Type | HTTP web framework (library) |
| go.mod dependents | Thousands of Go projects |

### Fuzz targets

1. `FuzzJSONBinding` — JSON request body binding (BindBody with arbitrary bytes)
2. `FuzzGinPathMatch` — URL path parameter matching (router core)
3. `FuzzFormBinding` — Form POST data binding

### Upstream PR

https://github.com/gin-gonic/gin/pull/4703

🤖 Generated with [Claude Code](https://claude.com/claude-code)