### PR TITLE
Add rustbgpd project

### DIFF
--- a/projects/rustbgpd/Dockerfile
+++ b/projects/rustbgpd/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-rust:ubuntu-24-04
+RUN git clone --depth 1 https://github.com/lance0/rustbgpd rustbgpd
+RUN rustup update nightly
+ENV RUSTUP_TOOLCHAIN=nightly
+RUN cargo install cargo-fuzz --locked
+WORKDIR rustbgpd
+COPY build.sh $SRC/

--- a/projects/rustbgpd/build.sh
+++ b/projects/rustbgpd/build.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# rustbgpd carries one cargo-fuzz crate per fuzzed workspace crate.
+# Target names are globally unique across the four directories.
+FUZZ_DIRS="crates/wire crates/policy crates/evpn crates/mrt"
+TARGET_DIR="fuzz/target/x86_64-unknown-linux-gnu/release"
+
+for dir in $FUZZ_DIRS; do
+  pushd "$SRC/rustbgpd/$dir"
+  cargo fuzz build -O --debug-assertions
+  for f in fuzz/fuzz_targets/*.rs; do
+    name=$(basename "${f%.rs}")
+    cp "$TARGET_DIR/$name" "$OUT/"
+    # Ship the in-tree seed corpus when one exists.
+    if [ -d "fuzz/seeds/$name" ]; then
+      zip -jr "$OUT/${name}_seed_corpus.zip" "fuzz/seeds/$name"
+    fi
+  done
+  popd
+done

--- a/projects/rustbgpd/project.yaml
+++ b/projects/rustbgpd/project.yaml
@@ -1,0 +1,25 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+homepage: "https://github.com/lance0/rustbgpd"
+main_repo: "https://github.com/lance0/rustbgpd"
+language: rust
+base_os_version: ubuntu-24-04
+primary_contact: "lancey3@gmail.com"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer


### PR DESCRIPTION
## Summary

- onboard rustbgpd, an API-first BGP daemon for route-server and control-plane use cases
- build all 17 existing `cargo-fuzz` targets across the wire, policy, EVPN, and MRT crates
- publish the matching in-tree seed corpora
- use the Ubuntu 24.04 Rust builder with a current nightly toolchain, required by rustbgpd's Rust 1.95 MSRV

rustbgpd parses untrusted BGP, policy, and MRT inputs at a network control-plane boundary. I maintain the project, and `primary_contact` is my Google account.

## Validation

- `python3 infra/ci/check_base_os.py projects/rustbgpd`
- `python3 infra/presubmit.py -s`
- `python3 infra/helper.py build_image --pull rustbgpd`
- `python3 infra/helper.py build_fuzzers --clean --engine libfuzzer --sanitizer address rustbgpd`
- `python3 infra/helper.py check_build --engine libfuzzer --sanitizer address rustbgpd`
- exact executable inventory: 17 targets
- fresh-corpus `decode_update` run: 6,453,112 executions in 61 seconds

The inventory gate was also mutation-tested by omitting the MRT fuzz crate: it failed with exactly `snapshot_reader_drain` and `warm_bundle_manifest` missing, then passed after restoration and a clean rebuild.