### PR TITLE
mruby: fix run_tests.sh by upgrading to Ubuntu 24

### DIFF
--- a/projects/mruby/Dockerfile
+++ b/projects/mruby/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y build-essential ruby bison ninja-build \
     cmake zlib1g-dev libbz2-dev liblzma-dev
 RUN git clone --depth 1 https://github.com/mruby/mruby mruby

--- a/projects/mruby/Dockerfile
+++ b/projects/mruby/Dockerfile
@@ -20,9 +20,17 @@ RUN apt-get update && apt-get install -y build-essential ruby bison ninja-build 
 RUN git clone --depth 1 https://github.com/mruby/mruby mruby
 RUN git clone --depth 1 https://github.com/bshastry/mruby_seeds.git mruby_seeds
 RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
+# CMAKE_CXX_STANDARD=14 matches the standard libprotobuf-mutator hard-codes for
+# the protobuf/abseil it downloads (see cmake/external/protobuf.cmake). Without
+# it, libprotobuf-mutator's own objects build at the compiler default of C++17
+# while protobuf builds at C++14, and abseil then disagrees with itself over
+# whether absl::string_view is std::string_view - which surfaces as undefined
+# references to google::protobuf symbols taking std::__1::basic_string_view when
+# linking mruby_proto_fuzzer. build.sh passes the same standard for the
+# translation units it compiles against these headers.
 RUN mkdir LPM; \
   cd LPM; \
-  cmake $SRC/libprotobuf-mutator -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release; \
+  cmake $SRC/libprotobuf-mutator -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=14; \
   ninja;
 
 COPY *.sh $SRC/

--- a/projects/mruby/Dockerfile
+++ b/projects/mruby/Dockerfile
@@ -20,14 +20,11 @@ RUN apt-get update && apt-get install -y build-essential ruby bison ninja-build 
 RUN git clone --depth 1 https://github.com/mruby/mruby mruby
 RUN git clone --depth 1 https://github.com/bshastry/mruby_seeds.git mruby_seeds
 RUN git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
-# CMAKE_CXX_STANDARD=14 matches the standard libprotobuf-mutator hard-codes for
-# the protobuf/abseil it downloads (see cmake/external/protobuf.cmake). Without
-# it, libprotobuf-mutator's own objects build at the compiler default of C++17
-# while protobuf builds at C++14, and abseil then disagrees with itself over
-# whether absl::string_view is std::string_view - which surfaces as undefined
-# references to google::protobuf symbols taking std::__1::basic_string_view when
-# linking mruby_proto_fuzzer. build.sh passes the same standard for the
-# translation units it compiles against these headers.
+# CMAKE_CXX_STANDARD must match the standard libprotobuf-mutator builds its
+# bundled protobuf/abseil with (see cmake/external/protobuf.cmake). Otherwise
+# abseil disagrees with itself over whether absl::string_view is
+# std::string_view and mruby_proto_fuzzer fails to link. build.sh passes the
+# same standard.
 RUN mkdir LPM; \
   cd LPM; \
   cmake $SRC/libprotobuf-mutator -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=14; \

--- a/projects/mruby/build.sh
+++ b/projects/mruby/build.sh
@@ -22,8 +22,31 @@ export LD=$CC
 export LDFLAGS="$CFLAGS"
 rake all
 
-# This should be allowed to fail. So long as it does not fail in `run_tests.sh`
-rake test || true
+# Build the test driver. This is allowed to fail; `run_tests.sh` is what gates
+# on the test results.
+rake test:build || true
+
+# Record how the pristine tree scores, so that run_tests.sh has a reference
+# point instead of hard-coded test counts that go stale whenever upstream adds
+# or removes tests. Per batch: the number of passing tests, and the number of
+# problems (KO + Crash + Warning) that are already present before any patch.
+#
+# Written only when absent. Chronos evaluates a patch by re-running build.sh
+# over the patched tree, and overwriting the baseline there would compare the
+# patched tree against itself and detect nothing. The Chronos cached image is
+# built from a pristine checkout, so the file it captures is the pristine one.
+if [ ! -f $SRC/mruby_test_baseline ]; then
+  for batch in lib bin; do
+    rake test:run:$batch > /tmp/baseline_${batch}.out 2>&1 || true
+    awk -v batch="$batch" '
+      /^ *OK: [0-9]+$/      { ok = $NF }
+      /^ *KO: [0-9]+$/      { ko = $NF }
+      /^ *Crash: [0-9]+$/   { crash = $NF }
+      /^ *Warning: [0-9]+$/ { warning = $NF }
+      END { if (ok != "") printf "%s %d %d\n", batch, ok, ko + crash + warning }
+    ' /tmp/baseline_${batch}.out >> $SRC/mruby_test_baseline
+  done
+fi
 
 # build fuzzers
 FUZZ_TARGET=$SRC/mruby/oss-fuzz/mruby_fuzzer.c

--- a/projects/mruby/build.sh
+++ b/projects/mruby/build.sh
@@ -22,31 +22,9 @@ export LD=$CC
 export LDFLAGS="$CFLAGS"
 rake all
 
-# Build the test driver. This is allowed to fail; `run_tests.sh` is what gates
-# on the test results.
+# Build the test driver so that run_tests.sh has something to run. Allowed to
+# fail; run_tests.sh is what gates on the test results.
 rake test:build || true
-
-# Record how the pristine tree scores, so that run_tests.sh has a reference
-# point instead of hard-coded test counts that go stale whenever upstream adds
-# or removes tests. Per batch: the number of passing tests, and the number of
-# problems (KO + Crash + Warning) that are already present before any patch.
-#
-# Written only when absent. Chronos evaluates a patch by re-running build.sh
-# over the patched tree, and overwriting the baseline there would compare the
-# patched tree against itself and detect nothing. The Chronos cached image is
-# built from a pristine checkout, so the file it captures is the pristine one.
-if [ ! -f $SRC/mruby_test_baseline ]; then
-  for batch in lib bin; do
-    rake test:run:$batch > /tmp/baseline_${batch}.out 2>&1 || true
-    awk -v batch="$batch" '
-      /^ *OK: [0-9]+$/      { ok = $NF }
-      /^ *KO: [0-9]+$/      { ko = $NF }
-      /^ *Crash: [0-9]+$/   { crash = $NF }
-      /^ *Warning: [0-9]+$/ { warning = $NF }
-      END { if (ok != "") printf "%s %d %d\n", batch, ok, ko + crash + warning }
-    ' /tmp/baseline_${batch}.out >> $SRC/mruby_test_baseline
-  done
-fi
 
 # build fuzzers
 FUZZ_TARGET=$SRC/mruby/oss-fuzz/mruby_fuzzer.c

