### PR TITLE
Add OSS-Fuzz integration for aquasecurity/trivy — vulnerability scanner

### DIFF
--- a/projects/trivy/Dockerfile
+++ b/projects/trivy/Dockerfile
@@ -1,0 +1,4 @@
+FROM gcr.io/oss-fuzz-base/base-builder-go
+COPY . $SRC/repo
+COPY build.sh $SRC/
+WORKDIR $SRC/repo

--- a/projects/trivy/build.sh
+++ b/projects/trivy/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -eu
+go mod download
+compile_go_fuzzer github.com/aquasecurity/trivy FuzzPURLParse fuzz_purl_parse
+compile_go_fuzzer github.com/aquasecurity/trivy FuzzPURLRoundTrip fuzz_purl_roundtrip

--- a/projects/trivy/project.yaml
+++ b/projects/trivy/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/aquasecurity/trivy"
+language: go
+primary_contact: "security@aquasec.com"
+main_repo: "https://github.com/aquasecurity/trivy"
+sanitizers: [address, memory]
+fuzzing_engines: [libfuzzer]


### PR DESCRIPTION
trivy. Upstream: https://github.com/aquasecurity/trivy/pull/10841