### PR TITLE
libyaml: Increment document count only after successful copy

### DIFF
--- a/projects/libyaml/libyaml_dumper_fuzzer.c
+++ b/projects/libyaml/libyaml_dumper_fuzzer.c
@@ -247,11 +247,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
         break;
       }
 
-      if (!copy_document(&documents[document_number++], &document)) {
+      if (!copy_document(&documents[document_number], &document)) {
         yaml_document_delete(&document);
         equal = true;
         break;
       }
+      document_number++;
       if (!(yaml_emitter_dump(&emitter, &document) ||
             (yaml_emitter_flush(&emitter) && 0))) {
         equal = true;


### PR DESCRIPTION
The libyaml dumper fuzzer increments `document_number` before it knows whether `copy_document()` succeeded. If the copy fails, the final cleanup loop consequently passes an uninitialized `yaml_document_t` to `yaml_document_delete()`.

Increment the count only after a successful copy. This keeps the cleanup range limited to initialized documents.

I reproduced the failure with the 806-byte input attached to yaml/libyaml#312. On OSS-Fuzz master at `4e65aea32254fe988ac4b84dbb088d2d08d789e7`, the current harness aborts under ASan in `yaml_document_delete()`; with this change, the same input exits normally under ASan and UBSan.

This is the same lifetime rule applied to the event count in #15096, now applied to the remaining dumper path.