### PR TITLE
Add OSS-Fuzz integration for markedjs/marked — markdown parser (18 GHSA)

### DIFF
--- a/projects/handlebars/Dockerfile
+++ b/projects/handlebars/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-fuzz-base/base-builder-javascript
+COPY build.sh \/
+RUN git clone --depth 1 https://github.com/handlebars-lang/handlebars.js.git
+COPY fuzz.js \/handlebars
+WORKDIR \/handlebars

--- a/projects/handlebars/build.sh
+++ b/projects/handlebars/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+npm install
+npm install --save-dev @jazzer.js/core
+compile_javascript_fuzzer handlebars fuzz.js -i handlebars --sync

--- a/projects/handlebars/fuzz.js
+++ b/projects/handlebars/fuzz.js
@@ -1,0 +1,5 @@
+// Fuzz harness for Handlebars — template engine (21 GHSA advisories)
+const Handlebars = require("handlebars");
+module.exports.fuzz = function (data) {
+  try { Handlebars.compile(data.toString()); } catch (e) {}
+};

--- a/projects/handlebars/project.yaml
+++ b/projects/handlebars/project.yaml
@@ -1,0 +1,5 @@
+homepage: "https://github.com/handlebars-lang/handlebars.js"
+language: javascript
+main_repo: "https://github.com/handlebars-lang/handlebars.js"
+fuzzing_engines: [libfuzzer]
+sanitizers: [none]

--- a/projects/marked/Dockerfile
+++ b/projects/marked/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM gcr.io/oss-fuzz-base/base-builder-javascript
-COPY build.sh \/
+COPY build.sh $SRC/
 RUN git clone --depth 1 https://github.com/markedjs/marked.git
-COPY fuzz.js \/marked
-WORKDIR \/marked
+COPY fuzz.js $SRC/marked
+WORKDIR $SRC/marked

--- a/projects/marked/Dockerfile
+++ b/projects/marked/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-fuzz-base/base-builder-javascript
+COPY build.sh \/
+RUN git clone --depth 1 https://github.com/markedjs/marked.git
+COPY fuzz.js \/marked
+WORKDIR \/marked

--- a/projects/marked/build.sh
+++ b/projects/marked/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+npm install
+npm install --save-dev @jazzer.js/core
+compile_javascript_fuzzer marked fuzz.js -i marked --sync

--- a/projects/marked/fuzz.js
+++ b/projects/marked/fuzz.js
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Fuzz harness for marked — markdown parser (18 GHSA advisories)
 const marked = require("marked");
 module.exports.fuzz = function (data) {

--- a/projects/marked/fuzz.js
+++ b/projects/marked/fuzz.js
@@ -1,0 +1,5 @@
+// Fuzz harness for marked — markdown parser (18 GHSA advisories)
+const marked = require("marked");
+module.exports.fuzz = function (data) {
+  try { marked.parse(data.toString()); } catch (e) {}
+};

--- a/projects/marked/project.yaml
+++ b/projects/marked/project.yaml
@@ -1,0 +1,5 @@
+homepage: "https://github.com/markedjs/marked"
+language: javascript
+main_repo: "https://github.com/markedjs/marked"
+fuzzing_engines: [libfuzzer]
+sanitizers: [none]


### PR DESCRIPTION
## marked. JS markdown parser. 18 GHSA.