### PR TITLE
mpv: un-pin Meson version

### DIFF
--- a/projects/mpv/Dockerfile
+++ b/projects/mpv/Dockerfile
@@ -22,9 +22,8 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV VIRTUAL_ENV=$SRC/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Meson is pinned to get around https://github.com/mesonbuild/meson/issues/14524
 RUN python -m venv $VIRTUAL_ENV && \
-    python -m pip --no-cache-dir install meson==1.7.2 ninja
+    python -m pip --no-cache-dir install meson ninja
 
 RUN git clone --depth 1 https://github.com/mpv-player/mpv mpv
 RUN git clone --depth 1 https://github.com/FFmpeg/FFmpeg ffmpeg


### PR DESCRIPTION
The regression was fixed some time ago. Now fontconfig requires Meson >= 1.11.0.

Fixes: subprojects/fontconfig-2.18.3/meson.build:3:18: ERROR: Meson version is 1.7.2 but project requires >= 1.11.0