### PR TITLE
fix(cifuzz): add none and introspector to valid sanitizers

### DIFF
--- a/infra/cifuzz/config_utils.py
+++ b/infra/cifuzz/config_utils.py
@@ -29,7 +29,7 @@ import constants
 import re
 import subprocess
 
-SANITIZERS = ['address', 'memory', 'undefined', 'coverage']
+SANITIZERS = ['address', 'memory', 'undefined', 'coverage', 'none', 'introspector']
 BASE_OS_VERSION_REGEX = re.compile(r'\s*base_os_version\s*:\s*([^\s]+)')
 
 # TODO(metzman): Set these on config objects so there's one source of truth.


### PR DESCRIPTION
Fixes #15907

This adds `none` and `introspector` to the allowed `SANITIZERS` list in `config_utils.py`. 

Right now, CIFuzz is locked up for JavaScript projects because `config_utils.py` rejects `none` as an invalid sanitizer, but the `compile` script actually requires `none` (or `coverage`) to build JS fuzzers. `introspector` was also missing from the validator despite being valid for Python and JVM.

This simple change bridges the gap between the config validator and the compile constraints so JS fuzzing runs can proceed. Tests in `config_utils_test.py` have been run and still pass.
