### PR TITLE
gstramer: Add missing dependencies

### DIFF
--- a/projects/gstreamer/Dockerfile
+++ b/projects/gstreamer/Dockerfile
@@ -16,7 +16,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN apt-get update && \
-   apt-get install -y make autoconf automake libtool build-essential pkg-config bison flex patchelf nasm
+   apt-get install -y make autoconf automake libtool build-essential pkg-config bison flex patchelf nasm gperf
 
 RUN pip3 install --disable-pip-version-check --no-cache-dir \
         pip==25.1.1


### PR DESCRIPTION
This PR fixes the Dockerfile for project gstreamer which include a new dependency installation to accommodate build changes upstream.