### PR TITLE
fix(urllib3): bound bytes consumed for response body and content type

### DIFF
--- a/projects/urllib3/fuzz_requests.py
+++ b/projects/urllib3/fuzz_requests.py
@@ -57,9 +57,12 @@ def TestOneInput(data):
     fdp = atheris.FuzzedDataProvider(data)
 
     global GLOBAL_RESPONSE_BODY, GLOBAL_RESPONSE_CODE, GLOBAL_CONTENT_TYPE
-    GLOBAL_RESPONSE_BODY = fdp.ConsumeBytes(sys.maxsize)
+
+    body_len = fdp.ConsumeIntInRange(0, 65536)
+    GLOBAL_RESPONSE_BODY = fdp.ConsumeBytes(body_len)
     GLOBAL_RESPONSE_CODE = fdp.ConsumeIntInRange(200, 599)
-    GLOBAL_CONTENT_TYPE = fdp.ConsumeBytes(sys.maxsize)
+    content_type_len = fdp.ConsumeIntInRange(0, 256)
+    GLOBAL_CONTENT_TYPE = fdp.ConsumeBytes(content_type_len)
 
     requestType = fdp.PickValueInList(REQUEST_METHODS)
 


### PR DESCRIPTION
Fixes #15451

**Issue:**
The `projects/urllib3/fuzz_requests.py` oss-fuzz harness currently crashes with a `ReadTimeoutError` on large inputs. This occurs because the harness calls `fdp.ConsumeBytes(sys.maxsize)` for `GLOBAL_RESPONSE_BODY`, which immediately drains the entire fuzzer input buffer. Consequently, all subsequent `fdp.*` calls (response code, content type, request method, headers, and form data) have no bytes left to consume and remain unvaried. This effectively restricts the fuzzer to only fuzzing the response body size and masks a significant coverage gap.

**Fix:**
This PR bounds the bytes consumed for `GLOBAL_RESPONSE_BODY` and `GLOBAL_CONTENT_TYPE`. By using `fdp.ConsumeIntInRange()` to determine a sensible limit for the body (up to 65536 bytes) and content type (up to 256 bytes) before consuming the bytes, we ensure enough data remains to populate and mutate other request parameters. This eliminates the OOM/timeout crashes on large files and allows the fuzzer to explore the library's request encoding, header handling, retry logic, and content-type processing.
