### PR TITLE
scrypt: fix broken build

### DIFF
--- a/projects/scrypt/build.sh
+++ b/projects/scrypt/build.sh
@@ -16,6 +16,9 @@
 ################################################################################
 
 # Build the fuzzers and project source code
+rustup toolchain install nightly --profile minimal
+export RUSTUP_TOOLCHAIN=nightly
+RUSTFLAGS= cargo install cargo-fuzz
 cargo fuzz build
 
 # Copy built fuzzer binaries to $OUT


### PR DESCRIPTION
The build failed because the Rust base image does not provide the `cargo‑fuzz` subcommand:

```
error: no such command: `fuzz`
```

The build script now:

- Installs the current nightly Rust toolchain without pinning a specific date.
- Installs the unpinned cargo‑fuzz package.
- Clears OSS‑Fuzz sanitizer RUSTFLAGS while building cargo‑fuzz, preventing sanitizer flags from breaking its procedural‑macro dependencies.