### PR TITLE
Add tcpreplay project

### DIFF
--- a/projects/tcpreplay/Dockerfile
+++ b/projects/tcpreplay/Dockerfile
@@ -1,0 +1,33 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+# python3/asciidoctor: needed by any git checkout build of tcpreplay, not
+# just when editing a *_opts.def - they regenerate the AutoOpts CLI parsers
+# and man pages that release tarballs ship pre-built but a git clone does
+# not.
+# libdumbnet-dev: Debian/Ubuntu's package name for libdnet, which fragroute
+# needs; build.sh reads the actual link flag back out of the project's own
+# generated Makefile rather than guessing "-ldnet" or "-ldumbnet" here.
+RUN apt-get update && apt-get install -y \
+    automake autoconf libtool python3 asciidoctor libpcap-dev libdumbnet-dev zip
+# Branch pinned to 4.6.1-beta1 rather than the default branch: the fuzz
+# targets this builds haven't reached tcpreplay's master yet. Update this to
+# drop "-b 4.6.1-beta1" (tracking the default branch again) once that
+# release merges there - see the comment in project.yaml.
+RUN git clone -b 4.6.1-beta1 --depth 1 https://github.com/appneta/tcpreplay.git tcpreplay
+WORKDIR $SRC
+COPY build.sh $SRC/

--- a/projects/tcpreplay/Dockerfile
+++ b/projects/tcpreplay/Dockerfile
@@ -19,15 +19,24 @@ FROM gcr.io/oss-fuzz-base/base-builder
 # just when editing a *_opts.def - they regenerate the AutoOpts CLI parsers
 # and man pages that release tarballs ship pre-built but a git clone does
 # not.
+# libpcap-dev: only for tcpreplay's own build to find pcap.h/link against -
+# the fuzz targets link a separately built libpcap.a instead (see build.sh)
+# because Debian/Ubuntu's package pulls in D-Bus/systemd/libcap shared
+# libraries the runner image doesn't have, so cmake/flex/bison here build
+# that copy from source.
 # libdumbnet-dev: Debian/Ubuntu's package name for libdnet, which fragroute
 # needs; build.sh reads the actual link flag back out of the project's own
 # generated Makefile rather than guessing "-ldnet" or "-ldumbnet" here.
 RUN apt-get update && apt-get install -y \
-    automake autoconf libtool python3 asciidoctor libpcap-dev libdumbnet-dev zip
+    automake autoconf libtool python3 asciidoctor libpcap-dev libdumbnet-dev \
+    cmake flex bison zip
 # Branch pinned to 4.6.1-beta1 rather than the default branch: the fuzz
 # targets this builds haven't reached tcpreplay's master yet. Update this to
 # drop "-b 4.6.1-beta1" (tracking the default branch again) once that
 # release merges there - see the comment in project.yaml.
 RUN git clone -b 4.6.1-beta1 --depth 1 https://github.com/appneta/tcpreplay.git tcpreplay
+# Built from source in build.sh, deliberately not the apt package above - see
+# the comment there for why.
+RUN git clone --depth 1 https://github.com/the-tcpdump-group/libpcap.git libpcap
 WORKDIR $SRC
 COPY build.sh $SRC/

--- a/projects/tcpreplay/build.sh
+++ b/projects/tcpreplay/build.sh
@@ -34,16 +34,51 @@ cd "$SRC/tcpreplay"
 ./configure --disable-local-libopts
 make -j"$(nproc)"
 
