### PR TITLE
avm: add AV2 decoder fuzzing

### DIFF
--- a/projects/avm/Dockerfile
+++ b/projects/avm/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN git clone --depth 1 https://github.com/AOMediaCodec/avm.git avm
+WORKDIR avm
+
+COPY build.sh $SRC/

--- a/projects/avm/Dockerfile
+++ b/projects/avm/Dockerfile
@@ -16,6 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 
+RUN apt-get update && apt-get install -y yasm
 RUN git clone --depth 1 https://github.com/AOMediaCodec/avm.git avm
 WORKDIR avm
 

--- a/projects/avm/build.sh
+++ b/projects/avm/build.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+build_dir="$WORK/build"
+rm -rf "$build_dir"
+mkdir -p "$build_dir"
+
+extra_flags="-DDO_RANGE_CHECK_CLAMP=1 -DAVM_MAX_ALLOCABLE_MEMORY=1073741824"
+
+cmake -S "$SRC/avm" -B "$build_dir" \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DCMAKE_C_COMPILER="$CC" \
+  -DCMAKE_CXX_COMPILER="$CXX" \
+  -DCMAKE_C_FLAGS="$CFLAGS" \
+  -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+  -DAVM_EXTRA_C_FLAGS="$extra_flags" \
+  -DAVM_EXTRA_CXX_FLAGS="$extra_flags" \
+  -DCONFIG_PIC=1 \
+  -DCONFIG_AV2_ENCODER=0 \
+  -DCONFIG_SIZE_LIMIT=1 \
+  -DDECODE_HEIGHT_LIMIT=12288 \
+  -DDECODE_WIDTH_LIMIT=12288 \
+  -DENABLE_APPS=0 \
+  -DENABLE_DOCS=0 \
+  -DENABLE_EXAMPLES=0 \
+  -DENABLE_TESTS=0 \
+  -DENABLE_TOOLS=0
+
+cmake --build "$build_dir" --parallel "$(nproc)"
+
+"$CXX" $CXXFLAGS -std=c++11 -DDECODER=av2 \
+  -I"$SRC/avm" -I"$build_dir" \
+  "$SRC/avm/examples/av2_dec_fuzzer.cc" \
+  -o "$OUT/av2_dec_fuzzer" \
+  "$LIB_FUZZING_ENGINE" "$build_dir/libavm.a"

--- a/projects/avm/build.sh
+++ b/projects/avm/build.sh
@@ -23,10 +23,6 @@ extra_flags="-DDO_RANGE_CHECK_CLAMP=1 -DAVM_MAX_ALLOCABLE_MEMORY=1073741824"
 
 cmake -S "$SRC/avm" -B "$build_dir" \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-  -DCMAKE_C_COMPILER="$CC" \
-  -DCMAKE_CXX_COMPILER="$CXX" \
-  -DCMAKE_C_FLAGS="$CFLAGS" \
-  -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
   -DAVM_EXTRA_C_FLAGS="$extra_flags" \
   -DAVM_EXTRA_CXX_FLAGS="$extra_flags" \
   -DCONFIG_PIC=1 \
@@ -42,7 +38,7 @@ cmake -S "$SRC/avm" -B "$build_dir" \
 
 cmake --build "$build_dir" --parallel "$(nproc)"
 
-"$CXX" $CXXFLAGS -std=c++11 -DDECODER=av2 \
+"$CXX" $CXXFLAGS -std=c++17 \
   -I"$SRC/avm" -I"$build_dir" \
   "$SRC/avm/examples/av2_dec_fuzzer.cc" \
   -o "$OUT/av2_dec_fuzzer" \

--- a/projects/avm/project.yaml
+++ b/projects/avm/project.yaml
@@ -1,0 +1,9 @@
+homepage: "https://github.com/AOMediaCodec/avm"
+language: c++
+primary_contact: "wtc@google.com"
+main_repo: "https://github.com/AOMediaCodec/avm.git"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+  - undefined

--- a/projects/avm/project.yaml
+++ b/projects/avm/project.yaml
@@ -1,6 +1,11 @@
 homepage: "https://github.com/AOMediaCodec/avm"
 language: c++
 primary_contact: "wtc@google.com"
+auto_ccs:
+  - "urvang@google.com"
+  - "leolzhao@global.tencent.com"
+  - "yunqingwang@google.com"
+  - "jzern@google.com"
 main_repo: "https://github.com/AOMediaCodec/avm.git"
 fuzzing_engines:
   - libfuzzer

--- a/projects/avm/project.yaml
+++ b/projects/avm/project.yaml
@@ -1,8 +1,8 @@
 homepage: "https://github.com/AOMediaCodec/avm"
 language: c++
-primary_contact: "wtc@google.com"
+primary_contact: "urvang@google.com"
 auto_ccs:
-  - "urvang@google.com"
+  - "wtc@google.com"
   - "leolzhao@global.tencent.com"
   - "yunqingwang@google.com"
   - "jzern@google.com"
@@ -12,3 +12,4 @@ fuzzing_engines:
 sanitizers:
   - address
   - undefined
+  - memory


### PR DESCRIPTION
Add AVM as a standalone OSS-Fuzz project and build its existing `examples/av2_dec_fuzzer.cc` target. This addresses AOMediaCodec/libavif#3348: AVM is currently reached indirectly through libavif, while its native AV2 decoder harness is not running continuously.

The integration builds decoder-only AVM with its upstream fuzzing allocation and frame-size limits, disables unrelated apps, tools, and tests, and supports AddressSanitizer and UndefinedBehaviorSanitizer.

Validation:
- OSS-Fuzz project checks pass.
- AddressSanitizer build and local fuzz run pass and reach decoder initialization and decode paths.
- UndefinedBehaviorSanitizer build and 15,000-run local fuzz smoke test pass.

Assisted-by: OpenAI Codex:gpt-5.6-sol
