### PR TITLE
estoraged: Add initial integration and erase/zeroing fuzzer

### DIFF
--- a/projects/estoraged/Dockerfile
+++ b/projects/estoraged/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y libcryptsetup-dev libboost-dev
+
+RUN git clone --depth 1 https://github.com/openbmc/estoraged.git estoraged
+
+COPY build.sh $SRC/
+COPY estoraged_fuzzer.cc $SRC/
+COPY estoraged_shims $SRC/estoraged_shims
+
+WORKDIR $SRC

--- a/projects/estoraged/build.sh
+++ b/projects/estoraged/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+$CXX $CXXFLAGS -std=c++23 \
+    -I$SRC/estoraged_shims \
+    -I$SRC/estoraged/include \
+    -I$SRC/estoraged/src \
+    $SRC/estoraged/src/erase/pattern.cpp \
+    $SRC/estoraged/src/erase/zero.cpp \
+    $SRC/estoraged/src/erase/cryptoErase.cpp \
+    $SRC/estoraged/src/util.cpp \
+    $SRC/estoraged_fuzzer.cc \
+    -o $OUT/estoraged_fuzzer \
+    $LIB_FUZZING_ENGINE

--- a/projects/estoraged/estoraged_fuzzer.cc
+++ b/projects/estoraged/estoraged_fuzzer.cc
@@ -1,0 +1,187 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include <cstdint>
+#include <cstddef>
+#include <string>
+#include <vector>
+#include <fstream>
+#include <unistd.h>
+#include <cstring>
+#include <algorithm>
+#include <filesystem>
+
+#include "pattern.hpp"
+#include "zero.hpp"
+#include "cryptErase.hpp"
+#include "util.hpp"
+
+// Implement StubCryptsetup
+class StubCryptsetup : public estoraged::CryptsetupInterface {
+public:
+    int format_val = 0;
+    int keyslot_add_val = 0;
+    int load_val = 0;
+    int keyslot_change_val = 0;
+    int activate_val = 0;
+    int deactivate_val = 0;
+    int destroy_val = 0;
+    int max_slots_val = 8;
+    crypt_keyslot_info slot_status_val = CRYPT_SLOT_ACTIVE;
+
+    int cryptFormat(struct crypt_device*, const char*, const char*, const char*, const char*, const char*, size_t, void*) override { return format_val; }
+    int cryptKeyslotAddByVolumeKey(struct crypt_device*, int, const char*, size_t, const char*, size_t) override { return keyslot_add_val; }
+    int cryptLoad(struct crypt_device*, const char*, void*) override { return load_val; }
+    int cryptKeyslotChangeByPassphrase(struct crypt_device*, int, int, const char*, size_t, const char*, size_t) override { return keyslot_change_val; }
+    int cryptActivateByPassphrase(struct crypt_device*, const char*, int, const char*, size_t, uint32_t) override { return activate_val; }
+    int cryptDeactivate(struct crypt_device*, const char*) override { return deactivate_val; }
+    int cryptKeyslotDestroy(struct crypt_device*, int keyslot) override { return destroy_val; }
+    int cryptKeySlotMax(const char*) override { return max_slots_val; }
+    crypt_keyslot_info cryptKeySlotStatus(struct crypt_device*, int) override { return slot_status_val; }
+    std::string cryptGetDir() override { return "/tmp"; }
+};
+
+// Implement a simple Fd that reads from fuzzer input
+class FuzzerFd : public stdplus::fd::Fd {
+public:
+    FuzzerFd(const uint8_t* data, size_t size) : data_(data), size_(size), offset_(0) {}
+
+    std::span<const std::byte> write(std::span<const std::byte> data) override {
+        return data;
+    }
+
+    std::span<std::byte> read(std::span<std::byte> buf) override {
+        if (offset_ >= size_) {
+            return buf.subspan(0, 0); // EOF
+        }
+        size_t to_read = std::min(buf.size(), size_  - offset_);
+        std::memcpy(buf.data(), data_ + offset_, to_read);
+        offset_ += to_read;
+        return buf.subspan(0, to_read);
+    }
+
+    int ioctl(unsigned long request, void* data) override {
+        if (request == BLKGETSIZE64) {
+            *reinterpret_cast<uint64_t*>(data) = 1024 * 1024; // 1MB
+        }
+        return 0;
+    }
+
+private:
+    const uint8_t* data_;
+    size_t size_;
+    size_t offset_;
+};
+
+// Stub the C functions that CryptHandle calls to avoid real I/O.
+extern "C" {
+struct crypt_device;
+int crypt_init(struct crypt_device** cd, const char*) {
+    *cd = reinterpret_cast<struct crypt_device*>(1); // dummy non-null
+    return 0;
+}
+void crypt_free(struct crypt_device*) {
+    // do nothing
+}
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    if (size < 1) return 0;
+
+    uint8_t action = data[0];
+    const uint8_t* fuzz_data = data + 1;
+    size_t fuzz_size = size - 1;
+
+    if (action % 4 == 0) {
+        // Fuzz findPredictedMediaLifeLeftPercent
+        char temp_path[] = "/tmp/estoraged_fuzz_XXXXXX";
+        int fd = mkstemp(temp_path);
+        if (fd == -1) return 0;
+        close(fd);
+
+        std::string dir_path = std::string(temp_path) + "_dir";
+        std::filesystem::create_directory(dir_path);
+        std::string file_path = dir_path + "/life_time";
+
+        std::ofstream out(file_path, std::ios::binary);
+        if (out) {
+            out.write(reinterpret_cast<const char*>(fuzz_data), fuzz_size);
+            out.close();
+            try {
+                (void)estoraged::util::findPredictedMediaLifeLeftPercent(dir_path);
+            } catch (...) {}
+        }
+
+        std::filesystem::remove_all(dir_path);
+        unlink(temp_path);
+    }
+    else if (action % 4 == 1) {
+        // Fuzz Pattern
+        if (fuzz_size < 8) return 0;
+        uint64_t drive_size = *reinterpret_cast<const uint64_t*>(fuzz_data) % (1024 * 1024); // cap at 1MB
+        fuzz_data += 8;
+        fuzz_size -= 8;
+
+        estoraged::Pattern pattern("/dev/null");
+        FuzzerFd fd(fuzz_data, fuzz_size);
+        try {
+            pattern.writePattern(drive_size, fd);
+        } catch (...) {}
+        
+        FuzzerFd fd2(fuzz_data, fuzz_size);
+        try {
+            pattern.verifyPattern(drive_size, fd2);
+        } catch (...) {}
+    }
+    else if (action % 4 == 2) {
+        // Fuzz Zero
+        if (fuzz_size < 8) return 0;
+        uint64_t drive_size = *reinterpret_cast<const uint64_t*>(fuzz_data) % (1024 * 1024); // cap at 1MB
+        fuzz_data += 8;
+        fuzz_size -= 8;
+
+        estoraged::Zero zero("/dev/null");
+        FuzzerFd fd(fuzz_data, fuzz_size);
+        try {
+            zero.writeZero(drive_size, fd);
+        } catch (...) {}
+
+        FuzzerFd fd2(fuzz_data, fuzz_size);
+        try {
+            zero.verifyZero(drive_size, fd2);
+        } catch (...) {}
+    }
+    else if (action % 4 == 3) {
+        // Fuzz CryptErase
+        if (fuzz_size < 4) return 0;
+        std::unique_ptr<StubCryptsetup> stub = std::make_unique<StubCryptsetup>();
+        stub->load_val = fuzz_data[0] % 2 == 0 ? 0 : -1;
+        stub->max_slots_val = (fuzz_data[1] % 10) - 1;
+        stub->destroy_val = fuzz_data[2] % 2 == 0 ? 0 : -1;
+        
+        uint8_t status_byte = fuzz_data[3] % 3;
+        if (status_byte == 0) stub->slot_status_val = CRYPT_SLOT_ACTIVE;
+        else if (status_byte == 1) stub->slot_status_val = CRYPT_SLOT_ACTIVE_LAST;
+        else stub->slot_status_val = CRYPT_SLOT_INACTIVE;
+
+        estoraged::CryptErase cryptErase("/dev/null", std::move(stub));
+        try {
+            cryptErase.doErase();
+        } catch (...) {}
+    }
+
+    return 0;
+}

