### PR TITLE
mdbook-i18n-helpers: fix broken build

### DIFF
--- a/projects/mdbook-i18n-helpers/Dockerfile
+++ b/projects/mdbook-i18n-helpers/Dockerfile
@@ -18,7 +18,6 @@ FROM gcr.io/oss-fuzz-base/base-builder-rust
 
 RUN git clone --depth 1 https://github.com/google/mdbook-i18n-helpers.git
 
-# See https://github.com/serde-rs/serde/issues/2770#issuecomment-2212162225
-ENV RUSTUP_TOOLCHAIN nightly-2024-07-07
+ENV RUSTUP_TOOLCHAIN nightly
 WORKDIR mdbook-i18n-helpers
 COPY build.sh $SRC/


### PR DESCRIPTION
Update the Rust nightly toolchain used by mdbook-i18n-helpers.
Commit 7181fcd updated the project dependencies and introduced mdbook-renderer 0.5.3, whose manifest requires Edition 2024 support. The previously pinned nightly-2024-07-07 toolchain uses Cargo 1.81 nightly, which cannot parse this manifest and causes cargo fuzz build to fail before compilation.
Using the current nightly toolchain provides the required Cargo support while leaving the existing fuzz targets and build logic unchanged.