### PR TITLE
gstreamer: update primary e-mail address

### DIFF
--- a/projects/gstreamer/project.yaml
+++ b/projects/gstreamer/project.yaml
@@ -1,6 +1,6 @@
 homepage: "https://gstreamer.freedesktop.org/"
 language: c++
-primary_contact: "gstreamer-security@lists.freedesktop.org"
+primary_contact: "oss-fuzz@gstreamer.org"
 auto_ccs:
  - "bilboed@bilboed.com"
  - "tim@centricular.com"


### PR DESCRIPTION
The security mailing list is no longer in use and generates bounces.

cc @bilboed