### PR TITLE
fix(security): prevent command injection in MCP tools

### DIFF
--- a/infra/experimental/mcp/client.py
+++ b/infra/experimental/mcp/client.py
@@ -217,8 +217,7 @@ def initialize_oss_fuzz() -> None:
   if not os.path.exists(oss_fuzz_mcp_config.BASE_OSS_FUZZ_DIR):
     logger.info('Cloning OSS-Fuzz repository...')
     subprocess.check_call(
-        f'git clone https://github.com/google/oss-fuzz.git {oss_fuzz_mcp_config.BASE_OSS_FUZZ_DIR}',
-        shell=True)
+        ['git', 'clone', 'https://github.com/google/oss-fuzz.git', oss_fuzz_mcp_config.BASE_OSS_FUZZ_DIR])
 
   os.makedirs(oss_fuzz_mcp_config.BASE_PROJECTS_DIR, exist_ok=True)
 
@@ -316,9 +315,7 @@ def prepare_oss_fuzz_project(project_name: str) -> bool:
 
   try:
     subprocess.check_call(
-        'git clone ' + main_repo + ' ' +
-        os.path.join(oss_fuzz_mcp_config.BASE_PROJECTS_DIR, project_name),
-        shell=True,
+        ['git', 'clone', main_repo, os.path.join(oss_fuzz_mcp_config.BASE_PROJECTS_DIR, project_name)],
         timeout=60 * 10)
   except subprocess.CalledProcessError as e:
     logger.info(f"Error cloning project {project_name}: {e}")
