### PR TITLE
dom4j: don't let deeply nested XML take down the fuzzer

### DIFF
--- a/projects/dom4j/DOMReaderFuzzer.java
+++ b/projects/dom4j/DOMReaderFuzzer.java
@@ -34,6 +34,11 @@ public class DOMReaderFuzzer {
     try (AutoCloseable ignored = BugDetectors.allowNetworkConnections()) {
 
       DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      // DOMReader.readTree/readElement recurse once per level of nesting, so an
+      // unbounded document overflows the stack instead of hitting a bug in
+      // dom4j. Refuse anything deeper than what a sane XML consumer accepts.
+      factory.setAttribute(
+          "http://www.oracle.com/xml/jaxp/properties/maxElementDepth", "100");
       DocumentBuilder builder;
       org.w3c.dom.Document doc;
 

--- a/projects/dom4j/DOMReaderFuzzer.java
+++ b/projects/dom4j/DOMReaderFuzzer.java
@@ -26,7 +26,6 @@ import java.lang.IllegalArgumentException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.ByteArrayInputStream;
-import java.util.List;
 
 public class DOMReaderFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {


### PR DESCRIPTION
#16036 reports DOMReaderFuzzer falling over on deeply nested XML. It isn't dom4j's fault: DOMReader.readTree/readElement recurse once per level of nesting, so a document nested a thousand levels deep runs the stack out, and StackOverflowError is an Error, which sails past both catch clauses in the target and gets filed as a crash.

Rather than swallowing the Error, I'd rather not hand the parser a document that deep at all. The factory now sets the maxElementDepth limit to 100, so anything deeper is refused with a SAXParseException while parsing, which the target already returns on.

How I checked it: stubbed the jazzer API and a DOMReader that recurses the way dom4j's does, compiled the target before and after, and ran the same two inputs through both on JDK 17.

before - shallow doc (3 levels) reaches DOMReader; deep doc (1334 levels) escapes as StackOverflowError.
after - shallow doc still reaches DOMReader at 3 levels; deep doc is rejected by the parser and never gets there.

Also dropped an unused import while I was in the file.