### PR TITLE
Onboard PLDM to OSS-Fuzz

### DIFF
--- a/projects/pldm/Dockerfile
+++ b/projects/pldm/Dockerfile
@@ -1,0 +1,35 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+# Install ninja-build from apt, and the latest meson from pip3
+RUN apt-get update && apt-get install -y ninja-build && pip3 install meson
+
+# Install libpldm as a static library, disabling C++ bindings and tools
+RUN git clone --depth 1 https://github.com/openbmc/libpldm.git libpldm && \
+    cd libpldm && \
+    meson setup build --buildtype=release --default-library=static -Dtests=false -Dbindings=[] -Dtools=[] && \
+    ninja -C build install
+
+# Clone the main pldm repository
+RUN git clone --depth 1 https://gbmc.googlesource.com/pldm/ pldm
+
+WORKDIR pldm
+
+COPY pldm_package_parser_fuzzer.cc $SRC/
+COPY pldm_shims/ $SRC/pldm_shims/
+COPY build.sh $SRC/

--- a/projects/pldm/build.sh
+++ b/projects/pldm/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Compile the fuzzer using our shims to bypass D-Bus/systemd dependencies
+$CXX $CXXFLAGS -std=c++23 \
+    -I$SRC/pldm_shims \
+    -I$SRC/pldm \
+    -I/usr/local/include \
+    $SRC/pldm/fw-update/package_parser.cpp \
+    $SRC/pldm_package_parser_fuzzer.cc \
+    -o $OUT/pldm_package_parser_fuzzer \
+    $LIB_FUZZING_ENGINE -lpldm

--- a/projects/pldm/pldm_package_parser_fuzzer.cc
+++ b/projects/pldm/pldm_package_parser_fuzzer.cc
@@ -1,0 +1,44 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include "fw-update/package_parser.hpp"
+#include <cstdint>
+#include <cstddef>
+#include <vector>
+#include <memory>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    if (size < 1) {
+        return 0;
+    }
+
+    std::vector<uint8_t> fwPkgHdr(data, data + size);
+
+    try {
+        auto parser = pldm::fw_update::parsePkgHeader(fwPkgHdr);
+        if (parser) {
+            // We use the total size of the fuzzer input as the package size.
+            // In a real scenario, the package size is the sum of the header and the payload.
+            // Since the fuzzer input contains both, 'size' is the correct total size.
+            parser->parse(fwPkgHdr, size);
+        }
+    } catch (...) {
+        // Ignore all exceptions thrown by the parser, as they represent
+        // expected behavior when parsing invalid or malformed packages.
+    }
+
+    return 0;
+}

