### PR TITLE
ntopng: fix broken build (librrd-dev dependency)

### DIFF
--- a/projects/ntopng/Dockerfile
+++ b/projects/ntopng/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool ninja-build \
     liblzma-dev libzstd-dev pkg-config libglib2.0-dev groff libxml2-dev \
-    libcurl4-openssl-dev libsqlite3-dev flex bison
+    libcurl4-openssl-dev libsqlite3-dev flex bison librrd-dev
 
 # Ntopng
 RUN git clone --depth 1 https://github.com/ntop/ntopng.git ntopng


### PR DESCRIPTION
ntopng used to build rrdtool from source code shipped in the third-party folder, when the librrd-dev package was not installed. This source code has been now removed and it only relies on installed librrd-dev (detected by pkg-config). This fixes the Dockerfile to install librrd-dev.