### PR TITLE
bc-gh: fix broken build

### DIFF
--- a/projects/bc-gh/project.yaml
+++ b/projects/bc-gh/project.yaml
@@ -8,4 +8,4 @@ fuzzing_engines:
   - afl
   - honggfuzz
   - centipede
-disabled: true
+disabled: false


### PR DESCRIPTION
The original build.sh failed when executing ./configure -Z. In bc version 7.2.0, configure.sh adopts the getopts string abBcdDeEfgGhHik:lmMNO:p:PrS:s:T- and no longer supports the -Z flag, resulting in an invalid option error. Previously, the -Z flag was used to enable the OSS-Fuzz build mode, while the latest version has deprecated this flag and controls the OSS-Fuzz feature exclusively via the compile-time macro BC_ENABLE_OSSFUZZ.

After removing the invalid -Z flag and adopting ./configure.sh -H -N, a latent upstream bug was exposed. The test_target variable in configure.sh contains a literal newline that spans multiple lines, breaking the sed-based substring_replace() function. Since the script uses ! as the sed delimiter, the unexpected newline in the replacement content causes an unterminated sed substitution command and leads to build failures.

This fix first patches the malformed multi-line variable before configuration execution, and invokes ./configure.sh -H -N with valid flags. The project is then fully built via make. After the default compilation, five core source files including vm.c, data.c, lex.c, bc_lex.c and dc_lex.c are recompiled with the macros -DBC_ENABLE_OSSFUZZ=1 and -DNDEBUG.

These macros enable the OSS-Fuzz-specific data loading logic inside bc_vm_exec(), and eliminate invalid references to bc_vm_readLine under the BC_MODE_STDIN branch, resolving compilation and runtime compatibility issues when OSS-Fuzz mode is enabled. The regenerated fuzz object files replace the original ones during the linking phase, and are finally linked with the two fuzzer entry points src/bc_fuzzer.c and src/dc_fuzzer.c.

Considering that OSS-Fuzz clones the upstream repository from scratch in every build, persistent local modifications are not available. Therefore, a dynamic sed patch is added to fix the configure.sh syntax issue during each build, ensuring a stable and complete compilation pipeline.