### PR TITLE
harfbuzz: Build MSan-instrumented zlib from source

### DIFF
--- a/projects/harfbuzz/Dockerfile
+++ b/projects/harfbuzz/Dockerfile
@@ -19,5 +19,6 @@ RUN apt-get update && apt-get install -y python3-pip ragel pkg-config zlib1g-dev
     pip3 install --upgrade pip && \
     pip3 install meson==1.2.0 ninja
 RUN git clone --depth 1 https://github.com/harfbuzz/harfbuzz.git
+RUN git clone --depth 1 https://github.com/madler/zlib.git
 WORKDIR harfbuzz
 COPY build.sh $SRC/

--- a/projects/harfbuzz/build.sh
+++ b/projects/harfbuzz/build.sh
@@ -25,6 +25,18 @@ if [ "$ARCHITECTURE" = "i386" ]; then
   export PKG_CONFIG_LIBDIR=/usr/lib/i386-linux-gnu/pkgconfig
 fi
 
+# MSan: the system zlib is not instrumented, so stores done inside its
+# inflate() are invisible to MSan and inflated buffers look uninitialized,
+# producing false use-of-uninitialized-value reports.  Build an
+# MSan-instrumented zlib from source and make meson pick it up instead.
+if [ "${SANITIZER:-}" = "memory" ]; then
+  pushd $SRC/zlib
+  ./configure --static --prefix=$WORK/zlib
+  make -j$(nproc) install
+  popd
+  export PKG_CONFIG_PATH="$WORK/zlib/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+fi
+
 # setup
 build=$WORK/build
 


### PR DESCRIPTION
The harfbuzz MSan build links the system `zlib1g`, which is not MSan-instrumented. Stores performed inside its `inflate()` are invisible to MSan, so buffers filled by decompression still look uninitialized, and later reads of them produce false use-of-uninitialized-value reports.

Example: ClusterFuzz testcase 5190826362994688 against hb-vector-fuzzer reports a use-of-uninitialized-value in `hb_pdf_build_indexed_smask` (indexed-PNG soft-mask path), even though that code only proceeds after zlib reports `Z_STREAM_END` with `total_out` equal to the full buffer size — i.e. every byte was written.

Fix: for `SANITIZER=memory`, build a static zlib from source with the sanitizer flags and prepend its pkgconfig directory to `PKG_CONFIG_PATH`, so meson's `dependency('zlib')` picks it up instead of the system copy (the build already passes `--prefer-static`).

Verified the mechanism locally with a minimal MSan A/B test modeling the same malloc → `inflate()` → branch-on-inflated-byte pattern: with system zlib MSan fires the same report; with a from-source MSan-built zlib it is clean, and `pkg-config --libs --cflags zlib` resolves to the instrumented copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
