### PR TITLE
Add proto2mcp project

### DIFF
--- a/projects/proto2mcp/Dockerfile
+++ b/projects/proto2mcp/Dockerfile
@@ -1,0 +1,4 @@
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/protocgen/proto2mcp $SRC/proto2mcp
+WORKDIR $SRC/proto2mcp
+COPY build.sh $SRC/

--- a/projects/proto2mcp/build.sh
+++ b/projects/proto2mcp/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -eu
+# OSS-Fuzz build script for proto2mcp
+# See https://google.github.io/oss-fuzz/getting-started/new-project-guide/go-lang/
+
+compile_native_go_fuzzer github.com/protocgen/proto2mcp/pkg/mcpruntime FuzzSanitizeErrorMessage fuzz_sanitize_error_message
+compile_native_go_fuzzer github.com/protocgen/proto2mcp/pkg/mcpruntime FuzzTruncateUTF8 fuzz_truncate_utf8
+compile_native_go_fuzzer github.com/protocgen/proto2mcp/pkg/mcpruntime FuzzUnmarshalToolInput fuzz_unmarshal_tool_input
+compile_native_go_fuzzer github.com/protocgen/proto2mcp/pkg/mcpruntime FuzzResourceKeyExtraction fuzz_resource_key_extraction

--- a/projects/proto2mcp/project.yaml
+++ b/projects/proto2mcp/project.yaml
@@ -1,0 +1,11 @@
+homepage: "https://github.com/protocgen/proto2mcp"
+language: go
+primary_contact: "brucearctor@users.noreply.github.com"
+auto_ccs:
+- "brucearctor@users.noreply.github.com"
+fuzzing_engines:
+- libfuzzer
+sanitizers:
+- address
+main_repo: "https://github.com/protocgen/proto2mcp"
+vendor_ccs: []


### PR DESCRIPTION
## New Project: proto2mcp

**Project URL:** https://github.com/protocgen/proto2mcp
**Language:** Go
**Contact:** brucearctor@users.noreply.github.com

### What is proto2mcp?

A protoc plugin that generates type-safe [MCP](https://modelcontextprotocol.io/) tool servers from protobuf service definitions. Used to bridge LLM agents with existing gRPC/ConnectRPC backends.

### Fuzz Targets (4)

| Target | What it covers |
|--------|---------------|
| `FuzzSanitizeErrorMessage` | Error message scrubbing — ensures no path/IP leakage, length bounded |
| `FuzzTruncateUTF8` | UTF-8 safe truncation — already found a real bug (v0.12.3) |
| `FuzzUnmarshalToolInput` | Protojson unmarshal of arbitrary agent input — no panics |
| `FuzzResourceKeyExtraction` | JSON key extraction from untrusted agent arguments |

### Why fuzz?

proto2mcp sits between untrusted LLM agent input and backend services. The fuzz targets cover the exact parsing boundary where malformed input enters the system. Fuzzing already found one bug: `truncateUTF8` produced invalid UTF-8 from lone lead bytes (fixed in v0.12.3).

### Build verification

Tested locally with:

```bash
python3 infra/helper.py build_fuzzers proto2mcp
python3 infra/helper.py check_build proto2mcp
```