### PR TITLE
fix(infra): resolve test mocking error and OS exit-code portability

### DIFF
--- a/infra/helper_test.py
+++ b/infra/helper_test.py
@@ -33,7 +33,7 @@ class ShellTest(unittest.TestCase):
   """Tests 'shell' command."""
 
   @mock.patch('helper.docker_run')
-  @mock.patch('helper.build_image_impl')
+  @mock.patch('common_utils.build_image_impl')
   def test_base_runner_debug(self, _, __):
     """Tests that shell base-runner-debug works as intended."""
     image_name = 'base-runner-debug'

--- a/infra/utils_test.py
+++ b/infra/utils_test.py
@@ -102,7 +102,7 @@ class ExecuteTest(unittest.TestCase):
       out, err, err_code = utils.execute(['ls', 'notarealdir'],
                                          location=tmp_dir,
                                          check_result=False)
-      self.assertEqual(err_code, 2)
+      self.assertNotEqual(err_code, 0)
       self.assertIsNotNone(err)
       self.assertEqual(out, '')
       with self.assertRaises(RuntimeError):


### PR DESCRIPTION
### Description
This PR fixes two distinct bugs in the infrastructure test suite:
1. **Mocking Error in helper_test.py (`test_base_runner_debug`)**: The test mocked `helper.build_image_impl`, but the core helper implementation uses `common_utils.build_image_impl` directly. This bypassed the mock, executing real Docker build commands and causing the test to fail on environments without Docker.
2. **OS Exit-Code Portability in utils_test.py (`test_error_command`)**: The test asserted a strict exit code of `2` when command execution fails. However, the exit code of `ls` on macOS on failure is `1`, while on Linux it is `2`. Changing the assertion to check for a non-zero exit code makes the test OS-independent.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test improvements

### Related Issues
Fixes OS-dependent unit test failures on macOS and fixes test suite mock bypass on Docker commands.

### Changes Made
- **`infra/helper_test.py`**: Updated target of `@mock.patch` to `common_utils.build_image_impl`.
- **`infra/utils_test.py`**: Updated `test_error_command` to assert a non-zero exit code (`self.assertNotEqual(err_code, 0)`) rather than exactly `2`.

### Testing
- [x] All existing tests pass
- [x] Manual testing performed

---