### PR TITLE
nsmd: Remove fuzzer-side validation to allow finding OOB bugs

### DIFF
--- a/projects/nsmd/decode_get_histogram_data_resp_fuzzer.cc
+++ b/projects/nsmd/decode_get_histogram_data_resp_fuzzer.cc
@@ -50,27 +50,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
         return 0;
     }
 
-    uint8_t completion_code = payload[sizeof(struct nsm_msg_hdr) + 1];
-    if (completion_code == NSM_SUCCESS || completion_code == NSM_ACCEPTED) {
-        if (payload_len >= sizeof(struct nsm_msg_hdr) + sizeof(struct nsm_get_histogram_data_resp)) {
-            const struct nsm_get_histogram_data_resp* resp = reinterpret_cast<const struct nsm_get_histogram_data_resp*>(payload + sizeof(struct nsm_msg_hdr));
-            uint16_t num_of_buckets = le16toh(resp->num_of_buckets);
-            uint8_t type = resp->bucket_data_type;
-            size_t elem_size = 1;
-            switch(type) {
-                case 0: case 1: elem_size = 1; break;
-                case 2: case 3: elem_size = 2; break;
-                case 4: case 5: elem_size = 4; break;
-                case 6: case 7: elem_size = 8; break;
-                case 8: elem_size = 4; break; // NvS24_8 is float (4 bytes)
-                default: elem_size = 1; break;
-            }
-            size_t header_size = sizeof(struct nsm_msg_hdr) + offsetof(struct nsm_get_histogram_data_resp, bucket_data);
-            if (payload_len < header_size || (size_t)num_of_buckets * elem_size > payload_len - header_size) {
-                return 0;
-            }
-        }
-    }
 
     std::vector<uint8_t> out_buf(65536, 0);
     uint8_t fuzz_cc = 0;

--- a/projects/nsmd/decode_get_histogram_format_resp_fuzzer.cc
+++ b/projects/nsmd/decode_get_histogram_format_resp_fuzzer.cc
@@ -50,27 +50,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
         return 0;
     }
 
-    uint8_t completion_code = payload[sizeof(struct nsm_msg_hdr) + 1];
-    if (completion_code == NSM_SUCCESS || completion_code == NSM_ACCEPTED) {
-        if (payload_len >= sizeof(struct nsm_msg_hdr) + sizeof(struct nsm_get_histogram_format_resp)) {
-            const struct nsm_get_histogram_format_resp* resp = reinterpret_cast<const struct nsm_get_histogram_format_resp*>(payload + sizeof(struct nsm_msg_hdr));
-            uint16_t num_of_buckets = le16toh(resp->metadata.num_of_buckets);
-            uint8_t type = resp->metadata.bucket_data_type;
-            size_t elem_size = 1;
-            switch(type) {
-                case 0: case 1: elem_size = 1; break;
-                case 2: case 3: elem_size = 2; break;
-                case 4: case 5: elem_size = 4; break;
-                case 6: case 7: elem_size = 8; break;
-                case 8: elem_size = 4; break; // NvS24_8 is float (4 bytes)
-                default: elem_size = 1; break;
-            }
-            size_t header_size = sizeof(struct nsm_msg_hdr) + offsetof(struct nsm_get_histogram_format_resp, bucket_offsets);
-            if (payload_len < header_size || (size_t)num_of_buckets * elem_size > payload_len - header_size) {
-                return 0;
-            }
-        }
-    }
 
     std::vector<uint8_t> out_buf(65536, 0);
     uint8_t fuzz_cc = 0;

--- a/projects/nsmd/fuzzer_helpers.h
+++ b/projects/nsmd/fuzzer_helpers.h
@@ -25,53 +25,5 @@ extern "C" {
 
 // Validates that the packet actually contains the number of bytes specified in the headers
 inline bool validate_nsm_msg_length(const uint8_t* payload, size_t payload_len) {
-    if (payload_len < sizeof(struct nsm_msg_hdr)) {
-        return false;
-    }
-    const struct nsm_msg_hdr* hdr = reinterpret_cast<const struct nsm_msg_hdr*>(payload);
-    
-    if (hdr->request) {
-        // Request v1
-        if (payload_len >= sizeof(struct nsm_msg_hdr) + sizeof(struct nsm_common_req)) {
-            const struct nsm_common_req* req = reinterpret_cast<const struct nsm_common_req*>(payload + sizeof(struct nsm_msg_hdr));
-            uint32_t data_size = req->data_size;
-            if (payload_len >= sizeof(struct nsm_msg_hdr) + sizeof(struct nsm_common_req) + data_size) {
-                return true;
-            }
-        }
-        
-        // Request v2
-        if (payload_len >= sizeof(struct nsm_msg_hdr) + sizeof(struct nsm_common_req_v2)) {
-            const struct nsm_common_req_v2* req_v2 = reinterpret_cast<const struct nsm_common_req_v2*>(payload + sizeof(struct nsm_msg_hdr));
-            uint32_t data_size_v2 = le16toh(req_v2->data_size);
-            if (payload_len >= sizeof(struct nsm_msg_hdr) + sizeof(struct nsm_common_req_v2) + data_size_v2) {
-                return true;
-            }
-        }
-        return false;
-    } else {
-        // Response
-        if (payload_len < sizeof(struct nsm_msg_hdr) + 2) { // command + completion_code
-            return false;
-        }
-        uint8_t completion_code = payload[sizeof(struct nsm_msg_hdr) + 1];
-        if (completion_code != NSM_SUCCESS && completion_code != NSM_ACCEPTED) {
-            // Non-success response
-            if (payload_len >= sizeof(struct nsm_msg_hdr) + sizeof(struct nsm_common_non_success_resp)) {
-                return true;
-            }
-            return false;
-        }
-        
-        // Success response
-        if (payload_len < sizeof(struct nsm_msg_hdr) + sizeof(struct nsm_common_resp)) {
-            return false;
-        }
-        const struct nsm_common_resp* resp = reinterpret_cast<const struct nsm_common_resp*>(payload + sizeof(struct nsm_msg_hdr));
-        uint32_t data_size = le16toh(resp->data_size);
-        if (payload_len >= sizeof(struct nsm_msg_hdr) + sizeof(struct nsm_common_resp) + data_size) {
-            return true;
-        }
-        return false;
-    }
+    return payload_len >= sizeof(struct nsm_msg_hdr);
 }


### PR DESCRIPTION
Simplify validate_nsm_msg_length in fuzzer_helpers.h to only check for the minimum header size, allowing the fuzzer to pass malformed payloads to the decoders.

Remove local payload length validation from:
- decode_get_histogram_format_resp_fuzzer.cc
- decode_get_histogram_data_resp_fuzzer.cc