### PR TITLE
Add LakeSource project (libFuzzer parser harness)

### DIFF
--- a/projects/lakesource/Dockerfile
+++ b/projects/lakesource/Dockerfile
@@ -1,0 +1,14 @@
+# LakeSource E2 libFuzzer harness - OSS-Fuzz project image.
+#
+# Upstream (google/oss-fuzz projects/lakesource): the infra clones main_repo
+# (https://github.com/Cisne-047/lakesource) into $SRC/lakesource, which is
+# why WORKDIR is $SRC/lakesource. The docker build context is the project
+# directory only (Dockerfile + build.sh + project.yaml), never the engine
+# tree. Do not RUN git clone. Do not COPY the engine tree.
+# Local helper.py sessions (tools/fuzz/run_oss_fuzz_local.*) bind-mount the
+# local checkout over the same WORKDIR; the file serves both lanes.
+
+FROM gcr.io/oss-fuzz-base/base-builder
+
+COPY build.sh $SRC/
+WORKDIR $SRC/lakesource

--- a/projects/lakesource/build.sh
+++ b/projects/lakesource/build.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# LakeSource E2 libFuzzer harness — OSS-Fuzz build script.
+#
+# Builds tools/fuzz/llvm_fuzzer_harness.cpp with -fsanitize=fuzzer,address
+# against the minimal decoder closure of lakesource_runtime:
+#
+#   runtime/src/vtf_texture.cpp   (ParseVtfBytes)
+#   runtime/src/net_client.cpp    (DecodeClientInputPacket / handshake decoders;
+#                                  portable Win32/POSIX split, no sockets touched
+#                                  on the pure-decode path)
+#   runtime/src/replication.cpp   (DecodeEntitySnapshot / DecodePhysicsSnapshot)
+#
+# Headers come from runtime/include only (std-only). No other engine sources,
+# no third-party deps, no downloads.
+#
+# OSS-Fuzz conventions honored: $CXX/$CXXFLAGS/$LIB_FUZZING_ENGINE from the
+# base image, artifacts to $OUT (fuzzer binary + seed corpus zip named
+# <fuzzer>_seed_corpus.zip). Do not add -fsanitize=fuzzer,address when
+# LIB_FUZZING_ENGINE is set — CXXFLAGS already carries the sanitizer.
+#
+# Local smoke (outside OSS-Fuzz / helper.py), from the repo root:
+#   CXX=clang++ CXXFLAGS="-O1 -g" OUT=out/oss-fuzz WORK=/tmp/lakesource-oss \
+#     bash tools/fuzz/oss_fuzz/build.sh
+
+set -eu
+
+# Resolve the LakeSource checkout both ways it can be reached:
+#  - inside OSS-Fuzz / helper.py, where this file is copied to $SRC/build.sh
+#    and the local checkout is bind-mounted at $SRC/lakesource;
+#  - in-repo, invoked directly as tools/fuzz/oss_fuzz/build.sh.
+if [ -n "${SRC:-}" ] && [ -d "$SRC/lakesource/tools/fuzz/oss_fuzz" ]; then
+    REPO="$SRC/lakesource"
+else
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    REPO="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+fi
+
+: "${CXX:?CXX must be set by OSS-Fuzz base-builder (clang++)}"
+: "${CXXFLAGS:?CXXFLAGS must be set by OSS-Fuzz base-builder}"
+: "${OUT:?OUT must point at the OSS-Fuzz artifact directory}"
+: "${WORK:?WORK must point at the OSS-Fuzz scratch directory}"
+
+mkdir -p "$OUT"
+
+# Word-splitting of CXXFLAGS / LIB_FUZZING_ENGINE is the OSS-Fuzz contract.
+# shellcheck disable=SC2086
+if [ -n "${LIB_FUZZING_ENGINE:-}" ]; then
+    "$CXX" $CXXFLAGS $LIB_FUZZING_ENGINE -std=c++20 \
+        -I"$REPO/runtime/include" \
+        "$REPO/tools/fuzz/llvm_fuzzer_harness.cpp" \
+        "$REPO/runtime/src/vtf_texture.cpp" \
+        "$REPO/runtime/src/net_client.cpp" \
+        "$REPO/runtime/src/replication.cpp" \
+        -o "$OUT/libfuzzer_parser_harness"
+else
+    "$CXX" $CXXFLAGS -std=c++20 -fsanitize=fuzzer,address \
+        -I"$REPO/runtime/include" \
+        "$REPO/tools/fuzz/llvm_fuzzer_harness.cpp" \
+        "$REPO/runtime/src/vtf_texture.cpp" \
+        "$REPO/runtime/src/net_client.cpp" \
+        "$REPO/runtime/src/replication.cpp" \
+        -o "$OUT/libfuzzer_parser_harness"
+fi
+
+# Seed corpus: byte-for-byte parity with tools/fuzz/run_parser_corpus.ps1
+# (same New-SeedBytes values, same trunc/flip mutants, same file names) so a
+# local run and the OSS-Fuzz upload start from identical inputs.
+SEED_DIR="$WORK/lakesource_seed_corpus"
+rm -rf "$SEED_DIR"
+mkdir -p "$SEED_DIR"
+
+python3 - "$SEED_DIR" <<'PYEOF'
+import os, sys
+
+out = sys.argv[1]
+seeds = {
+    "vtf": ("vtf", bytes([0x56, 0x54, 0x46, 0x00, 7, 0, 1, 0, 0xFF, 0xFF])),   # VTF\0 + junk
+    "vpk": ("vpk", bytes([0x34, 0x12, 0xAA, 0x55, 1, 2, 3, 4])),
+    "bsp": ("bsp", bytes([0x56, 0x42, 0x53, 0x50, 0, 0, 0, 0, 0xFF])),         # VBSP
+    "mdl": ("mdl", bytes([0x49, 0x44, 0x53, 0x54, 1, 0, 0, 0, 0xEE])),         # IDST
+    "net": ("lsci", bytes([0x4C, 0x53, 0x43, 0x49]) + bytes([0, 0, 0, 0, 9, 8, 7, 6])),  # LSCI
+}
+
+for kind, (ext, blob) in seeds.items():
+    names = {
+        "seed_%s.%s" % (kind, ext): blob,
+        # trunc: first half, at least one byte (matches the ps1 runner).
+        "mut_trunc_%s.%s" % (kind, ext): blob[: max(1, len(blob) // 2)],
+        # flip: byte 0 xor 0xFF (matches the ps1 runner).
+        "mut_flip_%s.%s" % (kind, ext):
+            bytes([blob[0] ^ 0xFF]) + blob[1:],
+    }
+    for name, payload in names.items():
+        with open(os.path.join(out, name), "wb") as handle:
+            handle.write(payload)
+PYEOF
+
+# base-builder ships zip; fall back to python's zipfile elsewhere.
+if command -v zip >/dev/null 2>&1; then
+    zip -j -q "$OUT/libfuzzer_parser_harness_seed_corpus.zip" "$SEED_DIR"/*
+else
+    python3 - "$SEED_DIR" "$OUT/libfuzzer_parser_harness_seed_corpus.zip" <<'PYEOF'
+import os, sys, zipfile
+
+src, dst = sys.argv[1], sys.argv[2]
+with zipfile.ZipFile(dst, "w", zipfile.ZIP_STORED) as archive:
+    for name in sorted(os.listdir(src)):
+        archive.write(os.path.join(src, name), name)
+PYEOF
+fi
+
+echo "# LakeSource E2 harness built:"
+echo "#   $OUT/libfuzzer_parser_harness"
+echo "#   $OUT/libfuzzer_parser_harness_seed_corpus.zip"

--- a/projects/lakesource/project.yaml
+++ b/projects/lakesource/project.yaml
@@ -1,0 +1,16 @@
+# LakeSource OSS-Fuzz project manifest.
+#
+# LakeSource is a clean-room engine rewrite (MIT, see ENGINE_LICENSE.md in
+# the repo). The fuzz targets link only clean-room MIT code: the VTF parser,
+# the net client/handshake decoders, and the entity/physics snapshot
+# replication decoders. Valve-licensed Source SDK trees (sp/, mp/) are not
+# part of any fuzz target.
+
+homepage: "https://github.com/Cisne-047/lakesource"
+language: c++
+main_repo: "https://github.com/Cisne-047/lakesource"
+
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
Adds `projects/lakesource` for the LakeSource engine (https://github.com/Cisne-047/lakesource).

**What LakeSource is:** a clean-room engine rewrite (MIT, see `ENGINE_LICENSE.md`) with its own BSP/VPK/VTF/MDL-style asset parsers, a deterministic Jolt-based physics layer, an entity I/O system, and a Vulkan/DX renderer. The Valve-licensed Source SDK trees in the same repository (`sp/`, `mp/`) are **not** part of any fuzz target — the harness links only MIT clean-room code.

**Fuzzer:** `libfuzzer_parser_harness` — one `LLVMFuzzerTestOneInput` entry point that magic-sniffs each input and dispatches to the real, fail-closed production decoders:

- `VTF\0` header inputs → `ParseVtfBytes` (VTF texture parser)
- exact `LSCI` packet size → `DecodeClientInputPacket`
- exact handshake packet sizes → `DecodeHandshakeHello` / `DecodeHandshakeAck` (`LSHE`/`LSHA`)
- always, best-effort → `DecodeEntitySnapshot` + `DecodePhysicsSnapshot` against a null baseline

These decoders take explicit `packet_bytes` / `input` spans and must be bounds-safe by design — a crash or sanitizer hit is treated as a real finding (no try/catch in the harness).

**Dependencies:** none beyond the base-builder toolchain. `build.sh` compiles the harness plus three clean-room translation units (`runtime/src/vtf_texture.cpp`, `runtime/src/net_client.cpp`, `runtime/src/replication.cpp`) with headers from `runtime/include` only — no downloads, no engine tree, no third-party libs. Seed corpus (15 files: VTF/VPK/BSP/MDL/LSCI magic-tagged seeds + truncation/byte-flip mutants) is generated deterministically so local runs and the OSS-Fuzz corpus start from identical inputs.

**Local verification:** the project files were verified with a stock clang 18.1.3 toolchain (Ubuntu 24.04, WSL) — `build.sh` produced the harness + seed-corpus zip, and a 20-second libFuzzer campaign completed **6,326,682 execs with 0 crashes / leaks / timeouts** (ASan build, `-fsanitize=fuzzer,address`).

The engine repo carries its CI (`lakesource_fuzz_cron.yml`, weekly 300 s libFuzzer lane on the same harness), so this project shares code that is exercised continuously upstream.

Maintainers: happy to adjust `project.yaml` fields (primary_contact, auto_close, etc.) or build flags — just comment. Thank you!