### PR TITLE
pydantic: fix broken build

### DIFF
--- a/projects/pydantic/build.sh
+++ b/projects/pydantic/build.sh
@@ -14,9 +14,8 @@
 # limitations under the License.
 #
 ################################################################################
-ln -s /usr/local/bin/python3 /usr/local/bin/python
-sed -i "s/__version__/compiled=\"hack\"\n__version__/g" pydantic/__init__.py
-make install
+ln -sf /usr/local/bin/python3 /usr/local/bin/python
+pip install .
 
 # Build fuzzers in $OUT.
 for fuzzer in $(find $SRC -name 'fuzz_*.py'); do


### PR DESCRIPTION
The Pydantic build failed before installing the project because build.sh unconditionally ran ln -s /usr/local/bin/python3 /usr/local/bin/python, while /usr/local/bin/python already existed in the Ubuntu 24.04 Python builder image, causing ln to exit with File exists. This change makes the link creation overwrite-safe with ln -sf and installs the checked-out project directly with pip install . instead of modifying pydantic/__init__.py and invoking make install. With these changes, both fuzz targets were generated successfully and the AddressSanitizer, libFuzzer, x86_64 check_build completed successfully.