### PR TITLE
Add OSS-Fuzz integration for tokio-rs/axum — Rust web framework (26K stars)

### DIFF
--- a/projects/axum/Dockerfile
+++ b/projects/axum/Dockerfile
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 FROM gcr.io/oss-fuzz-base/base-builder-rust
-RUN git clone --depth 1 https://github.com/tokio-rs/axum axum
+RUN git clone --depth 1 https://github.com/tokio-rs/axum.git axum
 WORKDIR axum
 COPY build.sh $SRC/

--- a/projects/axum/Dockerfile
+++ b/projects/axum/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+RUN git clone --depth 1 https://github.com/tokio-rs/axum axum
+WORKDIR axum
+COPY build.sh $SRC/

--- a/projects/axum/build.sh
+++ b/projects/axum/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cd $SRC/axum
+cargo fuzz build -O --debug-assertions
+cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_request $OUT/
+cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_uri $OUT/
+cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_headers $OUT/

--- a/projects/axum/build.sh
+++ b/projects/axum/build.sh
@@ -15,6 +15,4 @@
 
 cd $SRC/axum
 cargo fuzz build -O --debug-assertions
-cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_request $OUT/
-cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_uri $OUT/
-cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_headers $OUT/
+cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_* $OUT/

--- a/projects/axum/project.yaml
+++ b/projects/axum/project.yaml
@@ -1,0 +1,7 @@
+homepage: "https://github.com/tokio-rs/axum"
+language: rust
+primary_contact: "security@tokio.rs"
+main_repo: "https://github.com/tokio-rs/axum"
+sanitizers: [address]
+fuzzing_engines: [libfuzzer]
+auto_ccs: ["security@tokio.rs"]


### PR DESCRIPTION
## tokio-rs/axum — First Rust integration

| Metric | Value |
|---|---|
| Stars | 26,245 |
| Language | Rust |
| Type | Web framework (pre-auth HTTP) |

### Fuzz targets
- `fuzz_request` — HTTP request routing
- `fuzz_uri` — URI parsing (pre-auth)
- `fuzz_headers` — HTTP header parsing (pre-auth)

### Upstream PR
https://github.com/tokio-rs/axum/pull/3795