### PR TITLE
tpm2-tss update

### DIFF
--- a/projects/tpm2-tss/Dockerfile
+++ b/projects/tpm2-tss/Dockerfile
@@ -13,75 +13,125 @@
 # limitations under the License.
 #
 ################################################################################
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PIP_REQUIRE_VIRTUALENV=0
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
 RUN apt-get update && \
     apt-get install -y \
-    autoconf-archive \
-    curl \
-    libcmocka0 \
-    libcmocka-dev \
-    net-tools \
-    build-essential \
-    git \
-    pkg-config \
-    gcc \
-    g++ \
-    m4 \
-    libtool \
-    automake \
-    libgcrypt20-dev \
-    libssl-dev \
+    acl \
     autoconf \
-    gnulib \
-    wget \
-    doxygen \
-    libdbus-1-dev \
-    libglib2.0-dev \
-    clang-6.0 \
-    clang-tools-6.0 \
-    pandoc \
-    lcov \
-    libcurl4-openssl-dev \
+    autoconf-archive \
+    automake \
+    bear \
+    build-essential \
+    clang \
+    clang-format \
+    clang-tidy \
+    clang-tools \
+    curl \
     dbus-x11 \
-    python-yaml \
-    python3-yaml \
+    default-jdk \
+    default-jre \
+    doxygen \
+    expect \
+    g++ \
+    gawk \
+    gcc \
+    git \
+    gnulib \
+    gnutls-bin \
+    iproute2 \
+    lcov \
+    libcmocka-dev \
+    libcmocka0 \
+    libcurl4-openssl-dev \
+    libdbus-1-dev \
+    libengine-pkcs11-openssl \
+    libftdi-dev \
+    libgcrypt20-dev \
+    libglib2.0-dev \
+    libgmp-dev \
+    libjson-c-dev \
+    libjson-glib-dev \
+    libmbedtls-dev \
+    libnss3-tools \
+    libseccomp-dev \
+    libsqlite3-dev \
+    libssl-dev \
+    libtasn1-6-dev \
+    libtool \
+    libusb-1.0-0-dev \
+    libyaml-dev \
+    m4 \
+    net-tools \
+    opensc \
+    pandoc \
+    pkg-config \
+    python3 \
+    python3-pip \
+    rustc \
+    socat \
+    sqlite3 \
+    uthash-dev \
+    uuid-dev \
     vim-common \
-    acl
+    wget \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 100
-RUN update-alternatives --install /usr/bin/scan-build scan-build /usr/bin/scan-build-6.0 100
-
-ARG autoconf_archive=autoconf-archive-2018.03.13
-WORKDIR /tmp 
-RUN wget --quiet --show-progress --progress=dot:giga "http://mirror.kumi.systems/gnu/autoconf-archive/$autoconf_archive.tar.xz" \
-		&& tar -xf $autoconf_archive.tar.xz \
-        && rm $autoconf_archive.tar.xz \
-        && cd $autoconf_archive \
-        && ./configure --prefix=/usr \
-        && make -j $(nproc) && make install
-RUN rm -fr $autoconf_archive.tar.xz
-
-ARG ibmtpm_name=ibmtpm1661
-WORKDIR /tmp
-RUN wget --quiet --show-progress --progress=dot:giga "https://downloads.sourceforge.net/project/ibmswtpm2/$ibmtpm_name.tar.gz" \
-	&& sha256sum $ibmtpm_name.tar.gz | grep ^55145928ad2b24f34be6a0eacf9fb492e10e0ea919b8428c721fa970e85d6147 \
+ARG ibmtpm_name=ibmtpm1682
+RUN cd /tmp \
+	&& wget $WGET_EXTRA_FLAGS "https://downloads.sourceforge.net/project/ibmswtpm2/$ibmtpm_name.tar.gz" \
+	&& sha1sum $ibmtpm_name.tar.gz | grep ^651800d0b87cfad55b004fbdace4e41dce800a61 \
 	&& mkdir -p $ibmtpm_name \
