### PR TITLE
tarantool: compile_lua_fuzzer is not a test

### DIFF
--- a/projects/tarantool/build.sh
+++ b/projects/tarantool/build.sh
@@ -177,3 +177,6 @@ done
 
 cp $TARANTOOL_PATH "$OUT/$LUA_RUNTIME_NAME"
 cp -R $LUA_MODULES_DIR "$OUT/"
+
+# Don't consider compile_lua_fuzzer as a test.
+rm -f "$OUT/compile_lua_fuzzer" "$SRC/compile_lua_fuzzer"


### PR DESCRIPTION
OSS Fuzz runs compile_lua_fuzzer as a test:

2026-07-02 09:14:37,924 - root - INFO - Running fuzzer: compile_lua_fuzzer. <snipped>
2026-07-02 09:14:38,032 - root - WARNING - Failed to download corpus for compile_lua_fuzzer. 2026-07-02 09:14:38,033 - root - INFO - Starting fuzzing Fuzzing logs:
2026-07-02 09:14:38,181 - root - INFO - Fuzzer: compile_lua_fuzzer. Detected bug. 2026-07-02 09:14:38,181 - root - INFO - Trying to reproduce crash using: /tmp/tmpc5unb3ic/tmpfzl7oeou. basename: invalid option -- 'r'
Try 'basename --help' for more information.

The patch fixes that.

Log: https://github.com/tarantool/tarantool/actions/runs/28577868674/job/84730651481?pr=12882