### PR TITLE
go-ldap: fix broken build

### DIFF
--- a/projects/go-ldap/build.sh
+++ b/projects/go-ldap/build.sh
@@ -15,8 +15,7 @@
 #
 ################################################################################
 
+cd v3
 go get github.com/AdamKorcz/go-118-fuzz-build/testing
-
-compile_native_go_fuzzer github.com/go-ldap/ldap    FuzzParseDN                 fuzz_parse_dn
-compile_native_go_fuzzer github.com/go-ldap/ldap    FuzzDecodeEscapedSymbols    fuzz_decode_escaped_symbols
-compile_native_go_fuzzer github.com/go-ldap/ldap    FuzzEscapeDN                fuzz_escape_dn
+export GOFLAGS="-buildvcs=false"
+compile_native_go_fuzzer github.com/go-ldap/ldap/v3 FuzzGetLDAPError fuzz_get_ldap_error


### PR DESCRIPTION
The fuzzing build failed because build.sh ran `go get` from the repository root, where no go.mod file exists. The current Go module is located in the v3 directory.

The existing fuzz targets also referenced the legacy `github.com/go-ldap/ldap` module and fuzz functions that are no longer present in the current source tree.

Update the build script to build from the v3 module directory, use the `github.com/go-ldap/ldap/v3` module path, replace the removed fuzz targets with FuzzGetLDAPError, and disable VCS metadata injection during the build.
