### PR TITLE
fix(infra): correct mock.patch target for build_image_impl in helper_test

### DIFF
--- a/infra/helper_test.py
+++ b/infra/helper_test.py
@@ -33,7 +33,7 @@ class ShellTest(unittest.TestCase):
   """Tests 'shell' command."""
 
   @mock.patch('helper.docker_run')
-  @mock.patch('helper.build_image_impl')
+  @mock.patch('common_utils.build_image_impl')
   def test_base_runner_debug(self, _, __):
     """Tests that shell base-runner-debug works as intended."""
     image_name = 'base-runner-debug'


### PR DESCRIPTION
### What changed

In `ShellTest.test_base_runner_debug` inside `infra/helper_test.py`, the mock decorator was incorrectly targeting `helper.build_image_impl`:

```python
# Before (incorrect)
@mock.patch('helper.build_image_impl')

# After (correct)
@mock.patch('common_utils.build_image_impl')
```

### Why it was wrong

**`build_image_impl` is defined in `common_utils.py`, not in `helper.py`.**

Python's `unittest.mock.patch` works by replacing the name **at the location where it is defined** (or where it is imported and used). Since `helper.build_image_impl` does not exist as a name in the `helper` module, the patch had **no effect** — the real `build_image_impl` function was being called silently during the test, making it neither a true unit test nor reliable in environments without Docker.

### Impact

- The test `test_base_runner_debug` was not actually isolating the unit under test.
- Any side effects from the real `build_image_impl` (e.g., Docker calls) could cause non-deterministic failures in CI.
- This fix ensures the mock is applied correctly so the test runs fast, isolated, and without external dependencies.

### No functional changes

Only the test file is modified. No production code is affected.