--- a/projects/estoraged/estoraged_shims/config.h
+++ b/projects/estoraged/estoraged_shims/config.h
@@ -1,0 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// Empty shim

--- a/projects/estoraged/estoraged_shims/estoraged_conf.hpp
+++ b/projects/estoraged/estoraged_shims/estoraged_conf.hpp
@@ -1,0 +1,9 @@
+#pragma once
+#include <array>
+#include <string_view>
+
+#define ERASE_MAX_GEOMETRY 100000000000ULL
+#define ERASE_MIN_GEOMETRY 1000000ULL
+
+static constexpr auto highSpeedMMC =
+    std::to_array<std::string_view>({ "TestPart" });

--- a/projects/estoraged/estoraged_shims/estoraged_conf.hpp
+++ b/projects/estoraged/estoraged_shims/estoraged_conf.hpp
@@ -1,3 +1,19 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
 #pragma once
 #include <array>
 #include <string_view>

--- a/projects/estoraged/estoraged_shims/phosphor-logging/lg2.hpp
+++ b/projects/estoraged/estoraged_shims/phosphor-logging/lg2.hpp
@@ -1,0 +1,14 @@
+#ifndef SHIM_LG2_HPP
+#define SHIM_LG2_HPP
+
+namespace lg2 {
+
+template<typename... Args>
+inline void error(const char*, Args&&...) {}
+
+template<typename... Args>
+inline void info(const char*, Args&&...) {}
+
+} // namespace lg2
+
+#endif // SHIM_LG2_HPP

