### PR TITLE
g-api-py-oauthlib: fix broken build

### DIFF
--- a/projects/g-api-py-oauthlib/build.sh
+++ b/projects/g-api-py-oauthlib/build.sh
@@ -15,7 +15,7 @@
 #
 ################################################################################
 
-pip3 install .
+pip3 install google-auth-oauthlib
 for fuzzer in $(find $SRC -name 'fuzz_*.py'); do
   compile_python_fuzzer $fuzzer
 done


### PR DESCRIPTION
The fuzzing build failed because `build.sh` attempted to run:

     pip3 install .

The cloned repository does not contain `setup.py` or `pyproject.toml`, so pip considered the source directory non-installable and aborted the build.

Install the published google-auth-oauthlib package from PyPI instead. This provides the package imported by `fuzz_config.py` while preserving the existing fuzzing harness and build flow.