### PR TITLE
curl: add coverage extra args to ignore curl_fuzzer build directory

### DIFF
--- a/projects/curl/project.yaml
+++ b/projects/curl/project.yaml
@@ -17,4 +17,5 @@ fuzzing_engines:
 architectures:
   - x86_64
   - i386
+coverage_extra_args: -ignore-filename-regex=.*curl_fuzzer/build/.*
 main_repo: 'https://github.com/curl/curl.git'


### PR DESCRIPTION
Ignore the curl-fuzzer build directory when doing coverage stats.