### PR TITLE
tensorflow-serving: fix project build at HEAD (Bazel 7.7.0 pin, tensorflow.patch refresh, static libc++)

### DIFF
--- a/projects/tensorflow-serving/build.sh
+++ b/projects/tensorflow-serving/build.sh
@@ -59,8 +59,16 @@ synchronize_coverage_directories() {
 
 git apply  --ignore-space-change --ignore-whitespace $SRC/tensorflow-serving.diff
 
+# Pin the Bazel version the pinned TensorFlow dependency is built with.
+# bazelisk otherwise resolves the latest release (9.x), which no longer reads
+# WORKSPACE repositories, so '@com_google_fuzztest' (required by
+# setup_configs to define --config=oss-fuzz) becomes unresolvable.
+echo "7.7.0" > .bazelversion
+
 bazel run @com_google_fuzztest//bazel:setup_configs >> /etc/bazel.bazelrc
-bazel build --config=oss-fuzz --subcommands --spawn_strategy=sandboxed //tensorflow_serving/util:json_tensor_test_fuzz
+# Link libc++ statically: the hermetic rules_ml_toolchain clang otherwise
+# links its own dynamic libc++.so.1, which base-runner does not ship.
+bazel build --config=oss-fuzz --linkopt=-static-libstdc++ --linkopt=-l:libc++abi.a --subcommands --spawn_strategy=sandboxed //tensorflow_serving/util:json_tensor_test_fuzz
 
 cp bazel-bin/tensorflow_serving/util/json_tensor_test_fuzz $OUT/json_tensor_test_fuzz
 

--- a/projects/tensorflow-serving/tensorflow-serving.diff
+++ b/projects/tensorflow-serving/tensorflow-serving.diff
@@ -79,3 +79,76 @@ index de1203a7..dd18da94 100644
      # ==== TensorFlow Decision Forests ===
      http_archive(
          name = "org_tensorflow_decision_forests",
+
+diff --git a/third_party/tensorflow/tensorflow.patch b/third_party/tensorflow/tensorflow.patch
+index bf11ed6..35feb0a 100644
+--- a/third_party/tensorflow/tensorflow.patch
++++ b/third_party/tensorflow/tensorflow.patch
+@@ -59,18 +59,6 @@ diff --git a/tensorflow/core/platform/rules_cc.bzl b/tensorflow/core/platform/ru
+ +cc_library = cc_library_oss
+  cc_shared_library = _cc_shared_library
+  cc_test = _cc_test
+-diff --git a/tensorflow/core/tfrt/graph_executor/graph_execution_options.h b/tensorflow/core/tfrt/graph_executor/graph_execution_options.h
+---- a/tensorflow/core/tfrt/graph_executor/graph_execution_options.h
+-+++ b/tensorflow/core/tfrt/graph_executor/graph_execution_options.h
+-@@ -144,6 +144,8 @@
+-   // The optional name for debugging purposes. If empty, the runtime will pick a
+-   // name e.g. the joined string of input names and output names.
+-   std::string name;
+-+  std::optional<absl::Time> rpc_deadline_for_batching_task_cancellation;
+-+  std::function<bool()> is_rpc_cancelled_callback;
+- };
+- 
+- // Creates the default `SessionOptions` from a `GraphExecutionOptions`.
+ diff --git a/tensorflow/tensorflow.bzl b/tensorflow/tensorflow.bzl
+ --- a/tensorflow/tensorflow.bzl
+ +++ b/tensorflow/tensorflow.bzl
+@@ -97,32 +85,6 @@ diff --git a/tensorflow/workspace3.bzl b/tensorflow/workspace3.bzl
+  
+      tf_http_archive(
+          name = "io_bazel_rules_closure",
+-diff --git a/third_party/tf_runtime/workspace.bzl b/third_party/tf_runtime/workspace.bzl
+---- a/third_party/tf_runtime/workspace.bzl
+-+++ b/third_party/tf_runtime/workspace.bzl
+-@@ -15,8 +15,8 @@
+-         strip_prefix = "runtime-{commit}".format(commit = TFRT_COMMIT),
+-         urls = tf_mirror_urls("https://github.com/tensorflow/runtime/archive/{commit}.tar.gz".format(commit = TFRT_COMMIT)),
+-         repo_mapping = {
+--            "@tsl": "@tsl",
+--            "@xla": "@xla",
+-+            "@tsl": "@local_tsl",
+-+            "@xla": "@local_xla",
+-         },
+-         # A patch file can be provided for atomic commits to both TF and TFRT.
+-         # The job that bumps the TFRT_COMMIT also resets patch_file to 'None'.
+-diff --git a/third_party/xla/xla/backends/gpu/collectives/gpu_communicator.h b/third_party/xla/xla/backends/gpu/collectives/gpu_communicator.h
+---- a/third_party/xla/xla/backends/gpu/collectives/gpu_communicator.h
+-+++ b/third_party/xla/xla/backends/gpu/collectives/gpu_communicator.h
+-@@ -91,7 +91,7 @@
+- 
+-   // A packed kernel argument type for passing device communicator to device
+-   // kernels (byte storage appropriately sized to fit platform-specific handle).
+--  using PackedKernelArg = std::array<std::byte, 200>;
+-+  using PackedKernelArg = std::array<std::byte, 256>;
+-   virtual PackedKernelArg PackKernelArg() const = 0;
+- 
+-   template <typename Sink>
+ diff --git a/third_party/xla/xla/tsl/cuda/BUILD.bazel b/third_party/xla/xla/tsl/cuda/BUILD.bazel
+ --- a/third_party/xla/xla/tsl/cuda/BUILD.bazel
+ +++ b/third_party/xla/xla/tsl/cuda/BUILD.bazel
+@@ -207,13 +169,14 @@ diff --git a/third_party/xla/xla/tsl/cuda/BUILD.bazel b/third_party/xla/xla/tsl/
+          "@com_google_absl//absl/container:flat_hash_set",
+          "@local_config_cuda//cuda:cuda_headers",
+          "@tsl//tsl/platform:dso_loader",
+-@@ -376,7 +376,7 @@
++@@ -391,8 +391,8 @@
+      visibility = ["//visibility:public"],
+      deps = if_cuda_is_configured([
+          # keep sorted
+ -        "//xla/tsl/platform:logging",
+ +        "//xla/tsl/platform:logging", "//xla/tsl/platform/default:dso_loader",
+          "@com_google_absl//absl/container:flat_hash_set",
++         "@com_google_absl//absl/strings:string_view",
+          "@local_config_cuda//cuda:cuda_headers",
+          "@local_config_nccl//:nccl_headers",
+ @@ -411,7 +411,7 @@


### PR DESCRIPTION
The `tensorflow-serving` project currently fails to build at HEAD. Three independent breaks; all verified fixed by this change (the full `build_image` -> `build_fuzzers --sanitizer address --architecture x86_64` -> `reproduce` sequence passes afterwards):

1. **Bazel 9.x dropped WORKSPACE repositories.** bazelisk resolves the latest release, in which `@com_google_fuzztest` (required by `setup_configs` to define `--config=oss-fuzz`) is unresolvable. Fix: pin `.bazelversion` to 7.7.0 — the version the pinned TF commit (`2f504bd`) builds with.

2. **`third_party/tensorflow/tensorflow.patch` is stale against serving's own TF pin** (tensorflow/serving@549f7a1 pins `2f504bd`): 3 hunks no longer apply (the `graph_execution_options.h` fields, the `tf_runtime` `repo_mapping` block, and the `gpu_communicator.h` `PackedKernelArg` alias all changed upstream) and 1 hunk needs a context refresh (`absl/strings:string_view` inserted in `xla/tsl/cuda/BUILD.bazel`). The `org_tensorflow` repository fetch fails with `CONTENT_DOES_NOT_MATCH_TARGET` otherwise. Fix: refresh the patch inside `tensorflow-serving.diff`.

3. **Binaries link a dynamic `libc++.so.1`** from the hermetic `rules_ml_toolchain`, which base-runner does not ship — fuzzers fail to load at run time (`error while loading shared libraries: libc++.so.1`). Fix: `-static-libstdc++ -l:libc++abi.a`.

After these, the existing `json_tensor_test_fuzz@JsonFuzzTest.TheF` target builds and loads in base-runner (verified), and out-of-tree REST-JSON harnesses over `Fill{Predict,Classification,Regression}RequestFromJson` reproduce the known unbounded-recursion crash under ASAN (`tensorflow_serving/util/json_tensor.cc:393` in `FillTensorProto`, the parse-side half of CVE-2025-0649) — relevant context for #15357 and tensorflow/serving#4143, which add such targets but currently cannot build on top of the project as-is.
