### PR TITLE
Add go-urlpattern to OSS-Fuzz

### DIFF
--- a/projects/go-urlpattern/Dockerfile
+++ b/projects/go-urlpattern/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/dunglas/go-urlpattern
+WORKDIR $SRC/go-urlpattern
+COPY build.sh $SRC/

--- a/projects/go-urlpattern/build.sh
+++ b/projects/go-urlpattern/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+compile_native_go_fuzzer_v2 github.com/dunglas/go-urlpattern/internal/fuzz FuzzNew FuzzNew
+compile_native_go_fuzzer_v2 github.com/dunglas/go-urlpattern/internal/fuzz FuzzURLPatternInit FuzzURLPatternInit
+
+zip -j $OUT/FuzzNew_seed_corpus.zip $SRC/go-urlpattern/internal/fuzz/testdata/fuzz/FuzzNew/*
+zip -j $OUT/FuzzURLPatternInit_seed_corpus.zip $SRC/go-urlpattern/internal/fuzz/testdata/fuzz/FuzzURLPatternInit/*

--- a/projects/go-urlpattern/project.yaml
+++ b/projects/go-urlpattern/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://github.com/dunglas/go-urlpattern"
+language: go
+primary_contact: "kevin@les-tilleuls.coop"
+main_repo: "https://github.com/dunglas/go-urlpattern"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
## Summary
Adds [github.com/dunglas/go-urlpattern](https://github.com/dunglas/go-urlpattern) to OSS-Fuzz, a spec-compliant Go implementation of the [WHATWG URL Pattern Living Standard](https://urlpattern.spec.whatwg.org/), validated against the [web-platform-tests](https://web-platform-tests.org) `urlpattern` suite.

It's used by:
- [Caddy](https://github.com/caddyserver/caddy)'s `MatchURLPattern` HTTP request matcher ([caddyserver/caddy#7787](https://github.com/caddyserver/caddy/pull/7787))
- [Mercure](https://github.com/dunglas/mercure)'s URLPattern topic matcher ([dunglas/mercure#1278](https://github.com/dunglas/mercure/pull/1278))

Two native Go fuzz targets are harnessed from `internal/fuzz/fuzz_test.go`:
- `FuzzNew` — constructor-string pattern + baseURL through `urlpattern.New`
- `FuzzURLPatternInit` — struct-based `URLPatternInit` fields

Both already found and fixed real panics in the target project (dunglas/go-urlpattern#14, dunglas/go-urlpattern#15) before this submission.

## Test plan
- [x] `python3 infra/helper.py build_image go-urlpattern`
- [x] `python3 infra/helper.py build_fuzzers go-urlpattern` — both `FuzzNew` and `FuzzURLPatternInit` compile to libFuzzer binaries with seed corpora zipped correctly