### PR TITLE
fix(helper): avoid unhandled EOFError in build_image when running non-interactively

### DIFF
--- a/infra/helper.py
+++ b/infra/helper.py
@@ -699,8 +699,13 @@ def build_image(args):
   elif args.no_pull:
     pull = False
   else:
-    y_or_n = raw_input('Pull latest base images (compiler/runtime)? (y/N): ')
-    pull = y_or_n.lower() == 'y'
+    try:
+      y_or_n = raw_input('Pull latest base images (compiler/runtime)? (y/N): ')
+      pull = y_or_n.lower() == 'y'
+    except EOFError:
+      logger.error('No input available. Please specify --pull or --no-pull '
+                   'when running non-interactively.')
+      return False
 
   if pull:
     logger.info('Pulling latest base images...')


### PR DESCRIPTION
Fixes #15970

**Issue:**
When executing `python3 infra/helper.py build_image <project>` without specifying either the `--pull` or `--no-pull` arguments, the script prompts the user for a pull decision using `raw_input`. If this command is run in a non-interactive environment (e.g. CI/CD or with standard input closed/redirected to `/dev/null`), `raw_input` throws an unhandled `EOFError`, exposing a confusing Python traceback and causing the automation to fail unpredictably.

**Fix:**
This PR catches the `EOFError` exception raised by `raw_input` during the prompt. Instead of emitting a traceback, it cleanly catches the exception, logs a concise error message (`No input available. Please specify --pull or --no-pull when running non-interactively.`), and safely exits the image build process with a failed status. This gives automated callers a stable CLI diagnostic and clearly communicates how to resolve the issue.
