### PR TITLE
Add OSS-Fuzz integration for EigenScript

### DIFF
--- a/projects/eigenscript/Dockerfile
+++ b/projects/eigenscript/Dockerfile
@@ -1,0 +1,5 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y --no-install-recommends make
+RUN git clone --depth 1 https://github.com/InauguralSystems/EigenScript.git eigenscript
+WORKDIR eigenscript
+COPY build.sh $SRC/

--- a/projects/eigenscript/Dockerfile
+++ b/projects/eigenscript/Dockerfile
@@ -1,3 +1,19 @@
+# Copyright 2026 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y --no-install-recommends make
 RUN git clone --depth 1 https://github.com/InauguralSystems/EigenScript.git eigenscript

--- a/projects/eigenscript/build.sh
+++ b/projects/eigenscript/build.sh
@@ -1,4 +1,20 @@
 #!/bin/bash -eu
+# Copyright 2026 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
 # OSS-Fuzz build script for EigenScript.
 #
 # OSS-Fuzz provides $CC, $CFLAGS, $LIB_FUZZING_ENGINE — we just thread

--- a/projects/eigenscript/build.sh
+++ b/projects/eigenscript/build.sh
@@ -1,0 +1,61 @@
+#!/bin/bash -eu
+# OSS-Fuzz build script for EigenScript.
+#
+# OSS-Fuzz provides $CC, $CFLAGS, $LIB_FUZZING_ENGINE — we just thread
+# those through. The fuzzer source lives at fuzz/fuzz_eigenscript.c and
+# runs the same tokenize -> parse -> compile -> vm_execute pipeline
+# main.c does.
+
+# Files that make up the runtime, excluding main.c and the optional
+# extensions. Keep this in sync with FUZZ_SOURCES in the project's
+# Makefile if it ever drifts.
+RUNTIME_SOURCES=(
+    src/eigenscript.c
+    src/lexer.c
+    src/parser.c
+    src/builtins.c
+    src/builtins_tensor.c
+    src/hash.c
+    src/arena.c
+    src/strbuf.c
+    src/ext_store.c
+    src/fmt.c
+    src/lint.c
+    src/chunk.c
+    src/compiler.c
+    src/vm.c
+    src/jit.c
+    src/trace.c
+)
+
+$CC $CFLAGS \
+    -DEIGENSCRIPT_EXT_HTTP=0 \
+    -DEIGENSCRIPT_EXT_MODEL=0 \
+    -DEIGENSCRIPT_EXT_DB=0 \
+    -DEIGENSCRIPT_VERSION='"oss-fuzz"' \
+    -c fuzz/fuzz_eigenscript.c -o fuzz_eigenscript.o
+
+OBJS=()
+for src in "${RUNTIME_SOURCES[@]}"; do
+    obj="$(basename "$src" .c).o"
+    $CC $CFLAGS \
+        -DEIGENSCRIPT_EXT_HTTP=0 \
+        -DEIGENSCRIPT_EXT_MODEL=0 \
+        -DEIGENSCRIPT_EXT_DB=0 \
+        -DEIGENSCRIPT_VERSION='"oss-fuzz"' \
+        -c "$src" -o "$obj"
+    OBJS+=("$obj")
+done
+
+$CC $CFLAGS $LIB_FUZZING_ENGINE \
+    fuzz_eigenscript.o "${OBJS[@]}" \
+    -lm -lpthread \
+    -o $OUT/fuzz_eigenscript
+
+# Seed corpus: zip up the existing corpus dir. OSS-Fuzz uses
+# <fuzzer_name>_seed_corpus.zip alongside the binary.
+zip -j $OUT/fuzz_eigenscript_seed_corpus.zip fuzz/corpus/*
+
+# Dictionary for keywords + punctuation — speeds up coverage growth
+# on a grammared input like a programming language.
+cp fuzz/eigenscript.dict $OUT/fuzz_eigenscript.dict

--- a/projects/eigenscript/project.yaml
+++ b/projects/eigenscript/project.yaml
@@ -1,0 +1,14 @@
+homepage: "https://github.com/InauguralSystems/EigenScript"
+language: c
+primary_contact: "contact@inauguralsystems.com"
+main_repo: "https://github.com/InauguralSystems/EigenScript.git"
+file_github_issue: true
+sanitizers:
+  - address
+  - undefined
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+architectures:
+  - x86_64


### PR DESCRIPTION
## Project

[EigenScript](https://github.com/InauguralSystems/EigenScript) is an MIT-licensed C-implemented language runtime: lexer → parser → bytecode compiler → stack VM (computed-goto dispatch) with a copy-and-patch x86-64 JIT, plus an observer system and a temporal/replay layer.

## Fuzz target

`fuzz_eigenscript` drives the full pipeline (`tokenize` → `parse` → `compile_ast` → `vm_execute`) on each input — the same path `main.c` takes. The harness, libFuzzer dictionary, and seed corpus all live upstream in the [`fuzz/`](https://github.com/InauguralSystems/EigenScript/tree/main/fuzz) directory. The repo already has a `make fuzz-libfuzzer` target that mirrors `build.sh`.

## Files

- `project.yaml` — C, libFuzzer/AFL/honggfuzz, address + undefined.
- `Dockerfile` — `base-builder`, clones upstream, copies `build.sh`.
- `build.sh` — threads `$CC $CFLAGS $LIB_FUZZING_ENGINE` through to the runtime sources, ships seed corpus + dictionary.

## Contact

`primary_contact` is set to a monitored maintainer alias; `file_github_issue: true` is enabled.

Happy to revise — let me know if anything in the config needs adjustment.