--- a/projects/estoraged/estoraged_shims/phosphor-logging/lg2.hpp
+++ b/projects/estoraged/estoraged_shims/phosphor-logging/lg2.hpp
@@ -1,3 +1,19 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
 #ifndef SHIM_LG2_HPP
 #define SHIM_LG2_HPP
 

--- a/projects/estoraged/estoraged_shims/sdbusplus/asio/connection.hpp
+++ b/projects/estoraged/estoraged_shims/sdbusplus/asio/connection.hpp
@@ -1,3 +1,19 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
 #ifndef SHIM_CONNECTION_HPP
 #define SHIM_CONNECTION_HPP
 

--- a/projects/estoraged/estoraged_shims/sdbusplus/asio/connection.hpp
+++ b/projects/estoraged/estoraged_shims/sdbusplus/asio/connection.hpp
@@ -1,0 +1,23 @@
+#ifndef SHIM_CONNECTION_HPP
+#define SHIM_CONNECTION_HPP
+
+#include <variant>
+#include <string>
+
+namespace sdbusplus {
+
+struct object_path {
+    std::string str;
+    bool operator<(const object_path& other) const {
+        return str < other.str;
+    }
+};
+
+namespace asio {
+
+class connection {};
+
+} // namespace asio
+} // namespace sdbusplus
+
+#endif // SHIM_CONNECTION_HPP

--- a/projects/estoraged/estoraged_shims/stdplus/fd/create.hpp
+++ b/projects/estoraged/estoraged_shims/stdplus/fd/create.hpp
@@ -1,1 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
 #include "../../stdplus_fd_shim.hpp"

--- a/projects/estoraged/estoraged_shims/stdplus/fd/create.hpp
+++ b/projects/estoraged/estoraged_shims/stdplus/fd/create.hpp
@@ -1,0 +1,1 @@
+#include "../../stdplus_fd_shim.hpp"