@@ -336,10 +333,8 @@ async def does_project_build(project: str) -> bool:
   successful"""
   try:
     subprocess.check_call(
-        f'python3 {oss_fuzz_mcp_config.BASE_OSS_FUZZ_DIR}/infra/helper.py build_fuzzers '
-        + project,
+        ['python3', f'{oss_fuzz_mcp_config.BASE_OSS_FUZZ_DIR}/infra/helper.py', 'build_fuzzers', project],
         cwd=oss_fuzz_mcp_config.BASE_OSS_FUZZ_DIR,
-        shell=True,
         timeout=60 * 20)
   except subprocess.CalledProcessError:
     return False
@@ -349,10 +344,8 @@ async def does_project_build(project: str) -> bool:
 
   try:
     subprocess.check_call(
-        f'python3 {oss_fuzz_mcp_config.BASE_OSS_FUZZ_DIR}/infra/helper.py check_build '
-        + project,
+        ['python3', f'{oss_fuzz_mcp_config.BASE_OSS_FUZZ_DIR}/infra/helper.py', 'check_build', project],
         cwd=oss_fuzz_mcp_config.BASE_OSS_FUZZ_DIR,
-        shell=True,
         timeout=60 * 10)
 
   except subprocess.CalledProcessError:
@@ -785,9 +778,7 @@ def prepare_new_oss_fuzz_project(project_name: str, project_url: str) -> bool:
 
   try:
     subprocess.check_call(
-        'git clone ' + project_url + ' ' +
-        os.path.join(oss_fuzz_mcp_config.BASE_PROJECTS_DIR, project_name),
-        shell=True,
+        ['git', 'clone', project_url, os.path.join(oss_fuzz_mcp_config.BASE_PROJECTS_DIR, project_name)],
         timeout=60 * 10)
   except subprocess.CalledProcessError as e:
     logger.info("Error cloning project %s: %s", project_name, e)

--- a/infra/experimental/mcp/oss_fuzz_server.py
+++ b/infra/experimental/mcp/oss_fuzz_server.py
@@ -109,10 +109,8 @@ async def check_if_oss_fuzz_project_builds() -> bool:
 
   try:
     logger.info('Building OSS-Fuzz project: %s', project_name)
-    subprocess.check_call('python3 infra/helper.py build_fuzzers ' +
-                          project_name,
+    subprocess.check_call(['python3', 'infra/helper.py', 'build_fuzzers', project_name],
                           cwd=oss_fuzz_mcp_config.BASE_OSS_FUZZ_DIR,
-                          shell=True,
                           stdout=subprocess.DEVNULL,
                           stderr=subprocess.STDOUT,
                           timeout=60 * 20)
@@ -163,10 +161,8 @@ async def build_and_get_build_logs_from_oss_fuzz() -> str:
 
   try:
     logger.info("Building OSS-Fuzz project: '%s'", project_name)
-    subprocess.check_call('python3 infra/helper.py build_fuzzers ' +
-                          project_name,
+    subprocess.check_call(['python3', 'infra/helper.py', 'build_fuzzers', project_name],
                           cwd=oss_fuzz_mcp_config.BASE_OSS_FUZZ_DIR,
-                          shell=True,
                           stdout=log_stdout,
                           stderr=subprocess.STDOUT,
                           timeout=60 * 20)
@@ -257,9 +253,8 @@ async def check_run_tests(
   log_stdout = open(target_logs, 'w', encoding='utf-8')
   try:
     subprocess.check_call(
-        f'infra/experimental/chronos/check_tests.sh {project_name} c++',
+        ['infra/experimental/chronos/check_tests.sh', project_name, 'c++'],
         cwd=oss_fuzz_mcp_config.BASE_OSS_FUZZ_DIR,
-        shell=True,
         stdout=log_stdout,
         stderr=subprocess.STDOUT,
         timeout=60 * 20)
@@ -305,10 +300,8 @@ async def check_oss_fuzz_fuzzers() -> str:
     os.remove(target_logs)
   log_stdout = open(target_logs, 'w', encoding='utf-8')
   try:
-    subprocess.check_call('python3 infra/helper.py build_fuzzers ' +
-                          project_name,
+    subprocess.check_call(['python3', 'infra/helper.py', 'build_fuzzers', project_name],
                           cwd=oss_fuzz_mcp_config.BASE_OSS_FUZZ_DIR,
-                          shell=True,
                           stdout=log_stdout,
                           stderr=subprocess.STDOUT,
                           timeout=60 * 20)
@@ -329,9 +322,8 @@ async def check_oss_fuzz_fuzzers() -> str:
     os.remove(check_target_logs)
   log_stdout = open(check_target_logs, 'w', encoding='utf-8')
   try:
-    subprocess.check_call('python3 infra/helper.py check_build ' + project_name,
+    subprocess.check_call(['python3', 'infra/helper.py', 'check_build', project_name],
                           cwd=oss_fuzz_mcp_config.BASE_OSS_FUZZ_DIR,
-                          shell=True,
                           stdout=log_stdout,
                           stderr=subprocess.STDOUT,
                           timeout=60 * 30)
@@ -600,10 +592,8 @@ async def get_coverage_of_oss_fuzz_project(project_name):
   try:
     logger.info("Building OSS-Fuzz project: '%s'", project_name)
     subprocess.check_call(
-        'python3 infra/helper.py introspector --coverage-only --seconds=10 ' +
-        project_name,
+        ['python3', 'infra/helper.py', 'introspector', '--coverage-only', '--seconds=10', project_name],
         cwd=oss_fuzz_mcp_config.BASE_OSS_FUZZ_DIR,
-        shell=True,
         stdout=log_stdout,
         stderr=subprocess.STDOUT,
         timeout=60 * 20)


### PR DESCRIPTION
The `infra/experimental/mcp/oss_fuzz_server.py` and `infra/experimental/mcp/client.py` files construct shell commands using string concatenation with external inputs (like project names and repository URLs) and execute them using `subprocess.check_call` with `shell=True`. This introduces command injection vulnerabilities, which could allow arbitrary command execution on the host machine running the MCP server or client.

This patch migrates these `subprocess.check_call` invocations to use explicit argument lists instead of raw strings, and removes the `shell=True` parameter. By doing so, Python passes arguments directly to the subprocess API, preventing the system shell from evaluating shell metacharacters within the variable contents.
