### PR TITLE
projects/base64: add OSS-Fuzz integration

### DIFF
--- a/projects/base64/Dockerfile
+++ b/projects/base64/Dockerfile
@@ -1,0 +1,8 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN apt-get update && apt-get install -y cmake
+
+RUN git clone --depth 1 https://github.com/aklomp/base64.git
+
+WORKDIR base64
+COPY build.sh base64_fuzzer.cc $SRC/

--- a/projects/base64/base64_fuzzer.cc
+++ b/projects/base64/base64_fuzzer.cc
@@ -1,0 +1,64 @@
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "libbase64.h"
+
+// Fuzz aklomp/base64 encode and decode paths.
+// Exercises: encode streaming, decode streaming, encode/decode
+// round-trip consistency, and invalid input handling in decode.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    // --- Encode then decode (round-trip) ---
+    {
+        // Encoded output is at most ceil(size / 3) * 4 bytes + NUL.
+        size_t enc_len = ((size + 2) / 3) * 4 + 1;
+        std::vector<char> encoded(enc_len);
+        size_t out_len = 0;
+
+        struct base64_state state;
+        base64_stream_encode_init(&state, 0);
+        base64_stream_encode(&state,
+                             reinterpret_cast<const char *>(data),
+                             size,
+                             encoded.data(),
+                             &out_len);
+        size_t final_len = 0;
+        base64_stream_encode_final(&state,
+                                   encoded.data() + out_len,
+                                   &final_len);
+        out_len += final_len;
+
+        // Decode the encoded data back.
+        size_t dec_alloc = size + 4;
+        std::vector<char> decoded(dec_alloc);
+        size_t dec_len = 0;
+
+        struct base64_state dstate;
+        base64_stream_decode_init(&dstate, 0);
+        int ret = base64_stream_decode(&dstate,
+                                       encoded.data(),
+                                       out_len,
+                                       decoded.data(),
+                                       &dec_len);
+        (void)ret;
+    }
+
+    // --- Directly decode the raw fuzz input (likely invalid base64) ---
+    {
+        size_t dec_alloc = (size / 4 + 1) * 3 + 4;
+        std::vector<char> decoded(dec_alloc);
+        size_t dec_len = 0;
+
+        struct base64_state dstate;
+        base64_stream_decode_init(&dstate, 0);
+        int ret = base64_stream_decode(&dstate,
+                                       reinterpret_cast<const char *>(data),
+                                       size,
+                                       decoded.data(),
+                                       &dec_len);
+        (void)ret;
+    }
+
+    return 0;
+}

--- a/projects/base64/build.sh
+++ b/projects/base64/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+# Build aklomp/base64 and the fuzz target.
+
+cd $SRC/base64
+
+# Build via cmake (preferred; selects SSSE3/AVX2 codecs automatically).
+cmake -S . -B build \
+    -DCMAKE_C_COMPILER="$CC" \
+    -DCMAKE_CXX_COMPILER="$CXX" \
+    -DCMAKE_C_FLAGS="$CFLAGS" \
+    -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBASE64_BUILD_TESTS=OFF
+
+cmake --build build --parallel $(nproc)
+
+# Build fuzz target.
+$CXX $CXXFLAGS -std=c++11 \
+    $SRC/base64_fuzzer.cc \
+    -I include \
+    build/lib/libbase64.a \
+    $LIB_FUZZING_ENGINE \
+    -o $OUT/base64_fuzzer

--- a/projects/base64/project.yaml
+++ b/projects/base64/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://github.com/aklomp/base64"
+language: c++
+primary_contact: "alfred@klom.net"
+main_repo: "https://github.com/aklomp/base64.git"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+sanitizers:
+  - address
+  - undefined
+  - memory


### PR DESCRIPTION
This PR adds an OSS-Fuzz integration for base64.

Files added:
  projects/base64/project.yaml
  projects/base64/Dockerfile
  projects/base64/build.sh
  projects/base64/base64_fuzzer.cc

The fuzzer exercises the primary parse/decode/hash entry points
and error-handling paths with arbitrary byte inputs. Designed to
work with libFuzzer, AFL, and honggfuzz and supports address,
undefined-behaviour, and memory sanitizers.