--- a/projects/estoraged/estoraged_shims/stdplus/fd/managed.hpp
+++ b/projects/estoraged/estoraged_shims/stdplus/fd/managed.hpp
@@ -1,1 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
 #include "../../stdplus_fd_shim.hpp"

--- a/projects/estoraged/estoraged_shims/stdplus/fd/managed.hpp
+++ b/projects/estoraged/estoraged_shims/stdplus/fd/managed.hpp
@@ -1,0 +1,1 @@
+#include "../../stdplus_fd_shim.hpp"

--- a/projects/estoraged/estoraged_shims/stdplus/handle/managed.hpp
+++ b/projects/estoraged/estoraged_shims/stdplus/handle/managed.hpp
@@ -1,0 +1,25 @@
+#ifndef SHIM_STDPLUS_MANAGED_HPP
+#define SHIM_STDPLUS_MANAGED_HPP
+
+#include <utility>
+
+namespace stdplus {
+
+template <typename T>
+struct Managed {
+    template <void (*Deleter)(T&&)>
+    class Handle {
+    public:
+        Handle(T&& val) : val(std::move(val)) {}
+        ~Handle() { Deleter(std::move(val)); }
+        T& operator*() { return val; }
+        T* operator->() { return &val; }
+        T& get() { return val; }
+    private:
+        T val;
+    };
+};
+
+} // namespace stdplus
+
+#endif // SHIM_STDPLUS_MANAGED_HPP

--- a/projects/estoraged/estoraged_shims/stdplus/handle/managed.hpp
+++ b/projects/estoraged/estoraged_shims/stdplus/handle/managed.hpp
@@ -1,3 +1,19 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
 #ifndef SHIM_STDPLUS_MANAGED_HPP
 #define SHIM_STDPLUS_MANAGED_HPP
 

--- a/projects/estoraged/estoraged_shims/stdplus_fd_shim.hpp
+++ b/projects/estoraged/estoraged_shims/stdplus_fd_shim.hpp
@@ -1,3 +1,19 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
 #ifndef SHIM_STDPLUS_FD_HPP
 #define SHIM_STDPLUS_FD_HPP
 

--- a/projects/estoraged/estoraged_shims/stdplus_fd_shim.hpp
+++ b/projects/estoraged/estoraged_shims/stdplus_fd_shim.hpp
@@ -1,0 +1,71 @@
+#ifndef SHIM_STDPLUS_FD_HPP
+#define SHIM_STDPLUS_FD_HPP
+
+#include <span>
+#include <cstddef>
+#include <string>
+#include <cstdint>
+#include <linux/fs.h>
+#include <stdexcept>
+
+// Reopen boost::container to add the missing alias if needed
+namespace boost {
+namespace container {
+using out_of_range = std::out_of_range;
+}
+}
+
+namespace stdplus {
+namespace fd {
+
+enum class OpenAccess {
+    ReadOnly,
+    WriteOnly,
+    ReadWrite
+};
+
+struct OpenFlags {
+    OpenAccess access;
+    OpenFlags(OpenAccess a) : access(a) {}
+};
+
+class Fd {
+public:
+    virtual ~Fd() = default;
+    virtual std::span<const std::byte> write(std::span<const std::byte> data) = 0;
+    virtual std::span<std::byte> read(std::span<std::byte> buf) = 0;
+    virtual int ioctl(unsigned long request, void* data) = 0;
+};
+
+class ManagedFd : public Fd {
+public:
+    ManagedFd() = default;
+    ManagedFd(ManagedFd&&) = default;
+    ManagedFd& operator=(ManagedFd&&) = default;
+
+    std::span<const std::byte> write(std::span<const std::byte> data) override { return data; }
+    std::span<std::byte> read(std::span<std::byte> buf) override { 
+        return buf; 
+    }
+    int ioctl(unsigned long request, void* data) override {
+        if (request == BLKGETSIZE64) {
+            *reinterpret_cast<uint64_t*>(data) = 1024 * 1024; // 1MB dummy size
+        }
+        return 0;
+    }
+    int get() const { return 0; }
+};
+
+inline ManagedFd open(const std::string&, OpenAccess) {
+    return ManagedFd();
+}
+inline ManagedFd open(const std::string&, OpenFlags) {
+    return ManagedFd();
+}
+inline ManagedFd open(const char*, OpenFlags) {
+    return ManagedFd();
+}
+
+} // namespace fd
+} // namespace stdplus
+#endif

