### PR TITLE
dragonfly: fix broken build

### DIFF
--- a/projects/dragonfly/build.sh
+++ b/projects/dragonfly/build.sh
@@ -15,5 +15,63 @@
 #
 ################################################################################
 
-compile_go_fuzzer github.com/dragonflyoss/Dragonfly/dfget/core/uploader FuzzParseParams uploader_fuzz
-compile_go_fuzzer github.com/dragonflyoss/Dragonfly/supernode/daemon/mgr/cdn Fuzz cdn_fuzz
+cd /src/Dragonfly
+cat > pkg/digest/fuzz.go << 'FUZZ_EOF'
+package digest
+
+import (
+	"strings"
+)
+
+func FuzzParse(data []byte) int {
+	s := string(data)
+	s = strings.TrimSpace(s)
+	_, err := Parse(s)
+	if err != nil {
+		return 0
+	}
+	return 1
+}
+FUZZ_EOF
+
+cat > pkg/net/http/fuzz.go << 'FUZZ_EOF'
+package http
+
+import (
+	"strconv"
+	"strings"
+)
+
+func FuzzParseRange(data []byte) int {
+	s := string(data)
+	parts := strings.SplitN(s, "\n", 2)
+	if len(parts) < 2 {
+		return 0
+	}
+	rangeStr := parts[0]
+	sizeStr := strings.TrimSpace(parts[1])
+	size, err := strconv.ParseInt(sizeStr, 10, 64)
+	if err != nil {
+		return 0
+	}
+	_, _ = ParseRange(rangeStr, size)
+	_, _ = ParseURLMetaRange(rangeStr, size)
+	return 1
+}
+FUZZ_EOF
+
+cat > pkg/dfnet/fuzz.go << 'FUZZ_EOF'
+package dfnet
+
+func FuzzNetAddrJSON(data []byte) int {
+	var addr NetAddr
+	if err := addr.UnmarshalJSON(data); err != nil {
+		return 0
+	}
+	return 1
+}
+FUZZ_EOF
+
+compile_go_fuzzer d7y.io/dragonfly/v2/pkg/digest FuzzParse fuzz_digest_parse
+compile_go_fuzzer d7y.io/dragonfly/v2/pkg/net/http FuzzParseRange fuzz_http_range
+compile_go_fuzzer d7y.io/dragonfly/v2/pkg/dfnet FuzzNetAddrJSON fuzz_dfnet_json


### PR DESCRIPTION
The old build.sh referenced two packages that no longer exist:
  - github.com/dragonflyoss/Dragonfly/dfget/core/uploader
  - github.com/dragonflyoss/Dragonfly/supernode/daemon/mgr/cdn

After the Dragonfly v2 refactor, the module path changed from
github.com/dragonflyoss/Dragonfly to d7y.io/dragonfly/v2, and the
dfget/ and supernode/ directories were removed, causing the go build
to fail with "no required module provides package ...".

Fix:
Rewrote build.sh to build fuzzer targets against packages that still
exist under the v2 module path:
  - d7y.io/dragonfly/v2/pkg/digest    (FuzzParse)
  - d7y.io/dragonfly/v2/pkg/net/http  (FuzzParseRange)
  - d7y.io/dragonfly/v2/pkg/dfnet     (FuzzNetAddrJSON)

Since the upstream repo does not ship fuzzer entry points, the build
script generates the corresponding fuzz.go files via heredoc after
cloning the source, keeping the fix fully self-contained in this
project config with no upstream changes required.