### PR TITLE
bazel-rules-fuzzing-test: fix broken build

### DIFF
--- a/projects/bazel-rules-fuzzing-test/build.sh
+++ b/projects/bazel-rules-fuzzing-test/build.sh
@@ -19,6 +19,17 @@
 # Work around https://github.com/bazelbuild/bazel/issues/21592: 
 # The `layering_check` feature does not work with `--spawn_strategy=standalone`,
 # which is the default for OSS-Fuzz builds.
-export BAZEL_EXTRA_BUILD_FLAGS="--spawn_strategy=sandboxed"
+AFLPP_RT=""
+for f in /src/aflplusplus/afl-llvm-rt.o /src/aflplusplus/llvm_mode/afl-llvm-rt.o /src/aflplusplus/afl-compiler-rt.o; do
+    if [ -f "$f" ]; then
+        AFLPP_RT="$f"
+        break
+    fi
+done
+if [ -n "$AFLPP_RT" ]; then
+    export BAZEL_EXTRA_BUILD_FLAGS="--spawn_strategy=sandboxed --linkopt=${AFLPP_RT}"
+else
+    export BAZEL_EXTRA_BUILD_FLAGS="--spawn_strategy=sandboxed"
+fi
 
 bazel_build_fuzz_tests


### PR DESCRIPTION
The build previously failed while linking several fuzz targets, including `empty_fuzz_test_raw_`, `empty_fuzz_test_with_dict_raw_`, and `empty_fuzz_test_with_corpus_raw_`. The linker reported unresolved AFL++ runtime symbols, including `__afl_manual_init`, `__afl_fuzz_ptr`, `__afl_persistent_loop`, `__afl_fuzz_len`, `__afl_area_ptr`, and `__afl_map_size`. These references originate from `aflpp_driver.o` in `rules_fuzzing_oss_fuzz/oss_fuzz_engine.a`. This indicates that the AFL++ driver was linked into the fuzz targets, but the corresponding AFL++ runtime object was missing from the final link command.

The previous `build.sh` set only `BAZEL_EXTRA_BUILD_FLAGS` to use sandboxed spawning as a workaround for Bazel's layering-check behavior. This change retains that workaround and also searches for an AFL++ runtime object in the OSS-Fuzz build image. When a supported runtime object is found, the script passes it to Bazel through `--linkopt`, ensuring that the final link includes the runtime definitions required by the AFL++ driver.

The change was validated with the following command:

```bash
python3.10 infra/helper.py check_build --sanitizer address --engine afl --architecture x86_64 bazel-rules-fuzzing-test
```

The check completed successfully for all generated fuzz targets.