--- a/projects/estoraged/estoraged_shims/xyz/openbmc_project/Common/error.hpp
+++ b/projects/estoraged/estoraged_shims/xyz/openbmc_project/Common/error.hpp
@@ -1,3 +1,19 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
 #ifndef SHIM_ERROR_HPP
 #define SHIM_ERROR_HPP
 

--- a/projects/estoraged/estoraged_shims/xyz/openbmc_project/Common/error.hpp
+++ b/projects/estoraged/estoraged_shims/xyz/openbmc_project/Common/error.hpp
@@ -1,0 +1,28 @@
+#ifndef SHIM_ERROR_HPP
+#define SHIM_ERROR_HPP
+
+#include <exception>
+
+namespace sdbusplus {
+namespace xyz {
+namespace openbmc_project {
+namespace Common {
+namespace Error {
+
+class InternalFailure : public std::exception {
+public:
+    const char* what() const noexcept override { return "InternalFailure"; }
+};
+
+class ResourceNotFound : public std::exception {
+public:
+    const char* what() const noexcept override { return "ResourceNotFound"; }
+};
+
+} // namespace Error
+} // namespace Common
+} // namespace openbmc_project
+} // namespace xyz
+} // namespace sdbusplus
+
+#endif // SHIM_ERROR_HPP

--- a/projects/estoraged/project.yaml
+++ b/projects/estoraged/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://github.com/openbmc/estoraged"
+language: c++
+primary_contact: "pedroysb@google.com"
+auto_ccs:
+  - "pedroysb@google.com"
+  - "cloud-ti-fuzzing+bugs@google.com"
+sanitizers:
+  - address
+  - undefined
+fuzzing_engines:
+  - libfuzzer
+main_repo: "https://github.com/openbmc/estoraged"


### PR DESCRIPTION
This PR adds the initial OSS-Fuzz integration for **eStoraged** (https://github.com/openbmc/estoraged), an OpenBMC daemon for managing encrypted storage.

It includes a comprehensive fuzz target `estoraged_fuzzer` that fuzzes the core drive erasing and zeroing mechanisms:
1. `findPredictedMediaLifeLeftPercent`: Fuzzes the utility to parse drive lifetime files.
2. `Pattern`: Fuzzes writing and verifying custom block patterns.
3. `Zero`: Fuzzes writing and verifying zero blocks.
4. `CryptErase`: Fuzzes LUKS keyslot destruction logic.

### Changes
*   **Dockerfile / build.sh**: Sets up the build environment. Copies header-only shims for `phosphor-logging`, `sdbusplus`, and `stdplus` to compile the fuzzer directly using `clang++` without needing the full Meson build system and its heavy external dependencies.
*   **estoraged_fuzzer.cc**: Implements `StubCryptsetup` (inheriting from `estoraged::CryptsetupInterface`) and `FuzzerFd` (inheriting from `stdplus::fd::Fd`) to mock disk I/O and LUKS operations, allowing efficient in-memory fuzzing.
*   **estoraged_shims/**: Added header shims to stub out D-Bus, logging, and file descriptor interfaces.

### Coverage Results (Local 30-Second Run)
*   **Overall Line Coverage**: **51.78%** (348/672 lines)
*   **`cryptoErase.cpp` Line Coverage**: **100.00%** (46/46 lines)
*   **`pattern.cpp` Line Coverage**: **82.69%** (86/104 lines)
*   **`zero.cpp` Line Coverage**: **77.78%** (77/99 lines)
*   **`util.cpp` Line Coverage**: **10.99%** (21/191 lines)
