### PR TITLE
[pest] Copy the sql fuzz target to $OUT

### DIFF
--- a/projects/pest/build.sh
+++ b/projects/pest/build.sh
@@ -22,3 +22,4 @@ cp $SRC/pest/meta/fuzz/target/x86_64-unknown-linux-gnu/release/parser $OUT/
 cp $SRC/pest/grammars/fuzz/target/x86_64-unknown-linux-gnu/release/toml $OUT/
 cp $SRC/pest/grammars/fuzz/target/x86_64-unknown-linux-gnu/release/json $OUT/
 cp $SRC/pest/grammars/fuzz/target/x86_64-unknown-linux-gnu/release/http $OUT/
+cp $SRC/pest/grammars/fuzz/target/x86_64-unknown-linux-gnu/release/sql $OUT/


### PR DESCRIPTION
The sql target has existed in pest's grammars/fuzz since it was added, and cargo fuzz build already builds it, but build.sh never copied the binary out, so it has never been fuzzed.

Reference: https://github.com/pest-parser/pest/blob/master/grammars/fuzz/fuzz_targets/sql.rs
