### PR TITLE
[qt] Migrate to Ubuntu 24.04

### DIFF
--- a/projects/qt/Dockerfile
+++ b/projects/qt/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 
 RUN apt-get update && apt-get install -y libssl-dev ninja-build libc6-dev:i386
 

--- a/projects/qt/project.yaml
+++ b/projects/qt/project.yaml
@@ -12,6 +12,7 @@ architectures:
  - x86_64
  - i386
 help_url: "https://code.qt.io/cgit/qt/qtbase.git/plain/tests/libfuzzer/README"
+base_os_version: ubuntu-24-04
 
 fuzzing_engines:
   - honggfuzz


### PR DESCRIPTION
Qt can still be built on Ubuntu 20.04 but for Qt 6.13, that's not an officially supported platform anymore.

Thanks to @timblechmann for spotting this and preparing the change.