### PR TITLE
bitcoin: enable IPC fuzz target

### DIFF
--- a/projects/bitcoin-core/Dockerfile
+++ b/projects/bitcoin-core/Dockerfile
@@ -20,7 +20,7 @@ FROM gcr.io/oss-fuzz-base/base-builder
 # * https://github.com/bitcoin/bitcoin/blob/master/doc/build-unix.md#dependencies
 # * https://github.com/bitcoin/bitcoin/blob/master/depends/README.md#for-linux-including-i386-arm-cross-compilation
 RUN apt-get update && apt-get install -y \
-  build-essential curl g++-multilib make \
+  build-essential curl g++-10 g++-multilib make \
   patch python3 zip
 
 RUN git clone --depth=1 https://github.com/bitcoin/bitcoin.git bitcoin-core

--- a/projects/bitcoin-core/Dockerfile
+++ b/projects/bitcoin-core/Dockerfile
@@ -18,9 +18,9 @@ FROM gcr.io/oss-fuzz-base/base-builder
 
 # Packages taken from:
 # * https://github.com/bitcoin/bitcoin/blob/master/doc/build-unix.md#dependencies
-# * https://github.com/bitcoin/bitcoin/blob/master/depends/README.md#for-linux-including-i386-arm-cross-compilation
+# * https://github.com/bitcoin/bitcoin/blob/master/depends/README.md#ubuntu--debian
 RUN apt-get update && apt-get install -y \
-  build-essential curl g++-10 g++-multilib make \
+  build-essential curl g++-10 make \
   patch python3 zip
 
 RUN git clone --depth=1 https://github.com/bitcoin/bitcoin.git bitcoin-core

--- a/projects/bitcoin-core/build.sh
+++ b/projects/bitcoin-core/build.sh
@@ -39,11 +39,10 @@ export CPPFLAGS="-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -DBOOST_M
 (
   cd depends
   sed -i --regexp-extended '/.*rm -rf .*extract_dir.*/d' ./funcs.mk  # Keep extracted source
-  # Disable IPC until a fuzz test actually needs it
-  # At that point, as workaround can be added to remove capnps
-  # internal oss-fuzz detection: https://github.com/google/oss-fuzz/pull/14203#issuecomment-3461008642
+  # Prevent Cap'n Proto from building its own OSS-Fuzz target.
+  unset LIB_FUZZING_ENGINE
   make HOST=$BUILD_TRIPLET DEBUG=1 NO_QT=1 NO_ZMQ=1 NO_USDT=1 \
-       NO_IPC=1 \
+       build_CC=gcc-10 build_CXX=g++-10 \
        AR=llvm-ar NM=llvm-nm RANLIB=llvm-ranlib STRIP=llvm-strip \
        -j$(nproc)
 )


### PR DESCRIPTION
Bitcoin added an ipc fuzz target in https://github.com/bitcoin/bitcoin/pull/35118.

This PR enables ipc dependencies in the oss-fuzz build, so this target is included.
  
Also unsets `LIB_FUZZING_ENGINE` while building dependencies to prevent `capnp` from enabling its own oss-fuzz targets. Because this happens in a subshell, the fuzzing engine remains available when linking Bitcoin's fuzz binary.

Now uses clang for native build tools because the default GCC version is outdated for the `capnp` build