### PR TITLE
g-api-python-bigquery-storage: fix broken build

### DIFF
--- a/projects/g-api-python-bigquery-storage/build.sh
+++ b/projects/g-api-python-bigquery-storage/build.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 ################################################################################
-GRPC_PYTHON_CFLAGS="${CFLAGS}" GRPC_PYTHON_BUILD_SYSTEM_RE2=true GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=true GRPC_PYTHON_BUILD_SYSTEM_ZLIB=true pip3 install .
+GRPC_PYTHON_CFLAGS="${CFLAGS}" GRPC_PYTHON_BUILD_SYSTEM_RE2=true GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=true GRPC_PYTHON_BUILD_SYSTEM_ZLIB=true pip3 install google-cloud-bigquery-storage
 
 # Build fuzzers in $OUT.
 for fuzzer in $(find $SRC -name 'fuzz_*.py'); do

--- a/projects/g-api-python-bigquery-storage/fuzz_avroparser.py
+++ b/projects/g-api-python-bigquery-storage/fuzz_avroparser.py
@@ -15,6 +15,7 @@
 import sys
 import atheris
 
+from google.cloud.bigquery_storage_v1.reader import _AvroStreamParser
 from google.cloud.bigquery_storage_v1.types import ReadSession
 from google.protobuf.json_format import Parse
 


### PR DESCRIPTION
The fuzzing build failed because build.sh attempted to install the repository with:

`pip3 install .`

The cloned source directory does not contain setup.py or pyproject.toml, so pip reported that the directory was not installable.

Install the published `google-cloud-bigquery-storage` package instead.
Also `import _AvroStreamParser` explicitly in the Avro fuzz target to ensure the referenced parser is available at runtime.