### PR TITLE
Replace PostgreSQL primary_contact with active maintainer

### DIFF
--- a/projects/postgresql/project.yaml
+++ b/projects/postgresql/project.yaml
@@ -1,11 +1,11 @@
 base_os_version: ubuntu-24-04
 homepage: "https://postgresql.org"
 main_repo: "https://github.com/postgres/postgres"
-primary_contact: "sfrost@snowman.net"
+primary_contact: "daniel@yesql.se"
 language: c
 auto_ccs:
   - "ouyangyunshu@google.com"
-  - "frost.stephen.p@gmail.com"
+  - "dgustafssonpgeu@gmail.com"
   - "aseering@google.com"
 fuzzing_engines:
   - libfuzzer


### PR DESCRIPTION
This is a PR intended to revive the PostgreSQL participation in Google OSS-Fuzz by replacing the current inactive primary_contact with a new active maintainer of the PostgreSQL project.

Stephen Frost is no longer active in the PostgreSQL project.  Daniel Gustafsson is a long-time PostgreSQL Major Contributor [0] and code committer [1,2].  This change has been approved by the PostgreSQL Core Team [3].

  Daniel Gustafsson
  Email: daniel@yesql.se, dgustafsson@postgresql.org
  Gmail: dgustafssonpgeu@gmail.com
  Github: @danielgustafsson

Once merged, the plan is to extend the PostgreSQL fuzz test coverage by adding new tests.

[0] https://www.postgresql.org/community/contributors/
[1] https://www.postgresql.org/developer/committers/
[2] https://github.com/postgres/postgres/commits?author=danielgustafsson
[3] https://www.postgresql.org/developer/core/