-	&& tar xvf $ibmtpm_name.tar.gz -C $ibmtpm_name \
-	&& rm $ibmtpm_name.tar.gz
-WORKDIR $ibmtpm_name/src
-RUN CFLAGS="-I/usr/local/openssl/include" make -j$(nproc) \
-&& cp tpm_server /usr/local/bin
-RUN rm -fr $ibmtpm_name/src $ibmtpm_name.tar.gz
+	&& (tar xv --no-same-owner -f $ibmtpm_name.tar.gz -C $ibmtpm_name \
+		|| python3 -c 'import sys, tarfile; archive="/tmp/%s.tar.gz" % sys.argv[1]; dest="/tmp/%s" % sys.argv[1]; tarfile.open(archive, "r:gz").extractall(dest)' "$ibmtpm_name") \
+	&& rm $ibmtpm_name.tar.gz \
+	&& cd $ibmtpm_name/src \
+	&& sed -i 's/0x300000ff/0x310000ff/' TpmToOsslMath.h \
+	&& sed -i 's/-DTPM_NUVOTON/-DTPM_NUVOTON $(CFLAGS)/' makefile \
+	&& CFLAGS="-DNV_MEMORY_SIZE=32768 -DMIN_EVICT_OBJECTS=7" make -j$(nproc) \
+	&& cp tpm_server /usr/local/bin \
+	&& strip /usr/local/bin/tpm_server || true \
+	&& rm -fr /tmp/$ibmtpm_name
 
