### PR TITLE
libssh: Use github mirror for better availability

### DIFF
--- a/projects/libssh/Dockerfile
+++ b/projects/libssh/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y cmake zlib1g-dev libssl-dev libcmocka0 libcmocka-dev
 
-RUN git clone --depth=1 https://git.libssh.org/projects/libssh.git
+RUN git clone --depth=1 https://github.com/libssh/libssh-mirror.git libssh
 
 WORKDIR libssh
 COPY build.sh run_tests.sh $SRC/


### PR DESCRIPTION
From the last 7 builds, only one succeeded due to connection error to our main repository:

https://oss-fuzz-build-logs.storage.googleapis.com/index.html#libssh

We have github and gitlab mirrors so lets change the repository to that one.