### PR TITLE
qt: preparation for qtmultimedia

### DIFF
--- a/projects/qt/Dockerfile
+++ b/projects/qt/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 
 RUN apt-get update && apt-get install -y libssl-dev ninja-build libc6-dev:i386
 

--- a/projects/qt/Dockerfile
+++ b/projects/qt/Dockerfile
@@ -16,7 +16,9 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 
-RUN apt-get update && apt-get install -y libssl-dev ninja-build libc6-dev:i386
+RUN apt-get update && apt-get install -y libssl-dev ninja-build libc6-dev:i386 \
+    libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libswresample-dev \
+    libpulse-dev libpipewire-0.3-dev
 
 RUN git clone --depth 1 https://github.com/AFLplusplus/AFLplusplus.git myaflplusplus && \
     cp -r myaflplusplus/dictionaries afldictionaries && \
@@ -29,7 +31,7 @@ WORKDIR $SRC/qt
 RUN git clone --depth 1 --branch dev git://code.qt.io/qt/qt5.git .
 
 RUN ./init-repository --force \
-    --module-subset=qtbase,qtqa,qtimageformats,qtsvg \
+    --module-subset=qtbase,qtqa,qtimageformats,qtsvg,qtmultimedia \
     --depth 1 \
     --no-optional-deps
 RUN cp qtqa/fuzzing/oss-fuzz/build.sh $SRC/

--- a/projects/qt/Dockerfile
+++ b/projects/qt/Dockerfile
@@ -30,5 +30,6 @@ RUN git clone --depth 1 --branch dev git://code.qt.io/qt/qt5.git .
 
 RUN ./init-repository --force \
     --module-subset=qtbase,qtqa,qtimageformats,qtsvg \
+    --depth 1 \
     --no-optional-deps
 RUN cp qtqa/fuzzing/oss-fuzz/build.sh $SRC/

--- a/projects/qt/Dockerfile
+++ b/projects/qt/Dockerfile
@@ -23,16 +23,12 @@ RUN git clone --depth 1 https://github.com/AFLplusplus/AFLplusplus.git myaflplus
     cp -r myaflplusplus/testcases afltestcases && \
     rm -rf myaflplusplus
 
-# Simulate a classic Qt folder structure
 RUN mkdir qt
 WORKDIR $SRC/qt
 
-RUN git clone --branch dev --depth 1 git://code.qt.io/qt/qt5.git && \
-    cp -r qt5/cmake . && \
-    rm -rf qt5
-RUN git clone --branch dev --depth 5000 git://code.qt.io/qt/qtbase.git
-RUN git clone --branch dev --depth 1 git://code.qt.io/qt/qtimageformats.git
-RUN git clone --branch dev --depth 1 git://code.qt.io/qt/qtsvg.git
-RUN cmake -DSYNC_TO_MODULE=qtsvg -DSYNC_TO_BRANCH=dev -P cmake/QtSynchronizeRepo.cmake
-RUN git clone --branch dev --depth 1 git://code.qt.io/qt/qtqa.git
+RUN git clone --depth 1 --branch dev git://code.qt.io/qt/qt5.git .
+
+RUN ./init-repository --force \
+    --module-subset=qtbase,qtqa,qtimageformats,qtsvg \
+    --no-optional-deps
 RUN cp qtqa/fuzzing/oss-fuzz/build.sh $SRC/

--- a/projects/qt/project.yaml
+++ b/projects/qt/project.yaml
@@ -12,6 +12,7 @@ architectures:
  - x86_64
  - i386
 help_url: "https://code.qt.io/cgit/qt/qtbase.git/plain/tests/libfuzzer/README"
+base_os_version: ubuntu-24-04
 
 fuzzing_engines:
   - honggfuzz


### PR DESCRIPTION
This is a proof of concept for integrating qtmultimedia's fuzz tests into oss-fuzz.

it includes some cleanups:
* using `init-repository` to clone qt's submodules with their dependencies instead of cloning manually. note: this requires a `--depth` argument for shallow clones, which is not yet merged into qt5.git: https://codereview.qt-project.org/c/qt/qt5/+/760920 (it can probably not merged before landing this)
* moving to ubuntu 24.04 as 20.04 is not officially supported anymore and qtmultimedia will want newer ffmpeg. (it will require a few compile fixes in qt for newer libc++, which will require the submodule update bot to cycle)

the PR contains multiple independent patches. some could be landed independently, but it's probably best to land them all at once.

CC @rlohning 