### PR TITLE
dropbear: Move the corpus repository

### DIFF
--- a/projects/dropbear/Dockerfile
+++ b/projects/dropbear/Dockerfile
@@ -15,8 +15,8 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y libz-dev autoconf mercurial
-RUN hg clone https://hg.ucc.asn.au/dropbear-fuzzcorpus dropbear-corpus
+RUN apt-get update && apt-get install -y libz-dev autoconf
+RUN git clone https://dropbear.nl/git/dropbear-fuzzcorpus dropbear-corpus
 RUN git clone https://github.com/mkj/dropbear dropbear
 WORKDIR dropbear
 COPY build.sh *.options $SRC/

--- a/projects/dropbear/Dockerfile
+++ b/projects/dropbear/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y libz-dev autoconf
+RUN apt-get update && apt-get install -y libz-dev
 RUN git clone https://dropbear.nl/git/dropbear-fuzzcorpus dropbear-corpus
 RUN git clone https://github.com/mkj/dropbear dropbear
 WORKDIR dropbear


### PR DESCRIPTION
The old hg one was being overwhelmed by bots.
New static git should be stronger.