### PR TITLE
hobbes: keep apt lists so the introspector build can install its packages

### DIFF
--- a/projects/hobbes/Dockerfile
+++ b/projects/hobbes/Dockerfile
@@ -27,8 +27,9 @@ RUN apt-get update && \
         zlib1g-dev libncurses-dev libzstd-dev libreadline-dev \
         wget gnupg lsb-release software-properties-common && \
     wget -qO- https://apt.llvm.org/llvm.sh | bash -s -- $HOBBES_LLVM_VERSION && \
-    apt-get install -y --no-install-recommends llvm-$HOBBES_LLVM_VERSION-dev && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get install -y --no-install-recommends llvm-$HOBBES_LLVM_VERSION-dev
+# The package lists are kept: the introspector build installs a few packages
+# from the compile script without running apt-get update first.
 
 RUN git clone --depth 1 https://github.com/morganstanley/hobbes.git $SRC/hobbes
 


### PR DESCRIPTION
The introspector build for hobbes has failed every day (fuzzing and coverage builds pass). The Dockerfile removed `/var/lib/apt/lists/*` after installing its packages, and the introspector path in `base-builder/compile` then runs `apt-get install -y libjpeg-dev zlib1g-dev libyaml-dev` without an `apt-get update` first:

```
Step #6 - "compile-libfuzzer-introspector-x86_64": E: Unable to locate package libjpeg-dev
Step #6 - "compile-libfuzzer-introspector-x86_64": E: Unable to locate package libyaml-dev
```

(from https://oss-fuzz-build-logs.storage.googleapis.com/log-56bf03d7-41e8-4a4a-9d30-fc0185226a47.txt)

Keep the package lists in the image so that install works. Verified by rebuilding the image locally and running the same `apt-get install` inside it, which now succeeds.