### PR TITLE
nfstream: include NumPy exceptions module in fuzz target

### DIFF
--- a/projects/nfstream/build.sh
+++ b/projects/nfstream/build.sh
@@ -19,7 +19,9 @@ python3 -m pip install -U  .
 
 # Build fuzzers in $OUT.
 for fuzzer in $(find $SRC -name '*_fuzzer.py'); do
-  compile_python_fuzzer $fuzzer --hidden-import=_cffi_backend
+  compile_python_fuzzer $fuzzer \
+    --hidden-import=_cffi_backend \
+    --hidden-import=numpy._core._exceptions
 done
 
 zip -j $OUT/pcap_fuzzer_seed_corpus.zip tests/pcaps/*


### PR DESCRIPTION
## Problem

Every `nfstream` OSS-Fuzz build currently fails `bad_build_check`, and has since NumPy 2.3.0
entered the base image. The target is built, then dies before reaching
`LLVMFuzzerTestOneInput`:

```
BAD BUILD: /tmp/not-out/.../pcap_fuzzer seems to have either startup crash or exit:
Traceback (most recent call last):
  File "numpy/_core/__init__.py", line 24, in <module>
  File "numpy/_core/multiarray.py", line 11, in <module>
ModuleNotFoundError: No module named 'numpy._core._exceptions'
...
ImportError: Unable to import required dependency numpy.
[PYI-225:ERROR] Failed to execute script 'pcap_fuzzer' due to unhandled exception!
```

The seed corpus and the packaging command complete successfully; the resulting frozen
executable fails during startup because its import graph is incomplete.

## Cause

NumPy's `_multiarray_umath` extension imports five classes from `numpy._core._exceptions`
during its initialisation, via `IMPORT_GLOBAL` in
[`numpy/_core/src/multiarray/npy_static_data.c`](https://github.com/numpy/numpy/blob/v2.4.6/numpy/_core/src/multiarray/npy_static_data.c#L144-L157)
— `_ArrayMemoryError`, `_UFuncBinaryResolutionError`, `_UFuncInputCastingError`,
`_UFuncNoLoopError` and `_UFuncOutputCastingError`. Those imports live in compiled C, so
PyInstaller's static analysis cannot see them and the module is never collected.

It used to be collected indirectly because `numpy._core._methods` imported it at Python
level. NumPy commit
[a51a4f5](https://github.com/numpy/numpy/commit/a51a4f5c10aa9b7962ff1e7e9b5f9b7d91c51489)
removed that import during cleanup.

The build image pairs PyInstaller 6.10.0 with NumPy 2.4.6, and PyInstaller selects NumPy's
own vendored hook — the build log shows `hook-numpy.py` loaded from
`site-packages/numpy/_pyinstaller`, not from `site-packages/PyInstaller/hooks`. That vendored
hook declares only:

```python
hiddenimports = ['numpy._core._dtype_ctypes', 'numpy._core._multiarray_tests']
```

PyInstaller fixed its own copy of the hook in
[pyinstaller#9162](https://github.com/pyinstaller/pyinstaller/pull/9162), which adds
`numpy._core._exceptions` for NumPy >= 2.3.0 and first shipped in PyInstaller 6.14.1. That
version also carries the `$PyInstaller-Hook-Priority: 1` marker its hook needs to take
precedence over NumPy's vendored one — 6.13.0 already had the marker but not the hidden
import, so 6.14.1 is the first release with both, later than the 6.10.0 in the image.

## Fix

Declare the module explicitly:

```bash
compile_python_fuzzer $fuzzer \
  --hidden-import=_cffi_backend \
  --hidden-import=numpy._core._exceptions
```

This is preferable to pinning NumPy or overriding PyInstaller: it addresses the observed
startup failure directly, works with the image as it stands, and becomes redundant but
harmless once the image carries a PyInstaller new enough to supply the hidden import itself.

## Testing

`bash -n projects/nfstream/build.sh` passes. Runtime validation will come from OSS-Fuzz's
`build_fuzzers` and `check_build` steps; `check_build` currently reproduces the startup
failure and will directly verify this fix.
