### PR TITLE
Add cpace-x25519 project

### DIFF
--- a/projects/cpace-x25519/Dockerfile
+++ b/projects/cpace-x25519/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+
+RUN git clone --depth 1 https://github.com/the-sarge/cpace-x25519.git
+WORKDIR $SRC/cpace-x25519
+
+COPY build.sh $SRC/

--- a/projects/cpace-x25519/build.sh
+++ b/projects/cpace-x25519/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exec "$SRC/cpace-x25519/ossfuzz/build.sh"

--- a/projects/cpace-x25519/project.yaml
+++ b/projects/cpace-x25519/project.yaml
@@ -1,0 +1,23 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+homepage: "https://github.com/the-sarge/cpace-x25519"
+language: go
+primary_contact: "the-sarge@the-sarge.com"
+main_repo: "https://github.com/the-sarge/cpace-x25519.git"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+help_url: "https://github.com/the-sarge/cpace-x25519/blob/main/SECURITY.md"


### PR DESCRIPTION
Add OSS-Fuzz coverage for cpace-x25519, a Go implementation of the CPACE-X25519-SHA512 PAKE profile.

This project entry delegates to the cpace-x25519 repository's checked-in `ossfuzz/build.sh`, which builds 15 native Go fuzz targets with `compile_native_go_fuzzer`:

- `fuzz_decode_message_a`
- `fuzz_decode_message_b`
- `fuzz_decode_message_c`
- `fuzz_draft_invalid_vector_json_loader`
- `fuzz_draft_vector_json_loader`
- `fuzz_initiator_finish_with_fuzzed_message_b`
- `fuzz_message_a_round_trip`
- `fuzz_message_b_round_trip`
- `fuzz_message_c_round_trip`
- `fuzz_protocol_consistency`
- `fuzz_protocol_mismatch`
- `fuzz_respond_with_fuzzed_message_a`
- `fuzz_responder_finish_with_fuzzed_message_c`
- `fuzz_scalar_mult_vfy`
- `fuzz_x25519_differential_ecdh`

Validation run locally from this OSS-Fuzz checkout against cpace-x25519 commit `a2f892f785991b8ac20d60979c1f32639287f0d4`:

```sh
DOCKER_DEFAULT_PLATFORM=linux/amd64 python3 infra/helper.py build_image --architecture x86_64 --pull cpace-x25519
DOCKER_DEFAULT_PLATFORM=linux/amd64 python3 infra/helper.py build_fuzzers --architecture x86_64 --sanitizer address --clean cpace-x25519 /Users/josh/code/github.com/the-sarge/cpace-x25519
DOCKER_DEFAULT_PLATFORM=linux/amd64 python3 infra/helper.py check_build --architecture x86_64 --sanitizer address cpace-x25519
```

All commands passed. The produced fuzzer binaries matched the cpace-x25519 registry exactly, ignoring `llvm-symbolizer`.

Note: `google/oss-fuzz#15480` was a prior submission for the original `github.com/the-sarge/cpace` module and does not onboard this `github.com/the-sarge/cpace-x25519` fork.
