### PR TITLE
trust-dns: Enable debug assertions

### DIFF
--- a/projects/trust-dns/build.sh
+++ b/projects/trust-dns/build.sh
@@ -15,5 +15,5 @@
 #
 ################################################################################
 
-cargo fuzz build -O
+cargo fuzz build -O --debug-assertions
 cp fuzz/target/x86_64-unknown-linux-gnu/release/message $OUT/


### PR DESCRIPTION
This enables debug assertions when building Hickory DNS (née Trust-DNS). I recently caught an [interesting bug](https://github.com/hickory-dns/hickory-dns/issues/3743) by running a debug build of a fuzzer locally, so we may stand to benefit from doing the same in OSS-Fuzz.