### PR TITLE
observal: initial integration

### DIFF
--- a/projects/observal/Dockerfile
+++ b/projects/observal/Dockerfile
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2026 RAWx18 <rawx18.dev@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-python:latest@sha256:6b2b3a7e4a2da50de47f94925cffbe34747e1aae4f33d7f07ba6c681dd648b23
+
+# uv 0.11.25 (multi-arch: linux/amd64, linux/arm64)
+COPY --from=ghcr.io/astral-sh/uv:0.11.25@sha256:1e3808aa9023d0980e7c15b1fa7c1ac16ff35925780cf5c459858b2d693f01a9 /uv /uvx /bin/
+
+RUN git clone --depth 1 https://github.com/Observal/Observal.git observal
+WORKDIR $SRC/observal
+
+# Must install into the system interpreter: compile_python_fuzzer runs the
+# system PyInstaller, which resolves imports against /usr/local site-packages
+# only, so anything in a virtualenv is silently omitted from the bundle.
+RUN uv export --frozen --only-group fuzz --no-emit-project --no-editable -o /tmp/fuzz-requirements.txt \
+    && uv pip install --system --no-cache --require-hashes -r /tmp/fuzz-requirements.txt
+
+COPY build.sh $SRC/

--- a/projects/observal/build.sh
+++ b/projects/observal/build.sh
@@ -1,0 +1,44 @@
+#!/bin/bash -eu
+# SPDX-FileCopyrightText: 2026 RAWx18 <rawx18.dev@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# The fuzz targets import directly from the checkout. PyInstaller needs each
+# source root and the model catalogue used by observal_shared.
+REPO_DIR="$SRC/observal"
+FUZZ_DIR="$REPO_DIR/fuzz"
+SERVER_DIR="$REPO_DIR/observal-server"
+SHARED_DIR="$REPO_DIR/packages/observal-shared"
+
+for fuzzer in "$FUZZ_DIR"/*_fuzzer.py; do
+  target="$(basename -s .py "$fuzzer")"
+
+  compile_python_fuzzer "$fuzzer" \
+    --paths="$REPO_DIR" \
+    --paths="$SERVER_DIR" \
+    --paths="$SHARED_DIR" \
+    --add-data="$SHARED_DIR/observal_shared/harness_models:observal_shared/harness_models"
+
+  if [[ -d "$FUZZ_DIR/corpus/$target" ]]; then
+    zip -j "$OUT/${target}_seed_corpus.zip" "$FUZZ_DIR/corpus/$target"/*
+  fi
+
+  if [[ -f "$FUZZ_DIR/dictionaries/${target}.dict" ]]; then
+    cp "$FUZZ_DIR/dictionaries/${target}.dict" "$OUT/${target}.dict"
+  fi
+done

--- a/projects/observal/project.yaml
+++ b/projects/observal/project.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2026 RAWx18 <rawx18.dev@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+homepage: "https://github.com/Observal/Observal"
+main_repo: "https://github.com/Observal/Observal.git"
+language: python
+primary_contact: "rawx18.dev@gmail.com"
+auto_ccs:
+  - "harisrini21@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+  - undefined


### PR DESCRIPTION
## Summary

This PR integrates [Observal](https://github.com/Observal/Observal) into OSS-Fuzz.

Observal is an Apache-2.0 licensed registry and observability control plane for AI
coding agents. Its core job is to ingest, parse, redact and replay session
transcripts produced by ten different AI coding harnesses. That parsing surface is
fed entirely by data the project does not control, which is what we want fuzzed
continuously.

Four Atheris targets already exist and are maintained in the project's own
repository under [`fuzz/`](https://github.com/Observal/Observal/tree/main/fuzz).
This PR adds only the three-file project configuration.

## The project

| | |
| --- | --- |
| Repository | https://github.com/Observal/Observal |
| Homepage | https://observal.io/ |
| License | Apache-2.0 |
| Language | Python (`>=3.11`) |
| Distribution | PyPI [`observal-cli`](https://pypi.org/project/observal-cli/), GHCR container images, Helm chart |

### Adoption and project health

As of 2026-08-13:

- **2,358 stars**, 471 forks, **58 contributors**
- **46 releases** published to PyPI, currently at v1.12.1; released roughly weekly
- **OpenSSF Best Practices: Gold** ([project 13472](https://www.bestpractices.dev/projects/13472)) — 100% of passing, silver and gold criteria
- **OpenSSF Scorecard: 9.5** ([report](https://scorecard.dev/viewer/?uri=github.com/Observal/Observal)), with Code-Review, Branch-Protection, Security-Policy, Pinned-Dependencies and SAST all at 9–10
- Documented [security policy](https://github.com/Observal/Observal/blob/main/SECURITY.md) with a private disclosure channel, 48-hour acknowledgement and 30-day resolution targets, plus a published security assurance case
- Actively maintained: CodeQL, Gitleaks, dependency review, SBOM generation and signed release provenance all run in CI

## Why this project should be fuzzed

Observal's largest untrusted input is the **harness session transcript**. The flow is:

1. An AI coding harness (Claude Code, Cursor, Kiro, Copilot, Codex CLI, OpenCode,
   Goose, Antigravity, Pi, Copilot CLI) writes JSONL to disk.
2. A session-push hook, or `observal reconcile`, uploads the raw lines to
   `POST /api/v1/ingest/session`.
3. The server classifies each line and stores it verbatim.
4. The line is decoded again on the read path every time the trace viewer opens
   a session.

That is ten independent per-harness parsers operating on attacker-influenced data,
with a write path and a read path that must agree.

The second reason is **redaction**. Observal handles authentication tokens, API
keys and enterprise telemetry. Two redaction layers are the single chokepoint that
strips credentials before anything is stored or bundled into a support archive. A
parsing or redaction bug there is a credential-disclosure bug, not just a crash.

## Fuzz targets

| Target | Trust boundary |
| --- | --- |
| `session_jsonl_fuzzer` | Session transcripts end to end: ingest classification on the write path, `parse_raw_events` on the read path. The first input byte selects which harness parser to drive, so one target covers all ten. |
| `session_structure_fuzzer` | The same pipeline, driven by Hypothesis-generated transcript records rather than raw bytes, to reach handler branches that byte mutation rarely gets past the JSON decoder to hit. Polyglot: also runs under pytest for shrinking and replay. |
| `secrets_redactor_fuzzer` | `services.secrets_redactor.redact_secrets`, applied to every line and preview before storage. |
| `support_redaction_fuzzer` | `observal_cli.support.redaction`, the chokepoint for `observal support bundle`. |

### Harness design

- **Fully in-process.** No target opens a socket, reads credentials, or touches
  PostgreSQL, ClickHouse or Redis. Nothing depends on the clock. A crash reproduces
  from its input alone.
- **Bounded inputs.** Every target caps input size so slow units are not reported
  as timeouts.
- **Expected rejections return; anything else is a finding.** A decode error on
  malformed input is not a bug; any other exception is.
- **Seed corpora and dictionaries** live in the project repo under `fuzz/corpus/`
  and `fuzz/dictionaries/` and are picked up automatically by `build.sh`. A repo
  test asserts every registered harness parser still has a seed reaching it.

## What this PR adds

```
projects/observal/project.yaml     30 lines
projects/observal/Dockerfile       34 lines
projects/observal/build.sh         44 lines   (mode 755)
```

Nothing else is touched. `build.sh` globs `fuzz/*_fuzzer.py`, so new targets added
upstream are picked up without further changes here.

### Build notes

- Dependencies are resolved from the project's committed `uv.lock`, exported to a
  requirements file, and installed with `--require-hashes`, so the image build is
  reproducible and hash-verified.
- They are installed into the **system interpreter** rather than a virtualenv,
  because `compile_python_fuzzer` runs the base image's PyInstaller, which resolves
  imports against `/usr/local` site-packages only. This is called out in a comment
  in the Dockerfile.
- The base image is referenced by tag *and* digest. This is deliberate
  supply-chain pinning on our side; happy to drop the digest if you would rather
  projects always track the freshest base image.

## Local validation

Everything below was run against the real base images before opening this PR:

| Command | Result |
| --- | --- |
| `docker build --no-cache --pull -t gcr.io/oss-fuzz/observal projects/observal` | OK |
| `infra/helper.py build_fuzzers observal` | OK |
| `infra/helper.py check_build observal` | **Check build passed** (4/4) |
| `infra/helper.py build_fuzzers --sanitizer undefined observal` | OK |
| `infra/helper.py check_build --sanitizer undefined observal` | **Check build passed** (4/4) |
| `infra/helper.py build_fuzzers --sanitizer coverage observal` | OK |
| `infra/helper.py run_fuzzer observal <each target> -- -runs=3000` | OK, no findings |
| `infra/presubmit.py` | Success |

The build was verified with a cold, cache-free image build to confirm it does not
depend on any local layer cache.

## Maintenance

- The three files here are mirrored in the project repo at `fuzz/oss-fuzz/` and are
  currently byte-identical. The project's contributor docs require both copies to be
  updated in the same change, so they do not drift.
- Confirmed builds succeed for both declared sanitizers before submission, and we
  will keep them building.
- Reports will be triaged by the contacts below, with confirmed crashes turned into
  in-repo regression tests alongside the fix.