### PR TITLE
pendulum: fix broken build

### DIFF
--- a/projects/pendulum/Dockerfile
+++ b/projects/pendulum/Dockerfile
@@ -17,3 +17,5 @@ RUN pip3 install --upgrade pip tzdata
 RUN git clone https://github.com/sdispater/pendulum pendulum
 COPY *.sh *py $SRC/
 WORKDIR $SRC/pendulum
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+ENV PATH="/root/.cargo/bin:${PATH}"

--- a/projects/pendulum/build.sh
+++ b/projects/pendulum/build.sh
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 ################################################################################
+unset RUSTFLAGS
+unset CARGO_ENCODED_RUSTFLAGS
 pip3 install .
 
 # Build fuzzers in $OUT.


### PR DESCRIPTION
Pendulum commit 5c01d00c52142b16934a6c3e2f191c42dd8bfb24 switched the package build backend from Poetry to Maturin, making pip3 install . require Cargo to compile the Rust extension. The existing OSS-Fuzz image did not provide a usable Rust toolchain, and keeping OSS-Fuzz’s Rust sanitizer flags caused stable Rust to reject the nightly-only -Zsanitizer option and nightly Rust to fail while resolving PyO3 proc-macro crates. The fix installs stable Rust and clears RUSTFLAGS and CARGO_ENCODED_RUSTFLAGS before the Maturin build, allowing the Pendulum fuzzer to build successfully.