### PR TITLE
noyalib: initial integration

### DIFF
--- a/projects/noyalib/Dockerfile
+++ b/projects/noyalib/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+RUN git clone --depth 1 https://github.com/sebastienrousseau/noyalib noyalib
+WORKDIR noyalib
+COPY build.sh $SRC/

--- a/projects/noyalib/build.sh
+++ b/projects/noyalib/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+cd "$SRC/noyalib/fuzz"
+
+cargo fuzz build -O --debug-assertions
+
+# Every [[bin]] in fuzz/Cargo.toml is a target; ship each with the
+# shared seed corpus and the YAML dictionary.
+FUZZ_TARGET_OUTPUT_DIR="target/x86_64-unknown-linux-gnu/release"
+for f in fuzz_targets/*.rs; do
+  target=$(basename "$f" .rs)
+  cp "$FUZZ_TARGET_OUTPUT_DIR/$target" "$OUT/"
+  zip -q -j "$OUT/${target}_seed_corpus.zip" corpus/seed/*
+  cp yaml.dict "$OUT/${target}.dict"
+done

--- a/projects/noyalib/project.yaml
+++ b/projects/noyalib/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/sebastienrousseau/noyalib"
+main_repo: "https://github.com/sebastienrousseau/noyalib"
+language: rust
+primary_contact: "sebastian.rousseau@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+vendor_ccs: []


### PR DESCRIPTION
Initial OSS-Fuzz integration for [noyalib](https://github.com/sebastienrousseau/noyalib), a pure-Rust YAML 1.2 library (serde data binding plus lossless CST editing, `#![forbid(unsafe_code)]`, 406/406 on the official YAML test suite).

12 libFuzzer targets via cargo fuzz (parser, round-trip, CST editors, strict/1.1 modes, differential), each with a seed corpus and YAML dictionary. I am the primary maintainer; the contact email matches my commit identity.

Verified locally: the project image builds and `compile` succeeds in it (x86_64, ASan): all 12 targets build and ship with corpus + dict. The run check needs your x86_64 CI: this was verified on an Apple Silicon host where x86_64 ASan binaries cannot execute under emulation. Each target runs clean natively via cargo fuzz.