### PR TITLE
libcoap: Support fuzzing i386

### DIFF
--- a/projects/libcoap/Dockerfile
+++ b/projects/libcoap/Dockerfile
@@ -16,6 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
+    libssl1.1:i386 libssl-dev:i386 \
     pkg-config libcunit1 libcunit1-doc libcunit1-dev
 RUN git clone https://github.com/obgm/libcoap.git libcoap
 WORKDIR libcoap

--- a/projects/libcoap/build.sh
+++ b/projects/libcoap/build.sh
@@ -19,10 +19,22 @@ if [ "$SANITIZER" == "introspector" ]; then
   export WARNING_CFLAGS="${CFLAGS}"
 fi
 
+# So the correct architecture specific pkgs are installed.
+# These cant be installed in Dockerfile as they want to overwrite the x86_64 versions.
+if [ a$ARCHITECTURE = ai386 ] ; then
+    NEW_PKGS="pkg-config:i386 libcunit1:i386 libcunit1-dev:i386"
+    apt-get install -y ${NEW_PKGS} > /dev/null
+    ldconfig
+fi
+
 ./autogen.sh && ./configure --disable-doxygen --disable-manpages \
                             --with-openssl --enable-tests        \
                             --disable-thread-safe                \
-    && make -j$(nproc)
+    && make clean > /dev/null && make -j$(nproc)
+
+# Do a sanity check
+tests/testdriver 2>&1 | egrep -v passed
 
 # build all fuzzer targets
+make -C tests/oss-fuzz -f Makefile.oss-fuzz clean
 make -C tests/oss-fuzz -f Makefile.oss-fuzz

--- a/projects/libcoap/project.yaml
+++ b/projects/libcoap/project.yaml
@@ -1,5 +1,5 @@
 homepage: "https://libcoap.net/"
-language: c++
+language: c
 primary_contact: "bergmann@tzi.org"
 auto_ccs:
     - "libcoap@gmail.com"
@@ -8,3 +8,6 @@ auto_ccs:
     - "david@adalogics.com"
     - "adam@adalogics.com"
 main_repo: 'https://github.com/obgm/libcoap.git'
+architectures:
+    - x86_64
+    - i386


### PR DESCRIPTION
Adds in support for installing the required i386 pkgs if i386.