### PR TITLE
[connectedhomeip] Enable MemorySanitizer

### DIFF
--- a/projects/connectedhomeip/Dockerfile
+++ b/projects/connectedhomeip/Dockerfile
@@ -29,10 +29,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN rustup install nightly
 RUN rustup default nightly
 
-# TODO(MSAN, DO NOT MERGE as-is): until the chip-side MSAN-fuzz changes land upstream, clone the
-# fork branch that carries `scripts/build/build_msan_sysroot.sh --oss-fuzz` (used by the sysroot
-# bake below) and the MSAN fuzz wiring. Revert to project-chip/connectedhomeip master once merged.
-RUN git clone --depth=1 -b AA/msan-fuzztests https://github.com/Alami-Amine/connectedhomeip.git connectedhomeip
+RUN git clone --depth=1 https://github.com/project-chip/connectedhomeip.git connectedhomeip
 
 # PW_PROJECT_ROOT is used in requirements.build.txt
 ENV PW_PROJECT_ROOT=$SRC/connectedhomeip
@@ -47,13 +44,9 @@ RUN cd $SRC/connectedhomeip && scripts/checkout_submodules.py --shallow --platfo
 SHELL ["/bin/bash", "-c"]
 RUN cd $SRC/connectedhomeip && . scripts/bootstrap.sh
 
-# Tooling for the MSAN-instrumented dependency sysroot that build.sh builds when
-# SANITIZER=memory (see build.sh). The sysroot is built in build.sh -- NOT here -- because the
-# deps' ./configure / meson run MSAN-instrumented test binaries, which require ASLR entropy to be
-# lowered (vm.mmap_rnd_bits=28). The OSS-Fuzz `compile` wrapper sets that and runs the build
-# privileged; `docker build` can neither sysctl nor disable ASLR (seccomp blocks personality()),
-# so a Dockerfile-time bake fails intermittently. meson + the python `packaging` module are
-# GLib's build requirements; ninja/wget/pkg-config were installed above.
+# meson + packaging: GLib build deps for the MSAN dependency sysroot that build.sh builds when
+# SANITIZER=memory (built there, not here -- the deps' configure/meson run instrumented binaries
+# that need lowered ASLR, which only the privileged `compile` step provides).
 RUN pip3 install meson packaging
 
 COPY build.sh $SRC/

--- a/projects/connectedhomeip/Dockerfile
+++ b/projects/connectedhomeip/Dockerfile
@@ -21,7 +21,7 @@ FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && \
     apt-get install -y --no-install-recommends pkg-config libssl-dev libdbus-1-dev libglib2.0-dev libglib2.0-0\
         libavahi-client-dev ninja-build libmount-dev libblkid-dev \
-        unzip libgirepository1.0-dev libcairo2-dev libreadline-dev patchelf file libevent-dev
+        unzip libgirepository1.0-dev libcairo2-dev libreadline-dev patchelf file libevent-dev wget
 
 # Install Rust for building `cryptography` python package when bootstraping pigweed
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
@@ -29,7 +29,10 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN rustup install nightly
 RUN rustup default nightly
 
-RUN git clone --depth=1 https://github.com/project-chip/connectedhomeip.git connectedhomeip
+# TODO(MSAN, DO NOT MERGE as-is): until the chip-side MSAN-fuzz changes land upstream, clone the
+# fork branch that carries `scripts/build/build_msan_sysroot.sh --oss-fuzz` (used by the sysroot
+# bake below) and the MSAN fuzz wiring. Revert to project-chip/connectedhomeip master once merged.
+RUN git clone --depth=1 -b AA/msan-fuzztests https://github.com/Alami-Amine/connectedhomeip.git connectedhomeip
 
 # PW_PROJECT_ROOT is used in requirements.build.txt
 ENV PW_PROJECT_ROOT=$SRC/connectedhomeip
