### PR TITLE
cairo: fix fuzz-introspector integration

### DIFF
--- a/projects/cairo/Dockerfile
+++ b/projects/cairo/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 ################################################################################
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 RUN apt-get update && \
     apt-get install -y python3-pip gtk-doc-tools libffi-dev autotools-dev libtool gperf
 RUN pip3 install -U meson==1.6.0 ninja packaging

--- a/projects/cairo/Dockerfile
+++ b/projects/cairo/Dockerfile
@@ -21,6 +21,23 @@ RUN pip3 install -U meson==1.6.0 ninja packaging
 RUN git clone --depth 1 https://gitlab.freedesktop.org/cairo/cairo.git && \
     zip -q $SRC/cairo_seed_corpus.zip $SRC/cairo/test/reference/* && \
     zip -q $SRC/svg-render-fuzzer_seed_corpus.zip $SRC/cairo/test/svg/*.svg
+RUN cd cairo && meson subprojects download
+
+# pre-install all dependencies into /deps to exclude them from fuzz-introspector
+RUN mkdir /deps && cd cairo && \
+    meson subprojects foreach \
+        meson setup \
+            --prefix=/deps \
+            --libdir=lib \
+            --default-library=static \
+            -Db_lundef=false \
+            _builddir && \
+    meson subprojects foreach \
+        ninja -C _builddir && \
+    meson subprojects foreach \
+        ninja -C _builddir install
+# *convince* fuzz-introspector not to analyze all harnesses in subprojects
+RUN rm -rf cairo/subprojects/*
 
 ADD https://raw.githubusercontent.com/google/fuzzing/master/dictionaries/png.dict $SRC/cairo.dict
 ADD https://raw.githubusercontent.com/google/fuzzing/master/dictionaries/svg.dict $SRC/svg-render-fuzzer.dict

--- a/projects/cairo/Dockerfile
+++ b/projects/cairo/Dockerfile
@@ -16,10 +16,8 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && \
     apt-get install -y python3-pip gtk-doc-tools libffi-dev autotools-dev libtool gperf
-RUN pip3 install -U meson==1.4.0 ninja packaging
+RUN pip3 install -U meson==1.6.0 ninja packaging
 
-RUN git clone --depth 1 git://git.sv.nongnu.org/freetype/freetype2.git
-RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/glib
 RUN git clone --depth 1 https://gitlab.freedesktop.org/cairo/cairo.git && \
     zip -q $SRC/cairo_seed_corpus.zip $SRC/cairo/test/reference/* && \
     zip -q $SRC/svg-render-fuzzer_seed_corpus.zip $SRC/cairo/test/svg/*.svg

--- a/projects/cairo/build.sh
+++ b/projects/cairo/build.sh
@@ -40,12 +40,14 @@ if [[ "$SANITIZER" == introspector ]]; then
     # https://github.com/mesonbuild/meson/issues/6377#issuecomment-575977919
     MESON_CFLAGS="${CFLAGS//-fuse-ld=gold/ }"
     MESON_CXXFLAGS="${CXXFLAGS//-fuse-ld=gold/ }"
+    MESON_OPTIONS="-Db_lto=true"
 
     export CC_LD=gold
     export CXX_LD=gold
 else
     MESON_CFLAGS=$CFLAGS
     MESON_CXXFLAGS=$CXXFLAGS
+    MESON_OPTIONS=""
 fi
 
 # Build cairo
@@ -58,6 +60,7 @@ CXXFLAGS=MESON_CXXFLAGS meson \
     --default-library=static \
     -Db_lundef=false \
     --wrap-mode=nofallback \
+    $MESON_OPTIONS \
     _builddir
 ninja -C _builddir
 ninja -C _builddir install

--- a/projects/cairo/build.sh
+++ b/projects/cairo/build.sh
@@ -14,47 +14,48 @@
 # limitations under the License.
 #
 ################################################################################
+
+# For fuzz-introspector, exclude all external code from reports
+export FUZZ_INTROSPECTOR_CONFIG=$SRC/fuzz_introspector_exclusion.config
+cat > $FUZZ_INTROSPECTOR_CONFIG <<EOF
+FILES_TO_AVOID
+cairo/subprojects
+EOF
+
 PREFIX=$WORK/prefix
-mkdir -p $PREFIX
 
 export PKG_CONFIG="`which pkg-config` --static"
 export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig
 export PATH=$PREFIX/bin:$PATH
 
-BUILD=$WORK/build
-
+# BUILD=$WORK/build
 rm -rf $WORK/*
-rm -rf $BUILD
-mkdir -p $BUILD
 
-# Build glib
-pushd $SRC/glib/
-meson \
+# dirty fix #1: tell meson to use gold on fuzz-introspector builds
+# https://github.com/google/oss-fuzz/pull/7583#issuecomment-1104011067
+if [[ "$SANITIZER" == introspector ]]; then
+    # -fuse-ld=gold can't be passed via CFLAGS/CXXFLAGS/LDFLAGS due to
+    # https://github.com/mesonbuild/meson/issues/6377 and
+    # https://github.com/mesonbuild/meson/issues/6377#issuecomment-575977919
+    MESON_CFLAGS="${CFLAGS//-fuse-ld=gold/ }"
+    MESON_CXXFLAGS="${CXXFLAGS//-fuse-ld=gold/ }"
+
+    export CC_LD=gold
+    export CXX_LD=gold
+else
+    MESON_CFLAGS=$CFLAGS
+    MESON_CXXFLAGS=$CXXFLAGS
+fi
+
+# Build cairo
+pushd $SRC/cairo
+CFLAGS="-DDEBUG_SVG_RENDER $MESON_CFLAGS" \
+CXXFLAGS=MESON_CXXFLAGS meson \
     setup \
     --prefix=$PREFIX \
     --libdir=lib \
     --default-library=static \
     -Db_lundef=false \
-    -Doss_fuzz=enabled \
-    -Dlibmount=disabled \
-    _builddir
-ninja -C _builddir
-ninja -C _builddir install
-popd
-
-pushd $SRC/freetype2
-./autogen.sh
-./configure --prefix="$PREFIX" --disable-shared PKG_CONFIG_PATH="$PKG_CONFIG_PATH"
-make -j$(nproc)
-make install
-
-# Build cairo
-pushd $SRC/cairo
-CFLAGS="-DDEBUG_SVG_RENDER $CFLAGS" meson \
-    setup \
-    --prefix=$PREFIX \
-    --libdir=lib \
-    --default-library=static \
     _builddir
 ninja -C _builddir
 ninja -C _builddir install
@@ -75,7 +76,7 @@ fi
 PREDEPS_LDFLAGS="-Wl,-Bdynamic -ldl -lm -lc -pthread -lrt -lpthread"
 DEPS="gmodule-2.0 glib-2.0 gio-2.0 gobject-2.0 freetype2 cairo cairo-gobject cairo-script-interpreter"
 BUILD_CFLAGS="$CFLAGS `pkg-config --static --cflags $DEPS` -I$SRC/fuzz"
-BUILD_LDFLAGS="-Wl,-static `pkg-config --static --libs $DEPS`"
+BUILD_LDFLAGS="`pkg-config --static --libs $DEPS`"
 
 fuzzers=$(find $SRC/fuzz/ -name "*_fuzzer.c")
 for f in $fuzzers ; do
@@ -104,3 +105,6 @@ for f in $SRC/cairo/test/svg/fuzzer/svg-render-fuzzer.c ; do
     $LIB_FUZZING_ENGINE \
     -Wl,-Bdynamic
 done
+
+# dirty fix #2: delete subprojects to speed up analysis
+rm -rf $SRC/cairo/subprojects/*

--- a/projects/cairo/build.sh
+++ b/projects/cairo/build.sh
@@ -19,19 +19,20 @@
 export FUZZ_INTROSPECTOR_CONFIG=$SRC/fuzz_introspector_exclusion.config
 cat > $FUZZ_INTROSPECTOR_CONFIG <<EOF
 FILES_TO_AVOID
-cairo/subprojects
+subprojects
 EOF
 
 PREFIX=$WORK/prefix
+CAIRO_DEPS=/deps
 
 export PKG_CONFIG="`which pkg-config` --static"
-export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig
-export PATH=$PREFIX/bin:$PATH
+export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig:$CAIRO_DEPS/lib/pkgconfig
+export PATH=$PREFIX/bin:$CAIRO_DEPS/bin:$PATH
 
 # BUILD=$WORK/build
 rm -rf $WORK/*
 
-# dirty fix #1: tell meson to use gold on fuzz-introspector builds
+# workaround: tell meson to use gold on fuzz-introspector builds
 # https://github.com/google/oss-fuzz/pull/7583#issuecomment-1104011067
 if [[ "$SANITIZER" == introspector ]]; then
     # -fuse-ld=gold can't be passed via CFLAGS/CXXFLAGS/LDFLAGS due to
@@ -56,6 +57,7 @@ CXXFLAGS=MESON_CXXFLAGS meson \
     --libdir=lib \
     --default-library=static \
     -Db_lundef=false \
+    --wrap-mode=nofallback \
     _builddir
 ninja -C _builddir
 ninja -C _builddir install
@@ -106,5 +108,5 @@ for f in $SRC/cairo/test/svg/fuzzer/svg-render-fuzzer.c ; do
     -Wl,-Bdynamic
 done
 
-# dirty fix #2: delete subprojects to speed up analysis
-rm -rf $SRC/cairo/subprojects/*
+# copy deps into $OUT so fuzz-introspector can see the header files
+rsync -avr $CAIRO_DEPS/ $OUT/deps

--- a/projects/cairo/build.sh
+++ b/projects/cairo/build.sh
@@ -53,7 +53,7 @@ fi
 # Build cairo
 pushd $SRC/cairo
 CFLAGS="-DDEBUG_SVG_RENDER $MESON_CFLAGS" \
-CXXFLAGS=MESON_CXXFLAGS meson \
+CXXFLAGS=$MESON_CXXFLAGS meson \
     setup \
     --prefix=$PREFIX \
     --libdir=lib \

--- a/projects/cairo/project.yaml
+++ b/projects/cairo/project.yaml
@@ -18,3 +18,4 @@ fuzzing_engines:
   - honggfuzz
   - libfuzzer
 
+base_os_version: ubuntu-24-04


### PR DESCRIPTION
Fuzz introspector builds of cairo were [broken since Feb. 2025](https://introspector.oss-fuzz.com/project-profile?project=cairo), presumably due to an incompatibility with the meson build system. Fix this by removing `-fuse-ld=gold` from `CFLAGS` (as discussed in #7583).

The second important change is that I moved all external dependencies to build in the Dockerfile. This is [recommended by fuzz-introspector](https://fuzz-introspector.readthedocs.io/en/latest/user-guides/control-instrumentation.html) to focus reports on the actual target code, instead of diluting coverage data with dependency code.

I intend to use the now-working fuzz-introspector analysis for some harness improvements (still working on that).