### PR TITLE
mod-auth-openidc: add new project

### DIFF
--- a/projects/mod-auth-openidc/Dockerfile
+++ b/projects/mod-auth-openidc/Dockerfile
@@ -1,0 +1,39 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
+
+# apache2-dev is needed for the httpd headers and apxs that configure probes for;
+# the module's Apache server symbols are stubbed by test/stub.c, so the server
+# itself is never linked. The rest are the module's link dependencies.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        make autoconf automake libtool pkg-config wget \
+        apache2-dev \
+        libapr1-dev libaprutil1-dev \
+        libcurl4-openssl-dev libssl-dev libpcre2-dev \
+        zlib1g-dev
+
+# jansson and cjose sit directly on the JSON/JOSE parse paths that fuzz_json and
+# fuzz_jwt drive, so both are built from source under $CFLAGS rather than taken
+# from the distro -- otherwise the sanitizers see nothing inside them and the
+# coverage report stops at the library boundary. cjose is not itself an OSS-Fuzz
+# project, so this is the only instrumented build it gets.
+RUN git clone --depth=1 https://github.com/akheron/jansson $SRC/jansson
+RUN git clone --depth=1 https://github.com/OpenIDC/cjose $SRC/cjose
+
+RUN git clone --depth=1 https://github.com/OpenIDC/mod_auth_openidc $SRC/mod_auth_openidc
+WORKDIR $SRC/mod_auth_openidc
+COPY build.sh $SRC/

--- a/projects/mod-auth-openidc/build.sh
+++ b/projects/mod-auth-openidc/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Deliberately thin: the real recipe lives in the project's own tree, so adding
+# or renaming a fuzz target never needs a PR against oss-fuzz.
+"$SRC/mod_auth_openidc/test/fuzz/oss-fuzz-build.sh"

--- a/projects/mod-auth-openidc/project.yaml
+++ b/projects/mod-auth-openidc/project.yaml
@@ -1,0 +1,20 @@
+homepage: "https://www.openidc.com/"
+language: c
+primary_contact: "hans.zandbelt@openidc.com"
+auto_ccs:
+  - "support@openidc.com"
+main_repo: "https://github.com/OpenIDC/mod_auth_openidc"
+
+# ASan + UBSan only. MemorySanitizer requires every linked library to be
+# instrumented; apr, apr-util, curl and openssl come from the distro here (see
+# the note in build.sh), so MSan would report uninitialised reads inside them.
+sanitizers:
+  - address
+  - undefined
+
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz
+
+base_os_version: ubuntu-24-04


### PR DESCRIPTION
[mod_auth_openidc](https://github.com/OpenIDC/mod_auth_openidc) is an OpenID Certified™ authentication and authorization module for the Apache 2.x HTTP server that implements the OpenID Connect 1.x and FAPI 2.x Relying Party functionality — the de-facto way to put OIDC authentication in front of Apache-served content, and a security boundary in a lot of deployments.

### Targets

The four fuzz targets already live in the project's own tree under `test/fuzz/`, and are exercised there two ways today: a seed-corpus replay under `make check` with the ordinary toolchain, and a clang/libFuzzer job in the project's CI. This PR builds the same targets under OSS-Fuzz.

| target | function under test | reached via |
|---|---|---|
| `fuzz_base64` | `oidc_util_base64url_decode` | cookies, state, JWT segments |
| `fuzz_url` | `oidc_validate_redirect_url` | the open-redirect guard |
| `fuzz_jwt` | `oidc_jwt_parse` | compact JWS/JWE structural parse |
| `fuzz_json` | `oidc_json_decode_object` | token / userinfo / metadata |

### Notes

- `build.sh` here is deliberately one line calling `test/fuzz/oss-fuzz-build.sh` in the project's own tree, so adding a target, a corpus or a dictionary is a change there and does not need a PR against this repo.
- `jansson` and `cjose` are built from source under `$CFLAGS` because they sit directly on the parsed paths. `cjose` is not itself an OSS-Fuzz project, so this is the only instrumented build it gets.
- `apr`, `apr-util`, `openssl`, `curl` and `pcre2` come from distro packages, so `memory` is not in the requested sanitizers. Promoting them to instrumented source builds is the intended follow-up.
- Seed corpora ship per target. `fuzz_url` additionally gets the project's curated list of 834 open-redirect payloads, one input per file.

### Validation

Run locally against this exact tree:

- `infra/helper.py build_image mod-auth-openidc`
- `infra/helper.py build_fuzzers mod-auth-openidc` — all four targets built
- `infra/helper.py check_build mod-auth-openidc` — `Check build passed`
- `infra/helper.py run_fuzzer mod-auth-openidc fuzz_jwt -- -max_total_time=25` — 2,730,910 executions, 2758 new units added, no crashes
