### PR TITLE
[elfutils] switch to sr.ht mirror

### DIFF
--- a/projects/elfutils/Dockerfile
+++ b/projects/elfutils/Dockerfile
@@ -17,6 +17,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && \
     apt-get install -y pkg-config make autoconf autopoint zlib1g-dev zlib1g-dev:i386 flex gawk bison
-RUN git clone --depth 1 https://sourceware.org/git/elfutils.git
+RUN git clone --depth 1 https://git.sr.ht/~sourceware/elfutils
 WORKDIR elfutils
 COPY build.sh *.c *.zip $SRC/


### PR DESCRIPTION
to avoid triggering the nginx throttler the elfutils project installed.

https://sourceware.org/pipermail/elfutils-devel/2026q3/009607.html
```
It isn't you personally. Sourceware is seeing waves of AI scraperbot
attacks through residential proxies. Which means there are millions of
ip addresses hitting the server (often just fetching one or two items
and then disappearing). So it is really hard to properly throttle the
actual abusers. See also the lwn articles Fighting the AI scraperbot
scourge https://lwn.net/Articles/1008897/ and An update on the scraper
situation https://lwn.net/Articles/1080822/ and the sourceware
fediverse updates: https://fosstodon.org/@sourceware

So there are a couple of ways around the nginx throttler we installed,
get a bugzilla account and use that through the ip you are cloning from
or get a developer account and git clone through ssh, use the git
protocol to clone git://sourceware.org/git/elfutils.git use the forge
https://forge.sourceware.org/elfutils/elfutils-mirror or sr.ht mirror
https://git.sr.ht/~sourceware/elfutils/
```