### PR TITLE
[bzip2] Stream decompressor output and export seed corpus

### DIFF
--- a/projects/bzip2/build.sh
+++ b/projects/bzip2/build.sh
@@ -39,6 +39,7 @@ done
 # 1) look for all ".bz2" files in ./bzip2 and ./bzip2-test that are <100k
 # 2) remove base file name collisions
 # 3) add to (bzip2_decompress_target_seed_corpus.zip) archive
+rm -f "$OUT/bzip2_decompress_target_seed_corpus.zip"
 find $SRC/bzip2* -type f -name "*.bz2" -size -100k \
   | awk -F/ '{a[$NF]=$0}END{for(i in a)print a[i]}' \
-  | zip -j0r bzip2_decompress_target_seed_corpus.zip -@
+  | zip -j0r "$OUT/bzip2_decompress_target_seed_corpus.zip" -@

--- a/projects/bzip2/bzip2_decompress_target.c
+++ b/projects/bzip2/bzip2_decompress_target.c
@@ -17,46 +17,56 @@
 */
 
 #include "bzlib.h"
-#include <stdint.h>
-#include <stdlib.h>
-#include <assert.h>
-#include <string.h>
 #include <limits.h>
+#include <stdint.h>
+#include <string.h>
 
-extern int BZ2_bzBuffToBuffDecompress(char* dest,
-                                      unsigned int* destLen,
-                                      char*         source,
-                                      unsigned int  sourceLen,
-                                      int           small,
-                                      int           verbosity);
+#define OUTPUT_BUFFER_SIZE 4096
+/* Bound work on valid decompression bombs without limiting the input ratio. */
+#define MAX_OUTPUT_SIZE (16 * 1024 * 1024)
+
+static void
+decompress(const uint8_t *data, size_t size, int small)
+{
+    bz_stream stream;
+    char outbuf[OUTPUT_BUFFER_SIZE];
+    size_t total_out = 0;
+    int r;
+
+    memset(&stream, 0, sizeof(stream));
+    r = BZ2_bzDecompressInit(&stream, /*verbosity=*/0, small);
+    if (r != BZ_OK) {
+        return;
+    }
+
+    stream.next_in = (char *)data;
+    stream.avail_in = (unsigned int)size;
+    do {
+        unsigned int before_in = stream.avail_in;
+
+        stream.next_out = outbuf;
+        stream.avail_out = sizeof(outbuf);
+        r = BZ2_bzDecompress(&stream);
+        total_out += sizeof(outbuf) - stream.avail_out;
+
+        /* BZ_OK without consuming input or producing output needs more data. */
+        if (r == BZ_OK && before_in == stream.avail_in &&
+                stream.avail_out == sizeof(outbuf)) {
+            break;
+        }
+    } while (r == BZ_OK && total_out < MAX_OUTPUT_SIZE &&
+            (stream.avail_in != 0 || stream.avail_out == 0));
+
+    BZ2_bzDecompressEnd(&stream);
+}
 
 int
 LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-    int r, small;
-    unsigned int nOut;
-
-    // Reject inputs that would cause integer overflow in size*2
-    // since nOut is unsigned int and the API uses unsigned int for sizes
-    if (size > UINT_MAX / 2) {
+    if (size > UINT_MAX) {
         return 0;
     }
 
-    // See: https://github.com/google/bzip2-rpc/blob/master/unzcrash.c#L39
-    nOut = (unsigned int)(size * 2);
-    char *outbuf = malloc(nOut);
-    if (!outbuf) {
-        return 0;
-    }
-    small = size % 2;
-    r = BZ2_bzBuffToBuffDecompress(outbuf, &nOut, (char *)data, (unsigned int)size,
-            small, /*verbosity=*/0);
-
-    if (r != BZ_OK) {
-#ifdef __DEBUG__
-        fprintf(stdout, "Decompression error: %d\n", r);
-#endif
-    }
-    free(outbuf);
+    decompress(data, size, /*small=*/size % 2);
     return 0;
 }


### PR DESCRIPTION
## Summary

- stream decompressor output through a fixed 4 KiB scratch buffer instead of limiting output to twice the compressed input size
- bound valid output processing at 16 MiB and stop if the decompressor makes no progress
- write the existing decompression seed archive to `$OUT` so OSS-Fuzz retains it

## Rationale

`BZ2_bzBuffToBuffDecompress` currently receives an output capacity of `2 * input_size`. Valid bzip2 streams can expand far beyond that ratio, so the target returns `BZ_OUTBUFF_FULL` before exercising the rest of the stream. All three upstream quick-test samples exceed the current limit:

| Seed | Compressed | Decompressed | Ratio |
| --- | ---: | ---: | ---: |
| `sample1.bz2` | 32,348 | 98,696 | 3.05x |
| `sample2.bz2` | 73,732 | 212,340 | 2.88x |
| `sample3.bz2` | 235 | 120,244 | 511.68x |

A deterministic 1 MiB zero-filled input compresses to 45 bytes. The old 90-byte output buffer returns `BZ_OUTBUFF_FULL` (`-8`); the streaming path reaches `BZ_STREAM_END` (`4`) after producing all 1,048,576 bytes.

The build script also creates `bzip2_decompress_target_seed_corpus.zip` in the container working directory after `cd bzip2`, rather than in `$OUT`. The archive is therefore absent from the build artifacts.

## Verification

- `python3 infra/helper.py build_fuzzers bzip2 --sanitizer address --clean`
- `python3 infra/helper.py build_fuzzers bzip2 --sanitizer undefined`
- `python3 infra/helper.py check_build bzip2 --sanitizer undefined`
- replayed the exported 34-file seed corpus under UBSan with no failures
- replayed a 408-file evolved corpus under Linux ASan/UBSan with no failures

For a deterministic `-runs=0` replay of the same exported corpus, the old target initialized at 450 edges / 1,344 features; the streaming target initialized at 464 edges / 1,574 features.