### PR TITLE
publicsuffix-list: fix broken build

### DIFF
--- a/projects/publicsuffix-list/build.sh
+++ b/projects/publicsuffix-list/build.sh
@@ -18,8 +18,5 @@
 sed 's/package main/package tools/g' -i ./tools/newgtlds.go
 rm ./tools/newgtlds_test.go
 cp $SRC/fuzz_test.go ./tools/
-go mod init github.com/publicsuffix/list
-go mod tidy
 printf "package tools\nimport _ \"github.com/AdamKorcz/go-118-fuzz-build/testing\"\n" > ./tools/register.go
-go mod tidy
-compile_native_go_fuzzer github.com/publicsuffix/list/tools FuzzTest FuzzTest
+cd tools && go mod tidy && compile_native_go_fuzzer github.com/publicsuffix/list/tools FuzzTest FuzzTest


### PR DESCRIPTION
The build script created a new Go module at the repository root, while `tools/go.mod` already defines `github.com/publicsuffix/list/tools` as a separate nested module. As a result, the root module contained no packages, `go mod tidy` reported that `"all" matched no packages`, and `compile_native_go_fuzzer` could not resolve `github.com/publicsuffix/list/tools`. This change removes the redundant root module initialization and runs dependency resolution and fuzz target compilation from the existing `tools` module.
