### PR TITLE
hobbes: initial integration

### DIFF
--- a/projects/hobbes/Dockerfile
+++ b/projects/hobbes/Dockerfile
@@ -1,0 +1,36 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+# hobbes is an embedded compiler and JIT built on LLVM. The base image's LLVM
+# is not installed as a development package, so take a versioned one from
+# apt.llvm.org; 18 is covered by the project's own CI matrix.
+ENV HOBBES_LLVM_VERSION=18
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        cmake make python3 zip \
+        zlib1g-dev libncurses-dev libzstd-dev libreadline-dev \
+        wget gnupg lsb-release software-properties-common && \
+    wget -qO- https://apt.llvm.org/llvm.sh | bash -s -- $HOBBES_LLVM_VERSION && \
+    apt-get install -y --no-install-recommends llvm-$HOBBES_LLVM_VERSION-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 https://github.com/morganstanley/hobbes.git $SRC/hobbes
+
+WORKDIR $SRC/hobbes
+COPY build.sh $SRC/

--- a/projects/hobbes/build.sh
+++ b/projects/hobbes/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# The build lives in the hobbes tree so that harness changes and build changes
+# stay in one commit. See fuzz/README.md there.
+exec "$SRC/hobbes/fuzz/oss-fuzz-build.sh"

--- a/projects/hobbes/project.yaml
+++ b/projects/hobbes/project.yaml
@@ -1,0 +1,18 @@
+homepage: "https://github.com/morganstanley/hobbes"
+main_repo: "https://github.com/morganstanley/hobbes.git"
+language: c++
+primary_contact: "brianegge@gmail.com"
+# MemorySanitizer is omitted deliberately: hobbes links LLVM from a
+# distribution package, and MSan requires every dependency to be instrumented.
+sanitizers:
+  - address
+  - undefined
+architectures:
+  - x86_64
+# Centipede is omitted deliberately: its prebuilt runner is compiled against
+# libc++, and this build has to drop -stdlib=libc++ to match the libstdc++ LLVM
+# it links (see fuzz/oss-fuzz-build.sh), so the two cannot be linked together.
+fuzzing_engines:
+  - libfuzzer
+  - afl
+  - honggfuzz


### PR DESCRIPTION
[hobbes](https://github.com/morganstanley/hobbes) is an embedded compiler and
JIT for structured data, used to write low-latency trading systems and to store
and query the data they produce.

I am the primary contact and a maintainer on the project; the harnesses and the
build script were merged upstream in
[morganstanley/hobbes#531](https://github.com/morganstanley/hobbes/pull/531).

## Fuzz targets

Three harnesses, covering the surfaces that take untrusted bytes:

| target | surface |
|---|---|
| `fuzz-type-decode` | the binary type decoder |
| `fuzz-fregion-reader` | the fregion structured-log file reader |
| `fuzz-parse-expr` | the expression parser (ships a dictionary and a seed corpus) |

They live in `fuzz/` in the project tree alongside the real build script, which
`projects/hobbes/build.sh` is a one-line wrapper around, so that a change to a
harness and the change to its build land in one commit.

## Configuration notes

- **MemorySanitizer is not enabled.** hobbes links LLVM from an apt package, and
  MSan needs every dependency instrumented.
- **Centipede is not enabled.** Its prebuilt runner is compiled against libc++,
  while this build must drop `-stdlib=libc++` to match the libstdc++ LLVM it
  links; the two cannot be linked together (`undefined reference to
  std::__1::bad_function_call`).
- **A per-target `.options` file disables ASan's `detect_container_overflow`.**
  hobbes links an LLVM that OSS-Fuzz did not build, so the two disagree about
  `std::vector`'s container annotations.
- **`fuzz-parse-expr` also disables leak detection.** It reuses one `hobbes::cc`
  whose boot-code arenas are not reclaimed per input, so LSan reports them
  (23166 bytes in 422 allocations, from `hobbes::cc::cc()`).

## Testing

Built and run locally against the current `main` of the project, in the
OSS-Fuzz container:

| command | result |
|---|---|
| `build_fuzzers --sanitizer address` + `check_build` | pass |
| `build_fuzzers --sanitizer undefined` + `check_build` | pass |
| `build_fuzzers --engine afl` + `check_build` | pass |
| `build_fuzzers --engine honggfuzz` + `check_build` | pass |
| `run_fuzzer` × 3 targets, `-runs=2000` | pass, no crashes |

`$OUT` is about 120 MB, and a fuzzer build takes roughly three minutes on eight
cores. `ldd` on each target inside `base-runner` resolves every dependency;
LLVM is linked statically.

The same harnesses also run on every pull request to the project through
ClusterFuzzLite, sharing this build script.