### PR TITLE
Add OSS-Fuzz integration for scrapy/scrapy — web scraping framework (17 GHSA)

### DIFF
--- a/projects/scrapy/Dockerfile
+++ b/projects/scrapy/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-fuzz-base/base-builder-python
+RUN pip3 install atheris scrapy
+COPY . $SRC/scrapy
+COPY build.sh $SRC/
+WORKDIR $SRC/scrapy

--- a/projects/scrapy/build.sh
+++ b/projects/scrapy/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+pip3 install atheris scrapy
+compile_python_fuzzer fuzz_scrapy.py

--- a/projects/scrapy/project.yaml
+++ b/projects/scrapy/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/scrapy/scrapy"
+language: python
+primary_contact: "security@scrapy.org"
+main_repo: "https://github.com/scrapy/scrapy"
+sanitizers: [address, undefined]
+fuzzing_engines: [libfuzzer]


### PR DESCRIPTION
## scrapy/scrapy. Python web scraping. 17 GHSA. Upstream: https://github.com/scrapy/scrapy/pull/7609