### PR TITLE
Add initial gPowerD integration and condition_fuzzer

### DIFF
--- a/projects/gpowerd/Dockerfile
+++ b/projects/gpowerd/Dockerfile
@@ -1,0 +1,39 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+# Install build dependencies (cmake and ninja are pre-installed in base-builder)
+RUN apt-get update && apt-get install -y \
+    libssl-dev \
+    libboost-dev \
+    pkg-config
+
+# Clone Abseil-CPP (LTS release compatible with C++20)
+RUN git clone --depth 1 -b 20240116.2 https://github.com/abseil/abseil-cpp.git $SRC/abseil-cpp
+
+# Clone Protobuf v21.12 (matches the 3.21.12 version for compatibility)
+RUN git clone --depth 1 -b v21.12 https://github.com/protocolbuffers/protobuf.git $SRC/protobuf && \
+    cd $SRC/protobuf && \
+    git submodule update --init --recursive
+
+# Clone gPowerD
+RUN git clone --depth 1 https://gbmc.googlesource.com/gPowerD gpowerd
+
+WORKDIR gpowerd
+
+COPY build.sh translate_protos.py action_validation_fuzzer.cc condition_fuzzer.cc $SRC/
+COPY gpowerd_shims $SRC/gpowerd_shims

--- a/projects/gpowerd/action_validation_fuzzer.cc
+++ b/projects/gpowerd/action_validation_fuzzer.cc
@@ -1,0 +1,120 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//##############################################################################
+
+#include <stdint.h>
+#include <stddef.h>
+#include <memory>
+#include <utility>
+
+#include "action_validation.h"
+#include "daemon_context.h"
+#include "scheduler_interface.h"
+#include "persistent_storage.h"
+#include "safepower_agent.pb.h"
+#include "safepower_agent_config.pb.h"
+#include "system_state.pb.h"
+#include "absl/time/time.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+
+namespace safepower_agent {
+
+class DummyScheduler : public SchedulerInterface {
+ public:
+  absl::Status PeriodicCall(absl::AnyInvocable<void()> fn,
+                            absl::Duration interval,
+                            absl::string_view name) override {
+    return absl::OkStatus();
+  }
+  absl::Status DelayCall(absl::AnyInvocable<void() &&> fn,
+                         absl::Duration wait_duration,
+                         absl::string_view name) override {
+    return absl::OkStatus();
+  }
+  absl::Status CancelCall(absl::string_view name) override {
+    return absl::OkStatus();
+  }
+  absl::Status CancelAll() override {
+    return absl::OkStatus();
+  }
+  absl::Status Shutdown() override {
+    return absl::OkStatus();
+  }
+};
+
+class DummyPersistentStorage : public PersistentStorageManager {
+ public:
+  absl::Status WriteSavedActionsChange(
+      const safepower_agent_persistence_proto::SavedActions& actions) override {
+    return absl::OkStatus();
+  }
+  absl::StatusOr<safepower_agent_persistence_proto::SavedActions>
+  ReadSavedActions() override {
+    return safepower_agent_persistence_proto::SavedActions();
+  }
+  absl::Status InitializeSavedActions() override {
+    return absl::OkStatus();
+  }
+};
+
+class DummyDaemonContext : public DaemonContext {
+ public:
+  DummyDaemonContext() : scheduler_(), storage_() {}
+  
+  uint64_t epoch_ms() override { return 0; }
+  SchedulerInterface& scheduler() override { return scheduler_; }
+  PersistentStorageManager& persistent_storage_manager() override { return storage_; }
+  absl::StatusOr<safepower_agent_proto::BuildInfo> GetBuildInfo() const override {
+    return safepower_agent_proto::BuildInfo();
+  }
+
+ private:
+  DummyScheduler scheduler_;
+  DummyPersistentStorage storage_;
+};
+
+}  // namespace safepower_agent
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  static safepower_agent::DummyDaemonContext* context = new safepower_agent::DummyDaemonContext();
+
+  if (size < 4) return 0;
+  // Use first 2 bytes for size of request
+  uint16_t req_size = (data[0] << 8) | data[1];
+  if (req_size > size - 2) return 0;
+  
+  safepower_agent_proto::StartActionRequest request;
+  if (!request.ParseFromArray(data + 2, req_size)) {
+    return 0;
+  }
+  
+  safepower_agent_proto::SystemState initial_system_state;
+  if (!initial_system_state.ParseFromArray(data + 2 + req_size, size - 2 - req_size)) {
+    return 0;
+  }
+  
+  absl::Time start_time = absl::FromUnixSeconds(1234567890);
+  safepower_agent_config::ConditionValidationOptions options;
+  options.set_max_boots(10);
+  options.set_max_timeout_seconds(3600);
+  std::string node_entity_tag = "node-1";
+  if (!initial_system_state.node_state().empty()) {
+    node_entity_tag = initial_system_state.node_state().begin()->first;
+  }
+
+  safepower_agent::ValidateRequest(request, node_entity_tag, initial_system_state, start_time, options);
+  return 0;
+}

