### PR TITLE
Add yaraast Python fuzzing project

### DIFF
--- a/projects/yaraast/Dockerfile
+++ b/projects/yaraast/Dockerfile
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright 2026 The YARA AST Project Authors. All rights reserved.
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/yaraast/Dockerfile
+++ b/projects/yaraast/Dockerfile
@@ -1,0 +1,21 @@
+################################################################################
+# Copyright 2026 The YARA AST Project Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-python
+
+RUN python3 -m pip install --no-cache-dir pyinstaller
+RUN git clone --depth 1 https://github.com/seifreed/yaraast.git "$SRC/yaraast"
+WORKDIR "$SRC/yaraast"

--- a/projects/yaraast/build.sh
+++ b/projects/yaraast/build.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -eu
+
+################################################################################
+# Copyright 2026 The YARA AST Project Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+python3 -m pip install .
+
+for target in parser roundtrip; do
+  pyinstaller --distpath "$OUT" --onefile \
+    --name "yaraast_${target}_fuzzer.pkg" "fuzz/run_${target}_fuzz.py"
+  cat > "$OUT/yaraast_${target}_fuzzer" <<EOF
+#!/bin/sh
+exec "\$(dirname "\$0")/yaraast_${target}_fuzzer.pkg" "\$@"
+EOF
+  chmod +x "$OUT/yaraast_${target}_fuzzer"
+done

--- a/projects/yaraast/build.sh
+++ b/projects/yaraast/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 ################################################################################
-# Copyright 2026 The YARA AST Project Authors. All rights reserved.
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/yaraast/project.yaml
+++ b/projects/yaraast/project.yaml
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright 2026 The YARA AST Project Authors. All rights reserved.
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/yaraast/project.yaml
+++ b/projects/yaraast/project.yaml
@@ -1,0 +1,28 @@
+################################################################################
+# Copyright 2026 The YARA AST Project Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+homepage: "https://github.com/seifreed/yaraast"
+language: python3
+primary_contact: "mriverolopez@gmail.com"
+main_repo: "https://github.com/seifreed/yaraast.git"
+auto_ccs:
+  - "mriverolopez@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+  - undefined
+file_github_issue: true


### PR DESCRIPTION
## Summary

Add YaraAST as a Python OSS-Fuzz project with parser and accepted-input round-trip fuzzers.

The project-owned fuzz harnesses remain in the YaraAST repository under `fuzz/`. This PR adds
the OSS-Fuzz metadata, Python builder image, and PyInstaller wrappers required by the Python
integration contract.

## Validation

- `bash -n oss-fuzz/build.sh`
- YaraAST OSS-Fuzz configuration validator
- Parser and round-trip fuzz target regression tests
- Static project metadata checks

The Docker helper build was started locally, but the base image download did not finish in the
available environment. OSS-Fuzz CI should run the authoritative build checks.
