### PR TITLE
fix: close HTTP response and file handles to prevent resource leaks

### DIFF
--- a/infra/build/build_status/fuzz_introspector_page_gen.py
+++ b/infra/build/build_status/fuzz_introspector_page_gen.py
@@ -231,8 +231,8 @@ def fetch_fuzz_introspector_summary(report_url):
   """
   # Extract json summary file.
   summary_url = report_url.replace('fuzz_report.html', 'summary.json')
-  response = urlopen(summary_url)
-  json_data = json.loads(response.read())
+  with urlopen(summary_url) as response:
+    json_data = json.loads(response.read())
 
   # 1) Extract fuzzer count. This corresponds to all but two elements at the
   # top level of the dictionary.
@@ -251,7 +251,8 @@ def fetch_fuzz_introspector_summary(report_url):
   # Momentarily, we will get this from the HTML page because it's not yet
   # in the summary.json. This will change in the near future, but in the
   # spirit of time we keep it like this for now.
-  fuzz_report_html = urlopen(report_url).read()
+  with urlopen(report_url) as resp:
+    fuzz_report_html = resp.read()
   soup = BeautifulSoup(fuzz_report_html, 'html.parser')
   target_divs = soup.findAll('text', {'class': 'percentage'})
 

--- a/infra/chronos/coverage_test_collection.py
+++ b/infra/chronos/coverage_test_collection.py
@@ -108,9 +108,8 @@ def run_llvm_html_generation(objects, out_dir, workdir=COV_WORKDIR):
       f'-instr-profile={instr_profile}',
       objects,
   ]
-  stdout_fp = open(os.path.join(out_dir, 'summary.json'), 'w')
-  subprocess.check_call(' '.join(cmd), shell=True, stdout=stdout_fp)
-  stdout_fp.close()
+  with open(os.path.join(out_dir, 'summary.json'), 'w') as stdout_fp:
+    subprocess.check_call(' '.join(cmd), shell=True, stdout=stdout_fp)
 
 
 def reset_cov_workdir():


### PR DESCRIPTION
## Summary

Fix resource leaks by ensuring proper closure of HTTP responses and file handles using context managers.

## Changes

- Use `with open(...)` context manager in `coverage_test_collection.py` to ensure file handle closure
- Use `with urlopen(...)` context manager in `fuzz_introspector_page_gen.py` to properly close HTTP responses

## Impact

Prevents potential resource exhaustion from unclosed file handles and HTTP connections, especially in long-running processes.

## Testing

Local environment limitations prevent full dynamic testing; relying on CI/CD automated tests for verification.

---

I apologize for any inconvenience caused by this PR. I noticed these resource leaks while reviewing the codebase and wanted to contribute a fix. Please let me know if any changes are needed.