--- a/projects/gpowerd/build.sh
+++ b/projects/gpowerd/build.sh
@@ -1,0 +1,131 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# 1. Build Abseil-CPP from source
+echo "Building Abseil..."
+mkdir -p $SRC/abseil-cpp/build
+cd $SRC/abseil-cpp/build
+cmake \
+  -DCMAKE_CXX_COMPILER=$CXX \
+  -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+  -DCMAKE_CXX_STANDARD=20 \
+  -DCMAKE_INSTALL_PREFIX=$SRC/abseil_install \
+  -DBUILD_TESTING=OFF \
+  ..
+make -j$(nproc) install
+
+# 2. Build Protobuf from source
+echo "Building Protobuf..."
+mkdir -p $SRC/protobuf/build
+cd $SRC/protobuf/build
+cmake \
+  -DCMAKE_CXX_COMPILER=$CXX \
+  -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+  -DCMAKE_CXX_STANDARD=20 \
+  -Dprotobuf_BUILD_TESTS=OFF \
+  -DCMAKE_INSTALL_PREFIX=$SRC/protobuf_install \
+  ..
+make -j$(nproc) install
+
+# Go back to gpowerd directory
+cd $SRC/gpowerd
+
+# Translate Protobuf Editions (2023) to proto2
+python3 $SRC/translate_protos.py
+
+# Fix compatibility issues in source files
+# Convert absl::string_view to std::string for set_message in convert_proto.cc
+sed -i 's/status.message()/std::string(status.message())/g' convert_proto.cc
+
+# Convert absl::string_view to std::string for map find() in action_validation.cc
+sed -i 's/find(node_entity_tag)/find(std::string(node_entity_tag))/g' action_validation.cc
+
+# Fix absl::StrFormat of absl::Time in action_validation.cc
+python3 -c "
+import re
+with open('action_validation.cc', 'r') as f:
+  content = f.read()
+content = re.sub(
+    r'timeout = %v\",\s*start_time \+ max_timeout',
+    'timeout = %s\",\n                      absl::FormatTime(start_time + max_timeout)',
+    content
+)
+with open('action_validation.cc', 'w') as f:
+  f.write(content)
+"
+
+# Replace try_lock/unlock with WriterTryLock/WriterUnlock on absl::Mutex in state_updater.h
+sed -i 's/listeners_mutex_.try_lock()/listeners_mutex_.WriterTryLock()/g' state_updater.h
+sed -i 's/listeners_mutex_.unlock()/listeners_mutex_.WriterUnlock()/g' state_updater.h
+
+# Add & to MutexLock calls in all C++ files (older Abseil MutexLock takes a pointer)
+sed -i 's/\(absl::\)\?MutexLock\s\+\([a-zA-Z0-9_]*\)\s*(\([^)]*\))/\1MutexLock \2(\&\3)/g' *.cc *.h
+
+# Use ShortDebugString() for protobuf messages in absl::StrCat in condition.cc
+sed -i 's/Abort condition matched: ", condition/Abort condition matched: ", condition.ShortDebugString()/g' condition.cc
+sed -i 's/Unknown timeout type: ", condition/Unknown timeout type: ", condition.ShortDebugString()/g' condition.cc
+sed -i 's/Unknown condition type: ", condition/Unknown condition type: ", condition.ShortDebugString()/g' condition.cc
+
+# Compile protobufs using the newly built protoc
+$SRC/protobuf_install/bin/protoc --cpp_out=. -Iproto proto/*.proto
+
+# Get compiler and linker flags for OpenSSL (system library, C-based so no ABI issue)
+OPENSSL_FLAGS=$(pkg-config --cflags --libs openssl)
+
+# Compile action_validation_fuzzer
+$CXX $CXXFLAGS -std=c++20 \
+  -I. \
+  -Iproto \
+  -Ibmc \
+  -I$SRC/gpowerd_shims \
+  -I$SRC/abseil_install/include \
+  -I$SRC/protobuf_install/include \
+  *.pb.cc \
+  action_validation.cc \
+  condition.cc \
+  state_merge.cc \
+  convert_proto.cc \
+  daemon_context.cc \
+  callback_manager.cc \
+  $SRC/action_validation_fuzzer.cc \
+  -o $OUT/action_validation_fuzzer \
+  $LIB_FUZZING_ENGINE \
+  $SRC/protobuf_install/lib/libprotobuf.a \
+  -Wl,--start-group $SRC/abseil_install/lib/libabsl_*.a -Wl,--end-group \
+  $OPENSSL_FLAGS
+
+# Compile condition_fuzzer
+$CXX $CXXFLAGS -std=c++20 \
+  -I. \
+  -Iproto \
+  -Ibmc \
+  -I$SRC/gpowerd_shims \
+  -I$SRC/abseil_install/include \
+  -I$SRC/protobuf_install/include \
+  *.pb.cc \
+  action_validation.cc \
+  condition.cc \
+  state_merge.cc \
+  convert_proto.cc \
+  daemon_context.cc \
+  callback_manager.cc \
+  $SRC/condition_fuzzer.cc \
+  -o $OUT/condition_fuzzer \
+  $LIB_FUZZING_ENGINE \
+  $SRC/protobuf_install/lib/libprotobuf.a \
+  -Wl,--start-group $SRC/abseil_install/lib/libabsl_*.a -Wl,--end-group \
+  $OPENSSL_FLAGS

--- a/projects/gpowerd/condition_fuzzer.cc
+++ b/projects/gpowerd/condition_fuzzer.cc
@@ -1,0 +1,61 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include <stdint.h>
+#include <stddef.h>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "condition.h"
+#include "action.pb.h"
+#include "system_state.pb.h"
+#include "absl/time/time.h"
+#include <fuzzer/FuzzedDataProvider.h>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  FuzzedDataProvider provider(data, size);
+
+  // Split the data into two parts for the two protobufs
+  // We use a 50/50 split of the remaining bytes
+  size_t remaining = provider.remaining_bytes();
+  if (remaining < 2) {
+    return 0;
+  }
+  size_t size1 = provider.ConsumeIntegralInRange<size_t>(0, remaining - 1);
+  std::string proto1_bytes = provider.ConsumeBytesAsString(size1);
+  std::string proto2_bytes = provider.ConsumeRemainingBytesAsString();
+
+  safepower_agent_proto::Condition condition;
+  if (!condition.ParseFromString(proto1_bytes)) {
+    return 0;
+  }
+
+  safepower_agent_proto::SystemState system_state;
+  if (!system_state.ParseFromString(proto2_bytes)) {
+    return 0;
+  }
+
+  // Generate some timestamps
+  absl::Time start_time = absl::FromUnixSeconds(1719657600); // Static base time
+  absl::Time current_time = start_time + absl::Seconds(provider.ConsumeIntegralInRange<int64_t>(0, 3600 * 24));
+
+  // Call the target API
+  auto [status, matches] = safepower_agent::Condition::Matches(
+      condition, system_state, start_time, current_time);
+
+  return 0;
+}

--- a/projects/gpowerd/gpowerd_shims/absl/base/nullability.h
+++ b/projects/gpowerd/gpowerd_shims/absl/base/nullability.h
@@ -1,0 +1,30 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Done.
+
+#ifndef SHIM_ABSL_BASE_NULLABILITY_H_
+#define SHIM_ABSL_BASE_NULLABILITY_H_
+
+namespace absl {
+
+template <typename T>
+using Nullable = T;
+
+template <typename T>
+using Nonnull = T;
+
+}  // namespace absl
+
+#endif  // SHIM_ABSL_BASE_NULLABILITY_H_

--- a/projects/gpowerd/gpowerd_shims/absl/log/check.h
+++ b/projects/gpowerd/gpowerd_shims/absl/log/check.h
@@ -1,0 +1,39 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Done.
+
+#ifndef SHIM_ABSL_LOG_CHECK_H_
+#define SHIM_ABSL_LOG_CHECK_H_
+
+#include <iostream>
+
+#define CHECK(condition) if (!(condition)) std::cerr << "CHECK FAILED: " #condition << " "
+#define CHECK_OK(status) CHECK((status).ok())
+#define DCHECK(condition) if (!(condition)) std::cerr << "DCHECK FAILED: " #condition << " "
+#define DCHECK_OK(status) DCHECK((status).ok())
+#define CHECK_EQ(a, b) CHECK((a) == (b))
+#define CHECK_NE(a, b) CHECK((a) != (b))
+#define CHECK_LT(a, b) CHECK((a) < (b))
+#define CHECK_LE(a, b) CHECK((a) <= (b))
+#define CHECK_GT(a, b) CHECK((a) > (b))
+#define CHECK_GE(a, b) CHECK((a) >= (b))
+#define DCHECK_EQ(a, b) DCHECK((a) == (b))
+#define DCHECK_NE(a, b) DCHECK((a) != (b))
+#define DCHECK_LT(a, b) DCHECK((a) < (b))
+#define DCHECK_LE(a, b) DCHECK((a) <= (b))
+#define DCHECK_GT(a, b) DCHECK((a) > (b))
+#define DCHECK_GE(a, b) DCHECK((a) >= (b))
+
+#endif  // SHIM_ABSL_LOG_CHECK_H_

--- a/projects/gpowerd/gpowerd_shims/absl/log/log.h
+++ b/projects/gpowerd/gpowerd_shims/absl/log/log.h
@@ -1,0 +1,31 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Done.
+
+#ifndef SHIM_ABSL_LOG_LOG_H_
+#define SHIM_ABSL_LOG_LOG_H_
+
+#include <iostream>
+
+#define LOG(severity) std::cerr << #severity << ": "
+#define LOG_IF(severity, condition) if (condition) std::cerr << #severity << ": "
+#define LOG_EVERY_N(severity, n) std::cerr << #severity << ": "
+#define LOG_FIRST_N(severity, n) std::cerr << #severity << ": "
+#define LOG_EVERY_N_SEC(severity, n) std::cerr << #severity << ": "
+#define DLOG(severity) std::cerr << #severity << ": "
+#define VLOG(severity) std::cerr << "V" << severity << ": "
+#define DFATAL FATAL
+
+#endif  // SHIM_ABSL_LOG_LOG_H_

--- a/projects/gpowerd/gpowerd_shims/one/offline_node_entities.pb.h
+++ b/projects/gpowerd/gpowerd_shims/one/offline_node_entities.pb.h
@@ -1,0 +1,35 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Done.
+
+#ifndef SHIM_ONE_OFFLINE_NODE_ENTITIES_PB_H_
+#define SHIM_ONE_OFFLINE_NODE_ENTITIES_PB_H_
+
+namespace production_msv {
+namespace node_entities_proto {
+
+class OfflineNodeEntityInformation {
+ public:
+  OfflineNodeEntityInformation() = default;
+  OfflineNodeEntityInformation(const OfflineNodeEntityInformation&) = default;
+  OfflineNodeEntityInformation(OfflineNodeEntityInformation&&) = default;
+  OfflineNodeEntityInformation& operator=(const OfflineNodeEntityInformation&) = default;
+  OfflineNodeEntityInformation& operator=(OfflineNodeEntityInformation&&) = default;
+};
+
+}  // namespace node_entities_proto
+}  // namespace production_msv
+
+#endif  // SHIM_ONE_OFFLINE_NODE_ENTITIES_PB_H_

--- a/projects/gpowerd/project.yaml
+++ b/projects/gpowerd/project.yaml
@@ -1,6 +1,9 @@
 homepage: "https://gbmc.googlesource.com/gPowerD/"
 language: c++
 primary_contact: "javanlacerda@google.com"
+auto_ccs:
+  - pedroysb@google.com
+  - cloud-ti-fuzzing+bugs@google.com
 fuzzing_engines:
   - libfuzzer
 sanitizers:

--- a/projects/gpowerd/project.yaml
+++ b/projects/gpowerd/project.yaml
@@ -1,0 +1,11 @@
+homepage: "https://gbmc.googlesource.com/gPowerD/"
+language: c++
+primary_contact: "javanlacerda@google.com"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+  - undefined
+architectures:
+  - x86_64
+main_repo: "https://gbmc.googlesource.com/gPowerD/"

--- a/projects/gpowerd/translate_protos.py
+++ b/projects/gpowerd/translate_protos.py
@@ -1,0 +1,65 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+import re
+import glob
+import sys
+
+def translate_proto(filepath):
+  with open(filepath, 'r') as f:
+    content = f.read()
+
+  # Replace edition with syntax = "proto2";
+  content = re.sub(r'edition\s*=\s*"2023"\s*;', 'syntax = "proto2";', content)
+
+  # Remove file-level features
+  content = re.sub(r'option\s+features\.[a-zA-Z_.]+\s*=\s*[a-zA-Z_]+\s*;', '', content)
+
+  # Extract all oneof blocks and replace them with placeholders
+  oneofs = []
+  def replace_oneof(match):
+    oneofs.append(match.group(0))
+    return f"__ONEOF_PLACEHOLDER_{len(oneofs) - 1}__"
+
+  # Match oneof block: oneof name { ... }
+  content = re.sub(r'(?s)\boneof\s+[a-zA-Z0-9_]+\s*\{[^}]*\}', replace_oneof, content)
+
+  # Prepend 'optional ' to all singular fields in the rest of the file.
+  # This regex matches across multiple lines ([^;]*) until the semicolon.
+  pattern = r'(?m)^(\s*)(?!(optional|repeated|required|map|oneof|message|enum|import|package|option|syntax|extensions|reserved|edition)[\s\n])([a-zA-Z0-9_.]+)\s+([a-zA-Z0-9_.]+)\s*=\s*(\d+)([^;]*);'
+  content = re.sub(pattern, r'\1optional \3 \4 = \5\6;', content)
+
+  # Restore oneof blocks
+  for i, oneof_block in enumerate(oneofs):
+    placeholder = f"__ONEOF_PLACEHOLDER_{i}__"
+    content = content.replace(placeholder, oneof_block)
+
+  # Clean up the features.field_presence option from all fields (including inside oneofs)
+  content = re.sub(r'\s*\[\s*features\.field_presence\s*=\s*EXPLICIT\s*\]', '', content)
+  content = re.sub(r',\s*features\.field_presence\s*=\s*EXPLICIT', '', content)
+  content = re.sub(r'features\.field_presence\s*=\s*EXPLICIT\s*,\s*', '', content)
+  content = re.sub(r'(?s)features\s*\{\s*field_presence\s*:\s*[A-Z]+\s*\}', '', content)
+
+  with open(filepath, 'w') as f:
+    f.write(content)
+
+def main():
+  for proto_file in glob.glob('proto/*.proto'):
+    print(f"Translating {proto_file}...")
+    translate_proto(proto_file)
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
This PR adds the initial OSS-Fuzz integration for **gPowerD** (https://gbmc.googlesource.com/gPowerD/), a daemon for managing power states.

It includes two fuzz targets:
1.  `action_validation_fuzzer`: Targets the main request validation API (`ValidateRequest`).
2.  `condition_fuzzer`: A new target focusing on the core condition evaluation engine (`Condition::Matches`), bypassing the strict request validation bottleneck.

### Changes
*   **Dockerfile / build.sh**: Added source builds for `Abseil-CPP` and `Protobuf v21.12` using `libc++` to ensure ABI compatibility with the OSS-Fuzz runner environment.
*   **action_validation_fuzzer.cc**: Updated to dynamically extract and use the `node_entity_tag` from the generated system state to improve path exploration.
*   **condition_fuzzer.cc**: Added to fuzz `safepower_agent::Condition::Matches` using `FuzzedDataProvider` to split input bytes.
*   **gpowerd_shims/**: Added header shims to stub out internal dependencies and Google-specific logging macros.

### Coverage Results (Local 5-Minute Run)
*   **Overall Line Coverage**: **28.24%** (172/609 lines)
*   **`condition.cc` Line Coverage**: **44.41%** (147/331 lines)
*   **`action_validation.cc` Line Coverage**: **12.14%** (17/140 lines)
