### PR TITLE
jsoup: catch re2j runtime pattern complexity errors

### DIFF
--- a/projects/jsoup/CssHtmlFuzzer.java
+++ b/projects/jsoup/CssHtmlFuzzer.java
@@ -23,16 +23,15 @@ import org.jsoup.select.Selector;
 
 public class CssHtmlFuzzer {
     public static void fuzzerTestOneInput(FuzzedDataProvider data) {
-        String css = data.consumeString(100);
-        Evaluator query;
         try {
-            query = Selector.evaluatorOf(css);
-        } catch (ValidationException | Selector.SelectorParseException ignored) {
-            return;
-        }
+            String css = data.consumeString(100);
+            Evaluator query = Selector.evaluatorOf(css);
 
-        String html = data.consumeRemainingAsString();
-        Document doc = Jsoup.parse(html, "https://example.com");
-        doc.select(query);
+            String html = data.consumeRemainingAsString();
+            Document doc = Jsoup.parse(html, "https://example.com");
+            doc.select(query);
+        } catch (ValidationException | Selector.SelectorParseException ignored) {
+            // invalid or overly complex selector
+        }
     }
 }


### PR DESCRIPTION
Update jsoup's CSS/HTML fuzzer to treat selector validation failures as rejected inputs.

jsoup now normalizes re2j runtime pattern-complexity errors into `ValidationException`. The fuzzer should ignore these expected validation failures alongside selector parse errors.

Validation:

- `python3 infra/helper.py check_build jsoup CssHtmlFuzzer`