### PR TITLE
Fix memory leak in Xpdf's fuzz_JBIG2.cc

### DIFF
--- a/projects/xpdf/fuzz_JBIG2.cc
+++ b/projects/xpdf/fuzz_JBIG2.cc
@@ -78,8 +78,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         {
           currentObj.getStream()->reset();
         }
+        currentObj.free();
       }
-      currentObj.free();
     }
   }
   catch (...)


### PR DESCRIPTION
Objects should be freed as often as they are created.

This change was discussed with and approved by Derek B. Noonburg from the Xpdf project.