--- a/projects/mruby/build.sh
+++ b/projects/mruby/build.sh
@@ -63,9 +63,19 @@ if [[ $FUZZING_ENGINE == libfuzzer && $CFLAGS != *sanitize=memory* ]]; then
     PROTO_CONVERTER=$SRC/mruby/oss-fuzz/proto_to_ruby.cpp
     rm -rf $SRC/mruby/genfiles
     mkdir $SRC/mruby/genfiles
+    # Everything that touches protobuf headers must agree with the C++ standard
+    # the bundled protobuf and abseil were compiled with, which
+    # libprotobuf-mutator hard-codes to 14 in
+    # cmake/external/protobuf.cmake (-DCMAKE_CXX_STANDARD=14). Abseil selects
+    # between its own absl::string_view and std::string_view based on that
+    # standard, so a C++17 consumer of a C++14 build looks for
+    # google::protobuf symbols taking std::__1::basic_string_view and fails to
+    # link. The Dockerfile pins libprotobuf-mutator itself to the same
+    # standard; PROTO_STD keeps these translation units in step.
+    PROTO_STD="-std=c++14"
     $SRC/LPM/external.protobuf/bin/protoc --proto_path=$SRC/mruby/oss-fuzz ruby.proto --cpp_out=$SRC/mruby/genfiles
-    $CXX -c $CXXFLAGS $SRC/mruby/genfiles/ruby.pb.cc -DNDEBUG -o $SRC/mruby/genfiles/ruby.pb.o -I $SRC/LPM/external.protobuf/include
-    $CXX -I $SRC/mruby/include -I $SRC/mruby/build/host/include -I $SRC/LPM/external.protobuf/include $CXXFLAGS $PROTO_FUZZ_TARGET $SRC/mruby/genfiles/ruby.pb.o $PROTO_CONVERTER \
+    $CXX -c $CXXFLAGS $PROTO_STD $SRC/mruby/genfiles/ruby.pb.cc -DNDEBUG -o $SRC/mruby/genfiles/ruby.pb.o -I $SRC/LPM/external.protobuf/include
+    $CXX -I $SRC/mruby/include -I $SRC/mruby/build/host/include -I $SRC/LPM/external.protobuf/include $CXXFLAGS $PROTO_STD $PROTO_FUZZ_TARGET $SRC/mruby/genfiles/ruby.pb.o $PROTO_CONVERTER \
       -I $SRC/mruby/genfiles \
       -I $SRC/libprotobuf-mutator \
       -lz -lm \

--- a/projects/mruby/build.sh
+++ b/projects/mruby/build.sh
@@ -22,8 +22,8 @@ export LD=$CC
 export LDFLAGS="$CFLAGS"
 rake all
 
-# Build the test driver so that run_tests.sh has something to run. Allowed to
-# fail; run_tests.sh is what gates on the test results.
+# Build the test driver for run_tests.sh. Allowed to fail; run_tests.sh is what
+# gates on the test results.
 rake test:build || true
 
 # build fuzzers
@@ -44,34 +44,16 @@ only_ascii = 1
 EOF
 cp $SRC/mruby/oss-fuzz/config/mruby_fuzzer.options $SRC/mruby/oss-fuzz/config/mruby_proto_fuzzer.options
 
-# Build the proto fuzzer, for libFuzzer with ASan or UBSan only.
-#
-# libprotobuf-mutator drives this target through LLVMFuzzerCustomMutator, which
-# is a libFuzzer-only interface. Under AFL++ or honggfuzz that hook is never
-# called, so the target degrades to byte mutation of a serialized protobuf,
-# where almost every input fails to parse and never reaches mruby at all. It is
-# therefore not worth building for the other engines, and building it there
-# drags libprotobuf-mutator and the whole protobuf/absl static link surface into
-# those links, which is where the AFL build breaks with undefined references to
-# google::protobuf symbols taking std::__1::basic_string_view: the mutator and
-# its bundled protobuf disagree on whether absl::string_view is std::string_view.
-#
-# MemorySanitizer is excluded because neither protobuf nor libprotobuf-mutator
-# is MSan-instrumented, which would produce false reports.
+# libprotobuf-mutator only mutates through libFuzzer's custom mutator hook, so
+# this target does nothing useful under the other engines. MSan is excluded
+# because protobuf and libprotobuf-mutator are not instrumented for it.
 if [[ $FUZZING_ENGINE == libfuzzer && $CFLAGS != *sanitize=memory* ]]; then
     PROTO_FUZZ_TARGET=$SRC/mruby/oss-fuzz/mruby_proto_fuzzer.cpp
     PROTO_CONVERTER=$SRC/mruby/oss-fuzz/proto_to_ruby.cpp
     rm -rf $SRC/mruby/genfiles
     mkdir $SRC/mruby/genfiles
-    # Everything that touches protobuf headers must agree with the C++ standard
-    # the bundled protobuf and abseil were compiled with, which
-    # libprotobuf-mutator hard-codes to 14 in
-    # cmake/external/protobuf.cmake (-DCMAKE_CXX_STANDARD=14). Abseil selects
-    # between its own absl::string_view and std::string_view based on that
-    # standard, so a C++17 consumer of a C++14 build looks for
-    # google::protobuf symbols taking std::__1::basic_string_view and fails to
-    # link. The Dockerfile pins libprotobuf-mutator itself to the same
-    # standard; PROTO_STD keeps these translation units in step.
+    # Must match the standard the bundled protobuf/abseil were built with; see
+    # the Dockerfile.
     PROTO_STD="-std=c++14"
     $SRC/LPM/external.protobuf/bin/protoc --proto_path=$SRC/mruby/oss-fuzz ruby.proto --cpp_out=$SRC/mruby/genfiles
     $CXX -c $CXXFLAGS $PROTO_STD $SRC/mruby/genfiles/ruby.pb.cc -DNDEBUG -o $SRC/mruby/genfiles/ruby.pb.o -I $SRC/LPM/external.protobuf/include

