### PR TITLE
httpsfv: initial integration

### DIFF
--- a/projects/httpsfv/Dockerfile
+++ b/projects/httpsfv/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/dunglas/httpsfv.git
+COPY build.sh $SRC/
+WORKDIR $SRC/httpsfv

--- a/projects/httpsfv/build.sh
+++ b/projects/httpsfv/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+go get github.com/AdamKorcz/go-118-fuzz-build/testing
+
+compile_native_go_fuzzer github.com/dunglas/httpsfv FuzzUnmarshalList fuzz_unmarshal_list
+compile_native_go_fuzzer github.com/dunglas/httpsfv FuzzUnmarshalDictionary fuzz_unmarshal_dictionary
+compile_native_go_fuzzer github.com/dunglas/httpsfv FuzzUnmarshalItem fuzz_unmarshal_item

--- a/projects/httpsfv/project.yaml
+++ b/projects/httpsfv/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/dunglas/httpsfv"
+primary_contact: "kevin@les-tilleuls.coop"
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+main_repo: "https://github.com/dunglas/httpsfv.git"
+file_github_issue: True


### PR DESCRIPTION
Adds [httpsfv](https://github.com/dunglas/httpsfv), a Go implementation of RFC 9651 (Structured Field Values for HTTP).

The library parses attacker-controlled HTTP header values. It is used in the Go HTTP ecosystem, notably by [webtransport-go](https://github.com/quic-go/webtransport-go) (quic-go), and by various server and middleware projects ([importers](https://pkg.go.dev/github.com/dunglas/httpsfv?tab=importedby)).

A parsing panic was recently reported privately (GHSA-jj78-73gf-wr5j, fixed in v1.1.1), and fuzzing immediately found a second one, so continuous fuzzing is warranted. The repository already contains three native Go fuzz targets covering all parsing entry points (`UnmarshalList`, `UnmarshalDictionary`, `UnmarshalItem`), including marshal/unmarshal round-trip checks.

I am the maintainer of the project.
