### PR TITLE
fix(openvpn): plug memory leak of rl6 in fuzz_route

### DIFF
--- a/projects/openvpn/fuzz_route.c
+++ b/projects/openvpn/fuzz_route.c
@@ -196,6 +196,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   if (route_list_inited) {
     gc_free(&rl.gc);
   }
+  if (route_list_ipv6_inited) {
+    gc_free(&rl6.gc);
+  }
   env_set_destroy(c.es);
   context_gc_free(&c);
 


### PR DESCRIPTION
Fixes #11353

In `projects/openvpn/fuzz_route.c`, the `LLVMFuzzerTestOneInput` loop correctly initializes memory allocations for both `rl` (IPv4 routing list) and `rl6` (IPv6 routing list) via `init_route_list` and `init_route_ipv6_list`.

However, at the end of the fuzzer loop iteration, it only frees the garbage collection context for `rl.gc` and completely neglects to free `rl6.gc`. This causes a memory leak that quickly balloons and forces the fuzzer process to OOM, effectively degrading its ability to continue finding bugs during a fuzzing session.

This patch adds the missing `gc_free(&rl6.gc)` conditional, explicitly plugging the memory leak.
