### PR TITLE
[tensorflow] Build the TFLite interpreter fuzz target

### DIFF
--- a/projects/tensorflow/build.sh
+++ b/projects/tensorflow/build.sh
@@ -209,7 +209,7 @@ export FUZZTEST_DO_SYNC="no"
 
 # Set fuzz targets. Exclude cc/ops and core/kernels/fuzzing as they depend on
 # ops::Placeholder which was removed from TF's C++ ops API.
-export FUZZTEST_TARGET_FOLDER="//tensorflow/security/fuzzing/cc:all+//tensorflow/cc/saved_model/...+//tensorflow/cc/framework/fuzzing/...+//tensorflow/core/common_runtime/...+//tensorflow/core/framework/..."
+export FUZZTEST_TARGET_FOLDER="//tensorflow/security/fuzzing/cc:all+//tensorflow/cc/saved_model/...+//tensorflow/cc/framework/fuzzing/...+//tensorflow/core/common_runtime/...+//tensorflow/core/framework/...+//tensorflow/lite/fuzzing:all"
 
 # Remove the cc/ops BUILD file - those fuzzers use removed Placeholder API
 rm -f $SRC/tensorflow/tensorflow/security/fuzzing/cc/ops/BUILD


### PR DESCRIPTION
### Why this is needed

[tensorflow/tensorflow#126109](https://github.com/tensorflow/tensorflow/pull/126109) added `tensorflow/lite/fuzzing/interpreter_fuzz.cc` — the **first OSS-Fuzz harness for the TensorFlow Lite runtime**. It merged into TensorFlow `master` on 2026-08-27 as [`cf6867d`](https://github.com/tensorflow/tensorflow/commit/cf6867de5f11354b0c58f71909e1b6895e20cccf).

That harness is currently dead code as far as OSS-Fuzz is concerned:

* `projects/tensorflow/Dockerfile` already does `git clone --depth 1 .../tensorflow`, so the new source **is** in the build context.
* `projects/tensorflow/build.sh` exports `FUZZTEST_TARGET_FOLDER`, which `compile_fuzztests.sh` passes to `bazel query`/`bazel cquery` to discover fuzz targets.
* `//tensorflow/lite/...` is not in that list, so the query never sees `interpreter_fuzz`. It is silently skipped — no build error, no target.

This one-line change adds `//tensorflow/lite/fuzzing:all` so the target is discovered and built.

### Why scoped to `:all` on one package

`//tensorflow/lite/...` would recurse the entire TFLite tree and pull in unrelated `cc_test` targets that happen to depend on fuzztest. Scoping to the `fuzzing` package keeps discovery tight and stays correct as more TFLite harnesses are added alongside this one.

### What it covers

TFLite previously had **zero** OSS-Fuzz coverage. The harness drives the interpreter end to end — `VerifyAndBuildFromBuffer` → `InterpreterBuilder` → `AllocateTensors()` → `Invoke()` — which reaches the builtin kernel implementations, the arena planner, and the shape-propagation paths. It uses `BuiltinOpResolverWithoutDefaultDelegates` so it exercises reference/optimized CPU kernels rather than a delegate, and caps model size at 1 MiB and total input tensor bytes at 64 MiB to stay inside the OSS-Fuzz memory budget.

### Verification

The resulting target is named `interpreter_fuzz@TfLiteFuzz.FuzzInterpreter`, per the `{binary}@{entrypoint}` convention that `compile_fuzztests.sh` uses for fuzztest entrypoints:

```
$ python3 infra/helper.py build_image tensorflow
$ python3 infra/helper.py build_fuzzers --sanitizer address --architecture x86_64 tensorflow
$ ls build/out/tensorflow/ | grep interpreter_fuzz
```

`project.yaml` is unchanged — the existing `address`/`undefined` sanitizers and `libfuzzer` engine apply.
