### PR TITLE
envguardr: add initial integration

### DIFF
--- a/projects/envguardr/Dockerfile
+++ b/projects/envguardr/Dockerfile
@@ -1,0 +1,31 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-javascript
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  curl \
+  ca-certificates \
+  gnupg \
+  git \
+  && curl -fsSL https://deb.nodesource.com/setup_26.x | bash - \
+  && apt-get install -y --no-install-recommends nodejs \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth=1 https://github.com/fontebasso/envguardr.git $SRC/envguardr
+WORKDIR $SRC/envguardr
+
+COPY build.sh $SRC/

--- a/projects/envguardr/build.sh
+++ b/projects/envguardr/build.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd "$SRC/envguardr"
+
+npm ci
+npm run build
+
+cp -r "$SRC/envguardr" "$OUT/envguardr"
+
+mkdir -p "$OUT/node/bin"
+cp "$(command -v node)" "$OUT/node/bin/node"
+
+"$OUT/node/bin/node" --version | grep -E '^v26\.' >/dev/null
+
+create_jazzer_wrapper() {
+  local fuzz_target="$1"
+  local fuzzer_name
+  fuzzer_name="$(basename -s .js "$fuzz_target")"
+
+  cat > "$OUT/$fuzzer_name" <<EOF
+#!/bin/bash
+# LLVMFuzzerTestOneInput
+project_dir=\$(dirname "\$0")/envguardr
+node_bin=\$(dirname "\$0")/node/bin/node
+
+exec "\$node_bin" "\$project_dir/node_modules/@jazzer.js/core/dist/cli.js" "\$project_dir/$fuzz_target" --sync \$JAZZERJS_EXTRA_ARGS -- "\$@"
+EOF
+
+  chmod +x "$OUT/$fuzzer_name"
+}
+
+create_jazzer_wrapper "fuzz/validate-env.fuzz.js"
+create_jazzer_wrapper "fuzz/validate-env-custom-validators.fuzz.js"
+create_jazzer_wrapper "fuzz/validate-env-schema.fuzz.js"
+create_jazzer_wrapper "fuzz/validate-env-edge-cases.fuzz.js"

--- a/projects/envguardr/project.yaml
+++ b/projects/envguardr/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://fontebasso.github.io/envguardr/"
+language: javascript
+primary_contact: "samuel.txd@gmail.com"
+main_repo: "https://github.com/fontebasso/envguardr.git"
+file_github_issue: true
+base_os_version: ubuntu-24-04
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - none


### PR DESCRIPTION
## Summary

Adds the initial OSS-Fuzz integration for `envguardr`.

## Details

- Adds project configuration for `envguardr`
- Adds the Docker build environment
- Adds the OSS-Fuzz build script
- Builds the JavaScript fuzz targets from the upstream repository
- Uses `ubuntu-24-04` and Node.js 26

## Validation

Tested locally with:

```bash
python3 infra/helper.py build_image envguardr
python3 infra/helper.py build_fuzzers --sanitizer none envguardr
python3 infra/helper.py check_build envguardr
```

The fuzzers were also executed locally with `run_fuzzer` and completed without crashes.