### PR TITLE
monero: bump OpenSSL dep and remove unused defs

### DIFF
--- a/projects/monero/Dockerfile
+++ b/projects/monero/Dockerfile
@@ -72,8 +72,8 @@ RUN set -ex \
 ENV BOOST_ROOT /usr/local/boost_${BOOST_VERSION}
 
 # OpenSSL
-ARG OPENSSL_VERSION=1.1.1g
-ARG OPENSSL_HASH=ddb04774f1e32f0c49751e21b67216ac87852ceb056b75209af2443400636d46
+ARG OPENSSL_VERSION=1.1.1w
+ARG OPENSSL_HASH=cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8
 RUN set -ex \
     && curl -s -O -L https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
     && echo "${OPENSSL_HASH}  openssl-${OPENSSL_VERSION}.tar.gz" | sha256sum -c \

--- a/projects/monero/build.sh
+++ b/projects/monero/build.sh
@@ -15,22 +15,18 @@
 #
 ################################################################################
 
-export BOOST_ROOT=/src/monero/boost_1_70_0
-export OPENSSL_ROOT_DIR=/src/monero/openssl-1.1.1g
-
 cd monero
-sed -i -e 's/include(FindCcache)/# include(FindCcache)/' CMakeLists.txt
 git submodule init
 git submodule update
 mkdir -p build
 cd build
-export CXXFLAGS="${CXXFLAGS} -fPIC -DBOOST_NO_INCLASS_MEMBER_INITIALIZATION"
 # Upstream monero (commit 65c15857, "cmake: use boost provided module") switched
 # to find_package(Boost ... CONFIG) and dropped its internal
 # `set(Boost_USE_STATIC_RUNTIME ON)`. The OSS-Fuzz image builds Boost with
 # `runtime-link=static`, so config-mode find_package rejects that variant unless
 # Boost_USE_STATIC_RUNTIME is ON. Re-supply it here to match the image's Boost.
-cmake -D OSSFUZZ=ON -D STATIC=ON -D BUILD_TESTS=ON -D USE_LTO=OFF -D ARCH="default" -D Boost_USE_STATIC_RUNTIME=ON ..
+cmake -D OSSFUZZ=ON -D STATIC=ON -D BUILD_TESTS=ON -D USE_LTO=OFF -D ARCH="default" \
+      -D Boost_USE_STATIC_RUNTIME=ON -D USE_COMPILER_CACHE=OFF ..
 
 TESTS="\
   base58_fuzz_tests \


### PR DESCRIPTION
* OpenSSL 1.1.1 has had a *lot* of security patches since 1.1.1g
* `BOOST_ROOT` and `OPENSSL_ROOT_DIR` don't do anything here
* Instead of patching the CMakeLists file (which didn't work), simply set `USE_COMPILER_CACHE=OFF`
* `-fPIC` is the default in Monero already
* `BOOST_NO_INCLASS_MEMBER_INITIALIZATION` isn't needed for compilation AFAICT

SHA256 sum for 1.1.1w can be cross-referenced here: https://mta.openssl.org/pipermail/openssl-announce/2023-September/000274.html