@@ -43,5 +46,14 @@ RUN cd $SRC/connectedhomeip && scripts/checkout_submodules.py --shallow --platfo
 # Bootstrap pigweed environment
 SHELL ["/bin/bash", "-c"]
 RUN cd $SRC/connectedhomeip && . scripts/bootstrap.sh
+
+# Tooling for the MSAN-instrumented dependency sysroot that build.sh builds when
+# SANITIZER=memory (see build.sh). The sysroot is built in build.sh -- NOT here -- because the
+# deps' ./configure / meson run MSAN-instrumented test binaries, which require ASLR entropy to be
+# lowered (vm.mmap_rnd_bits=28). The OSS-Fuzz `compile` wrapper sets that and runs the build
+# privileged; `docker build` can neither sysctl nor disable ASLR (seccomp blocks personality()),
+# so a Dockerfile-time bake fails intermittently. meson + the python `packaging` module are
+# GLib's build requirements; ninja/wget/pkg-config were installed above.
+RUN pip3 install meson packaging
 
 COPY build.sh $SRC/

--- a/projects/connectedhomeip/build.sh
+++ b/projects/connectedhomeip/build.sh
@@ -33,15 +33,11 @@ OSS_FUZZ_CXX="${CXX:-}"
 OSS_FUZZ_CFLAGS="${CFLAGS:-}"
 OSS_FUZZ_CXXFLAGS="${CXXFLAGS:-}"
 
-# MemorySanitizer needs every linked dependency instrumented. Build the MSAN-instrumented
-# dependency sysroot (GLib/OpenSSL/zlib/libffi/pcre2) HERE rather than in the Dockerfile: the
-# deps' ./configure and meson run MSAN-instrumented test binaries, which require lowered ASLR
-# entropy. The OSS-Fuzz `compile` wrapper sets vm.mmap_rnd_bits=28 and runs this privileged
-# before invoking build.sh; `docker build` can do neither, so a Dockerfile-time bake fails.
-# Done before activate.sh so it uses OSS-Fuzz's clang ($CC/$CFLAGS, which already carry
-# -fsanitize=memory) and the system meson/ninja. libc++ is NOT built -- OSS-Fuzz ships an
-# instrumented one at /usr/msan (applied via -stdlib=libc++); only the C deps are built, with
-# the same $CFLAGS as the fuzzers. Adds ~5-15 min to the memory build.
+# MSAN needs every linked dependency instrumented. Build the MSAN-instrumented sysroot
+# (GLib/OpenSSL/zlib/libffi/pcre2) here -- before activate.sh, so it uses OSS-Fuzz's clang and
+# $CFLAGS. Not in the Dockerfile: the deps' configure/meson run instrumented test binaries that
+# need vm.mmap_rnd_bits=28, which only the privileged `compile` step provides. libc++ is skipped
+# (OSS-Fuzz ships an instrumented one at /usr/msan). Adds ~5-15 min to the memory build.
 MSAN_SYSROOT="$SRC/msan-sysroot"
 if [ "${SANITIZER:-}" == "memory" ]; then
   scripts/build/build_msan_sysroot.sh --oss-fuzz --out-dir "$MSAN_SYSROOT"
@@ -62,16 +58,12 @@ export CXX="$OSS_FUZZ_CXX"
 export CFLAGS="$OSS_FUZZ_CFLAGS"
 export CXXFLAGS="$OSS_FUZZ_CXXFLAGS"
 
