### PR TITLE
envoy: reduce fuzz binary sizes

### DIFF
--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -40,6 +40,10 @@ if [ -n "$CXX" ]; then
   echo "--action_env=CXX=${CXX}"
 fi
 echo "--host_action_env=CC=gcc"
+echo "--copt=-gz=zlib"
+echo "--linkopt=-Wl,--compress-debug-sections=zlib"
+echo "--linkopt=-Wl,--icf=all"
+echo "--linkopt=-Wl,--gc-sections"
 if [ "$SANITIZER" = "undefined" ]
 then
   # Bazel uses clang to link binary, which does not link clang_rt ubsan library for C++ automatically.


### PR DESCRIPTION
The Envoy fuzz builds are quite large, and there are out of space errors, for example:
```
    Step #23 - "compile-libfuzzer-undefined-x86_64": + tar -xvf bazel-bin/test/extensions/filters/listener/proxy_protocol/proxy_protocol_fuzz_test_oss_fuzz.tar -C /workspace/out/libfuzzer-undefined-x86_64
    ...
    Step #23 - "compile-libfuzzer-undefined-x86_64": ./proxy_protocol_fuzz_test
    Step #23 - "compile-libfuzzer-undefined-x86_64": tar: ./proxy_protocol_fuzz_test: Wrote only 6656 of 10240 bytes
    Step #23 - "compile-libfuzzer-undefined-x86_64": tar: Exiting with failure status due to previous errors
```

This change does the following (thanks to the LLM tools for suggestions):
- `-gz=zlib` / `--compress-debug-sections=zlib`: Compresses DWARF debug sections in generated binaries, typically reducing binary/symbol size by 50%–70% while keeping symbolicated stack traces intact for OSS-Fuzz sanitizer reports.
- `--icf=all`: Identical Code Folding merges duplicate functions at link time to shrink compiled C++ code.
- `--gc-sections`: Removes unused code sections from final linked binaries.
