### PR TITLE
Add Apache Shiro to the OSS-fuzz

### DIFF
--- a/projects/apache-shiro/project.yaml
+++ b/projects/apache-shiro/project.yaml
@@ -1,0 +1,16 @@
+fuzzing_engines:
+  - libfuzzer
+homepage: https://shiro.apache.org
+main_repo: https://github.com/apache/shiro
+language: jvm
+primary_contact: "lennyprimak@gmail.com"
+auto_ccs:
+  - "security@shiro.apache.org"
+  - "lprimak@apache.org"
+sanitizers:
+  - address
+  - memory:
+      experimental: True
+  - undefined
+vendor_ccs:
+  - "lenny@flowlogix.com"


### PR DESCRIPTION
Please add Apache Shiro to the oss-fuzz registry

Apache Shiro is a Java Application security framework.

- 15 years old
- 4,400+ stars
- Widely used Java dependency
- Many security reports and CVEs already processed

Thank you