### PR TITLE
[qt] Use time based shallow clone for qtbase

### DIFF
--- a/projects/qt/Dockerfile
+++ b/projects/qt/Dockerfile
@@ -30,7 +30,7 @@ WORKDIR $SRC/qt
 RUN git clone --branch dev --depth 1 git://code.qt.io/qt/qt5.git && \
     cp -r qt5/cmake . && \
     rm -rf qt5
-RUN git clone --branch dev --depth 5000 git://code.qt.io/qt/qtbase.git
+RUN git clone --branch dev --shallow-since='-6 months' git://code.qt.io/qt/qtbase.git
 RUN git clone --branch dev --depth 1 git://code.qt.io/qt/qtimageformats.git
 RUN git clone --branch dev --depth 1 git://code.qt.io/qt/qtsvg.git
 RUN cmake -DSYNC_TO_MODULE=qtsvg -DSYNC_TO_BRANCH=dev -P cmake/QtSynchronizeRepo.cmake


### PR DESCRIPTION
Cloning the last 5000 commits worked fine but it's usually too much and may theoretically be to little. At the time of writing, cloning the last six months will clone less than 5000, but it may grow when needed.
Qt's major releases happen twice a year. It's safe to assume that the sources were updated at least once in that time.