-# MemorySanitizer: link the instrumented dependency sysroot built above instead of the
-# uninstrumented system GLib/OpenSSL/zlib/etc, and apply the MSAN ignorelist. Without
-# instrumented dependencies, MSAN reports endless false positives from uninstrumented library
-# internals -- the reason MSAN was previously disabled for this project. PKG_CONFIG_PATH makes
-# Matter's GN pick up the instrumented static libs; it must be exported before `gn gen`.
-#
-# -DCHIP_MEMORY_SANITIZER_ENABLED=1 turns on Matter's in-tree MSan instrumentation guards (e.g.
-# the if_nameindex() unpoisoning in InetInterfaceImplDefault.cpp). That macro is normally defined
-# only by the GN sanitize_memory config (the local MSan unit-test build); OSS-Fuzz enables MSan
-# via $CFLAGS instead, so we set it here. It flows to every TU through the global oss_fuzz config.
+# Point pkg-config at the instrumented sysroot (before `gn gen`) so Matter links the instrumented
+# static deps, not the uninstrumented system libs, and apply the MSAN ignorelist -- otherwise MSAN
+# drowns in false positives from uninstrumented deps (why it was disabled here before).
+# -DCHIP_MEMORY_SANITIZER_ENABLED=1 enables Matter's in-tree MSan guards (e.g. if_nameindex
+# unpoisoning); the GN sanitize_memory config normally defines it, but OSS-Fuzz drives MSan via
+# $CFLAGS, so set it here.
 if [ "${SANITIZER:-}" == "memory" ]; then
   export PKG_CONFIG_PATH="$MSAN_SYSROOT/lib/pkgconfig:$MSAN_SYSROOT/lib64/pkgconfig:${PKG_CONFIG_PATH:-}"
   msan_ignorelist="$SRC/connectedhomeip/build/config/compiler/msan_ignorelist.txt"
@@ -134,13 +126,9 @@ if [[ "${FUZZING_ENGINE:-libfuzzer}" == "libfuzzer" ]]; then
   fi
 fi
 
-# Copy some GLib and GIO runtime libraries into $OUT so fuzzed all-clusters app can run under
-# OSS-Fuzz base-runner, which does not provide these libraries.
-#
-# Skipped for MemorySanitizer: these are the uninstrumented system GLib libraries, and injecting
-# them at runtime reintroduces exactly the false positives MSAN was disabled for. The MSAN build
-# links the instrumented GLib statically from the sysroot (see the SANITIZER==memory block
-# above), so no runtime .so is needed.
+# Copy GLib/GIO runtime libs into $OUT so the all-clusters app runs under base-runner (which lacks
+# them). Skipped for MSAN: these uninstrumented libs would reintroduce the false positives MSAN
+# was disabled for -- the MSAN build links instrumented GLib statically from the sysroot instead.
 if [ "${SANITIZER:-}" != "memory" ]; then
   mkdir -p $OUT/lib
   cp /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0 $OUT/lib/

--- a/projects/connectedhomeip/build.sh
+++ b/projects/connectedhomeip/build.sh
@@ -33,6 +33,20 @@ OSS_FUZZ_CXX="${CXX:-}"
 OSS_FUZZ_CFLAGS="${CFLAGS:-}"
 OSS_FUZZ_CXXFLAGS="${CXXFLAGS:-}"
 
+# MemorySanitizer needs every linked dependency instrumented. Build the MSAN-instrumented
+# dependency sysroot (GLib/OpenSSL/zlib/libffi/pcre2) HERE rather than in the Dockerfile: the
+# deps' ./configure and meson run MSAN-instrumented test binaries, which require lowered ASLR
+# entropy. The OSS-Fuzz `compile` wrapper sets vm.mmap_rnd_bits=28 and runs this privileged
+# before invoking build.sh; `docker build` can do neither, so a Dockerfile-time bake fails.
+# Done before activate.sh so it uses OSS-Fuzz's clang ($CC/$CFLAGS, which already carry
+# -fsanitize=memory) and the system meson/ninja. libc++ is NOT built -- OSS-Fuzz ships an
+# instrumented one at /usr/msan (applied via -stdlib=libc++); only the C deps are built, with
+# the same $CFLAGS as the fuzzers. Adds ~5-15 min to the memory build.
+MSAN_SYSROOT="$SRC/msan-sysroot"
+if [ "${SANITIZER:-}" == "memory" ]; then
+  scripts/build/build_msan_sysroot.sh --oss-fuzz --out-dir "$MSAN_SYSROOT"
+fi
+
 # Activate Pigweed environment
 set +u
 PW_ENVSETUP_QUIET=1 source scripts/activate.sh
