### PR TITLE
Add OSS-Fuzz integration for argoproj/argo-cd — GitOps CD (30 GHSA)

### DIFF
--- a/projects/argo-cd/Dockerfile
+++ b/projects/argo-cd/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+COPY . $SRC/argo-cd
+COPY build.sh $SRC/
+WORKDIR $SRC/argo-cd

--- a/projects/argo-cd/build.sh
+++ b/projects/argo-cd/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+go mod download
+compile_go_fuzzer github.com/argoproj/argo-cd/v3 FuzzDecodePEMCertificate fuzz_decode_pem_certificate
+compile_go_fuzzer github.com/argoproj/argo-cd/v3 FuzzParseTLSCertificates fuzz_parse_tls_certificates

--- a/projects/argo-cd/project.yaml
+++ b/projects/argo-cd/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/argoproj/argo-cd"
+language: go
+primary_contact: "security@argoproj.io"
+main_repo: "https://github.com/argoproj/argo-cd"
+sanitizers: [address, memory]
+fuzzing_engines: [libfuzzer]


### PR DESCRIPTION
## argoproj/argo-cd — GitOps Standard

| Metric | Value |
|---|---|
| Stars | 23,111 |
| GHSA Advisories | 30 |
| Type | GitOps continuous delivery |

### Upstream PR
https://github.com/argoproj/argo-cd/pull/28257

### Fuzz targets
- `FuzzDecodePEMCertificate` — PEM cert parsing
- `FuzzParseTLSCertificates` — TLS cert bundle parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)