### PR TITLE
setuptools: fix broken build

### DIFF
--- a/projects/setuptools/build.sh
+++ b/projects/setuptools/build.sh
@@ -37,6 +37,7 @@ pip3 install .
 popd
 
 pip3 install .
+pip3 install 'setuptools<82'
 
 cd ../
 mkdir forbuilding


### PR DESCRIPTION
After installing the current setuptools release (82.0.1), the build environment can no longer import pkg_resources, causing altgraph to fail during import. Since PyInstaller imports altgraph during initialization, compile_python_fuzzer fails before any fuzz target is built.

Installing setuptools<82 restores the availability of pkg_resources, allows altgraph to import successfully, and enables PyInstaller to complete the fuzzer packaging process.