### PR TITLE
infra: avoid excessive objdump calls and adjust all.sh

### DIFF
--- a/infra/base-images/all.sh
+++ b/infra/base-images/all.sh
@@ -33,19 +33,26 @@
 # The first argument is the version tag, e.g., 'latest', 'ubuntu-20-04'.
 VERSION_TAG=${1:-latest}
 
-# Get the directory where this script is located to find the helper script.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-
-# Fetch the official list of images from the Python source of truth.
-# This avoids duplicating the image list and ensures this script is always
-# up-to-date.
-IMAGE_LIST=$(python3 "${SCRIPT_DIR}/list_images.py")
+IMAGE_LIST=(
+    "base-clang"
+    "base-builder"
+    "base-builder-go"
+    "base-builder-javascript"
+    "base-builder-jvm"
+    "base-builder-python"
+    "base-builder-ruby"
+    "base-builder-rust"
+    "base-builder-swift"
+    "base-runner"
+    "base-runner-debug"
+    "indexer"
+)
 
 echo "Building version: ${VERSION_TAG}"
 echo "Images to build: ${IMAGE_LIST}"
 
 # Loop through the official list of images and build each one.
-for image_name in ${IMAGE_LIST}; do
+for image_name in ${IMAGE_LIST[@]}; do
   image_dir="infra/base-images/${image_name}"
   
   if [ "${VERSION_TAG}" == "latest" ]; then

--- a/infra/base-images/base-runner/bad_build_check
+++ b/infra/base-images/base-runner/bad_build_check
@@ -354,10 +354,19 @@ function check_mixed_sanitizers {
     echo "UNSUPPORTED ARCHITECTURE"
     exit 1
   fi
-  local ASAN_CALLS=$(objdump -dC $FUZZER | egrep "${CALL_INSN}__asan" -c)
-  local DFSAN_CALLS=$(objdump -dC $FUZZER | egrep "${CALL_INSN}__dfsan" -c)
-  local MSAN_CALLS=$(objdump -dC $FUZZER | egrep "${CALL_INSN}__msan" -c)
-  local UBSAN_CALLS=$(objdump -dC $FUZZER | egrep "${CALL_INSN}__ubsan" -c)
+  # Disassemble once and count all four sanitizers in the same pass. Running
+  # `objdump -dC` four times over the same binary is wasteful: fuzz targets are
+  # frequently hundreds of MB, and the disassembly dominates the cost of this
+  # check.
+  local ASAN_CALLS DFSAN_CALLS MSAN_CALLS UBSAN_CALLS
+  read ASAN_CALLS DFSAN_CALLS MSAN_CALLS UBSAN_CALLS < <(
+      objdump -dC $FUZZER | \
+          grep -Eo "${CALL_INSN}__(asan|dfsan|msan|ubsan)" | \
+          awk '/__asan$/  { a++ }
+               /__dfsan$/ { d++ }
+               /__msan$/  { m++ }
+               /__ubsan$/ { u++ }
+               END        { print a+0, d+0, m+0, u+0 }')
 
 
   if [[ "$SANITIZER" = address ]]; then

--- a/infra/indexer/frontend/ast_visitor.cc
+++ b/infra/indexer/frontend/ast_visitor.cc
@@ -36,7 +36,17 @@
 #include "clang/AST/PrettyPrinter.h"
 #include "clang/AST/TemplateBase.h"
 #include "clang/AST/Type.h"
+// Upstream renamed clang/Basic/TypeTraits.h to clang/Basic/BuiltinTraits.h
+// during LLVM 24 development. The indexer is integrated against a newer LLVM
+// than the revision base-clang pins (see OUR_LLVM_REVISION in
+// infra/base-images/base-clang/checkout_build_install_llvm.sh), so accept
+// either spelling instead of requiring the two to move in lockstep.
+// Ref: https://github.com/google/oss-fuzz/commit/0f4d4d3004beb4946db46905163b1638777395a9#commitcomment-198554014
+#if __has_include("clang/Basic/BuiltinTraits.h")
 #include "clang/Basic/BuiltinTraits.h"
+#else
+#include "clang/Basic/TypeTraits.h"
+#endif
 #include "clang/Basic/FileEntry.h"
 #include "clang/Basic/OperatorKinds.h"
 #include "clang/Basic/SourceLocation.h"


### PR DESCRIPTION
We're currently doing excessive objdump calls in the bad build check. We only need it once to calculate the sanitizer keywords.

Also adjust all.sh so it's no longer needed to set up specific Python packages to build the base images. This also makes it very easy to quickly adjust which base images to build by modifying the file. This is how it was earlier which IMO works better when adjusting the base images.