### PR TITLE
boost: add regex fuzz target for c_regex_traits

### DIFF
--- a/projects/boost/boost_regex_c_traits_fuzzer.cc
+++ b/projects/boost/boost_regex_c_traits_fuzzer.cc
@@ -1,0 +1,77 @@
+/* Copyright 2026 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+// The ideal place for this fuzz target is the boost repository.
+//
+// The existing regex fuzz targets (boost_regex_fuzzer, boost_regex_pattern_fuzzer,
+// boost_regex_replace_fuzzer) all use boost::regex, i.e.
+//   basic_regex<char, regex_traits<char, cpp_regex_traits<char>>>.
+// This target instead instantiates the parser over c_regex_traits, which is a
+// separate template instantiation with its own syntax_type() implementation and
+// is not otherwise exercised. It also varies the syntax_option_type flags, which
+// the existing targets leave at their default.
+
+#include <boost/regex.hpp>
+#include <fuzzer/FuzzedDataProvider.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace {
+
+using c_regex_t = boost::basic_regex<char, boost::c_regex_traits<char>>;
+
+// Only the documented bits of syntax_option_type. Feeding the parser undocumented
+// bits would not represent a supported way of calling the library.
+constexpr unsigned kFlagMask =
+    // main syntax group (bits 0-1)
+    boost::regbase::basic_syntax_group | boost::regbase::literal |
+    // perl/basic subtype options (bits 8-13)
+    boost::regbase::no_bk_refs | boost::regbase::no_perl_ex |
+    boost::regbase::no_mod_m | boost::regbase::mod_x |
+    boost::regbase::mod_s | boost::regbase::no_mod_s |
+    // options common to all groups (bits 16-24)
+    boost::regbase::no_escape_in_lists | boost::regbase::newline_alt |
+    boost::regbase::no_except | boost::regbase::failbit |
+    boost::regbase::icase | boost::regbase::collate |
+    boost::regbase::nosubs | boost::regbase::save_subexpression_location |
+    boost::regbase::no_empty_expressions;
+
+}  // namespace
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+  FuzzedDataProvider fdp(Data, Size);
+
+  const uint32_t raw_flags = fdp.ConsumeIntegral<uint32_t>();
+  const auto flags =
+      static_cast<c_regex_t::flag_type>(raw_flags & kFlagMask);
+
+  const std::string pattern = fdp.ConsumeRandomLengthString(256);
+  const std::string text = fdp.ConsumeRemainingBytesAsString();
+
+  c_regex_t re;
+  try {
+    re.assign(pattern.data(), pattern.size(), flags);
+    // With no_except the parser reports failure through status() instead of
+    // throwing, so an unusable expression must not be handed to regex_search.
+    if (re.status() == 0) {
+      boost::match_results<std::string::const_iterator> what;
+      (void)boost::regex_search(text, what, re, boost::match_default);
+    }
+  } catch (const boost::regex_error &) {
+    // Expected for malformed patterns.
+  } catch (const std::runtime_error &) {
+    // Boost.Regex reports resource limits this way.
+  }
+
+  return 0;
+}

--- a/projects/boost/build.sh
+++ b/projects/boost/build.sh
@@ -29,6 +29,7 @@ echo "using clang : ossfuzz : $CXX : <compileflags>\"$CXXFLAGS\" <linkflags>\"$C
 $CXX $CXXFLAGS -I . ../boost_regex_fuzzer.cc libs/regex/src/*.cpp $LIB_FUZZING_ENGINE -o boost_regex_fuzzer
 $CXX $CXXFLAGS -I . ../boost_regex_pattern_fuzzer.cc libs/regex/src/*.cpp $LIB_FUZZING_ENGINE -o boost_regex_pattern_fuzzer
 $CXX $CXXFLAGS -I . ../boost_regex_replace_fuzzer.cc libs/regex/src/*.cpp $LIB_FUZZING_ENGINE -o boost_regex_replace_fuzzer
+$CXX $CXXFLAGS -I . ../boost_regex_c_traits_fuzzer.cc libs/regex/src/*.cpp $LIB_FUZZING_ENGINE -o boost_regex_c_traits_fuzzer
 
 #boost property tree parsers
 $CXX $CXXFLAGS -I . ../boost_ptree_xmlread_fuzzer.cc  $LIB_FUZZING_ENGINE -o boost_ptree_xmlread_fuzzer


### PR DESCRIPTION
Boost.Regex currently has three fuzz targets — `boost_regex_fuzzer`,
`boost_regex_pattern_fuzzer` and `boost_regex_replace_fuzzer`. All three use
`boost::regex`, which is
`basic_regex<char, regex_traits<char, cpp_regex_traits<char>>>`, and all three
leave `syntax_option_type` at its default value.

This target covers two things none of them reach:

1. **A different template instantiation.** It parses through
   `basic_regex<char, c_regex_traits<char>>`. `basic_regex_parser` is a template
   over the traits type and `c_regex_traits` supplies its own `syntax_type()`,
   so this is a distinct instantiation of the whole parser rather than a
   different runtime path through shared code.

2. **The syntax flags.** The existing targets never vary `syntax_option_type`.
   This one derives it from the input, masked to the documented bits of
   `syntax_option_type` so the target only exercises supported ways of calling
   the library.

The target reaches an assertion failure in
`basic_regex_parser::parse_perl_extension()` — `BOOST_ASSERT(this->m_traits
.syntax_type(*m_position) == regex_constants::syntax_close_mark)`.

To be precise about what earned the finding: it is the flag variation, not the
traits type. On current boost the same assertion is reachable through the
default `regex_traits` as well, so the reason the existing targets never hit it
is that they leave `syntax_option_type` at its default, not that they use a
different traits class. (On boost 1.71 the default traits does *not* abort and
`c_regex_traits` does, but that is a v4/v5 difference, not the point here.) The
`c_regex_traits` coverage in point 1 above stands on its own as untested
instantiation; it is not what produced this bug.

I kept this as a separate target rather than adding flag variation to
`boost_regex_fuzzer`, because changing that target's input layout would change
what its accumulated corpus decodes to. Happy to fold it in instead if you would
rather not carry another target.

The pattern reduces to `(?:\R` followed by any byte that is not `)`, with
`newline_alt | no_except`. `no_except` is the essential ingredient: without it
the parse error is reported by throwing and the assertion is never reached. It
is assert-only — under `NDEBUG` the same input returns cleanly with a non-zero
`status()`, and I could not produce a memory-safety consequence in a release
build. Reported upstream as boostorg/regex#285.

13-byte reproducer for this target (encodes the pattern `(?:\R\x0c` plus the
two flags, in this target's `FuzzedDataProvider` layout):

```
283f3a5c5c520c5c4100000600
```

```console
$ printf '\x28\x3f\x3a\x5c\x5c\x52\x0c\x5c\x41\x00\x00\x06\x00' > poc
$ python3 infra/helper.py reproduce boost boost_regex_c_traits_fuzzer poc
boost_regex_c_traits_fuzzer: ./boost/regex/v5/basic_regex_parser.hpp:2613: bool
  boost::re_detail_600::basic_regex_parser<char, boost::c_regex_traits<char>>::parse_perl_extension()
  [charT = char, traits = boost::c_regex_traits<char>]:
  Assertion `this->m_traits.syntax_type(*m_position) == regex_constants::syntax_close_mark' failed.
```

This is not a crash-on-everything target. From an empty corpus a 5-minute run
completed 2.2M executions at ~7.3k exec/s (peak RSS 152 MB) without tripping
the assertion; a 30-minute run rediscovered it independently. So it needs a
specific pattern and flag combination, but the target does reach it on its own.

Verified locally on this branch:

- `infra/presubmit.py` — Success
- `infra/helper.py build_fuzzers boost` — builds `boost_regex_c_traits_fuzzer`
- `infra/helper.py check_build boost` — passes, new target included
- `infra/helper.py reproduce boost boost_regex_c_traits_fuzzer <poc>` — reproduces
  the assertion against current boost (stack frames in `regex/v5/`)

Disclosure: this fuzz target was drafted with LLM assistance and then reviewed,
reduced and verified by hand.
