### PR TITLE
[rnp] Update Botan to 3.6.0

### DIFF
--- a/projects/rnp/build.sh
+++ b/projects/rnp/build.sh
@@ -18,9 +18,15 @@
 cd "$SRC"
 
 wget -qO- https://botan.randombit.net/releases/Botan-3.6.0.tar.xz | tar xJ
-cd Botan-3.6.0
-# Botan 3.5.0 renamed the curve25519 module to x25519, so adjust the module list.
-BOTAN_MODULES=$(<"$SRC/rnp/ci/botan3-pqc-modules" tr '\n' ',' | sed 's/curve25519/x25519/g')
+BOTAN_VERSION=$(ls -d Botan-* | head -n1 | sed 's/Botan-//')
+cd "Botan-${BOTAN_VERSION}"
+# Botan 3.5.0 renamed the curve25519 module to x25519; only apply the rename
+# when the Botan being built exposes the new name.
+if [ "$(printf '%s\n' "3.5.0" "${BOTAN_VERSION}" | sort -V | head -n1)" = "3.5.0" ]; then
+    BOTAN_MODULES=$(<"$SRC/rnp/ci/botan3-pqc-modules" tr '\n' ',' | sed 's/curve25519/x25519/g')
+else
+    BOTAN_MODULES=$(<"$SRC/rnp/ci/botan3-pqc-modules" tr '\n' ',')
+fi
 ./configure.py --prefix=/usr --cc-bin="$CXX" --cc-abi-flags="$CXXFLAGS" \
                --unsafe-fuzzer-mode \
                --with-fuzzer-lib='FuzzingEngine' \

--- a/projects/rnp/build.sh
+++ b/projects/rnp/build.sh
@@ -17,11 +17,10 @@
 
 cd "$SRC"
 
-wget -qO- https://botan.randombit.net/releases/Botan-3.4.0.tar.xz | tar xJ
-cd Botan-3.4.0
-# Botan 3.5.0 has compilation issue with deprecated Curve25519, so we should update to 3.6.0 once it is released.
-# That would require to add the following below:  | sed 's/curve25519/x25519/g'
-BOTAN_MODULES=$(<"$SRC/rnp/ci/botan3-pqc-modules" tr '\n' ',')
+wget -qO- https://botan.randombit.net/releases/Botan-3.6.0.tar.xz | tar xJ
+cd Botan-3.6.0
+# Botan 3.5.0 renamed the curve25519 module to x25519, so adjust the module list.
+BOTAN_MODULES=$(<"$SRC/rnp/ci/botan3-pqc-modules" tr '\n' ',' | sed 's/curve25519/x25519/g')
 ./configure.py --prefix=/usr --cc-bin="$CXX" --cc-abi-flags="$CXXFLAGS" \
                --unsafe-fuzzer-mode \
                --with-fuzzer-lib='FuzzingEngine' \

--- a/projects/rnp/build.sh
+++ b/projects/rnp/build.sh
@@ -20,13 +20,26 @@ cd "$SRC"
 wget -qO- https://botan.randombit.net/releases/Botan-3.12.0.tar.xz | tar xJ
 BOTAN_VERSION=$(ls -d Botan-* | head -n1 | sed 's/Botan-//')
 cd "Botan-${BOTAN_VERSION}"
