### PR TITLE
Add OSS-Fuzz integration for hashicorp/consul — service mesh (30 GHSA, 30K stars)

### DIFF
--- a/projects/consul/Dockerfile
+++ b/projects/consul/Dockerfile
@@ -1,4 +1,18 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM gcr.io/oss-fuzz-base/base-builder-go
-COPY . $SRC/consul
+COPY . $SRC/repo
 COPY build.sh $SRC/
-WORKDIR $SRC/consul
+WORKDIR $SRC/repo

--- a/projects/consul/Dockerfile
+++ b/projects/consul/Dockerfile
@@ -1,0 +1,4 @@
+FROM gcr.io/oss-fuzz-base/base-builder-go
+COPY . $SRC/consul
+COPY build.sh $SRC/
+WORKDIR $SRC/consul

--- a/projects/consul/build.sh
+++ b/projects/consul/build.sh
@@ -1,4 +1,18 @@
 #!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 go mod download
 compile_go_fuzzer github.com/hashicorp/consul FuzzACLTokenUnmarshal fuzz_acl_token
 compile_go_fuzzer github.com/hashicorp/consul FuzzACLPolicyUnmarshal fuzz_acl_policy

--- a/projects/consul/build.sh
+++ b/projects/consul/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -eu
+go mod download
+compile_go_fuzzer github.com/hashicorp/consul FuzzACLTokenUnmarshal fuzz_acl_token
+compile_go_fuzzer github.com/hashicorp/consul FuzzACLPolicyUnmarshal fuzz_acl_policy

--- a/projects/consul/project.yaml
+++ b/projects/consul/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/hashicorp/consul"
+language: go
+primary_contact: "security@hashicorp.com"
+main_repo: "https://github.com/hashicorp/consul"
+sanitizers: [address, memory]
+fuzzing_engines: [libfuzzer]


### PR DESCRIPTION
## hashicorp/consul. 30K stars, 30 GHSA. ACL token/policy JSON parsing. Upstream: https://github.com/hashicorp/consul/pull/23652