### PR TITLE
bump Go version to v1.26.4

### DIFF
--- a/infra/base-images/base-builder/install_go.sh
+++ b/infra/base-images/base-builder/install_go.sh
@@ -18,9 +18,9 @@
 cd /tmp
 
 export GOROOT=/root/.go
-wget https://go.dev/dl/go1.25.0.linux-amd64.tar.gz
+wget https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 mkdir temp-go
-tar -C temp-go/ -xzf go1.25.0.linux-amd64.tar.gz
+tar -C temp-go/ -xzf go1.26.4.linux-amd64.tar.gz
 
 mkdir /root/.go/
 mv temp-go/go/* /root/.go/

--- a/infra/base-images/base-runner/install_go.sh
+++ b/infra/base-images/base-runner/install_go.sh
@@ -21,9 +21,9 @@ case $(uname -m) in
     x86_64)
       # Download and install Go.
       export GOROOT=/root/.go
-      wget https://go.dev/dl/go1.25.0.linux-amd64.tar.gz
+      wget https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
       mkdir temp-go
-      tar -C temp-go/ -xzf go1.25.0.linux-amd64.tar.gz
+      tar -C temp-go/ -xzf go1.26.4.linux-amd64.tar.gz
 
       mkdir $GOROOT
       mv temp-go/go/* /root/.go/


### PR DESCRIPTION
Fixes #15307.

@AdamKorcz @DavidKorczynski Could you please take a look at this PR? Go 1.27 is getting released next month, and I would love to be able to drop Go 1.25 support in quic-go asap. Currently, this is not possible because OSS-Fuzz ships with Go 1.25.0.