### PR TITLE
Add httrack project

### DIFF
--- a/projects/httrack/Dockerfile
+++ b/projects/httrack/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
+RUN apt-get update && apt-get install -y \
+    make autoconf automake libtool autoconf-archive zlib1g-dev
+RUN git clone --depth 1 --recurse-submodules \
+    https://github.com/xroche/httrack.git httrack
+WORKDIR httrack
+COPY build.sh $SRC/

--- a/projects/httrack/build.sh
+++ b/projects/httrack/build.sh
@@ -22,11 +22,35 @@
 ./configure --disable-shared --disable-https AR=llvm-ar RANLIB=llvm-ranlib
 make -j"$(nproc)" -C src libhttrack.la
 
+# TEMPORARY DEBUG (revert before merge): identify why GNU ld rejects the
+# afl-clang-fast archive (ELF vs bitcode vs empty members).
+echo "=== DEBUG: toolchain ==="
+ld --version | head -1 || true
+$CC --version || true
+echo "=== DEBUG: object/archive headers ==="
+wc -c src/libhttrack_la-htscore.o || true
+od -An -tx1 -N16 src/libhttrack_la-htscore.o || true
+readelf -h src/libhttrack_la-htscore.o 2>&1 | head -8 || true
+od -An -tx1 -N16 src/.libs/libhttrack.a || true
+nm src/libhttrack_la-htscore.o 2>&1 | head -3 || true
+llvm-nm src/libhttrack_la-htscore.o 2>&1 | head -3 || true
+
 for f in charset meta idna entities unescape filters url; do
     $CC $CFLAGS -DHAVE_CONFIG_H -I. -Isrc -Isrc/coucal \
         -c "fuzz/fuzz-$f.c" -o "fuzz-$f.o"
     # shellcheck disable=SC2086
     $CXX $CXXFLAGS "fuzz-$f.o" -o "$OUT/fuzz-$f" \
