### PR TITLE
reload4j: fix broken build

### DIFF
--- a/projects/reload4j/build.sh
+++ b/projects/reload4j/build.sh
@@ -28,6 +28,7 @@ pushd "/tmp"
 popd
 
 pushd "${SRC}/reload4j"
+	sed -i '/import sun.rmi.runtime/d' src/main/java/org/apache/log4j/NewAsyncAppender.java
 	${MVN} package ${MVN_FLAGS}
 	${MVN} install ${MVN_FLAGS}
 	CURRENT_VERSION=$(${MVN} org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate \


### PR DESCRIPTION
The reload4j build fails because NewAsyncAppender.java imports the JDK-internal class sun.rmi.runtime.Log, while the java.rmi module does not export the sun.rmi.runtime package to application code. Upstream commit 70dba2d205f17cedc9ccd555877ffe13b2909216 added this import, although it has not been counterfactually verified as the root-cause commit. Since the imported type is unused, remove the import before compiling reload4j to resolve the module-access error without changing NewAsyncAppender behavior.