### PR TITLE
Add OSS-Fuzz integration for actix/actix-web — Rust web framework (24K stars)

### DIFF
--- a/projects/actix-web/Dockerfile
+++ b/projects/actix-web/Dockerfile
@@ -1,0 +1,5 @@
+# Copyright 2026 Google LLC
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+RUN git clone --depth 1 https://github.com/actix/actix-web actix-web
+WORKDIR actix-web
+COPY build.sh $SRC/

--- a/projects/actix-web/Dockerfile
+++ b/projects/actix-web/Dockerfile
@@ -1,5 +1,21 @@
 # Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM gcr.io/oss-fuzz-base/base-builder-rust
-RUN git clone --depth 1 https://github.com/actix/actix-web actix-web
+RUN git clone --depth 1 https://github.com/actix/actix-web
+seanmonstar/reqwest
+rwf2/Rocket
+clap-rs/clap.git actix-web
 WORKDIR actix-web
 COPY build.sh $SRC/

--- a/projects/actix-web/build.sh
+++ b/projects/actix-web/build.sh
@@ -1,5 +1,18 @@
 #!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cd $SRC/actix-web
 cargo fuzz build -O --debug-assertions
-cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_header_parse $OUT/
-cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_uri_parse $OUT/
+cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_* $OUT/

--- a/projects/actix-web/build.sh
+++ b/projects/actix-web/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -eu
+cd $SRC/actix-web
+cargo fuzz build -O --debug-assertions
+cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_header_parse $OUT/
+cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_uri_parse $OUT/

--- a/projects/actix-web/project.yaml
+++ b/projects/actix-web/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/actix/actix-web"
+language: rust
+primary_contact: "security@actix.rs"
+main_repo: "https://github.com/actix/actix-web"
+sanitizers: [address]
+fuzzing_engines: [libfuzzer]


### PR DESCRIPTION
## actix/actix-web. Rust web framework, 24K stars. Upstream: https://github.com/actix/actix-web/pull/4099