### PR TITLE
ipykernel: fix broken build

### DIFF
--- a/projects/ipykernel/build.sh
+++ b/projects/ipykernel/build.sh
@@ -15,6 +15,7 @@
 #
 ################################################################################
 pip3 install .
+IPYPARALLEL_SERIALIZE_DIR=$(python3 -c 'import importlib.metadata, pathlib; print(pathlib.Path(importlib.metadata.distribution("ipyparallel").locate_file("ipyparallel/serialize")).as_posix())')
 for fuzzer in $(find $SRC -name 'fuzz_*.py'); do
-  compile_python_fuzzer $fuzzer
+  compile_python_fuzzer $fuzzer --add-data "$IPYPARALLEL_SERIALIZE_DIR:ipyparallel_serialize"
 done

--- a/projects/ipykernel/fuzz_serialization_roundtrip.py
+++ b/projects/ipykernel/fuzz_serialization_roundtrip.py
@@ -15,7 +15,7 @@
 import sys
 import atheris
 import ipykernel
-from ipykernel.serialize import deserialize_object, serialize_object
+from ipyparallel_serialize_loader import deserialize_object, serialize_object
 
 
 def ConsumeRandomLengthBufferList(fdp):

--- a/projects/ipykernel/fuzz_unpack_roundtrip.py
+++ b/projects/ipykernel/fuzz_unpack_roundtrip.py
@@ -15,7 +15,7 @@
 import sys
 import atheris
 import ipykernel
-from ipykernel.serialize import unpack_apply_message, pack_apply_message
+from ipyparallel_serialize_loader import unpack_apply_message, pack_apply_message
 
 
 def ConsumeRandomLengthBufferList(fdp):

--- a/projects/ipykernel/ipyparallel_serialize_loader.py
+++ b/projects/ipykernel/ipyparallel_serialize_loader.py
@@ -1,0 +1,58 @@
+#!/usr/bin/python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Load ipyparallel serialization helpers without importing ipyparallel."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _serialize_dir() -> Path:
+    if getattr(sys, "frozen", False):
+        return Path(sys._MEIPASS) / "ipyparallel_serialize"
+
+    dist = importlib.metadata.distribution("ipyparallel")
+    return Path(dist.locate_file("ipyparallel/serialize"))
+
+
+def _load_serialize_package():
+    package_name = "_oss_fuzz_ipyparallel_serialize"
+    if package_name in sys.modules:
+        return sys.modules[package_name]
+
+    package_dir = _serialize_dir()
+    spec = importlib.util.spec_from_file_location(
+        package_name,
+        package_dir / "__init__.py",
+        submodule_search_locations=[str(package_dir)],
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load ipyparallel.serialize from {package_dir}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[package_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_serialize = _load_serialize_package()
+
+deserialize_object = _serialize.deserialize_object
+serialize_object = _serialize.serialize_object
+unpack_apply_message = _serialize.unpack_apply_message
+pack_apply_message = _serialize.pack_apply_message


### PR DESCRIPTION
Update the ipykernel fuzzers to use the current serialization implementation instead of the removed `ipykernel.serialize` module.

The `ipykernel.serialize` module was deprecated upstream and has since been removed. The affected fuzzers import it during startup, before processing any fuzz input, so the missing module causes both targets to fail immediately with ModuleNotFoundError.

The corresponding helpers are now provided by `ipyparallel.serialize`: deserialize_object, serialize_object, unpack_apply_message, and pack_apply_message.

A direct import from `ipyparallel.serialize` is not used because importing that submodule first executes `ipyparallel.__init__.py`. This pulls in unrelated ipyparallel.cluster code, and the PyInstaller-built fuzzers then fail at startup because a cluster resource is not included in the one-file bundle.

This patch adds a small loader that loads only the `ipyparallel.serialize` package under a private module name. It also explicitly includes the ipyparallel/serialize package files in the PyInstaller bundle so they remain available at runtime.
