### PR TITLE
fix(security): restrict main_repo URL to trusted hosting domains to prevent SSRF

### DIFF
--- a/infra/pr_helper.py
+++ b/infra/pr_helper.py
@@ -65,18 +65,60 @@ def is_known_contributor(content, email):
           email in content.get('auto_ccs', []))
 
 
+# Trusted repository hosting domains for OSS-Fuzz projects.
+# The criticality_score tool fetches data from these URLs; restricting to
+# known-good domains prevents SSRF via attacker-controlled project.yaml.
+_TRUSTED_REPO_DOMAINS = frozenset([
+    'github.com',
+    'gitlab.com',
+    'bitbucket.org',
+    'chromium.googlesource.com',
+    'android.googlesource.com',
+    'boringssl.googlesource.com',
+    'fuchsia.googlesource.com',
+    'dart.googlesource.com',
+    'go.googlesource.com',
+    'skia.googlesource.com',
+    'swiftpackageindex.com',
+    'savannah.gnu.org',
+    'git.savannah.gnu.org',
+    'sourceware.org',
+])
+
+
 def _sanitize_repo_url(url):
-  """Sanitizes a repository URL from project.yaml."""
+  """Sanitizes and validates a repository URL from project.yaml.
+
+  Security: restricts repo URLs to trusted hosting domains to prevent SSRF.
+  The criticality_score subprocess makes outbound HTTP requests to the
+  supplied URL; an attacker controlling project.yaml in a PR could supply
+  an arbitrary URL to probe internal network resources or exfiltrate runner
+  metadata.
+  """
   if url is None:
     return None
   url = str(url)
   for char in ('\n', '\r', '\x00'):
     url = url.replace(char, '')
-  # Support SSH-style URLs (git@host:path).
+  # Support SSH-style URLs (git@host:path) for known domains only.
   if url.startswith('git@'):
+    host = url[4:].split(':')[0]
+    if host not in _TRUSTED_REPO_DOMAINS:
+      return None
     return url
   parsed = urlparse(url)
   if parsed.scheme not in ('https', 'http', 'git') or not parsed.netloc:
+    return None
+  # Restrict to trusted repository hosting domains.
+  netloc = parsed.netloc.lower()
+  # Strip port if present.
+  hostname = netloc.split(':')[0]
+  # Allow exact matches and subdomains of trusted domains.
+  is_trusted = any(
+      hostname == domain or hostname.endswith('.' + domain)
+      for domain in _TRUSTED_REPO_DOMAINS
+  )
+  if not is_trusted:
     return None
   return parsed.geturl()
 


### PR DESCRIPTION
## Summary

Adds a domain allowlist to `_sanitize_repo_url()` in `infra/pr_helper.py` to prevent Server-Side Request Forgery (SSRF) via attacker-controlled `main_repo` URLs in new project PRs.

## Vulnerability Details

When a contributor opens a PR to add a new OSS-Fuzz project, `pr_helper.py` reads the fork's `project.yaml` via the GitHub API and passes `main_repo` to the `criticality_score` subprocess:

```python
new_project = github.get_integrated_project_info()  # reads fork's project.yaml
repo_url = _sanitize_repo_url(new_project.get('main_repo'))
report = subprocess.run([CRITICALITY_SCORE_PATH, ..., repo_url], ...)
```

The `criticality_score` binary makes real outbound HTTP requests to compute project metrics. The previous `_sanitize_repo_url` only validated URL scheme (`https`/`http`/`git`) and netloc presence — it accepted **any hostname**, including attacker-controlled servers.

**Attack:** Open a PR adding a project with:
```yaml
main_repo: https://attacker.example.com/collect?runner=oss-fuzz
```

The `criticality_score` binary will connect to `attacker.example.com` from the GitHub Actions runner, enabling:
- **SSRF**: probe internal network resources (cloud metadata at `169.254.169.254`, internal services)
- **IP/environment disclosure** of the runner
- **Timing-based network topology mapping**

**Trigger:** Any GitHub user can open a PR to add a new OSS-Fuzz project. No maintainer action required to trigger the workflow — it fires automatically on `pull_request_target` when `projects/**` paths change.

## Fix

Added `_TRUSTED_REPO_DOMAINS` — an explicit allowlist of known repository hosting services (GitHub, GitLab, Bitbucket, various `*.googlesource.com` domains, etc.). Only URLs whose hostname exactly matches or is a subdomain of a trusted domain are permitted. SSH-style `git@` URLs are restricted to the same allowlist.

## Testing

Existing `pr_helper_test.py` covers URL sanitization. No behavior change for valid project URLs pointing to trusted hosts.