-        $LIB_FUZZING_ENGINE src/.libs/libhttrack.a -lz -lpthread
+        $LIB_FUZZING_ENGINE src/.libs/libhttrack.a -lz -lpthread ||
+        { # TEMPORARY DEBUG: which link strategy survives?
+            echo "=== DEBUG: default link failed, retrying with lld ==="
+            # shellcheck disable=SC2086
+            $CXX $CXXFLAGS -fuse-ld=lld "fuzz-$f.o" -o "$OUT/fuzz-$f" \
+                $LIB_FUZZING_ENGINE src/.libs/libhttrack.a -lz -lpthread ||
+                { echo "=== DEBUG: lld failed too, linking bare objects ==="
+                    # shellcheck disable=SC2086
+                    $CXX $CXXFLAGS "fuzz-$f.o" -o "$OUT/fuzz-$f" \
+                        $LIB_FUZZING_ENGINE src/libhttrack_la-*.o \
+                        src/coucal/libhttrack_la-*.o \
+                        src/minizip/libhttrack_la-*.o -lz -lpthread; }; }
     zip -j "$OUT/fuzz-${f}_seed_corpus.zip" fuzz/corpus/"$f"/*
 done

--- a/projects/httrack/build.sh
+++ b/projects/httrack/build.sh
@@ -18,7 +18,8 @@
 # Build the static engine library with the OSS-Fuzz toolchain, then link the
 # in-tree libFuzzer harnesses (fuzz/) against $LIB_FUZZING_ENGINE.
 ./bootstrap
-./configure --disable-shared --disable-https
+# llvm-ar/ranlib: GNU ranlib leaves afl-clang-fast archives index-less.
+./configure --disable-shared --disable-https AR=llvm-ar RANLIB=llvm-ranlib
 make -j"$(nproc)" -C src libhttrack.la
 
 for f in charset meta idna entities unescape filters url; do

--- a/projects/httrack/build.sh
+++ b/projects/httrack/build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Build the static engine library with the OSS-Fuzz toolchain, then link the
+# in-tree libFuzzer harnesses (fuzz/) against $LIB_FUZZING_ENGINE.
+./bootstrap
+./configure --disable-shared --disable-https
+make -j"$(nproc)" -C src libhttrack.la
+
+for f in charset meta idna entities unescape filters url; do
+    $CC $CFLAGS -DHAVE_CONFIG_H -I. -Isrc -Isrc/coucal \
+        -c "fuzz/fuzz-$f.c" -o "fuzz-$f.o"
+    # shellcheck disable=SC2086
+    $CXX $CXXFLAGS "fuzz-$f.o" -o "$OUT/fuzz-$f" \
+        $LIB_FUZZING_ENGINE src/.libs/libhttrack.a -lz -lpthread
+    zip -j "$OUT/fuzz-${f}_seed_corpus.zip" fuzz/corpus/"$f"/*
+done

--- a/projects/httrack/build.sh
+++ b/projects/httrack/build.sh
@@ -18,39 +18,17 @@
 # Build the static engine library with the OSS-Fuzz toolchain, then link the
 # in-tree libFuzzer harnesses (fuzz/) against $LIB_FUZZING_ENGINE.
 ./bootstrap
-# llvm-ar/ranlib: GNU ranlib leaves afl-clang-fast archives index-less.
-./configure --disable-shared --disable-https AR=llvm-ar RANLIB=llvm-ranlib
+# afl-cc rewrites -fcf-protection into CFI+LTO, emitting bitcode objects GNU
+# binutils can't archive/link: drop the CET flag, archive with the llvm tools.
+ax_cv_check_cflags___fcf_protection=no \
+    ./configure --disable-shared --disable-https AR=llvm-ar RANLIB=llvm-ranlib
 make -j"$(nproc)" -C src libhttrack.la
-
-# TEMPORARY DEBUG (revert before merge): identify why GNU ld rejects the
-# afl-clang-fast archive (ELF vs bitcode vs empty members).
-echo "=== DEBUG: toolchain ==="
-ld --version | head -1 || true
-$CC --version || true
-echo "=== DEBUG: object/archive headers ==="
-wc -c src/libhttrack_la-htscore.o || true
-od -An -tx1 -N16 src/libhttrack_la-htscore.o || true
-readelf -h src/libhttrack_la-htscore.o 2>&1 | head -8 || true
-od -An -tx1 -N16 src/.libs/libhttrack.a || true
-nm src/libhttrack_la-htscore.o 2>&1 | head -3 || true
-llvm-nm src/libhttrack_la-htscore.o 2>&1 | head -3 || true
 
 for f in charset meta idna entities unescape filters url; do
     $CC $CFLAGS -DHAVE_CONFIG_H -I. -Isrc -Isrc/coucal \
         -c "fuzz/fuzz-$f.c" -o "fuzz-$f.o"
     # shellcheck disable=SC2086
     $CXX $CXXFLAGS "fuzz-$f.o" -o "$OUT/fuzz-$f" \
-        $LIB_FUZZING_ENGINE src/.libs/libhttrack.a -lz -lpthread ||
-        { # TEMPORARY DEBUG: which link strategy survives?
-            echo "=== DEBUG: default link failed, retrying with lld ==="
-            # shellcheck disable=SC2086
-            $CXX $CXXFLAGS -fuse-ld=lld "fuzz-$f.o" -o "$OUT/fuzz-$f" \
-                $LIB_FUZZING_ENGINE src/.libs/libhttrack.a -lz -lpthread ||
-                { echo "=== DEBUG: lld failed too, linking bare objects ==="
-                    # shellcheck disable=SC2086
-                    $CXX $CXXFLAGS "fuzz-$f.o" -o "$OUT/fuzz-$f" \
-                        $LIB_FUZZING_ENGINE src/libhttrack_la-*.o \
-                        src/coucal/libhttrack_la-*.o \
-                        src/minizip/libhttrack_la-*.o -lz -lpthread; }; }
+        $LIB_FUZZING_ENGINE src/.libs/libhttrack.a -lz -lpthread
     zip -j "$OUT/fuzz-${f}_seed_corpus.zip" fuzz/corpus/"$f"/*
 done

--- a/projects/httrack/project.yaml
+++ b/projects/httrack/project.yaml
@@ -1,0 +1,13 @@
+base_os_version: ubuntu-24-04
+homepage: "https://www.httrack.com/"
+language: c
+primary_contact: "xroche@gmail.com"
+main_repo: "https://github.com/xroche/httrack.git"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+sanitizers:
+  - address
+  - undefined
+architectures:
+  - x86_64


### PR DESCRIPTION
Integrates HTTrack Website Copier (https://www.httrack.com/), an offline website mirroring tool that parses hostile input off the network. I maintain the project.

The harnesses in `projects/httrack/build.sh` are the ones already maintained in the upstream `fuzz/` tree behind an `--enable-fuzzers` build gate, replayed against their seed corpora in CI under ASan/UBSan. They cover the pure `(data,size)` parsers that handle untrusted crawled input: the charset/UTF-8/IDNA codecs, the meta-tag charset sniffer, the HTML entity and URL percent decoders, the wildcard filter matcher, and the URL parser. Seed corpora ship alongside the harnesses.

Built and validated locally with `infra/helper.py build_fuzzers` and `check_build` for both the address and undefined sanitizers.

`primary_contact` is my own address.