--- a/projects/pldm/pldm_shims/common/types.hpp
+++ b/projects/pldm/pldm_shims/common/types.hpp
@@ -1,0 +1,93 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <string>
+#include <tuple>
+#include <variant>
+#include <vector>
+
+namespace pldm
+{
+
+namespace fw_update
+{
+
+// Descriptor definition
+using DescriptorType = uint16_t;
+using DescriptorData = std::vector<uint8_t>;
+using VendorDefinedDescriptorTitle = std::string;
+using VendorDefinedDescriptorData = std::vector<uint8_t>;
+using VendorDefinedDescriptorInfo =
+    std::tuple<VendorDefinedDescriptorTitle, VendorDefinedDescriptorData>;
+using Descriptors =
+    std::multimap<DescriptorType,
+                  std::variant<DescriptorData, VendorDefinedDescriptorInfo>>;
+
+// Component information
+using CompClassification = uint16_t;
+using CompIdentifier = uint16_t;
+
+// PackageHeaderInformation
+using PackageHeaderSize = size_t;
+using PackageVersion = std::string;
+using ComponentBitmapBitLength = uint16_t;
+using PackageHeaderChecksum = uint32_t;
+
+// FirmwareDeviceIDRecords
+using DeviceIDRecordCount = uint8_t;
+using DeviceUpdateOptionFlags = std::bitset<32>;
+using ApplicableComponents = std::vector<size_t>;
+using ComponentImageSetVersion = std::string;
+using FirmwareDevicePackageData = std::vector<uint8_t>;
+using FirmwareDeviceIDRecord =
+    std::tuple<DeviceUpdateOptionFlags, ApplicableComponents,
+               ComponentImageSetVersion, Descriptors,
+               FirmwareDevicePackageData>;
+using FirmwareDeviceIDRecords = std::vector<FirmwareDeviceIDRecord>;
+
+// ComponentImageInformation
+using ComponentImageCount = uint16_t;
+using CompComparisonStamp = uint32_t;
+using CompOptions = std::bitset<16>;
+using ReqCompActivationMethod = std::bitset<16>;
+using CompLocationOffset = uint32_t;
+using CompSize = uint32_t;
+using CompVersion = std::string;
+using ComponentImageInfo =
+    std::tuple<CompClassification, CompIdentifier, CompComparisonStamp,
+               CompOptions, ReqCompActivationMethod, CompLocationOffset,
+               CompSize, CompVersion>;
+using ComponentImageInfos = std::vector<ComponentImageInfo>;
+
+enum class ComponentImageInfoPos : size_t
+{
+    CompClassificationPos = 0,
+    CompIdentifierPos = 1,
+    CompComparisonStampPos = 2,
+    CompOptionsPos = 3,
+    ReqCompActivationMethodPos = 4,
+    CompLocationOffsetPos = 5,
+    CompSizePos = 6,
+    CompVersionPos = 7,
+};
+
+} // namespace fw_update
+} // namespace pldm

--- a/projects/pldm/pldm_shims/common/utils.hpp
+++ b/projects/pldm/pldm_shims/common/utils.hpp
@@ -1,0 +1,61 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <string>
+#include <algorithm>
+#include <cctype>
+
+// Forward declaration of variable_field from libpldm
+struct variable_field;
+
+namespace pldm
+{
+namespace utils
+{
+
+inline std::string toString(const struct variable_field& var)
+{
+    // We will cast the struct pointers. In libpldm, variable_field is:
+    // struct variable_field { const uint8_t* ptr; size_t length; }
+    // We can access them via reinterpret_cast if needed, or since we include
+    // libpldm headers in the fuzzer, the full definition will be available.
+    
+    // To be safe and compile without knowing the exact layout of variable_field here,
+    // we can implement this in a .cpp file or just assume the definition is available
+    // because this header is always included after libpldm headers.
+    // In package_parser.cpp:
+    // #include <libpldm/firmware_update.h> (defines variable_field)
+    // #include <phosphor-logging/lg2.hpp>
+    // So the definition is indeed available!
+    
+    const uint8_t* ptr = reinterpret_cast<const uint8_t*>(var.ptr);
+    size_t length = var.length;
+
+    if (ptr == nullptr || !length)
+    {
+        return "";
+    }
+
+    std::string str(reinterpret_cast<const char*>(ptr), length);
+    std::replace_if(
+        str.begin(), str.end(), [](const char& c) { return !std::isprint(c); }, ' ');
+    return str;
+}
+
+} // namespace utils
+} // namespace pldm

--- a/projects/pldm/pldm_shims/phosphor-logging/lg2.hpp
+++ b/projects/pldm/pldm_shims/phosphor-logging/lg2.hpp
@@ -1,0 +1,38 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#define PHOSPHOR_LOG2_USING
+
+namespace lg2
+{
+// Mock logging functions
+template<typename... Args>
+inline void error(const char*, Args&&...) {}
+
+template<typename... Args>
+inline void info(const char*, Args&&...) {}
+
+template<typename... Args>
+inline void warning(const char*, Args&&...) {}
+
+template<typename... Args>
+inline void debug(const char*, Args&&...) {}
+}
+
+// Bring them into the global namespace or let the using namespace handle it
+using namespace lg2;

