### PR TITLE
tomcat: fix broken build

### DIFF
--- a/projects/tomcat/WsPingPongFuzzer.java
+++ b/projects/tomcat/WsPingPongFuzzer.java
@@ -69,7 +69,7 @@ public class WsPingPongFuzzer {
         ctx = tomcat.addContext("", null);
         ctx.addApplicationListener(TesterEchoServer.Config.class.getName());
         Tomcat.addServlet(ctx, "default", new DefaultServlet());
-        ctx.addServletMappingDecoded("/", "default");
+        ctx.addServletMapping("/", "default");
 
         connector1 = tomcat.getConnector();
         connector1.setPort(0);


### PR DESCRIPTION
The build successfully compiled several fuzzers but failed on `WsPingPongFuzzer.java`. The fix replaced `ctx.addServletMappingDecoded("/", "default");` with `ctx.addServletMapping("/", "default");` in `WsPingPongFuzzer.java`. The build log indicates a compilation error because `addServletMappingDecoded` cannot be found.

> error: cannot find symbol 
> ctx.addServletMappingDecoded("/", "default");