### PR TITLE
connectedhomeip: build pw_fuzzer / Google FuzzTest targets

### DIFF
--- a/projects/connectedhomeip/Dockerfile
+++ b/projects/connectedhomeip/Dockerfile
@@ -29,7 +29,10 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN rustup install nightly
 RUN rustup default nightly
 
-RUN git clone --depth=1 https://github.com/project-chip/connectedhomeip.git connectedhomeip
+# DO NOT MERGE -- temporary: clone the fork branch carrying the connectedhomeip-side
+# pw_fuzzer/OSS-Fuzz support (project-chip/connectedhomeip#72573) so this PR's CI can build it.
+# Revert to the project-chip master clone once that lands upstream.
+RUN git clone --depth=1 -b pw-fuzztest-ossfuzz https://github.com/Alami-Amine/connectedhomeip.git connectedhomeip
 
 # PW_PROJECT_ROOT is used in requirements.build.txt
 ENV PW_PROJECT_ROOT=$SRC/connectedhomeip

--- a/projects/connectedhomeip/Dockerfile
+++ b/projects/connectedhomeip/Dockerfile
@@ -29,10 +29,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN rustup install nightly
 RUN rustup default nightly
 
-# DO NOT MERGE -- temporary: clone the fork branch carrying the connectedhomeip-side
-# pw_fuzzer/OSS-Fuzz support (project-chip/connectedhomeip#72573) so this PR's CI can build it.
-# Revert to the project-chip master clone once that lands upstream.
-RUN git clone --depth=1 -b pw-fuzztest-ossfuzz https://github.com/Alami-Amine/connectedhomeip.git connectedhomeip
+RUN git clone --depth=1 https://github.com/project-chip/connectedhomeip.git connectedhomeip
 
 # PW_PROJECT_ROOT is used in requirements.build.txt
 ENV PW_PROJECT_ROOT=$SRC/connectedhomeip

--- a/projects/connectedhomeip/build.sh
+++ b/projects/connectedhomeip/build.sh
@@ -24,6 +24,15 @@ fi
 
 cd $SRC/connectedhomeip
 
+# Preserve the OSS-Fuzz-provided toolchain settings. The pw_fuzzer / FuzzTest toolchain
+# (//build/toolchain/pw_fuzzer) reads $CC/$CXX/$CFLAGS/$CXXFLAGS at `gn gen` time so its
+# libFuzzer runtime matches OSS-Fuzz's instrumentation; Pigweed's activate.sh may change
+# the environment, so capture these first and restore them before `gn gen`.
+OSS_FUZZ_CC="${CC:-}"
+OSS_FUZZ_CXX="${CXX:-}"
+OSS_FUZZ_CFLAGS="${CFLAGS:-}"
+OSS_FUZZ_CXXFLAGS="${CXXFLAGS:-}"
+
 # Activate Pigweed environment
 set +u
 PW_ENVSETUP_QUIET=1 source scripts/activate.sh
@@ -32,10 +41,19 @@ set -u
 #This adds zap-cli to PATH, needed for fuzzing all-clusters-app
 export PATH="/src/connectedhomeip/.environment/cipd/packages/zap/:$PATH"
 
+# Restore the OSS-Fuzz toolchain settings so `gn gen` (run below while the Pigweed
+# environment is active) sees them.
+export CC="$OSS_FUZZ_CC"
+export CXX="$OSS_FUZZ_CXX"
+export CFLAGS="$OSS_FUZZ_CFLAGS"
+export CXXFLAGS="$OSS_FUZZ_CXXFLAGS"
+
 # Create a build directory with the following options:
 # - `oss_fuzz` enables OSS-Fuzz build
 # - `is_clang` selects clang toolchains (does not support AFL fuzzing engine)
 # - `enable_rrti` enables RTTI to support UBSan build
