### PR TITLE
go-dhcp: register FuzzBroadcastRawUDPConnReadFrom from nclient4

### DIFF
--- a/projects/go-dhcp/build.sh
+++ b/projects/go-dhcp/build.sh
@@ -23,3 +23,4 @@ sed -i '58s/^/\/\//g' dhcpv6/dhcpv6_test.go
 compile_native_go_fuzzer github.com/insomniacslk/dhcp/dhcpv4       FuzzDHCPv4    fuzz_DHCPv4
 compile_native_go_fuzzer github.com/insomniacslk/dhcp/dhcpv6       FuzzDHCPv6    fuzz_DHCPv6
 compile_native_go_fuzzer github.com/insomniacslk/dhcp/rfc1035label FuzzLabel     fuzz_Label
+compile_native_go_fuzzer github.com/insomniacslk/dhcp/dhcpv4/nclient4 FuzzBroadcastRawUDPConnReadFrom fuzz_BroadcastRawUDPConnReadFrom


### PR DESCRIPTION
This registers the receive-path fuzz target from insomniacslk/dhcp#588 so OSS-Fuzz actually exercises it. Today the go-dhcp build compiles only `FuzzDHCPv4`, `FuzzDHCPv6`, and `FuzzLabel`, so `FuzzBroadcastRawUDPConnReadFrom` (in `dhcpv4/nclient4`) only runs its seed corpus under `go test`.

Draft until insomniacslk/dhcp#588 merges: the build clones `insomniacslk/dhcp` master and the target is not there yet, so it will fail to build until then. Once #588 lands this passes.

The target is written to be self-contained (its own mock and frame builder, no reliance on the package's other test files), so `go-118-fuzz-build` can compile it. I checked `go-118-fuzz-build -func FuzzBroadcastRawUDPConnReadFrom` produces the fuzzer archive against that code locally, and the target runs clean under native `go test -fuzz` (~10M executions, no crashes).
