### PR TITLE
[qt] Don't check out files when cloning

### DIFF
--- a/projects/qt/Dockerfile
+++ b/projects/qt/Dockerfile
@@ -30,9 +30,9 @@ WORKDIR $SRC/qt
 RUN git clone --branch dev --depth 1 git://code.qt.io/qt/qt5.git && \
     cp -r qt5/cmake . && \
     rm -rf qt5
-RUN git clone --branch dev --shallow-since='-6 months' git://code.qt.io/qt/qtbase.git
+RUN git clone --branch dev --no-checkout --shallow-since='-6 months' git://code.qt.io/qt/qtbase.git
 RUN git clone --branch dev --depth 1 git://code.qt.io/qt/qtimageformats.git
-RUN git clone --branch dev --depth 1 git://code.qt.io/qt/qtsvg.git
+RUN git clone --branch dev --no-checkout --depth 1 git://code.qt.io/qt/qtsvg.git
 RUN cmake -DSYNC_TO_MODULE=qtsvg -DSYNC_TO_BRANCH=dev -P cmake/QtSynchronizeRepo.cmake
 RUN git clone --branch dev --depth 1 git://code.qt.io/qt/qtqa.git
 RUN cp qtqa/fuzzing/oss-fuzz/build.sh $SRC/


### PR DESCRIPTION
QtSynchronizeRepo will check out the files after selecting the right revision. This avoids adding files from an unused revision to the Docker image.

Files in qtimageformats are still being checked out while cloning because this repository is not being touched by QtSynchronizeRepo.