### PR TITLE
Zenoh: Use --depth 1 to decrease the traffic usage

### DIFF
--- a/projects/zenoh/Dockerfile
+++ b/projects/zenoh/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-rust
 
-RUN git clone https://github.com/eclipse-zenoh/zenoh.git
+RUN git clone --depth 1 https://github.com/eclipse-zenoh/zenoh.git
 COPY build.sh $SRC
 
 WORKDIR $SRC/


### PR DESCRIPTION
Here is an error while accessing GitHub.
Use `--depth 1` to avoid retrieving the whole data from GitHub.

```
Step #1 - "build-ad06b35f-e036-4dd4-9731-6330d9858bfa": Status: Downloaded newer image for gcr.io/oss-fuzz-base/base-builder-rust:latest
Step #1 - "build-ad06b35f-e036-4dd4-9731-6330d9858bfa":  ---> ca7fddb1d9ad
Step #1 - "build-ad06b35f-e036-4dd4-9731-6330d9858bfa": Step 2/4 : RUN git clone https://github.com/eclipse-zenoh/zenoh.git
Step #1 - "build-ad06b35f-e036-4dd4-9731-6330d9858bfa":  ---> Running in 50a6806e67b9
Step #1 - "build-ad06b35f-e036-4dd4-9731-6330d9858bfa": [91mCloning into 'zenoh'...
Step #1 - "build-ad06b35f-e036-4dd4-9731-6330d9858bfa": [0m[91mfatal: unable to access 'https://github.com/eclipse-zenoh/zenoh.git/': Failed to connect to github.com port 443: Connection timed out
Step #1 - "build-ad06b35f-e036-4dd4-9731-6330d9858bfa": The command '/bin/sh -c git clone https://github.com/eclipse-zenoh/zenoh.git' returned a non-zero code: 128
Finished Step #1 - "build-ad06b35f-e036-4dd4-9731-6330d9858bfa"
ERROR
ERROR: build step 1 "gcr.io/cloud-builders/docker" failed: step exited with non-zero status: 128
Step #1 - "build-ad06b35f-e036-4dd4-9731-6330d9858bfa": [0m
```

https://oss-fuzz-build-logs.storage.googleapis.com/log-4e660159-0160-4962-a05d-7964e758225e.txt