### PR TITLE
powerdns: Revert the bundling of dnsdist deps

### DIFF
--- a/projects/powerdns/build.sh
+++ b/projects/powerdns/build.sh
@@ -86,15 +86,6 @@ if [ -f dnsdistdist/fuzz_dnsdistcache.cc ]; then
         meson compile -C ${build_dir} fuzz-targets
         # copy the fuzzing target binaries
         find ${build_dir} -type f -executable -name 'fuzz-target-*' -exec cp {} ${OUT}/ \;
-
-        # Bundle dnsdist runtime libraries missing from the runner image.
-        mkdir -p ${OUT}/lib
-        for b in ${OUT}/fuzz-target-dnsdist*; do
-            [ -e "$b" ] || continue
-            ldd "$b" | awk '/=> \/.*(libluajit|libedit|libsodium)/{print $3}' \
-                | xargs -r -I{} cp -n {} ${OUT}/lib/
-            patchelf --set-rpath '$ORIGIN/lib' "$b" 2>/dev/null || true
-        done
     fi
 
     # back to the pdns/ directory


### PR DESCRIPTION
I don't understand the point of this change introduced in 12477273e8d9734cce139fb5dded4957e398e1be, the new fuzzing target mentioned in the PR runs fine for me without it:
```
python3 infra/helper.py run_fuzzer powerdns fuzz-target-dnsdist-ecs
vm.mmap_rnd_bits = 28
/out/fuzz-target-dnsdist-ecs -- -rss_limit_mb=2560 -timeout=25 /tmp/fuzz-target-dnsdist-ecs_corpus < /dev/null
INFO: libFuzzer ignores flags that start with '--'
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 1304339067
INFO: Loaded 1 modules   (22212 inline 8-bit counters): 22212 [0x560bd40efd20, 0x560bd40f53e4),
INFO: Loaded 1 PC tables (22212 PCs): 22212 [0x560bd40f53e8,0x560bd414c028),
INFO:        0 files found in /tmp/fuzz-target-dnsdist-ecs_corpus
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
INFO: A corpus is not provided, starting from an empty corpus
[...]
```

and the existing fuzzing targets were already using the same dependencies.