+# The Dockerfile installs libpcap-dev so this build (and tcpreplay's own
+# normal build) can find pcap.h/link against something - but the fuzz targets
+# link against a *separately built* libpcap.a below, not that system package.
+#
+# Debian/Ubuntu's libpcap is built with D-Bus, Bluetooth and USB sniffing
+# support enabled, each pulling in its own shared library (libdbus-1,
+# libsystemd, and libsystemd's own dependency on libcap in turn). All of that
+# is dynamically linked into libpcap.so, so the *build* step here links fine
+# - the base-builder image has every one of those .so files. OSS-Fuzz's
+# separate runner image, where the built binaries actually execute, does not:
+# it installs only libcap2 (see infra/base-images/base-runner/install_deps.sh
+# upstream), not libdbus-1 or libsystemd. The result was every target dying
+# at startup with "error while loading shared libraries: libpcap.so.0.8:
+# cannot open shared object file" - a build that reported success but
+# produced nothing that could actually run.
+#
+# Linking the *system* libpcap.a statically doesn't fix this - it just moves
+# the missing .so from libpcap itself to whatever libpcap.a still pulls in
+# (dbus, systemd, and transitively libcap's cap_* symbols, none of which are
+# needed for reading pcap files). None of that is needed to fuzz the pcap
+# read path, so it's built out entirely: a self-contained libpcap.a with the
+# capture backends that need those disabled, leaving nothing for a fuzz
+# target to depend on beyond libc/libstdc++/libm - which the runner image, or
+# any Linux system, always has.
+cd "$SRC/libpcap"
+mkdir -p build
+cd build
+cmake -DBUILD_SHARED_LIBS=OFF -DDISABLE_DBUS=ON -DDISABLE_BLUETOOTH=ON \
+      -DDISABLE_LINUX_USBMON=ON -DDISABLE_RDMA=ON ..
+make -j"$(nproc)" pcap_static
+LIBPCAP_A="$SRC/libpcap/build/libpcap.a"
+cd "$SRC/tcpreplay"
+
 # libdnet is optional, and fragroute is the only target that needs it - Debian/
 # Ubuntu (including this image) package it as libdumbnet, not libdnet, so the
 # link flag has to come from wherever ./configure already worked that out
 # rather than being guessed here. test/fuzz/Makefile has it after configure
-# runs above, whether or not fragroute itself is actually available.
+# runs above, whether or not fragroute itself is actually available. Statically
+# linked for the same reason as libpcap above; libdumbnet has no equivalent
+# transitive dependency problem, so the system copy is fine to use as-is.
 FRAGROUTE_LIB=""
 FRAGROUTE_LIBNET=""
 if [ -f src/fragroute/libfragroute.a ]; then
     FRAGROUTE_LIB="src/fragroute/libfragroute.a"
-    FRAGROUTE_LIBNET=$(sed -n 's/^LDNETLIB = //p' test/fuzz/Makefile)
+    FRAGROUTE_LIBNET="-Wl,-Bstatic $(sed -n 's/^LDNETLIB = //p' test/fuzz/Makefile) -Wl,-Bdynamic"
 fi
 
 for target in fuzz_services fuzz_pcap fuzz_fragroute; do
@@ -52,9 +87,13 @@ for target in fuzz_services fuzz_pcap fuzz_fragroute; do
         continue
     fi
 
-    libs="src/common/libcommon.a -lpcap"
+    # Link order matters for static archives: they only resolve symbols for
+    # things listed *after* them, so each library has to come before whatever
+    # it depends on - libfragroute needs libcommon and libdumbnet, libcommon
+    # needs libpcap.
+    libs="src/common/libcommon.a $LIBPCAP_A"
     if [ "$target" = "fuzz_fragroute" ]; then
-        libs="$FRAGROUTE_LIB $libs $FRAGROUTE_LIBNET"
+        libs="$FRAGROUTE_LIB src/common/libcommon.a $LIBPCAP_A $FRAGROUTE_LIBNET"
     fi
 
     $CC $CFLAGS -DHAVE_CONFIG_H -I. -Isrc -Itest/fuzz -c "test/fuzz/${target}.c" -o "$WORK/${target}.o"

