### PR TITLE
meshoptimizer: link the CMake archive and build the two existing upstream fuzz harnesses

### DIFF
--- a/projects/meshoptimizer/build.sh
+++ b/projects/meshoptimizer/build.sh
@@ -20,5 +20,6 @@ cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ..
 make -j$(nproc)
 
 cd ..
-find . -name "*.o" -exec ar rcs fuzz_lib.a {} \;
-$CXX $CXXFLAGS tools/codecfuzz.cpp -o $OUT/codecfuzzer $LIB_FUZZING_ENGINE fuzz_lib.a
+$CXX $CXXFLAGS tools/codecfuzz.cpp -o $OUT/codecfuzzer $LIB_FUZZING_ENGINE build/libmeshoptimizer.a
+$CXX $CXXFLAGS tools/clusterfuzz.cpp -o $OUT/clusterfuzzer $LIB_FUZZING_ENGINE build/libmeshoptimizer.a
+$CXX $CXXFLAGS tools/simplifyfuzz.cpp -o $OUT/simplifyfuzzer $LIB_FUZZING_ENGINE build/libmeshoptimizer.a


### PR DESCRIPTION
Two changes to `projects/meshoptimizer/build.sh`, both small:

1. Link `build/libmeshoptimizer.a` directly instead of reconstructing an archive from loose object
   files with `find … | ar`.
2. Build `tools/clusterfuzz.cpp` and `tools/simplifyfuzz.cpp`, which upstream already maintains but
   OSS-Fuzz has never compiled.

```diff
 cd ..
-find . -name "*.o" -exec ar rcs fuzz_lib.a {} \;
-$CXX $CXXFLAGS tools/codecfuzz.cpp -o $OUT/codecfuzzer $LIB_FUZZING_ENGINE fuzz_lib.a
+$CXX $CXXFLAGS tools/codecfuzz.cpp -o $OUT/codecfuzzer $LIB_FUZZING_ENGINE build/libmeshoptimizer.a
+$CXX $CXXFLAGS tools/clusterfuzz.cpp -o $OUT/clusterfuzzer $LIB_FUZZING_ENGINE build/libmeshoptimizer.a
+$CXX $CXXFLAGS tools/simplifyfuzz.cpp -o $OUT/simplifyfuzzer $LIB_FUZZING_ENGINE build/libmeshoptimizer.a
```

## On the `ar` line

The CMake build already produces `build/libmeshoptimizer.a`, and since `MESHOPT_BUILD_DEMO` and
`MESHOPT_BUILD_GLTFPACK` both default to OFF and this script passes no options, the library's own
objects are the only `.o` files under the tree. So the `find`/`ar` step reconstructs an archive that
already exists.

This came up once before, in passing: on [zeux/meshoptimizer#215](https://github.com/zeux/meshoptimizer/pull/215)
— a PR of AdamKorcz's about removing an ossfuzz make rule — zeux asked, as one of two curiosity
questions, *"Would it be easier to use the .a library that CMake build produces? Not clear why you
need to use `ar` to rebuild it from .o artefacts"*. The answer was "Yes, it probably will be. I will
try it out." OSS-Fuzz PR #4895 was still open at the time and merged a week later with the `ar` line
intact; `build.sh` has not been touched since (`4dcfe1a`, 2021-01-05). I'm not presenting this as a
request that was made of anyone — it was an aside — just as the reason I looked at it.

## On the two harnesses

`tools/clusterfuzz.cpp` and `tools/simplifyfuzz.cpp` both define `LLVMFuzzerTestOneInput`, but
`build.sh` has only ever compiled `codecfuzz.cpp`. Their make prerequisites indicate what each is
aimed at:

```make
242:codecfuzz: tools/codecfuzz.cpp src/vertexcodec.cpp src/indexcodec.cpp src/meshletcodec.cpp
245:clusterfuzz: tools/clusterfuzz.cpp src/clusterizer.cpp src/partition.cpp
248:simplifyfuzz: tools/simplifyfuzz.cpp src/simplifier.cpp
```

(at upstream `300f7d3c6c9f7a7a45dbb547c971f99c53544344`; in the OSS-Fuzz build all three link the
whole archive, so these are the intended targets rather than a linkage boundary). `clusterfuzz.cpp`
drives `meshopt_buildMeshlets{,Flex,Scan,Spatial}` and `meshopt_partitionClusters`;
`simplifyfuzz.cpp` drives `meshopt_simplify`, `meshopt_simplifyWithAttributes` and
`meshopt_simplifyWithUpdate`.

## Prior discussion, including a criticism of these two harnesses

[zeux/meshoptimizer#1050](https://github.com/zeux/meshoptimizer/pull/1050) (closed unmerged, July
2026) proposed two *different* harnesses — `opacitymapfuzz.cpp` and `optimizefuzz.cpp`, not these.
Three things zeux said there bear directly on this PR, and I should quote the third as well as the
first two:

- He assumed OSS-Fuzz was not running simplify/cluster, which is what this fixes.
- He suggested it would be *"cleaner & better if most of these would be merged into a single
  source"*, keeping codecfuzz separate because the codecs operate on fundamentally untrusted data.
- **"simplifyfuzz & clusterfuzz are currently using `rand()` to generate vertex data so I'd imagine
  this would need to use the data provider."**

That last point is a fair objection to wiring these two up as-is: with `rand()` driving the vertex
data, libFuzzer's input is not fully steering the harness, so coverage feedback is weaker than it
looks and reproducing a crash from an artifact may not be reliable. I've left the harnesses
untouched rather than rewrite someone else's code in an OSS-Fuzz PR, but if the preferred order is
"fix the input plumbing upstream first, wire up second", that's a reasonable call and I'd rather
follow it than land this and have the targets produce noisy or irreproducible reports.

## What I actually ran

Locally, via `infra/helper.py` — **not** on this PR's CI, where `trial-build (oss-fuzz-base)`
reported `neutral` / "Changed files did not match file filter", so OSS-Fuzz's own build has not
exercised this change:

- `build_fuzzers meshoptimizer` — exit 0; all three targets compiled and landed in `$OUT`. This is
  the default engine/sanitizer combination only (libfuzzer + address); I have not built the afl,
  honggfuzz, centipede, or undefined/memory configurations that `project.yaml` lists.
- `check_build meshoptimizer` — exit 0, bad-build checks passed on all three binaries.
- 20-second smoke run of each; all three execute and fuzz.

## Note on resource cost

This takes the project from one target to three. Happy to trim to `simplifyfuzzer` alone —
`src/simplifier.cpp` is the largest of the three files at ~104 KB — if three is more fleet time than
this project warrants.
