### PR TITLE
projects/selinux/project.yaml: add other selinux maintainers

### DIFF
--- a/projects/selinux/project.yaml
+++ b/projects/selinux/project.yaml
@@ -12,6 +12,8 @@ auto_ccs:
   - jwcart2@gmail.com
   - cgzones@googlemail.com
   - stephen.smalley.work@gmail.com
+  - paul@paul-moore.com
+  - jason@perfinion.com
 main_repo: 'https://github.com/SELinuxProject/selinux'
 
 fuzzing_engines:


### PR DESCRIPTION
Add Paul Moore (@pcmoore) and Jason Zaman (@perfinion), both active SELinux maintainers, to the cc list. These addresses are allegedly Google mail accounts despite not being @gmail.com; let us know if these won't work and we will provide gmail ones.