--- a/projects/mruby/build.sh
+++ b/projects/mruby/build.sh
@@ -44,8 +44,21 @@ only_ascii = 1
 EOF
 cp $SRC/mruby/oss-fuzz/config/mruby_fuzzer.options $SRC/mruby/oss-fuzz/config/mruby_proto_fuzzer.options
 
-# Build proto fuzzer: ASan and UBSan
-if [[ $CFLAGS != *sanitize=memory* ]]; then
+# Build the proto fuzzer, for libFuzzer with ASan or UBSan only.
+#
+# libprotobuf-mutator drives this target through LLVMFuzzerCustomMutator, which
+# is a libFuzzer-only interface. Under AFL++ or honggfuzz that hook is never
+# called, so the target degrades to byte mutation of a serialized protobuf,
+# where almost every input fails to parse and never reaches mruby at all. It is
+# therefore not worth building for the other engines, and building it there
+# drags libprotobuf-mutator and the whole protobuf/absl static link surface into
+# those links, which is where the AFL build breaks with undefined references to
+# google::protobuf symbols taking std::__1::basic_string_view: the mutator and
+# its bundled protobuf disagree on whether absl::string_view is std::string_view.
+#
+# MemorySanitizer is excluded because neither protobuf nor libprotobuf-mutator
+# is MSan-instrumented, which would produce false reports.
+if [[ $FUZZING_ENGINE == libfuzzer && $CFLAGS != *sanitize=memory* ]]; then
     PROTO_FUZZ_TARGET=$SRC/mruby/oss-fuzz/mruby_proto_fuzzer.cpp
     PROTO_CONVERTER=$SRC/mruby/oss-fuzz/proto_to_ruby.cpp
     rm -rf $SRC/mruby/genfiles

--- a/projects/mruby/project.yaml
+++ b/projects/mruby/project.yaml
@@ -1,5 +1,6 @@
 homepage: https://www.mruby.org/
 language: c++
+base_os_version: ubuntu-24-04
 primary_contact: "yukihiro@gmail.com"
 auto_ccs:
   - "bshas3@gmail.com"

--- a/projects/mruby/run_tests.sh
+++ b/projects/mruby/run_tests.sh
@@ -25,152 +25,202 @@
 #   Warning: 0
 #      Skip: 18
 #
-# "KO" is an assertion failure, "Crash" is a test body that raised an
-# unexpected exception, and "Skip" is a test that opted out (18 of them need
-# features this build does not enable, e.g. backtraces). Only KO and Crash mean
-# something is wrong; test/assert.rb exits non-zero on exactly those two.
+# "KO" is an assertion failure, "Crash" is a test body that raised an unexpected
+# exception, "Warning" is a test body that ran but asserted nothing, and "Skip"
+# is a test that opted out (some need features this build does not enable, e.g.
+# backtraces). mruby itself exits non-zero on KO and Crash only.
 #
-# This script parses those numbers instead of grepping for hard-coded counts,
-# so it keeps working as upstream adds tests, and it tolerates a named list of
-# pre-existing failures so that a failure introduced by a patch is still
-# reported.
+# Nothing here hard-codes a test count. The counts above are illustrative; the
+# script parses whatever the run reports and compares it against the baseline
+# build.sh recorded from the pristine tree ($SRC/mruby_test_baseline, one
+# "<batch> <passing> <problems>" line per batch). That baseline is regenerated
+# every time the project image is built, so it tracks upstream as tests are
+# added or removed, and it only has to be accurate within a single image, which
+# is the window Chronos operates in. If the file is missing (an image built
+# before this was introduced) the script falls back to the KNOWN_FAILURES list
+# below and says so.
 #
 # This script only *runs* the tests, it deliberately does not rebuild them.
 # Rebuilding after a patch is the job of build.sh / replay_build.sh, which run
 # with the sanitizer flags in $CFLAGS. Those flags are added at runtime by
 # OSS-Fuzz's `compile` and are not persisted into the Chronos cached image, so
 # a rake invocation here that had to relink would fail on undefined __asan_*
-# symbols. build.sh already builds the mrbtest driver (via `rake test`) and the
-# mruby binaries the binary tests drive (via `rake all`), so both batches
-# already reflect the patched sources by the time this runs.
+# symbols. build.sh already builds the mrbtest driver and the mruby binaries
+# the binary tests drive, so both batches reflect the patched sources already.
 #
 # No network access is required or used.
 
-# Pre-existing failures in mruby master that this script tolerates.
+# Fallback tolerance, used only when no recorded baseline is available. Each
+# entry is matched as a fixed string against the assertion report, and it is a
+# tolerance rather than an expectation: an entry that stops appearing does not
+# fail this script.
 #
-# Each entry is matched as a fixed string against the assertion report. The
-# list is a tolerance, not an expectation: an entry that stops appearing does
-# not fail this script, so upstream fixing one of these is not a breakage and
-# the list only needs pruning for hygiene.
-#
-# 1. "inherited hook runs before class body" (test/t/class.rb) - every test
-#    file shares one constant namespace inside the single mrbtest binary, and
-#    test/t/module.rb already defines a top-level `class B` derived from
-#    Object, so class.rb reopening it as `class B < A` raises
-#    "TypeError: superclass mismatch for B". This is order-dependent constant
-#    pollution in mruby's own test suite, unrelated to the fuzzing build.
+# 1. "inherited hook runs before class body" (test/t/class.rb) - every test file
+#    shares one constant namespace inside the single mrbtest binary, and
+#    test/t/module.rb already defines a top-level `class B` derived from Object,
+#    so class.rb reopening it as `class B < A` raises "TypeError: superclass
+#    mismatch for B". Order-dependent constant pollution in mruby's own test
+#    suite, unrelated to the fuzzing build.
 KNOWN_FAILURES=(
   "inherited hook runs before class body"
 )
 
