### PR TITLE
Add OSS-Fuzz integration for clap-rs/clap — Rust CLI parser (16K stars)

### DIFF
--- a/projects/clap/Dockerfile
+++ b/projects/clap/Dockerfile
@@ -1,4 +1,17 @@
 # Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM gcr.io/oss-fuzz-base/base-builder-rust
 RUN git clone --depth 1 https://github.com/clap-rs/clap.git clap
 WORKDIR clap

--- a/projects/clap/Dockerfile
+++ b/projects/clap/Dockerfile
@@ -1,0 +1,5 @@
+# Copyright 2026 Google LLC
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+RUN git clone --depth 1 https://github.com/clap-rs/clap.git clap
+WORKDIR clap
+COPY build.sh $SRC/

--- a/projects/clap/build.sh
+++ b/projects/clap/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -eu
+cd $SRC/clap
+cargo fuzz build -O --debug-assertions
+cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_parse $OUT/

--- a/projects/clap/build.sh
+++ b/projects/clap/build.sh
@@ -1,4 +1,18 @@
 #!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cd $SRC/clap
 cargo fuzz build -O --debug-assertions
-cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_parse $OUT/
+cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_* $OUT/

--- a/projects/clap/project.yaml
+++ b/projects/clap/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/clap-rs/clap"
+language: rust
+primary_contact: "security@rust-lang.org"
+main_repo: "https://github.com/clap-rs/clap"
+sanitizers: [address]
+fuzzing_engines: [libfuzzer]

--- a/projects/tower/Dockerfile
+++ b/projects/tower/Dockerfile
@@ -1,0 +1,5 @@
+# Copyright 2026 Google LLC
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+RUN git clone --depth 1 https://github.com/tower-rs/tower.git tower
+WORKDIR tower
+COPY build.sh $SRC/

--- a/projects/tower/build.sh
+++ b/projects/tower/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -eu
+cd $SRC/tower
+cargo fuzz build -O --debug-assertions
+cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_parse $OUT/

--- a/projects/tower/project.yaml
+++ b/projects/tower/project.yaml
@@ -1,0 +1,6 @@
+homepage: "https://github.com/tower-rs/tower"
+language: rust
+primary_contact: "security@rust-lang.org"
+main_repo: "https://github.com/tower-rs/tower"
+sanitizers: [address]
+fuzzing_engines: [libfuzzer]


### PR DESCRIPTION
## clap. Rust CLI parser. Upstream: https://github.com/clap-rs/clap/pull/6410