### PR TITLE
libiec61850: Fix build of fuzzers

### DIFF
--- a/projects/libiec61850/Dockerfile
+++ b/projects/libiec61850/Dockerfile
@@ -19,4 +19,3 @@ RUN git clone https://github.com/mz-automation/libiec61850
 
 WORKDIR $SRC
 COPY build.sh $SRC/
-COPY fuzz_decode.options $SRC/fuzz_decode.options

--- a/projects/libiec61850/build.sh
+++ b/projects/libiec61850/build.sh
@@ -20,12 +20,15 @@ mkdir build && cd build
 cmake ../
 make
 
-$CC $CFLAGS $LIB_FUZZING_ENGINE ../fuzz/fuzz_mms_decode.c -c \
-	-I../src/iec61850/inc -I../src/mms/inc -I../src/common/inc \
-	-I../hal/inc -I../src/logging
+# Header include dirs (exclude src/vs, whose stdbool.h shim shadows the system one).
+INC="$(find ../src ../hal -name '*.h' -not -path '*/vs/*' -printf '-I%h\n' | sort -u) -Iconfig -I../config"
 
-
-$CXX $CXXFLAGS -fuse-ld=lld $LIB_FUZZING_ENGINE fuzz_mms_decode.o -o $OUT/fuzz_mms_decode ./src/libiec61850.a ./hal/libhal.a
-
-# Copy over the options file
-cp $SRC/fuzz_decode.options $OUT/fuzz_decode.options
+# Build every harness in the upstream fuzz/ directory.
+for src in ../fuzz/*.c; do
+	fuzzer=$(basename "$src" .c)
+	$CC $CFLAGS -include stdbool.h $LIB_FUZZING_ENGINE "$src" -c -o "${fuzzer}.o" $INC
+	$CXX $CXXFLAGS -fuse-ld=lld $LIB_FUZZING_ENGINE "${fuzzer}.o" \
+		-o "$OUT/${fuzzer}" ./src/libiec61850.a ./hal/libhal.a
+	# Disable leak detection for these stateful receive/server harnesses.
+	printf '[asan]\ndetect_leaks=0\n' > "$OUT/${fuzzer}.options"
+done

--- a/projects/libiec61850/fuzz_decode.options
+++ b/projects/libiec61850/fuzz_decode.options
@@ -1,2 +1,0 @@
-[libfuzzer]
-detect_leaks=0


### PR DESCRIPTION
Originally, the build script just compile a single fuzzer, but the upstream maintainers has added 6 more fuzzers in their repository but the build script in OSS-Fuzz is not changed. Thus this PR fixes the build script to compile and execute all fuzzers from the upstream repository for project libie61850.