### PR TITLE
[envoy] using docker-local glibc

### DIFF
--- a/projects/envoy/Dockerfile
+++ b/projects/envoy/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 
 
 RUN apt-get update && apt-get -y install  \
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get -y install  \
     golang          \
     rsync           \
     python3         \
-    libtinfo5
+    libtinfo6
 
 RUN git clone https://github.com/envoyproxy/envoy.git
 WORKDIR $SRC/envoy/

--- a/projects/envoy/Dockerfile
+++ b/projects/envoy/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 
-FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
+FROM gcr.io/oss-fuzz-base/base-builder
 
 
 RUN apt-get update && apt-get -y install  \
@@ -30,12 +30,12 @@ RUN apt-get update && apt-get -y install  \
     golang          \
     rsync           \
     python3         \
-    libtinfo6       \
+    libtinfo5       \
     libunwind-dev   \
     libclang-dev
 
 RUN ln -s /usr/lib/x86_64-linux-gnu/libunwind.a /usr/local/lib/libunwind.a && \
-    ln -s /usr/lib/llvm-18/lib/libclang.so /usr/local/lib/libclang.so
+    ln -s /usr/lib/llvm-10/lib/libclang.so /usr/local/lib/libclang.so
 
 RUN git clone https://github.com/envoyproxy/envoy.git
 WORKDIR $SRC/envoy/

--- a/projects/envoy/Dockerfile
+++ b/projects/envoy/Dockerfile
@@ -30,7 +30,12 @@ RUN apt-get update && apt-get -y install  \
     golang          \
     rsync           \
     python3         \
-    libtinfo6
+    libtinfo6       \
+    libunwind-dev   \
+    libclang-dev
+
+RUN ln -s /usr/lib/x86_64-linux-gnu/libunwind.a /usr/local/lib/libunwind.a && \
+    ln -s /usr/lib/llvm-18/lib/libclang.so /usr/local/lib/libclang.so
 
 RUN git clone https://github.com/envoyproxy/envoy.git
 WORKDIR $SRC/envoy/

--- a/projects/envoy/WORKSPACE
+++ b/projects/envoy/WORKSPACE
@@ -26,7 +26,7 @@ envoy_python_dependencies()
 
 load("//bazel:dependency_imports.bzl", "envoy_dependency_imports")
 
-envoy_dependency_imports()
+envoy_dependency_imports(use_host_tools = True)
 
 load("//bazel:repo.bzl", "envoy_repo")
 

--- a/projects/envoy/WORKSPACE
+++ b/projects/envoy/WORKSPACE
@@ -26,7 +26,7 @@ envoy_python_dependencies()
 
 load("//bazel:dependency_imports.bzl", "envoy_dependency_imports")
 
-envoy_dependency_imports(use_host_tools = True)
+envoy_dependency_imports()
 
 load("//bazel:repo.bzl", "envoy_repo")
 

--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -35,14 +35,12 @@ declare -r EXTRA_BAZEL_FLAGS="$(
 echo "--features=-layering_check"
 if [ -n "$CC" ]; then
   echo "--action_env=CC=${CC}"
-  echo "--repo_env=CC=${CC}"
 fi
 if [ -n "$CXX" ]; then
   echo "--action_env=CXX=${CXX}"
-  echo "--repo_env=CXX=${CXX}"
 fi
-echo "--host_action_env=CC=${CC:-clang}"
-echo "--host_action_env=CXX=${CXX:-clang++}"
+echo "--host_action_env=CC=gcc"
+echo "--host_action_env=CXX=g++"
 echo "--copt=-gz=zlib"
 echo "--linkopt=-Wl,--compress-debug-sections=zlib"
 echo "--linkopt=-Wl,--icf=all"

--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -33,8 +33,9 @@ declare -r EXTRA_BAZEL_FLAGS="$(
 # Disabling layering_check because it breaks the abseil build. See
 # https://github.com/google/oss-fuzz/blob/f0fa8b5cd3f99b5905e91b336d07a870ca1bc2e3/projects/abseil-cpp/build.sh#L17-L21.
 echo "--features=-layering_check"
