### PR TITLE
openssl: Update old and new versions

### DIFF
--- a/projects/openssl/Dockerfile
+++ b/projects/openssl/Dockerfile
@@ -18,16 +18,16 @@ FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make
 RUN git clone --depth 1 https://github.com/openssl/openssl.git
 RUN cd $SRC/openssl/ && git submodule update --init fuzz/corpora
-RUN git clone --depth 1 --branch openssl-3.0 https://github.com/openssl/openssl.git openssl30
 RUN git clone --depth 1 --branch openssl-3.4 https://github.com/openssl/openssl.git openssl34
 RUN git clone --depth 1 --branch openssl-3.5 https://github.com/openssl/openssl.git openssl35
 RUN git clone --depth 1 --branch openssl-3.6 https://github.com/openssl/openssl.git openssl36
 RUN git clone --depth 1 --branch openssl-4.0 https://github.com/openssl/openssl.git openssl40
-RUN cd $SRC/openssl30/ && git submodule update --init fuzz/corpora
+RUN git clone --depth 1 --branch openssl-4.1 https://github.com/openssl/openssl.git openssl41
 RUN cd $SRC/openssl34/ && git submodule update --init fuzz/corpora
 RUN cd $SRC/openssl35/ && git submodule update --init fuzz/corpora
 RUN cd $SRC/openssl36/ && git submodule update --init fuzz/corpora
 RUN cd $SRC/openssl40/ && git submodule update --init fuzz/corpora
+RUN cd $SRC/openssl41/ && git submodule update --init fuzz/corpora
 WORKDIR openssl
 COPY build.sh *.options replay_build.sh run_tests.sh $SRC/
 ENV AFL_SKIP_OSSFUZZ=1

--- a/projects/openssl/build.sh
+++ b/projects/openssl/build.sh
@@ -93,8 +93,6 @@ if [[ "$SANITIZER" == introspector || -n "${INDEXER_BUILD:-}" || -n "${CAPTURE_R
   exit 0
 fi
 
-cd $SRC/openssl30/
-build_fuzzers "_30" "" "engines"
 cd $SRC/openssl34/
 build_fuzzers "_34" "no-apps no-docs" "engines"
 cd $SRC/openssl35/
@@ -103,3 +101,5 @@ cd $SRC/openssl36/
 build_fuzzers "_36" "no-apps no-docs" "engines"
 cd $SRC/openssl40/
 build_fuzzers "_40" "no-apps no-docs" ""
+cd $SRC/openssl41/
+build_fuzzers "_41" "no-apps no-docs" ""


### PR DESCRIPTION
- 3.0 is EOL since 2026-09-07
- 4.1 was released on 2026-09-10: https://github.com/openssl/openssl/releases/tag/openssl-4.1.0-alpha1