### PR TITLE
connectedhomeip: fix fuzz-introspector build timeout by excluding third_party from analysis

### DIFF
--- a/projects/connectedhomeip/Dockerfile
+++ b/projects/connectedhomeip/Dockerfile
@@ -44,6 +44,20 @@ RUN cd $SRC/connectedhomeip && scripts/checkout_submodules.py --shallow --platfo
 SHELL ["/bin/bash", "-c"]
 RUN cd $SRC/connectedhomeip && . scripts/bootstrap.sh
 
+# Work around the Fuzz Introspector build timeout (oss-fuzz#13153). base-builder's `compile` runs
+# the introspector source analysis (tree-sitter parse of the whole tree + a per-harness call-graph
+# pass) BEFORE build.sh. On connectedhomeip that is ~4h just to load ~32k files' trees, plus ~6h
+# over the ~230 fuzz harnesses vendored under third_party -- together exceeding the build deadline.
+# Because the analysis runs before build.sh, move third_party out of the source tree here (after
+# bootstrap, which needs third_party/pigweed) so the analysis skips ~15k files and those ~230
+# harnesses; build.sh moves it back before `gn gen`, so the actual asan/msan/coverage fuzz builds
+# are unaffected. The stash dir is outside $SRC so the analysis (--target-dir=$SRC) never walks it.
+# Also drop the dead all-clusters-minimal-app fuzz driver (a whole-application harness built by no
+# target) so the analysis doesn't spend time on its Matter-wide call graph.
+RUN cd $SRC/connectedhomeip && \
+    rm -f examples/all-clusters-minimal-app/linux/fuzzing-main.cpp && \
+    mv third_party /opt/chip-third-party-stash
+
 # meson + packaging: GLib build deps for the MSAN dependency sysroot that build.sh builds when
 # SANITIZER=memory (built there, not here -- the deps' configure/meson run instrumented binaries
 # that need lowered ASLR, which only the privileged `compile` step provides).

--- a/projects/connectedhomeip/build.sh
+++ b/projects/connectedhomeip/build.sh
@@ -24,6 +24,14 @@ fi
 
 cd $SRC/connectedhomeip
 
+# The Dockerfile moved third_party out of the source tree so Fuzz Introspector's analysis (which
+# runs before build.sh) skips it and stays within the build deadline (see the Dockerfile / oss-fuzz
+# #13153). Restore it now -- before `gn gen` -- so every build (asan/msan/coverage/introspector)
+# compiles normally. The introspector analysis has already run by this point.
+if [ -d /opt/chip-third-party-stash ] && [ ! -e third_party ]; then
+  mv /opt/chip-third-party-stash third_party
+fi
+
 # Preserve the OSS-Fuzz-provided toolchain settings. The pw_fuzzer / FuzzTest toolchain
 # (//build/toolchain/pw_fuzzer) reads $CC/$CXX/$CFLAGS/$CXXFLAGS at `gn gen` time so its
 # libFuzzer runtime matches OSS-Fuzz's instrumentation; Pigweed's activate.sh may change


### PR DESCRIPTION
**What**: Restores the Fuzz Introspector build for connectedhomeip, which has failed every day since 2024-12-17 with `context deadline exceeded` (#13153).

**Root cause**: `base-builder/compile` runs the introspector source analysis before `build.sh`. On connectedhomeip it runs ~11h and times out — ~4.3h in the initial whole-tree tree-sitter load (dominated by files vendored under `third_party`) plus ~6h across 239 "harnesses", ~230 of which are fuzzers vendored by dependencies (mbedtls, openthread, libdatachannel's bundled copy of LLVM's Fuzzer test suite, boringssl, ...) rather than connectedhomeip's own ~10 targets.

**Fix**: Because the analysis runs before `build.sh`, `third_party` is moved out of the source tree in the `Dockerfile` (after `bootstrap.sh`, which needs `third_party/pigweed`) and restored in `build.sh` before `gn gen`. The real asan/msan/coverage builds are unaffected — they compile with `third_party` restored; only the pre-build introspector analysis sees the reduced tree. The dead `all-clusters-minimal-app` fuzzing driver (compiled by no target) is also dropped.

**Effect**: The introspector report becomes scoped to connectedhomeip's own code rather than descending into vendored dependency internals — the useful scope here, and a report where there has been none for ~7 months.

**Testing**: Verified locally that (1) with `third_party` excluded the analysis clears the tree-sitter load in seconds (was ~4.3h) and processes connectedhomeip's own harnesses through to report generation, and (2) `build_fuzzers --sanitizer address` still compiles all targets with `third_party` restored by `build.sh`. The exact introspector wall-clock will be confirmed by the periodic cloud build.

Fixes #13153
