### PR TITLE
projects/kfilemetadata: disable centipede fuzzing engine

### DIFF
--- a/projects/kfilemetadata/project.yaml
+++ b/projects/kfilemetadata/project.yaml
@@ -4,4 +4,8 @@ primary_contact: tsdgeos@gmail.com
 sanitizers:
   - address
   - undefined
+fuzzing_engines:
+  - libfuzzer
+  - honggfuzz
+  - afl
 main_repo: "https://invent.kde.org/frameworks/kfilemetadata.git"


### PR DESCRIPTION
Disables the centipede fuzzing engine for kfilemetadata.

Ref #15905