### PR TITLE
Add OSS-Fuzz integration for rwf2/Rocket — Rust web framework (25K stars)

### DIFF
--- a/projects/reqwest/Dockerfile
+++ b/projects/reqwest/Dockerfile
@@ -1,0 +1,5 @@
+# Copyright 2026 Google LLC
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+RUN git clone --depth 1 https://github.com/seanmonstar/reqwest.git reqwest
+WORKDIR reqwest
+COPY build.sh $SRC/

--- a/projects/reqwest/build.sh
+++ b/projects/reqwest/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -eu
+cd $SRC/reqwest
+cargo fuzz build -O --debug-assertions
+cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_url /

--- a/projects/reqwest/project.yaml
+++ b/projects/reqwest/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/seanmonstar/reqwest"
+language: rust
+primary_contact: "security@rust-lang.org"
+main_repo: "https://github.com/seanmonstar/reqwest"
+sanitizers: [address]
+fuzzing_engines: [libfuzzer]

--- a/projects/rocket/Dockerfile
+++ b/projects/rocket/Dockerfile
@@ -1,5 +1,19 @@
 # Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM gcr.io/oss-fuzz-base/base-builder-rust
-RUN git clone --depth 1 https://github.com/rwf2/Rocket.git rocket
+RUN git clone --depth 1 https://github.com/rwf2/Rocket
+clap-rs/clap.git rocket
 WORKDIR rocket
 COPY build.sh $SRC/

--- a/projects/rocket/Dockerfile
+++ b/projects/rocket/Dockerfile
@@ -1,0 +1,5 @@
+# Copyright 2026 Google LLC
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+RUN git clone --depth 1 https://github.com/rwf2/Rocket.git rocket
+WORKDIR rocket
+COPY build.sh $SRC/

--- a/projects/rocket/build.sh
+++ b/projects/rocket/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -eu
+cd $SRC/rocket
+cargo fuzz build -O --debug-assertions
+cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_url /

--- a/projects/rocket/build.sh
+++ b/projects/rocket/build.sh
@@ -1,4 +1,18 @@
 #!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cd $SRC/rocket
 cargo fuzz build -O --debug-assertions
-cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_url /
+cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_* $OUT/

--- a/projects/rocket/project.yaml
+++ b/projects/rocket/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/rwf2/Rocket"
+language: rust
+primary_contact: "security@rust-lang.org"
+main_repo: "https://github.com/rwf2/Rocket"
+sanitizers: [address]
+fuzzing_engines: [libfuzzer]


### PR DESCRIPTION
## Rocket. Rust web framework. Upstream: https://github.com/rwf2/Rocket/pull/2999