### PR TITLE
Apache POI: Update to JDK 17

### DIFF
--- a/projects/apache-poi/Dockerfile
+++ b/projects/apache-poi/Dockerfile
@@ -24,12 +24,13 @@ rm -rf maven.zip
 ENV MVN $SRC/maven-3.9.12/apache-maven-3.9.12/bin/mvn
 ENV TARGET_PACKAGE_PREFIX org.apache.poi.*:org.apache.xmlbeans.*
 
-# Newer JDK releases are listed at https://github.com/adoptium/temurin11-binaries/releases/
-RUN curl -L https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.29%2B7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.29_7.tar.gz -o OpenJDK11U-jdk_x64_linux_hotspot_11.0.29_7.tar.gz && \
-  tar xvf OpenJDK11U-jdk_x64_linux_hotspot_11.0.29_7.tar.gz && \
-  rm -rf OpenJDK11U-jdk_x64_linux_hotspot_11.0.29_7.tar.gz
+# Newer JDK releases are listed at https://adoptium.net/en-GB/temurin/releases?version=17&os=linux&arch=x64&package=jdk
+# https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_x64_linux_hotspot_17.0.19_10.tar.gz
+RUN curl -L https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_x64_linux_hotspot_17.0.19_10.tar.gz -o OpenJDK17U-jdk_x64_linux_hotspot_17.0.19_10.tar.gz && \
+  tar xvf OpenJDK17U-jdk_x64_linux_hotspot_17.0.19_10.tar.gz && \
+  rm -rf OpenJDK17U-jdk_x64_linux_hotspot_17.0.19_10.tar.gz
 
-ENV JAVA_HOME_11 $SRC/jdk-11.0.29+7
+ENV JAVA_HOME_17 $SRC/jdk-17.0.19+10
 
 WORKDIR ${SRC}
 #
@@ -59,7 +60,7 @@ RUN cd ${SRC}/poi && rm `find \
 
 # run a small Gradle task to perform the downloading of Gradle distribution here
 # this avoids this step when using the Docker image later
-RUN cd ${SRC}/poi && chmod a+x gradlew && JAVA_HOME=$JAVA_HOME_11 ./gradlew wrapper
+RUN cd ${SRC}/poi && chmod a+x gradlew && JAVA_HOME=$JAVA_HOME_17 ./gradlew wrapper
 
 ADD pom.xml build.sh ${SRC}/
 ADD src/ ${SRC}/src/

--- a/projects/apache-poi/build.sh
+++ b/projects/apache-poi/build.sh
@@ -45,7 +45,7 @@ pushd "/tmp"
 	${MVN} install:install-file -Dfile=${JAZZER_API_PATH} \
 		-DgroupId="com.code-intelligence" \
 		-DartifactId="jazzer-api" \
-		-Dversion="0.29.1" \
+		-Dversion="0.30.0" \
 		-Dpackaging=jar \
 		 ${MVN_FLAGS}
 popd

--- a/projects/apache-poi/build.sh
+++ b/projects/apache-poi/build.sh
@@ -18,7 +18,7 @@
 MVN_FLAGS="--no-transfer-progress -DskipTests"
 ALL_JARS=""
 LIBRARY_NAME="poi"
-GRADLE_FLAGS="-x javadoc -x test -Dfile.encoding=UTF-8 -Porg.gradle.java.installations.fromEnv=JAVA_HOME_11 --console=plain"
+GRADLE_FLAGS="-x javadoc -x test -Dfile.encoding=UTF-8 -Porg.gradle.java.installations.fromEnv=JAVA_HOME_17 --console=plain"
 
 echo Copy libraries for java.awt in place
 ls /usr/lib/x86_64-linux-gnu/
@@ -37,8 +37,8 @@ cp /usr/lib/x86_64-linux-gnu/libXext.so.6* \
 echo Main Java
 ${JAVA_HOME}/bin/java -version
 
-echo Java 11
-${JAVA_HOME_11}/bin/java -version
+echo Java 17
+${JAVA_HOME_17}/bin/java -version
 
 # Install the build servers' jazzer-api into the maven repository.
 pushd "/tmp"

--- a/projects/apache-poi/pom.xml
+++ b/projects/apache-poi/pom.xml
@@ -44,7 +44,7 @@
 		<dependency>
 			<groupId>com.code-intelligence</groupId>
 			<artifactId>jazzer-api</artifactId>
-			<version>0.29.1</version>
+			<version>0.30.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>
@@ -84,7 +84,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.25.3</version>
+			<version>2.26.0</version>
 		</dependency>
 
 		<!-- Not a real dependency of Apache POI, but can be triggered via malformed documents -->


### PR DESCRIPTION
Apache POI switched to minimum JDK 17 on the development branch, 
thus oss-fuzz should also use this version otherwise compilation of 
sources fails.

See the [current build failure](https://oss-fuzz-build-logs.storage.googleapis.com/log-f48628f9-5c14-42cf-a357-4b7d54cd353c.txt)

Also update Jazzer and Log4j to the latest versions.