### PR TITLE
Add OSS-Fuzz integration for minio/minio — S3 object storage (61K stars, 15 GHSA)

### DIFF
--- a/projects/minio/Dockerfile
+++ b/projects/minio/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+COPY . $SRC/minio
+COPY build.sh $SRC/
+WORKDIR $SRC/minio

--- a/projects/minio/build.sh
+++ b/projects/minio/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+go mod download
+compile_go_fuzzer github.com/minio/minio FuzzAmzDateParse fuzz_amz_date_parse
+compile_go_fuzzer github.com/minio/minio FuzzAmzHeaderParse fuzz_amz_header_parse
+compile_go_fuzzer github.com/minio/minio FuzzAmzReplicationTS fuzz_amz_replication_ts

--- a/projects/minio/project.yaml
+++ b/projects/minio/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/minio/minio"
+language: go
+primary_contact: "security@min.io"
+main_repo: "https://github.com/minio/minio"
+sanitizers: [address, memory]
+fuzzing_engines: [libfuzzer]


### PR DESCRIPTION
## minio/minio — S3-Compatible Object Storage

| Metric | Value |
|---|---|
| Stars | 61,215 |
| GHSA Advisories | 15 |
| Type | Object storage (S3 API) |

### Fuzz targets
- `FuzzAmzDateParse` — AWS date header parsing (pre-auth SigV4 boundary)
- `FuzzAmzHeaderParse` — HTTP time header parsing
- `FuzzAmzReplicationTS` — Replication timestamp parsing

Note: minio/minio repo is archived on GitHub. Fuzz targets target the `internal/amztime` package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)