@@ -47,6 +61,18 @@ export CC="$OSS_FUZZ_CC"
 export CXX="$OSS_FUZZ_CXX"
 export CFLAGS="$OSS_FUZZ_CFLAGS"
 export CXXFLAGS="$OSS_FUZZ_CXXFLAGS"
+
+# MemorySanitizer: link the instrumented dependency sysroot built above instead of the
+# uninstrumented system GLib/OpenSSL/zlib/etc, and apply the MSAN ignorelist. Without
+# instrumented dependencies, MSAN reports endless false positives from uninstrumented library
+# internals -- the reason MSAN was previously disabled for this project. PKG_CONFIG_PATH makes
+# Matter's GN pick up the instrumented static libs; it must be exported before `gn gen`.
+if [ "${SANITIZER:-}" == "memory" ]; then
+  export PKG_CONFIG_PATH="$MSAN_SYSROOT/lib/pkgconfig:$MSAN_SYSROOT/lib64/pkgconfig:${PKG_CONFIG_PATH:-}"
+  msan_ignorelist="$SRC/connectedhomeip/build/config/compiler/msan_ignorelist.txt"
+  export CFLAGS="$CFLAGS -fsanitize-ignorelist=$msan_ignorelist"
+  export CXXFLAGS="$CXXFLAGS -fsanitize-ignorelist=$msan_ignorelist"
+fi
 
 # Create a build directory with the following options:
 # - `oss_fuzz` enables OSS-Fuzz build
@@ -103,17 +129,25 @@ if [[ "${FUZZING_ENGINE:-libfuzzer}" == "libfuzzer" ]]; then
   fi
 fi
 
-# Copy some GLib and GIO runtime libraries into $OUT so fuzzed all-clusters app can run under OSS-Fuzz base-runner, which does not provide these libraries.
-mkdir -p $OUT/lib
-cp /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0 $OUT/lib/
-cp /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0 $OUT/lib/
-cp /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0 $OUT/lib/
-cp /usr/lib/x86_64-linux-gnu/libgmodule-2.0.so.0 $OUT/lib/
+# Copy some GLib and GIO runtime libraries into $OUT so fuzzed all-clusters app can run under
+# OSS-Fuzz base-runner, which does not provide these libraries.
+#
+# Skipped for MemorySanitizer: these are the uninstrumented system GLib libraries, and injecting
+# them at runtime reintroduces exactly the false positives MSAN was disabled for. The MSAN build
+# links the instrumented GLib statically from the sysroot (see the SANITIZER==memory block
+# above), so no runtime .so is needed.
+if [ "${SANITIZER:-}" != "memory" ]; then
+  mkdir -p $OUT/lib
+  cp /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0 $OUT/lib/
+  cp /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0 $OUT/lib/
+  cp /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0 $OUT/lib/
+  cp /usr/lib/x86_64-linux-gnu/libgmodule-2.0.so.0 $OUT/lib/
 
