### PR TITLE
guava: add Android immutable collections fuzz target

### DIFF
--- a/projects/guava/AndroidImmutableCollectionsHashFloodingFuzzer.java
+++ b/projects/guava/AndroidImmutableCollectionsHashFloodingFuzzer.java
@@ -1,0 +1,138 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import com.code_intelligence.jazzer.api.FuzzerSecurityIssueMedium;
+import com.google.common.collect.ImmutableBiMap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+/** Detects algorithmic-complexity hash flooding in Android-flavor immutable collections. */
+public final class AndroidImmutableCollectionsHashFloodingFuzzer {
+  // A magic prefix prevents ordinary random inputs from repeatedly exercising the maximum-cost
+  // case. Jazzer's comparison instrumentation can still discover this structured input.
+  private static final byte[] MAGIC = {'H', 'F', 'v', '1'};
+  private static final long MAX_REASONABLE_EQUALS = 1_000_000L;
+
+  private AndroidImmutableCollectionsHashFloodingFuzzer() {}
+
+  public static void fuzzerTestOneInput(byte[] input) {
+    if (input.length < MAGIC.length + 2 || !hasMagicPrefix(input)) {
+      return;
+    }
+
+    int collection = Byte.toUnsignedInt(input[MAGIC.length]) % 3;
+    int collisionBits = 6 + (Byte.toUnsignedInt(input[MAGIC.length + 1]) % 7);
+    int count = 1 << collisionBits;
+
+    CollisionKey.resetEqualsCalls();
+    switch (collection) {
+      case 0:
+        ImmutableMap.Builder<CollisionKey, Integer> map =
+            ImmutableMap.builderWithExpectedSize(count);
+        for (int i = 0; i < count; i++) {
+          map.put(new CollisionKey(i, collisionBits), i);
+        }
+        map.buildOrThrow();
+        break;
+      case 1:
+        ImmutableSet.Builder<CollisionKey> set = ImmutableSet.builderWithExpectedSize(count);
+        for (int i = 0; i < count; i++) {
+          set.add(new CollisionKey(i, collisionBits));
+        }
+        set.build();
+        break;
+      default:
+        ImmutableBiMap.Builder<CollisionKey, Integer> bimap = ImmutableBiMap.builder();
+        for (int i = 0; i < count; i++) {
+          bimap.put(new CollisionKey(i, collisionBits), i);
+        }
+        bimap.buildOrThrow();
+        break;
+    }
+
+    long equalsCalls = CollisionKey.equalsCalls();
+    if (equalsCalls > MAX_REASONABLE_EQUALS) {
+      throw new FuzzerSecurityIssueMedium(
+          "Probable hash-flooding algorithmic-complexity denial of service in "
+              + collectionName(collection)
+              + ": "
+              + count
+              + " distinct keys with one String hash required "
+              + equalsCalls
+              + " equals calls during construction (limit "
+              + MAX_REASONABLE_EQUALS
+              + ").");
+    }
+  }
+
+  private static boolean hasMagicPrefix(byte[] input) {
+    for (int i = 0; i < MAGIC.length; i++) {
+      if (input[i] != MAGIC[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static String collectionName(int collection) {
+    switch (collection) {
+      case 0:
+        return "ImmutableMap";
+      case 1:
+        return "ImmutableSet";
+      default:
+        return "ImmutableBiMap";
+    }
+  }
+
+  /** Comparable wrapper around distinct strings from Java's Aa/BB collision family. */
+  private static final class CollisionKey implements Comparable<CollisionKey> {
+    private static long equalsCalls;
+    private final int id;
+    private final String value;
+
+    CollisionKey(int id, int bits) {
+      this.id = id;
+      StringBuilder result = new StringBuilder(bits * 2);
+      for (int bit = 0; bit < bits; bit++) {
+        result.append(((id >>> bit) & 1) == 0 ? "Aa" : "BB");
+      }
+      this.value = result.toString();
+    }
+
+    static void resetEqualsCalls() {
+      equalsCalls = 0;
+    }
+
+    static long equalsCalls() {
+      return equalsCalls;
+    }
+
+    @Override
+    public int hashCode() {
+      return value.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      equalsCalls++;
+      return other instanceof CollisionKey && value.equals(((CollisionKey) other).value);
+    }
+
+    @Override
+    public int compareTo(CollisionKey other) {
+      return Integer.compare(id, other.id);
+    }
+  }
+}

--- a/projects/guava/build.sh
+++ b/projects/guava/build.sh
@@ -21,6 +21,21 @@ CURRENT_VERSION=$($MVN org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate
  -Dexpression=project.version -q -DforceStdout)
 cp "guava/target/guava-$CURRENT_VERSION.jar" "$OUT/guava.jar"
 
+# Build the Android flavor from the same checkout. Existing targets continue to use the JRE jar.
+$MVN -f android/pom.xml -pl guava -am $MAVEN_ARGS \
+  -Dcheckstyle.skip=true -Drat.skip=true -Dmaven.javadoc.skip=true \
+  -Danimal.sniffer.skip=true package
+mapfile -t ANDROID_JARS < <(
+  find android/guava/target -maxdepth 1 -type f -name 'guava-*.jar' \
+    ! -name '*-sources.jar' ! -name '*-javadoc.jar' ! -name '*-tests.jar' | sort
+)
+[[ ${#ANDROID_JARS[@]} -eq 1 ]] || {
+  printf 'Expected exactly one Android Guava jar, found %s: %s\n' \
+    "${#ANDROID_JARS[@]}" "${ANDROID_JARS[*]-}" >&2
+  exit 1
+}
+cp "${ANDROID_JARS[0]}" "$OUT/guava-android.jar"
+
 ALL_JARS="guava.jar"
 
 # The classpath at build-time includes the project jars in $OUT as well as the
@@ -29,11 +44,22 @@ BUILD_CLASSPATH=$(echo $ALL_JARS | xargs printf -- "$OUT/%s:"):$JAZZER_API_PATH
 
 # All .jar and .class files lie in the same directory as the fuzzer at runtime.
 RUNTIME_CLASSPATH=$(echo $ALL_JARS | xargs printf -- "\$this_dir/%s:"):\$this_dir
-javac -cp $BUILD_CLASSPATH ${SRC}/*.java
+ANDROID_RUNTIME_CLASSPATH="\$this_dir/guava-android.jar:\$this_dir"
+mapfile -t JRE_FUZZERS < <(
+  find "$SRC" -maxdepth 1 -type f -name '*Fuzzer.java' \
+    ! -name 'AndroidImmutableCollectionsHashFloodingFuzzer.java' | sort
+)
+javac -cp "$BUILD_CLASSPATH" "${JRE_FUZZERS[@]}"
+javac -cp "$OUT/guava-android.jar:$JAZZER_API_PATH" \
+  "$SRC/AndroidImmutableCollectionsHashFloodingFuzzer.java"
 install ${SRC}/*.class ${OUT}/
 
 for fuzzer in $(find $SRC -name '*Fuzzer.java' -maxdepth 1); do
   fuzzer_basename=$(basename -s .java $fuzzer)
+  target_classpath=$RUNTIME_CLASSPATH
+  if [[ $fuzzer_basename == AndroidImmutableCollectionsHashFloodingFuzzer ]]; then
+    target_classpath=$ANDROID_RUNTIME_CLASSPATH
+  fi
 
   # Create an execution wrapper that executes Jazzer with the correct arguments.
   echo "#!/bin/bash
@@ -46,7 +72,7 @@ else
 fi
 LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\":\$this_dir \
 \$this_dir/jazzer_driver --agent_path=\$this_dir/jazzer_agent_deploy.jar \
---cp=$RUNTIME_CLASSPATH \
+--cp=$target_classpath \
 --target_class=$fuzzer_basename \
 --jvm_args=\"\$mem_settings\" \
 \$@" > $OUT/$fuzzer_basename


### PR DESCRIPTION
## guava: fuzz Android immutable collection hash flooding

### Summary

This adds a Jazzer target for the Android flavor of Guava's immutable map, set, and bimap implementations. The existing Guava OSS-Fuzz targets run against the JRE artifact; the build now also produces `guava-android.jar`, and only the new target uses that artifact.

The target exercises construction with distinct keys from Java's deterministic `Aa`/`BB` string-hash collision family. It uses an equality-operation budget as a deterministic semantic oracle for pathological probing. A four-byte structured prefix keeps ordinary random inputs inexpensive while remaining discoverable through Jazzer's comparison instrumentation.

### Build changes

- Build the Android flavor from the same Guava checkout.
- Copy it to `$OUT/guava-android.jar`.
- Compile the Android target against that artifact.
- Keep every existing Guava target on `$OUT/guava.jar`.
- Select the Android runtime classpath while generating only the new target's launcher.

### Local validation

Run:

```bash
python3 infra/helper.py build_image guava
python3 infra/helper.py build_fuzzers guava
python3 infra/helper.py check_build guava
```

The accompanying local verifier also checks a non-triggering 64-key control, all three 4,096-key collection modes, and a bounded mutation campaign beginning with a non-crashing seed.

### Scope

This PR changes only:

- `projects/guava/build.sh`
- `projects/guava/AndroidImmutableCollectionsHashFloodingFuzzer.java`

It does not change Guava production code or the Dockerfile.
