### PR TITLE
quicz: add fuzzing project

### DIFF
--- a/projects/quicz/Dockerfile
+++ b/projects/quicz/Dockerfile
@@ -1,0 +1,24 @@
+# OSS-Fuzz builder image for quicz. Provides the sanitizer + libFuzzer
+# toolchain and the Zig compiler needed to build the pure-Zig fuzz driver.
+#
+# This file is copied into projects/quicz/ for submission; the build context is
+# that directory, which also holds build.sh (see the trailing COPY).
+FROM gcr.io/oss-fuzz-base/base-builder
+
+# Zig 0.16.0 is shipped per-arch; pick the tarball matching the builder arch.
+RUN set -eux; \
+    apt-get update && apt-get install -y --no-install-recommends \
+        wget xz-utils ca-certificates; \
+    case "$(uname -m)" in \
+        x86_64) ZIG_ARCH=x86_64-linux ;; \
+        aarch64) ZIG_ARCH=aarch64-linux ;; \
+        *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;; \
+    esac; \
+    wget -q "https://ziglang.org/download/0.16.0/zig-${ZIG_ARCH}-0.16.0.tar.xz" -O /tmp/zig.tar.xz; \
+    tar -xJf /tmp/zig.tar.xz -C /opt; \
+    ln -s /opt/zig-*/zig /usr/local/bin/zig; \
+    zig version
+
+RUN git clone --depth 1 https://github.com/venjiang/quicz.git $SRC/quicz
+WORKDIR $SRC/quicz
+COPY build.sh $SRC/build.sh

--- a/projects/quicz/build.sh
+++ b/projects/quicz/build.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# OSS-Fuzz build script. Compiles the quicz fuzz driver into a libFuzzer
+# binary linked against the OSS-Fuzz-provided $CC with ASan/UBSan.
+#
+# The driver is pure Zig with a C ABI entry (`quicz_fuzz_drive`); we compile
+# it to a static object with Zig, then link it with libFuzzer's main via $CXX.
+set -eux
+
+# Zig static object exposing quicz_fuzz_drive (callconv .c).
+# Module graph: --dep quicz must precede -Mroot; -Mquicz exposes src/lib.zig.
+# -lc: the fuzz targets use std.heap.c_allocator (malloc), which ASan tracks;
+# page_allocator mmaps land in ASan-unmapped shadow and cause false SEGV on
+# memcpy interception. (Note: Zig's -fPIC is a no-op for static objects here;
+# PIC/TLS is handled at final link via lld -no-pie below.)
+zig build-lib --dep quicz -Mroot=src/quic/fuzz_c_abi.zig -Mquicz=src/lib.zig \
+    -femit-bin="$OUT/quicz_fuzz_drive.o" \
+    -OReleaseSafe \
+    -lc \
+    --name quicz_fuzz_drive
+
+# C shim that maps libFuzzer's LLVMFuzzerTestOneInput to quicz_fuzz_drive.
+cat > "$OUT/quicz_main.cpp" <<'EOF'
+#include <cstddef>
+#include <cstdint>
+extern "C" void quicz_fuzz_drive(unsigned mode, const uint8_t* data, size_t size);
+// libFuzzer entry: run mode 8 (state machine) plus the parse sweep (mode ~0).
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    if (size == 0) return 0;
+    quicz_fuzz_drive(8, data, size);
+    quicz_fuzz_drive(~0u, data, size);
+    return 0;
+}
+EOF
+
+# Link with the OSS-Fuzz compiler (brings libFuzzer + sanitizers). The
+# ${VAR:-} guards keep this usable when run outside the OSS-Fuzz env (local
+# preflight) where $LDFLAGS may be unset.
+# -fuse-ld=lld -no-pie: the Zig static object ignores -fPIC (emits absolute
+# R_X86_64_32S), and its threadlocal (Io.Threaded) TLS relocations
+# (TPOFF32/DTPOFF32) truncate under the default GNU-ld PIE link. lld + -no-pie
+# links both correctly.
+$CXX $CXXFLAGS -std=c++17 -fuse-ld=lld -no-pie \
+    "$OUT/quicz_main.cpp" "$OUT/quicz_fuzz_drive.o" \
+    -o "$OUT/quicz_fuzz" \
+    ${LIB_FUZZING_ENGINE:-} ${LDFLAGS:-}
+
+echo "OSS-Fuzz build complete: $OUT/quicz_fuzz"

--- a/projects/quicz/project.yaml
+++ b/projects/quicz/project.yaml
@@ -1,0 +1,15 @@
+# OSS-Fuzz project manifest for quicz.
+# See https://google.github.io/oss-fuzz/getting-started/new-project-guide/
+homepage: "https://github.com/venjiang/quicz"
+language: c++   # libFuzzer harness is C++; the target under test is pure Zig.
+primary_contact: "venjiang@gmail.com"
+auto_ccs:
+  - "venjiang@gmail.com"
+sanitizers:
+  - address
+  - undefined
+fuzzing_engines:
+  - libfuzzer
+architectures:
+  - x86_64
+  - aarch64


### PR DESCRIPTION
Adds the OSS-Fuzz project for [quicz](https://github.com/venjiang/quicz), a pure-Zig QUIC implementation (RFC 8999/9000/9001/9002) with pure-Zig TLS 1.3 and HTTP/3.

The fuzz driver is pure Zig with a C ABI entry (`quicz_fuzz_drive`); `build.sh` compiles it to a static object with Zig, then links it with libFuzzer + ASan/UBSan via `$CXX` (lld + `-no-pie` for the Zig TLS relocations).

Validated locally:
```
infra/helper.py build_fuzzers quicz   # OK
infra/helper.py check_build quicz     # Check build passed.
```
Provide Build Log URL: local preflight only (running in our Linux container).

Sanitizers: address, undefined. Engines: libfuzzer. Arch: x86_64, aarch64.