### PR TITLE
fwupd: Fix build to include rust modules

### DIFF
--- a/projects/fwupd/Dockerfile
+++ b/projects/fwupd/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder-rust
 RUN apt-get update && apt-get install -y pkg-config zlib1g-dev libffi-dev liblzma-dev libcbor-dev
 RUN python3 -m pip install -U jinja2 packaging meson ninja
 RUN git clone --depth 1 https://github.com/fwupd/fwupd.git fwupd


### PR DESCRIPTION
This PR fixes the base docker image for project fwupd. Since 27th August, the upstream fwupd repository includes the rust cargo build process as part of the fuzzer build. But the base building image has no cargo installed and cause building error from 27th August. this PR fixes the problem but switching the base building to the rust alternative to accommodate the new rust cargo build process enabled from the upstream repository.