### PR TITLE
open5gs: Add new fuzzer to build.sh

### DIFF
--- a/projects/open5gs/build.sh
+++ b/projects/open5gs/build.sh
@@ -32,6 +32,7 @@ sed -i '/^rule STATIC_LINKER$/,/^$/{
 
 ninja -C builddir -k 0 \
     tests/fuzzing/gtp_message_fuzz \
+    tests/fuzzing/ipfw_rule_fuzz \
     tests/fuzzing/nas_message_fuzz \
     tests/fuzzing/ngap_message_fuzz \
     tests/fuzzing/s1ap_message_fuzz \
@@ -41,6 +42,7 @@ ninja -C builddir -k 0 \
     tests/fuzzing/sbi_sm_context_fuzz
 
 cp builddir/tests/fuzzing/gtp_message_fuzz $OUT/gtp_message_fuzz
+cp builddir/tests/fuzzing/ipfw_rule_fuzz $OUT/ipfw_rule_fuzz
 cp builddir/tests/fuzzing/nas_message_fuzz $OUT/nas_message_fuzz
 cp builddir/tests/fuzzing/ngap_message_fuzz $OUT/ngap_message_fuzz
 cp builddir/tests/fuzzing/s1ap_message_fuzz $OUT/s1ap_message_fuzz
@@ -51,6 +53,7 @@ mkdir -p $OUT/lib/
 cp /lib/x86_64-linux-gnu/libtalloc.so* $OUT/lib/
 
 cp tests/fuzzing/gtp_message_fuzz_seed_corpus.zip $OUT/gtp_message_fuzz_seed_corpus.zip
+cp tests/fuzzing/ipfw_rule_fuzz_seed_corpus.zip $OUT/ipfw_rule_fuzz_seed_corpus.zip
 cp tests/fuzzing/nas_message_fuzz_seed_corpus.zip $OUT/nas_message_fuzz_seed_corpus.zip
 cp tests/fuzzing/pfcp_message_fuzz_seed_corpus.zip $OUT/pfcp_message_fuzz_seed_corpus.zip
 cp tests/fuzzing/nas_5gs_message_fuzz_seed_corpus.zip $OUT/nas_5gs_message_fuzz_seed_corpus.zip


### PR DESCRIPTION
This PR updates the build.sh of project open5gs to accommodate new fuzzer added in https://github.com/open5gs/open5gs/pull/4752.