-# Floors on the number of passing tests per batch, not exact counts. They sit
-# well below the current numbers (1998 and 105) so that adding tests upstream
-# does not break this script, while a suite that dies early or silently stops
-# running most of its tests is still caught.
-LIB_MIN_OK=1900
-BIN_MIN_OK=100
+# How far the passing count may fall below the baseline before it is treated as
+# a regression, as a percentage. This absorbs a test or two legitimately turning
+# into a Skip in this build, while still catching a patch that stops a
+# meaningful part of the suite from running at all. It is a ratio rather than an
+# absolute count so it stays meaningful at any suite size.
+PASS_FLOOR_PERCENT=90
 
-# mruby counts a test whose body ran but executed no assertion at all as a
-# "Warn" and does not fail on it. Both batches currently report 0, and a patch
-# that makes a test stop asserting is exactly the kind of silent regression
-# Chronos needs to catch, so treat any warning as a failure. Raise this if
-# upstream ever introduces a warning that is expected in this build.
-MAX_WARNINGS=0
+BASELINE_FILE=${BASELINE_FILE:-$SRC/mruby_test_baseline}
 
-LIB_LOG=/tmp/mruby_test_lib.out
-BIN_LOG=/tmp/mruby_test_bin.out
+# The rake tasks for the two batches. They are invoked separately instead of
+# through `rake test`, which runs them as prerequisites of a single task: a
+# failure in the library batch aborts rake before the binary batch ever starts,
+# hiding anything the binary tests would have caught.
+BATCHES=(lib bin)
 
-# The two batches are invoked separately instead of through `rake test`, which
-# runs them as prerequisites of a single task: a failure in the library batch
-# aborts rake before the binary batch ever starts, hiding anything the binary
-# tests would have caught. Each batch's exit status is ignored here because the
-# parsed summaries below are what decide the result.
+declare -A BATCH_LOG=()
+for batch in "${BATCHES[@]}"; do
+  BATCH_LOG[$batch]=/tmp/mruby_test_${batch}.out
+done
+
 (
 cd $SRC/mruby
-rake test:run:lib > "$LIB_LOG" 2>&1 || true
-rake test:run:bin > "$BIN_LOG" 2>&1 || true
+for batch in "${BATCHES[@]}"; do
+  # Exit status is deliberately ignored; the parsed summary is what decides.
+  rake "test:run:${batch}" > "${BATCH_LOG[$batch]}" 2>&1 || true
+done
 )
 
 # Read a single "<field>: <number>" value out of a batch's summary block.
 summary_field() {
-  awk -v field="$2" '$0 ~ "^ *"field": [0-9]+$" {value=$NF} END {print value}' "$1"
+  awk -v field="$2" '$0 ~ "^ *"field": [0-9]+$" {value=$NF} END {print value+0}' "$1"
 }
 
 # The assertion report lines describing failures, i.e. every reported line that
 # is not a Skip or a Warn. Crash lines are prefixed with the exception class
-# rather than a fixed marker, so they are identified by the trailing
-# "(core)" / "(mrbgems: <gem>)" origin that assertion_string always appends.
+# rather than a fixed marker, so they are identified by the trailing "(core)" /
+# "(mrbgems: <gem>)" origin that assertion_string always appends.
 failure_lines() {
   sed -n '1,/^ *Total: [0-9]*$/p' "$1" |
     grep -E '\((core|mrbgems: [^)]*)\)$' | grep -vE '^(Skip|Warn): ' || true
 }
 
