### PR TITLE
projects: add sindook

### DIFF
--- a/projects/sindook/Dockerfile
+++ b/projects/sindook/Dockerfile
@@ -1,0 +1,4 @@
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/ruddro-roy/sindook
+WORKDIR sindook
+COPY build.sh $SRC/

--- a/projects/sindook/Dockerfile
+++ b/projects/sindook/Dockerfile
@@ -1,3 +1,18 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
 FROM gcr.io/oss-fuzz-base/base-builder-go
 RUN git clone --depth 1 https://github.com/ruddro-roy/sindook
 WORKDIR sindook

--- a/projects/sindook/build.sh
+++ b/projects/sindook/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eu
+compile_native_go_fuzzer github.com/ruddro-roy/sindook/internal/box FuzzOpen fuzz_box_open
+compile_native_go_fuzzer github.com/ruddro-roy/sindook/internal/box FuzzOpenPassphrase fuzz_box_open_passphrase
+compile_native_go_fuzzer github.com/ruddro-roy/sindook/internal/box FuzzSealOpenRoundTrip fuzz_box_seal_open_round_trip
+compile_native_go_fuzzer github.com/ruddro-roy/sindook/internal/box FuzzBitFlip fuzz_box_bit_flip
+compile_native_go_fuzzer github.com/ruddro-roy/sindook/internal/armor FuzzArmor fuzz_armor
+compile_native_go_fuzzer github.com/ruddro-roy/sindook/xwing FuzzDecapsulate fuzz_xwing_decapsulate

--- a/projects/sindook/build.sh
+++ b/projects/sindook/build.sh
@@ -1,4 +1,19 @@
 #!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
 compile_native_go_fuzzer github.com/ruddro-roy/sindook/internal/box FuzzOpen fuzz_box_open
 compile_native_go_fuzzer github.com/ruddro-roy/sindook/internal/box FuzzOpenPassphrase fuzz_box_open_passphrase
 compile_native_go_fuzzer github.com/ruddro-roy/sindook/internal/box FuzzSealOpenRoundTrip fuzz_box_seal_open_round_trip

--- a/projects/sindook/project.yaml
+++ b/projects/sindook/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://github.com/ruddro-roy/sindook"
+language: go
+main_repo: "https://github.com/ruddro-roy/sindook"
+primary_contact: "roy@ruddro.com"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
Adds sindook, post-quantum file encryption in Go: X25519 + ML-KEM-768 through the X-Wing hybrid KEM, implemented from draft-connolly-cfrg-xwing-kem-10, validated against the draft's Appendix C vectors and cross-tested against Cloudflare CIRCL and filippo.io/mlkem768/xwing on every CI run.

Six native Go fuzz targets, all maintained in the project repo and already running as CI smoke tests there: four cover the container format (header parsing with attacker-controlled KDF parameters, payload stream, seal/open round trip, single-byte-mutation rejection), one covers the strict ASCII armor decoder, one covers KEM decapsulation determinism including the implicit-rejection path. Around 15M local executions to date with no findings.

Fuzzing setup in the project repo: https://github.com/ruddro-roy/sindook/tree/main/oss-fuzz

primary_contact is the maintainer's Google Workspace account.