### PR TITLE
Add spif-rust fuzzing project

### DIFF
--- a/projects/spif-rust/Dockerfile
+++ b/projects/spif-rust/Dockerfile
@@ -1,0 +1,4 @@
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+RUN git clone --depth 1 https://github.com/intelogroup/spif.git spif
+COPY build.sh $SRC/
+WORKDIR spif/spif-rust

--- a/projects/spif-rust/build.sh
+++ b/projects/spif-rust/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -eu
+cd fuzz-libfuzzer
+cargo fuzz build -O
+for target in fuzz_read fuzz_read_strict; do
+  cp target/x86_64-unknown-linux-gnu/release/$target $OUT/
+done

--- a/projects/spif-rust/project.yaml
+++ b/projects/spif-rust/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/intelogroup/spif"
+language: rust
+primary_contact: "jimkalinov@gmail.com"
+main_repo: "https://github.com/intelogroup/spif"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+


### PR DESCRIPTION
SPIF (Signed Provenance Interchange Format) is a binary CBOR-based
provenance/attestation format with ed25519 signatures and a DAG of
trace/payload nodes. Rust implementation: https://github.com/intelogroup/spif

Two libFuzzer targets:
- fuzz_read — SPIFReader::read, unsigned-tolerant parse path
- fuzz_read_strict — SPIFReader::strict, signature-required parse path

Both run locally today under cargo-fuzz with 0 crashes across 10M+
combined executions; see SECURITY.md in the repo for current numbers
and threat-model coverage. Build verified locally via `cargo +nightly
fuzz build -O` for both targets (aarch64-apple-darwin) — this PR's
Dockerfile/build.sh has not yet been run through the actual OSS-Fuzz
Linux container, flagging that plainly rather than claiming otherwise.