### PR TITLE
sleuthkit: build fuzzer for the XPRESS (MS-XCA) decompressors

### DIFF
--- a/projects/sleuthkit/build.sh
+++ b/projects/sleuthkit/build.sh
@@ -34,4 +34,14 @@ sed -i 's/-Werror//g' Makefile.am
 make -j$(nproc)
 
 # Copy the fuzzer binaries to the output directory.
-cp *_fuzzer ${OUT}
+cp *_fuzzer ${OUT} || true
+
+# Build the XPRESS (MS-XCA) fuzzer once the codec lands upstream
+# (sleuthkit/sleuthkit#3531). The codec is standalone, so it can be
+# compiled directly without linking libtsk.
+if [ -f tsk/fs/xpress.c ]; then
+  $CC $CFLAGS -c tsk/fs/xpress.c -I./tsk/fs -o $WORK/xpress.o
+  $CXX $CXXFLAGS -std=c++17 -I${SRC} \
+      ossfuzz/tsk_xpress_fuzzer.cc $WORK/xpress.o \
+      -o $OUT/tsk_xpress_fuzzer $LIB_FUZZING_ENGINE
+fi


### PR DESCRIPTION
Adds a libFuzzer target for the XPRESS (MS-XCA) decompressors that were added to Sleuth Kit in sleuthkit/sleuthkit#3531:

- `ossfuzz/tsk_xpress_fuzzer.cc` (in the sleuthkit repo) drives both variants: byte 0 selects plain LZ77 or LZ77+Huffman, bytes 1-4 carry the uncompressed size for the Huffman variant, the rest is the compressed stream.
- The build is conditional: the fuzzer only builds once `tsk/fs/xpress.c` exists in the upstream clone, so this PR does not break the project if the codec PR has not landed yet.
- A seed corpus (16 inputs) derived from the MS-XCA test corpus in `unit_tests/base/xpress_test_data.h` is zipped into the output.

Verified locally: the fuzzer input layout decodes all 16 corpus vectors to their exact sizes (gcc, -Wall -Wextra clean).