### PR TITLE
fix some repo_main for several projects

### DIFF
--- a/projects/geos/Dockerfile
+++ b/projects/geos/Dockerfile
@@ -17,6 +17,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y cmake
 # fallback to github if main git server is not responding
-RUN git clone --depth 1 https://git.osgeo.org/gitea/geos/geos.git || git clone --depth 1 https://github.com/libgeos/geos.git
+RUN git clone --depth 1 https://gitea.osgeo.org/geos/geos || git clone --depth 1 https://github.com/libgeos/geos.git
 COPY run_tests.sh build.sh $SRC/
 WORKDIR $SRC/geos

--- a/projects/geos/project.yaml
+++ b/projects/geos/project.yaml
@@ -9,7 +9,7 @@ auto_ccs :
 sanitizers:
 - address
 - undefined
-main_repo: 'https://git.osgeo.org/gitea/geos/geos.git'
+main_repo: "https://gitea.osgeo.org/geos/geos"
 
 fuzzing_engines:
   - afl

--- a/projects/poppler/project.yaml
+++ b/projects/poppler/project.yaml
@@ -12,7 +12,7 @@ fuzzing_engines:
 auto_ccs:
   - jonathan@titanous.com
   - adam.reichold@t-online.de
-main_repo: 'https://anongit.freedesktop.org/git/poppler/poppler.git'
+main_repo: "https://gitlab.freedesktop.org/poppler/poppler"
 fuzzing_engines:
  - afl
  - honggfuzz

--- a/projects/postgis/Dockerfile
+++ b/projects/postgis/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 
-RUN git clone --depth 1 https://git.osgeo.org/gitea/postgis/postgis.git postgis
+RUN git clone --depth 1 https://gitea.osgeo.org/postgis/postgis postgis
 WORKDIR postgis
 RUN bash ./fuzzers/install_oss_fuzz_build_deps.sh
 RUN apt-get update && \

--- a/projects/postgis/project.yaml
+++ b/projects/postgis/project.yaml
@@ -6,7 +6,7 @@ auto_ccs:
   - "even.rouault@gmail.com"
   - "pramsey@cleverelephant.ca"
   - "komzpa@gmail.com"
-main_repo: 'https://git.osgeo.org/gitea/postgis/postgis.git'
+main_repo: "https://gitea.osgeo.org/postgis/postgis"
 
 fuzzing_engines:
   - afl

--- a/projects/python-markdownify/Dockerfile
+++ b/projects/python-markdownify/Dockerfile
@@ -15,6 +15,6 @@
 ##########################################################################
 FROM gcr.io/oss-fuzz-base/base-builder-python
 RUN pip3 install --upgrade pip
-RUN git clone http://github.com/matthewwithanm/python-markdownify python-markdownify
+RUN git clone https://github.com/matthewwithanm/python-markdownify python-markdownify
 COPY *.sh *py $SRC/
 WORKDIR $SRC/python-markdownify

--- a/projects/python-markdownify/project.yaml
+++ b/projects/python-markdownify/project.yaml
@@ -1,5 +1,5 @@
-homepage: http://github.com/matthewwithanm/python-markdownify
-main_repo: http://github.com/matthewwithanm/python-markdownify
+homepage: https://github.com/matthewwithanm/python-markdownify
+main_repo: https://github.com/matthewwithanm/python-markdownify
 language: python
 fuzzing_engines:
 - libfuzzer


### PR DESCRIPTION
## Overview

This PR fixes repository URLs in `project.yaml` (`main_repo` / `homepage`) and corresponding `Dockerfile`s for four OSS-Fuzz projects (`geos`, `poppler`, `postgis`, `python-markdownify`).

These changes resolve repository mirroring errors caused by domain host migrations (OSGeo Gitea, Freedesktop GitLab) and enforce HTTPS for GitHub links.

---

## Detailed Summary of Changes

| Project | Target Files | Previous URL | Updated URL | Reason |
| :--- | :--- | :--- | :--- | :--- |
| **`geos`** | `project.yaml`, `Dockerfile` | `https://git.osgeo.org/gitea/geos/geos.git` | `https://gitea.osgeo.org/geos/geos` | Migrated OSGeo Gitea domain host |
| **`poppler`** | `project.yaml` | `https://anongit.freedesktop.org/git/poppler/poppler.git` | `https://gitlab.freedesktop.org/poppler/poppler` | Migrated Freedesktop Git host |
| **`postgis`** | `project.yaml`, `Dockerfile` | `https://git.osgeo.org/gitea/postgis/postgis.git` | `https://gitea.osgeo.org/postgis/postgis` | Migrated OSGeo Gitea domain host |
| **`python-markdownify`** | `project.yaml`, `Dockerfile` | `http://github.com/matthewwithanm/python-markdownify` | `https://github.com/matthewwithanm/python-markdownify` | Enforce HTTPS protocol |

---

## Testing & Verification

- Executed `python3 infra/presubmit.py` locally; all modified project configurations and Dockerfiles passed validation cleanly.
