### PR TITLE
Switch open62541 to use Openssl

### DIFF
--- a/projects/open62541/Dockerfile
+++ b/projects/open62541/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
-RUN apt-get update && apt-get install -y make cmake python3-six wget libmbedtls-dev
+RUN apt-get update && apt-get install -y make cmake python3-six wget
 RUN git clone --depth 1 https://github.com/open62541/open62541.git -bmaster open62541
 WORKDIR open62541
 RUN git submodule update --init --recursive

--- a/projects/open62541/build.sh
+++ b/projects/open62541/build.sh
@@ -71,7 +71,7 @@ function build_open62541_fuzzers() {
         -DBUILD_SHARED_LIBS=OFF \
         -DUA_BUILD_EXAMPLES=OFF \
         -DUA_LOGLEVEL=600 \
-        -DUA_ENABLE_ENCRYPTION=ON \
+        -DUA_ENABLE_ENCRYPTION=OPENSSL \
         -DUA_BUILD_OSS_FUZZ=ON \
         "$SRC_DIR/"
 

--- a/projects/open62541/project.yaml
+++ b/projects/open62541/project.yaml
@@ -2,8 +2,6 @@ base_os_version: ubuntu-24-04
 homepage: "https://open62541.org/"
 language: c++
 primary_contact: "julius.pfrommer@gmail.com"
-auto_ccs:
- - "chris_paul.iatrou@tu-dresden.de"
 fuzzing_engines:
  - libfuzzer
  - afl


### PR DESCRIPTION
We switched to the new mbedTLS PSA API.
This is not available on Ubuntu 24.04 for oss-fuzz.

Switch the build to OpenSSL instead.