### PR TITLE
symphonia: Add build files to complete integration

### DIFF
--- a/projects/symphonia/Dockerfile
+++ b/projects/symphonia/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+
+RUN git clone https://github.com/pdeljanov/Symphonia $SRC/symphonia
+WORKDIR $SRC/symphonia/symphonia
+
+COPY build.sh $SRC/

--- a/projects/symphonia/build.sh
+++ b/projects/symphonia/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# The fuzz crate lives at symphonia/fuzz within the repository and declares
+# its own cargo workspace, so build artifacts land under fuzz/target/.
+cd $SRC/symphonia/symphonia
+
+cargo fuzz build -O
+
+cargo fuzz list | while read -r target; do
+  cp "fuzz/target/x86_64-unknown-linux-gnu/release/$target" "$OUT/"
+done

--- a/projects/symphonia/project.yaml
+++ b/projects/symphonia/project.yaml
@@ -1,6 +1,10 @@
 homepage: "https://docs.rs/symphonia/"
 main_repo: "https://github.com/pdeljanov/Symphonia.git"
 language: rust
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
 primary_contact: "jophba@chromium.org"
 auto_ccs:
   - philip.deljanov@gmail.com


### PR DESCRIPTION
Completes the integration for **symphonia** (approved in #14981, which added only `project.yaml`).

- **Dockerfile**: based on `base-builder-rust`, clones https://github.com/pdeljanov/Symphonia.
- **build.sh**: runs `cargo fuzz build -O` from the `symphonia/` crate directory (the fuzz crate lives at `symphonia/fuzz` and declares its own workspace, so artifacts land under `fuzz/target/`), then copies all 15 fuzz targets (8 decoders, 7 demuxers) to `$OUT`.
- **project.yaml**: explicitly pins `fuzzing_engines: [libfuzzer]` and `sanitizers: [address]`, the supported options for Rust projects.

All 15 targets were verified to build with `cargo fuzz build -O` locally.