-check_batch() {
-  local name=$1 log=$2 min_ok=$3
-  local total ok ko crash warning tolerated=0 failures pattern
+# Look up a field of a batch's baseline line, empty when there is no baseline.
+baseline_field() {
+  [[ -r $BASELINE_FILE ]] || return 0
+  awk -v batch="$1" -v col="$2" '$1 == batch {print $col}' "$BASELINE_FILE"
+}
 
-  if [[ ! -s $log ]] || ! grep -qE '^ *Total: [0-9]+$' "$log"; then
-    echo "FAIL [$name]: no test summary was produced, so the batch did not run"
-    echo "             to completion (crashed or missing test driver)."
+ran_any=0
+result=0
+
+check_batch() {
+  local batch=$1 log=${BATCH_LOG[$1]}
+  local total ok ko crash warning skip problems accounted
+  local base_ok base_problems tolerated floor pattern source
+
+  if grep -q "Don't know how to build task" "$log" 2>/dev/null; then
+    # The task was renamed or removed upstream. No amount of parsing can adapt
+    # to that, so fail loudly and name the task that needs updating rather than
+    # silently testing nothing.
+    echo "FAIL [$batch]: rake task 'test:run:$batch' no longer exists."
+    echo "             mruby restructured its test tasks; update BATCHES."
     return 1
   fi
 
+  if [[ ! -s $log ]] || ! grep -qE '[^[:space:]]' "$log"; then
+    # The task exists but produced nothing, e.g. upstream disabled bintest for
+    # this build config. Not a failure on its own; the check that at least one
+    # batch ran covers the case where they all vanish.
+    echo "[$batch] not enabled in this build, skipped."
+    return 0
+  fi
+
+  if ! grep -qE '^ *Total: [0-9]+$' "$log"; then
+    echo "FAIL [$batch]: the batch produced output but no summary, so it did"
+    echo "             not run to completion (crashed test driver)."
+    return 1
+  fi
+
+  ran_any=1
   total=$(summary_field "$log" Total)
   ok=$(summary_field "$log" OK)
   ko=$(summary_field "$log" KO)
   crash=$(summary_field "$log" Crash)
   warning=$(summary_field "$log" Warning)
+  skip=$(summary_field "$log" Skip)
 
-  if [[ ${#KNOWN_FAILURES[@]} -gt 0 ]]; then
+  # Every test must be accounted for in exactly one bucket. If this does not
+  # hold, the report format changed and every number below is untrustworthy, so
+  # refuse to pass rather than silently mis-parse a future format.
+  accounted=$((ok + ko + crash + warning + skip))
+  if [[ $total -ne $accounted ]]; then
+    echo "FAIL [$batch]: summary does not add up ($ok+$ko+$crash+$warning+$skip"
+    echo "             = $accounted, reported Total $total). The report format"
+    echo "             changed; this script needs updating."
+    return 1
+  fi
+
+  problems=$((ko + crash + warning))
+  base_ok=$(baseline_field "$batch" 2)
+  base_problems=$(baseline_field "$batch" 3)
+
+  if [[ -n $base_ok && -n $base_problems ]]; then
+    tolerated=$base_problems
+    floor=$((base_ok * PASS_FLOOR_PERCENT / 100))
+    source="baseline $base_ok passing / $base_problems pre-existing"
+  else
+    # No baseline: fall back to the hand-maintained list and do not police the
+    # passing count, since there is nothing trustworthy to compare it against.
+    tolerated=0
     for pattern in "${KNOWN_FAILURES[@]}"; do
       if grep -qF "$pattern" "$log"; then
         tolerated=$((tolerated + 1))
       fi
     done
+    floor=0
+    source="no baseline, tolerating $tolerated known failure(s)"
   fi
-  failures=$((ko + crash))
 
-  echo "[$name] Total: $total  OK: $ok  KO: $ko  Crash: $crash" \
-       "Warning: $warning (tolerated pre-existing failures: $tolerated)"
+  echo "[$batch] Total: $total  OK: $ok  KO: $ko  Crash: $crash" \
+       "Warning: $warning  Skip: $skip ($source)"
 
-  if [[ $warning -gt $MAX_WARNINGS ]]; then
-    echo "FAIL [$name]: $warning test(s) executed no assertion, expected at most"
-    echo "             $MAX_WARNINGS."
+  if [[ $problems -gt $tolerated ]]; then
+    echo "FAIL [$batch]: $problems problem(s) reported, $tolerated tolerated."
+    echo "             Failing tests reported:"
+    failure_lines "$log" | sed 's/^/               /'
     sed -n '1,/^ *Total: [0-9]*$/p' "$log" | grep -E '^Warn: ' |
       sed 's/^/               /' || true
     return 1
   fi
 
-  if [[ $ok -lt $min_ok ]]; then
-    echo "FAIL [$name]: only $ok tests passed, expected at least $min_ok."
-    echo "             Failing tests reported:"
-    failure_lines "$log" | sed 's/^/               /'
-    return 1
-  fi
-
-  # Any failure beyond the tolerated ones is a regression. Comparing the total
-  # against the number of tolerated entries still present also covers the case
-  # where a tolerated failure got fixed and a new one appeared in its place.
-  if [[ $failures -ne $tolerated ]]; then
-    echo "FAIL [$name]: $failures failing test(s) but only $tolerated tolerated."
-    echo "             Failing tests reported:"
-    failure_lines "$log" | sed 's/^/               /'
+  if [[ $ok -lt $floor ]]; then
+    echo "FAIL [$batch]: only $ok tests passed, below $PASS_FLOOR_PERCENT% of the"
+    echo "             $base_ok recorded for the pristine tree. The suite"
+    echo "             stopped running a meaningful part of itself."
     return 1
   fi
 
   return 0
 }
 
-result=0
-check_batch "library" "$LIB_LOG" "$LIB_MIN_OK" || result=1
-check_batch "bintest" "$BIN_LOG" "$BIN_MIN_OK" || result=1
+for batch in "${BATCHES[@]}"; do
+  check_batch "$batch" || result=1
+done
+
+if [[ $ran_any -eq 0 ]]; then
+  echo "FAIL: no test batch produced a summary, so nothing was actually tested."
+  result=1
+fi
 
 if [[ $result -ne 0 ]]; then
   # The batch output otherwise only exists in /tmp, which goes away with the
   # container, so surface enough of it to diagnose the failure.
-  for log in "$LIB_LOG" "$BIN_LOG"; do
-    echo "================ tail of $log ================"
-    tail -40 "$log" 2>&1 || true
+  for batch in "${BATCHES[@]}"; do
+    echo "================ tail of ${BATCH_LOG[$batch]} ================"
+    tail -40 "${BATCH_LOG[$batch]}" 2>&1 || true
   done
   exit 1
 fi

--- a/projects/mruby/run_tests.sh
+++ b/projects/mruby/run_tests.sh
@@ -15,20 +15,15 @@
 #
 ################################################################################
 #
-# mruby's test suite passes cleanly in this build, so there is nothing here to
-# interpret: test/assert.rb reports success only when both KO (assertion
-# failures) and Crash (tests raising an unexpected exception) are zero, and
-# both test runners exit non-zero otherwise. `set -e` turns that into a failed
-# run_tests.sh, which is exactly the signal Chronos needs.
+# Both test runners exit non-zero when a test fails, so `set -e` is the whole
+# gate; there is nothing to parse.
 #
-# The two batches are invoked separately rather than through `rake test`.
-# `rake test` depends on test:build, which is free to decide something needs
-# relinking. The sanitizer flags exist in $CFLAGS only while OSS-Fuzz's
-# `compile` is running and are not persisted into the Chronos cached image, so
-# a relink here would fail on undefined __asan_* symbols. These two tasks have
-# no build prerequisites and only run what build.sh already produced.
+# The batches run as two separate tasks rather than via `rake test`, which
+# depends on test:build and may decide to relink. Sanitizer flags are only in
+# $CFLAGS while OSS-Fuzz's `compile` runs, so a relink here would fail on
+# undefined __asan_* symbols. Building is build.sh's job; these tasks only run.
 #
-# No network access is required or used.
+# Requires no network access.
 
 (
 cd $SRC/mruby

--- a/projects/mruby/run_tests.sh
+++ b/projects/mruby/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eux
+#!/bin/bash -eu
 # Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,27 +14,165 @@
 # limitations under the License.
 #
 ################################################################################
+#
+# mruby's test suite runs in two batches, both of which report through
+# test/assert.rb and therefore share one summary format:
+#
+#     Total: 2017
+#        OK: 1998
+#        KO: 0
+#     Crash: 1
+#   Warning: 0
+#      Skip: 18
+#
+# "KO" is an assertion failure, "Crash" is a test body that raised an
+# unexpected exception, and "Skip" is a test that opted out (18 of them need
+# features this build does not enable, e.g. backtraces). Only KO and Crash mean
+# something is wrong; test/assert.rb exits non-zero on exactly those two.
+#
+# This script parses those numbers instead of grepping for hard-coded counts,
+# so it keeps working as upstream adds tests, and it tolerates a named list of
+# pre-existing failures so that a failure introduced by a patch is still
+# reported.
+#
+# This script only *runs* the tests, it deliberately does not rebuild them.
+# Rebuilding after a patch is the job of build.sh / replay_build.sh, which run
+# with the sanitizer flags in $CFLAGS. Those flags are added at runtime by
+# OSS-Fuzz's `compile` and are not persisted into the Chronos cached image, so
+# a rake invocation here that had to relink would fail on undefined __asan_*
+# symbols. build.sh already builds the mrbtest driver (via `rake test`) and the
+# mruby binaries the binary tests drive (via `rake all`), so both batches
+# already reflect the patched sources by the time this runs.
+#
+# No network access is required or used.
 
-(
-export LD=$CC
-export LDFLAGS="$CFLAGS"
-cd $SRC/mruby
-rake test > /tmp/test.out 2>&1
+# Pre-existing failures in mruby master that this script tolerates.
+#
+# Each entry is matched as a fixed string against the assertion report. The
+# list is a tolerance, not an expectation: an entry that stops appearing does
+# not fail this script, so upstream fixing one of these is not a breakage and
+# the list only needs pruning for hygiene.
+#
+# 1. "inherited hook runs before class body" (test/t/class.rb) - every test
+#    file shares one constant namespace inside the single mrbtest binary, and
+#    test/t/module.rb already defines a top-level `class B` derived from
+#    Object, so class.rb reopening it as `class B < A` raises
+#    "TypeError: superclass mismatch for B". This is order-dependent constant
+#    pollution in mruby's own test suite, unrelated to the fuzzing build.
+KNOWN_FAILURES=(
+  "inherited hook runs before class body"
 )
 
-# There are two test runs, each of which executes many tests. Neither of these
-# must have crashing tests and that they have successful tests as well.
-# For the first batch We expect 165x tests to succeed and some tests skipped,
-# and 100 for the second batch.
-# I suspect the skipping causes
-# rake to return an error code. However, in normal circumastances we see
-# 9 tests skipped.
-grep "OK: 165" /tmp/test.out
-grep "OK: 100" /tmp/test.out
+# Floors on the number of passing tests per batch, not exact counts. They sit
+# well below the current numbers (1998 and 105) so that adding tests upstream
+# does not break this script, while a suite that dies early or silently stops
+# running most of its tests is still caught.
+LIB_MIN_OK=1900
+BIN_MIN_OK=100
 
-if [[ `grep "Crash: 0" /tmp/test.out | wc -l` != '2' ]]; then
-    exit 1
+# mruby counts a test whose body ran but executed no assertion at all as a
+# "Warn" and does not fail on it. Both batches currently report 0, and a patch
+# that makes a test stop asserting is exactly the kind of silent regression
+# Chronos needs to catch, so treat any warning as a failure. Raise this if
+# upstream ever introduces a warning that is expected in this build.
+MAX_WARNINGS=0
+
+LIB_LOG=/tmp/mruby_test_lib.out
+BIN_LOG=/tmp/mruby_test_bin.out
+
+# The two batches are invoked separately instead of through `rake test`, which
+# runs them as prerequisites of a single task: a failure in the library batch
+# aborts rake before the binary batch ever starts, hiding anything the binary
+# tests would have caught. Each batch's exit status is ignored here because the
+# parsed summaries below are what decide the result.
+(
+cd $SRC/mruby
+rake test:run:lib > "$LIB_LOG" 2>&1 || true
+rake test:run:bin > "$BIN_LOG" 2>&1 || true
+)
+
+# Read a single "<field>: <number>" value out of a batch's summary block.
+summary_field() {
+  awk -v field="$2" '$0 ~ "^ *"field": [0-9]+$" {value=$NF} END {print value}' "$1"
+}
+
+# The assertion report lines describing failures, i.e. every reported line that
+# is not a Skip or a Warn. Crash lines are prefixed with the exception class
+# rather than a fixed marker, so they are identified by the trailing
+# "(core)" / "(mrbgems: <gem>)" origin that assertion_string always appends.
+failure_lines() {
+  sed -n '1,/^ *Total: [0-9]*$/p' "$1" |
+    grep -E '\((core|mrbgems: [^)]*)\)$' | grep -vE '^(Skip|Warn): ' || true
+}
+
+check_batch() {
+  local name=$1 log=$2 min_ok=$3
+  local total ok ko crash warning tolerated=0 failures pattern
+
+  if [[ ! -s $log ]] || ! grep -qE '^ *Total: [0-9]+$' "$log"; then
+    echo "FAIL [$name]: no test summary was produced, so the batch did not run"
+    echo "             to completion (crashed or missing test driver)."
+    return 1
+  fi
+
+  total=$(summary_field "$log" Total)
+  ok=$(summary_field "$log" OK)
+  ko=$(summary_field "$log" KO)
+  crash=$(summary_field "$log" Crash)
+  warning=$(summary_field "$log" Warning)
+
+  if [[ ${#KNOWN_FAILURES[@]} -gt 0 ]]; then
+    for pattern in "${KNOWN_FAILURES[@]}"; do
+      if grep -qF "$pattern" "$log"; then
+        tolerated=$((tolerated + 1))
+      fi
+    done
+  fi
+  failures=$((ko + crash))
+
+  echo "[$name] Total: $total  OK: $ok  KO: $ko  Crash: $crash" \
+       "Warning: $warning (tolerated pre-existing failures: $tolerated)"
+
+  if [[ $warning -gt $MAX_WARNINGS ]]; then
+    echo "FAIL [$name]: $warning test(s) executed no assertion, expected at most"
+    echo "             $MAX_WARNINGS."
+    sed -n '1,/^ *Total: [0-9]*$/p' "$log" | grep -E '^Warn: ' |
+      sed 's/^/               /' || true
+    return 1
+  fi
+
+  if [[ $ok -lt $min_ok ]]; then
+    echo "FAIL [$name]: only $ok tests passed, expected at least $min_ok."
+    echo "             Failing tests reported:"
+    failure_lines "$log" | sed 's/^/               /'
+    return 1
+  fi
+
+  # Any failure beyond the tolerated ones is a regression. Comparing the total
+  # against the number of tolerated entries still present also covers the case
+  # where a tolerated failure got fixed and a new one appeared in its place.
+  if [[ $failures -ne $tolerated ]]; then
+    echo "FAIL [$name]: $failures failing test(s) but only $tolerated tolerated."
+    echo "             Failing tests reported:"
+    failure_lines "$log" | sed 's/^/               /'
+    return 1
+  fi
+
+  return 0
+}
+
+result=0
+check_batch "library" "$LIB_LOG" "$LIB_MIN_OK" || result=1
+check_batch "bintest" "$BIN_LOG" "$BIN_MIN_OK" || result=1
+
+if [[ $result -ne 0 ]]; then
+  # The batch output otherwise only exists in /tmp, which goes away with the
+  # container, so surface enough of it to diagnose the failure.
+  for log in "$LIB_LOG" "$BIN_LOG"; do
+    echo "================ tail of $log ================"
+    tail -40 "$log" 2>&1 || true
+  done
+  exit 1
 fi
-if [[ `grep "KO: 0" /tmp/test.out | wc -l` != '2' ]]; then
-    exit 1
-fi
+
+echo "mruby tests passed."

--- a/projects/mruby/run_tests.sh
+++ b/projects/mruby/run_tests.sh
@@ -15,214 +15,23 @@
 #
 ################################################################################
 #
-# mruby's test suite runs in two batches, both of which report through
-# test/assert.rb and therefore share one summary format:
+# mruby's test suite passes cleanly in this build, so there is nothing here to
+# interpret: test/assert.rb reports success only when both KO (assertion
+# failures) and Crash (tests raising an unexpected exception) are zero, and
+# both test runners exit non-zero otherwise. `set -e` turns that into a failed
+# run_tests.sh, which is exactly the signal Chronos needs.
 #
-#     Total: 2017
-#        OK: 1998
-#        KO: 0
-#     Crash: 1
-#   Warning: 0
-#      Skip: 18
-#
-# "KO" is an assertion failure, "Crash" is a test body that raised an unexpected
-# exception, "Warning" is a test body that ran but asserted nothing, and "Skip"
-# is a test that opted out (some need features this build does not enable, e.g.
-# backtraces). mruby itself exits non-zero on KO and Crash only.
-#
-# Nothing here hard-codes a test count. The counts above are illustrative; the
-# script parses whatever the run reports and compares it against the baseline
-# build.sh recorded from the pristine tree ($SRC/mruby_test_baseline, one
-# "<batch> <passing> <problems>" line per batch). That baseline is regenerated
-# every time the project image is built, so it tracks upstream as tests are
-# added or removed, and it only has to be accurate within a single image, which
-# is the window Chronos operates in. If the file is missing (an image built
-# before this was introduced) the script falls back to the KNOWN_FAILURES list
-# below and says so.
-#
-# This script only *runs* the tests, it deliberately does not rebuild them.
-# Rebuilding after a patch is the job of build.sh / replay_build.sh, which run
-# with the sanitizer flags in $CFLAGS. Those flags are added at runtime by
-# OSS-Fuzz's `compile` and are not persisted into the Chronos cached image, so
-# a rake invocation here that had to relink would fail on undefined __asan_*
-# symbols. build.sh already builds the mrbtest driver and the mruby binaries
-# the binary tests drive, so both batches reflect the patched sources already.
+# The two batches are invoked separately rather than through `rake test`.
+# `rake test` depends on test:build, which is free to decide something needs
+# relinking. The sanitizer flags exist in $CFLAGS only while OSS-Fuzz's
+# `compile` is running and are not persisted into the Chronos cached image, so
+# a relink here would fail on undefined __asan_* symbols. These two tasks have
+# no build prerequisites and only run what build.sh already produced.
 #
 # No network access is required or used.
 
-# Fallback tolerance, used only when no recorded baseline is available. Each
-# entry is matched as a fixed string against the assertion report, and it is a
-# tolerance rather than an expectation: an entry that stops appearing does not
-# fail this script.
-#
-# 1. "inherited hook runs before class body" (test/t/class.rb) - every test file
-#    shares one constant namespace inside the single mrbtest binary, and
-#    test/t/module.rb already defines a top-level `class B` derived from Object,
-#    so class.rb reopening it as `class B < A` raises "TypeError: superclass
-#    mismatch for B". Order-dependent constant pollution in mruby's own test
-#    suite, unrelated to the fuzzing build.
-KNOWN_FAILURES=(
-  "inherited hook runs before class body"
-)
-
-# How far the passing count may fall below the baseline before it is treated as
-# a regression, as a percentage. This absorbs a test or two legitimately turning
-# into a Skip in this build, while still catching a patch that stops a
-# meaningful part of the suite from running at all. It is a ratio rather than an
-# absolute count so it stays meaningful at any suite size.
-PASS_FLOOR_PERCENT=90
-
-BASELINE_FILE=${BASELINE_FILE:-$SRC/mruby_test_baseline}
-
-# The rake tasks for the two batches. They are invoked separately instead of
-# through `rake test`, which runs them as prerequisites of a single task: a
-# failure in the library batch aborts rake before the binary batch ever starts,
-# hiding anything the binary tests would have caught.
-BATCHES=(lib bin)
-
-declare -A BATCH_LOG=()
-for batch in "${BATCHES[@]}"; do
-  BATCH_LOG[$batch]=/tmp/mruby_test_${batch}.out
-done
-
 (
 cd $SRC/mruby
-for batch in "${BATCHES[@]}"; do
-  # Exit status is deliberately ignored; the parsed summary is what decides.
-  rake "test:run:${batch}" > "${BATCH_LOG[$batch]}" 2>&1 || true
-done
+rake test:run:lib
+rake test:run:bin
 )
-
-# Read a single "<field>: <number>" value out of a batch's summary block.
-summary_field() {
-  awk -v field="$2" '$0 ~ "^ *"field": [0-9]+$" {value=$NF} END {print value+0}' "$1"
-}
-
-# The assertion report lines describing failures, i.e. every reported line that
-# is not a Skip or a Warn. Crash lines are prefixed with the exception class
-# rather than a fixed marker, so they are identified by the trailing "(core)" /
-# "(mrbgems: <gem>)" origin that assertion_string always appends.
-failure_lines() {
-  sed -n '1,/^ *Total: [0-9]*$/p' "$1" |
-    grep -E '\((core|mrbgems: [^)]*)\)$' | grep -vE '^(Skip|Warn): ' || true
-}
-
-# Look up a field of a batch's baseline line, empty when there is no baseline.
-baseline_field() {
-  [[ -r $BASELINE_FILE ]] || return 0
-  awk -v batch="$1" -v col="$2" '$1 == batch {print $col}' "$BASELINE_FILE"
-}
-
-ran_any=0
-result=0
-
-check_batch() {
-  local batch=$1 log=${BATCH_LOG[$1]}
-  local total ok ko crash warning skip problems accounted
-  local base_ok base_problems tolerated floor pattern source
-
-  if grep -q "Don't know how to build task" "$log" 2>/dev/null; then
-    # The task was renamed or removed upstream. No amount of parsing can adapt
-    # to that, so fail loudly and name the task that needs updating rather than
-    # silently testing nothing.
-    echo "FAIL [$batch]: rake task 'test:run:$batch' no longer exists."
-    echo "             mruby restructured its test tasks; update BATCHES."
-    return 1
-  fi
-
-  if [[ ! -s $log ]] || ! grep -qE '[^[:space:]]' "$log"; then
-    # The task exists but produced nothing, e.g. upstream disabled bintest for
-    # this build config. Not a failure on its own; the check that at least one
-    # batch ran covers the case where they all vanish.
-    echo "[$batch] not enabled in this build, skipped."
-    return 0
-  fi
-
-  if ! grep -qE '^ *Total: [0-9]+$' "$log"; then
-    echo "FAIL [$batch]: the batch produced output but no summary, so it did"
-    echo "             not run to completion (crashed test driver)."
-    return 1
-  fi
-
-  ran_any=1
-  total=$(summary_field "$log" Total)
-  ok=$(summary_field "$log" OK)
-  ko=$(summary_field "$log" KO)
-  crash=$(summary_field "$log" Crash)
-  warning=$(summary_field "$log" Warning)
-  skip=$(summary_field "$log" Skip)
-
-  # Every test must be accounted for in exactly one bucket. If this does not
-  # hold, the report format changed and every number below is untrustworthy, so
-  # refuse to pass rather than silently mis-parse a future format.
-  accounted=$((ok + ko + crash + warning + skip))
-  if [[ $total -ne $accounted ]]; then
-    echo "FAIL [$batch]: summary does not add up ($ok+$ko+$crash+$warning+$skip"
-    echo "             = $accounted, reported Total $total). The report format"
-    echo "             changed; this script needs updating."
-    return 1
-  fi
-
-  problems=$((ko + crash + warning))
-  base_ok=$(baseline_field "$batch" 2)
-  base_problems=$(baseline_field "$batch" 3)
-
-  if [[ -n $base_ok && -n $base_problems ]]; then
-    tolerated=$base_problems
-    floor=$((base_ok * PASS_FLOOR_PERCENT / 100))
-    source="baseline $base_ok passing / $base_problems pre-existing"
-  else
-    # No baseline: fall back to the hand-maintained list and do not police the
-    # passing count, since there is nothing trustworthy to compare it against.
-    tolerated=0
-    for pattern in "${KNOWN_FAILURES[@]}"; do
-      if grep -qF "$pattern" "$log"; then
-        tolerated=$((tolerated + 1))
-      fi
-    done
-    floor=0
-    source="no baseline, tolerating $tolerated known failure(s)"
-  fi
-
-  echo "[$batch] Total: $total  OK: $ok  KO: $ko  Crash: $crash" \
-       "Warning: $warning  Skip: $skip ($source)"
-
-  if [[ $problems -gt $tolerated ]]; then
-    echo "FAIL [$batch]: $problems problem(s) reported, $tolerated tolerated."
-    echo "             Failing tests reported:"
-    failure_lines "$log" | sed 's/^/               /'
-    sed -n '1,/^ *Total: [0-9]*$/p' "$log" | grep -E '^Warn: ' |
-      sed 's/^/               /' || true
-    return 1
-  fi
-
-  if [[ $ok -lt $floor ]]; then
-    echo "FAIL [$batch]: only $ok tests passed, below $PASS_FLOOR_PERCENT% of the"
-    echo "             $base_ok recorded for the pristine tree. The suite"
-    echo "             stopped running a meaningful part of itself."
-    return 1
-  fi
-
-  return 0
-}
-
-for batch in "${BATCHES[@]}"; do
-  check_batch "$batch" || result=1
-done
-
-if [[ $ran_any -eq 0 ]]; then
-  echo "FAIL: no test batch produced a summary, so nothing was actually tested."
-  result=1
-fi
-
-if [[ $result -ne 0 ]]; then
-  # The batch output otherwise only exists in /tmp, which goes away with the
-  # container, so surface enough of it to diagnose the failure.
-  for batch in "${BATCHES[@]}"; do
-    echo "================ tail of ${BATCH_LOG[$batch]} ================"
-    tail -40 "${BATCH_LOG[$batch]}" 2>&1 || true
-  done
-  exit 1
-fi
-
-echo "mruby tests passed."


### PR DESCRIPTION
The goal of this PR is to improve the [Chronos ](https://github.com/google/oss-fuzz/tree/master/infra/chronos) support for `mruby`. `mruby` has some failing tests on Ruby 2.7 which is what the Ubuntu 20 base image uses. Upgrading to Ubuntu 24 resolved this problem and consequently means we can remove the check for failing tests that we have:

```
python3 infra/helper.py check-tests mruby --integrity-check
...
Skip: Method call in rescue => backtrace isn't available (core)
  Total: 2049
     OK: 2028
     KO: 0
  Crash: 0
Warning: 2
   Skip: 19
   Time: 3.03 seconds

>>> Bintest host <<<
bintest - Command Binary Test

.........................................................................................................
  Total: 105
     OK: 105
     KO: 0
  Crash: 0
Warning: 0
   Skip: 0
   Time: 7.53 seconds
+ python3 /chronos/integrity_validator_run_tests.py diff-patch after
```