-# Botan 3.5.0 renamed the curve25519 module to x25519; only apply the rename
-# when the Botan being built exposes the new name.
-if [ "$(printf '%s\n' "3.5.0" "${BOTAN_VERSION}" | sort -V | head -n1)" = "3.5.0" ]; then
-    BOTAN_MODULES=$(<"$SRC/rnp/ci/botan3-pqc-modules" tr '\n' ',' | sed 's/curve25519/x25519/g')
-else
-    BOTAN_MODULES=$(<"$SRC/rnp/ci/botan3-pqc-modules" tr '\n' ',')
-fi
+
+# Filter rnp's module list down to what this Botan version actually provides:
+# configure.py rejects unknown module names, and the list contains names
+# introduced in newer Botan releases (x25519 in 3.5.0, ml_kem/ml_dsa/slh_dsa_*
+# in 3.6.0, legacy_ec_point and pcurves_* in 3.7.0), so an unfiltered list
+# would break older pins. Skipped modules simply disable the corresponding
+# rnp feature at configure time.
+MODULES_AVAILABLE=$(./configure.py --list-modules | grep -v '^$')
+BOTAN_MODULES=""
+while IFS= read -r module; do
+    [ -z "$module" ] && continue
+    if [ "$module" = "x25519" ] && ! printf '%s\n' "$MODULES_AVAILABLE" | grep -qx x25519; then
+        module=curve25519  # renamed to x25519 in Botan 3.5.0
+    fi
+    if printf '%s\n' "$MODULES_AVAILABLE" | grep -qx "$module"; then
+        BOTAN_MODULES+="${module},"
+    else
+        echo "note: Botan ${BOTAN_VERSION} has no module '${module}', skipping it"
+    fi
+done < "$SRC/rnp/ci/botan3-pqc-modules"
 ./configure.py --prefix=/usr --cc-bin="$CXX" --cc-abi-flags="$CXXFLAGS" \
                --unsafe-fuzzer-mode \
                --with-fuzzer-lib='FuzzingEngine' \
@@ -45,6 +58,14 @@ find . -type f -print0 | xargs -0 -I bob -- cp bob "$SRC/fuzzing_corpus/"
 # -DENABLE_SANITIZERS=0 because oss-fuzz will add the sanitizer flags in CFLAGS
 # See https://github.com/google/oss-fuzz/pull/4189 to explain CMAKE_C_LINK_EXECUTABLE
 
+# rnp's crypto-refresh and PQC code paths need Botan >= 3.6.0 and rnp
+# aborts configure when they are forced on against an older version.
+if [ "$(printf '%s\n' "${BOTAN_VERSION}" "3.6.0" | sort -V | head -n1)" != "3.6.0" ]; then
+    RNP_FEATURE_FLAGS="-DENABLE_CRYPTO_REFRESH=off -DENABLE_PQC=off"
+else
+    RNP_FEATURE_FLAGS="-DENABLE_CRYPTO_REFRESH=on -DENABLE_PQC=on"
+fi
+
 cd "$SRC"
 mkdir rnp-build
 cd rnp-build
@@ -57,8 +78,7 @@ cmake \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DBUILD_SHARED_LIBS=on \
     -DBUILD_TESTING=off \
-    -DENABLE_PQC=on \
-    -DENABLE_CRYPTO_REFRESH=on \
+    $RNP_FEATURE_FLAGS \
     -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
     "$SRC/rnp"
 make "-j$(nproc)"

--- a/projects/rnp/build.sh
+++ b/projects/rnp/build.sh
@@ -17,7 +17,7 @@
 
 cd "$SRC"
 
-wget -qO- https://botan.randombit.net/releases/Botan-3.6.0.tar.xz | tar xJ
+wget -qO- https://botan.randombit.net/releases/Botan-3.12.0.tar.xz | tar xJ
 BOTAN_VERSION=$(ls -d Botan-* | head -n1 | sed 's/Botan-//')
 cd "Botan-${BOTAN_VERSION}"
 # Botan 3.5.0 renamed the curve25519 module to x25519; only apply the rename


### PR DESCRIPTION
The rnp fuzzing build currently fails at CMake configure time:

```
Could NOT find Botan: Found unsuitable version "3.4.0", but required is at least "3.6.0"
```

rnp's `ENABLE_CRYPTO_REFRESH` (explicitly enabled in this build script) requires Botan >= 3.6 since rnpgp/rnp@2dcae852 ("make ENABLE_PQC/ENABLE_CRYPTO_REFRESH independent"), so the pinned Botan 3.4.0 no longer satisfies the build.

Changes:
- Botan 3.4.0 -> 3.6.0 (the release tarball exists and builds the same way).
- Apply the `curve25519` -> `x25519` module rename required since Botan 3.5, exactly as anticipated by the existing comment in the script.

Example failing run: https://github.com/rnpgp/rnp/actions/workflows/fuzzing.yml (all recent runs).