-# Set an rpath on the fuzz target binaries (ELF only; the FuzzTest wrapper scripts and the
-# non-executable shared FuzzTest binaries are matched too — patchelf on the shared ELF, the
-# `file ... ELF` guard skips the shell-script wrappers).
-for f in $OUT/fuzz-*; do
-    file "$f" | grep -q "ELF" && patchelf --set-rpath '$ORIGIN/lib' "$f"
-done
-patchelf --set-rpath '$ORIGIN' $OUT/lib/*.so* 2>/dev/null
+  # Set an rpath on the fuzz target binaries (ELF only; the FuzzTest wrapper scripts and the
+  # non-executable shared FuzzTest binaries are matched too — patchelf on the shared ELF, the
+  # `file ... ELF` guard skips the shell-script wrappers).
+  for f in $OUT/fuzz-*; do
+      file "$f" | grep -q "ELF" && patchelf --set-rpath '$ORIGIN/lib' "$f"
+  done
+  patchelf --set-rpath '$ORIGIN' $OUT/lib/*.so* 2>/dev/null
+fi

--- a/projects/connectedhomeip/build.sh
+++ b/projects/connectedhomeip/build.sh
@@ -67,11 +67,16 @@ export CXXFLAGS="$OSS_FUZZ_CXXFLAGS"
 # instrumented dependencies, MSAN reports endless false positives from uninstrumented library
 # internals -- the reason MSAN was previously disabled for this project. PKG_CONFIG_PATH makes
 # Matter's GN pick up the instrumented static libs; it must be exported before `gn gen`.
+#
+# -DCHIP_MEMORY_SANITIZER_ENABLED=1 turns on Matter's in-tree MSan instrumentation guards (e.g.
+# the if_nameindex() unpoisoning in InetInterfaceImplDefault.cpp). That macro is normally defined
+# only by the GN sanitize_memory config (the local MSan unit-test build); OSS-Fuzz enables MSan
+# via $CFLAGS instead, so we set it here. It flows to every TU through the global oss_fuzz config.
 if [ "${SANITIZER:-}" == "memory" ]; then
   export PKG_CONFIG_PATH="$MSAN_SYSROOT/lib/pkgconfig:$MSAN_SYSROOT/lib64/pkgconfig:${PKG_CONFIG_PATH:-}"
   msan_ignorelist="$SRC/connectedhomeip/build/config/compiler/msan_ignorelist.txt"
-  export CFLAGS="$CFLAGS -fsanitize-ignorelist=$msan_ignorelist"
-  export CXXFLAGS="$CXXFLAGS -fsanitize-ignorelist=$msan_ignorelist"
+  export CFLAGS="$CFLAGS -fsanitize-ignorelist=$msan_ignorelist -DCHIP_MEMORY_SANITIZER_ENABLED=1"
+  export CXXFLAGS="$CXXFLAGS -fsanitize-ignorelist=$msan_ignorelist -DCHIP_MEMORY_SANITIZER_ENABLED=1"
 fi
 
 # Create a build directory with the following options:

--- a/projects/connectedhomeip/project.yaml
+++ b/projects/connectedhomeip/project.yaml
@@ -12,9 +12,10 @@ auto_ccs:
 sanitizers:
   - address
   - undefined
-# MemorySanitizer is deactivated due to false positives related to Glib
-# For MSan; Glib and all others libs should be compiled with MSan
-#  - memory
+  # MemorySanitizer: the dependencies (GLib, OpenSSL, zlib, libffi, pcre2) are built
+  # instrumented in build.sh via build_msan_sysroot.sh --oss-fuzz, resolving the prior
+  # GLib-related false positives that previously had MSan disabled here.
+  - memory
 fuzzing_engines:
   - libfuzzer
   - honggfuzz


### PR DESCRIPTION
#### What

Re-enables the `memory` (MemorySanitizer) sanitizer for `connectedhomeip`.

MSAN requires every linked object to be instrumented. When `SANITIZER=memory`, `build.sh` builds an MSAN-instrumented dependency sysroot (GLib, OpenSSL, zlib, libffi, pcre2) via `scripts/build/build_msan_sysroot.sh --oss-fuzz` and links the fuzzers against it. libc++ is **not** rebuilt — OSS-Fuzz's instrumented `/usr/msan` libc++ is used via `-stdlib=libc++`. This resolves the GLib-related false positives that previously had MSan disabled here. Both the legacy libFuzzer targets and the pw_fuzzer/FuzzTest targets pick up MSAN through the existing env-driven (`$CFLAGS`) build path.

The chip-side support (`scripts/build/build_msan_sysroot.sh --oss-fuzz` and the fuzz-target wiring) is merged in `project-chip/connectedhomeip`, so the Dockerfile builds against its `master`.

#### Why the dependency build is in build.sh, not the Dockerfile

The dependencies' `./configure`/meson steps run MSAN-instrumented test binaries, which require lowered ASLR entropy (`vm.mmap_rnd_bits=28`) and privilege — both of which the `compile` wrapper provides at build time but `docker build` cannot.
