### PR TITLE
openssl: Remove 3.3 and add 4.0 branch

### DIFF
--- a/projects/openssl/Dockerfile
+++ b/projects/openssl/Dockerfile
@@ -19,15 +19,15 @@ RUN apt-get update && apt-get install -y make
 RUN git clone --depth 1 https://github.com/openssl/openssl.git
 RUN cd $SRC/openssl/ && git submodule update --init fuzz/corpora
 RUN git clone --depth 1 --branch openssl-3.0 https://github.com/openssl/openssl.git openssl30
-RUN git clone --depth 1 --branch openssl-3.3 https://github.com/openssl/openssl.git openssl33
 RUN git clone --depth 1 --branch openssl-3.4 https://github.com/openssl/openssl.git openssl34
 RUN git clone --depth 1 --branch openssl-3.5 https://github.com/openssl/openssl.git openssl35
 RUN git clone --depth 1 --branch openssl-3.6 https://github.com/openssl/openssl.git openssl36
+RUN git clone --depth 1 --branch openssl-4.0 https://github.com/openssl/openssl.git openssl40
 RUN cd $SRC/openssl30/ && git submodule update --init fuzz/corpora
-RUN cd $SRC/openssl33/ && git submodule update --init fuzz/corpora
 RUN cd $SRC/openssl34/ && git submodule update --init fuzz/corpora
 RUN cd $SRC/openssl35/ && git submodule update --init fuzz/corpora
 RUN cd $SRC/openssl36/ && git submodule update --init fuzz/corpora
+RUN cd $SRC/openssl40/ && git submodule update --init fuzz/corpora
 WORKDIR openssl
 COPY build.sh *.options replay_build.sh run_tests.sh $SRC/
 ENV AFL_SKIP_OSSFUZZ=1

--- a/projects/openssl/build.sh
+++ b/projects/openssl/build.sh
@@ -95,11 +95,11 @@ fi
 
 cd $SRC/openssl30/
 build_fuzzers "_30" "" "engines"
-cd $SRC/openssl33/
-build_fuzzers "_33" "no-apps no-docs" "engines"
 cd $SRC/openssl34/
 build_fuzzers "_34" "no-apps no-docs" "engines"
 cd $SRC/openssl35/
 build_fuzzers "_35" "no-apps no-docs" "engines"
 cd $SRC/openssl36/
 build_fuzzers "_36" "no-apps no-docs" "engines"
+cd $SRC/openssl40/
+build_fuzzers "_40" "no-apps no-docs" ""


### PR DESCRIPTION
OpenSSL 3.3 is EOL, 4.0 is missing (no engines in 4.0).