### PR TITLE
imageio: fix broken build

### DIFF
--- a/projects/imageio/Dockerfile
+++ b/projects/imageio/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder-python
 RUN apt update && apt-get install -y zlib1g-dev libjpeg8-dev
-RUN pip3 install cython numpy
+RUN pip3 install cython 'numpy<2'
 
 RUN git clone https://github.com/imageio/imageio
 

--- a/projects/imageio/build.sh
+++ b/projects/imageio/build.sh
@@ -15,9 +15,9 @@
 #
 ################################################################################
 
-python3 setup.py build install
+python3 -m pip install .
 
 # Build fuzzers in $OUT.
 for fuzzer in $(find . -name 'fuzz_*.py'); do
-  compile_python_fuzzer $fuzzer
+  compile_python_fuzzer $fuzzer --copy-metadata imageio
 done


### PR DESCRIPTION
The ImageIO fuzzing build failed because `build.sh` invoked:

```
python3 setup.py build install
```

The current ImageIO repository uses the `pyproject.toml` build flow and no longer contains `setup.py`. Use `python3 -m pip install .` instead.

The fuzz target is packaged with PyInstaller. With the latest NumPy 2.x release, the generated fuzz binary failed at startup because the bundled application could not import:

```
numpy._core._exceptions
```

Restrict NumPy to the compatible major‑version range with `numpy<2` without pinning a specific release.

The existing fuzz harness also terminated on short or malformed inputs. Pillow can raise `struct.error` while parsing incomplete image headers, but the harness previously caught only ValueError and RuntimeError. Update the upstream fuzz harness to use ImageIO v3, skip very short inputs, and catch all expected image parsing exceptions.

Use `--copy-metadata imageio` when compiling the Python fuzz target so that the installed ImageIO package metadata is preserved in the PyInstaller bundle.