### PR TITLE
sigstore-java: fix broken build

### DIFF
--- a/projects/sigstore-java/build.sh
+++ b/projects/sigstore-java/build.sh
@@ -17,6 +17,6 @@
 
 # Specifying the target package prefix for java frontend
 export TARGET_PACKAGE_PREFIX=dev.sigstore.*
-
+export CIFUZZ=true
 # Call build script provided by sigsotre-java/fuzzing
 $SRC/sigstore-java/fuzzing/oss_fuzz_build.sh


### PR DESCRIPTION
Resolves the sigstore-java build failure under OSS-Fuzz's JVM 17 environment by exporting CIFUZZ=true in build.sh. Currently, the project's settings.gradle.kts throws an UnsupportedOperationException when the launching JVM version is below 21 unless the CIFUZZ environment variable is explicitly set to true. Exporting this variable bypasses this strict check and safely activates the upstream-defined JVM 17 compatibility toolchain fallback logic in ToolchainProperties.kt, allowing the fuzz targets to build successfully without requiring a global builder JDK upgrade.