### PR TITLE
Add hyper-compress project

### DIFF
--- a/projects/hyper-compress/Dockerfile
+++ b/projects/hyper-compress/Dockerfile
@@ -1,0 +1,10 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN git clone --depth 1 \
+    https://chromium.googlesource.com/chromium/tools/depot_tools.git \
+    /opt/depot_tools
+ENV PATH="/opt/depot_tools:${PATH}"
+
+RUN git clone --depth 1 https://github.com/alam00000/bentopdf-hyper-compress.git $SRC/hyper-compress
+WORKDIR $SRC/hyper-compress
+COPY build.sh $SRC/

--- a/projects/hyper-compress/build.sh
+++ b/projects/hyper-compress/build.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -eu
+
+PIN=162c9521f74c17bb0c8595608f23ab22cec3d407
+ENGINE=$SRC/hyper-compress
+CHECKOUT=$SRC/pdfium-checkout
+
+mkdir -p "$CHECKOUT"
+cd "$CHECKOUT"
+if [ ! -d pdfium ]; then
+  gclient config --unmanaged https://pdfium.googlesource.com/pdfium.git
+  gclient sync --revision "pdfium@$PIN" -D --no-history
+fi
+
+"$ENGINE/core/build/apply-sources.sh" "$CHECKOUT/pdfium"
+
+cd "$CHECKOUT/pdfium"
+OUTDIR=out/ossfuzz
+mkdir -p "$OUTDIR"
+GN_SAN="is_asan=true"
+case "${SANITIZER:-address}" in
+  undefined) GN_SAN="is_ubsan_security=true" ;;
+  coverage)  GN_SAN="" ;;
+esac
+cat > "$OUTDIR/args.gn" <<ARGS
+is_debug = false
+treat_warnings_as_errors = false
+pdf_use_skia = false
+pdf_enable_xfa = false
+pdf_enable_v8 = false
+pdf_enable_brotli = true
+is_component_build = false
+clang_use_chrome_plugins = false
+pdf_is_standalone = true
+pdf_is_complete_lib = true
+pdf_use_partition_alloc = false
+use_custom_libcxx = false
+use_sysroot = true
+symbol_level = 1
+target_os = "linux"
+target_cpu = "x64"
+$GN_SAN
+ARGS
+buildtools/linux64/gn gen "$OUTDIR" --root=.
+third_party/ninja/ninja -C "$OUTDIR" pdfium
+
+$CXX $CXXFLAGS -std=c++17   -I"$ENGINE/sdk/native/include"   -c "$ENGINE/fuzz/jpegli_stub.cc" -o /tmp/jpegli_stub.o
+
+$CXX $CXXFLAGS -std=c++17   -I"$ENGINE/sdk/native/include"   "$ENGINE/fuzz/fuzz_compress.cc" /tmp/jpegli_stub.o   -Wl,--whole-archive "$OUTDIR/obj/libpdfium.a" -Wl,--no-whole-archive   $LIB_FUZZING_ENGINE   -o "$OUT/fuzz_compress"
+
+cd "$ENGINE"
+zip -j "$OUT/fuzz_compress_seed_corpus.zip" fuzz/corpus/*

--- a/projects/hyper-compress/project.yaml
+++ b/projects/hyper-compress/project.yaml
@@ -1,0 +1,11 @@
+homepage: "https://github.com/alam00000/bentopdf-hyper-compress"
+language: c++
+primary_contact: "abdullahtapadar01@gmail.com"
+main_repo: "https://github.com/alam00000/bentopdf-hyper-compress"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+  - undefined
+architectures:
+  - x86_64


### PR DESCRIPTION
Hyper Compress is the PDF compression engine behind BentoPDF (https://github.com/alam00000/bentopdf). It's a PDFium-based native engine that parses and rewrites untrusted PDFs, so fuzzing is a natural fit.

Source: https://github.com/alam00000/bentopdf-hyper-compress (AGPL-3.0).

The fuzz target covers document load and the full compression pass with libFuzzer. The build pulls the pinned PDFium checkout with gclient, same as our CI. A seed corpus is included, and crashers we've found before are kept as regression seeds.

I'm the maintainer; abdullahtapadar01@gmail.com is my Google account for ClusterFuzz access.
