### PR TITLE
[dns-aid] Initial integration

### DIFF
--- a/projects/dns-aid/Dockerfile
+++ b/projects/dns-aid/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM gcr.io/oss-fuzz-base/base-builder-python
+RUN git clone --depth 1 https://github.com/dns-aid/dns-aid-core dns-aid-core
+COPY build.sh $SRC/
+WORKDIR $SRC/dns-aid-core

--- a/projects/dns-aid/build.sh
+++ b/projects/dns-aid/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+pip3 install .
+
+# Build the parser fuzz harness shipped in the dns-aid-core repository.
+compile_python_fuzzer "$SRC/dns-aid-core/tests/fuzz/fuzz_parsers.py"

--- a/projects/dns-aid/project.yaml
+++ b/projects/dns-aid/project.yaml
@@ -1,0 +1,11 @@
+auto_ccs:
+- iracic82@gmail.com
+fuzzing_engines:
+- libfuzzer
+homepage: https://github.com/dns-aid/dns-aid-core
+language: python
+main_repo: https://github.com/dns-aid/dns-aid-core
+primary_contact: ingmar.vg@gmail.com
+sanitizers:
+- address
+- undefined


### PR DESCRIPTION
## Project

**DNS-AID** (https://github.com/dns-aid/dns-aid-core) is the reference implementation of IETF [draft-mozleywilliams-dnsop-dnsaid](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/) — DNS-based discovery and identification of AI agents. It is published on PyPI as [`dns-aid`](https://pypi.org/project/dns-aid/) and is on a standards track within the IETF dnsop working group, with the project headed toward Linux Foundation hosting.

## Why fuzzing matters here

The library's core job is parsing **untrusted, attacker-controllable input**: DNS SVCB/TXT record data (including RFC 9460 private-use SvcParamKeys), agent FQDNs, DNS-hosted index documents, and JSON discovery documents fetched over HTTP. Any deployment resolves records published by arbitrary third-party domains, so parser robustness is directly security-relevant.

## Integration

- Language: Python (Atheris). The harness lives in the project repo at [`tests/fuzz/fuzz_parsers.py`](https://github.com/dns-aid/dns-aid-core/blob/main/tests/fuzz/fuzz_parsers.py) and dispatches across the SVCB parameter parser, FQDN parsers, TXT index/value parsers, HTTP index document parser, and input validators. It already runs weekly in the project's own CI.
- Contacts: primary + CC are project maintainers (Google accounts).
- Project security policy: https://github.com/dns-aid/dns-aid-core/blob/main/SECURITY.md (private reporting enabled; 48h initial response).

## Status

Draft until dns-aid/dns-aid-core#218 (which adds the harness to `main`) merges — will mark ready for review right after. Happy to adjust anything about the integration.