### PR TITLE
skia: fix build

### DIFF
--- a/projects/skia/build.sh
+++ b/projects/skia/build.sh
@@ -48,6 +48,7 @@ SKIA_ARGS="skia_build_fuzzers=true
            skia_use_freetype=true
            skia_use_system_freetype2=false
            skia_use_wuffs=true
+           skia_use_partition_alloc=false
            skia_provide_default_fuzz_engine=false"
 
 # Even though GPU is "enabled" for all these builds, none really


### PR DESCRIPTION
Skia already intends to disable the shim under sanitizers (build_overrides/partition_alloc.gni: "Sanitizers replace the allocator, don't replace it ourselves"), but that guard tests the sanitize GN arg, which OSS-Fuzz never sets — it passes -fsanitize= via extra_cflags. The flag forces the outcome Skia already wanted