### PR TITLE
Add OSS-Fuzz integration for gofiber/fiber — Express-like Go web framework (40K stars)

### DIFF
--- a/projects/fiber/Dockerfile
+++ b/projects/fiber/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+COPY . $SRC/fiber
+COPY build.sh $SRC/
+WORKDIR $SRC/fiber

--- a/projects/fiber/build.sh
+++ b/projects/fiber/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+go mod download
+compile_go_fuzzer github.com/gofiber/fiber/v3 FuzzFiberRouteMatch fuzz_fiber_route_match
+compile_go_fuzzer github.com/gofiber/fiber/v3 FuzzFiberBodyParser fuzz_fiber_body_parser

--- a/projects/fiber/project.yaml
+++ b/projects/fiber/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/gofiber/fiber"
+language: go
+primary_contact: "security@gofiber.io"
+main_repo: "https://github.com/gofiber/fiber"
+sanitizers: [address, memory]
+fuzzing_engines: [libfuzzer]


### PR DESCRIPTION
## gofiber/fiber — Express-inspired Go web framework

| Metric | Value |
|---|---|
| Stars | 39,832 |
| GHSA Advisories | 3 |
| Type | HTTP web framework (library) |

### Upstream PR
https://github.com/gofiber/fiber/pull/4428

### Fuzz targets
- `FuzzFiberRouteMatch` — Route matching with arbitrary paths/methods
- `FuzzFiberBodyParser` — JSON body binding with arbitrary bytes

🤖 Generated with [Claude Code](https://claude.com/claude-code)