### PR TITLE
Zenoh: stabilize rust coverage builds

### DIFF
--- a/projects/zenoh/build.sh
+++ b/projects/zenoh/build.sh
@@ -35,6 +35,8 @@ package_seed_corpora() {
 run_corpus_generator() {
     local target_dir="$1"
     shift
+    local toolchain="$1"
+    shift
 
     # OSS-Fuzz sets sanitizer-specific RUSTFLAGS/CFLAGS/CXXFLAGS for fuzz
     # builds. The corpus generators are regular helper binaries, and building
@@ -49,24 +51,27 @@ run_corpus_generator() {
         -u CFLAGS \
         -u CXXFLAGS \
         CARGO_TARGET_DIR="${target_dir}" \
-        cargo +nightly run "$@"
+        cargo "${toolchain}" run "$@"
 }
+
+# Needed for coverage to work.
+nightly="+$RUSTUP_TOOLCHAIN"
 
 # Enter the zenoh folder
 cd zenoh
 
 # zenoh-codec
 cd commons/zenoh-codec/fuzz
-run_corpus_generator /tmp/zenoh-codec-corpus --bin gen_all_corpora
-cargo +nightly fuzz build
+run_corpus_generator /tmp/zenoh-codec-corpus "$nightly" --bin gen_all_corpora
+cargo "$nightly" fuzz build
 
 package_seed_corpora
 cd ../../../
 
 # zenoh-protocol
 cd commons/zenoh-protocol/fuzz
-run_corpus_generator /tmp/zenoh-protocol-corpus --bin gen_endpoint_corpus
-cargo +nightly fuzz build
+run_corpus_generator /tmp/zenoh-protocol-corpus "$nightly" --bin gen_endpoint_corpus
+cargo "$nightly" fuzz build
 
 package_seed_corpora
 cd ../../../

--- a/projects/zenoh/project.yaml
+++ b/projects/zenoh/project.yaml
@@ -6,6 +6,9 @@ sanitizers:
 fuzzing_engines:
   - libfuzzer
 language: rust
+coverage_extra_args: >
+  -ignore-filename-regex=.*/registry/src/.*crates.io.*/.*
+  -ignore-filename-regex=.*/rustc/.*
 auto_ccs:
   - "sasha@zettascale.space"
   - "julien@zettascale.space"


### PR DESCRIPTION
There is a failure in the coverage log
https://oss-fuzz-build-logs.storage.googleapis.com/log-c8e05841-61c3-4a6d-9ebe-7b049feb8d0e.txt

```
Step #5: Already have image (with digest): gcr.io/oss-fuzz-base/base-runner
Step #5: warning [/corpus/endpoint_from_str.zip]:  zipfile is empty
Step #5: Failed to unpack the corpus for endpoint_from_str. This usually means that corpus backup for a particular fuzz target does not exist. If a fuzz target was added in the last 24 hours, please wait one more day. Otherwise, something is wrong with the fuzz target or the infrastructure, and corpus pruning task does not finish successfully.
Step #5: warning [/corpus/network_message.zip]:  zipfile is empty
Step #5: Failed to unpack the corpus for network_message. This usually means that corpus backup for a particular fuzz target does not exist. If a fuzz target was added in the last 24 hours, please wait one more day. Otherwise, something is wrong with the fuzz target or the infrastructure, and corpus pruning task does not finish successfully.
Step #5: warning [/corpus/scouting_message.zip]:  zipfile is empty
Step #5: Failed to unpack the corpus for scouting_message. This usually means that corpus backup for a particular fuzz target does not exist. If a fuzz target was added in the last 24 hours, please wait one more day. Otherwise, something is wrong with the fuzz target or the infrastructure, and corpus pruning task does not finish successfully.
Step #5: warning [/corpus/transport_message.zip]:  zipfile is empty
Step #5: Failed to unpack the corpus for transport_message. This usually means that corpus backup for a particular fuzz target does not exist. If a fuzz target was added in the last 24 hours, please wait one more day. Otherwise, something is wrong with the fuzz target or the infrastructure, and corpus pruning task does not finish successfully.
Step #5: ********************************************************************************
Step #5: Code coverage report generation failed.
Step #5: To reproduce, run:
Step #5: python infra/helper.py build_image zenoh
Step #5: python infra/helper.py build_fuzzers --sanitizer coverage zenoh
Step #5: python infra/helper.py coverage zenoh
Step #5: ********************************************************************************
Finished Step #5
ERROR
ERROR: build step 5 "gcr.io/oss-fuzz-base/base-runner" failed: step exited with non-zero status: 1
```

Refer to [wasmi](https://github.com/google/oss-fuzz/tree/master/projects/wasmi), we should make some updates, including `coverage_extra_args` in `project.yaml` and `nightly="+$RUSTUP_TOOLCHAIN"` in `build.sh`
