### PR TITLE
projects/aegis-p2p: add AEGIS-P2P fuzzing integration

### DIFF
--- a/projects/aegis-p2p/Dockerfile
+++ b/projects/aegis-p2p/Dockerfile
@@ -1,0 +1,20 @@
+﻿# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+RUN git clone --depth 1 https://github.com/AresMaxima/aegis-p2p aegis-p2p
+WORKDIR aegis-p2p/aegis-core
+COPY build.sh $SRC/

--- a/projects/aegis-p2p/build.sh
+++ b/projects/aegis-p2p/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cargo fuzz build fuzz_ingest_frame
+cp target/x86_64-unknown-linux-gnu/release/fuzz_ingest_frame $OUT/

--- a/projects/aegis-p2p/project.yaml
+++ b/projects/aegis-p2p/project.yaml
@@ -1,0 +1,25 @@
+﻿# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+homepage: "https://github.com/AresMaxima/aegis-p2p"
+language: rust
+primary_contact: "security@aegis-p2p.org"
+main_repo: "https://github.com/AresMaxima/aegis-p2p"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+  - undefined


### PR DESCRIPTION
This PR adds AEGIS-P2P (AresMaxima) to Google OSS-Fuzz for continuous fuzzing of post-quantum network frames.