### PR TITLE
freerdp: Disable LeakSanitizer for new fuzzer

### DIFF
--- a/projects/freerdp/build.sh
+++ b/projects/freerdp/build.sh
@@ -68,6 +68,11 @@ do
     cp $f $OUT/
 done
 
+# Disable leak detection for the RAIL fuzzer (rail_order_recv stream-ownership leak).
+if [ -f $OUT/TestFuzzChannelRail ]; then
+    printf '[asan]\ndetect_leaks=0\n' > $OUT/TestFuzzChannelRail.options
+fi
+
 # Build test
 mkdir $SRC/FreeRDP/build-test
 cd $SRC/FreeRDP/build-test


### PR DESCRIPTION
This PR fixes the build for freerdp to disable the LeakSanitizer for the new fuzzer.