### PR TITLE
remove duplicated main_repo for rust-coreutils

### DIFF
--- a/projects/poppler/project.yaml
+++ b/projects/poppler/project.yaml
@@ -13,7 +13,3 @@ auto_ccs:
   - jonathan@titanous.com
   - adam.reichold@t-online.de
 main_repo: "https://gitlab.freedesktop.org/poppler/poppler"
-fuzzing_engines:
- - afl
- - honggfuzz
- - libfuzzer

--- a/projects/rust-coreutils/project.yaml
+++ b/projects/rust-coreutils/project.yaml
@@ -12,4 +12,3 @@ vendor_ccs:
   - "dhofstet@gmail.com"
 # Bug reports are public by default:
 view_restrictions: none
-main_repo: 'https://github.com/uutils/coreutils'


### PR DESCRIPTION
Remove duplicated main_repo for rust-coreutils and fuzzing_engines for poppler.