+# - `pw_enable_fuzz_test_targets` builds the pw_fuzzer / Google FuzzTest targets in
+#   libFuzzer-compatibility mode, in addition to the legacy libFuzzer targets.
 # - `chip_enable_thread_safety_checks` disabled since OSS-Fuzz clang does not
 #   seem to currently support or need this analysis
 # - `chip_enable_openthread` disabled since OSS-Fuzz clang issues a compile
@@ -48,6 +66,7 @@ gn gen out/fuzz_targets \
     oss_fuzz=true \
     is_clang=true \
     enable_rtti=true \
+    pw_enable_fuzz_test_targets=true \
     chip_enable_thread_safety_checks=false \
     chip_enable_thread=false \
     target_ldflags=[\"-fuse-ld=lld\"]"
@@ -55,10 +74,34 @@ gn gen out/fuzz_targets \
 # Deactivate Pigweed environment to use OSS-Fuzz toolchains
 deactivate
 
-# Compile fuzz targets
+# Compile the legacy libFuzzer fuzz targets
 ninja -C out/fuzz_targets fuzz_tests
 
 cp out/fuzz_targets/tests/* $OUT/
+
+# Compile the pw_fuzzer / Google FuzzTest targets and generate one OSS-Fuzz fuzz target per
+# FUZZ_TEST case. A FuzzTest binary hosts many cases and is run one case at a time
+# (--fuzz=<Suite.Case>), so gen_pw_fuzztest_oss_fuzz_wrappers.sh emits a detectable wrapper
+# per case (see that script). FuzzTest binaries are libFuzzer-compatible, so only build them
+# for the libFuzzer engine; honggfuzz/centipede cannot drive a libFuzzer-compatibility binary.
+if [[ "${FUZZING_ENGINE:-libfuzzer}" == "libfuzzer" ]]; then
+  ninja -C out/fuzz_targets pw_fuzz_tests
+  bash "$SRC/connectedhomeip/scripts/build/gen_pw_fuzztest_oss_fuzz_wrappers.sh" \
+    "$OUT" out/fuzz_targets/chip_pw_fuzztest/tests/fuzz-*-pw
+
+  # The FuzzChipCert harness seeds from a source-tree directory that is not present in the
+  # OSS-Fuzz runner (which runs fuzzers without the build tree). Provide those seeds the
+  # location-independent OSS-Fuzz way -- one <target>_seed_corpus.zip per generated chip-cert
+  # target -- so libFuzzer uses them as the initial corpus. (The harness itself tolerates the
+  # directory being absent.)
+  chip_cert_seeds=credentials/test/operational-certificates-error-cases
+  if [ -d "$chip_cert_seeds" ]; then
+    for wrapper in "$OUT"/fuzz-chip-cert-pw@*; do
+      [ -e "$wrapper" ] || continue
+      python3 -m zipfile -c "${wrapper}_seed_corpus.zip" "$chip_cert_seeds"/
+    done
+  fi
+fi
 
 # Copy some GLib and GIO runtime libraries into $OUT so fuzzed all-clusters app can run under OSS-Fuzz base-runner, which does not provide these libraries.
 mkdir -p $OUT/lib
@@ -67,8 +110,10 @@ cp /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0 $OUT/lib/
 cp /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0 $OUT/lib/
 cp /usr/lib/x86_64-linux-gnu/libgmodule-2.0.so.0 $OUT/lib/
 
+# Set an rpath on the fuzz target binaries (ELF only; the FuzzTest wrapper scripts and the
+# non-executable shared FuzzTest binaries are matched too — patchelf on the shared ELF, the
+# `file ... ELF` guard skips the shell-script wrappers).
 for f in $OUT/fuzz-*; do
     file "$f" | grep -q "ELF" && patchelf --set-rpath '$ORIGIN/lib' "$f"
 done
 patchelf --set-rpath '$ORIGIN' $OUT/lib/*.so* 2>/dev/null
-	

--- a/projects/connectedhomeip/build.sh
+++ b/projects/connectedhomeip/build.sh
@@ -110,17 +110,10 @@ cp /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0 $OUT/lib/
 cp /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0 $OUT/lib/
 cp /usr/lib/x86_64-linux-gnu/libgmodule-2.0.so.0 $OUT/lib/
 
-# Set an rpath on the legacy libFuzzer targets in $OUT (ELF only; the `file ... ELF` guard
-# skips the FuzzTest wrapper shell scripts).
+# Set an rpath on the fuzz target binaries (ELF only; the FuzzTest wrapper scripts and the
+# non-executable shared FuzzTest binaries are matched too — patchelf on the shared ELF, the
+# `file ... ELF` guard skips the shell-script wrappers).
 for f in $OUT/fuzz-*; do
     file "$f" | grep -q "ELF" && patchelf --set-rpath '$ORIGIN/lib' "$f"
 done
-
-# pw_fuzzer shared FuzzTest binaries live in $OUT/bin (kept out of target discovery); point
-# their rpath one level up at $OUT/lib in case a harness needs the bundled runtime libs.
-if [ -d "$OUT/bin" ]; then
-    for f in "$OUT"/bin/*; do
-        file "$f" | grep -q "ELF" && patchelf --set-rpath '$ORIGIN/../lib' "$f"
-    done
-fi
 patchelf --set-rpath '$ORIGIN' $OUT/lib/*.so* 2>/dev/null

--- a/projects/connectedhomeip/build.sh
+++ b/projects/connectedhomeip/build.sh
@@ -110,10 +110,17 @@ cp /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0 $OUT/lib/
 cp /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0 $OUT/lib/
 cp /usr/lib/x86_64-linux-gnu/libgmodule-2.0.so.0 $OUT/lib/
 
-# Set an rpath on the fuzz target binaries (ELF only; the FuzzTest wrapper scripts and the
-# non-executable shared FuzzTest binaries are matched too — patchelf on the shared ELF, the
-# `file ... ELF` guard skips the shell-script wrappers).
+# Set an rpath on the legacy libFuzzer targets in $OUT (ELF only; the `file ... ELF` guard
+# skips the FuzzTest wrapper shell scripts).
 for f in $OUT/fuzz-*; do
     file "$f" | grep -q "ELF" && patchelf --set-rpath '$ORIGIN/lib' "$f"
 done
+
+# pw_fuzzer shared FuzzTest binaries live in $OUT/bin (kept out of target discovery); point
+# their rpath one level up at $OUT/lib in case a harness needs the bundled runtime libs.
+if [ -d "$OUT/bin" ]; then
+    for f in "$OUT"/bin/*; do
+        file "$f" | grep -q "ELF" && patchelf --set-rpath '$ORIGIN/../lib' "$f"
+    done
+fi
 patchelf --set-rpath '$ORIGIN' $OUT/lib/*.so* 2>/dev/null


### PR DESCRIPTION
Builds connectedhomeip's pw_fuzzer / Google FuzzTest harnesses in libFuzzer-compatibility mode, in addition to the existing libFuzzer targets.

`build.sh` changes:
- Preserve the OSS-Fuzz `$CC`/`$CXX`/`$CFLAGS`/`$CXXFLAGS` across Pigweed's `activate.sh` and restore them before `gn gen`, so the FuzzTest toolchain's libFuzzer runtime matches OSS-Fuzz's instrumentation.
- Pass `pw_enable_fuzz_test_targets=true` and build the `pw_fuzz_tests` group.
- Emit one fuzz target per `FUZZ_TEST` case (a FuzzTest binary hosts many cases, each run via `--fuzz=<Suite.Case>`). libFuzzer engine only — honggfuzz/centipede cannot drive a libFuzzer-compatibility binary.
- Supply `FuzzChipCert` seeds as `<target>_seed_corpus.zip` (the harness otherwise reads them from a source-tree directory that is absent in the runner).

**Depends on project-chip/connectedhomeip#72573**, which adds the `pw_enable_fuzz_test_targets` arg, the `pw_fuzz_tests` group, and `gen_pw_fuzztest_oss_fuzz_wrappers.sh`. Kept as a draft until that lands in connectedhomeip `master`; the build here will fail to configure until then.
