### PR TITLE
json-flattener: bump Gson to 2.13.2 and Java to 17 in fuzz-targets

### DIFF
--- a/projects/json-flattener/project-parent/fuzz-targets/pom.xml
+++ b/projects/json-flattener/project-parent/fuzz-targets/pom.xml
@@ -10,9 +10,9 @@
     <description>fuzz</description>
 
     <properties>
-        <java.version>11</java.version>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <java.version>17</java.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.10.1</version>
+            <version>2.13.2</version>
         </dependency>
 
 


### PR DESCRIPTION
The `fuzz-targets` module pinned Gson 2.10.1, which predates Gson's default JSON nesting limit (255, introduced in 2.11.0) and parses arbitrarily deep arrays. That is what let oss-fuzz issue 553637751 (`StackOverflowError` in `JsonFlattener.jsonVal2Obj` on deeply nested arrays in `KEEP_ARRAYS` mode) reach the library: with the parsers json-flattener actually ships and tests against (Gson 2.13.2, Jackson 3, nesting limits 255 and 500) the same input is rejected at parse time and never reaches the flattener.

This aligns the harness with the versions the project builds against:

- Gson 2.10.1 → 2.13.2 (the `provided` version declared by json-base 3.0.0, and the test version in json-flattener's own pom)
- Java 11 → 17 (json-flattener requires Java 17 since 0.18.0)

Verified locally with `infra/helper.py build_fuzzers` and `check_build`; a synthetic 20000-level nested array crashes `FlattenFuzzer` with the old Gson and is cleanly rejected with the new one.

I am the primary contact for this project.
