### PR TITLE
ruby: initialize ruby VM in fuzz_prism (fixes #16065)

### DIFF
--- a/projects/ruby/fuzz_prism.cpp
+++ b/projects/ruby/fuzz_prism.cpp
@@ -21,16 +21,24 @@ limitations under the License.
 #include <string.h>
 #include <string>
 #include <fuzzer/FuzzedDataProvider.h>
+#include "ruby.h"
 
 extern "C" {
 #include "prism.h"
 }
+
+static int ruby_initialized = 0;
 
 extern "C" int
 LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     if (size == 0) {
         return 0;
+    }
+
+    if (!ruby_initialized) {
+        ruby_init();
+        ruby_initialized = 1;
     }
 
     // Create arena for AST-lifetime allocations


### PR DESCRIPTION
## Description
Fixes #16065.

In projects/ruby/fuzz_prism.cpp, ruby_init() was not called prior to calling pm_arena_new(). In CRuby builds, Prism's allocator delegates to ruby_xcalloc, which accesses GET_VM()->ractor.main_ractor. Because the Ruby VM was uninitialized, this resulted in a NULL-pointer dereference (SEGV at offset 0x558) on any input of 1 byte or more.

This patch adds the standard one-time ruby_init() initialization guard (matching the pattern used across other Ruby harnesses in this project, e.g. fuzz_hash.cpp, fuzz_iseq.cpp, fuzz_string.cpp).