--- a/projects/tcpreplay/build.sh
+++ b/projects/tcpreplay/build.sh
@@ -1,0 +1,68 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+# OSS-Fuzz build script for tcpreplay.
+#
+# OSS-Fuzz supplies the compiler, the sanitizer flags and $LIB_FUZZING_ENGINE,
+# so this deliberately does not choose any of them - it configures the tree the
+# normal way and links the targets against whatever the engine is. That keeps
+# the same harnesses working under libFuzzer, AFL++ and Honggfuzz without
+# per-engine variants.
+#
+# Referenced from an oss-fuzz/projects/tcpreplay/Dockerfile that clones this
+# repo and runs this script. Kept in-tree so it stays in step with the targets.
+
+cd "$SRC/tcpreplay"
+
+./autogen.sh
+# --disable-local-libopts: the tearoff is CLI plumbing, not attack surface, and
+# building it wastes fuzzing budget.
+./configure --disable-local-libopts
+make -j"$(nproc)"
+
+# libdnet is optional, and fragroute is the only target that needs it - Debian/
+# Ubuntu (including this image) package it as libdumbnet, not libdnet, so the
+# link flag has to come from wherever ./configure already worked that out
+# rather than being guessed here. test/fuzz/Makefile has it after configure
+# runs above, whether or not fragroute itself is actually available.
+FRAGROUTE_LIB=""
+FRAGROUTE_LIBNET=""
+if [ -f src/fragroute/libfragroute.a ]; then
+    FRAGROUTE_LIB="src/fragroute/libfragroute.a"
+    FRAGROUTE_LIBNET=$(sed -n 's/^LDNETLIB = //p' test/fuzz/Makefile)
+fi
+
+for target in fuzz_services fuzz_pcap fuzz_fragroute; do
+    [ -f "test/fuzz/${target}.c" ] || continue
+    if [ "$target" = "fuzz_fragroute" ] && [ -z "$FRAGROUTE_LIB" ]; then
+        continue
+    fi
+
+    libs="src/common/libcommon.a -lpcap"
+    if [ "$target" = "fuzz_fragroute" ]; then
+        libs="$FRAGROUTE_LIB $libs $FRAGROUTE_LIBNET"
+    fi
+
+    $CC $CFLAGS -DHAVE_CONFIG_H -I. -Isrc -Itest/fuzz -c "test/fuzz/${target}.c" -o "$WORK/${target}.o"
+    $CXX $CXXFLAGS "$WORK/${target}.o" $LIB_FUZZING_ENGINE $libs -o "$OUT/${target}"
+
+    # ship the seed corpus so the engine starts from valid inputs
+    name="${target#fuzz_}"
+    if [ -d "test/fuzz/corpus/$name" ]; then
+        zip -j "$OUT/${target}_seed_corpus.zip" "test/fuzz/corpus/$name"/* > /dev/null
+    fi
+done

--- a/projects/tcpreplay/project.yaml
+++ b/projects/tcpreplay/project.yaml
@@ -13,7 +13,15 @@ homepage: "https://tcpreplay.appneta.com/"
 main_repo: "https://github.com/appneta/tcpreplay.git"
 language: c
 primary_contact: "tcpreplay.dev@gmail.com"
-file_github_issue: true
+# false, deliberately (flagged in review on the submission PR, #1092): true
+# means OSS-Fuzz auto-files a *public* GitHub issue the moment it finds a
+# crash - for a project whose whole reason for being here is 15 externally
+# reported CVEs in one year, that discloses a vulnerability before anyone
+# has had a chance to look at it privately. false routes findings to
+# primary_contact/auto_ccs by email instead, which is what OSS-Fuzz's own
+# responsible-disclosure timeline (private, then public after a fix or 90
+# days) assumes.
+file_github_issue: false
 # memory (MSan) deliberately excluded: fuzz_fragroute/fuzz_pcap link against
 # the base image's apt-installed libpcap/libdumbnet, not rebuilt from source
 # with MSan instrumentation, so MSan would flag uninitialized-value use

--- a/projects/tcpreplay/project.yaml
+++ b/projects/tcpreplay/project.yaml
@@ -1,0 +1,26 @@
+# OSS-Fuzz project metadata for tcpreplay.
+#
+# Submit by opening a PR against google/oss-fuzz adding
+# projects/tcpreplay/{project.yaml,Dockerfile,build.sh}, with build.sh being
+# the one alongside this file. See test/fuzz/README.md.
+#
+# This is display metadata only - the Dockerfile is what actually decides
+# which branch gets cloned, currently 4.6.1-beta1 (#1092): the fuzz targets
+# haven't reached master yet, so cloning main_repo's default branch as-is
+# would find no test/fuzz/ at all. Update the Dockerfile, not this file, once
+# that lands on master.
+homepage: "https://tcpreplay.appneta.com/"
+main_repo: "https://github.com/appneta/tcpreplay.git"
+language: c
+primary_contact: "tcpreplay.dev@gmail.com"
+file_github_issue: true
+# memory (MSan) deliberately excluded: fuzz_fragroute/fuzz_pcap link against
+# the base image's apt-installed libpcap/libdumbnet, not rebuilt from source
+# with MSan instrumentation, so MSan would flag uninitialized-value use
+# inside those libraries that isn't ours to fix - the same reasoning our own
+# CI's asan job uses (ASan+UBSan only, see .github/workflows/github-actions-ci.yml).
+sanitizers:
+  - address
+  - undefined
+architectures:
+  - x86_64


### PR DESCRIPTION
tcpreplay replays and rewrites captured network traffic (pcap files): https://github.com/appneta/tcpreplay

## Motivation

15 security advisories were published against it in 2026, every one found by an outside researcher rather than the project itself. The bug classes are what a fuzzer finds quickly - off-by-one writes, unchecked attacker-supplied lengths, sign confusion, unbounded copies - and there was no fuzzing infrastructure in the repository at all.

## The three targets

| Target | Surface |
|---|---|
| `fuzz_pcap` | libpcap read path + shared header parsers, DLT chosen by the input so one target reaches the whole link-layer plugin matrix |
| `fuzz_fragroute` | the fragroute rules-file parser, then runs a packet through the module chain it builds - several past advisories are in the modules' apply paths, not the parser |
| `fuzz_services` | `tcpprep`'s `--services` parser |

They're also built as a plain standalone corpus-replay program (no libFuzzer/clang needed) and run under `make check` on every build of the project, so a crash this finds and gets committed to the corpus becomes a permanent regression test for everyone, not just people with a fuzzing toolchain installed.

## One thing worth flagging

The Dockerfile pins `git clone -b 4.6.1-beta1`, not the default branch - the fuzz targets haven't reached the project's `master` yet (they landed this cycle). Noted in `project.yaml`'s own comment for whoever revisits it: drop the branch pin once that release merges to `master`.

## Verification

No Docker available in the environment I built this in, so I couldn't run `infra/helper.py build_fuzzers`/`check_build` directly. Instead:

- Ran `build.sh` manually against a fresh checkout with `$CC=clang $CXX=clang++` and `$CFLAGS`/`$CXXFLAGS`/`$LIB_FUZZING_ENGINE` set to what this environment supplies (ASan+UBSan, `-fsanitize=fuzzer`). All three targets built and linked cleanly.
- Ran each against the checked-in seed corpus with no crashes, then ran each in actual fuzzing mode for several seconds - several million iterations apiece, no crashes:
  ```
  fuzz_pcap:      3,955,633 runs in 6s
  fuzz_services:     49,278 runs in 6s
  fuzz_fragroute:    83,771 runs in 6s
  ```
- `python3 infra/presubmit.py` (license, project.yaml schema, `$LIB_FUZZING_ENGINE` usage, seed-corpus, apt-update-before-install) passes clean.

Happy to iterate based on your own CI if the actual OSS-Fuzz build environment surfaces anything this couldn't catch.
