### PR TITLE
go-git: Add go-git/reftable

### DIFF
--- a/projects/go-git/Dockerfile
+++ b/projects/go-git/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir -p "${ORG_ROOT}"
 # The fuzzed components are scattered around multiple repositories.
 # Here we clone all of them and cache their go dependencies.
 # The build process happens as build.sh iterate over each one of them.
-ARG REPOSITORIES="go-git go-billy"
+ARG REPOSITORIES="go-git go-billy reftable"
 RUN for repo in ${REPOSITORIES}; do \
     git clone --depth 1 "https://github.com/go-git/${repo}" "${ORG_ROOT}/${repo}"; \
     cd "${ORG_ROOT}/${repo}"; \


### PR DESCRIPTION
Expands fuzzing to [go-git's fork](https://github.com/go-git/reftable) of [reftable](https://github.com/google/reftable) (now archived).