### PR TITLE
checkstyle: fix broken build

### DIFF
--- a/projects/checkstyle/Dockerfile
+++ b/projects/checkstyle/Dockerfile
@@ -14,6 +14,12 @@
 #
 ##########################################################################
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends openjdk-21-jdk && \
+    rm -rf /var/lib/apt/lists/*
+ENV JAVA_HOME="/usr/lib/jvm/java-21-openjdk-amd64"
+ENV JVM_LD_LIBRARY_PATH="$JAVA_HOME/lib/server"
+ENV PATH="$JAVA_HOME/bin:$PATH"
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip \
   -o maven.zip && \
   unzip maven.zip -d $SRC/maven && \

--- a/projects/checkstyle/build.sh
+++ b/projects/checkstyle/build.sh
@@ -18,6 +18,19 @@ export TARGET_PACKAGE_PREFIX="com.puppycrawl.tools.checkstyle."
 
 MAVEN_ARGS="-Dmaven.test.skip=true -Djavac.src.version=15 -Djavac.target.version=15 --update-snapshots"
 $MVN clean package $MAVEN_ARGS
+BUNDLED_JAVA_HOME=$OUT/$(basename $JAVA_HOME)
+rm -rf $BUNDLED_JAVA_HOME
+cp -a $JAVA_HOME $OUT/
+while read -r LINK
+do
+  TARGET=$(readlink "$LINK")
+  case "$TARGET" in
+    /etc/java-21-openjdk/*|/etc/ssl/certs/java/*)
+      rm -f "$LINK"
+      cp -a "$TARGET" "$LINK"
+      ;;
+  esac
+done < <(find $BUNDLED_JAVA_HOME -type l)
 
 BUILD_CLASSPATH=
 RUNTIME_CLASSPATH=
@@ -61,7 +74,10 @@ do
     mem_settings='-Xmx2048m:-Xss1024k'
   fi
 
-  LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\":\$this_dir \
+  export JAVA_HOME=\$this_dir/$(basename $JAVA_HOME)
+  export LD_LIBRARY_PATH=\"\$JAVA_HOME/lib/server\":\$this_dir
+  export PATH=\$JAVA_HOME/bin:\$PATH
+
   \$this_dir/jazzer_driver --agent_path=\$this_dir/jazzer_agent_deploy.jar \
   --cp=$RUNTIME_CLASSPATH \
   --target_class=$fuzzer_basename \


### PR DESCRIPTION
Checkstyle `commit c831ac7d561cbc12c98cc8394995798c506970c5` changed the minimum required Java version from 17 to 21. The OSS-Fuzz JVM builder provided JDK 17, causing Maven Enforcer's RequireJavaVersion rule to fail.

Install `JDK 21` in the build image and bundle the JDK with the fuzzer artifacts so the Jazzer runtime uses the same JDK. 