### PR TITLE
Add OSS-Fuzz integration for moby/buildkit — Docker build system (7 GHSA, 10K stars)

### DIFF
--- a/projects/buildkit/Dockerfile
+++ b/projects/buildkit/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+COPY . $SRC/buildkit
+COPY build.sh $SRC/
+WORKDIR $SRC/buildkit

--- a/projects/buildkit/build.sh
+++ b/projects/buildkit/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+go mod download
+compile_go_fuzzer github.com/moby/buildkit FuzzDockerfileParser fuzz_dockerfile_parser
+compile_go_fuzzer github.com/moby/buildkit FuzzDockerfileDirectives fuzz_dockerfile_directives
+compile_go_fuzzer github.com/moby/buildkit FuzzParseHeredoc fuzz_parse_heredoc

--- a/projects/buildkit/project.yaml
+++ b/projects/buildkit/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/moby/buildkit"
+language: go
+primary_contact: "security@docker.com"
+main_repo: "https://github.com/moby/buildkit"
+sanitizers: [address, memory]
+fuzzing_engines: [libfuzzer]


### PR DESCRIPTION
## moby/buildkit — Docker Build System

| Metric | Value |
|---|---|
| Stars | 10,039 |
| GHSA Advisories | 7 |
| Type | Supply chain / Dockerfile parser |

### Upstream PR
https://github.com/moby/buildkit/pull/6868

### Fuzz targets
- `FuzzDockerfileParser` — Dockerfile parsing with arbitrary content
- `FuzzDockerfileDirectives` — Directive parsing
- `FuzzParseHeredoc` — Heredoc parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)