### PR TITLE
selinux: update the primary contact

### DIFF
--- a/projects/selinux/project.yaml
+++ b/projects/selinux/project.yaml
@@ -1,6 +1,6 @@
 homepage: "https://github.com/SELinuxProject/selinux"
 language: c
-primary_contact: "nicolas.iooss_ossfuzzselinux@m4x.org"
+primary_contact: "stephen.smalley.work@gmail.com"
 builds_per_day: 4
 sanitizers:
   - address
@@ -8,7 +8,6 @@ sanitizers:
   - memory
 auto_ccs:
   - evverx@gmail.com
-  - nicolas.iooss.ossfuzz@gmail.com
   - omosnacek@gmail.com
   - jwcart2@gmail.com
   - cgzones@googlemail.com


### PR DESCRIPTION
Since I am leaving the SELinux userspace maintainers team, the primary contact address for SELinux needs to be updated. Stephen Smalley (@stephensmalley) has agreed to take over.