### PR TITLE
Update Kea repo to be standalone

### DIFF
--- a/projects/kea/Dockerfile
+++ b/projects/kea/Dockerfile
@@ -21,17 +21,16 @@ RUN apt-get update && \
       libboost-filesystem-dev libboost-program-options-dev libboost-thread-dev \
       libpq-dev libmariadb-dev libkrb5-dev
 RUN mkdir -p /opt/boost-headers && \
-    wget https://archives.boost.io/release/1.83.0/source/boost_1_83_0.tar.gz && \
+    wget --progress=dot:giga https://archives.boost.io/release/1.83.0/source/boost_1_83_0.tar.gz && \
     tar -xzf boost_1_83_0.tar.gz -C /opt/boost-headers --strip-components=1 && \
     rm -f boost_1_83_0.tar.gz && mkdir -p /usr/local/include && \
     ln -s /opt/boost-headers/boost /usr/local/include/boost
 RUN mkdir -p /src/log4cplus && \
-    wget https://github.com/log4cplus/log4cplus/releases/download/REL_2_1_2/log4cplus-2.1.2.tar.gz && \
+    wget --progress=dot:giga https://github.com/log4cplus/log4cplus/releases/download/REL_2_1_2/log4cplus-2.1.2.tar.gz && \
     tar -xzf log4cplus-2.1.2.tar.gz -C /src/log4cplus --strip-components=1 && \
     rm -f log4cplus-2.1.2.tar.gz
 RUN python3 -m pip install --no-cache-dir --upgrade "meson>=1.1,<2"
 
 RUN git clone https://gitlab.isc.org/isc-projects/kea kea
-RUN git clone https://github.com/AdaLogics/ada-fuzzers ada-fuzzers
 COPY build.sh $SRC/
 WORKDIR kea

--- a/projects/kea/build.sh
+++ b/projects/kea/build.sh
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 ################################################################################
-# Copy key fuzzers/dict/seeds
-cp -r $SRC/ada-fuzzers/projects/kea $SRC/kea-fuzzer
 
-# Run build script
-$SRC/kea-fuzzer/build.sh
+# Run build script.
+"${SRC}/kea/src/fuzz/build.sh"

--- a/projects/kea/project.yaml
+++ b/projects/kea/project.yaml
@@ -1,16 +1,19 @@
 base_os_version: ubuntu-24-04
 homepage: "https://gitlab.isc.org/isc-projects/kea"
 language: c++
-primary_contact: "david@adalogics.com"
+primary_contact: "tomek@isc.org"
 auto_ccs:
-  - "adam@adalogics.com"
-  - "arthur.chan@adalogics.com"
-  - "tomek@isc.org"
   - "razvan@isc.org"
   - "andrei@isc.org"
   - "wlodek.wencel@gmail.com"
-main_repo: 'https://gitlab.isc.org/isc-projects/kea'
+vendor_ccs:
+  - "david@adalogics.com"
+  - "adam@adalogics.com"
+  - "arthur.chan@adalogics.com"
+main_repo: "https://gitlab.isc.org/isc-projects/kea"
 fuzzing_engines:
   - libfuzzer
 sanitizers:
   - address
+  - thread
+  - undefined


### PR DESCRIPTION
- Fuzzing harnesses were copied from the ada-fuzzers repo to the kea repo. The ada-fuzzers repo is no longer strictly required so it can be removed.
- Address some hadolint warnings about wget in Dockerfile.
- Enable two other sanitizers.