### PR TITLE
Add filament project

### DIFF
--- a/projects/filament/Dockerfile
+++ b/projects/filament/Dockerfile
@@ -1,0 +1,14 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+# Filament needs a recent CMake + Ninja; the base image already ships clang and
+# the sanitizer/fuzzer runtimes used via $CC/$CXX/$CFLAGS/$LIB_FUZZING_ENGINE.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ninja-build libc++-dev libc++abi-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 https://github.com/google/filament.git $SRC/filament
+
+WORKDIR $SRC/filament
+# Fuzz target sources live alongside this integration (not yet upstreamed); they
+# are dropped into a dedicated libs/ subdirectory by build.sh.
+COPY filameshio_fuzzer.cpp gltfio_meshopt_fuzzer.cpp gltfio_accessor_fuzzer.cpp $SRC/
+COPY build.sh $SRC/

--- a/projects/filament/build.sh
+++ b/projects/filament/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/filament/build.sh
+++ b/projects/filament/build.sh
@@ -1,0 +1,96 @@
+#!/bin/bash -eu
+# OSS-Fuzz build script for google/filament.
+# Builds three libFuzzer targets over filament's untrusted-asset loaders:
+#   filameshio_fuzzer      -> MeshReader::loadMeshFromBuffer        (.filamesh)
+#   gltfio_meshopt_fuzzer  -> gltfio EXT_meshopt_compression decode (glTF/GLB)
+#   gltfio_accessor_fuzzer -> gltfio cgltf accessor unpack          (glTF/GLB, sparse)
+#
+# OSS-Fuzz provides $CC/$CXX/$CFLAGS/$CXXFLAGS (sanitizer + fuzzer-no-link
+# instrumentation), $LIB_FUZZING_ENGINE (the libFuzzer main), $OUT and $WORK.
+
+cd $SRC/filament
+
+# ---------------------------------------------------------------------------
+# 1. Drop the fuzz targets into a dedicated library subdirectory.
+# ---------------------------------------------------------------------------
+FUZZ_DIR=libs/filament_ossfuzz
+mkdir -p $FUZZ_DIR
+cp $SRC/filameshio_fuzzer.cpp $SRC/gltfio_meshopt_fuzzer.cpp $SRC/gltfio_accessor_fuzzer.cpp $FUZZ_DIR/
+
+cat > $FUZZ_DIR/CMakeLists.txt <<'EOF'
+# OSS-Fuzz fuzz targets. Instrumentation comes from CMAKE_*_FLAGS (= $CFLAGS/
+# $CXXFLAGS); the libFuzzer main comes from $LIB_FUZZING_ENGINE.
+set(FUZZ_LINK "$ENV{LIB_FUZZING_ENGINE}")
+
+add_executable(filameshio_fuzzer filameshio_fuzzer.cpp)
+target_link_libraries(filameshio_fuzzer PRIVATE filameshio filament utils math)
+target_compile_options(filameshio_fuzzer PRIVATE -Wno-everything)
+target_link_options(filameshio_fuzzer PRIVATE ${FUZZ_LINK})
+
+foreach(t gltfio_meshopt_fuzzer gltfio_accessor_fuzzer)
+  add_executable(${t} ${t}.cpp)
+  target_link_libraries(${t} PRIVATE gltfio_core)
+  target_include_directories(${t} PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}/../gltfio/src
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/cgltf)
+  target_compile_options(${t} PRIVATE -Wno-everything)
+  target_link_options(${t} PRIVATE ${FUZZ_LINK})
+endforeach()
+EOF
+
+# Wire the subdirectory into the top-level build (after the last libs/ entry).
+if ! grep -q "add_subdirectory(\${LIBRARIES}/filament_ossfuzz)" CMakeLists.txt; then
+  # Insert right after the gltfio library is added so its targets exist.
+  sed -i 's#\(add_subdirectory(${LIBRARIES}/gltfio)\)#\1\nadd_subdirectory(${LIBRARIES}/filament_ossfuzz)#' CMakeLists.txt
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Toolchain compatibility fixes for building under clang + OSS-Fuzz flags.
+#    filament builds with -Werror and clang thread-safety attributes that the
+#    OSS-Fuzz clang rejects; relax those so instrumentation flags don't trip them.
+# ---------------------------------------------------------------------------
+for f in filament/CMakeLists.txt filament/backend/CMakeLists.txt libs/utils/CMakeLists.txt; do
+  sed -i 's/PRIVATE -Wthread-safety)/PRIVATE -Wno-thread-safety)/g' $f || true
+  sed -i '/^[[:space:]]*-Werror$/d' $f || true
+done
+
+# ---------------------------------------------------------------------------
+# 3. Configure. NDEBUG is essential: filament gates cgltf_validate behind
+#    #ifndef NDEBUG and meshoptimizer enforces decoder preconditions with
+#    assert() only -- i.e. the release config is the vulnerable one we fuzz.
+# ---------------------------------------------------------------------------
+BUILD=$WORK/build
+mkdir -p $BUILD
+cmake -GNinja -S $SRC/filament -B $BUILD \
+  -DCMAKE_C_COMPILER="$CC" \
+  -DCMAKE_CXX_COMPILER="$CXX" \
+  -DCMAKE_C_FLAGS="$CFLAGS -DNDEBUG" \
+  -DCMAKE_CXX_FLAGS="$CXXFLAGS -DNDEBUG" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DUSE_STATIC_LIBCXX=OFF \
+  -DFILAMENT_SKIP_SAMPLES=ON \
+  -DFILAMENT_SKIP_SDL2=ON \
+  -DFILAMENT_SUPPORTS_VULKAN=OFF \
+  -DFILAMENT_SUPPORTS_OPENGL=OFF \
+  -DFILAMENT_ENABLE_MATDBG=OFF \
+  -DFILAMENT_USE_EXTERNAL_GLES3=OFF
+
+# ---------------------------------------------------------------------------
+# 4. Build only the three fuzz targets (pulls in their deps transitively).
+# ---------------------------------------------------------------------------
+cmake --build $BUILD --target filameshio_fuzzer gltfio_meshopt_fuzzer gltfio_accessor_fuzzer
+
+# ---------------------------------------------------------------------------
+# 5. Stage binaries and seed corpora.
+# ---------------------------------------------------------------------------
+for t in filameshio_fuzzer gltfio_meshopt_fuzzer gltfio_accessor_fuzzer; do
+  cp "$(find $BUILD -name $t -type f -perm -u+x | head -1)" $OUT/
+done
+
+# Seed corpora (optional but recommended): any sample assets shipped in-tree.
+if compgen -G "$SRC/filament/assets/models/**/*.glb" > /dev/null 2>&1; then
+  mkdir -p $WORK/gltf_seeds
+  find $SRC/filament/assets -name '*.glb' -exec cp {} $WORK/gltf_seeds/ \; 2>/dev/null || true
+  (cd $WORK/gltf_seeds && zip -q $OUT/gltfio_meshopt_fuzzer_seed_corpus.zip ./* 2>/dev/null) || true
+  cp -f $OUT/gltfio_meshopt_fuzzer_seed_corpus.zip $OUT/gltfio_accessor_fuzzer_seed_corpus.zip 2>/dev/null || true
+fi

--- a/projects/filament/build.sh
+++ b/projects/filament/build.sh
@@ -1,4 +1,19 @@
 #!/bin/bash -eu
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
 # OSS-Fuzz build script for google/filament.
 # Builds three libFuzzer targets over filament's untrusted-asset loaders:
 #   filameshio_fuzzer      -> MeshReader::loadMeshFromBuffer        (.filamesh)

--- a/projects/filament/filameshio_fuzzer.cpp
+++ b/projects/filament/filameshio_fuzzer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/filament/filameshio_fuzzer.cpp
+++ b/projects/filament/filameshio_fuzzer.cpp
@@ -1,3 +1,19 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
 // OSS-Fuzz target: filament .filamesh loader (MeshReader::loadMeshFromBuffer).
 // Covers F1 (UV1 alloc-vs-decode heap OOB write) and the .filamesh compressed paths.
 // Uses a headless NOOP-backend Engine so it runs without a GPU. The OOB in F1 is not assert-gated,

--- a/projects/filament/filameshio_fuzzer.cpp
+++ b/projects/filament/filameshio_fuzzer.cpp
@@ -1,0 +1,32 @@
+// OSS-Fuzz target: filament .filamesh loader (MeshReader::loadMeshFromBuffer).
+// Covers F1 (UV1 alloc-vs-decode heap OOB write) and the .filamesh compressed paths.
+// Uses a headless NOOP-backend Engine so it runs without a GPU. The OOB in F1 is not assert-gated,
+// so it is found under ASan in both debug and release builds.
+#include <filament/Engine.h>
+#include <filament/VertexBuffer.h>
+#include <filament/IndexBuffer.h>
+#include <filament/MaterialInstance.h>
+#include <filameshio/MeshReader.h>
+#include <utils/Entity.h>
+#include <cstdint>
+#include <cstddef>
+
+using namespace filament;
+using filamesh::MeshReader;
+
+static Engine* g_engine = nullptr;
+
+extern "C" int LLVMFuzzerInitialize(int*, char***) {
+    g_engine = Engine::create(Engine::Backend::NOOP);
+    return 0;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    if (!g_engine) return 0;
+    MeshReader::Mesh mesh = MeshReader::loadMeshFromBuffer(
+        g_engine, data, size, nullptr, nullptr, (MaterialInstance*) nullptr);
+    if (mesh.vertexBuffer) g_engine->destroy(mesh.vertexBuffer);
+    if (mesh.indexBuffer)  g_engine->destroy(mesh.indexBuffer);
+    if (!mesh.renderable.isNull()) g_engine->destroy(mesh.renderable);
+    return 0;
+}

--- a/projects/filament/gltfio_accessor_fuzzer.cpp
+++ b/projects/filament/gltfio_accessor_fuzzer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/filament/gltfio_accessor_fuzzer.cpp
+++ b/projects/filament/gltfio_accessor_fuzzer.cpp
@@ -1,0 +1,26 @@
+// OSS-Fuzz target: filament gltfio accessor unpack path (sparse accessors + bounds).
+// Feeds raw bytes as a glTF/GLB to filament's real cgltf, then unpacks every accessor into a buffer sized
+// for its base count -- exactly as gltfio's ResourceLoader does. Covers #6 (sparse-accessor CONTROLLED heap
+// OOB write via cgltf_accessor_unpack_floats) and accessor/bufferView bounds issues. The sparse OOB write is
+// NOT assert-gated, so it is found under ASan even in debug builds (and in release, cgltf_validate is off).
+#include <cgltf.h>
+#include <cstdint>
+#include <cstring>
+#include <cstdlib>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    cgltf_options opts; memset(&opts, 0, sizeof(opts));
+    cgltf_data* gltf = nullptr;
+    if (cgltf_parse(&opts, data, size, &gltf) != cgltf_result_success) return 0;
+    if (cgltf_load_buffers(&opts, gltf, nullptr) == cgltf_result_success) {
+        for (cgltf_size i = 0; i < gltf->accessors_count; ++i) {
+            cgltf_accessor* a = &gltf->accessors[i];
+            cgltf_size n = cgltf_accessor_unpack_floats(a, nullptr, 0);   // base count * components
+            if (n == 0 || n > (8u << 20)) continue;                       // bound work
+            float* out = (float*) malloc(n * sizeof(float));              // sized for base count (as gltfio)
+            if (out) { cgltf_accessor_unpack_floats(a, out, n); free(out); }
+        }
+    }
+    cgltf_free(gltf);
+    return 0;
+}

--- a/projects/filament/gltfio_accessor_fuzzer.cpp
+++ b/projects/filament/gltfio_accessor_fuzzer.cpp
@@ -1,3 +1,19 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
 // OSS-Fuzz target: filament gltfio accessor unpack path (sparse accessors + bounds).
 // Feeds raw bytes as a glTF/GLB to filament's real cgltf, then unpacks every accessor into a buffer sized
 // for its base count -- exactly as gltfio's ResourceLoader does. Covers #6 (sparse-accessor CONTROLLED heap

--- a/projects/filament/gltfio_meshopt_fuzzer.cpp
+++ b/projects/filament/gltfio_meshopt_fuzzer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/filament/gltfio_meshopt_fuzzer.cpp
+++ b/projects/filament/gltfio_meshopt_fuzzer.cpp
@@ -1,3 +1,19 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
 // OSS-Fuzz target: filament gltfio EXT_meshopt_compression decode path.
 // Feeds raw bytes as a glTF/GLB to filament's real cgltf, then runs the real
 // filament::gltfio::utility::decodeMeshoptCompression. Covers F2 (index %3), #3/#4 (oct/quat filters),

--- a/projects/filament/gltfio_meshopt_fuzzer.cpp
+++ b/projects/filament/gltfio_meshopt_fuzzer.cpp
@@ -1,0 +1,21 @@
+// OSS-Fuzz target: filament gltfio EXT_meshopt_compression decode path.
+// Feeds raw bytes as a glTF/GLB to filament's real cgltf, then runs the real
+// filament::gltfio::utility::decodeMeshoptCompression. Covers F2 (index %3), #3/#4 (oct/quat filters),
+// #5 (vertex byteStride>256 stack overflow), #7 (index sequence stride!=2).
+// NOTE: these meshopt preconditions are assert-only; build with -DNDEBUG (release, as OSS-Fuzz does for
+// the address sanitizer build) so the asserts are compiled out and ASan observes the real OOB writes.
+#include <cgltf.h>                 // filament third_party/cgltf (declarations; impl is in gltfio_core)
+#include "Utility.h"               // filament::gltfio::utility::decodeMeshoptCompression
+#include <cstdint>
+#include <cstring>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    cgltf_options opts; memset(&opts, 0, sizeof(opts));
+    cgltf_data* gltf = nullptr;
+    if (cgltf_parse(&opts, data, size, &gltf) != cgltf_result_success) return 0;
+    if (cgltf_load_buffers(&opts, gltf, nullptr) == cgltf_result_success) {
+        filament::gltfio::utility::decodeMeshoptCompression(gltf);   // real gltfio code path
+    }
+    cgltf_free(gltf);
+    return 0;
+}

--- a/projects/filament/project.yaml
+++ b/projects/filament/project.yaml
@@ -1,0 +1,14 @@
+homepage: "https://google.github.io/filament/"
+language: c++
+primary_contact: "chigorin.1337@gmail.com"
+main_repo: "https://github.com/google/filament"
+# Filament is Google's real-time physically based renderer. These fuzz targets
+# exercise the untrusted-asset loaders (glTF/GLB via gltfio, and the .filamesh
+# format via filameshio), which decode attacker-controlled buffer metadata.
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+  - undefined
+architectures:
+  - x86_64


### PR DESCRIPTION
### New project integration: google/filament

[filament](https://github.com/google/filament) is Google's open-source real-time physically based renderer (Android, desktop, web). It loads untrusted 3D assets, so its asset loaders are a meaningful attack surface. filament is not currently an OSS-Fuzz project and ships no first-party fuzz target (the only in-tree fuzzers are vendored third-party suites that don't exercise filament's loaders).

This integration adds three libFuzzer targets over filament's untrusted-asset decode paths:

| Target | Entry point | Format |
|---|---|---|
| `filameshio_fuzzer` | `filamesh::MeshReader::loadMeshFromBuffer` | `.filamesh` |
| `gltfio_meshopt_fuzzer` | `filament::gltfio::utility::decodeMeshoptCompression` (real cgltf parse + `EXT_meshopt_compression`) | glTF/GLB |
| `gltfio_accessor_fuzzer` | `cgltf_accessor_unpack_floats` over every accessor (incl. sparse) | glTF/GLB |

Notes for reviewers:
- Built `Release` with `-DNDEBUG` on purpose: filament gates `cgltf_validate` behind `#ifndef NDEBUG`, and meshoptimizer enforces its decoder preconditions with `assert()` only — so the shipping configuration is the one worth fuzzing (ASan still observes OOB writes).
- `build.sh` relaxes filament's `-Werror` / `-Wthread-safety` only as needed to build under the OSS-Fuzz clang + sanitizer flags; it uses the NOOP backend so the targets run headless (no GPU).
- `libc++`/`ninja` installed in the Dockerfile; targets link the real `filameshio` / `gltfio_core` libraries.

`primary_contact` set in `project.yaml`.
