### PR TITLE
Fix thrift-rb source revision attribution

### DIFF
--- a/projects/thrift-rb/project.yaml
+++ b/projects/thrift-rb/project.yaml
@@ -9,4 +9,4 @@ fuzzing_engines:
 sanitizers:
   - address
 
-main_repo: "https://github.com/apache/thrift"
+main_repo: "https://github.com/apache/thrift.git"


### PR DESCRIPTION
The build source map records Apache Thrift as https://github.com/apache/thrift.git, while `project.yaml` used the equivalent URL without `.git`. ClusterFuzz compares these URLs exactly when selecting the main component; the mismatch made it fall back to alphabetical ordering and report Ruzzy’s revision as the tested/regressed revision.

Using the canonical .git URL lets ClusterFuzz prioritize Apache Thrift and report its revision correctly.

https://oss-fuzz.com/testcase-detail/4583322718896128

<img width="2296" height="408" alt="CleanShot 2026-07-30 at 11 59 09@2x" src="https://github.com/user-attachments/assets/0ab1b338-2196-4eb1-b34d-531141601cbb" />
