### PR TITLE
publicsuffix: fix broken build

### DIFF
--- a/projects/publicsuffix-list/build.sh
+++ b/projects/publicsuffix-list/build.sh
@@ -15,11 +15,11 @@
 #
 ################################################################################
 
+export GOFLAGS="-buildvcs=false"
 sed 's/package main/package tools/g' -i ./tools/newgtlds.go
 rm ./tools/newgtlds_test.go
 cp $SRC/fuzz_test.go ./tools/
-go mod init github.com/publicsuffix/list
-go mod tidy
 printf "package tools\nimport _ \"github.com/AdamKorcz/go-118-fuzz-build/testing\"\n" > ./tools/register.go
+cd tools
 go mod tidy
 compile_native_go_fuzzer github.com/publicsuffix/list/tools FuzzTest FuzzTest


### PR DESCRIPTION
The fuzzing build failed because build.sh created a go.mod file and ran go mod tidy from the repository root. The repository root does not contain a Go package, so the generated module did not provide [github.com/publicsuffix/list/tools](https://github.com/publicsuffix/list/tools). As a result, `compile_native_go_fuzzer` failed with:

```
no required module provides package github.com/publicsuffix/list/tools
```

The tools directory is the actual Go module containing the fuzz target.
Remove the root‑level go mod init and go mod tidy commands, change into the tools directory before resolving dependencies, and disable VCS metadata injection during the build.