### PR TITLE
spif-py: new project

### DIFF
--- a/projects/spif-py/Dockerfile
+++ b/projects/spif-py/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-python
+RUN git clone --depth 1 https://github.com/intelogroup/spif.git spif
+COPY build.sh $SRC/
+COPY fuzz_targets/*.py $SRC/
+WORKDIR spif/spif

--- a/projects/spif-py/build.sh
+++ b/projects/spif-py/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+pip3 install .
+
+for fuzzer in $(find $SRC -name '*_fuzzer.py'); do
+  compile_python_fuzzer $fuzzer
+done
+
+zip -j $OUT/fuzz_decode_fuzzer_seed_corpus.zip spif/fixtures/cross_lang/*.spif
+zip -j $OUT/fuzz_decode_strict_fuzzer_seed_corpus.zip spif/fixtures/cross_lang/*.spif

--- a/projects/spif-py/fuzz_targets/fuzz_decode_fuzzer.py
+++ b/projects/spif-py/fuzz_targets/fuzz_decode_fuzzer.py
@@ -1,0 +1,32 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+import atheris
+import sys
+
+with atheris.instrument_imports():
+    import spif
+
+
+@atheris.instrument_func
+def TestOneInput(data):
+    try:
+        spif.SPIFReader().decode(data)
+    except spif.SPIFError:
+        return
+
+
+atheris.Setup(sys.argv, TestOneInput)
+atheris.Fuzz()

--- a/projects/spif-py/fuzz_targets/fuzz_decode_strict_fuzzer.py
+++ b/projects/spif-py/fuzz_targets/fuzz_decode_strict_fuzzer.py
@@ -1,0 +1,32 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+import atheris
+import sys
+
+with atheris.instrument_imports():
+    import spif
+
+
+@atheris.instrument_func
+def TestOneInput(data):
+    try:
+        spif.SPIFReader.strict().decode(data)
+    except spif.SPIFError:
+        return
+
+
+atheris.Setup(sys.argv, TestOneInput)
+atheris.Fuzz()

--- a/projects/spif-py/project.yaml
+++ b/projects/spif-py/project.yaml
@@ -1,0 +1,24 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+homepage: "https://github.com/intelogroup/spif"
+language: python
+primary_contact: "kalinovjim@gmail.com"
+main_repo: "https://github.com/intelogroup/spif"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+  - undefined


### PR DESCRIPTION
Adding spif-py (Python SPIF decoder/encoder) to OSS-Fuzz.

- Homepage/repo: https://github.com/intelogroup/spif
- Language: Python
- Fuzzing engine: libFuzzer (atheris-based harness)

Per the two-stage onboarding process, this PR contains only project.yaml.
Will follow up with Dockerfile/build.sh/fuzz targets once accepted.