-echo "--repo_env=BAZEL_USE_HOST_SYSROOT=True"
+echo "--repo_env=BAZEL_LLVM_PATH=/usr/local"
 echo "--repo_env=BAZEL_USE_LIBSTDCPP=True"
+echo "--repo_env=BAZEL_USE_HOST_SYSROOT=True"
 echo "--copt=-Wno-nullability-completeness"
 if [ -n "$CC" ]; then
   echo "--action_env=CC=${CC}"

--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -35,7 +35,6 @@ declare -r EXTRA_BAZEL_FLAGS="$(
 echo "--features=-layering_check"
 echo "--repo_env=BAZEL_LLVM_PATH=/usr/local"
 echo "--repo_env=BAZEL_USE_LIBSTDCPP=True"
-echo "--repo_env=BAZEL_USE_HOST_SYSROOT=True"
 echo "--copt=-Wno-nullability-completeness"
 if [ -n "$CC" ]; then
   echo "--action_env=CC=${CC}"

--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -35,11 +35,14 @@ declare -r EXTRA_BAZEL_FLAGS="$(
 echo "--features=-layering_check"
 if [ -n "$CC" ]; then
   echo "--action_env=CC=${CC}"
+  echo "--repo_env=CC=${CC}"
 fi
 if [ -n "$CXX" ]; then
   echo "--action_env=CXX=${CXX}"
+  echo "--repo_env=CXX=${CXX}"
 fi
-echo "--host_action_env=CC=gcc"
+echo "--host_action_env=CC=${CC:-clang}"
+echo "--host_action_env=CXX=${CXX:-clang++}"
 echo "--copt=-gz=zlib"
 echo "--linkopt=-Wl,--compress-debug-sections=zlib"
 echo "--linkopt=-Wl,--icf=all"

--- a/projects/envoy/build.sh
+++ b/projects/envoy/build.sh
@@ -33,6 +33,9 @@ declare -r EXTRA_BAZEL_FLAGS="$(
 # Disabling layering_check because it breaks the abseil build. See
 # https://github.com/google/oss-fuzz/blob/f0fa8b5cd3f99b5905e91b336d07a870ca1bc2e3/projects/abseil-cpp/build.sh#L17-L21.
 echo "--features=-layering_check"
+echo "--repo_env=BAZEL_USE_HOST_SYSROOT=True"
+echo "--repo_env=BAZEL_USE_LIBSTDCPP=True"
+echo "--copt=-Wno-nullability-completeness"
 if [ -n "$CC" ]; then
   echo "--action_env=CC=${CC}"
 fi


### PR DESCRIPTION
This PR updates the compiler used when building the fuzzers to be the one provided by the underlying ubuntu image.

Prior to this PR, the build process would use Envoy's hermetic LLVM to build the fuzzers.
However, the required glibc version by the LLVM is incompatible with the one provided by the underlying image.
We get the following error:
```
Step #3 - "compile-honggfuzz-address-x86_64": # Execution platform: @@internal_platforms_do_not_use//host:host
Step #3 - "compile-honggfuzz-address-x86_64": external/llvm_toolchain_llvm/bin/clang: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by external/llvm_toolchain_llvm/bin/clang)
Step #3 - "compile-honggfuzz-address-x86_64": external/llvm_toolchain_llvm/bin/clang: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.30' not found (required by external/llvm_toolchain_llvm/bin/clang)
Step #3 - "compile-honggfuzz-address-x86_64": external/llvm_toolchain_llvm/bin/clang: /lib/x86_64-linux-gnu/libstdc++.so.6: version `CXXABI_1.3.13' not found (required by external/llvm_toolchain_llvm/bin/clang)
Step #3 - "compile-honggfuzz-address-x86_64": external/llvm_toolchain_llvm/bin/clang: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by external/llvm_toolchain_llvm/bin/clang)
Step #3 - "compile-honggfuzz-address-x86_64": external/llvm_toolchain_llvm/bin/clang: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by external/llvm_toolchain_llvm/bin/clang)
Step #3 - "compile-honggfuzz-address-x86_64": external/llvm_toolchain_llvm/bin/clang: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by external/llvm_toolchain_llvm/bin/clang)
```

We tried to upgrade the underlying ubuntu image to v24.04, however other version incompatibilities were observed.