-ARG uthash="2.1.0"
-WORKDIR /tmp
-RUN wget --quiet --show-progress --progress=dot:giga "https://github.com/troydhanson/uthash/archive/v${uthash}.tar.gz" \
-	&& tar -xf v${uthash}.tar.gz \
-        && cp uthash-${uthash}/src/*.h /usr/include/
-RUN rm -rf uthash-${uthash}/ v${uthash}.tar.gz
+ARG libtpms_version=0.10.2
+ARG swtpm_version=0.10.1
+COPY libtpms.patch /tmp/libtpms.patch
+RUN cd /tmp/ \
+    && wget $WGET_EXTRA_FLAGS https://github.com/stefanberger/libtpms/archive/refs/tags/v$libtpms_version.tar.gz \
+    && (tar xv --no-same-owner -f v$libtpms_version.tar.gz \
+	|| python3 -c 'import sys, tarfile; archive="/tmp/v%s.tar.gz" % sys.argv[1]; dest="/tmp"; tarfile.open(archive, "r:gz").extractall(dest)' "$libtpms_version") \
+	&& cd /tmp/libtpms-$libtpms_version \
+	&& ./autogen.sh --prefix=/usr $LIBTPMS_AUTOGEN_EXTRA --with-openssl --with-tpm2 \
+        && (command -d patch && patch -p1 < /tmp/libtpms.patch || true) \
+	&& make -j$(nproc) \
+	&& make install \
+    && cd /tmp/ \
+	&& rm -fr /tmp/libtpms-$libtpms_version \
+    && rm -f /tmp/v$libtpms_version.tar.gz \
+    && wget $WGET_EXTRA_FLAGS https://github.com/stefanberger/swtpm/archive/refs/tags/v$swtpm_version.tar.gz \
+    && (tar xv --no-same-owner -f v$swtpm_version.tar.gz \
+	|| python3 -c 'import sys, tarfile; archive="/tmp/v%s.tar.gz" % sys.argv[1]; dest="/tmp"; tarfile.open(archive, "r:gz").extractall(dest)' "$swtpm_version") \
+	&& cd /tmp/swtpm-$swtpm_version \
+	&& ./autogen.sh --prefix=/usr \
+	&& make -j$(nproc) $SWTPM_MAKE_EXTRA \
+	&& make install \
+    && cd /tmp/ \
+	&& rm -fr /tmp/swtpm-$swtpm_version \
+    && rm -f /tmp/v$swtpm_version.tar.gz \
+    && rm /tmp/libtpms.patch
+
+
+WORKDIR /
+
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+RUN python3 -m pip install --no-cache-dir --break-system-packages \
+    compiledb \
+    && rm -rf /root/.cache/pip
 
 RUN git clone --depth 1 \
-  https://github.com/tpm2-software/tpm2-tss $SRC/tpm2-tss/
+	https://github.com/tpm2-software/tpm2-tss $SRC/tpm2-tss/
 WORKDIR $SRC/tpm2-tss/
 COPY *.sh $SRC/

--- a/projects/tpm2-tss/build.sh
+++ b/projects/tpm2-tss/build.sh
@@ -32,7 +32,8 @@ export GEN_FUZZ=1
   --disable-tcti-mssim \
   --disable-tcti-swtpm \
   --disable-tcti-spi-ftdi \
-  --disable-tcti-spi-lt2go \
+  --disable-tcti-spi-ltt2go \
+  --disable-tcti-i2c-ftdi \
   --disable-doxygen-doc \
   --disable-shared \
   --disable-fapi \

--- a/projects/tpm2-tss/libtpms.patch
+++ b/projects/tpm2-tss/libtpms.patch
@@ -1,0 +1,33 @@
+From fc8820cfaa8b5e17328f731df93911f6ab92443b Mon Sep 17 00:00:00 2001
+From: Stefan Berger <stefanb@linux.ibm.com>
+Date: Fri, 2 Jan 2026 11:37:31 -0500
+Subject: [PATCH] Fix a compilation error in TPMLIB_GetPlaintext
+
+Fix a compilation error that newer gcc versions may complain about:
+
+tpm_library.c: In function 'TPMLIB_GetPlaintext':
+tpm_library.c:441:11: error: assignment discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
+  441 |     start = strstr(stream, starttag);
+      |           ^
+At top level:
+cc1: note: unrecognized command-line option '-Wno-self-assign' may have been intended to silence earlier diagnostics
+cc1: all warnings being treated as errors
+
+Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>
+---
+ src/tpm_library.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/tpm_library.c b/src/tpm_library.c
+index f48f4fd38..7b2ea687e 100644
+--- a/src/tpm_library.c
++++ b/src/tpm_library.c
+@@ -435,7 +435,7 @@ static unsigned char *TPMLIB_GetPlaintext(const char *stream,
+                                           const char *endtag,
+                                           size_t *length)
+ {
+-    char *start, *end;
++    const char *start, *end;
+     unsigned char *plaintext = NULL;
+ 
+     start = strstr(stream, starttag);

--- a/projects/tpm2-tss/project.yaml
+++ b/projects/tpm2-tss/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://github.com/tpm2-software/tpm2-tss"
 language: c++
 primary_contact: "william.c.roberts@intel.com"

--- a/projects/tpm2-tss/project.yaml
+++ b/projects/tpm2-tss/project.yaml
@@ -13,4 +13,4 @@ sanitizers:
 # Disabled MSAN because of https://github.com/google/oss-fuzz/issues/6294
 #  - memory
   - undefined
-main_repo: 'https://github.com/tstruk/tpm2-tss.git'
+main_repo: 'https://github.com/tpm2-software/tpm2-tss.git'


### PR DESCRIPTION
This is an attempt at updating the CI-fuzz GitHub action of tpm2-tss.
Recently we had some other problems with the CIFuzz action (https://github.com/tpm2-software/tpm2-tss/issues/3129) and I became aware of this separate Docker image.

I adopted our official Ubuntu 24.04 tpm2-software Docker image for the changes (https://github.com/tpm2-software/tpm2-software-container/blob/master/ubuntu-24.04.docker.m4)

I have not yet tested these changes.