### PR TITLE
libtsm: build the maintained fork instead of the abandoned upstream tree

### DIFF
--- a/projects/libtsm/Dockerfile
+++ b/projects/libtsm/Dockerfile
@@ -15,8 +15,9 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config
+RUN apt-get update && apt-get install -y pkg-config python3-pip ninja-build && \
+    pip3 install --break-system-packages meson
 
-RUN git clone --depth 1 git://people.freedesktop.org/~dvdhrm/libtsm
+RUN git clone --depth 1 https://github.com/kmscon/libtsm
 WORKDIR libtsm
 COPY build.sh libtsm_fuzzer.c $SRC/

--- a/projects/libtsm/build.sh
+++ b/projects/libtsm/build.sh
@@ -16,14 +16,48 @@
 ################################################################################
 
 # build the library.
-./autogen.sh
-make -j$(nproc) clean
-make -j$(nproc) all
+#
+# --buildtype=plain so that meson adds no optimisation or debug flags of its
+# own and $CFLAGS is what actually reaches the compiler.
+# -Dwerror=false because the project defaults to werror=true, and a sanitizer
+# build raises warnings upstream's own CI does not see.
+#
+# LDFLAGS has to carry the sanitizer flags too: meson.build declares libtsm as
+# a shared_library, and linking one without -fsanitize=address leaves every
+# __asan_* and __sanitizer_cov_* reference undefined.
+# -Db_lundef=false drops meson's default -Wl,--no-undefined for the same
+# reason: a sanitized shared object legitimately has undefined runtime symbols.
+export LDFLAGS="${LDFLAGS:-} $CFLAGS"
+
+meson setup build \
+    --buildtype=plain \
+    -Db_lundef=false \
+    -Dwerror=false \
+    -Dtests=false \
+    -Dgtktsm=false
+ninja -C build
+
+# libtsm's meson.build declares only a shared library, so there is no static
+# archive to link the fuzzer against. Rather than duplicate upstream's source
+# list here -- which would silently go stale the next time a file is added --
+# archive the objects ninja actually emitted for it.
+#
+# One directory, not three: libtsm's wcwidth and shl dependencies are declared
+# with declare_dependency(sources: ...), so their translation units are
+# recompiled into libtsm.so's own object directory. Adding the separate
+# libwcwidth.a/libshl.a as well would define every one of their symbols twice.
+#
+# `find` rather than a shell glob: meson names an object built from outside the
+# target's own directory after its relative path, so shl-htable.c.o and
+# wcwidth.c.o land there as `.._shared_shl-htable.c.o` and
+# `.._.._external_wcwidth_wcwidth.c.o`. A `*.o` glob does not match a leading
+# dot, and would silently produce an archive missing exactly those two.
+find build/src/tsm -name '*.o' -print0 | xargs -0 ar rcs $WORK/libtsm.a
 
 # build your fuzzer(s)
-$CC $CFLAGS -c $SRC/libtsm_fuzzer.c -Isrc/tsm -o $SRC/libtsm_fuzzer.o
+$CC $CFLAGS -c $SRC/libtsm_fuzzer.c -Isrc/tsm -o $WORK/libtsm_fuzzer.o
 $CXX $CXXFLAGS \
     -o $OUT/libtsm_fuzzer \
-    $SRC/libtsm_fuzzer.o \
-    .libs/libtsm.a \
+    $WORK/libtsm_fuzzer.o \
+    $WORK/libtsm.a \
     $LIB_FUZZING_ENGINE

--- a/projects/libtsm/libtsm_fuzzer.c
+++ b/projects/libtsm/libtsm_fuzzer.c
@@ -18,7 +18,7 @@ static void terminal_write_fn(struct tsm_vte *vte,
     out[len % sizeof(out)] = u8[len];
 }
 