--- a/projects/pldm/pldm_shims/xyz/openbmc_project/Common/error.hpp
+++ b/projects/pldm/pldm_shims/xyz/openbmc_project/Common/error.hpp
@@ -1,0 +1,45 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <exception>
+
+namespace sdbusplus
+{
+namespace xyz
+{
+namespace openbmc_project
+{
+namespace Common
+{
+namespace Error
+{
+
+class InternalFailure : public std::exception
+{
+  public:
+    const char* what() const noexcept override
+    {
+        return "InternalFailure";
+    }
+};
+
+} // namespace Error
+} // namespace Common
+} // namespace openbmc_project
+} // namespace xyz
+} // namespace sdbusplus

--- a/projects/pldm/project.yaml
+++ b/projects/pldm/project.yaml
@@ -1,0 +1,11 @@
+homepage: "https://gbmc.googlesource.com/pldm/"
+language: c++
+primary_contact: "javanlacerda@google.com"
+auto_ccs:
+  - "javanlacerda@google.com"
+sanitizers:
+  - address
+  - undefined
+fuzzing_engines:
+  - libfuzzer
+main_repo: "https://gbmc.googlesource.com/pldm/"


### PR DESCRIPTION
This pull request integrates the **PLDM (Platform Level Data Model)** project into OSS-Fuzz, enabling continuous fuzzing of its firmware update package parsing logic.

## Summary of Changes

### 1. Project Configuration
* Added [project.yaml](file:///usr/local/google/home/javanlacerda/repos/oss-fuzz/projects/pldm/project.yaml) containing project metadata (homepage, language, contacts, sanitizers, and main repository).

### 2. Build Environment & Integration
* Added [Dockerfile](file:///usr/local/google/home/javanlacerda/repos/oss-fuzz/projects/pldm/Dockerfile):
  * Installs `ninja-build` and `meson` (via `pip3`).
  * Clones and builds `libpldm` as a static library (disabling tests, bindings, and tools).
  * Clones the main `pldm` repository.
  * Copies the fuzzer harness, shims, and build script into the container.
* Added [build.sh](file:///usr/local/google/home/javanlacerda/repos/oss-fuzz/projects/pldm/build.sh):
  * Compiles the fuzzer harness along with `fw-update/package_parser.cpp`.
  * Links the fuzzer against the static `libpldm` library.
  * Configures the include path to use the custom shims.

### 3. Fuzzer Harness
* Added [pldm_package_parser_fuzzer.cc](file:///usr/local/google/home/javanlacerda/repos/oss-fuzz/projects/pldm/pldm_package_parser_fuzzer.cc):
  * Targets the PLDM firmware update package parsing logic.
  * Feeds the fuzzer input data into `pldm::fw_update::parsePkgHeader()` and subsequently executes `parser->parse()` to fuzz the package parsing routines.
  * Safely catches and ignores all exceptions thrown during parsing, as they represent expected behavior for malformed packages.

### 4. Dependency Shims
To allow compiling `package_parser.cpp` and the fuzzer harness standalone without pulling in heavy D-Bus, systemd, and sdbusplus dependencies, we introduced a set of lightweight shims under [pldm_shims/](file:///usr/local/google/home/javanlacerda/repos/oss-fuzz/projects/pldm/pldm_shims):
* **`common/types.hpp`**: Defines firmware update type aliases (e.g., `DescriptorType`, `ComponentImageInfo`) used by the package parser.
* **`common/utils.hpp`**: Provides a shim for the `pldm::utils::toString` helper function to convert `variable_field` structures.
* **`phosphor-logging/lg2.hpp`**: Mocks the OpenBMC `lg2` logging namespace and functions (`error`, `info`, `warning`, `debug`) as no-ops.
* **`xyz/openbmc_project/Common/error.hpp`**: Mocks the `sdbusplus` `InternalFailure` exception class.
