### PR TITLE
connectedhomeip: enable the ICD server for the fuzz build

### DIFF
--- a/projects/connectedhomeip/build.sh
+++ b/projects/connectedhomeip/build.sh
@@ -91,9 +91,9 @@ fi
 #   error on GenericConnectivityManagerImpl_Thread.ipp and current fuzzing
 #   does not differentiate between thread/Wifi/TCP/UDP/BLE connectivity
 #   implementations.
-# - `chip_enable_icd_server` / `chip_enable_icd_lit` enable the ICD server and the
-#   Check-In Protocol, without which the ICD Management cluster command handlers
-#   are not compiled and the fuzz target covering them is configured out.
+# - `chip_enable_icd_server` / `chip_enable_icd_checkin` enable the ICD server and
+#   the Check-In Protocol, without which the ICD Management cluster command
+#   handlers are not compiled and the fuzz target covering them is configured out.
 # - `target_ldflags` forces compiler to use LLVM's linker
 gn gen out/fuzz_targets \
   --args="
@@ -104,7 +104,7 @@ gn gen out/fuzz_targets \
     chip_enable_thread_safety_checks=false \
     chip_enable_thread=false \
     chip_enable_icd_server=true \
-    chip_enable_icd_lit=true \
+    chip_enable_icd_checkin=true \
     target_ldflags=[\"-fuse-ld=lld\"]"
 
 # Deactivate Pigweed environment to use OSS-Fuzz toolchains

--- a/projects/connectedhomeip/build.sh
+++ b/projects/connectedhomeip/build.sh
@@ -91,6 +91,9 @@ fi
 #   error on GenericConnectivityManagerImpl_Thread.ipp and current fuzzing
 #   does not differentiate between thread/Wifi/TCP/UDP/BLE connectivity
 #   implementations.
+# - `chip_enable_icd_server` / `chip_enable_icd_lit` enable the ICD server and the
+#   Check-In Protocol, without which the ICD Management cluster command handlers
+#   are not compiled and the fuzz target covering them is configured out.
 # - `target_ldflags` forces compiler to use LLVM's linker
 gn gen out/fuzz_targets \
   --args="
@@ -100,6 +103,8 @@ gn gen out/fuzz_targets \
     pw_enable_fuzz_test_targets=true \
     chip_enable_thread_safety_checks=false \
     chip_enable_thread=false \
+    chip_enable_icd_server=true \
+    chip_enable_icd_lit=true \
     target_ldflags=[\"-fuse-ld=lld\"]"
 
 # Deactivate Pigweed environment to use OSS-Fuzz toolchains


### PR DESCRIPTION
Enables the ICD server and the Check-In Protocol for the connectedhomeip fuzz build.

The ICD Management cluster command handlers are compiled only when the ICD server is enabled, and `RegisterClient`/`UnregisterClient` additionally require the Check-In Protocol (`chip_enable_icd_checkin`). Without these two args the fuzz target covering those handlers is conditioned out of the `pw_fuzz_tests` group and never built, so it would be carried in-tree but never fuzzed.

**Depends on project-chip/connectedhomeip#73907**, which adds the target. Please hold until that merges -- ahead of it these args only enable extra ICD configuration with no target to exercise it.

Verified locally by building the full `pw_fuzz_tests` group with these args added: all 28 targets compile and link, and `fuzz-PASE-pw`, `fuzz-CASE-pw`, `fuzz-wifipaf-endpoint-pw`, `fuzz-bdx-transfer-session-pw` and `fuzz-chip-cert-pw` were re-run afterwards with no change in behaviour.
