### PR TITLE
xmlsec: remove automake adjustments

### DIFF
--- a/projects/xmlsec/Dockerfile
+++ b/projects/xmlsec/Dockerfile
@@ -17,9 +17,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config \
     libssl-dev wget liblzma-dev python3-dev
-# Build requires automake 1.16.3
-RUN curl -LO http://mirrors.kernel.org/ubuntu/pool/main/a/automake-1.16/automake_1.16.5-1.3_all.deb && \
-    apt install ./automake_1.16.5-1.3_all.deb    
 RUN git clone --depth 1 https://github.com/lsh123/xmlsec
 RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/libxml2.git
 RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/libxslt.git


### PR DESCRIPTION
We now have support for newer versions of automake through ubuntu 24

Fixes: https://github.com/google/oss-fuzz/issues/12335