### PR TITLE
grok: add rust support for mercury fuzzing

### DIFF
--- a/projects/grok/Dockerfile
+++ b/projects/grok/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder-rust
 
 RUN git clone --recursive --depth 1 https://github.com/GrokImageCompression/grok.git grok
 RUN git clone --depth 1 https://github.com/GrokImageCompression/grok-test-data.git grok-data

--- a/projects/grok/build.sh
+++ b/projects/grok/build.sh
@@ -18,10 +18,32 @@
 # Configure Test Data Path
 export GRK_DATA_ROOT=$SRC/grok-data
 
+# An explicit cargo target keeps RUSTFLAGS off build scripts and proc
+# macros, which rustc cannot load when instrumented.
+export CARGO_BUILD_TARGET="$(rustc -vV | sed -n 's/host: //p')"
+
+# mercury (rust) would need an msan-instrumented rust std, which this build
+# cannot provide, so msan disables mercury and the mercury fuzzer exercises
+# the c++ fallback path. Other sanitizers inherit -Zsanitizer from the
+# RUSTFLAGS exported by the compile script; libfuzzer builds also add sancov
+# so the fuzzer gets coverage feedback inside the rust code.
+MERCURY_CMAKE_ARGS=""
+if [ "$SANITIZER" = "memory" ]; then
+    MERCURY_CMAKE_ARGS="-DCARGO_EXECUTABLE=/bin/false"
+elif [ "${FUZZING_ENGINE:-}" = "libfuzzer" ]; then
+    if [ "$SANITIZER" = "address" ] || [ "$SANITIZER" = "undefined" ]; then
+        export RUSTFLAGS="${RUSTFLAGS:-} -Cpasses=sancov-module \
+            -Cllvm-args=-sanitizer-coverage-level=4 \
+            -Cllvm-args=-sanitizer-coverage-inline-8bit-counters \
+            -Cllvm-args=-sanitizer-coverage-pc-table \
+            -Cllvm-args=-sanitizer-coverage-trace-compares"
+    fi
+fi
+
 # Build grok core code and unit test
 mkdir build
 cd build
-cmake .. -DGRK_BUILD_CODEC=ON -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=ON
+cmake .. -DGRK_BUILD_CODEC=ON -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=ON $MERCURY_CMAKE_ARGS
 make clean -s
 make -j$(nproc) -s
 cd ..


### PR DESCRIPTION
grok now embeds a rust static library (mercury). Switch to base-builder-rust so a real toolchain is present, add sancov/asan instrumentation for the rust code in libfuzzer builds, and keep mercury disabled under msan since rust's std is not msan-instrumented. Verified locally with helper.py build_fuzzers for address, undefined and memory, and run_fuzzer on the address build.