### PR TITLE
wabt: Remove wasm-decompile usage

### DIFF
--- a/projects/wabt/read_binary_ir_fuzzer.cc
+++ b/projects/wabt/read_binary_ir_fuzzer.cc
@@ -20,7 +20,6 @@
 #include "wabt/binary-reader-ir.h"
 #include "wabt/binary-reader.h"
 #include "wabt/binary-writer.h"
-#include "wabt/decompiler.h"
 #include "wabt/ir.h"
 #include "wabt/option-parser.h"
 #include "wabt/stream.h"
@@ -42,9 +41,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   if (wabt::Succeeded(wabt::ReadBinaryIr("", text.data(), text.size(), options, &errors, &module))) {
     wabt::ValidateOptions validate_options(features);
     if (wabt::Succeeded(wabt::ValidateModule(&module, &errors, validate_options))) {
-      wabt::DecompileOptions decompile_options;
-      wabt::Decompile(module, decompile_options);
-
       wabt::MemoryStream stream;
       wabt::WriteBinaryOptions write_binary_options;
       wabt::WriteBinaryModule(&stream, &module, write_binary_options);


### PR DESCRIPTION
I'm trying delete this feature in https://github.com/WebAssembly/wabt/pull/2769