### PR TITLE
abseil-cpp: fix stale-variable round-trip checks in string_escape_fuzzer

### DIFF
--- a/projects/abseil-cpp/string_escape_fuzzer.cc
+++ b/projects/abseil-cpp/string_escape_fuzzer.cc
@@ -44,7 +44,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 	std::string encoded, decoded;
 	absl::Base64Escape(str, &encoded);
 	absl::Base64Unescape(encoded, &decoded);
-	if (str != unescaped)
+	if (str != decoded)
 		abort();
 
 	absl::WebSafeBase64Escape(str, &encoded);
@@ -55,7 +55,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 	std::string hex_result, bytes_result;
 	hex_result = absl::BytesToHexString(str);
 	bytes_result = absl::HexStringToBytes(hex_result);
-	if (str != decoded)
+	if (str != bytes_result)
 		abort();
 
 	return 0;


### PR DESCRIPTION
The Base64 and hex round-trip checks compared variables not written by the transformation under test (`unescaped` instead of `decoded`, and `decoded` instead of `bytes_result`), and each was pinned true by the immediately preceding check, so neither `abort()` was reachable. Fixes #16078.

🤖 Generated with [Claude Code](https://claude.com/claude-code)