### PR TITLE
Add OSS-Fuzz integration for expressjs/express — Node.js framework (6 GHSA)

### DIFF
--- a/projects/axios/Dockerfile
+++ b/projects/axios/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-fuzz-base/base-builder-javascript
+COPY build.sh \/
+RUN git clone --depth 1 https://github.com/axios/axios.git
+COPY fuzz.js \/axios
+WORKDIR \/axios

--- a/projects/axios/build.sh
+++ b/projects/axios/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+npm install
+npm install --save-dev @jazzer.js/core
+compile_javascript_fuzzer axios fuzz.js -i axios --sync

--- a/projects/axios/fuzz.js
+++ b/projects/axios/fuzz.js
@@ -1,0 +1,12 @@
+// Fuzz harness for axios — HTTP client (30 GHSA advisories)
+const axios = require("axios");
+
+module.exports.fuzz = function (data) {
+  try {
+    // URL parsing
+    const url = data.toString();
+    if (url.length > 0) {
+      axios.get(url).catch(() => {});
+    }
+  } catch (e) {}
+};

--- a/projects/axios/project.yaml
+++ b/projects/axios/project.yaml
@@ -1,0 +1,5 @@
+homepage: "https://github.com/axios/axios"
+language: javascript
+main_repo: "https://github.com/axios/axios"
+fuzzing_engines: [libfuzzer]
+sanitizers: [none]

--- a/projects/express/Dockerfile
+++ b/projects/express/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM gcr.io/oss-fuzz-base/base-builder-javascript
-COPY build.sh \/
+COPY build.sh $SRC/
 RUN git clone --depth 1 https://github.com/expressjs/express.git
-COPY fuzz.js \/express
-WORKDIR \/express
+COPY fuzz.js $SRC/express
+WORKDIR $SRC/express

--- a/projects/express/Dockerfile
+++ b/projects/express/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-fuzz-base/base-builder-javascript
+COPY build.sh \/
+RUN git clone --depth 1 https://github.com/expressjs/express.git
+COPY fuzz.js \/express
+WORKDIR \/express

--- a/projects/express/build.sh
+++ b/projects/express/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+npm install
+npm install --save-dev @jazzer.js/core
+compile_javascript_fuzzer express fuzz.js -i express --sync

--- a/projects/express/fuzz.js
+++ b/projects/express/fuzz.js
@@ -1,0 +1,10 @@
+// Fuzz harness for express — Node.js framework (6 GHSA advisories)
+const express = require("express");
+
+module.exports.fuzz = function (data) {
+  try {
+    const path = data.toString();
+    const app = express();
+    app.get(path, (req, res) => { res.send("ok"); });
+  } catch (e) {}
+};

--- a/projects/express/fuzz.js
+++ b/projects/express/fuzz.js
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Fuzz harness for express — Node.js framework (6 GHSA advisories)
 const express = require("express");
 

--- a/projects/express/project.yaml
+++ b/projects/express/project.yaml
@@ -1,0 +1,5 @@
+homepage: "https://github.com/expressjs/express"
+language: javascript
+main_repo: "https://github.com/expressjs/express"
+fuzzing_engines: [libfuzzer]
+sanitizers: [none]


### PR DESCRIPTION
## expressjs/express. JS web framework. 6 GHSA.