-static int term_draw_cell(struct tsm_screen *screen, uint32_t id,
+static int term_draw_cell(struct tsm_screen *screen, uint64_t id,
                           const uint32_t *ch, size_t len,
                           unsigned int cwidth, unsigned int posx,
                           unsigned int posy,

--- a/projects/libtsm/libtsm_fuzzer.c
+++ b/projects/libtsm/libtsm_fuzzer.c
@@ -1,6 +1,16 @@
-// Copyright 2016 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include "libtsm.h"
 

--- a/projects/libtsm/project.yaml
+++ b/projects/libtsm/project.yaml
@@ -1,11 +1,11 @@
-homepage: "https://www.freedesktop.org/wiki/Software/kmscon/libtsm/"
+homepage: "https://github.com/kmscon/libtsm"
 language: c++
 primary_contact: "dh.herrmann@gmail.com"
 sanitizers:
   - address
   - memory
   - undefined
-main_repo: 'git://people.freedesktop.org/~dvdhrm/libtsm'
+main_repo: 'https://github.com/kmscon/libtsm'
 
 fuzzing_engines:
   - afl


### PR DESCRIPTION
### Summary

`projects/libtsm` has cloned `git://people.freedesktop.org/~dvdhrm/libtsm` since 2016. That tree's HEAD is `b73acb4c`, committed **2014-04-24**, and it has not moved since. Development continued in a fork, now at [github.com/kmscon/libtsm](https://github.com/kmscon/libtsm) (v4.7.1, released this month) — which is what [Arch](https://archlinux.org/packages/extra/x86_64/libtsm/), Debian and Alpine package as `libtsm` today.

The build has been green the whole time, so nothing surfaced the staleness.

### Why it matters

A global-buffer-overflow in the dead tree has been re-reported by OSS-Fuzz **ten times over eight years** and never fixed:

`OSV-2016-4`, `OSV-2016-5`, `OSV-2017-121`, `OSV-2017-157`, `OSV-2017-161`, `OSV-2017-167`, [`OSV-2020-1448`](https://osv.dev/vulnerability/OSV-2020-1448), `OSV-2021-289`, `OSV-2021-1373`, `OSV-2024-777`

All are *"Global-buffer-overflow in vte_write_debug"*. They are separate records only because inlining shuffles the second frame between `do_execute`, `do_action`, `csi_dev_attr`, `do_trans` and `send_primary_da`, so the dedup key changes. The `fixed:` commit on those records equals the `introduced:` commit, which is a bisection artifact of a repository that never moves.

It is one line:

```c
static void send_primary_da(struct tsm_vte *vte)
{
	vte_write(vte, "\e[?60;1;6;9;15c", 17);
}
```

The literal is ESC + 14 characters + NUL = 16 bytes, so the hardcoded 17 reads one byte past it on any input carrying a Device Attributes query. Reported downstream in 2015 ([tmux/tmux#49](https://github.com/tmux/tmux/issues/49), freedesktop bug 91335) and fixed in the fork in January 2018 with `sizeof(str) - 1`.

### Changes

- **Dockerfile** — clone `https://github.com/kmscon/libtsm`; install meson + ninja instead of autotools, since the fork moved to meson.
- **build.sh** — drive meson. `LDFLAGS` carries the sanitizer flags and `-Db_lundef=false` is set, because the project declares a `shared_library` and meson otherwise links it with `-Wl,--no-undefined` against a runtime that is not linked into a `.so`. The objects meson emits are archived rather than upstream's source list being duplicated here.
- **libtsm_fuzzer.c** — `tsm_screen_draw_cb`'s first argument widened from `uint32_t` to `uint64_t` between the two trees; the callback signature follows.
- **project.yaml** — `homepage` and `main_repo` point at the new location.

### Verification

Built and run locally, `x86_64` / `libfuzzer` / `address`.

**Before** (current `master`), on a 3-byte input `\e[c`:

```
==7==ERROR: AddressSanitizer: global-buffer-overflow ... READ of size 1
    #0 vte_write_debug /src/libtsm/src/tsm/tsm-vte.c:514:8
    #1 do_trans        /src/libtsm/src/tsm/tsm-vte.c:1858:3
    #2 tsm_vte_input   /src/libtsm/src/tsm/tsm-vte.c
DEDUP_TOKEN: vte_write_debug--do_trans--tsm_vte_input
0x... is located 48 bytes before global variable '.str.131'
```

That `DEDUP_TOKEN` is `OSV-2024-777`'s crash state exactly.

**After** (this PR): the same input exits 0, and a 30-second run completes **195,839 executions** with no crash.

### One thing left for a maintainer

`primary_contact` is unchanged — it is the original author's address and is almost certainly stale, but it is not mine to reassign. A committer on the fork should probably take it over so the reports have somewhere to land.